### PR TITLE
feat(server): capture stack traces for BaseAPIError in dev mode

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -391,6 +391,22 @@ require.ErrorAs(t, err, &jerr)
 
 ---
 
+### ~~Slim Module Interface + Remove Stutter from Framework Modules~~
+**Status:** ✅ Completed (ADR-014, 2026-03-16)
+**Context:** The framework modules `outbox`, `scheduler`, and `keystore` previously stuttered (`OutboxModule`, `SchedulerModule`, `KeystoreModule`) with `//nolint:revive` suppressions, and were forced to provide no-op `RegisterRoutes` / `DeclareMessaging` implementations because the core `app.Module` interface required all five methods. This violated Interface Segregation and made the no-op stubs look like missing implementations rather than intentional opt-outs.
+
+**Resolution:**
+- **Stutter removed**: `outbox.OutboxModule` → `outbox.Module`, `scheduler.SchedulerModule` → `scheduler.Module`, `keystore.KeystoreModule` → `keystore.Module`. All `//nolint:revive` suppressions deleted. Constructors are now `outbox.NewModule()`, `scheduler.NewModule()`, `keystore.NewModule()`.
+- **`app.Module` slimmed to three methods**: `Name()`, `Init(*ModuleDeps) error`, `Shutdown() error`. Modules that don't serve HTTP or AMQP no longer implement no-op stubs.
+- **Optional capabilities are duck-typed at registration**: `RouteRegisterer`, `MessagingDeclarer`, `JobProvider`, `OutboxProvider`, and `KeyStoreProvider` live in [app/module.go](app/module.go). `ModuleRegistry` type-asserts each module before invoking the optional method — same pattern Go's standard library uses (e.g., `io.ReaderFrom` is opportunistically detected by `io.Copy`). This is the Go-idiomatic answer to Java's "implement just the interfaces you need" — composition at the **call site**, not at the **type definition**.
+
+**Related:**
+- [wiki/adr-014-slim-module-interface.md](wiki/adr-014-slim-module-interface.md)
+- [app/module.go](app/module.go) — core + optional interface declarations
+- [app/module_registry.go](app/module_registry.go) — type-assertion dispatch
+
+---
+
 ## Contributing to This Backlog
 
 When adding items to this backlog:

--- a/TODO.md
+++ b/TODO.md
@@ -12,34 +12,6 @@ This document tracks future enhancements, technical improvements, and nice-to-ha
 
 ## P0 - Critical
 
-### Stack Traces in Development Mode
-**Status:** Planned
-**Context:** Currently, errors return messages without stack traces. In development mode, stack traces would significantly improve debugging.
-
-**Requirements:**
-- Add stack trace capture to `BaseAPIError` when `app.env = development`
-- Include file:line information in error details
-- Ensure zero performance impact in production mode
-- Consider using existing libraries (e.g., `github.com/pkg/errors` or custom implementation)
-
-**Implementation Notes:**
-```go
-// Potential approach in server/errors.go
-type BaseAPIError struct {
-    code       string
-    message    string
-    httpStatus int
-    details    map[string]any
-    stackTrace []string // nil in production
-}
-```
-
-**Related:**
-- ADR-001: Enhanced Handler System (error handling section)
-- [server/errors.go](server/errors.go)
-
----
-
 ### Security Audit Annotations for WhereRaw()
 **Status:** Planned
 **Context:** `WhereRaw()` bypasses SQL safety mechanisms. All usage should require explicit security review annotation.
@@ -388,6 +360,23 @@ require.ErrorAs(t, err, &jerr)
 **Implementation:**
 - [database/postgresql/connection.go](database/postgresql/connection.go)
 - [database/oracle/connection.go](database/oracle/connection.go)
