### PR TITLE
feat(tracking): Implement OpenTelemetry metrics for AMQP operations

### DIFF
--- a/messaging/internal/tracking/metrics.go
+++ b/messaging/internal/tracking/metrics.go
@@ -1,0 +1,366 @@
+package tracking
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	// Meter name for AMQP messaging metrics instrumentation
+	amqpMeterName = "go-bricks/messaging"
+
+	// Standard OTel messaging metric names (semconv v1.37.0)
+	metricOperationDuration = "messaging.client.operation.duration"
+	metricMessagesSent      = "messaging.client.sent.messages"
+	metricMessagesConsumed  = "messaging.client.consumed.messages"
+
+	// Framework-specific operational metrics
+	metricPublishRetries   = "messaging.client.publish.retries"
+	metricConnectionCreate = "messaging.connection.create"
+	metricConnectionClose  = "messaging.connection.close"
+	metricChannelCreate    = "messaging.channel.create"
+	metricChannelClose     = "messaging.channel.close"
+
+	// Attribute keys (following OTel semconv)
+	attrMessagingSystem             = "messaging.system"
+	attrMessagingOperation          = "messaging.operation.name"
+	attrMessagingDestination        = "messaging.destination.name"
+	attrErrorType                   = "error.type"
+	attrMessagingRabbitMQExchange   = "messaging.rabbitmq.exchange"
+	attrMessagingRabbitMQRoutingKey = "messaging.rabbitmq.routing_key"
+	attrMessagingRabbitMQQueue      = "messaging.rabbitmq.queue"
+	attrRetryReason                 = "retry.reason"
+
+	// Operation types
+	operationPublish = "publish"
+	operationReceive = "receive"
+
+	// Messaging system identifier
+	messagingSystemRabbitMQ = "rabbitmq"
+)
+
+var (
+	// Singleton meter initialization
+	amqpMeter   metric.Meter
+	meterOnce   sync.Once
+	meterInitMu sync.Mutex
+
+	// Metric instruments (standard OTel metrics)
+	amqpOperationDuration metric.Float64Histogram
+	amqpMessagesSent      metric.Int64Counter
+	amqpMessagesConsumed  metric.Int64Counter
+
+	// Additional operational metrics
+	amqpPublishRetries   metric.Int64Counter
+	amqpConnectionCreate metric.Int64Counter
+	amqpConnectionClose  metric.Int64Counter
+	amqpChannelCreate    metric.Int64Counter
+	amqpChannelClose     metric.Int64Counter
+)
+
+// logMetricError logs a metric initialization or registration error to stderr.
+// This is a best-effort operation - metrics failures should not break the application.
+func logMetricError(metricName string, err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: Failed to initialize metric %s: %v\n", metricName, err)
+	}
+}
+
+// initAMQPMeter initializes the OpenTelemetry meter and metric instruments.
+// This function is called lazily and only once using sync.Once to ensure
+// thread-safe initialization.
+func initAMQPMeter() {
+	meterInitMu.Lock()
+	defer meterInitMu.Unlock()
+
+	// Prevent re-initialization if already set
+	if amqpMeter != nil {
+		return
+	}
+
+	// Get meter from global meter provider
+	amqpMeter = otel.Meter(amqpMeterName)
+
+	var err error
+
+	// Initialize operation duration histogram with explicit bucket boundaries per OTel semconv
+	// Buckets: [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]
+	amqpOperationDuration, err = amqpMeter.Float64Histogram(
+		metricOperationDuration,
+		metric.WithDescription("Duration of messaging operation initiated by a producer or consumer client"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10),
+	)
+	logMetricError(metricOperationDuration, err)
+
+	// Initialize sent messages counter
+	amqpMessagesSent, err = amqpMeter.Int64Counter(
+		metricMessagesSent,
+		metric.WithDescription("Number of messages producer attempted to send to the broker"),
+		metric.WithUnit("{message}"),
+	)
+	logMetricError(metricMessagesSent, err)
+
+	// Initialize consumed messages counter
+	amqpMessagesConsumed, err = amqpMeter.Int64Counter(
+		metricMessagesConsumed,
+		metric.WithDescription("Number of messages that were delivered to the application"),
+		metric.WithUnit("{message}"),
+	)
+	logMetricError(metricMessagesConsumed, err)
+
+	// Initialize publish retries counter
+	amqpPublishRetries, err = amqpMeter.Int64Counter(
+		metricPublishRetries,
+		metric.WithDescription("Number of message publish retry attempts due to NACK or timeout"),
+		metric.WithUnit("{retry}"),
+	)
+	logMetricError(metricPublishRetries, err)
+
+	// Initialize connection create counter
+	amqpConnectionCreate, err = amqpMeter.Int64Counter(
+		metricConnectionCreate,
+		metric.WithDescription("Number of AMQP connection creation events"),
+		metric.WithUnit("{connection}"),
+	)
+	logMetricError(metricConnectionCreate, err)
+
+	// Initialize connection close counter
+	amqpConnectionClose, err = amqpMeter.Int64Counter(
+		metricConnectionClose,
+		metric.WithDescription("Number of AMQP connection close events"),
+		metric.WithUnit("{connection}"),
+	)
+	logMetricError(metricConnectionClose, err)
+
+	// Initialize channel create counter
+	amqpChannelCreate, err = amqpMeter.Int64Counter(
+		metricChannelCreate,
+		metric.WithDescription("Number of AMQP channel creation events"),
+		metric.WithUnit("{channel}"),
+	)
+	logMetricError(metricChannelCreate, err)
+
+	// Initialize channel close counter
+	amqpChannelClose, err = amqpMeter.Int64Counter(
+		metricChannelClose,
+		metric.WithDescription("Number of AMQP channel close events"),
+		metric.WithUnit("{channel}"),
+	)
+	logMetricError(metricChannelClose, err)
+}
+
+// getAMQPMeter returns the initialized AMQP meter, initializing it if necessary.
+func getAMQPMeter() metric.Meter {
+	meterOnce.Do(initAMQPMeter)
+	return amqpMeter
+}
+
+// RecordAMQPPublishMetrics records OpenTelemetry metrics for an AMQP publish operation.
+// This function is called after a publish attempt to emit metrics about the operation.
+//
+// Parameters:
+//   - ctx: Context for metrics recording
+//   - exchange: The AMQP exchange name (empty string for default exchange)
+//   - routingKey: The routing key used for message delivery
+//   - duration: Time taken for the publish operation
+//   - err: Error if the operation failed, nil if successful
+//
+// Metrics recorded:
+// - messaging.client.operation.duration: Histogram of operation durations in seconds
+// - messaging.client.sent.messages: Counter of messages sent (incremented on success)
+//
+// The function is non-blocking and handles errors gracefully - metric recording failures
+// will not impact messaging operation execution.
+func RecordAMQPPublishMetrics(ctx context.Context, exchange, routingKey string, duration time.Duration, err error) {
+	// Ensure meter is initialized
+	meter := getAMQPMeter()
+	if meter == nil {
+		return
+	}
+
+	// Format destination name per OTel RabbitMQ convention (producer format)
+	destination := formatDestinationName(exchange, routingKey, "")
+	errorType := extractErrorType(err)
+
+	// Common attributes for metrics
+	commonAttrs := []attribute.KeyValue{
+		attribute.String(attrMessagingSystem, messagingSystemRabbitMQ),
+		attribute.String(attrMessagingOperation, operationPublish),
+		attribute.String(attrMessagingDestination, destination),
+	}
+
+	// Add granular attributes for filtering
+	if exchange != "" {
+		commonAttrs = append(commonAttrs, attribute.String(attrMessagingRabbitMQExchange, exchange))
+	}
+	if routingKey != "" {
+		commonAttrs = append(commonAttrs, attribute.String(attrMessagingRabbitMQRoutingKey, routingKey))
+	}
+
+	// Add error type if present
+	if errorType != "" {
+		commonAttrs = append(commonAttrs, attribute.String(attrErrorType, errorType))
+	}
+
+	// Record duration histogram (in seconds)
+	if amqpOperationDuration != nil {
+		durationSeconds := durationToSeconds(duration)
+		amqpOperationDuration.Record(ctx, durationSeconds, metric.WithAttributes(commonAttrs...))
+	}
+
+	// Record sent messages counter (only on success)
+	if amqpMessagesSent != nil && err == nil {
+		amqpMessagesSent.Add(ctx, 1, metric.WithAttributes(commonAttrs...))
+	}
+}
+
+// RecordAMQPConsumeMetrics records OpenTelemetry metrics for an AMQP consume operation.
+// This function is called automatically when a message is consumed to emit metrics.
+//
+// Metrics recorded:
+// - messaging.client.operation.duration: Histogram of operation durations in seconds
+// - messaging.client.consumed.messages: Counter of messages consumed
+//
+// The function is non-blocking and handles errors gracefully.
+func RecordAMQPConsumeMetrics(ctx context.Context, delivery *amqp.Delivery, queueName string, duration time.Duration, err error) {
+	// Ensure meter is initialized
+	meter := getAMQPMeter()
+	if meter == nil {
+		return
+	}
+
+	// Extract delivery information
+	var exchange, routingKey string
+	if delivery != nil {
+		exchange = delivery.Exchange
+		routingKey = delivery.RoutingKey
+	}
+
+	// Format destination name per OTel RabbitMQ convention (consumer format)
+	destination := formatDestinationName(exchange, routingKey, queueName)
+	errorType := extractErrorType(err)
+
+	// Common attributes for metrics
+	commonAttrs := []attribute.KeyValue{
+		attribute.String(attrMessagingSystem, messagingSystemRabbitMQ),
+		attribute.String(attrMessagingOperation, operationReceive),
+		attribute.String(attrMessagingDestination, destination),
+	}
+
+	// Add granular attributes for filtering
+	if exchange != "" {
+		commonAttrs = append(commonAttrs, attribute.String(attrMessagingRabbitMQExchange, exchange))
+	}
+	if routingKey != "" {
+		commonAttrs = append(commonAttrs, attribute.String(attrMessagingRabbitMQRoutingKey, routingKey))
+	}
+	if queueName != "" {
+		commonAttrs = append(commonAttrs, attribute.String(attrMessagingRabbitMQQueue, queueName))
+	}
+
+	// Add error type if present
+	if errorType != "" {
+		commonAttrs = append(commonAttrs, attribute.String(attrErrorType, errorType))
+	}
+
+	// Record duration histogram (in seconds) - only if duration is > 0
+	if amqpOperationDuration != nil && duration > 0 {
+		durationSeconds := durationToSeconds(duration)
+		amqpOperationDuration.Record(ctx, durationSeconds, metric.WithAttributes(commonAttrs...))
+	}
+
+	// Record consumed messages counter (only on success)
+	if amqpMessagesConsumed != nil && err == nil {
+		amqpMessagesConsumed.Add(ctx, 1, metric.WithAttributes(commonAttrs...))
+	}
+}
+
+// RecordPublishRetry records a publish retry attempt in the retry counter.
+// This is called each time a publish operation is retried due to NACK, timeout, or error.
+//
+// Parameters:
+//   - ctx: Context for metrics recording
+//   - exchange: The AMQP exchange name (empty string for default exchange)
+//   - routingKey: The routing key used for message delivery
+//   - reason: The reason for the retry (e.g., "nack", "timeout", "publish_error")
+func RecordPublishRetry(ctx context.Context, exchange, routingKey, reason string) {
+	// Ensure meter is initialized
+	meter := getAMQPMeter()
+	if meter == nil {
+		return
+	}
+
+	// Format destination name per OTel RabbitMQ convention (producer format)
+	destination := formatDestinationName(exchange, routingKey, "")
+
+	// Attributes for retry metric
+	attrs := []attribute.KeyValue{
+		attribute.String(attrMessagingSystem, messagingSystemRabbitMQ),
+		attribute.String(attrMessagingDestination, destination),
+		attribute.String(attrRetryReason, reason),
+	}
+
+	// Add granular attributes for filtering
+	if exchange != "" {
+		attrs = append(attrs, attribute.String(attrMessagingRabbitMQExchange, exchange))
+	}
+	if routingKey != "" {
+		attrs = append(attrs, attribute.String(attrMessagingRabbitMQRoutingKey, routingKey))
+	}
+
+	// Record retry counter
+	if amqpPublishRetries != nil {
+		amqpPublishRetries.Add(ctx, 1, metric.WithAttributes(attrs...))
+	}
+}
+
+// recordLifecycleEvent is a helper function to record connection or channel lifecycle events.
+// It reduces code duplication between RecordConnectionEvent and RecordChannelEvent.
+func recordLifecycleEvent(eventType string, err error, createCounter, closeCounter metric.Int64Counter) {
+	// Ensure meter is initialized
+	meter := getAMQPMeter()
+	if meter == nil {
+		return
+	}
+
+	errorType := extractErrorType(err)
+
+	// Attributes for lifecycle event
+	attrs := []attribute.KeyValue{
+		attribute.String(attrMessagingSystem, messagingSystemRabbitMQ),
+	}
+
+	// Add error type if present (for close events)
+	if errorType != "" {
+		attrs = append(attrs, attribute.String(attrErrorType, errorType))
+	}
+
+	// Record appropriate counter
+	ctx := context.Background()
+	if eventType == "create" && createCounter != nil {
+		createCounter.Add(ctx, 1, metric.WithAttributes(attrs...))
+	} else if eventType == "close" && closeCounter != nil {
+		closeCounter.Add(ctx, 1, metric.WithAttributes(attrs...))
+	}
+}
+
+// RecordConnectionEvent records AMQP connection lifecycle events.
+// eventType should be "create" or "close".
+func RecordConnectionEvent(eventType string, err error) {
+	recordLifecycleEvent(eventType, err, amqpConnectionCreate, amqpConnectionClose)
+}
+
+// RecordChannelEvent records AMQP channel lifecycle events.
+// eventType should be "create" or "close".
+func RecordChannelEvent(eventType string, err error) {
+	recordLifecycleEvent(eventType, err, amqpChannelCreate, amqpChannelClose)
+}

