### PR TITLE
refactor(jose): drop dormant cryptoadapter.AllowedTyps surface

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -302,22 +302,21 @@ go-bricks generate handler --name CreateUser --method POST --path /users
 
 ---
 
-### JOSE: Drop or Wire `cryptoadapter.AllowedTyps`
-**Status:** Cleanup / Planned
-**Context:** `cryptoadapter.{Decrypt,Verify}Options.AllowedTyps` was added speculatively at the time of the original JOSE design as a list-allowlist for the `typ` JOSE header. The field is exercised only by cryptoadapter's own unit tests — no production caller (jose package, server middleware, httpclient transport) ever sets it. Discovered during `/simplify` review of PR #332.
+### JOSE: Wire `Header.Typ` Into Observability or Drop
+**Status:** Conditional / Idea Stage
+**Context:** Both `cryptoadapter.Header.Typ` and the public `jose.Header.Typ` (returned from `Open()` as part of `OpenHeader{JWE, JWS}`) are populated on every JOSE request via `extractStringExtra(..., jose.HeaderType)`, but no caller reads either value. Server middleware discards the `OpenHeader` return at `server/jose.go`, and no observability span/log uses the field. Surfaced during `/simplify` review of the `AllowedTyps` cleanup PR — the same dormant-surface argument applies, with one asymmetry: `Typ` is part of a public return type, so dropping it is a (minor) API break, whereas `AllowedTyps` was an unused input flag.
 
-**The two states are both honest; the current half-loaded state is not:**
+**Two paths (pick one when this is taken up):**
 
-1. **Drop entirely:** remove `AllowedTyps` field, the corresponding `if len(opts.AllowedTyps) > 0` branches in `Decrypt`/`Verify`, the `ErrTypRejected` sentinel, and the `mapDecryptError`/`mapVerifyError` arms producing `JOSE_TYP_REJECTED`. Also drop the `JOSE_TYP_REJECTED` row from the CLAUDE.md failure-mode table (it would no longer be triggerable).
-2. **Wire it up:** add `Policy.AllowedTyps []string`, plumb it from the parser → opener → cryptoadapter, document configurable typ allowlists in the JOSE tag grammar (e.g. `typ=JOSE,JWS`).
+1. **Wire it up** — add `jwe.typ`/`jws.typ` attributes to the `jose.decode_request` span and to the request-log fields in `server/jose.go`. Cheap, makes the field actually load-bearing for diagnostics, and aligns with the reason the field was added in the first place.
+2. **Drop it** — remove from both `cryptoadapter.Header` and `jose.Header`, plus the two `extractStringExtra` calls. Minor break since `OpenHeader` is exposed by the public `Open()` API.
 
-**Recommendation:** Path 1. Visa Token Services and similar partners don't use the `typ` header for security gating, so the option is unlikely to ever be wired up. Removing dead surface area reduces reader confusion (the `/simplify` agent flagged it as "dormant API surface, not a live pattern to mirror").
+**Decision criteria:** Pick Path 1 if anyone hits a JOSE issue where knowing the peer's `typ` header would have helped triage. Pick Path 2 at the next opportunistic cleanup if nobody touches it.
 
 **Related:**
-- [jose/internal/cryptoadapter/cryptoadapter.go](jose/internal/cryptoadapter/cryptoadapter.go)
-- [jose/opener.go](jose/opener.go) — `mapDecryptError`/`mapVerifyError` `typ_rejected` arms
-- [jose/errors.go](jose/errors.go) — `ErrTypRejected`
-- [CLAUDE.md](CLAUDE.md) — JOSE failure-mode table
+- [jose/internal/cryptoadapter/cryptoadapter.go](jose/internal/cryptoadapter/cryptoadapter.go) — `Header.Typ` field + extractor calls in `Decrypt`/`Verify`
+- [jose/opener.go](jose/opener.go) — `Header.Typ` in the public diagnostic struct
+- [server/jose.go](server/jose.go) — current consumer that discards the return
 
 ---
 
@@ -414,6 +413,31 @@ require.ErrorAs(t, err, &jerr)
 - [jose/algorithms.go](jose/algorithms.go) — `allowedSigAlgs` declaration + comment block
 - [jose/algorithms_test.go](jose/algorithms_test.go) — `TestAllowlistRejectsES256` guard
 - [CLAUDE.md](CLAUDE.md) — JOSE Middleware → "Strict algorithm allowlist"
