### PR TITLE
feat: Implement trace ID propagation and W3C trace context support in HTTP client and server

### DIFF
--- a/examples/trace-propagation/README.md
+++ b/examples/trace-propagation/README.md
@@ -1,0 +1,54 @@
+# Trace ID Propagation Example
+
+This example demonstrates the HTTP client's automatic trace ID propagation functionality for improved observability in distributed systems.
+
+## Features Demonstrated
+
+1. **Automatic Trace ID Generation**: When no trace ID is provided, the client automatically generates a UUID
+2. **Context-Based Trace IDs**: Pass trace IDs through context for seamless propagation
+3. **Header Precedence**: Request headers take precedence over context values
+4. **Request Interceptor**: Alternative approach using interceptors for explicit control
+
+## Running the Example
+
+```bash
+cd examples/trace-propagation
+go run main.go
+```
+
+## Expected Output
+
+The example will show how trace IDs are automatically added to outbound HTTP requests:
+
+```
+=== Example 1: Automatic Trace ID ===
+Server received trace ID: 550e8400-e29b-41d4-a716-446655440000
+Response: {"message": "Hello", "traceId": "550e8400-e29b-41d4-a716-446655440000"}
+
+=== Example 2: Context Trace ID ===
+Server received trace ID: my-custom-trace-123
+Response: {"message": "Hello", "traceId": "my-custom-trace-123"}
+
+=== Example 3: Header Trace ID (precedence) ===
+Server received trace ID: header-trace-priority
+Response: {"message": "Hello", "traceId": "header-trace-priority"}
+
+=== Example 4: Trace ID Interceptor ===
+Server received trace ID: interceptor-trace-456
+Response: {"message": "Hello", "traceId": "interceptor-trace-456"}
+```
+
+## Key Concepts
+
+- **X-Request-ID Header**: Standard header used for request tracing
+- **Context Propagation**: Trace IDs flow through Go contexts
+- **Header Precedence**: Explicit headers override context values
+- **Zero Configuration**: Works automatically without setup
+- **Backward Compatible**: No breaking changes to existing code
+
+## Integration Patterns
+
+1. **Default Behavior**: Automatic trace ID propagation
+2. **Context Utilities**: `http.WithTraceID()` and `http.GetTraceIDFromContext()`
+3. **Request Interceptors**: `http.NewTraceIDInterceptor()` for explicit control
+4. **Header Override**: Set `X-Request-ID` header directly in request

