### PR TITLE
feat(httpclient,jose): JOSETransport for outbound JOSE-protected calls

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/gaborage/go-bricks/jose"
 	"github.com/gaborage/go-bricks/logger"
 )
 
@@ -141,6 +142,43 @@ func (b *Builder) WithHTTPClient(client *nethttp.Client) *Builder {
 // WithTransport sets a custom RoundTripper while still letting the builder manage other client settings.
 func (b *Builder) WithTransport(transport nethttp.RoundTripper) *Builder {
 	b.transport = transport
+	return b
+}
+
+// JOSEConfig groups the JOSE policy and resolver passed to Builder.WithJOSE.
+// A struct is used (rather than positional parameters) so future fields — clock
+// override, replay-cache hook, per-call policy resolver — can be added without
+// changing the WithJOSE signature.
+type JOSEConfig struct {
+	// Outbound is required: the policy used to sign+encrypt every outbound request body.
+	Outbound *jose.Policy
+	// Inbound is optional: when set, application/jose response bodies are decrypted+verified.
+	// Plaintext responses (e.g., pre-trust error envelopes from the counterparty) pass
+	// through unmodified.
+	Inbound *jose.Policy
+	// Resolver supplies keys for both Outbound and Inbound directions.
+	Resolver jose.KeyResolver
+}
+
+// WithJOSE configures a JOSETransport that signs+encrypts every outbound request body
+// and decrypts+verifies application/jose response bodies. Pass cfg.Inbound = nil when
+// the counterparty does not return JOSE-wrapped responses.
+//
+// Composition: WithJOSE wraps whatever transport is currently configured (set by an
+// earlier WithTransport or WithHTTPClient call) — so existing transport customizations
+// remain in the chain below the JOSE layer. Calling WithTransport AFTER WithJOSE
+// replaces the JOSE transport entirely.
+//
+// Per-attempt freshness: because httpclient retries by re-running the request build
+// loop, each retry produces a freshly-sealed payload — useful for protocols that
+// require unique iat/jti claims per attempt.
+func (b *Builder) WithJOSE(cfg JOSEConfig) *Builder {
+	b.transport = &JOSETransport{
+		Inner:    b.transport,
+		Outbound: cfg.Outbound,
+		Inbound:  cfg.Inbound,
+		Resolver: cfg.Resolver,
+	}
 	return b
 }
 

--- a/httpclient/jose_transport.go
+++ b/httpclient/jose_transport.go
@@ -1,0 +1,153 @@
+package httpclient
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"strings"
+
+	"github.com/gaborage/go-bricks/jose"
+)
+
+// JOSETransport is an http.RoundTripper that signs+encrypts outbound request bodies
+// (jose.Seal) and decrypts+verifies inbound response bodies (jose.Open) using a fixed
+// pair of policies and a single KeyResolver.
+//
+// Architectural placement: JOSETransport sits below the httpclient retry loop, so each
+// retry attempt produces a freshly-sealed request — important for protocols that
+// require unique iat/jti claims per attempt (Visa Token Services and similar).
+//
+// Response Content-Type discrimination: only application/jose responses are unwrapped;
+// other Content-Types pass through untouched. This mirrors the GoBricks server's hybrid
+// error envelope — pre-trust failures from the counterparty come back as plaintext
+// minimal JSON because the peer was never authenticated, and the transport must not
+// attempt to decrypt those.
+type JOSETransport struct {
+	// Inner is the underlying RoundTripper that performs the actual HTTP exchange.
+	// Nil defaults to nethttp.DefaultTransport.
+	Inner nethttp.RoundTripper
+
+	// Outbound is required: the policy used to sign+encrypt every outbound request body.
+	// A nil Outbound disables outbound wrapping entirely (the transport delegates to Inner).
+	Outbound *jose.Policy
+
+	// Inbound is optional: when set, application/jose responses are decrypted+verified.
+	// Other response Content-Types pass through unmodified so plaintext error envelopes
+	// from JOSE-aware counterparties (e.g., GoBricks pre-trust failures) remain readable.
+	Inbound *jose.Policy
+
+	// Resolver supplies keys for both Outbound (sign/encrypt) and Inbound (decrypt/verify).
+	// Required when either policy is set.
+	Resolver jose.KeyResolver
+}
+
+// RoundTrip wraps the request body with JOSE (when Outbound is set), forwards to the
+// inner transport, and unwraps the response body (when Inbound is set AND the response
+// Content-Type matches application/jose).
+func (t *JOSETransport) RoundTrip(req *nethttp.Request) (*nethttp.Response, error) {
+	inner := t.Inner
+	if inner == nil {
+		inner = nethttp.DefaultTransport
+	}
+
+	wrapped, err := t.wrapRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := inner.RoundTrip(wrapped)
+	if err != nil {
+		return resp, err
+	}
+
+	if err := t.unwrapResponse(resp); err != nil {
+		// Close body to prevent leak, then return the error so the caller sees the
+		// crypto failure instead of stale-but-readable ciphertext.
+		if resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		return nil, err
+	}
+	return resp, nil
+}
+
+// wrapRequest reads req.Body, seals it with the Outbound policy, and returns a clone
+// of req with the sealed body and updated Content-Type / Content-Length headers.
+// If Outbound is nil, returns req unchanged.
+func (t *JOSETransport) wrapRequest(req *nethttp.Request) (*nethttp.Request, error) {
+	if t.Outbound == nil {
+		return req, nil
+	}
+	if t.Resolver == nil {
+		return nil, fmt.Errorf("httpclient: JOSETransport requires a KeyResolver when Outbound is set")
+	}
+
+	plaintext, err := readAndCloseBody(req.Body)
+	if err != nil {
+		return nil, fmt.Errorf("httpclient: read request body: %w", err)
+	}
+
+	compact, err := jose.Seal(plaintext, t.Outbound, t.Resolver)
+	if err != nil {
+		return nil, err
+	}
+
+	clone := req.Clone(req.Context())
+	clone.Body = io.NopCloser(strings.NewReader(compact))
+	clone.ContentLength = int64(len(compact))
+	// GetBody enables stdlib-driven request replay: it's invoked on redirect-following,
+	// connection retry, and HTTP/2 retry-on-RST_STREAM. Without it those paths see an
+	// already-drained body and silently send an empty payload.
+	clone.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader(compact)), nil
+	}
+	clone.Header.Set("Content-Type", jose.ContentType)
+	return clone, nil
+}
+
+// unwrapResponse decrypts+verifies resp.Body when Inbound is set AND the response's
+// Content-Type indicates JOSE. Plaintext responses (e.g., pre-trust error envelopes
+// from a JOSE-aware peer) pass through unmodified.
+func (t *JOSETransport) unwrapResponse(resp *nethttp.Response) error {
+	if t.Inbound == nil || resp == nil || resp.Body == nil {
+		return nil
+	}
+	if !jose.IsContentType(resp.Header.Get("Content-Type")) {
+		return nil
+	}
+	if t.Resolver == nil {
+		return fmt.Errorf("httpclient: JOSETransport requires a KeyResolver when Inbound is set")
+	}
+
+	compact, err := readAndCloseBody(resp.Body)
+	if err != nil {
+		return fmt.Errorf("httpclient: read response body: %w", err)
+	}
+
+	plaintext, _, _, err := jose.Open(string(compact), t.Inbound, t.Resolver)
+	if err != nil {
+		return err
+	}
+
+	resp.Body = io.NopCloser(bytes.NewReader(plaintext))
+	resp.ContentLength = int64(len(plaintext))
+	resp.Header.Set("Content-Type", "application/json")
+	return nil
+}
+
+func readAndCloseBody(body io.ReadCloser) ([]byte, error) {
+	if body == nil {
+		return nil, nil
+	}
+	defer body.Close()
+	return io.ReadAll(body)
+}
+
+// IsJOSEError reports whether err is a JOSE crypto failure — kept as a thin re-export
+// of jose.IsError for discoverability from the httpclient package, since transport
+// callers typically already import httpclient and may not realize the canonical helper
+// lives in jose.
+func IsJOSEError(err error) bool {
+	return jose.IsError(err)
+}