+
+---
+
+### ~~JOSE: Drop `cryptoadapter.AllowedTyps`~~
+**Status:** ✅ Completed
+**Context:** `cryptoadapter.{Decrypt,Verify}Options.AllowedTyps` was a list-allowlist for the JWE/JWS `typ` header added speculatively in the original JOSE design. The field had test coverage in cryptoadapter's own unit tests but no production caller (jose package, server middleware, httpclient transport) ever set it. Discovered during `/simplify` review of PR #332.
+
+**Resolution (Path 1 of two options — drop, not wire):**
+- Removed `AllowedTyps` field from both `DecryptOptions` and `VerifyOptions`
+- Removed the `if len(opts.AllowedTyps) > 0` branches in `Decrypt` and `Verify`
+- Removed the `ErrTypRejected` sentinel from cryptoadapter and the parent jose package
+- Removed the `mapDecryptError` arm producing `JOSE_TYP_REJECTED` (the verify mapper never had one)
+- Removed the dead `contains()` helper that only the typ check used
+- Removed two cryptoadapter tests (`TestVerifyAcceptsEmptyTypInAllowlist`, `TestVerifyRejectsTypNotInAllowlist`)
+- Removed the `typ_rejected` case from the `TestMapDecryptErrorAllArms` table
+- Kept `Header.Typ` field and its extraction from `ExtraHeaders` — still useful for diagnostic logging on every request
+
+**Why Path 1 over Path 2 (add `Policy.AllowedTyps` + tag grammar):** No production code path read or set `AllowedTyps`. Visa Token Services and similar partners don't use the `typ` header for security gating. Removing the dead surface area is cheaper than continuing to maintain it as half-loaded API.
+
+**Note on CLAUDE.md:** the `JOSE_TYP_REJECTED` row was never actually in the failure-mode table on `main` — it was only in an early plan-file draft. Confirmed via grep before resolving.
+
+**Related:**
+- [jose/internal/cryptoadapter/cryptoadapter.go](jose/internal/cryptoadapter/cryptoadapter.go)
+- [jose/opener.go](jose/opener.go) — `mapDecryptError` (typ arm removed)
+- [jose/errors.go](jose/errors.go) — `ErrTypRejected` sentinel removed
 
 ---
 

