### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gaborage/go-bricks/security/code-scanning/1](https://github.com/gaborage/go-bricks/security/code-scanning/1)

The best way to fix the problem is to explicitly set a `permissions` block at the root level of the workflow file (.github/workflows/ci.yml), directly after the workflow `name`. This block should set the minimal permissions required for the jobs to run; in this case, that would be `contents: read`, as none of the jobs in this workflow appear to need broader permissions (such as write access to issues, pull requests, or repository contents). If future jobs do require write permissions, they can be assigned specifically via a more permissive job-level `permissions` block. This fix only requires editing the header of the workflow file and does not require any code or import changes elsewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to explicitly set read-only permissions for repository contents.
  * No changes to workflow triggers or execution steps.
  * No impact on application behavior or features; end-user experience remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->