--- a/httpclient/jose_transport.go
+++ b/httpclient/jose_transport.go
@@ -10,6 +10,11 @@ import (
 	"github.com/gaborage/go-bricks/jose"
 )
 
+// headerContentType is the canonical HTTP Content-Type header name. Extracted to a
+// const so it isn't repeated as a string literal at every Get/Set call site (SonarCloud
+// S1192). net/http does not provide a stdlib constant for header field names.
+const headerContentType = "Content-Type"
+
 // JOSETransport is an http.RoundTripper that signs+encrypts outbound request bodies
 // (jose.Seal) and decrypts+verifies inbound response bodies (jose.Open) using a fixed
 // pair of policies and a single KeyResolver.
@@ -102,7 +107,7 @@ func (t *JOSETransport) wrapRequest(req *nethttp.Request) (*nethttp.Request, err
 	clone.GetBody = func() (io.ReadCloser, error) {
 		return io.NopCloser(strings.NewReader(compact)), nil
 	}
-	clone.Header.Set("Content-Type", jose.ContentType)
+	clone.Header.Set(headerContentType, jose.ContentType)
 	return clone, nil
 }
 
@@ -113,7 +118,7 @@ func (t *JOSETransport) unwrapResponse(resp *nethttp.Response) error {
 	if t.Inbound == nil || resp == nil || resp.Body == nil {
 		return nil
 	}
-	if !jose.IsContentType(resp.Header.Get("Content-Type")) {
+	if !jose.IsContentType(resp.Header.Get(headerContentType)) {
 		return nil
 	}
 	if t.Resolver == nil {
@@ -132,7 +137,7 @@ func (t *JOSETransport) unwrapResponse(resp *nethttp.Response) error {
 
 	resp.Body = io.NopCloser(bytes.NewReader(plaintext))
 	resp.ContentLength = int64(len(plaintext))
-	resp.Header.Set("Content-Type", "application/json")
+	resp.Header.Set(headerContentType, "application/json")
 	return nil
 }
 

--- a/httpclient/jose_transport.go
+++ b/httpclient/jose_transport.go
@@ -2,6 +2,7 @@ package httpclient
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	nethttp "net/http"
@@ -14,6 +15,13 @@ import (
 // const so it isn't repeated as a string literal at every Get/Set call site (SonarCloud
 // S1192). net/http does not provide a stdlib constant for header field names.
 const headerContentType = "Content-Type"
+
+// DefaultMaxJOSEBodyBytes caps the size of an inbound JOSE response body when no
+// explicit MaxResponseBytes is set on JOSETransport. 10 MiB is comfortably larger than
+// any expected VTS-style payload (token responses are typically <2 KiB) but small
+// enough to bound peak memory if a counterparty (or attacker) sends a malicious
+// response. Defense-in-depth against memory exhaustion.
+const DefaultMaxJOSEBodyBytes int64 = 10 << 20 // 10 MiB
 
 // JOSETransport is an http.RoundTripper that signs+encrypts outbound request bodies
 // (jose.Seal) and decrypts+verifies inbound response bodies (jose.Open) using a fixed
@@ -45,6 +53,11 @@ type JOSETransport struct {
 	// Resolver supplies keys for both Outbound (sign/encrypt) and Inbound (decrypt/verify).
 	// Required when either policy is set.
 	Resolver jose.KeyResolver
+
+	// MaxResponseBytes bounds the response body read when Inbound is set. Zero means
+	// use DefaultMaxJOSEBodyBytes. A negative value disables the cap entirely (NOT
+	// recommended for untrusted counterparties).
+	MaxResponseBytes int64
 }
 
 // RoundTrip wraps the request body with JOSE (when Outbound is set), forwards to the
@@ -88,7 +101,9 @@ func (t *JOSETransport) wrapRequest(req *nethttp.Request) (*nethttp.Request, err
 		return nil, fmt.Errorf("httpclient: JOSETransport requires a KeyResolver when Outbound is set")
 	}
 
-	plaintext, err := readAndCloseBody(req.Body)
+	// Outbound body is from this application — trusted size — so no cap.
+	// The OOM concern is for untrusted inbound responses (handled in unwrapResponse).
+	plaintext, err := readAndCloseBody(req.Body, -1)
 	if err != nil {
 		return nil, fmt.Errorf("httpclient: read request body: %w", err)
 	}
@@ -125,7 +140,11 @@ func (t *JOSETransport) unwrapResponse(resp *nethttp.Response) error {
 		return fmt.Errorf("httpclient: JOSETransport requires a KeyResolver when Inbound is set")
 	}
 
-	compact, err := readAndCloseBody(resp.Body)
+	maxBytes := t.MaxResponseBytes
+	if maxBytes == 0 {
+		maxBytes = DefaultMaxJOSEBodyBytes
+	}
+	compact, err := readAndCloseBody(resp.Body, maxBytes)
 	if err != nil {
 		return fmt.Errorf("httpclient: read response body: %w", err)
 	}
@@ -141,12 +160,33 @@ func (t *JOSETransport) unwrapResponse(resp *nethttp.Response) error {
 	return nil
 }
 
-func readAndCloseBody(body io.ReadCloser) ([]byte, error) {
+// readAndCloseBody drains body up to maxBytes (negative = unbounded) and closes it.
+// Uses http.MaxBytesReader rather than io.LimitReader+length-check so an oversize
+// payload errors mid-stream — without that, up to maxBytes of memory would be
+// materialized on the heap before the overflow is detected.
+//
+// The overflow is mapped to a typed httpclient.ClientError (ValidationError) so
+// callers can distinguish it from network/IO errors via IsErrorType.
+func readAndCloseBody(body io.ReadCloser, maxBytes int64) ([]byte, error) {
 	if body == nil {
 		return nil, nil
 	}
 	defer body.Close()
-	return io.ReadAll(body)
+	if maxBytes < 0 {
+		return io.ReadAll(body)
+	}
+	b, err := io.ReadAll(nethttp.MaxBytesReader(nil, body, maxBytes))
+	if err != nil {
+		var maxErr *nethttp.MaxBytesError
+		if errors.As(err, &maxErr) {
+			return nil, NewValidationError(
+				fmt.Sprintf("JOSE response body exceeds %d bytes", maxBytes),
+				"response_body",
+			)
+		}
+		return nil, err
+	}
+	return b, nil
 }
 
 // IsJOSEError reports whether err is a JOSE crypto failure — kept as a thin re-export

--- a/httpclient/jose_transport_test.go
+++ b/httpclient/jose_transport_test.go
@@ -202,6 +202,39 @@ func TestJOSETransportPassthroughWhenOutboundNil(t *testing.T) {
 	assert.JSONEq(t, `{"untouched":true}`, string(body))
 }
 
+func TestJOSETransportRespectsMaxResponseBytes(t *testing.T) {
+	// Defense-in-depth: a JOSE-aware peer (or attacker) returning a Content-Type:
+	// application/jose body larger than MaxResponseBytes must produce an error before
+	// the body is buffered into memory in full.
+	f := jositest.NewBidirectionalFixture(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/jose")
+		w.WriteHeader(http.StatusOK)
+		// Write a body larger than the cap. The transport should reject it without
+		// attempting to decrypt — io.LimitReader caps the read at maxBytes+1.
+		_, _ = w.Write(bytes.Repeat([]byte("A"), 1024))
+	}))
+	defer server.Close()
+
+	transport := &httpclient.JOSETransport{
+		Outbound:         f.ClientOutbound,
+		Inbound:          f.ClientInbound,
+		Resolver:         f.Resolver,
+		MaxResponseBytes: 256, // 256 bytes — well under the 1024-byte payload
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL, bytes.NewReader([]byte(`{"x":1}`)))
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req) //nolint:bodyclose // resp is intentionally nil on this error path; transport closes the underlying body before returning
+	require.Error(t, err)
+	assert.Nil(t, resp, "response exceeding MaxResponseBytes must not be returned to the caller")
+	assert.Contains(t, err.Error(), "exceeds")
+	// The overflow surfaces as a typed ClientError of category ValidationError so
+	// callers can distinguish policy failures from I/O errors via IsErrorType.
+	assert.True(t, httpclient.IsErrorType(err, httpclient.ValidationError),
+		"oversize response must be a typed ValidationError, got %T: %v", err, err)
+}
+
 func TestJOSETransportOutboundRequiresResolver(t *testing.T) {
 	f := jositest.NewBidirectionalFixture(t)
 	transport := &httpclient.JOSETransport{Outbound: f.ClientOutbound, Resolver: nil}

--- a/httpclient/jose_transport_test.go
+++ b/httpclient/jose_transport_test.go
@@ -1,0 +1,223 @@
+package httpclient_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaborage/go-bricks/httpclient"
+	"github.com/gaborage/go-bricks/jose"
+	jositest "github.com/gaborage/go-bricks/jose/testing"
+	"github.com/gaborage/go-bricks/logger"
+)
+
+// joseEchoServer simulates a JOSE-aware partner: it decrypts the request, echoes the
+// plaintext back inside an encrypted response.
+func joseEchoServer(t *testing.T, f *jositest.BidirectionalFixture) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !jose.IsContentType(r.Header.Get("Content-Type")) {
+			http.Error(w, `{"code":"JOSE_PLAINTEXT_REJECTED","message":"need jose"}`, http.StatusUnsupportedMediaType)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		plaintext, _, _, err := jose.Open(string(body), f.PeerInbound, f.Resolver)
+		if err != nil {
+			http.Error(w, `{"code":"JOSE_DECRYPT_FAILED","message":"could not decrypt"}`, http.StatusUnauthorized)
+			return
+		}
+		respPayload := []byte(`{"echo":` + string(plaintext) + `}`)
+		compact, err := jose.Seal(respPayload, f.PeerOutbound, f.Resolver)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", jose.ContentType)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(compact))
+	}))
+}
+
+func TestJOSETransportRoundtripEncryptsAndDecrypts(t *testing.T) {
+	f := jositest.NewBidirectionalFixture(t)
+	server := joseEchoServer(t, f)
+	defer server.Close()
+
+	transport := &httpclient.JOSETransport{
+		Outbound: f.ClientOutbound,
+		Inbound:  f.ClientInbound,
+		Resolver: f.Resolver,
+	}
+
+	plaintextReq := `{"pan":"4111111111111111"}`
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL, bytes.NewReader([]byte(plaintextReq)))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"echo":{"pan":"4111111111111111"}}`, string(body))
+}
+
+func TestJOSETransportPreTrustErrorPassesThrough(t *testing.T) {
+	// When the partner returns a plaintext error envelope (Content-Type: application/json),
+	// the transport must NOT try to decrypt it — that's the GoBricks pre-trust failure
+	// shape. Caller should see the plaintext body and the original status code.
+	f := jositest.NewBidirectionalFixture(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"code":"JOSE_DECRYPT_FAILED","message":"bad key"}`))
+	}))
+	defer server.Close()
+
+	transport := &httpclient.JOSETransport{
+		Outbound: f.ClientOutbound,
+		Inbound:  f.ClientInbound,
+		Resolver: f.Resolver,
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL, bytes.NewReader([]byte(`{"pan":"x"}`)))
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"JOSE_DECRYPT_FAILED"`)
+}
+
+func TestJOSETransportTamperedResponseFailsClosed(t *testing.T) {
+	// If the partner returns Content-Type: application/jose but the body is corrupted,
+	// the transport MUST return an error (not stale-but-readable ciphertext) and close
+	// the body. This is the security invariant on the client side.
+	f := jositest.NewBidirectionalFixture(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/jose")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not.a.real.jose.payload"))
+	}))
+	defer server.Close()
+
+	transport := &httpclient.JOSETransport{
+		Outbound: f.ClientOutbound,
+		Inbound:  f.ClientInbound,
+		Resolver: f.Resolver,
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL, bytes.NewReader([]byte(`{"x":1}`)))
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req) //nolint:bodyclose // resp is intentionally nil on this error path; transport closes the underlying body before returning
+	require.Error(t, err)
+	assert.Nil(t, resp, "tampered response must not be returned to the caller")
+	assert.True(t, httpclient.IsJOSEError(err), "error must be identifiable as a JOSE crypto failure")
+}
+
+func TestJOSETransportOutboundOnlyMode(t *testing.T) {
+	// Some integrations send JOSE outbound but receive plaintext responses (one-way trust).
+	// With Inbound: nil, the transport encrypts requests and passes responses through.
+	f := jositest.NewBidirectionalFixture(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/jose", r.Header.Get("Content-Type"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	transport := &httpclient.JOSETransport{
+		Outbound: f.ClientOutbound,
+		Inbound:  nil,
+		Resolver: f.Resolver,
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL, bytes.NewReader([]byte(`{"x":1}`)))
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"ok":true}`, string(body))
+}
+
+func TestJOSETransportPassthroughWhenOutboundNil(t *testing.T) {
+	// Defensive: a transport with no policies set should be transparent. This makes
+	// JOSETransport safely composable inside a builder chain that may conditionally
+	// enable JOSE.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer server.Close()
+
+	transport := &httpclient.JOSETransport{}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL, bytes.NewReader([]byte(`{"untouched":true}`)))
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"untouched":true}`, string(body))
+}
+
+func TestJOSETransportOutboundRequiresResolver(t *testing.T) {
+	f := jositest.NewBidirectionalFixture(t)
+	transport := &httpclient.JOSETransport{Outbound: f.ClientOutbound, Resolver: nil}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.invalid", bytes.NewReader([]byte(`{}`)))
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req) //nolint:bodyclose // RoundTrip returns the configuration error before any HTTP exchange; no body to close
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "KeyResolver")
+}
+
+func TestIsJOSEErrorDistinguishesTransportFromCrypto(t *testing.T) {
+	// IsJOSEError lets callers skip retries on signature failures while still retrying
+	// on TCP resets. Plain net errors must not classify as JOSE errors.
+	assert.False(t, httpclient.IsJOSEError(errors.New("tcp reset by peer")))
+	assert.True(t, httpclient.IsJOSEError(&jose.Error{Sentinel: jose.ErrDecryptFailed, Code: "JOSE_DECRYPT_FAILED"}))
+}
+
+func TestBuilderWithJOSEWiresTransport(t *testing.T) {
+	// End-to-end through the Builder: WithJOSE should produce a working client.
+	f := jositest.NewBidirectionalFixture(t)
+	server := joseEchoServer(t, f)
+	defer server.Close()
+
+	log := logger.New("info", false)
+	client := httpclient.NewBuilder(log).
+		WithJOSE(httpclient.JOSEConfig{Outbound: f.ClientOutbound, Inbound: f.ClientInbound, Resolver: f.Resolver}).
+		Build()
+
+	resp, err := client.Post(context.Background(), &httpclient.Request{
+		URL:  server.URL,
+		Body: []byte(`{"hello":"world"}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.JSONEq(t, `{"echo":{"hello":"world"}}`, string(resp.Body))
+}

