### PR TITLE
feat(jose): drop ES256 from signature-algorithm allowlist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1237,8 +1237,7 @@ The `jose` package provides nested JWE-of-JWS protection on HTTP request and res
 **Key Features:**
 - **Struct-tag opt-in**: Add a `jose:` tag to a sentinel field on the request/response type — no per-route plumbing
 - **Bidirectional symmetry enforced**: both request and response must carry tags or neither (registration-time check)
-- **Strict algorithm allowlist**: `RS256`/`PS256`/`ES256` for signing; `RSA-OAEP-256` + `A256GCM` for encryption. `alg=none`, `HS*`, and `RSA1_5` are rejected at parse time
-- **ES256 caveat**: in the parser allowlist for forward compatibility, but unusable with the default `keystore.NewModule()` (which returns `*rsa.PrivateKey`/`*rsa.PublicKey`). Selecting `ES256` requires a custom `jose.KeyResolver` that returns ECDSA keys — out of scope for v1; the keystore module is RSA-only
+- **Strict algorithm allowlist**: `RS256`/`PS256` for signing; `RSA-OAEP-256` + `A256GCM` for encryption. `alg=none`, `HS*`, `RSA1_5`, and `ES256` are rejected at parse time. ECDSA support is gated on extending `keystore.KeyStore` to return ECDSA keys (tracked in TODO.md)
 - **Hybrid error envelope**: pre-trust failures (decrypt failed, signature invalid) emit a plaintext minimal `{code,message}` envelope to leak nothing to unauthenticated peers; post-trust handler errors emit the standard `APIResponse` envelope, encrypted with the route's outbound policy
 - **Fail-Fast at startup**: every `kid` is resolved against the keystore at `RegisterHandler` time. Missing keys, asymmetric tags, and `WithRawResponse()` conflicts panic at startup, never at runtime
 - **Observability**: spans (`jose.decode_request`, `jose.encode_response`), failure counter (`jose.failures.total` by code/direction), duration histogram (`jose.operation.duration`)

--- a/TODO.md
+++ b/TODO.md
@@ -64,28 +64,6 @@ query := qb.Select("id", "number").
 
 ---
 
-### JOSE: ECDSA Keystore Support or Drop ES256
-**Status:** Planned
-**Context:** `ES256` is in the JOSE signature-algorithm allowlist (`jose/algorithms.go:19`) but `keystore.NewModule()` only returns `*rsa.PrivateKey`/`*rsa.PublicKey`. A user who picks `sig_alg=ES256` in a `jose:` tag passes registration (the algorithm is in the allowlist), then crashes at runtime when the sealer/opener tries to use an ECDSA algorithm against an RSA key. Documented as a "v1 limitation" in CLAUDE.md but currently unenforced — a real footgun.
-
-**Two paths (pick one):**
-
-1. **Drop ES256** — remove `jose.ES256` from `allowedSigAlgs` until ECDSA support lands. One-line change, eliminates the footgun, no API breakage (no production code can be using ES256 today since it would crash).
-2. **Add ECDSA support** — extend `keystore.KeyStore` to return `crypto.Signer`/`crypto.PublicKey` (interface generalization), update `cryptoadapter.{Sign,Verify,Encrypt,Decrypt}` signatures to accept the broader types, dispatch by algorithm. Significant API change.
-
-**Trade-offs:**
-- Path 1 is safe and immediate; only removes a non-functional option.
-- Path 2 is the "right" answer architecturally but expands surface area without confirmed demand. Visa Token Services uses RS256/PS256 today; ES256 is forward-looking.
-
-**Recommendation:** Path 1 now, Path 2 only when a real partner requires ES256.
-
-**Related:**
-- [jose/algorithms.go](jose/algorithms.go)
-- [keystore/keystore.go](keystore/keystore.go)
-- [CLAUDE.md](CLAUDE.md) — JOSE Middleware → "ES256 caveat"
-
----
-
 ### Context Timeout Defaults
 **Status:** Planned
 **Context:** Framework requires `context.Context` everywhere but doesn't enforce timeout best practices.
@@ -276,6 +254,30 @@ go-bricks generate handler --name CreateUser --method POST --path /users
 
 ---
 