+
+---
+
+### ~~Stack Traces in Development Mode~~
+**Status:** ✅ Completed
+**Context:** `BaseAPIError` now captures the call-site stack on construction when running in `app.env = development` (or `dev`), and the response formatter renders the resolved frames under `error.details.stackTrace` for both the standard `APIResponse` envelope and raw-response routes.
+
+**Resolution:**
+- **Process-global capture flag** in [server/errors.go](server/errors.go) (`captureStackTraces atomic.Bool`) flipped by [server.New()](server/server.go) based on `cfg.App.Env`. Production paths pay one `atomic.Bool.Load()` per error and never invoke `runtime.Callers`.
+- **Lazy resolution**: PCs are stored as `[]uintptr` at construction; the expensive `runtime.CallersFrames` symbol resolution runs only when the formatter calls `StackTrace()` (which only happens in dev).
+- **`StackTracer` interface** mirrors the well-known `pkg/errors` convention. All built-in wrapper types (`NotFoundError`, `BadRequestError`, …) inherit it via method promotion since they embed `*BaseAPIError`. User-defined error types can implement it independently.
+- **Capture depth** capped at 32 frames; render key is `stackTrace`.
+
+**Related:**
+- [server/errors.go](server/errors.go) — `SetCaptureStackTraces`, `StackTracer`, `(*BaseAPIError).StackTrace`
+- [server/handler.go](server/handler.go) — `devDetails` helper used by both `formatErrorResponse` and `formatRawErrorResponse`
+- [server/server.go](server/server.go) — bootstrap wiring
 
 ---
 

--- a/server/errors.go
+++ b/server/errors.go
@@ -4,7 +4,38 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"runtime"
+	"sync/atomic"
 )
+
+// stackFrameDepth caps the number of stack frames captured per error.
+// Deep enough to span typical handler → service → repository chains; shallow
+// enough that capture stays in the low-microsecond range.
+const stackFrameDepth = 32
+
+// captureStackTraces is process-global because BaseAPIError construction
+// sites are scattered throughout user code and have no access to *config.Config.
+var captureStackTraces atomic.Bool
+
+// stackTraceDetailKey is the JSON key under APIErrorResponse.Details where
+// captured frames are exposed in development. Tests assert against this name,
+// and downstream tooling (dev consoles, IDE plugins) can match on it.
+const stackTraceDetailKey = "stackTrace"
+
+// SetCaptureStackTraces toggles stack-trace capture for all subsequently
+// created errors. Intended for the framework bootstrap (server.New) and tests.
+// Safe for concurrent use.
+func SetCaptureStackTraces(enabled bool) {
+	captureStackTraces.Store(enabled)
+}
+
+// StackTracer is implemented by errors that carry a captured stack trace.
+// The formatter uses this interface to surface frames in the response when
+// running in development. *BaseAPIError satisfies it, and every wrapper type
+// (NotFoundError, BadRequestError, …) inherits it via method promotion.
+type StackTracer interface {
+	StackTrace() []string
+}
 
 // BaseAPIError provides a basic implementation of IAPIError.
 type BaseAPIError struct {
@@ -12,16 +43,34 @@ type BaseAPIError struct {
 	message    string
 	httpStatus int
 	details    map[string]any
+	// stackPCs holds raw program counters captured at construction when
+	// SetCaptureStackTraces(true) is in effect. Resolving them to file:line
+	// strings is deferred to StackTrace() so production paths skip the
+	// symbol-lookup cost entirely.
+	stackPCs []uintptr
 }
 
 // NewBaseAPIError creates a new base API error.
 func NewBaseAPIError(code, message string, httpStatus int) *BaseAPIError {
-	return &BaseAPIError{
+	e := &BaseAPIError{
 		code:       code,
 		message:    message,
 		httpStatus: httpStatus,
 		details:    make(map[string]any),
 	}
+	if captureStackTraces.Load() {
+		e.stackPCs = captureStack(3) // skip runtime.Callers, captureStack, NewBaseAPIError
+	}
+	return e
+}
+
+func captureStack(skip int) []uintptr {
+	pcs := make([]uintptr, stackFrameDepth)
+	n := runtime.Callers(skip, pcs)
+	if n == 0 {
+		return nil
+	}
+	return pcs[:n]
 }
 
 // ErrorCode returns the error code.
@@ -65,6 +114,26 @@ func (e *BaseAPIError) Error() string {
 		return e.message
 	}
 	return e.code + ": " + e.message
+}
+
+// StackTrace resolves the captured program counters into readable
+// "file:line funcName" strings. Returns nil when no stack was captured —
+// either because SetCaptureStackTraces was off at construction time, or
+// because the error was built without NewBaseAPIError.
+func (e *BaseAPIError) StackTrace() []string {
+	if e == nil || len(e.stackPCs) == 0 {
+		return nil
+	}
+	frames := runtime.CallersFrames(e.stackPCs)
+	out := make([]string, 0, len(e.stackPCs))
+	for {
+		frame, more := frames.Next()
+		out = append(out, fmt.Sprintf("%s:%d %s", frame.File, frame.Line, frame.Function))
+		if !more {
+			break
+		}
+	}
+	return out
 }
 
 // NotFoundError represents resource not found errors.
@@ -237,4 +306,7 @@ func NewBusinessLogicError(code, message string) *BusinessLogicError {
 }
 
 // Compile-time interface assertions
-var _ IAPIError = (*BaseAPIError)(nil)
+var (
+	_ IAPIError   = (*BaseAPIError)(nil)
+	_ StackTracer = (*BaseAPIError)(nil)
+)

--- a/server/errors.go
+++ b/server/errors.go
@@ -64,6 +64,10 @@ func NewBaseAPIError(code, message string, httpStatus int) *BaseAPIError {
 	return e
 }
 
+// captureStack returns the call-site PCs above the caller. The skip value
+// must account for runtime.Callers itself, captureStack, and the API
+// constructor that invokes it; a wrong skip leaks framework internals into
+// the user-visible top frame.
 func captureStack(skip int) []uintptr {
 	pcs := make([]uintptr, stackFrameDepth)
 	n := runtime.Callers(skip, pcs)

--- a/server/errors_test.go
+++ b/server/errors_test.go
@@ -183,6 +183,31 @@ func TestStackTraceInErrorResponse(t *testing.T) {
 			"expected stack to include test file, got: %v", frames)
 	})
 