--- a/httpclient/jose_transport_test.go
+++ b/httpclient/jose_transport_test.go
@@ -20,6 +20,11 @@ import (
 
 // joseEchoServer simulates a JOSE-aware partner: it decrypts the request, echoes the
 // plaintext back inside an encrypted response.
+//
+// Handler runs in a goroutine spawned by httptest.NewServer, distinct from the test
+// goroutine. Per the testing package docs, require.* (which calls FailNow → Goexit)
+// must NOT be called from a non-test goroutine — it produces undefined behavior.
+// The handler uses t.Errorf + early return for diagnostics that survive that boundary.
 func joseEchoServer(t *testing.T, f *jositest.BidirectionalFixture) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -28,7 +33,11 @@ func joseEchoServer(t *testing.T, f *jositest.BidirectionalFixture) *httptest.Se
 			return
 		}
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		if err != nil {
+			t.Errorf("echo handler: read request body failed: %v", err)
+			http.Error(w, `{"code":"JOSE_READ_FAILED","message":"could not read body"}`, http.StatusBadRequest)
+			return
+		}
 		plaintext, _, _, err := jose.Open(string(body), f.PeerInbound, f.Resolver)
 		if err != nil {
 			http.Error(w, `{"code":"JOSE_DECRYPT_FAILED","message":"could not decrypt"}`, http.StatusUnauthorized)
@@ -36,7 +45,11 @@ func joseEchoServer(t *testing.T, f *jositest.BidirectionalFixture) *httptest.Se
 		}
 		respPayload := []byte(`{"echo":` + string(plaintext) + `}`)
 		compact, err := jose.Seal(respPayload, f.PeerOutbound, f.Resolver)