--- a/messaging/internal/tracking/metrics_test.go
+++ b/messaging/internal/tracking/metrics_test.go
@@ -1,0 +1,450 @@
+package tracking
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	obtest "github.com/gaborage/go-bricks/observability/testing"
+)
+
+const (
+	testExchange   = "test.exchange"
+	testRoutingKey = "test.key"
+	testQueueName  = "test-queue"
+)
+
+// resetMeterForTesting resets the meter state for testing purposes
+func resetMeterForTesting() {
+	meterOnce = sync.Once{}
+	amqpMeter = nil
+}
+
+func TestInitAMQPMeter(t *testing.T) {
+	// Reset meter for testing
+	resetMeterForTesting()
+
+	// Setup test meter provider
+	mp := obtest.NewTestMeterProvider()
+	defer func() {
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}()
+	otel.SetMeterProvider(mp)
+
+	// Initialize meter
+	initAMQPMeter()
+
+	// Verify meter is initialized
+	assert.NotNil(t, amqpMeter, "AMQP meter should be initialized")
+
+	// Verify all metric instruments are initialized
+	assert.NotNil(t, amqpOperationDuration, "Operation duration histogram should be initialized")
+	assert.NotNil(t, amqpMessagesSent, "Messages sent counter should be initialized")
+	assert.NotNil(t, amqpMessagesConsumed, "Messages consumed counter should be initialized")
+	assert.NotNil(t, amqpPublishRetries, "Publish retries counter should be initialized")
+	assert.NotNil(t, amqpConnectionCreate, "Connection create counter should be initialized")
+	assert.NotNil(t, amqpConnectionClose, "Connection close counter should be initialized")
+	assert.NotNil(t, amqpChannelCreate, "Channel create counter should be initialized")
+	assert.NotNil(t, amqpChannelClose, "Channel close counter should be initialized")
+
+	// Verify meter returns same instance on subsequent calls
+	meter2 := getAMQPMeter()
+	assert.Equal(t, amqpMeter, meter2, "getAMQPMeter should return same instance")
+}
+
+func TestRecordAMQPPublishMetricsSuccess(t *testing.T) {
+	// Setup test meter provider
+	mp := obtest.NewTestMeterProvider()
+	defer func() {
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}()
+	otel.SetMeterProvider(mp)
+
+	// Reset and reinitialize meter
+	resetMeterForTesting()
+	initAMQPMeter()
+
+	ctx := context.Background()
+	duration := 150 * time.Millisecond
+
+	// Record successful publish metrics
+	RecordAMQPPublishMetrics(ctx, testExchange, testRoutingKey, duration, nil)
+
+	// Collect metrics
+	rm := mp.Collect(t)
+
+	// Assert operation duration histogram
+	obtest.AssertMetricExists(t, rm, metricOperationDuration)
+	durationMetric := obtest.FindMetric(rm, metricOperationDuration)
+	require.NotNil(t, durationMetric)
+
+	// Verify histogram has data
+	histData, ok := durationMetric.Data.(metricdata.Histogram[float64])
+	require.True(t, ok, "Duration metric should be a histogram")
+	require.NotEmpty(t, histData.DataPoints, "Duration histogram should have data points")
+
+	// Verify duration value is in seconds
+	dp := histData.DataPoints[0]
+	assert.InDelta(t, 0.15, dp.Sum, 0.01, "Duration should be ~0.15 seconds")
+	assert.Equal(t, uint64(1), dp.Count, "Should have 1 recorded duration")
+
+	// Verify attributes
+	attrs := dp.Attributes.ToSlice()
+	assertHasAttribute(t, attrs, attrMessagingSystem, messagingSystemRabbitMQ)
+	assertHasAttribute(t, attrs, attrMessagingOperation, operationPublish)
+	assertHasAttribute(t, attrs, attrMessagingDestination, "test.exchange:test.key")
+	assertHasAttribute(t, attrs, attrMessagingRabbitMQExchange, "test.exchange")
+	assertHasAttribute(t, attrs, attrMessagingRabbitMQRoutingKey, "test.key")
+
+	// Assert messages sent counter
+	obtest.AssertMetricExists(t, rm, metricMessagesSent)
+	obtest.AssertMetricValue(t, rm, metricMessagesSent, int64(1))
+}
+
+func TestRecordAMQPPublishMetricsFailure(t *testing.T) {
+	// Setup test meter provider
+	mp := obtest.NewTestMeterProvider()
+	defer func() {
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}()
+	otel.SetMeterProvider(mp)
+
+	// Reset and reinitialize meter
+	resetMeterForTesting()
+	initAMQPMeter()
+
+	ctx := context.Background()
+	duration := 50 * time.Millisecond
+	testErr := context.Canceled
+
+	// Record failed publish metrics
+	RecordAMQPPublishMetrics(ctx, testExchange, testRoutingKey, duration, testErr)
+
+	// Collect metrics
+	rm := mp.Collect(t)
+
+	// Assert operation duration histogram (recorded even on failure)
+	obtest.AssertMetricExists(t, rm, metricOperationDuration)
+	durationMetric := obtest.FindMetric(rm, metricOperationDuration)
+	require.NotNil(t, durationMetric)
+
+	// Verify error.type attribute is present
+	histData := durationMetric.Data.(metricdata.Histogram[float64])
+	require.NotEmpty(t, histData.DataPoints)
+	attrs := histData.DataPoints[0].Attributes.ToSlice()
+	assertHasAttribute(t, attrs, attrErrorType, "context.Canceled")
+
+	// Assert messages sent counter is NOT incremented (failure case)
+	sentMetric := obtest.FindMetric(rm, metricMessagesSent)
+	if sentMetric != nil {
+		// If the metric exists, verify it's 0
+		sumData := sentMetric.Data.(metricdata.Sum[int64])
+		if len(sumData.DataPoints) > 0 {
+			assert.Equal(t, int64(0), sumData.DataPoints[0].Value, "Messages sent should be 0 on failure")
+		}
+	}
+}
+
+func TestRecordAMQPPublishMetricsDefaultExchange(t *testing.T) {
+	// Setup test meter provider
+	mp := obtest.NewTestMeterProvider()
+	defer func() {
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}()
+	otel.SetMeterProvider(mp)
+
+	// Reset and reinitialize meter
+	resetMeterForTesting()
+	initAMQPMeter()
+
+	ctx := context.Background()
+	exchange := "" // Default exchange
+	routingKey := "my-queue"
+	duration := 10 * time.Millisecond
+
+	// Record publish metrics
+	RecordAMQPPublishMetrics(ctx, exchange, routingKey, duration, nil)
+
+	// Collect metrics
+	rm := mp.Collect(t)
+
+	// Assert destination name format for default exchange
+	durationMetric := obtest.FindMetric(rm, metricOperationDuration)
+	require.NotNil(t, durationMetric)
+
+	histData := durationMetric.Data.(metricdata.Histogram[float64])
+	require.NotEmpty(t, histData.DataPoints)
+	attrs := histData.DataPoints[0].Attributes.ToSlice()
+
+	assertHasAttribute(t, attrs, attrMessagingDestination, ":my-queue")
+}
+
+func TestRecordAMQPConsumeMetricsSuccess(t *testing.T) {
+	// Setup test meter provider
+	mp := obtest.NewTestMeterProvider()
+	defer func() {
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}()
+	otel.SetMeterProvider(mp)
+
+	// Reset and reinitialize meter
+	resetMeterForTesting()
+	initAMQPMeter()
+
+	ctx := context.Background()
+	delivery := &amqp.Delivery{
+		Exchange:   "events",
+		RoutingKey: testRoutingKey,
+	}
+	queueName := testQueueName
+	duration := 25 * time.Millisecond
+
+	// Record consume metrics
+	RecordAMQPConsumeMetrics(ctx, delivery, queueName, duration, nil)
+
+	// Collect metrics
+	rm := mp.Collect(t)
+
+	// Assert operation duration histogram
+	obtest.AssertMetricExists(t, rm, metricOperationDuration)
+	durationMetric := obtest.FindMetric(rm, metricOperationDuration)
+	require.NotNil(t, durationMetric)
+
+	// Verify attributes
+	histData := durationMetric.Data.(metricdata.Histogram[float64])
+	require.NotEmpty(t, histData.DataPoints)
+	attrs := histData.DataPoints[0].Attributes.ToSlice()
+
+	assertHasAttribute(t, attrs, attrMessagingSystem, messagingSystemRabbitMQ)
+	assertHasAttribute(t, attrs, attrMessagingOperation, operationReceive)
+	assertHasAttribute(t, attrs, attrMessagingDestination, "events:test.key:test-queue")
+	assertHasAttribute(t, attrs, attrMessagingRabbitMQExchange, "events")
+	assertHasAttribute(t, attrs, attrMessagingRabbitMQRoutingKey, testRoutingKey)
+	assertHasAttribute(t, attrs, attrMessagingRabbitMQQueue, testQueueName)
+
+	// Assert messages consumed counter
+	obtest.AssertMetricExists(t, rm, metricMessagesConsumed)
+	obtest.AssertMetricValue(t, rm, metricMessagesConsumed, int64(1))
+}
+
+func TestRecordAMQPConsumeMetricsZeroDuration(t *testing.T) {
+	// Setup test meter provider
+	mp := obtest.NewTestMeterProvider()
+	defer func() {
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}()
+	otel.SetMeterProvider(mp)
+
+	// Reset and reinitialize meter
+	resetMeterForTesting()
+	initAMQPMeter()
+
+	ctx := context.Background()
+	delivery := &amqp.Delivery{
+		Exchange:   "events",
+		RoutingKey: testRoutingKey,
+	}
+	queueName := testQueueName
+	duration := 0 * time.Millisecond // Zero duration (initial receive)
+
+	// Record consume metrics
+	RecordAMQPConsumeMetrics(ctx, delivery, queueName, duration, nil)
+
+	// Collect metrics
+	rm := mp.Collect(t)
+
+	// Duration histogram should NOT be recorded when duration is 0
+	durationMetric := obtest.FindMetric(rm, metricOperationDuration)
+	if durationMetric != nil {
+		histData := durationMetric.Data.(metricdata.Histogram[float64])
+		assert.Empty(t, histData.DataPoints, "Duration should not be recorded when duration is 0")
+	}
+
+	// Messages consumed counter should still be incremented
+	obtest.AssertMetricValue(t, rm, metricMessagesConsumed, int64(1))
+}
+
+func TestRecordPublishRetry(t *testing.T) {
+	// Setup test meter provider
+	mp := obtest.NewTestMeterProvider()
+	defer func() {
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}()
+	otel.SetMeterProvider(mp)
+
+	// Reset and reinitialize meter
+	resetMeterForTesting()
+	initAMQPMeter()
+
+	ctx := context.Background()
+
+	// Record different retry reasons
+	RecordPublishRetry(ctx, testExchange, testRoutingKey, "nack")
+	RecordPublishRetry(ctx, testExchange, testRoutingKey, "timeout")
+	RecordPublishRetry(ctx, testExchange, testRoutingKey, "publish_error")
+
+	// Collect metrics
+	rm := mp.Collect(t)
+
+	// Assert retry counter exists
+	obtest.AssertMetricExists(t, rm, metricPublishRetries)
+	retryMetric := obtest.FindMetric(rm, metricPublishRetries)
+	require.NotNil(t, retryMetric)
+
+	// Verify total retry count
+	sumData := retryMetric.Data.(metricdata.Sum[int64])
+	totalRetries := int64(0)
+	for _, dp := range sumData.DataPoints {
+		totalRetries += dp.Value
+	}
+	assert.Equal(t, int64(3), totalRetries, "Should have 3 total retries")
+
+	// Verify retry reasons are recorded as attributes
+	reasonsFound := make(map[string]bool)
+	for _, dp := range sumData.DataPoints {
+		attrs := dp.Attributes.ToSlice()
+		for _, attr := range attrs {
+			if attr.Key == attrRetryReason {
+				reasonsFound[attr.Value.AsString()] = true
+			}
+		}
+	}
+	assert.True(t, reasonsFound["nack"], "Should have nack retry reason")
+	assert.True(t, reasonsFound["timeout"], "Should have timeout retry reason")
+	assert.True(t, reasonsFound["publish_error"], "Should have publish_error retry reason")
+}
+
+func TestRecordConnectionEvent(t *testing.T) {
+	// Setup test meter provider
+	mp := obtest.NewTestMeterProvider()
+	defer func() {
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}()
+	otel.SetMeterProvider(mp)
+
+	// Reset and reinitialize meter
+	resetMeterForTesting()
+	initAMQPMeter()
+
+	// Record connection create
+	RecordConnectionEvent("create", nil)
+
+	// Record connection close (with error)
+	RecordConnectionEvent("close", context.Canceled)
+
+	// Collect metrics
+	rm := mp.Collect(t)
+
+	// Assert connection create counter
+	obtest.AssertMetricExists(t, rm, metricConnectionCreate)
+	obtest.AssertMetricValue(t, rm, metricConnectionCreate, int64(1))
+
+	// Assert connection close counter
+	obtest.AssertMetricExists(t, rm, metricConnectionClose)
+	obtest.AssertMetricValue(t, rm, metricConnectionClose, int64(1))
+
+	// Verify error.type attribute on close event
+	closeMetric := obtest.FindMetric(rm, metricConnectionClose)
+	require.NotNil(t, closeMetric)
+	sumData := closeMetric.Data.(metricdata.Sum[int64])
+	require.NotEmpty(t, sumData.DataPoints)
+	attrs := sumData.DataPoints[0].Attributes.ToSlice()
+	assertHasAttribute(t, attrs, attrErrorType, "context.Canceled")
+}
+
+func TestRecordChannelEvent(t *testing.T) {
+	// Setup test meter provider
+	mp := obtest.NewTestMeterProvider()
+	defer func() {
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}()
+	otel.SetMeterProvider(mp)
+
+	// Reset and reinitialize meter
+	resetMeterForTesting()
+	initAMQPMeter()
+
+	// Record channel create
+	RecordChannelEvent("create", nil)
+
+	// Record channel close (no error)
+	RecordChannelEvent("close", nil)
+
+	// Collect metrics
+	rm := mp.Collect(t)
+
+	// Assert channel create counter
+	obtest.AssertMetricExists(t, rm, metricChannelCreate)
+	obtest.AssertMetricValue(t, rm, metricChannelCreate, int64(1))
+
+	// Assert channel close counter
+	obtest.AssertMetricExists(t, rm, metricChannelClose)
+	obtest.AssertMetricValue(t, rm, metricChannelClose, int64(1))
+}
+
+func TestHistogramBucketBoundaries(t *testing.T) {
+	// Setup test meter provider
+	mp := obtest.NewTestMeterProvider()
+	defer func() {
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}()
+	otel.SetMeterProvider(mp)
+
+	// Reset and reinitialize meter
+	resetMeterForTesting()
+	initAMQPMeter()
+
+	ctx := context.Background()
+	exchange := "test"
+	routingKey := "key"
+
+	// Record various durations to test bucket boundaries
+	testDurations := []time.Duration{
+		1 * time.Millisecond,   // 0.001s - should fall in first bucket
+		50 * time.Millisecond,  // 0.05s
+		500 * time.Millisecond, // 0.5s
+		2 * time.Second,        // 2s
+		5 * time.Second,        // 5s
+	}
+
+	for _, d := range testDurations {
+		RecordAMQPPublishMetrics(ctx, exchange, routingKey, d, nil)
+	}
+
+	// Collect metrics
+	rm := mp.Collect(t)
+
+	// Verify histogram exists and has correct number of recordings
+	durationMetric := obtest.FindMetric(rm, metricOperationDuration)
+	require.NotNil(t, durationMetric)
+
+	histData := durationMetric.Data.(metricdata.Histogram[float64])
+	require.NotEmpty(t, histData.DataPoints)
+
+	// Verify bucket boundaries match OTel semconv
+	expectedBounds := []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10}
+	assert.Equal(t, expectedBounds, histData.DataPoints[0].Bounds, "Histogram bucket boundaries should match OTel semconv")
+
+	// Verify count of recorded durations
+	assert.Equal(t, uint64(len(testDurations)), histData.DataPoints[0].Count, "Should have recorded all durations")
+}
+
+// Helper function to assert attribute value in attribute slice
+func assertHasAttribute(t *testing.T, attrs []attribute.KeyValue, key, expectedValue string) {
+	t.Helper()
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			assert.Equal(t, expectedValue, attr.Value.AsString(), "Attribute %s should have value %s", key, expectedValue)
+			return
+		}
+	}
+	t.Errorf("Attribute %s not found", key)
+}