+	t.Run("does_not_mutate_caller_details_map", func(t *testing.T) {
+		// Regression guard: devDetails must never write into the map returned
+		// by IAPIError.Details(). User-defined error types may return their
+		// internal map directly (the IAPIError contract doesn't pin down
+		// ownership), and silently mutating it is the kind of bug that
+		// surfaces only in production under concurrent access.
+		err := NewBadRequestError("trace + caller details")
+		err.WithDetails("requestId", "abc-123")
+
+		// Snapshot the user-visible details before render.
+		before := err.Details()
+		require.NotContains(t, before, stackTraceDetailKey,
+			"precondition: caller details should not contain stackTrace yet")
+
+		out := devDetails(err)
+		require.NotNil(t, out)
+		require.Contains(t, out, stackTraceDetailKey, "render output should include stackTrace")
+
+		after := err.Details()
+		assert.NotContains(t, after, stackTraceDetailKey,
+			"caller-visible details must remain free of stackTrace after devDetails runs")
+		assert.Equal(t, before, after,
+			"caller-visible details must be unchanged across devDetails calls")
+	})
+
 	t.Run("omitted_in_production", func(t *testing.T) {
 		e := echo.New()
 		e.HTTPErrorHandler = func(c *echo.Context, err error) {

--- a/server/errors_test.go
+++ b/server/errors_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -70,6 +71,139 @@ func TestBaseAPIError(t *testing.T) {
 	t.Run("details_nil_returns_nil", func(t *testing.T) {
 		err := &BaseAPIError{details: nil}
 		assert.Nil(t, err.Details())
+	})
+}
+
+// withStackCapture flips the process-global stack-capture flag for the duration
+// of a single test and restores it on cleanup. Tests that depend on the flag
+// must use this helper so they don't leak state into siblings.
+func withStackCapture(t *testing.T, enabled bool) {
+	t.Helper()
+	prev := captureStackTraces.Load()
+	SetCaptureStackTraces(enabled)
+	t.Cleanup(func() { SetCaptureStackTraces(prev) })
+}
+
+// containsFrame returns true if any frame string in the JSON-decoded slice
+// contains the given substring. JSON arrays decode as []any, so each element
+// is type-asserted back to string.
+func containsFrame(frames []any, substr string) bool {
+	for _, f := range frames {
+		if s, ok := f.(string); ok && strings.Contains(s, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBaseAPIErrorStackTraceCapture(t *testing.T) {
+	t.Run("disabled_by_default", func(t *testing.T) {
+		// Snapshot+restore even though we don't toggle, in case prior test left
+		// the flag flipped.
+		withStackCapture(t, false)
+
+		err := NewBaseAPIError("X", "no stack here", http.StatusBadRequest)
+		assert.Nil(t, err.StackTrace(), "no frames should be captured when flag is off")
+	})
+
+	t.Run("captured_when_enabled", func(t *testing.T) {
+		withStackCapture(t, true)
+
+		err := NewBaseAPIError("X", "with stack", http.StatusBadRequest)
+		frames := err.StackTrace()
+		require.NotEmpty(t, frames, "frames should be captured when flag is on")
+
+		// The top frame should point at this test file/function so a developer
+		// reading the response can immediately locate the origin.
+		assert.Contains(t, frames[0], "errors_test.go")
+		assert.Contains(t, frames[0], "TestBaseAPIErrorStackTraceCapture")
+	})
+
+	t.Run("specific_error_types_inherit_stack", func(t *testing.T) {
+		withStackCapture(t, true)
+
+		// Wrapper types (NotFoundError, BadRequestError, …) embed *BaseAPIError,
+		// so the StackTrace method is promoted and the StackTracer assertion
+		// succeeds without per-type plumbing.
+		bad := NewBadRequestError("missing field")
+		var st StackTracer = bad
+		assert.NotEmpty(t, st.StackTrace())
+	})
+
+	t.Run("nil_receiver_safe", func(t *testing.T) {
+		var err *BaseAPIError
+		assert.Nil(t, err.StackTrace())
+	})
+
+	t.Run("toggle_only_affects_subsequent_errors", func(t *testing.T) {
+		withStackCapture(t, false)
+		off := NewBaseAPIError("X", "off", http.StatusBadRequest)
+
+		SetCaptureStackTraces(true)
+		on := NewBaseAPIError("X", "on", http.StatusBadRequest)
+
+		assert.Nil(t, off.StackTrace(), "errors built before flip stay clean")
+		assert.NotEmpty(t, on.StackTrace(), "errors built after flip carry frames")
+	})
+}
+
+func TestStackTraceInErrorResponse(t *testing.T) {
+	withStackCapture(t, true)
+
+	t.Run("included_in_dev", func(t *testing.T) {
+		e := echo.New()
+		e.HTTPErrorHandler = func(c *echo.Context, err error) {
+			customErrorHandler(c, err, &config.Config{
+				App: config.AppConfig{Env: config.EnvDevelopment},
+			})
+		}
+		e.GET("/boom", func(_ *echo.Context) error {
+			return NewBadRequestError("with trace")
+		})
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/boom", http.NoBody)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		var resp APIResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.NotNil(t, resp.Error)
+		require.NotNil(t, resp.Error.Details)
+
+		raw, ok := resp.Error.Details[stackTraceDetailKey]
+		require.True(t, ok, "%s key should be present in dev", stackTraceDetailKey)
+		frames, ok := raw.([]any)
+		require.True(t, ok, "stackTrace should marshal as a JSON array")
+		require.NotEmpty(t, frames)
+		// The wrapper constructor (NewBadRequestError) sits at the top of the
+		// chain because it called NewBaseAPIError; the test handler closure
+		// shows up further down. Scanning the slice avoids coupling the test
+		// to the exact wrapper-skip depth.
+		assert.True(t, containsFrame(frames, "errors_test.go"),
+			"expected stack to include test file, got: %v", frames)
+	})
+
+	t.Run("omitted_in_production", func(t *testing.T) {
+		e := echo.New()
+		e.HTTPErrorHandler = func(c *echo.Context, err error) {
+			customErrorHandler(c, err, &config.Config{
+				App: config.AppConfig{Env: config.EnvProduction},
+			})
+		}
+		e.GET("/boom", func(_ *echo.Context) error {
+			// Capture flag is on (from outer Run), but the prod env must still
+			// strip the frames at render time.
+			return NewBadRequestError("trace must not leak")
+		})
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/boom", http.NoBody)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		var resp APIResponse
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.NotNil(t, resp.Error)
+		assert.Nil(t, resp.Error.Details, "production responses must not expose stack traces")
 	})
 }
 

--- a/server/handler.go
+++ b/server/handler.go
@@ -753,11 +753,8 @@ func formatErrorResponse(c *echo.Context, apiErr IAPIError, cfg *config.Config) 
 		Message: apiErr.Message(),
 	}
 
-	// Include details only in development environment
 	if isDevelopmentEnv(cfg.App.Env) {
-		if details := apiErr.Details(); details != nil {
-			errorResp.Details = details
-		}
+		errorResp.Details = devDetails(apiErr)
 	}
 
 	response := APIResponse{
@@ -770,6 +767,26 @@ func formatErrorResponse(c *echo.Context, apiErr IAPIError, cfg *config.Config) 
 
 	ensureTraceParentHeader(c)
 	return c.JSON(apiErr.HTTPStatus(), response)
+}
+
+// devDetails returns the dev-only details payload: caller-supplied details merged
+// with a "stackTrace" entry if the error implements StackTracer and a stack
+// was captured. Returns nil when nothing would be rendered, so callers can rely
+// on json `omitempty` to drop the field cleanly.
+func devDetails(apiErr IAPIError) map[string]any {
+	details := apiErr.Details()
+	if st, ok := apiErr.(StackTracer); ok {
+		if frames := st.StackTrace(); len(frames) > 0 {
+			if details == nil {
+				details = make(map[string]any, 1)
+			}
+			details[stackTraceDetailKey] = frames
+		}
+	}
+	if len(details) == 0 {
+		return nil
+	}
+	return details
 }
 
 // handleRawResponse formats and sends the HTTP response without the APIResponse envelope.
@@ -834,9 +851,7 @@ func formatRawErrorResponse(c *echo.Context, apiErr IAPIError, cfg *config.Confi
 	}
 
 	if isDevelopmentEnv(cfg.App.Env) {
-		if details := apiErr.Details(); details != nil {
-			payload.Details = details
-		}
+		payload.Details = devDetails(apiErr)
 	}
 
 	ensureTraceParentHeader(c)

--- a/server/handler.go
+++ b/server/handler.go
@@ -773,20 +773,29 @@ func formatErrorResponse(c *echo.Context, apiErr IAPIError, cfg *config.Config) 
 // with a "stackTrace" entry if the error implements StackTracer and a stack
 // was captured. Returns nil when nothing would be rendered, so callers can rely
 // on json `omitempty` to drop the field cleanly.
+//
+// The IAPIError interface does not guarantee Details() returns a copy
+// (BaseAPIError happens to, but user-defined error types may not), so we always
+// copy before injecting stackTrace to avoid mutating caller-owned state.
 func devDetails(apiErr IAPIError) map[string]any {
-	details := apiErr.Details()
-	if st, ok := apiErr.(StackTracer); ok {
-		if frames := st.StackTrace(); len(frames) > 0 {
-			if details == nil {
-				details = make(map[string]any, 1)
-			}
-			details[stackTraceDetailKey] = frames
-		}
+	src := apiErr.Details()
+	st, hasStack := apiErr.(StackTracer)
+	var frames []string
+	if hasStack {
+		frames = st.StackTrace()
 	}
-	if len(details) == 0 {
+	if len(src) == 0 && len(frames) == 0 {
 		return nil
 	}
-	return details
+
+	out := make(map[string]any, len(src)+1)
+	for k, v := range src {
+		out[k] = v
+	}
+	if len(frames) > 0 {
+		out[stackTraceDetailKey] = frames
+	}
+	return out
 }
 
 // handleRawResponse formats and sends the HTTP response without the APIResponse envelope.

--- a/server/server.go
+++ b/server/server.go
@@ -83,6 +83,8 @@ func (s *Server) buildFullPath(route string) string {
 // New creates a new HTTP server instance with the given configuration and logger.
 // It initializes Echo with middlewares, error handling, and health check endpoints.
 func New(cfg *config.Config, log logger.Logger) *Server {
+	SetCaptureStackTraces(isDevelopmentEnv(cfg.App.Env))
+
 	e := echo.New()
 	// Use an error handler that emits standardized APIResponse envelopes.
 	// Echo v5's Recover middleware wraps panics in middleware.PanicStackError;


### PR DESCRIPTION
## Summary

Closes the P0 TODO **"Stack Traces in Development Mode"**. When `cfg.App.Env=development` (or `dev`), `BaseAPIError` records the call-site stack on construction and the response formatter exposes the resolved frames under `error.details.stackTrace` for both the standard `APIResponse` envelope path and raw-response routes.

- **Process-global atomic gate** (`captureStackTraces atomic.Bool`) flipped once by `server.New()` from `cfg.App.Env`. Production paths cost a single `atomic.Bool.Load()` per error and never invoke `runtime.Callers` — meeting the *"zero perf impact in production"* requirement from `TODO.md`.
- **Lazy resolution**: stores raw `[]uintptr` PCs at construction; the expensive `runtime.CallersFrames` symbol resolution runs only when the dev formatter calls `StackTrace()`.
- **`StackTracer` interface** mirrors the `pkg/errors` convention. Built-in wrapper types (`NotFoundError`, `BadRequestError`, …) inherit it via method promotion since they embed `*BaseAPIError`. User-defined error types can implement it independently.
- **Shared `devDetails()` helper** in `handler.go` merges caller-supplied details with the auto-injected `stackTrace`; used by both `formatErrorResponse` and `formatRawErrorResponse`.

Also includes a small carried-over doc commit marking ADR-014 (slim Module interface + stutter removal) as completed in `TODO.md`.

## Test plan

- [x] `make check` (fmt + lint + race tests across the framework) — green
- [x] New tests in `server/errors_test.go` cover:
  - capture disabled by default
  - capture populated when flag is on (top frame contains expected file/func)
  - wrapper types (`NewBadRequestError`) inherit `StackTracer` via promotion
  - nil receiver safety on `(*BaseAPIError).StackTrace()`
  - toggle only affects subsequently-created errors (no retro-active capture)
  - prod env strips the trace from the response **even if the capture flag is on** (defense-in-depth invariant)
- [x] `/simplify` review pass applied (extracted `stackTraceDetailKey` constant, removed three WHAT-narrating comments per repo style)
- [ ] Manual smoke: launch demo app with `app.env: development`, force a 4xx, confirm `error.details.stackTrace` array shows in response body
- [ ] Manual smoke: same with `app.env: production`, confirm the field is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Error responses include stack traces in development environments.
  * Stack trace capture is enabled in development and disabled in production.
  * Stack trace details appear in both standard and raw API error responses.
  * Stack frames show file paths, line numbers, and function names.

* **Documentation**
  * TODO updated to reflect completed items about error stack behavior and module interface changes.

* **Tests**
  * Added tests covering stack-trace capture and response rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->