-		require.NoError(t, err)
+		if err != nil {
+			t.Errorf("echo handler: seal response failed: %v", err)
+			http.Error(w, `{"code":"JOSE_SEAL_FAILED","message":"could not seal response"}`, http.StatusInternalServerError)
+			return
+		}
 		w.Header().Set("Content-Type", jose.ContentType)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(compact))
@@ -164,7 +177,12 @@ func TestJOSETransportPassthroughWhenOutboundNil(t *testing.T) {
 	// JOSETransport safely composable inside a builder chain that may conditionally
 	// enable JOSE.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("passthrough handler: read request body failed: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(body)

--- a/jose/contenttype.go
+++ b/jose/contenttype.go
@@ -1,0 +1,34 @@
+package jose
+
+import (
+	"errors"
+	"strings"
+)
+
+// ContentType is the IANA-registered media type for compact JOSE serializations.
+// Used as the request and response Content-Type for JOSE-protected HTTP traffic.
+const ContentType = "application/jose"
+
+// IsContentType reports whether ct (typically a Content-Type header value) names the
+// JOSE compact-serialization media type. Matches application/jose with optional
+// parameters (e.g., "application/jose; charset=utf-8") case-insensitively per
+// RFC 7231 §3.1.1.1.
+func IsContentType(ct string) bool {
+	if ct == "" {
+		return false
+	}
+	if idx := strings.Index(ct, ";"); idx >= 0 {
+		ct = ct[:idx]
+	}
+	return strings.EqualFold(strings.TrimSpace(ct), ContentType)
+}
+
+// IsError reports whether err is (or wraps) a *jose.Error — useful for callers that
+// need to distinguish JOSE crypto failures (signature invalid, decrypt failed, kid
+// unknown, etc.) from network/transport errors. Equivalent to manually doing
+// `var jerr *jose.Error; errors.As(err, &jerr)` but reads as a single intent at the
+// call site.
+func IsError(err error) bool {
+	var jerr *Error
+	return errors.As(err, &jerr)
+}

--- a/jose/contenttype_test.go
+++ b/jose/contenttype_test.go
@@ -1,0 +1,44 @@
+package jose
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsContentTypeVariants(t *testing.T) {
+	tests := []struct {
+		name     string
+		ct       string
+		expected bool
+	}{
+		{name: "exact_match", ct: "application/jose", expected: true},
+		{name: "uppercase", ct: "Application/JOSE", expected: true},
+		{name: "with_charset_param", ct: "application/jose; charset=utf-8", expected: true},
+		{name: "leading_space", ct: " application/jose", expected: true},
+		{name: "different_subtype", ct: "application/jose+json", expected: false},
+		{name: "json", ct: "application/json", expected: false},
+		{name: "empty", ct: "", expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsContentType(tt.ct))
+		})
+	}
+}
+
+func TestIsErrorRecognizesJOSEError(t *testing.T) {
+	assert.True(t, IsError(&Error{Sentinel: ErrDecryptFailed, Code: "JOSE_DECRYPT_FAILED"}))
+
+	// Wrapped JOSE error must still classify (the canonical use case for IsError —
+	// a transport-level wrap should not hide the underlying classification).
+	wrapped := fmt.Errorf("transport: %w", &Error{Sentinel: ErrSignatureInvalid, Code: "JOSE_SIGNATURE_INVALID"})
+	assert.True(t, IsError(wrapped))
+
+	// Plain stdlib errors must NOT classify — that's the discrimination
+	// callers depend on for retry-policy decisions.
+	assert.False(t, IsError(errors.New("tcp reset by peer")))
+	assert.False(t, IsError(nil))
+}

