### PR TITLE
chore: Add initial codecov configuration file and ignore examples folder

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,3 @@
-# sample regex patterns
+# Coverage ignore patterns
 ignore:
   - "examples"  # ignore examples folder


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added configuration for code coverage reporting to exclude example content from coverage metrics, improving the accuracy of CI coverage signals. No functional or UI changes for end users; build and deployment behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->