--- a/jose/errors.go
+++ b/jose/errors.go
@@ -13,7 +13,6 @@ var (
 	ErrNoneAlgRejected     = errors.New("jose: alg=none rejected")
 	ErrKidMissing          = errors.New("jose: header missing kid")
 	ErrCritUnsupported     = errors.New("jose: unrecognized crit header value")
-	ErrTypRejected         = errors.New("jose: header typ not allowed")
 	ErrCtyRejected         = errors.New("jose: inner cty does not match policy")
 	ErrKidUnknown          = errors.New("jose: kid not registered")
 	ErrDecryptFailed       = errors.New("jose: decryption failed")

--- a/jose/internal/cryptoadapter/cryptoadapter.go
+++ b/jose/internal/cryptoadapter/cryptoadapter.go
@@ -17,7 +17,6 @@ var (
 	ErrParseSigned       = errors.New("cryptoadapter: parse signed failed")
 	ErrKidMissing        = errors.New("cryptoadapter: header missing kid")
 	ErrKidMismatch       = errors.New("cryptoadapter: header kid does not match expected")
-	ErrTypRejected       = errors.New("cryptoadapter: header typ not in allowlist")
 	ErrDecryptFailed     = errors.New("cryptoadapter: decrypt failed")
 	ErrVerifyFailed      = errors.New("cryptoadapter: signature verification failed")
 	ErrSignFailed        = errors.New("cryptoadapter: sign failed")
@@ -41,7 +40,6 @@ type DecryptOptions struct {
 	ExpectedKid       string
 	AllowedKeyAlgs    []jose.KeyAlgorithm
 	AllowedContentEnc []jose.ContentEncryption
-	AllowedTyps       []string // empty = no typ enforcement
 }
 
 // Decrypt parses a compact JWE, validates its protected header against the allowlists,
@@ -66,9 +64,6 @@ func Decrypt(compact string, key *rsa.PrivateKey, opts *DecryptOptions) ([]byte,
 	if opts.ExpectedKid != "" && hdr.Kid != opts.ExpectedKid {
 		return nil, hdr, ErrKidMismatch
 	}
-	if len(opts.AllowedTyps) > 0 && !contains(opts.AllowedTyps, hdr.Typ) {
-		return nil, hdr, ErrTypRejected
-	}
 
 	plaintext, err := jwe.Decrypt(key)
 	if err != nil {
@@ -81,7 +76,6 @@ func Decrypt(compact string, key *rsa.PrivateKey, opts *DecryptOptions) ([]byte,
 type VerifyOptions struct {
 	ExpectedKid    string
 	AllowedSigAlgs []jose.SignatureAlgorithm
-	AllowedTyps    []string
 }
 
 // Verify parses a compact JWS, validates the protected header, and verifies the signature
@@ -109,9 +103,6 @@ func Verify(compact string, key *rsa.PublicKey, opts *VerifyOptions) ([]byte, He
 	}
 	if opts.ExpectedKid != "" && hdr.Kid != opts.ExpectedKid {
 		return nil, hdr, ErrKidMismatch
-	}
-	if len(opts.AllowedTyps) > 0 && !contains(opts.AllowedTyps, hdr.Typ) {
-		return nil, hdr, ErrTypRejected
 	}
 
 	payload, err := jws.Verify(key)
@@ -197,13 +188,4 @@ func extractStringExtra(extras map[jose.HeaderKey]interface{}, key jose.HeaderKe
 	}
 	s, _ := v.(string)
 	return s
-}
-
-func contains(haystack []string, needle string) bool {
-	for _, s := range haystack {
-		if s == needle {
-			return true
-		}
-	}
-	return false
 }

--- a/jose/internal/cryptoadapter/cryptoadapter_test.go
+++ b/jose/internal/cryptoadapter/cryptoadapter_test.go
@@ -137,38 +137,6 @@ func TestDecryptRejectsKidMissing(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrKidMissing))
 }
 
-func TestVerifyAcceptsEmptyTypInAllowlist(t *testing.T) {
-	// Sign() does not set a typ header, so the verified header has typ="". This test
-	// exercises the AllowedTyps != nil branch with empty being explicitly permitted —
-	// covers the contains() helper without requiring the upstream library to support
-	// emitting a typ header at sign time.
-	key := newKey(t)
-	compact, err := Sign([]byte("x"), key, &SignOptions{Kid: "k", SigAlg: jose.RS256, Cty: "JWT"})
-	require.NoError(t, err)
-
-	_, _, err = Verify(compact, &key.PublicKey, &VerifyOptions{
-		ExpectedKid:    "k",
-		AllowedSigAlgs: []jose.SignatureAlgorithm{jose.RS256},
-		AllowedTyps:    []string{"", "JWT"},
-	})
-	require.NoError(t, err)
-}
-
-func TestVerifyRejectsTypNotInAllowlist(t *testing.T) {
-	key := newKey(t)
-	compact, err := Sign([]byte("x"), key, &SignOptions{Kid: "k", SigAlg: jose.RS256})
-	require.NoError(t, err)
-
-	// Empty typ not in allowlist => ErrTypRejected.
-	_, _, err = Verify(compact, &key.PublicKey, &VerifyOptions{
-		ExpectedKid:    "k",
-		AllowedSigAlgs: []jose.SignatureAlgorithm{jose.RS256},
-		AllowedTyps:    []string{"strict-only"},
-	})
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrTypRejected))
-}
-
 func TestDecryptRejectsDisallowedKeyAlg(t *testing.T) {
 	key := newKey(t)
 	compact, err := Encrypt([]byte("x"), &key.PublicKey, &EncryptOptions{

--- a/jose/opener.go
+++ b/jose/opener.go
@@ -132,14 +132,6 @@ func mapDecryptError(err error, _ *Policy, hdr *cryptoadapter.Header) *Error {
 			Kid:      hdr.Kid,
 			Cause:    err,
 		}
-	case errors.Is(err, cryptoadapter.ErrTypRejected):
-		return &Error{
-			Sentinel: ErrTypRejected,
-			Code:     "JOSE_TYP_REJECTED",
-			Status:   400,
-			Message:  "Disallowed typ header",
-			Cause:    err,
-		}
 	case errors.Is(err, cryptoadapter.ErrDecryptFailed):
 		return &Error{
 			Sentinel: ErrDecryptFailed,

--- a/jose/opener_test.go
+++ b/jose/opener_test.go
@@ -12,7 +12,7 @@ import (
 // Direct unit tests for mapDecryptError / mapVerifyError. The end-to-end roundtrip
 // covers ErrParseEncrypted, ErrDecryptFailed, ErrParseSigned, and ErrVerifyFailed
 // indirectly; the table tests below cover the remaining sentinels (ErrKidMissing,
-// ErrKidMismatch, ErrTypRejected, default) plus the full mapVerifyError surface.
+// ErrKidMismatch, default) plus the full mapVerifyError surface.
 
 func TestMapDecryptErrorAllArms(t *testing.T) {
 	hdr := cryptoadapter.Header{Kid: "k1", Alg: "RSA-OAEP-256", Enc: "A256GCM"}
@@ -25,7 +25,6 @@ func TestMapDecryptErrorAllArms(t *testing.T) {
 		{name: "parse_failed", in: cryptoadapter.ErrParseEncrypted, wantCode: "JOSE_MALFORMED", wantStat: 400},
 		{name: "kid_missing", in: cryptoadapter.ErrKidMissing, wantCode: "JOSE_KID_MISSING", wantStat: 401},
 		{name: "kid_mismatch", in: cryptoadapter.ErrKidMismatch, wantCode: "JOSE_KID_UNKNOWN", wantStat: 401},
-		{name: "typ_rejected", in: cryptoadapter.ErrTypRejected, wantCode: "JOSE_TYP_REJECTED", wantStat: 400},
 		{name: "decrypt_failed", in: cryptoadapter.ErrDecryptFailed, wantCode: "JOSE_DECRYPT_FAILED", wantStat: 401},
 		{name: "default_unknown", in: errors.New("something else"), wantCode: "JOSE_DECRYPT_FAILED", wantStat: 401},
 	}


### PR DESCRIPTION
## Summary

`cryptoadapter.{Decrypt,Verify}Options.AllowedTyps` was a list-allowlist for the JWE/JWS \`typ\` header added speculatively in the original JOSE design. It had cryptoadapter unit-test coverage but **no production caller ever set it** — neither the parent jose package, the server middleware, nor the httpclient transport plumbed it through. Discovered during \`/simplify\` review of PR #332.

This PR takes Path 1 of two options: **drop the dormant surface entirely**. Path 2 (wire it up via a new \`Policy.AllowedTyps\` and tag grammar) was not chosen because Visa Token Services and similar partners don't use \`typ\` for security gating — committing to that API shape now would be more speculation, not less.

## Wire impact
- **Behavioural:** none for any production caller (none read or set the field)
- **No new public errors removed** — \`JOSE_TYP_REJECTED\` was never wired into the CLAUDE.md failure-mode table on \`main\` (confirmed via grep); it only existed in an early plan-file draft
- **Test surface shrinks** by two cryptoadapter tests + one table case in \`TestMapDecryptErrorAllArms\`

## Internals removed
- \`AllowedTyps []string\` field from both \`DecryptOptions\` and \`VerifyOptions\`
- The \`if len(opts.AllowedTyps) > 0\` branches in \`Decrypt\` and \`Verify\`
- \`cryptoadapter.ErrTypRejected\` and \`jose.ErrTypRejected\` sentinels
- The dead \`contains()\` helper (was the only caller)
- \`mapDecryptError\`'s \`JOSE_TYP_REJECTED\` arm (verify never had one)
- Two cryptoadapter tests + one table case

## Internals kept
- \`Header.Typ\` field and its \`extractStringExtra(..., jose.HeaderType)\` extraction in \`Decrypt\`/\`Verify\` — still populated on every request, surfaced via the public \`OpenHeader\` return. \`/simplify\` flagged this as the same dormant-surface pattern, but the field is part of a public return type (different breaking-change cost from an unused input flag). Tracked as a P3 follow-up in TODO.md: **JOSE: Wire \`Header.Typ\` Into Observability or Drop**.

## Test plan
- [x] \`make check\` green (framework lint + race tests)
- [x] Repo-wide grep confirms zero residuals: \`AllowedTyps\`, \`ErrTypRejected\`, \`JOSE_TYP_REJECTED\` all gone
- [x] \`/simplify\` agents reviewed — only finding was the \`Header.Typ\` follow-up question, which is now in TODO.md
- [x] TODO.md: moved entry to Completed; new P3 conditional entry tracks \`Header.Typ\` decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the `typ` header allowlist validation feature from JOSE cryptographic operations, including the `AllowedTyps` configuration options and the `ErrTypRejected` error sentinel.

* **Tests**
  * Updated unit tests to remove validation checks related to the typ header allowlist feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->