--- a/jose/testing/fixtures.go
+++ b/jose/testing/fixtures.go
@@ -48,6 +48,63 @@ func NewTestResolver(keys map[string]any) jose.KeyResolver {
 	return r
 }
 
+// BidirectionalFixture is the test-scoped state for exercising both ends of a JOSE
+// channel — typical for VTS-style integrations where one side is the system under
+// test and the other side is replayed by an in-process httptest server. The fixture
+// holds two key pairs and the four matching policies (client outbound/inbound + peer
+// outbound/inbound) so a test can seal and open in either direction without rebuilding
+// the kid namespace.
+type BidirectionalFixture struct {
+	ClientPrivate *rsa.PrivateKey
+	PeerPrivate   *rsa.PrivateKey
+	Resolver      jose.KeyResolver
+
+	ClientOutbound *jose.Policy // client signs with client-key, encrypts to peer-key
+	ClientInbound  *jose.Policy // client decrypts with client-key, verifies with peer-key
+	PeerOutbound   *jose.Policy // peer signs with peer-key, encrypts to client-key
+	PeerInbound    *jose.Policy // peer decrypts with peer-key, verifies with client-key
+}
+
+// NewBidirectionalFixture returns a fixture with two freshly generated 2048-bit RSA
+// pairs and matching client/peer policies. Kid strings are fixed ("client-key" and
+// "peer-key") because production VTS-style integrations use matching kid names on
+// both ends — header kids on a sealed payload must match the receiver's expected
+// kid for ExpectedKid validation to pass.
+func NewBidirectionalFixture(t testing.TB) *BidirectionalFixture {
+	t.Helper()
+	clientPriv, _ := GenerateTestKeyPair(t)
+	peerPriv, _ := GenerateTestKeyPair(t)
+	resolver := NewTestResolver(map[string]any{
+		"client-key": clientPriv,
+		"peer-key":   peerPriv,
+	})
+	mkOut := func(signKid, encKid string) *jose.Policy {
+		return &jose.Policy{
+			Direction: jose.DirectionOutbound,
+			SignKid:   signKid, EncryptKid: encKid,
+			SigAlg: jose.DefaultSigAlg, KeyAlg: jose.DefaultKeyAlg,
+			Enc: jose.DefaultEnc, Cty: jose.DefaultCty,
+		}
+	}
+	mkIn := func(decKid, verKid string) *jose.Policy {
+		return &jose.Policy{
+			Direction:  jose.DirectionInbound,
+			DecryptKid: decKid, VerifyKid: verKid,
+			SigAlg: jose.DefaultSigAlg, KeyAlg: jose.DefaultKeyAlg,
+			Enc: jose.DefaultEnc, Cty: jose.DefaultCty,
+		}
+	}
+	return &BidirectionalFixture{
+		ClientPrivate:  clientPriv,
+		PeerPrivate:    peerPriv,
+		Resolver:       resolver,
+		ClientOutbound: mkOut("client-key", "peer-key"),
+		ClientInbound:  mkIn("client-key", "peer-key"),
+		PeerOutbound:   mkOut("peer-key", "client-key"),
+		PeerInbound:    mkIn("peer-key", "client-key"),
+	}
+}
+
 type mapResolver struct {
 	priv map[string]*rsa.PrivateKey
 	pub  map[string]*rsa.PublicKey

--- a/jose/testing/helpers_test.go
+++ b/jose/testing/helpers_test.go
@@ -71,3 +71,22 @@ func TestNewTestResolverPanicsOnUnsupportedType(t *testing.T) {
 		},
 	)
 }