--- a/examples/trace-propagation/main.go
+++ b/examples/trace-propagation/main.go
@@ -1,0 +1,83 @@
+// Package main demonstrates the HTTP client's automatic trace ID propagation
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	gobrickshttp "github.com/gaborage/go-bricks/http"
+	"github.com/gaborage/go-bricks/logger"
+)
+
+func main() {
+	// Create a test server that logs received headers
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		traceID := r.Header.Get("X-Request-ID")
+		traceParent := r.Header.Get("traceparent")
+		fmt.Printf("Server received trace ID: %s\n", traceID)
+		if traceParent != "" {
+			fmt.Printf("Server received traceparent: %s\n", traceParent)
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{"message": "Hello", "traceId": "%s"}`, traceID)
+	}))
+	defer server.Close()
+
+	// Create HTTP client
+	log := logger.New("info", false)
+	client := gobrickshttp.NewClient(log)
+
+	// Example 1: Automatic trace ID generation
+	fmt.Println("=== Example 1: Automatic Trace ID ===")
+	req1 := &gobrickshttp.Request{URL: server.URL}
+	resp1, err := client.Get(context.Background(), req1)
+	if err != nil {
+		log.Error().Err(err).Msg("Request 1 failed")
+		return
+	}
+	fmt.Printf("Response: %s\n\n", string(resp1.Body))
+
+	// Example 2: Context-provided trace ID
+	fmt.Println("=== Example 2: Context Trace ID ===")
+	ctx := gobrickshttp.WithTraceID(context.Background(), "my-custom-trace-123")
+	req2 := &gobrickshttp.Request{URL: server.URL}
+	resp2, err := client.Get(ctx, req2)
+	if err != nil {
+		log.Error().Err(err).Msg("Request 2 failed")
+		return
+	}
+	fmt.Printf("Response: %s\n\n", string(resp2.Body))
+
+	// Example 3: Header-provided trace ID (takes precedence)
+	fmt.Println("=== Example 3: Header Trace ID (precedence) ===")
+	ctxWithTrace := gobrickshttp.WithTraceID(context.Background(), "context-trace")
+	req3 := &gobrickshttp.Request{
+		URL: server.URL,
+		Headers: map[string]string{
+			"X-Request-ID": "header-trace-priority",
+		},
+	}
+	resp3, err := client.Get(ctxWithTrace, req3)
+	if err != nil {
+		log.Error().Err(err).Msg("Request 3 failed")
+		return
+	}
+	fmt.Printf("Response: %s\n\n", string(resp3.Body))
+
+	// Example 4: Using trace ID interceptor (alternative approach)
+	fmt.Println("=== Example 4: Trace ID Interceptor ===")
+	clientWithInterceptor := gobrickshttp.NewBuilder(log).
+		WithRequestInterceptor(gobrickshttp.NewTraceIDInterceptor()).
+		Build()
+
+	ctx4 := gobrickshttp.WithTraceID(context.Background(), "interceptor-trace-456")
+	req4 := &gobrickshttp.Request{URL: server.URL}
+	resp4, err := clientWithInterceptor.Get(ctx4, req4)
+	if err != nil {
+		log.Error().Err(err).Msg("Request 4 failed")
+		return
+	}
+	fmt.Printf("Response: %s\n", string(resp4.Body))
+}

--- a/http/interface.go
+++ b/http/interface.go
@@ -2,8 +2,31 @@ package http
 
 import (
 	"context"
+	crand "crypto/rand"
+	"encoding/hex"
 	nethttp "net/http"
+	"strings"
 	"time"
+
+	"github.com/google/uuid"
+)
+
+// contextKey is the type for context keys to avoid collisions
+type contextKey string
+
+const (
+	// traceIDKey is the context key for trace ID values
+	traceIDKey contextKey = "trace_id"
+	// traceParentKey is the context key for W3C Trace Context header value
+	traceParentKey contextKey = "traceparent"
+	// traceStateKey is the context key for W3C tracestate header value
+	traceStateKey contextKey = "tracestate"
+	// HeaderXRequestID is the standard header name for request tracing
+	HeaderXRequestID = "X-Request-ID"
+	// HeaderTraceParent is the W3C trace context header name
+	HeaderTraceParent = "traceparent"
+	// HeaderTraceState is the W3C trace context "tracestate" header name
+	HeaderTraceState = "tracestate"
 )
 
 // Client defines the REST client interface for making HTTP requests
@@ -63,4 +86,120 @@ type Config struct {
 	LogPayloads bool
 	// MaxPayloadLogBytes caps the number of body bytes logged when LogPayloads is enabled
 	MaxPayloadLogBytes int
+	// TraceIDHeader configures the header name used for trace ID propagation (default: X-Request-ID)
+	TraceIDHeader string
+	// NewTraceID generates a new trace ID when none is present (default: uuid)
+	NewTraceID func() string
+	// TraceIDExtractor allows advanced extraction of a trace ID from context; return ok=false to fallback to generator
+	TraceIDExtractor func(ctx context.Context) (traceID string, ok bool)
+	// EnableW3CTrace enables W3C Trace Context (traceparent/tracestate) propagation and generation
+	EnableW3CTrace bool
+}
+
+// Trace ID utility functions
+
+// WithTraceID adds a trace ID to the context for HTTP client propagation
+func WithTraceID(ctx context.Context, traceID string) context.Context {
+	return context.WithValue(ctx, traceIDKey, traceID)
+}
+
+// TraceIDFromContext returns a trace ID from context if present
+func TraceIDFromContext(ctx context.Context) (string, bool) {
+	if traceID, ok := ctx.Value(traceIDKey).(string); ok && traceID != "" {
+		return traceID, true
+	}
+	return "", false
+}
+
+// EnsureTraceID returns an existing trace ID from context or generates a new one
+func EnsureTraceID(ctx context.Context) string {
+	if traceID, ok := TraceIDFromContext(ctx); ok {
+		return traceID
+	}
+	return uuid.New().String()
+}
+
+// GetTraceIDFromContext remains for backward compatibility; it ensures a non-empty value
+func GetTraceIDFromContext(ctx context.Context) string {
+	return EnsureTraceID(ctx)
+}
+
+// WithTraceParent adds a W3C traceparent value to the context
+func WithTraceParent(ctx context.Context, traceParent string) context.Context {
+	return context.WithValue(ctx, traceParentKey, traceParent)
+}
+
+// TraceParentFromContext returns a traceparent from context if present
+func TraceParentFromContext(ctx context.Context) (string, bool) {
+	if tp, ok := ctx.Value(traceParentKey).(string); ok && tp != "" {
+		return tp, true
+	}
+	return "", false
+}
+
+// WithTraceState adds a W3C tracestate value to the context
+func WithTraceState(ctx context.Context, traceState string) context.Context {
+	return context.WithValue(ctx, traceStateKey, traceState)
+}
+
+// TraceStateFromContext returns a tracestate from context if present
+func TraceStateFromContext(ctx context.Context) (string, bool) {
+	if ts, ok := ctx.Value(traceStateKey).(string); ok && ts != "" {
+		return ts, true
+	}
+	return "", false
+}
+
+// GenerateTraceParent creates a minimal W3C traceparent header value.
+// Format: version(2)-trace-id(32)-span-id(16)-flags(2), e.g., "00-<32>-<16>-01"
+func GenerateTraceParent() string {
+	traceID := make([]byte, 16)
+	spanID := make([]byte, 8)
+	if _, err := crand.Read(traceID); err != nil {
+		traceID = []byte(strings.Repeat("\x00", 16))
+	}
+	if _, err := crand.Read(spanID); err != nil {
+		spanID = []byte(strings.Repeat("\x00", 8))
+	}
+	if allZero(traceID) {
+		traceID[len(traceID)-1] = 0x01
+	}
+	if allZero(spanID) {
+		spanID[len(spanID)-1] = 0x01
+	}
+	return "00-" + strings.ToLower(hex.EncodeToString(traceID)) + "-" + strings.ToLower(hex.EncodeToString(spanID)) + "-01"
+}
+
+func allZero(b []byte) bool {
+	for _, v := range b {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// NewTraceIDInterceptor creates a request interceptor that adds trace ID headers
+// This provides an alternative approach for users who want explicit control
+func NewTraceIDInterceptor() RequestInterceptor {
+	return func(ctx context.Context, req *nethttp.Request) error {
+		if req.Header.Get(HeaderXRequestID) == "" {
+			traceID := GetTraceIDFromContext(ctx)
+			req.Header.Set(HeaderXRequestID, traceID)
+		}
+		return nil
+	}
+}
+
+// NewTraceIDInterceptorFor creates an interceptor that uses a custom header name
+func NewTraceIDInterceptorFor(header string) RequestInterceptor {
+	if header == "" {
+		header = HeaderXRequestID
+	}
+	return func(ctx context.Context, req *nethttp.Request) error {
+		if req.Header.Get(header) == "" {
+			req.Header.Set(header, GetTraceIDFromContext(ctx))
+		}
+		return nil
+	}
 }

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -14,6 +14,9 @@ func SetupMiddlewares(e *echo.Echo, log logger.Logger, cfg *config.Config) {
 	// Request ID
 	e.Use(middleware.RequestID())
 
+	// Inject trace context into request context for outbound propagation
+	e.Use(TraceContext())
+
 	// Operation Tracker - Initialize AMQP and DB operation tracking for each request
 	e.Use(PerformanceStats())
 

--- a/server/trace_context.go
+++ b/server/trace_context.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	gobrickshttp "github.com/gaborage/go-bricks/http"
+	"github.com/labstack/echo/v4"
+)
+
+// TraceContext injects the resolved trace ID and W3C trace context headers
+// from the Echo request/response into the request context, so that outbound
+// HTTP clients can propagate them without depending on Echo.
+func TraceContext() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			req := c.Request()
+
+			// Resolve or generate the trace ID using existing server logic
+			traceID := getTraceID(c)
+
+			// Attach trace ID to request context
+			ctx := gobrickshttp.WithTraceID(req.Context(), traceID)
+
+			// Propagate W3C trace headers if present on inbound request
+			if tp := req.Header.Get(gobrickshttp.HeaderTraceParent); tp != "" {
+				ctx = gobrickshttp.WithTraceParent(ctx, tp)
+			}
+			if ts := req.Header.Get(gobrickshttp.HeaderTraceState); ts != "" {
+				ctx = gobrickshttp.WithTraceState(ctx, ts)
+			}
+
+			c.SetRequest(req.WithContext(ctx))
+			return next(c)
+		}
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic trace ID propagation in the HTTP client with configurable header, context utilities, and optional W3C traceparent/tracestate support.
  - Request interceptor for injecting trace IDs; logs now include trace IDs.
  - Server now propagates or generates traceparent on responses.
  - New middleware to inject and propagate trace context across requests.

- Documentation
  - Added a Trace ID Propagation example with README, usage instructions, and scenarios.

- Tests
  - Added tests covering trace ID behavior and W3C trace headers in client and server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->