--- a/messaging/internal/tracking/utils.go
+++ b/messaging/internal/tracking/utils.go
@@ -1,0 +1,64 @@
+package tracking
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// formatDestinationName formats the destination name per OpenTelemetry RabbitMQ conventions.
+//
+// For producers (no queue):
+//   - With exchange: "{exchange}:{routing_key}" (e.g., "user.events:user.created")
+//   - Default exchange (empty): ":{routing_key}" (e.g., ":user-queue")
+//
+// For consumers (with queue):
+//   - With exchange: "{exchange}:{routing_key}:{queue}" (e.g., "user.events:user.created:processor")
+//   - Default exchange (empty): ":{routing_key}:{queue}" (e.g., ":user.created:processor")
+//
+// This format allows for hierarchical grouping in metrics queries while maintaining
+// compatibility with OpenTelemetry semantic conventions for RabbitMQ.
+func formatDestinationName(exchange, routingKey, queue string) string {
+	if queue != "" {
+		// Consumer format: include queue name
+		if exchange == "" {
+			return fmt.Sprintf(":%s:%s", routingKey, queue)
+		}
+		return fmt.Sprintf("%s:%s:%s", exchange, routingKey, queue)
+	}
+
+	// Producer format: no queue
+	if exchange == "" {
+		return fmt.Sprintf(":%s", routingKey)
+	}
+	return fmt.Sprintf("%s:%s", exchange, routingKey)
+}
+
+// extractErrorType extracts the error type name for the error.type attribute.
+// Returns an empty string for nil errors (success case).
+//
+// For well-known errors, returns the canonical error name.
+// For other errors, returns the error type name (e.g., "*amqp.Error").
+func extractErrorType(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	// Handle well-known context errors
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "context.Canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "context.DeadlineExceeded"
+	default:
+		// Return error type name for other errors
+		return fmt.Sprintf("%T", err)
+	}
+}
+
+// durationToSeconds converts time.Duration to seconds (float64) per OTel requirement.
+// OpenTelemetry duration metrics must use seconds as the unit.
+func durationToSeconds(d time.Duration) float64 {
+	return float64(d.Nanoseconds()) / 1e9
+}