+
+func TestNewBidirectionalFixtureRoundtrip(t *testing.T) {
+	// Smoke test: seal with the client outbound, open with the peer inbound — both
+	// halves of the kid namespace must agree. Reverse direction also covered.
+	f := jositest.NewBidirectionalFixture(t)
+	require.NotNil(t, f.ClientPrivate)
+	require.NotNil(t, f.PeerPrivate)
+	require.NotNil(t, f.Resolver)
+
+	payload := []byte(`{"hello":"world"}`)
+
+	compact := jositest.SealForTest(t, payload, f.ClientOutbound, f.Resolver)
+	got, _ := jositest.OpenForTest(t, compact, f.PeerInbound, f.Resolver)
+	assert.Equal(t, payload, got)
+
+	compact = jositest.SealForTest(t, payload, f.PeerOutbound, f.Resolver)
+	got, _ = jositest.OpenForTest(t, compact, f.ClientInbound, f.Resolver)
+	assert.Equal(t, payload, got)
+}

--- a/server/jose.go
+++ b/server/jose.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -115,9 +114,6 @@ func newJOSEObservability(log logger.Logger, tracer trace.Tracer, mp metric.Mete
 	}
 	return o
 }
-
-// joseContentType is the IANA-registered media type for compact JOSE serializations.
-const joseContentType = "application/jose"
 
 // HandlerRegistryOption configures a HandlerRegistry at construction time.
 // Existing call sites that don't need JOSE pass no options and behave unchanged.
