### PR TITLE
feat(openapi): detect jose: tags and emit application/jose Content-Type

### DIFF
--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -8,6 +8,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -1147,6 +1148,32 @@ func (a *ProjectAnalyzer) populateTypeFields(typeInfo *models.TypeInfo, astFile 
 
 	// Extract fields from struct
 	typeInfo.Fields = a.extractStructFields(structType, typeInfo.Package)
+	// Scan for the JOSE sentinel field — the standard `_ struct{} `jose:"..."` ` pattern
+	// is filtered out of Fields by the unexported-name check, so JOSE detection runs as
+	// a separate pre-pass over raw struct fields.
+	typeInfo.JOSE = hasJOSESentinelTag(structType)
+}
+
+// hasJOSESentinelTag reports whether any field on the struct carries a `jose:"..."`
+// struct tag. Uses reflect.StructTag.Lookup rather than a substring match — the latter
+// would false-positive on tag values that happen to contain the literal `jose:"` (e.g.,
+// a description tag escaping a quoted reference to the jose namespace). Importing the
+// runtime jose package is not an option because the openapi tool is in its own go.mod.
+func hasJOSESentinelTag(s *ast.StructType) bool {
+	if s == nil || s.Fields == nil {
+		return false
+	}
+	for _, field := range s.Fields.List {
+		if field.Tag == nil {
+			continue
+		}
+		// Tag.Value carries the surrounding backticks; trim them so reflect parses correctly.
+		raw := strings.Trim(field.Tag.Value, "`")
+		if _, ok := reflect.StructTag(raw).Lookup("jose"); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // findStructDefinition searches for a struct type definition by name

--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -1154,11 +1154,17 @@ func (a *ProjectAnalyzer) populateTypeFields(typeInfo *models.TypeInfo, astFile 
 	typeInfo.JOSE = hasJOSESentinelTag(structType)
 }
 
-// hasJOSESentinelTag reports whether any field on the struct carries a `jose:"..."`
-// struct tag. Uses reflect.StructTag.Lookup rather than a substring match — the latter
-// would false-positive on tag values that happen to contain the literal `jose:"` (e.g.,
-// a description tag escaping a quoted reference to the jose namespace). Importing the
-// runtime jose package is not an option because the openapi tool is in its own go.mod.
+// hasJOSESentinelTag reports whether the struct uses the JOSE sentinel-field
+// convention — a blank-identifier field (`_`) carrying a `jose:"..."` struct tag.
+// Restricting to the sentinel pattern matches the documented convention and avoids
+// false-positives where a regular field happens to use the same tag namespace for
+// something else (the runtime jose.ScanType *would* try to parse such a tag and fail,
+// so the OpenAPI spec for that struct should not pre-emptively claim JOSE wrapping).
+//
+// reflect.StructTag.Lookup is used rather than a substring match on Tag.Value because
+// substring matching false-positives on tag values that contain the literal `jose:"`
+// (e.g., a description tag escaping a quoted reference). Importing the runtime jose
+// package is not an option because the openapi tool is in its own go.mod.
 func hasJOSESentinelTag(s *ast.StructType) bool {
 	if s == nil || s.Fields == nil {
 		return false
@@ -1167,7 +1173,11 @@ func hasJOSESentinelTag(s *ast.StructType) bool {
 		if field.Tag == nil {
 			continue
 		}
-		// Tag.Value carries the surrounding backticks; trim them so reflect parses correctly.
+		// Sentinel field: exactly one blank-identifier name. Embedded fields have
+		// len(Names) == 0 — those don't match the convention.
+		if len(field.Names) != 1 || field.Names[0].Name != "_" {
+			continue
+		}
 		raw := strings.Trim(field.Tag.Value, "`")
 		if _, ok := reflect.StructTag(raw).Lookup("jose"); ok {
 			return true

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -2822,13 +2822,9 @@ func TestHasJOSESentinelTag(t *testing.T) {
 	// these inputs (defense-in-depth in the analyzer pipeline), so without explicit
 	// tests a future refactor could silently regress the guards.
 	t.Run("nil_struct", func(t *testing.T) {
-		if hasJOSESentinelTag(nil) {
-			t.Error("hasJOSESentinelTag(nil) = true, want false")
-		}
+		assert.False(t, hasJOSESentinelTag(nil), "hasJOSESentinelTag(nil)")
 	})
 	t.Run("nil_fields", func(t *testing.T) {
-		if hasJOSESentinelTag(&ast.StructType{}) {
-			t.Error("hasJOSESentinelTag(&ast.StructType{}) = true, want false")
-		}
+		assert.False(t, hasJOSESentinelTag(&ast.StructType{}), "hasJOSESentinelTag(empty struct)")
 	})
 }

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -2745,30 +2745,30 @@ func TestParseParameterTags(t *testing.T) {
 }
 
 func TestHasJOSESentinelTag(t *testing.T) {
+	// parse uses ast.Inspect to find the first struct type literal in src — a single
+	// callback collapses what would otherwise be a nested decl→spec→type-assertion
+	// loop, keeping cognitive complexity well below the project's 15-statement cap.
 	parse := func(t *testing.T, src string) *ast.StructType {
 		t.Helper()
 		f, err := parser.ParseFile(token.NewFileSet(), "test.go", "package x\n"+src, 0)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
 		}
-		for _, decl := range f.Decls {
-			gen, ok := decl.(*ast.GenDecl)
-			if !ok {
-				continue
+		var found *ast.StructType
+		ast.Inspect(f, func(n ast.Node) bool {
+			if found != nil {
+				return false
 			}
-			for _, spec := range gen.Specs {
-				ts, ok := spec.(*ast.TypeSpec)
-				if !ok {
-					continue
-				}
-				st, ok := ts.Type.(*ast.StructType)
-				if ok {
-					return st
-				}
+			if st, ok := n.(*ast.StructType); ok {
+				found = st
+				return false
 			}
+			return true
+		})
+		if found == nil {
+			t.Fatal("no struct found")
 		}
-		t.Fatal("no struct found")
-		return nil
+		return found
 	}
 
 	tests := []struct {

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -2787,9 +2787,16 @@ func TestHasJOSESentinelTag(t *testing.T) {
 			want:   false,
 		},
 		{
-			name:   "jose_tag_on_named_field",
+			// Per the documented convention, only the sentinel `_ struct{}` field
+			// counts. A non-sentinel field with a jose tag must NOT opt the struct in.
+			name:   "jose_tag_on_named_field_must_not_match",
 			source: "type R struct { Inner string `jose:\"sign=k\"` }",
-			want:   true,
+			want:   false,
+		},
+		{
+			name:   "blank_field_without_jose_tag",
+			source: "type R struct { _ struct{} `unrelated:\"x\"`; PAN string }",
+			want:   false,
 		},
 		{
 			name:   "empty_struct",

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -2817,4 +2817,18 @@ func TestHasJOSESentinelTag(t *testing.T) {
 			}
 		})
 	}
+
+	// Lock in the nil-safety contract — the function's signature implies it tolerates
+	// these inputs (defense-in-depth in the analyzer pipeline), so without explicit
+	// tests a future refactor could silently regress the guards.
+	t.Run("nil_struct", func(t *testing.T) {
+		if hasJOSESentinelTag(nil) {
+			t.Error("hasJOSESentinelTag(nil) = true, want false")
+		}
+	})
+	t.Run("nil_fields", func(t *testing.T) {
+		if hasJOSESentinelTag(&ast.StructType{}) {
+			t.Error("hasJOSESentinelTag(&ast.StructType{}) = true, want false")
+		}
+	})
 }

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -2743,3 +2743,71 @@ func TestParseParameterTags(t *testing.T) {
 		})
 	}
 }
+
+func TestHasJOSESentinelTag(t *testing.T) {
+	parse := func(t *testing.T, src string) *ast.StructType {
+		t.Helper()
+		f, err := parser.ParseFile(token.NewFileSet(), "test.go", "package x\n"+src, 0)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		for _, decl := range f.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				st, ok := ts.Type.(*ast.StructType)
+				if ok {
+					return st
+				}
+			}
+		}
+		t.Fatal("no struct found")
+		return nil
+	}
+
+	tests := []struct {
+		name   string
+		source string
+		want   bool
+	}{
+		{
+			name:   "tagged_sentinel_field",
+			source: "type R struct { _ struct{} `jose:\"decrypt=k,verify=p\"`; PAN string `json:\"pan\"` }",
+			want:   true,
+		},
+		{
+			name:   "no_jose_tag",
+			source: "type R struct { PAN string `json:\"pan\" validate:\"required\"` }",
+			want:   false,
+		},
+		{
+			name:   "jose_tag_on_named_field",
+			source: "type R struct { Inner string `jose:\"sign=k\"` }",
+			want:   true,
+		},
+		{
+			name:   "empty_struct",
+			source: "type R struct {}",
+			want:   false,
+		},
+		{
+			name:   "jose_substring_in_other_tag_must_not_match",
+			source: "type R struct { Field string `description:\"prejose:\\\"x\\\"\"` }",
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasJOSESentinelTag(parse(t, tt.source))
+			if got != tt.want {
+				t.Errorf("hasJOSESentinelTag = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -29,6 +29,13 @@ const (
 	mediaJOSE = "application/jose"
 )
 
+// YAML indent depths reused across emitter call sites (S1192). Named by depth
+// because the same depth occurs at multiple structural positions.
+const (
+	indent10 = "          "   // 10 spaces
+	indent12 = "            " // 12 spaces
+)
+
 // OpenAPIGenerator creates OpenAPI specifications from project models
 type OpenAPIGenerator struct {
 	title       string
@@ -263,13 +270,6 @@ func (g *OpenAPIGenerator) writeResponses(sb *strings.Builder, route *models.Rou
 	joseResponse := route.Response != nil && route.Response.JOSE
 	joseRoute := joseResponse || (route.Request != nil && route.Request.JOSE)
 
-	// YAML indent constants for the responses subtree. Centralised so SonarCloud
-	// S1192 doesn't flag the indent literals each time a Response Object is added.
-	const (
-		responseIndent = "          "   // 10 spaces — under '200':/'400':
-		mediaIndent    = "            " // 12 spaces — under content.<contentType>:
-	)
-
 	sb.WriteString("      responses:\n")
 	sb.WriteString("        '200':\n")
 	if joseResponse {
@@ -277,17 +277,17 @@ func (g *OpenAPIGenerator) writeResponses(sb *strings.Builder, route *models.Rou
 		// description is a fixed field on Response, but NOT on Media Type Object.
 		// The Media Type schema describes the WIRE shape (a string token); the
 		// plaintext component schema is referenced from the description text.
-		writeJOSEDescription(sb, responseIndent, "SuccessResponse")
-		fmt.Fprintf(sb, "%scontent:\n", responseIndent)
-		writeMediaSchemaJOSE(sb, mediaIndent)
+		writeJOSEDescription(sb, indent10, "SuccessResponse")
+		writeContentLine(sb, indent10)
+		writeMediaSchemaJOSE(sb, indent12)
 	} else {
-		fmt.Fprintf(sb, "%sdescription: %s\n", responseIndent, g.getResponseDescription(route.Method))
-		fmt.Fprintf(sb, "%scontent:\n", responseIndent)
-		writeMediaSchemaRef(sb, mediaIndent, mediaJSON, "SuccessResponse")
+		fmt.Fprintf(sb, "%sdescription: %s\n", indent10, g.getResponseDescription(route.Method))
+		writeContentLine(sb, indent10)
+		writeMediaSchemaRef(sb, indent12, mediaJSON, "SuccessResponse")
 	}
 	sb.WriteString("        '400':\n")
-	fmt.Fprintf(sb, "%sdescription: Bad Request\n", responseIndent)
-	fmt.Fprintf(sb, "%scontent:\n", responseIndent)
+	fmt.Fprintf(sb, "%sdescription: Bad Request\n", indent10)
+	writeContentLine(sb, indent10)
 	// Pre-trust failures on JOSE routes are plaintext minimal envelopes per the
 	// security model: when decrypt/verify fails the peer is unauthenticated and the
 	// server leaks nothing beyond {code,message}.
@@ -295,7 +295,7 @@ func (g *OpenAPIGenerator) writeResponses(sb *strings.Builder, route *models.Rou
 	if joseRoute {
 		errorSchema = "JOSEErrorEnvelope"
 	}
-	writeMediaSchemaRef(sb, mediaIndent, mediaJSON, errorSchema)
+	writeMediaSchemaRef(sb, indent12, mediaJSON, errorSchema)
 }
 
 // writeJOSEDescription emits the canonical "JOSE compact serialization" description
@@ -339,6 +339,12 @@ func writeMediaSchemaJOSE(sb *strings.Builder, indent string) {
 	fmt.Fprintf(sb, "%s  schema:\n", indent)
 	fmt.Fprintf(sb, "%s    type: string\n", indent)
 	fmt.Fprintf(sb, "%s    format: jose\n", indent)
+}
+
+// writeContentLine emits "<indent>content:\n" — the YAML key that opens a Media Type
+// map under either a Response Object or a RequestBody Object.
+func writeContentLine(sb *strings.Builder, indent string) {
+	fmt.Fprintf(sb, "%scontent:\n", indent)
 }
 
 // getOperationID generates an operation ID for a route
@@ -750,7 +756,7 @@ func (g *OpenAPIGenerator) writeParameters(sb *strings.Builder, params []Paramet
 
 		// Write schema
 		sb.WriteString("          schema:\n")
-		g.writePropertySchema(sb, param.Schema, "            ")
+		g.writePropertySchema(sb, param.Schema, indent12)
 
 		if param.Example != nil {
 			// Marshal example value to YAML-compatible format
@@ -783,18 +789,18 @@ func (g *OpenAPIGenerator) writeRequestBody(sb *strings.Builder, reqType *models
 		// NOT nested inside content.<contentType> which would violate OpenAPI 3.0.1.
 		writeJOSEDescription(sb, "        ", schemaName)
 	}
-	sb.WriteString("        content:\n")
+	writeContentLine(sb, "        ")
 
 	switch {
 	case isJOSE:
 		// JOSE wire payload is a string token, not the plaintext schema. The plaintext
 		// component schema is referenced from the description text above.
-		writeMediaSchemaJOSE(sb, "          ")
+		writeMediaSchemaJOSE(sb, indent10)
 	case schemaName != "":
-		writeMediaSchemaRef(sb, "          ", contentType, schemaName)
+		writeMediaSchemaRef(sb, indent10, contentType, schemaName)
 	default:
 		// Inline schema (fallback — shouldn't happen with proper type extraction).
-		fmt.Fprintf(sb, "          %s:\n", contentType)
+		fmt.Fprintf(sb, "%s%s:\n", indent10, contentType)
 		sb.WriteString("            schema:\n")
 		sb.WriteString("              type: object\n")
 	}

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -263,7 +263,13 @@ func (g *OpenAPIGenerator) writeResponses(sb *strings.Builder, route *models.Rou
 	joseResponse := route.Response != nil && route.Response.JOSE
 	joseRoute := joseResponse || (route.Request != nil && route.Request.JOSE)
 
-	const contentIndent = "            "
+	// YAML indent constants for the responses subtree. Centralised so SonarCloud
+	// S1192 doesn't flag the indent literals each time a Response Object is added.
+	const (
+		responseIndent = "          "   // 10 spaces — under '200':/'400':
+		mediaIndent    = "            " // 12 spaces — under content.<contentType>:
+	)
+
 	sb.WriteString("      responses:\n")
 	sb.WriteString("        '200':\n")
 	if joseResponse {
@@ -271,17 +277,17 @@ func (g *OpenAPIGenerator) writeResponses(sb *strings.Builder, route *models.Rou
 		// description is a fixed field on Response, but NOT on Media Type Object.
 		// The Media Type schema describes the WIRE shape (a string token); the
 		// plaintext component schema is referenced from the description text.
-		writeJOSEDescription(sb, "          ", "SuccessResponse")
-		sb.WriteString("          content:\n")
-		writeMediaSchemaJOSE(sb, contentIndent)
+		writeJOSEDescription(sb, responseIndent, "SuccessResponse")
+		fmt.Fprintf(sb, "%scontent:\n", responseIndent)
+		writeMediaSchemaJOSE(sb, mediaIndent)
 	} else {
-		fmt.Fprintf(sb, "          description: %s\n", g.getResponseDescription(route.Method))
-		sb.WriteString("          content:\n")
-		writeMediaSchemaRef(sb, contentIndent, mediaJSON, "SuccessResponse")
+		fmt.Fprintf(sb, "%sdescription: %s\n", responseIndent, g.getResponseDescription(route.Method))
+		fmt.Fprintf(sb, "%scontent:\n", responseIndent)
+		writeMediaSchemaRef(sb, mediaIndent, mediaJSON, "SuccessResponse")
 	}
 	sb.WriteString("        '400':\n")
-	sb.WriteString("          description: Bad Request\n")
-	sb.WriteString("          content:\n")
+	fmt.Fprintf(sb, "%sdescription: Bad Request\n", responseIndent)
+	fmt.Fprintf(sb, "%scontent:\n", responseIndent)
 	// Pre-trust failures on JOSE routes are plaintext minimal envelopes per the
 	// security model: when decrypt/verify fails the peer is unauthenticated and the
 	// server leaks nothing beyond {code,message}.
@@ -289,7 +295,7 @@ func (g *OpenAPIGenerator) writeResponses(sb *strings.Builder, route *models.Rou
 	if joseRoute {
 		errorSchema = "JOSEErrorEnvelope"
 	}
-	writeMediaSchemaRef(sb, contentIndent, mediaJSON, errorSchema)
+	writeMediaSchemaRef(sb, mediaIndent, mediaJSON, errorSchema)
 }
 
 // writeJOSEDescription emits the canonical "JOSE compact serialization" description

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -324,7 +324,7 @@ func writeJOSEDescription(sb *strings.Builder, indent, plaintextSchema string) {
 //
 // Used for application/json bodies where the wire shape IS the documented schema.
 func writeMediaSchemaRef(sb *strings.Builder, indent, contentType, ref string) {
-	fmt.Fprintf(sb, "%s%s:\n", indent, contentType)
+	writeMediaTypeKey(sb, indent, contentType)
 	fmt.Fprintf(sb, "%s  schema:\n", indent)
 	fmt.Fprintf(sb, "%s    $ref: '#/components/schemas/%s'\n", indent, ref)
 }
@@ -335,7 +335,7 @@ func writeMediaSchemaRef(sb *strings.Builder, indent, contentType, ref string) {
 // shape). The plaintext schema is still emitted as a component and referenced from
 // the parent RequestBody/Response description text via writeJOSEDescription.
 func writeMediaSchemaJOSE(sb *strings.Builder, indent string) {
-	fmt.Fprintf(sb, "%s%s:\n", indent, mediaJOSE)
+	writeMediaTypeKey(sb, indent, mediaJOSE)
 	fmt.Fprintf(sb, "%s  schema:\n", indent)
 	fmt.Fprintf(sb, "%s    type: string\n", indent)
 	fmt.Fprintf(sb, "%s    format: jose\n", indent)
@@ -345,6 +345,12 @@ func writeMediaSchemaJOSE(sb *strings.Builder, indent string) {
 // map under either a Response Object or a RequestBody Object.
 func writeContentLine(sb *strings.Builder, indent string) {
 	fmt.Fprintf(sb, "%scontent:\n", indent)
+}
+
+// writeMediaTypeKey emits "<indent><mediaType>:\n" — the YAML key that opens a single
+// Media Type Object inside a content map (e.g. "application/json:" or "application/jose:").
+func writeMediaTypeKey(sb *strings.Builder, indent, mediaType string) {
+	fmt.Fprintf(sb, "%s%s:\n", indent, mediaType)
 }
 
 // getOperationID generates an operation ID for a route
@@ -800,7 +806,7 @@ func (g *OpenAPIGenerator) writeRequestBody(sb *strings.Builder, reqType *models
 		writeMediaSchemaRef(sb, indent10, contentType, schemaName)
 	default:
 		// Inline schema (fallback — shouldn't happen with proper type extraction).
-		fmt.Fprintf(sb, "%s%s:\n", indent10, contentType)
+		writeMediaTypeKey(sb, indent10, contentType)
 		sb.WriteString("            schema:\n")
 		sb.WriteString("              type: object\n")
 	}

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -238,7 +238,7 @@ func (g *OpenAPIGenerator) writeMethod(sb *strings.Builder, route *models.Route)
 
 	// Write request body if there are body fields
 	if len(bodyFields) > 0 && route.Request != nil {
-		g.writeRequestBody(sb, bodyFields, route.Request)
+		g.writeRequestBody(sb, route.Request)
 	}
 
 	// Responses
@@ -741,7 +741,7 @@ func (g *OpenAPIGenerator) writeParameters(sb *strings.Builder, params []Paramet
 // points at the documented plaintext shape — the wire payload is the compact JOSE
 // serialization that wraps that plaintext on decrypt+verify. Takes the full TypeInfo
 // (rather than a positional bool) so future flags compose without signature churn.
-func (g *OpenAPIGenerator) writeRequestBody(sb *strings.Builder, _ []models.FieldInfo, reqType *models.TypeInfo) {
+func (g *OpenAPIGenerator) writeRequestBody(sb *strings.Builder, reqType *models.TypeInfo) {
 	schemaName := ""
 	isJOSE := false
 	if reqType != nil {

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -236,8 +236,11 @@ func (g *OpenAPIGenerator) writeMethod(sb *strings.Builder, route *models.Route)
 		g.writeParameters(sb, params)
 	}
 
-	// Write request body if there are body fields
-	if len(bodyFields) > 0 && route.Request != nil {
+	// Write request body if there are body fields, OR if the route is JOSE-tagged
+	// (a JOSE request type may have only the sentinel field, with all "plaintext"
+	// fields filtered into header/path/query params or simply absent — but the route
+	// still expects an application/jose payload on the wire).
+	if route.Request != nil && (len(bodyFields) > 0 || route.Request.JOSE) {
 		g.writeRequestBody(sb, route.Request)
 	}
 
@@ -266,9 +269,11 @@ func (g *OpenAPIGenerator) writeResponses(sb *strings.Builder, route *models.Rou
 	if joseResponse {
 		// Description on the Response Object (spec-compliant) — per OpenAPI 3.0.1,
 		// description is a fixed field on Response, but NOT on Media Type Object.
-		writeJOSEDescription(sb, "          ")
+		// The Media Type schema describes the WIRE shape (a string token); the
+		// plaintext component schema is referenced from the description text.
+		writeJOSEDescription(sb, "          ", "SuccessResponse")
 		sb.WriteString("          content:\n")
-		writeMediaSchemaRef(sb, contentIndent, mediaJOSE, "SuccessResponse")
+		writeMediaSchemaJOSE(sb, contentIndent)
 	} else {
 		fmt.Fprintf(sb, "          description: %s\n", g.getResponseDescription(route.Method))
 		sb.WriteString("          content:\n")
@@ -294,28 +299,40 @@ func (g *OpenAPIGenerator) writeResponses(sb *strings.Builder, route *models.Rou
 // invoked at the parent level (under requestBody: or under '200':), not nested inside
 // the content/media-type block.
 //
-// indent is the YAML depth of the description: line itself (e.g., "        " for a
-// requestBody, "          " for a response).
-func writeJOSEDescription(sb *strings.Builder, indent string) {
+// indent is the YAML depth of the description: line itself. plaintextSchema is the
+// component schema name to reference from the description so consumers know what
+// shape the decrypted payload conforms to.
+func writeJOSEDescription(sb *strings.Builder, indent, plaintextSchema string) {
 	fmt.Fprintf(sb, "%sdescription: |\n", indent)
-	fmt.Fprintf(sb, "%s  JOSE compact serialization (signed-then-encrypted). The referenced\n", indent)
-	fmt.Fprintf(sb, "%s  schema documents the verified plaintext shape — wire payload is the\n", indent)
-	fmt.Fprintf(sb, "%s  JWE compact form whose plaintext, after decrypt+verify, conforms to it.\n", indent)
+	fmt.Fprintf(sb, "%s  JOSE compact serialization (signed-then-encrypted). The wire payload\n", indent)
+	fmt.Fprintf(sb, "%s  is a base64url-encoded JWE compact form whose plaintext, after\n", indent)
+	fmt.Fprintf(sb, "%s  decrypt+verify, conforms to the %s schema —\n", indent, plaintextSchema)
+	fmt.Fprintf(sb, "%s  see #/components/schemas/%s.\n", indent, plaintextSchema)
 }
 
-// writeMediaSchemaRef emits the canonical 3-line YAML block:
+// writeMediaSchemaRef emits a Media Type entry whose schema is a $ref to a component:
 //
 //	<indent><contentType>:
 //	<indent>  schema:
 //	<indent>    $ref: '#/components/schemas/<ref>'
 //
-// Centralised because the same shape appears in writeRequestBody and in both arms of
-// writeResponses; SonarCloud S1192 flags the literal duplication, but the deeper win
-// is a single edit point if we ever change the components/schemas path layout.
+// Used for application/json bodies where the wire shape IS the documented schema.
 func writeMediaSchemaRef(sb *strings.Builder, indent, contentType, ref string) {
 	fmt.Fprintf(sb, "%s%s:\n", indent, contentType)
 	fmt.Fprintf(sb, "%s  schema:\n", indent)
 	fmt.Fprintf(sb, "%s    $ref: '#/components/schemas/%s'\n", indent, ref)
+}
+
+// writeMediaSchemaJOSE emits a Media Type entry for application/jose where the schema
+// describes the on-the-wire payload as a string token (per OpenAPI 3.0.1 — the JOSE
+// compact serialization is a base64url-encoded string, NOT the decrypted plaintext
+// shape). The plaintext schema is still emitted as a component and referenced from
+// the parent RequestBody/Response description text via writeJOSEDescription.
+func writeMediaSchemaJOSE(sb *strings.Builder, indent string) {
+	fmt.Fprintf(sb, "%s%s:\n", indent, mediaJOSE)
+	fmt.Fprintf(sb, "%s  schema:\n", indent)
+	fmt.Fprintf(sb, "%s    type: string\n", indent)
+	fmt.Fprintf(sb, "%s    format: jose\n", indent)
 }
 
 // getOperationID generates an operation ID for a route
@@ -758,13 +775,18 @@ func (g *OpenAPIGenerator) writeRequestBody(sb *strings.Builder, reqType *models
 	if isJOSE {
 		// Description on the RequestBody Object (spec-compliant) — sibling of content,
 		// NOT nested inside content.<contentType> which would violate OpenAPI 3.0.1.
-		writeJOSEDescription(sb, "        ")
+		writeJOSEDescription(sb, "        ", schemaName)
 	}
 	sb.WriteString("        content:\n")
 
-	if schemaName != "" {
+	switch {
+	case isJOSE:
+		// JOSE wire payload is a string token, not the plaintext schema. The plaintext
+		// component schema is referenced from the description text above.
+		writeMediaSchemaJOSE(sb, "          ")
+	case schemaName != "":
 		writeMediaSchemaRef(sb, "          ", contentType, schemaName)
-	} else {
+	default:
 		// Inline schema (fallback — shouldn't happen with proper type extraction).
 		fmt.Fprintf(sb, "          %s:\n", contentType)
 		sb.WriteString("            schema:\n")

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -21,6 +21,14 @@ const (
 	formatInt64 = "int64"
 )
 
+// Media type constants for the OpenAPI content map. Centralized so a future rename
+// (e.g., to application/jose+json) is a one-line edit and so call sites in the spec
+// emitter can be statically searched by const reference, not by string literal.
+const (
+	mediaJSON = "application/json"
+	mediaJOSE = "application/jose"
+)
+
 // OpenAPIGenerator creates OpenAPI specifications from project models
 type OpenAPIGenerator struct {
 	title       string
@@ -230,23 +238,59 @@ func (g *OpenAPIGenerator) writeMethod(sb *strings.Builder, route *models.Route)
 
 	// Write request body if there are body fields
 	if len(bodyFields) > 0 && route.Request != nil {
-		g.writeRequestBody(sb, bodyFields, route.Request.Name)
+		g.writeRequestBody(sb, bodyFields, route.Request)
 	}
 
 	// Responses
+	g.writeResponses(sb, route)
+}
+
+// writeResponses emits the responses section. When the route's response carries a
+// jose: tag the success response uses Content-Type: application/jose; the 4xx
+// pre-trust failure path always uses application/json (peer is unauthenticated, so
+// the framework returns a plaintext minimal envelope, never JOSE-wrapped — see the
+// hybrid envelope contract in CLAUDE.md JOSE Middleware).
+func (g *OpenAPIGenerator) writeResponses(sb *strings.Builder, route *models.Route) {
+	joseResponse := route.Response != nil && route.Response.JOSE
+
 	sb.WriteString("      responses:\n")
 	sb.WriteString("        '200':\n")
 	fmt.Fprintf(sb, "          description: %s\n", g.getResponseDescription(route.Method))
 	sb.WriteString("          content:\n")
-	sb.WriteString("            application/json:\n")
-	sb.WriteString("              schema:\n")
-	sb.WriteString("                $ref: '#/components/schemas/SuccessResponse'\n")
+	if joseResponse {
+		fmt.Fprintf(sb, "            %s:\n", mediaJOSE)
+		sb.WriteString("              schema:\n")
+		sb.WriteString("                $ref: '#/components/schemas/SuccessResponse'\n")
+		writeJOSEDescription(sb, "              ")
+	} else {
+		fmt.Fprintf(sb, "            %s:\n", mediaJSON)
+		sb.WriteString("              schema:\n")
+		sb.WriteString("                $ref: '#/components/schemas/SuccessResponse'\n")
+	}
 	sb.WriteString("        '400':\n")
 	sb.WriteString("          description: Bad Request\n")
 	sb.WriteString("          content:\n")
-	sb.WriteString("            application/json:\n")
+	fmt.Fprintf(sb, "            %s:\n", mediaJSON)
 	sb.WriteString("              schema:\n")
-	sb.WriteString("                $ref: '#/components/schemas/ErrorResponse'\n")
+	if joseResponse {
+		// Pre-trust failures are plaintext minimal envelopes per the JOSE security model:
+		// when decrypt/verify fails the peer is unauthenticated and the server leaks
+		// nothing beyond {code,message}.
+		sb.WriteString("                $ref: '#/components/schemas/JOSEErrorEnvelope'\n")
+	} else {
+		sb.WriteString("                $ref: '#/components/schemas/ErrorResponse'\n")
+	}
+}
+
+// writeJOSEDescription emits the canonical "JOSE compact serialization" block used by
+// both the request-body and response sections. Centralized so the wording stays
+// consistent across the spec; indent controls the YAML depth (request body and
+// response.content live at different levels).
+func writeJOSEDescription(sb *strings.Builder, indent string) {
+	fmt.Fprintf(sb, "%sdescription: |\n", indent)
+	fmt.Fprintf(sb, "%s  JOSE compact serialization (signed-then-encrypted). The referenced\n", indent)
+	fmt.Fprintf(sb, "%s  schema documents the verified plaintext shape — wire payload is the\n", indent)
+	fmt.Fprintf(sb, "%s  JWE compact form whose plaintext, after decrypt+verify, conforms to it.\n", indent)
 }
 
 // getOperationID generates an operation ID for a route
@@ -339,6 +383,25 @@ func (g *OpenAPIGenerator) createStandardSchemas() map[string]*OpenAPISchema {
 				},
 			},
 			Required: []string{"error"},
+		},
+		// JOSEErrorEnvelope is the minimal plaintext error envelope returned for
+		// pre-trust JOSE failures (decrypt failed, signature invalid, kid unknown,
+		// etc.). The framework intentionally omits traceId/timestamp/framework
+		// metadata here — peer is unauthenticated and the envelope must leak
+		// nothing beyond the canonical {code,message} pair.
+		"JOSEErrorEnvelope": {
+			Type: "object",
+			Properties: map[string]*OpenAPIProperty{
+				"code": {
+					Type:        "string",
+					Description: "Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)",
+				},
+				"message": {
+					Type:        "string",
+					Description: "Constant-time generic message — never reveals which key was tried or which library detected the failure",
+				},
+			},
+			Required: []string{"code", "message"},
 		},
 	}
 }
@@ -648,12 +711,27 @@ func (g *OpenAPIGenerator) writeParameters(sb *strings.Builder, params []Paramet
 	}
 }
 
-// writeRequestBody writes the request body for an operation with only body fields
-func (g *OpenAPIGenerator) writeRequestBody(sb *strings.Builder, _ []models.FieldInfo, schemaName string) {
+// writeRequestBody writes the request body for an operation. When the request type
+// carries a jose: tag the Content-Type is application/jose and the schema $ref still
+// points at the documented plaintext shape — the wire payload is the compact JOSE
+// serialization that wraps that plaintext on decrypt+verify. Takes the full TypeInfo
+// (rather than a positional bool) so future flags compose without signature churn.
+func (g *OpenAPIGenerator) writeRequestBody(sb *strings.Builder, _ []models.FieldInfo, reqType *models.TypeInfo) {
+	schemaName := ""
+	isJOSE := false
+	if reqType != nil {
+		schemaName = reqType.Name
+		isJOSE = reqType.JOSE
+	}
+
 	sb.WriteString("      requestBody:\n")
 	sb.WriteString("        required: true\n")
 	sb.WriteString("        content:\n")
-	sb.WriteString("          application/json:\n")
+	if isJOSE {
+		fmt.Fprintf(sb, "          %s:\n", mediaJOSE)
+	} else {
+		fmt.Fprintf(sb, "          %s:\n", mediaJSON)
+	}
 	sb.WriteString("            schema:\n")
 
 	// Reference the schema if it has a name, otherwise inline it
@@ -662,6 +740,9 @@ func (g *OpenAPIGenerator) writeRequestBody(sb *strings.Builder, _ []models.Fiel
 	} else {
 		// Inline schema (fallback - shouldn't happen with proper type extraction)
 		sb.WriteString("              type: object\n")
+	}
+	if isJOSE {
+		writeJOSEDescription(sb, "            ")
 	}
 }
 

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -250,8 +250,15 @@ func (g *OpenAPIGenerator) writeMethod(sb *strings.Builder, route *models.Route)
 // pre-trust failure path always uses application/json (peer is unauthenticated, so
 // the framework returns a plaintext minimal envelope, never JOSE-wrapped — see the
 // hybrid envelope contract in CLAUDE.md JOSE Middleware).
+//
+// 4xx schema selection is driven by EITHER side carrying jose tags. The runtime
+// enforces bidirectional symmetry at registration, but the analyzer runs statically
+// against source so we can encounter asymmetric setups; in any such case the
+// pre-trust failure path is still routed through the JOSE plaintext-minimal
+// envelope by the runtime, so the OpenAPI spec must reflect that.
 func (g *OpenAPIGenerator) writeResponses(sb *strings.Builder, route *models.Route) {
 	joseResponse := route.Response != nil && route.Response.JOSE
+	joseRoute := joseResponse || (route.Request != nil && route.Request.JOSE)
 
 	sb.WriteString("      responses:\n")
 	sb.WriteString("        '200':\n")
@@ -272,7 +279,7 @@ func (g *OpenAPIGenerator) writeResponses(sb *strings.Builder, route *models.Rou
 	sb.WriteString("          content:\n")
 	fmt.Fprintf(sb, "            %s:\n", mediaJSON)
 	sb.WriteString("              schema:\n")
-	if joseResponse {
+	if joseRoute {
 		// Pre-trust failures are plaintext minimal envelopes per the JOSE security model:
 		// when decrypt/verify fails the peer is unauthenticated and the server leaks
 		// nothing beyond {code,message}.

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -265,28 +265,22 @@ func (g *OpenAPIGenerator) writeResponses(sb *strings.Builder, route *models.Rou
 	fmt.Fprintf(sb, "          description: %s\n", g.getResponseDescription(route.Method))
 	sb.WriteString("          content:\n")
 	if joseResponse {
-		fmt.Fprintf(sb, "            %s:\n", mediaJOSE)
-		sb.WriteString("              schema:\n")
-		sb.WriteString("                $ref: '#/components/schemas/SuccessResponse'\n")
+		writeMediaSchemaRef(sb, "            ", mediaJOSE, "SuccessResponse")
 		writeJOSEDescription(sb, "              ")
 	} else {
-		fmt.Fprintf(sb, "            %s:\n", mediaJSON)
-		sb.WriteString("              schema:\n")
-		sb.WriteString("                $ref: '#/components/schemas/SuccessResponse'\n")
+		writeMediaSchemaRef(sb, "            ", mediaJSON, "SuccessResponse")
 	}
 	sb.WriteString("        '400':\n")
 	sb.WriteString("          description: Bad Request\n")
 	sb.WriteString("          content:\n")
-	fmt.Fprintf(sb, "            %s:\n", mediaJSON)
-	sb.WriteString("              schema:\n")
+	// Pre-trust failures on JOSE routes are plaintext minimal envelopes per the
+	// security model: when decrypt/verify fails the peer is unauthenticated and the
+	// server leaks nothing beyond {code,message}.
+	errorSchema := "ErrorResponse"
 	if joseRoute {
-		// Pre-trust failures are plaintext minimal envelopes per the JOSE security model:
-		// when decrypt/verify fails the peer is unauthenticated and the server leaks
-		// nothing beyond {code,message}.
-		sb.WriteString("                $ref: '#/components/schemas/JOSEErrorEnvelope'\n")
-	} else {
-		sb.WriteString("                $ref: '#/components/schemas/ErrorResponse'\n")
+		errorSchema = "JOSEErrorEnvelope"
 	}
+	writeMediaSchemaRef(sb, "            ", mediaJSON, errorSchema)
 }
 
 // writeJOSEDescription emits the canonical "JOSE compact serialization" block used by
@@ -298,6 +292,21 @@ func writeJOSEDescription(sb *strings.Builder, indent string) {
 	fmt.Fprintf(sb, "%s  JOSE compact serialization (signed-then-encrypted). The referenced\n", indent)
 	fmt.Fprintf(sb, "%s  schema documents the verified plaintext shape — wire payload is the\n", indent)
 	fmt.Fprintf(sb, "%s  JWE compact form whose plaintext, after decrypt+verify, conforms to it.\n", indent)
+}
+
+// writeMediaSchemaRef emits the canonical 3-line YAML block:
+//
+//	<indent><contentType>:
+//	<indent>  schema:
+//	<indent>    $ref: '#/components/schemas/<ref>'
+//
+// Centralised because the same shape appears in writeRequestBody and in both arms of
+// writeResponses; SonarCloud S1192 flags the literal duplication, but the deeper win
+// is a single edit point if we ever change the components/schemas path layout.
+func writeMediaSchemaRef(sb *strings.Builder, indent, contentType, ref string) {
+	fmt.Fprintf(sb, "%s%s:\n", indent, contentType)
+	fmt.Fprintf(sb, "%s  schema:\n", indent)
+	fmt.Fprintf(sb, "%s    $ref: '#/components/schemas/%s'\n", indent, ref)
 }
 
 // getOperationID generates an operation ID for a route
@@ -730,22 +739,21 @@ func (g *OpenAPIGenerator) writeRequestBody(sb *strings.Builder, _ []models.Fiel
 		schemaName = reqType.Name
 		isJOSE = reqType.JOSE
 	}
+	contentType := mediaJSON
+	if isJOSE {
+		contentType = mediaJOSE
+	}
 
 	sb.WriteString("      requestBody:\n")
 	sb.WriteString("        required: true\n")
 	sb.WriteString("        content:\n")
-	if isJOSE {
-		fmt.Fprintf(sb, "          %s:\n", mediaJOSE)
-	} else {
-		fmt.Fprintf(sb, "          %s:\n", mediaJSON)
-	}
-	sb.WriteString("            schema:\n")
 
-	// Reference the schema if it has a name, otherwise inline it
 	if schemaName != "" {
-		fmt.Fprintf(sb, "              $ref: '#/components/schemas/%s'\n", schemaName)
+		writeMediaSchemaRef(sb, "          ", contentType, schemaName)
 	} else {
-		// Inline schema (fallback - shouldn't happen with proper type extraction)
+		// Inline schema (fallback — shouldn't happen with proper type extraction).
+		fmt.Fprintf(sb, "          %s:\n", contentType)
+		sb.WriteString("            schema:\n")
 		sb.WriteString("              type: object\n")
 	}
 	if isJOSE {

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -260,15 +260,19 @@ func (g *OpenAPIGenerator) writeResponses(sb *strings.Builder, route *models.Rou
 	joseResponse := route.Response != nil && route.Response.JOSE
 	joseRoute := joseResponse || (route.Request != nil && route.Request.JOSE)
 
+	const contentIndent = "            "
 	sb.WriteString("      responses:\n")
 	sb.WriteString("        '200':\n")
-	fmt.Fprintf(sb, "          description: %s\n", g.getResponseDescription(route.Method))
-	sb.WriteString("          content:\n")
 	if joseResponse {
-		writeMediaSchemaRef(sb, "            ", mediaJOSE, "SuccessResponse")
-		writeJOSEDescription(sb, "              ")
+		// Description on the Response Object (spec-compliant) — per OpenAPI 3.0.1,
+		// description is a fixed field on Response, but NOT on Media Type Object.
+		writeJOSEDescription(sb, "          ")
+		sb.WriteString("          content:\n")
+		writeMediaSchemaRef(sb, contentIndent, mediaJOSE, "SuccessResponse")
 	} else {
-		writeMediaSchemaRef(sb, "            ", mediaJSON, "SuccessResponse")
+		fmt.Fprintf(sb, "          description: %s\n", g.getResponseDescription(route.Method))
+		sb.WriteString("          content:\n")
+		writeMediaSchemaRef(sb, contentIndent, mediaJSON, "SuccessResponse")
 	}
 	sb.WriteString("        '400':\n")
 	sb.WriteString("          description: Bad Request\n")
@@ -280,13 +284,18 @@ func (g *OpenAPIGenerator) writeResponses(sb *strings.Builder, route *models.Rou
 	if joseRoute {
 		errorSchema = "JOSEErrorEnvelope"
 	}
-	writeMediaSchemaRef(sb, "            ", mediaJSON, errorSchema)
+	writeMediaSchemaRef(sb, contentIndent, mediaJSON, errorSchema)
 }
 
-// writeJOSEDescription emits the canonical "JOSE compact serialization" block used by
-// both the request-body and response sections. Centralized so the wording stays
-// consistent across the spec; indent controls the YAML depth (request body and
-// response.content live at different levels).
+// writeJOSEDescription emits the canonical "JOSE compact serialization" description
+// block. Per OpenAPI 3.0.1, Media Type Objects (under content.<contentType>:) do NOT
+// allow a description field — fixed fields are limited to schema, example, examples,
+// encoding. RequestBody and Response objects DO allow description, so the helper is
+// invoked at the parent level (under requestBody: or under '200':), not nested inside
+// the content/media-type block.
+//
+// indent is the YAML depth of the description: line itself (e.g., "        " for a
+// requestBody, "          " for a response).
 func writeJOSEDescription(sb *strings.Builder, indent string) {
 	fmt.Fprintf(sb, "%sdescription: |\n", indent)
 	fmt.Fprintf(sb, "%s  JOSE compact serialization (signed-then-encrypted). The referenced\n", indent)
@@ -746,6 +755,11 @@ func (g *OpenAPIGenerator) writeRequestBody(sb *strings.Builder, _ []models.Fiel
 
 	sb.WriteString("      requestBody:\n")
 	sb.WriteString("        required: true\n")
+	if isJOSE {
+		// Description on the RequestBody Object (spec-compliant) — sibling of content,
+		// NOT nested inside content.<contentType> which would violate OpenAPI 3.0.1.
+		writeJOSEDescription(sb, "        ")
+	}
 	sb.WriteString("        content:\n")
 
 	if schemaName != "" {
@@ -755,9 +769,6 @@ func (g *OpenAPIGenerator) writeRequestBody(sb *strings.Builder, _ []models.Fiel
 		fmt.Fprintf(sb, "          %s:\n", contentType)
 		sb.WriteString("            schema:\n")
 		sb.WriteString("              type: object\n")
-	}
-	if isJOSE {
-		writeJOSEDescription(sb, "            ")
 	}
 }
 

--- a/tools/openapi/internal/generator/openapi_test.go
+++ b/tools/openapi/internal/generator/openapi_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gaborage/go-bricks/tools/openapi/internal/models"
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )
 
@@ -2062,20 +2063,51 @@ func TestWriteRequestBodyJOSEContentType(t *testing.T) {
 	gen.writeRequestBody(&sb, &models.TypeInfo{Name: "CreateTokenRequest", JOSE: true})
 	out := sb.String()
 
-	if !strings.Contains(out, "application/jose:") {
-		t.Error("JOSE-flagged request body must use Content-Type application/jose")
-	}
-	if strings.Contains(out, "application/json:") {
-		t.Error("JOSE-flagged request body must NOT also emit application/json")
-	}
-	// Plaintext schema is preserved as the source of truth — wire format is the JOSE
-	// compact serialization wrapping a payload that conforms to this schema.
-	if !strings.Contains(out, "$ref: '#/components/schemas/CreateTokenRequest'") {
-		t.Error("JOSE-flagged request body must reference the plaintext schema")
-	}
-	if !strings.Contains(out, "JOSE compact serialization") {
-		t.Error("JOSE-flagged request body must include the descriptive note")
-	}
+	// Wire format: per OpenAPI 3.0.1, application/jose Media Type schema MUST describe
+	// the on-the-wire payload (a string token), not the decrypted plaintext shape.
+	assert.Contains(t, out, "application/jose:")
+	assert.NotContains(t, out, "application/json:")
+	assert.Contains(t, out, "type: string")
+	assert.Contains(t, out, "format: jose")
+
+	// Plaintext schema MUST NOT appear under content.application/jose — the spec
+	// reserves Media Type Object schema for the wire shape only. The plaintext
+	// component schema is still emitted (via generateSchemasFromTypes) and is
+	// referenced from the description text.
+	assert.NotContains(t, out, "application/jose:\n            schema:\n              $ref:")
+
+	// Description on the parent RequestBody Object (spec-compliant location) names
+	// the plaintext schema so consumers know what to expect after decrypt+verify.
+	assert.Contains(t, out, "JOSE compact serialization")
+	assert.Contains(t, out, "CreateTokenRequest schema")
+	assert.Contains(t, out, "#/components/schemas/CreateTokenRequest")
+}
+
+func TestWriteMethodEmitsRequestBodyForJOSEEvenWithEmptyBodyFields(t *testing.T) {
+	// Real bug caught by CodeRabbit: a JOSE-tagged request type whose plaintext
+	// fields all live in path/query/header params (or are absent entirely) would
+	// have produced no requestBody at all, even though the route still expects an
+	// application/jose payload on the wire. The fix drives the requestBody emission
+	// from `route.Request.JOSE || len(bodyFields) > 0`.
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+	spec, err := gen.Generate(&models.Project{
+		Name:    "JOSEOnlyApp",
+		Version: "1.0.0",
+		Modules: []models.Module{{
+			Name:    "vts",
+			Package: "vts",
+			Routes: []models.Route{{
+				Method:      "POST",
+				Path:        "/v1/tokens",
+				HandlerName: "createToken",
+				Request:     &models.TypeInfo{Name: "CreateTokenRequest", JOSE: true},
+				Response:    &models.TypeInfo{Name: "CreateTokenResponse", JOSE: true},
+			}},
+		}},
+	})
+	assert.NoError(t, err)
+	assert.Contains(t, spec, "requestBody:", "JOSE-only routes must still emit a requestBody")
+	assert.Contains(t, spec, "application/jose:", "the JOSE requestBody must be present even with no plaintext body fields")
 }
 
 func TestWriteResponsesJOSEPath(t *testing.T) {

--- a/tools/openapi/internal/generator/openapi_test.go
+++ b/tools/openapi/internal/generator/openapi_test.go
@@ -1747,7 +1747,7 @@ func TestWriteRequestBody(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var sb strings.Builder
-			gen.writeRequestBody(&sb, tt.bodyFields, &models.TypeInfo{Name: tt.schemaName})
+			gen.writeRequestBody(&sb, &models.TypeInfo{Name: tt.schemaName})
 			output := sb.String()
 
 			for _, expected := range tt.expectedOutput {
@@ -2059,7 +2059,7 @@ func TestGenerateWithParameters(t *testing.T) {
 func TestWriteRequestBodyJOSEContentType(t *testing.T) {
 	gen := New(defaultTitle, "1.0.0", defaultDescription)
 	var sb strings.Builder
-	gen.writeRequestBody(&sb, nil, &models.TypeInfo{Name: "CreateTokenRequest", JOSE: true})
+	gen.writeRequestBody(&sb, &models.TypeInfo{Name: "CreateTokenRequest", JOSE: true})
 	out := sb.String()
 
 	if !strings.Contains(out, "application/jose:") {

--- a/tools/openapi/internal/generator/openapi_test.go
+++ b/tools/openapi/internal/generator/openapi_test.go
@@ -652,12 +652,30 @@ func TestCreateStandardSchemas(t *testing.T) {
 	schemas := gen.createStandardSchemas()
 
 	// Test that standard schemas are created correctly
-	if len(schemas) != 2 {
-		t.Errorf("Expected 2 schemas, got %d", len(schemas))
+	if len(schemas) != 3 {
+		t.Errorf("Expected 3 schemas, got %d", len(schemas))
 	}
 
 	t.Run("SuccessResponse schema", func(t *testing.T) {
 		validateSuccessResponseSchema(t, schemas)
+	})
+
+	t.Run("JOSEErrorEnvelope schema", func(t *testing.T) {
+		schema, ok := schemas["JOSEErrorEnvelope"]
+		if !ok {
+			t.Fatal("JOSEErrorEnvelope schema missing — pre-trust JOSE failures need a documented envelope distinct from ErrorResponse")
+		}
+		// The envelope MUST NOT include framework metadata fields (meta, traceId)
+		// — that's the whole security argument for having it as a separate schema.
+		if _, hasMeta := schema.Properties["meta"]; hasMeta {
+			t.Error("JOSEErrorEnvelope must NOT carry meta — peer is unauthenticated, leak nothing")
+		}
+		if _, hasCode := schema.Properties["code"]; !hasCode {
+			t.Error("JOSEErrorEnvelope must include 'code' property")
+		}
+		if _, hasMsg := schema.Properties["message"]; !hasMsg {
+			t.Error("JOSEErrorEnvelope must include 'message' property")
+		}
 	})
 
 	t.Run("ErrorResponse schema", func(t *testing.T) {
@@ -1729,7 +1747,7 @@ func TestWriteRequestBody(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var sb strings.Builder
-			gen.writeRequestBody(&sb, tt.bodyFields, tt.schemaName)
+			gen.writeRequestBody(&sb, tt.bodyFields, &models.TypeInfo{Name: tt.schemaName})
 			output := sb.String()
 
 			for _, expected := range tt.expectedOutput {
@@ -2035,5 +2053,69 @@ func TestGenerateWithParameters(t *testing.T) {
 	err = yaml.Unmarshal([]byte(spec), &parsed)
 	if err != nil {
 		t.Fatalf(yamlParsingFailedMsg, err)
+	}
+}
+
+func TestWriteRequestBodyJOSEContentType(t *testing.T) {
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+	var sb strings.Builder
+	gen.writeRequestBody(&sb, nil, &models.TypeInfo{Name: "CreateTokenRequest", JOSE: true})
+	out := sb.String()
+
+	if !strings.Contains(out, "application/jose:") {
+		t.Error("JOSE-flagged request body must use Content-Type application/jose")
+	}
+	if strings.Contains(out, "application/json:") {
+		t.Error("JOSE-flagged request body must NOT also emit application/json")
+	}
+	// Plaintext schema is preserved as the source of truth — wire format is the JOSE
+	// compact serialization wrapping a payload that conforms to this schema.
+	if !strings.Contains(out, "$ref: '#/components/schemas/CreateTokenRequest'") {
+		t.Error("JOSE-flagged request body must reference the plaintext schema")
+	}
+	if !strings.Contains(out, "JOSE compact serialization") {
+		t.Error("JOSE-flagged request body must include the descriptive note")
+	}
+}
+
+func TestWriteResponsesJOSEPath(t *testing.T) {
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+	var sb strings.Builder
+	gen.writeResponses(&sb, &models.Route{
+		Method:   "POST",
+		Path:     "/v1/tokens",
+		Response: &models.TypeInfo{Name: "CreateTokenResponse", JOSE: true},
+	})
+	out := sb.String()
+
+	if !strings.Contains(out, "'200':") || !strings.Contains(out, "application/jose:") {
+		t.Error("JOSE-flagged 200 response must use application/jose")
+	}
+	// Pre-trust failure path: peer is unauthenticated so the envelope must be the
+	// minimal JOSEErrorEnvelope, NOT the framework's standard ErrorResponse (which
+	// carries traceId/meta and would leak fingerprint information).
+	if !strings.Contains(out, "$ref: '#/components/schemas/JOSEErrorEnvelope'") {
+		t.Error("JOSE 4xx response must reference JOSEErrorEnvelope (security invariant)")
+	}
+	if strings.Contains(out, "$ref: '#/components/schemas/ErrorResponse'") {
+		t.Error("JOSE 4xx response must NOT reference ErrorResponse — leaks framework metadata to unauthenticated peers")
+	}
+}
+
+func TestWriteResponsesNonJOSEUnchanged(t *testing.T) {
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+	var sb strings.Builder
+	gen.writeResponses(&sb, &models.Route{
+		Method:   "POST",
+		Path:     "/v1/users",
+		Response: &models.TypeInfo{Name: "User", JOSE: false},
+	})
+	out := sb.String()
+
+	if strings.Contains(out, "application/jose:") {
+		t.Error("non-JOSE response must NOT use application/jose")
+	}
+	if !strings.Contains(out, "$ref: '#/components/schemas/ErrorResponse'") {
+		t.Error("non-JOSE 4xx must reference standard ErrorResponse")
 	}
 }

--- a/tools/openapi/internal/generator/openapi_test.go
+++ b/tools/openapi/internal/generator/openapi_test.go
@@ -2102,6 +2102,32 @@ func TestWriteResponsesJOSEPath(t *testing.T) {
 	}
 }
 
+func TestWriteResponsesAsymmetricJOSERequestStillUsesJOSEErrorEnvelope(t *testing.T) {
+	// The runtime enforces bidirectional symmetry (request and response must both
+	// carry jose tags or neither). The analyzer runs statically against source —
+	// it can encounter asymmetric setups that a developer is in the middle of
+	// writing. In any such case the pre-trust failure path on the request side is
+	// still routed through the JOSE plaintext-minimal envelope by the runtime, so
+	// the OpenAPI 4xx schema must reference JOSEErrorEnvelope, NOT the standard
+	// ErrorResponse (which would leak traceId/meta).
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+	var sb strings.Builder
+	gen.writeResponses(&sb, &models.Route{
+		Method:   "POST",
+		Path:     "/v1/tokens",
+		Request:  &models.TypeInfo{Name: "TokenRequest", JOSE: true},
+		Response: &models.TypeInfo{Name: "TokenResponse", JOSE: false},
+	})
+	out := sb.String()
+
+	if !strings.Contains(out, "$ref: '#/components/schemas/JOSEErrorEnvelope'") {
+		t.Error("4xx path on JOSE-request route must reference JOSEErrorEnvelope (pre-trust failures fire on the request side)")
+	}
+	if strings.Contains(out, "$ref: '#/components/schemas/ErrorResponse'") {
+		t.Error("4xx path on JOSE-request route must NOT reference ErrorResponse — leaks traceId/meta to unauthenticated peers")
+	}
+}
+
 func TestWriteResponsesNonJOSEUnchanged(t *testing.T) {
 	gen := New(defaultTitle, "1.0.0", defaultDescription)
 	var sb strings.Builder

--- a/tools/openapi/internal/models/models.go
+++ b/tools/openapi/internal/models/models.go
@@ -34,6 +34,12 @@ type TypeInfo struct {
 	Package   string
 	IsPointer bool
 	Fields    []FieldInfo
+	// JOSE is true when the struct carries a `jose:"..."` tag on any field — typically
+	// a sentinel `_ struct{}` field. Routes whose request or response type is JOSE-tagged
+	// emit Content-Type: application/jose in the OpenAPI spec while keeping the documented
+	// plaintext schema as the source of truth (the on-the-wire compact JOSE serialization
+	// wraps that plaintext after decrypt-and-verify).
+	JOSE bool
 }
 
 // FieldInfo represents a struct field with validation metadata


### PR DESCRIPTION
## Summary

Adds the documented Phase 2 follow-up from #328 / #330: the OpenAPI generator now detects `jose:` struct tags on request/response types and emits `Content-Type: application/jose` for those routes. The documented plaintext schema is still referenced as the source of truth — the wire payload is the compact JOSE serialization that wraps that plaintext after decrypt+verify on the receiving side.

## What changes

- **`models.TypeInfo` gets a `JOSE bool` flag** populated by the analyzer.
- **`analyzer.hasJOSESentinelTag()`** uses `reflect.StructTag.Lookup()` rather than substring match — avoids false-positives on tag values that happen to contain the literal ``jose:"`` (covered by the `jose_substring_in_other_tag_must_not_match` table case).
- **Generator emits `application/jose`** for both the request body and 200 response when the type is JOSE-tagged.
- **4xx responses on JOSE routes** now reference a new `JOSEErrorEnvelope` component schema (minimal `{code, message}`) instead of the framework's standard `ErrorResponse`. This matches the runtime hybrid envelope contract: pre-trust failures must NOT carry `traceId`/`meta` because the peer is unauthenticated and the framework intentionally leaks nothing.
- **`writeJOSEDescription` helper** keeps the canonical "JOSE compact serialization" wording in one place across the request/response paths.
- **`mediaJSON` / `mediaJOSE` consts** replace 5× duplicate string literals.

## Test plan

- [x] `go test ./...` from `tools/openapi/` — all pass
- [x] `make check` (framework root) — clean
- [x] `make check-tool` — clean
- [x] Pre-push `/simplify` pass produced four findings; three applied in this PR (consts, helper extraction, `*TypeInfo` instead of positional `bool`), one deferred as informational (folding jose detection into `extractStructFields` to avoid double iteration — noted as not worth the refactor for build-time tooling)

## Security invariant tests

- `TestWriteResponsesJOSEPath` asserts that JOSE 4xx responses reference `JOSEErrorEnvelope` AND **explicitly** asserts they do NOT reference `ErrorResponse`. If a future change accidentally wires JOSE error paths through the standard envelope (which carries `traceId`/`meta`), this test fails.
- `TestCreateStandardSchemas` asserts the `JOSEErrorEnvelope` schema has no `meta` property.

## Plan reference

`/Users/gaborage/.claude/plans/1-nested-2-we-twinkly-cook.md` — Follow-up work, "OpenAPI integration — separate PR".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAPI generation emits application/jose for JOSE-marked request and success response content while preserving plaintext schema references.
  * Added a flag to mark JOSE-tagged types to drive JOSE-aware generation.
  * Introduced a JOSE-specific error envelope used for 4xx responses on JOSE-enabled routes.

* **Bug Fixes**
  * Improved detection of JOSE sentinel tags to avoid false-positive matches.

* **Tests**
  * Expanded tests for JOSE sentinel detection and JOSE-specific OpenAPI emission and error routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->