--- a/messaging/internal/tracking/utils_test.go
+++ b/messaging/internal/tracking/utils_test.go
@@ -1,0 +1,222 @@
+package tracking
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatDestinationName(t *testing.T) {
+	tests := []struct {
+		name       string
+		exchange   string
+		routingKey string
+		queue      string
+		expected   string
+	}{
+		// Producer formats (no queue)
+		{
+			name:       "producer_with_exchange",
+			exchange:   "user.events",
+			routingKey: testRoutingKey,
+			queue:      "",
+			expected:   "user.events:test.key",
+		},
+		{
+			name:       "producer_default_exchange",
+			exchange:   "",
+			routingKey: "user-queue",
+			queue:      "",
+			expected:   ":user-queue",
+		},
+		{
+			name:       "producer_empty_routing_key",
+			exchange:   "events",
+			routingKey: "",
+			queue:      "",
+			expected:   "events:",
+		},
+
+		// Consumer formats (with queue)
+		{
+			name:       "consumer_with_exchange",
+			exchange:   "user.events",
+			routingKey: testRoutingKey,
+			queue:      "processor",
+			expected:   "user.events:test.key:processor",
+		},
+		{
+			name:       "consumer_default_exchange",
+			exchange:   "",
+			routingKey: testRoutingKey,
+			queue:      "processor",
+			expected:   ":test.key:processor",
+		},
+		{
+			name:       "consumer_empty_routing_key",
+			exchange:   "events",
+			routingKey: "",
+			queue:      "processor",
+			expected:   "events::processor",
+		},
+		{
+			name:       "consumer_all_empty_except_queue",
+			exchange:   "",
+			routingKey: "",
+			queue:      "my-queue",
+			expected:   "::my-queue",
+		},
+
+		// Edge cases
+		{
+			name:       "all_empty_producer",
+			exchange:   "",
+			routingKey: "",
+			queue:      "",
+			expected:   ":",
+		},
+		{
+			name:       "special_characters_in_names",
+			exchange:   "event.exchange-v2",
+			routingKey: "user_created.v1",
+			queue:      "queue#1",
+			expected:   "event.exchange-v2:user_created.v1:queue#1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatDestinationName(tt.exchange, tt.routingKey, tt.queue)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractErrorType(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "nil_error",
+			err:      nil,
+			expected: "",
+		},
+		{
+			name:     "context_canceled",
+			err:      context.Canceled,
+			expected: "context.Canceled",
+		},
+		{
+			name:     "context_deadline_exceeded",
+			err:      context.DeadlineExceeded,
+			expected: "context.DeadlineExceeded",
+		},
+		{
+			name:     "wrapped_context_canceled",
+			err:      errors.Join(context.Canceled, errors.New("additional context")),
+			expected: "context.Canceled",
+		},
+		{
+			name:     "wrapped_context_deadline",
+			err:      errors.Join(context.DeadlineExceeded, errors.New("timeout")),
+			expected: "context.DeadlineExceeded",
+		},
+		{
+			name:     "generic_error",
+			err:      errors.New("generic error"),
+			expected: "*errors.errorString",
+		},
+		{
+			name:     "custom_error_type",
+			err:      &customError{msg: "custom"},
+			expected: "*tracking.customError",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractErrorType(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDurationToSeconds(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration time.Duration
+		expected float64
+	}{
+		{
+			name:     "zero_duration",
+			duration: 0,
+			expected: 0.0,
+		},
+		{
+			name:     "one_nanosecond",
+			duration: 1 * time.Nanosecond,
+			expected: 1e-9,
+		},
+		{
+			name:     "one_microsecond",
+			duration: 1 * time.Microsecond,
+			expected: 1e-6,
+		},
+		{
+			name:     "one_millisecond",
+			duration: 1 * time.Millisecond,
+			expected: 0.001,
+		},
+		{
+			name:     "one_second",
+			duration: 1 * time.Second,
+			expected: 1.0,
+		},
+		{
+			name:     "ten_seconds",
+			duration: 10 * time.Second,
+			expected: 10.0,
+		},
+		{
+			name:     "one_minute",
+			duration: 1 * time.Minute,
+			expected: 60.0,
+		},
+		{
+			name:     "fractional_seconds",
+			duration: 1500 * time.Millisecond, // 1.5 seconds
+			expected: 1.5,
+		},
+		{
+			name:     "very_small_duration",
+			duration: 100 * time.Nanosecond,
+			expected: 1e-7,
+		},
+		{
+			name:     "large_duration",
+			duration: 1 * time.Hour,
+			expected: 3600.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := durationToSeconds(tt.duration)
+			assert.InDelta(t, tt.expected, result, 1e-10, "Duration conversion should be accurate")
+		})
+	}
+}
+
+// Custom error type for testing
+type customError struct {
+	msg string
+}
+
+func (e *customError) Error() string {
+	return e.msg
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced OpenTelemetry metrics and tracing for messaging. Tracks publish/consume durations, successes/failures, retries, ACK/NACK, timeouts, and connection/channel lifecycle events. Standardized attributes (system, destination, exchange, routing key, queue, error type). Non-blocking recording with graceful error handling.

* Tests
  * Added comprehensive tests for meter initialization, publish/consume metrics (including zero duration and failures), retry counting, lifecycle events, destination formatting, error typing, duration conversion, and histogram boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->