@@ -289,7 +285,7 @@ func joseDecodeRequestInner(c *echo.Context, p *jose.Policy, r jose.KeyResolver)
 		return &joseAPIError{code: "JOSE_BODY_REQUIRED", message: "Request body required", status: http.StatusBadRequest}
 	}
 
-	if !isJOSEContentType(c.Request().Header.Get(echo.HeaderContentType)) {
+	if !jose.IsContentType(c.Request().Header.Get(echo.HeaderContentType)) {
 		return &joseAPIError{code: "JOSE_PLAINTEXT_REJECTED", message: "Request must be application/jose", status: http.StatusUnsupportedMediaType}
 	}
 
@@ -306,20 +302,6 @@ func joseDecodeRequestInner(c *echo.Context, p *jose.Policy, r jose.KeyResolver)
 	ctx = jose.WithClaims(ctx, claims)
 	c.SetRequest(c.Request().WithContext(ctx))
 	return nil
-}
-
-func isJOSEContentType(ct string) bool {
-	if ct == "" {
-		return false
-	}
-	// Match application/jose with optional parameters (charset, etc.) and case-insensitively
-	// per RFC 7231 §3.1.1.1.
-	idx := strings.Index(ct, ";")
-	main := ct
-	if idx >= 0 {
-		main = ct[:idx]
-	}
-	return strings.EqualFold(strings.TrimSpace(main), joseContentType)
 }
 
 // joseHandleResponseWithObs wraps joseHandleResponse with an OTEL span and records
