### PR TITLE
fix(metrics): standardize metric naming conventions in tracking package

### DIFF
--- a/database/internal/tracking/metrics.go
+++ b/database/internal/tracking/metrics.go
@@ -26,16 +26,16 @@ const (
 	metricDBDuration = "db.client.operation.duration"
 
 	// Connection pool metrics
-	metricPoolActive = "db.connection.pool.active"
-	metricPoolIdle   = "db.connection.pool.idle"
-	metricPoolTotal  = "db.connection.pool.total"
+	metricDBPoolActive = "db.connection.pool.active"
+	metricDBPoolIdle   = "db.connection.pool.idle"
+	metricDBPoolTotal  = "db.connection.pool.total"
 
-	metricDbSQLTable  = "db.sql.table"
-	metricDbOperation = "db.operation.name"
-	metricDbSystem    = "db.system"
+	metricDBSQLTable  = "db.sql.table"
+	metricDBOperation = "db.operation.name"
+	metricDBSystem    = "db.system"
 
 	// I/O metrics
-	metricRowsAffected = "db.rows.affected"
+	metricDBRowsAffected = "db.rows.affected"
 )
 
 var (
@@ -176,10 +176,10 @@ func initDBMeter() {
 
 	// Initialize counter for rows affected (write operations)
 	dbRowsAffectedCounter, err = dbMeter.Int64Counter(
-		metricRowsAffected,
+		metricDBRowsAffected,
 		metric.WithDescription("Number of rows affected by database operations"),
 	)
-	logMetricError(metricRowsAffected, err)
+	logMetricError(metricDBRowsAffected, err)
 }
 
 // getDBMeter returns the initialized database meter, initializing it if necessary.
@@ -215,9 +215,9 @@ func recordDBMetrics(ctx context.Context, tc *Context, query string, duration ti
 
 	// Common attributes for both metrics
 	commonAttrs := []attribute.KeyValue{
-		attribute.String(metricDbSystem, vendor),
-		attribute.String(metricDbOperation, operation),
-		attribute.String(metricDbSQLTable, table),
+		attribute.String(metricDBSystem, vendor),
+		attribute.String(metricDBOperation, operation),
+		attribute.String(metricDBSQLTable, table),
 	}
 
 	// Record counter with error attribute
@@ -416,9 +416,9 @@ func RegisterConnectionPoolMetrics(conn interface {
 	}
 
 	// Create gauges using helper function
-	reg.activeGauge = createGauge(meter, metricPoolActive, "Number of active database connections")
-	reg.idleGauge = createGauge(meter, metricPoolIdle, "Number of idle database connections")
-	reg.totalGauge = createGauge(meter, metricPoolTotal, "Maximum number of database connections configured")
+	reg.activeGauge = createGauge(meter, metricDBPoolActive, "Number of active database connections")
+	reg.idleGauge = createGauge(meter, metricDBPoolIdle, "Number of idle database connections")
+	reg.totalGauge = createGauge(meter, metricDBPoolTotal, "Maximum number of database connections configured")
 
 	// Collect non-nil gauges for callback registration
 	instruments := collectInstruments(reg.activeGauge, reg.idleGauge, reg.totalGauge)

--- a/database/internal/tracking/metrics_test.go
+++ b/database/internal/tracking/metrics_test.go
@@ -520,7 +520,7 @@ func TestRecordDBMetricsWithTableAttribute(t *testing.T) {
 
 				for _, dp := range sumData.DataPoints {
 					for _, attr := range dp.Attributes.ToSlice() {
-						if string(attr.Key) == metricDbSQLTable && attr.Value.AsString() == "users" {
+						if string(attr.Key) == metricDBSQLTable && attr.Value.AsString() == "users" {
 							foundTableAttr = true
 							break
 						}
@@ -764,9 +764,9 @@ func TestRegisterConnectionPoolMetricsWithDifferentNumericTypes(t *testing.T) {
 			rm := mp.Collect(t)
 
 			// Verify gauges exist
-			obtest.AssertMetricExists(t, rm, metricPoolActive)
-			obtest.AssertMetricExists(t, rm, metricPoolIdle)
-			obtest.AssertMetricExists(t, rm, metricPoolTotal)
+			obtest.AssertMetricExists(t, rm, metricDBPoolActive)
+			obtest.AssertMetricExists(t, rm, metricDBPoolIdle)
+			obtest.AssertMetricExists(t, rm, metricDBPoolTotal)
 
 			// Verify gauge values match expected (accounting for type conversion)
 			// Note: We can't directly assert gauge values without triggering the callback
@@ -810,9 +810,9 @@ func TestRegisterConnectionPoolMetricsWithInvalidTypes(t *testing.T) {
 	rm := mp.Collect(t)
 
 	// Gauges should exist (even if values are 0 due to conversion failure)
-	obtest.AssertMetricExists(t, rm, metricPoolActive)
-	obtest.AssertMetricExists(t, rm, metricPoolIdle)
-	obtest.AssertMetricExists(t, rm, metricPoolTotal)
+	obtest.AssertMetricExists(t, rm, metricDBPoolActive)
+	obtest.AssertMetricExists(t, rm, metricDBPoolIdle)
+	obtest.AssertMetricExists(t, rm, metricDBPoolTotal)
 }
 
 // TestRegisterConnectionPoolMetricsStatsError tests handling of Stats() errors.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Refactor
  - Renamed database-related metrics to DB-scoped identifiers (e.g., pool active/idle/total, rows affected, system, operation, SQL table). No behavior changes.
- Tests
  - Updated tests to assert the new metric names.

Note: If you consume these metrics in dashboards or alerts, review and update references to the new DB-prefixed names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->