+### JOSE: ECDSA Keystore Support
+**Status:** Conditional / Idea Stage
+**Context:** `ES256` was removed from the JOSE signature-algorithm allowlist because `keystore.NewModule()` returns only `*rsa.PrivateKey`/`*rsa.PublicKey` — selecting `sig_alg=ES256` would crash at runtime. To re-enable ES256 (or future ECDSA-family algorithms like `ES384`/`ES512`), the keystore needs to surface ECDSA keys.
+
+**Implementation outline:**
+- Generalize `keystore.KeyStore` from RSA-only to `crypto.Signer` / `crypto.PublicKey` (Go's standard interfaces) — a non-trivial API change since `*rsa.PrivateKey` callers currently rely on the concrete type
+- Update `cryptoadapter.{Sign,Verify,Encrypt,Decrypt}` to accept the broader interfaces and dispatch by algorithm class (RSA vs ECDSA)
+- Re-add `jose.ES256` to `allowedSigAlgs` in `jose/algorithms.go`
+- Remove the guard test `TestAllowlistRejectsES256` in `jose/algorithms_test.go`
+- Update CLAUDE.md JOSE Middleware allowlist line
+
+**Decision criteria:** Implement only when a real partner integration requires ES256/ECDSA. Visa Token Services uses RS256/PS256 today. Speculative API expansion now would lock the framework into a `crypto.Signer` shape before we know how a real ECDSA caller wants to interact with the keystore (file-based DER? PKCS#8? raw point coordinates? per-tenant rotation?).
+
+**Trade-offs:**
+- Keeps keystore API focused on the actual production case (PRO)
+- Defers a known feature gap (CON, but documented and guard-tested)
+
+**Related:**
+- [jose/algorithms.go](jose/algorithms.go) — `allowedSigAlgs` + comment block citing this entry
+- [jose/algorithms_test.go](jose/algorithms_test.go) — `TestAllowlistRejectsES256` guard test
+- [keystore/keystore.go](keystore/keystore.go)
+
+---
+
 ### JOSE: Replay Cache Interface (`jose.ReplayCache`)
 **Status:** Conditional / Idea Stage
 **Context:** Today the JOSE middleware verifies the JWS signature and exposes verified JWT claims via `jose.ClaimsFromContext(ctx)`, but does *not* enforce `iat`/`exp`/`jti` policies — applications must implement skew windows and replay detection themselves. The original plan noted this as a follow-up: *"if apps consistently re-implement skew/jti checks, lift them into a pluggable interface"*.
@@ -393,6 +395,25 @@ require.ErrorAs(t, err, &jerr)
 - [wiki/adr-014-slim-module-interface.md](wiki/adr-014-slim-module-interface.md)
 - [app/module.go](app/module.go) — core + optional interface declarations
 - [app/module_registry.go](app/module_registry.go) — type-assertion dispatch
+
+---
+
+### ~~JOSE: Drop ES256 from Algorithm Allowlist~~
+**Status:** ✅ Completed
+**Context:** `jose.ES256` was in the JOSE signature-algorithm allowlist but `keystore.NewModule()` returned RSA keys only — selecting `sig_alg=ES256` in a `jose:` tag passed registration but crashed at runtime when the cryptoadapter passed an `*rsa.PrivateKey` into go-jose's ECDSA signer path. Documented as a "v1 limitation" in CLAUDE.md but unenforced — a runtime footgun.
+
+**Resolution (Path 1 of two options):**
+- Removed `jose.ES256` from `allowedSigAlgs` in [jose/algorithms.go](jose/algorithms.go); added a comment citing the keystore RSA-only constraint
+- Added `TestAllowlistRejectsES256` as a guard test so the algorithm cannot be silently re-added without also extending keystore support
+- Updated CLAUDE.md JOSE Middleware allowlist line: now reads `RS256`/`PS256` only, `ES256` listed alongside `alg=none`/`HS*`/`RSA1_5` as parse-time rejected
+- Future ECDSA support tracked separately as P3 conditional work (see "JOSE: ECDSA Keystore Support" entry)
+
+**Why Path 1 over Path 2 (add ECDSA support):** No real partner integration currently requires ES256; Visa Token Services uses RS256/PS256. Adding `crypto.Signer`/`crypto.PublicKey` plumbing speculatively would lock the framework into an interface shape before observing how a real ECDSA caller wants to interact with the keystore.
+
+**Related:**
+- [jose/algorithms.go](jose/algorithms.go) — `allowedSigAlgs` declaration + comment block
+- [jose/algorithms_test.go](jose/algorithms_test.go) — `TestAllowlistRejectsES256` guard
+- [CLAUDE.md](CLAUDE.md) — JOSE Middleware → "Strict algorithm allowlist"
 
 ---
 

--- a/jose/algorithms.go
+++ b/jose/algorithms.go
@@ -13,10 +13,14 @@ const (
 // payloads and selectable for outbound. Symmetric algorithms (HS*) are forbidden because
 // the framework's key model is asymmetric (RSA keypairs in keystore). alg=none is forbidden
 // at the parser level by passing this allowlist into go-jose's ParseSigned.
+//
+// ES256 is intentionally absent: the keystore module returns *rsa.PrivateKey/PublicKey
+// only, so an ES256 selection would crash at runtime when the cryptoadapter passes the
+// RSA key into go-jose's ECDSA signer. Re-add only after extending keystore.KeyStore to
+// surface ECDSA keys (see TODO.md "JOSE: ECDSA Keystore Support").
 var allowedSigAlgs = []jose.SignatureAlgorithm{
 	jose.RS256,
 	jose.PS256,
-	jose.ES256,
 }
 
 // allowedKeyAlgs are the JWE key-wrapping algorithms. Only RSA-OAEP variants are accepted;

--- a/jose/algorithms.go
+++ b/jose/algorithms.go
@@ -17,7 +17,7 @@ const (
 // ES256 is intentionally absent: the keystore module returns *rsa.PrivateKey/PublicKey
 // only, so an ES256 selection would crash at runtime when the cryptoadapter passes the
 // RSA key into go-jose's ECDSA signer. Re-add only after extending keystore.KeyStore to
-// surface ECDSA keys (see TODO.md "JOSE: ECDSA Keystore Support").
+// surface ECDSA keys — see the "JOSE: ECDSA Keystore Support" backlog entry.
 var allowedSigAlgs = []jose.SignatureAlgorithm{
 	jose.RS256,
 	jose.PS256,

--- a/jose/algorithms_test.go
+++ b/jose/algorithms_test.go
@@ -34,9 +34,19 @@ func TestAllowlistRejectsRsa15(t *testing.T) {
 func TestAllowlistAllowsExpectedAlgs(t *testing.T) {
 	assert.True(t, IsAllowedSigAlg(jose.RS256))
 	assert.True(t, IsAllowedSigAlg(jose.PS256))
-	assert.True(t, IsAllowedSigAlg(jose.ES256))
 	assert.True(t, IsAllowedKeyAlg(jose.RSA_OAEP_256))
 	assert.True(t, IsAllowedEnc(jose.A256GCM))
+}
+
+// TestAllowlistRejectsES256 guards against re-adding ES256 to the allowlist
+// before keystore.KeyStore is extended to return ECDSA keys. See the comment
+// on allowedSigAlgs in algorithms.go and TODO.md "JOSE: ECDSA Keystore Support".
+// Mirrors TestAllowlistRejectsRsa15's loop-and-NotEqual pattern so the security
+// guard cluster reads as a set.
+func TestAllowlistRejectsES256(t *testing.T) {
+	for _, alg := range AllowedSigAlgs() {
+		assert.NotEqual(t, jose.ES256, alg)
+	}
 }
 
 func TestAllowedSigAlgsReturnsCopy(t *testing.T) {

--- a/jose/algorithms_test.go
+++ b/jose/algorithms_test.go
@@ -40,9 +40,9 @@ func TestAllowlistAllowsExpectedAlgs(t *testing.T) {
 
 // TestAllowlistRejectsES256 guards against re-adding ES256 to the allowlist
 // before keystore.KeyStore is extended to return ECDSA keys. See the comment
-// on allowedSigAlgs in algorithms.go and TODO.md "JOSE: ECDSA Keystore Support".
-// Mirrors TestAllowlistRejectsRsa15's loop-and-NotEqual pattern so the security
-// guard cluster reads as a set.
+// on allowedSigAlgs in algorithms.go and the "JOSE: ECDSA Keystore Support"
+// backlog entry. Mirrors TestAllowlistRejectsRsa15's loop-and-NotEqual pattern
+// so the security guard cluster reads as a set.
 func TestAllowlistRejectsES256(t *testing.T) {
 	for _, alg := range AllowedSigAlgs() {
 		assert.NotEqual(t, jose.ES256, alg)


### PR DESCRIPTION
## Summary

`jose.ES256` was in the JOSE signature-algorithm allowlist but the keystore module returns `*rsa.PrivateKey`/`*rsa.PublicKey` only — selecting `sig_alg=ES256` in a `jose:` tag would pass registration and then crash at runtime when the cryptoadapter passed an RSA key into go-jose's ECDSA signer path. Documented as a v1 limitation in CLAUDE.md, but unenforced — a real runtime footgun.

This PR closes the gap by removing ES256 from the allowlist, taking Path 1 of two options that were tracked in TODO.md. Path 2 (extending `keystore.KeyStore` to return `crypto.Signer`/`PublicKey`) is deferred until a real partner integration requires ECDSA — committing to a `Signer` interface shape now would lock us in before observing how a real ECDSA caller actually wants to interact with the keystore.

## Wire impact
- **Behavioural:** none for any caller that wasn't already crashing. Production code couldn't have been using ES256 (it would crash at first use).
- **Tag grammar:** `sig_alg=ES256` now fails registration with `JOSE_ALGORITHM_DISALLOWED` instead of crashing at request time.
- **Allowlist:** RS256, PS256 remain.

## Internals
- `allowedSigAlgs` reduced to RS256, PS256
- Added a `TestAllowlistRejectsES256` guard test mirroring the existing `TestAllowlistRejectsRsa15` loop pattern
- Allowlist comment now documents *why* ES256 is absent + cross-references the conditional ECDSA-support backlog entry
- TODO.md: moved entry to Completed; new conditional P3 entry tracks future ECDSA support

## Test plan
- [x] All four \`TestAllowlist*\` tests pass
- [x] \`make check\` green (framework lint + race tests)
- [x] CLAUDE.md JOSE Middleware allowlist line updated
- [x] TODO.md updated (Completed + new conditional P3 entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed ES256 (ECDSA) from accepted JWS signature algorithms; only RS256 and PS256 are permitted to avoid runtime issues.

* **Documentation**
  * Clarified RSA-only signature requirements and updated guidance on future ECDSA support.

* **Tests**
  * Added a guard test to ensure ES256 cannot be silently reintroduced.

* **Chores**
  * Split the previous TODO into a completed ES256 removal entry and a separate ECDSA keystore proposal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->