@@ -406,7 +388,7 @@ func (rh *responseHandler) joseHandleResponse(c *echo.Context, response any, api
 		return formatJOSEPlaintextError(c, sealErr)
 	}
 
-	c.Response().Header().Set(echo.HeaderContentType, joseContentType)
+	c.Response().Header().Set(echo.HeaderContentType, jose.ContentType)
 	c.Response().WriteHeader(status)
 	_, writeErr := c.Response().Write([]byte(compact))
 	return writeErr
@@ -456,7 +438,7 @@ func formatJOSEPostTrustError(c *echo.Context, apiErr IAPIError, p *jose.Policy,
 		return formatJOSEPlaintextError(c, sealErr)
 	}
 
-	c.Response().Header().Set(echo.HeaderContentType, joseContentType)
+	c.Response().Header().Set(echo.HeaderContentType, jose.ContentType)
 	c.Response().WriteHeader(apiErr.HTTPStatus())
 	_, writeErr := c.Response().Write([]byte(compact))
 	return writeErr

--- a/server/jose_options_test.go
+++ b/server/jose_options_test.go
@@ -87,7 +87,7 @@ func TestIsJOSEContentTypeVariants(t *testing.T) {
 		{"application/jose+json", false},
 	}
 	for _, tt := range tests {
-		assert.Equal(t, tt.expected, isJOSEContentType(tt.ct), "Content-Type=%q", tt.ct)
+		assert.Equal(t, tt.expected, jose.IsContentType(tt.ct), "Content-Type=%q", tt.ct)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds the documented Phase 7 follow-up from #328: an `http.RoundTripper` that signs+encrypts outbound request bodies and decrypts+verifies `application/jose` response bodies using the existing `jose.Sealer`/`jose.Opener` primitives. Sits below the httpclient retry layer so each retry produces a freshly-sealed payload (required for VTS-style protocols where `iat`/`jti` must be unique per attempt).

- **New**: `httpclient.JOSETransport` + `httpclient.JOSEConfig` + `Builder.WithJOSE` + `httpclient.IsJOSEError`
- **New**: `jose.ContentType` const + `jose.IsContentType` + `jose.IsError` helpers (extracted to consolidate duplication that was already in `server/jose.go` and would have been duplicated again in the transport)
- **New**: `jose.testing.BidirectionalFixture` + `NewBidirectionalFixture` (50-line fixture pattern from the transport tests, now reusable)
- **Refactored**: `server/jose.go` to use the canonical `jose.ContentType`/`jose.IsContentType` helpers (deleted ~13 lines of duplicate code)

## Design notes

- **Response Content-Type discrimination** mirrors the GoBricks server's hybrid envelope: only `application/jose` responses are unwrapped. Plaintext responses (e.g., counterparty pre-trust error envelopes) pass through unmodified — otherwise the transport would crash on legitimate 4xx errors from a JOSE-aware peer.
- **Tampered-response failure mode**: if a response claims `application/jose` but the body is corrupted, the transport returns a `*jose.Error` and closes the body. Callers never see stale ciphertext.
- **`JOSEConfig` struct** instead of positional params on `WithJOSE` so future additions (clock override, replay-cache hook, per-call resolver) don't require API breaks.
- **Per-call overrides** are deferred — this v1 supports one policy pair per builder, which matches the typical 1:1 VTS-style integration. Per-call overrides can be a thin wrapper helper later.

## Test plan

- [x] `go test -race ./jose/... ./server/... ./httpclient/...` — all pass
- [x] `make check` — clean (fmt + lint + test)
- [x] Coverage: jose/ 95.3%, jose/testing/ 89.5%, httpclient/ 90.9%, server/ 89.0% — all above 80% framework target
- [x] Pre-push `/simplify` pass surfaced 7 actionable findings; 5 fixed in this PR (consolidations above + redundant `clone.Header` removal + `GetBody` doc comment), 2 deferred as informational (test parallelism on sub-millisecond tests; `[]byte→string` copy in `jose.Open` API)

## Tests added

- Round-trip (encrypted request → decrypted response)
- Pre-trust error pass-through (plaintext error responses must NOT be decrypted)
- Tampered-response fail-closed (security invariant on the client side)
- Outbound-only mode (one-way trust)
- Passthrough when no policies set (transparent composability)
- Resolver-required validation (misconfiguration surfaced loudly)
- `IsJOSEError` discrimination from transport errors
- End-to-end builder integration

## Plan reference

`/Users/gaborage/.claude/plans/1-nested-2-we-twinkly-cook.md` — Follow-up work section, "Outbound httpclient JOSE — separate PR".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client supports JOSE signing/encryption of outbound requests and optional decrypt/verify of JOSE responses via configurable policies and key resolution.
  * Adds JOSE media-type detection and JOSE-specific error classification; enforces a configurable response size cap for JOSE payloads.

* **Tests**
  * Comprehensive unit and end-to-end tests covering transport roundtrips, error cases, passthrough behavior, and cryptographic fixtures.

* **Refactor**
  * Server reuses shared JOSE helpers for content-type handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->