### PR TITLE
feat(safety): add nil checks for response and context in middleware to prevent panics

### DIFF
--- a/server/timing.go
+++ b/server/timing.go
@@ -15,7 +15,11 @@ func Timing() echo.MiddlewareFunc {
 			err := next(c)
 			duration := time.Since(start)
 
-			c.Response().Header().Set("X-Response-Time", duration.String())
+			// SAFETY: Check if response is still valid (may be nil after timeout)
+			// This middleware runs AFTER the timeout middleware in the chain
+			if resp := c.Response(); resp != nil {
+				resp.Header().Set("X-Response-Time", duration.String())
+			}
 			return err
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevented rare crashes during timeouts by safely handling response headers.
  - Improved panic recovery to reliably log request identifiers without assuming a response exists.
  - Ensured response-time and trace headers are only set/read when available, avoiding nil dereferences.
  - Avoided processing already-canceled requests in tracing middleware, reducing spurious errors.
- Refactor
  - Streamlined header access by using local variables after safety checks for more reliable behavior under edge conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->