### PR TITLE
test(jose): normalize errors.As/Is to require.ErrorAs/assert.ErrorIs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -320,32 +320,6 @@ go-bricks generate handler --name CreateUser --method POST --path /users
 
 ---
 
-### JOSE: Normalize `errors.As` → `require.ErrorAs` in Tests
-**Status:** Cleanup / Planned
-**Context:** Mix of older `require.True(t, errors.As(err, &jerr))` and newer `require.ErrorAs(t, err, &jerr)` across the JOSE test suite (~11 sites in `jose/sealer_opener_test.go`, `jose/tag_test.go`, `jose/scanner_test.go`, `jose/testing/helpers_test.go`). `require.ErrorAs` is the preferred testify idiom: better failure messages on type mismatch, one line shorter, and already used by newer test files (e.g. `jose/policy_test.go`, `jose/resolver_test.go`).
-
-**Implementation:** Mechanical conversion. Each occurrence:
-```go
-// Before
-var jerr *Error
-require.True(t, errors.As(err, &jerr))
-// After
-var jerr *Error
-require.ErrorAs(t, err, &jerr)
-```
-
-**Trade-offs:**
-- Better test ergonomics (PRO)
-- Pure churn in git history (CON — minor)
-
-**Decision:** Bundle into a single low-risk cleanup PR; don't drip individual conversions across feature PRs.
-
-**Related:**
-- [jose/sealer_opener_test.go](jose/sealer_opener_test.go), [jose/tag_test.go](jose/tag_test.go), [jose/scanner_test.go](jose/scanner_test.go)
-- [jose/testing/helpers_test.go](jose/testing/helpers_test.go)
-
----
-
 ## Completed / Won't Do
 
 ### ~~Raw String WHERE Clauses~~
@@ -438,6 +412,23 @@ require.ErrorAs(t, err, &jerr)
 - [jose/internal/cryptoadapter/cryptoadapter.go](jose/internal/cryptoadapter/cryptoadapter.go)
 - [jose/opener.go](jose/opener.go) — `mapDecryptError` (typ arm removed)
 - [jose/errors.go](jose/errors.go) — `ErrTypRejected` sentinel removed
+
+---
+
+### ~~JOSE: Normalize `errors.As`/`errors.Is` → `require.ErrorAs`/`assert.ErrorIs` in Tests~~
+**Status:** ✅ Completed
+**Context:** The JOSE test suite mixed `require.True(t, errors.As(err, &jerr))` and `assert.True(t, errors.Is(err, X))` with the preferred testify idioms `require.ErrorAs(t, err, &jerr)` and `assert.ErrorIs(t, err, X)`. The newer style produces better failure messages on mismatch and saves a line per call site. Newer test files (e.g. `jose/policy_test.go`, `jose/resolver_test.go`) already used the upgraded idiom.
+
+**Resolution:**
+- Converted all 11 `errors.As` sites in `jose/sealer_opener_test.go` (8), `jose/tag_test.go` (1), `jose/scanner_test.go` (1), `jose/testing/helpers_test.go` (1)
+- Converted all 8 `errors.Is` sites in `jose/errors_test.go` (2 — including one `assert.False` → `assert.NotErrorIs`) and `jose/internal/cryptoadapter/cryptoadapter_test.go` (6)
+- Dropped the now-unused `errors` import from 5 files (kept in `jose/errors_test.go` because `errors.New` is still used to construct fixture errors)
+- Bundled `errors.Is` conversions in via `/simplify` agent surfaced them as the same idiom upgrade — saved a follow-up PR
+
+**Related:**
+- [jose/sealer_opener_test.go](jose/sealer_opener_test.go), [jose/tag_test.go](jose/tag_test.go), [jose/scanner_test.go](jose/scanner_test.go)
+- [jose/testing/helpers_test.go](jose/testing/helpers_test.go)
+- [jose/errors_test.go](jose/errors_test.go), [jose/internal/cryptoadapter/cryptoadapter_test.go](jose/internal/cryptoadapter/cryptoadapter_test.go)
 
 ---
 

--- a/jose/errors_test.go
+++ b/jose/errors_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestErrorIsMatchesSentinel(t *testing.T) {
 	e := &Error{Sentinel: ErrDecryptFailed, Code: "JOSE_DECRYPT_FAILED"}
-	assert.True(t, errors.Is(e, ErrDecryptFailed))
-	assert.False(t, errors.Is(e, ErrSignatureInvalid))
+	assert.ErrorIs(t, e, ErrDecryptFailed)
+	assert.NotErrorIs(t, e, ErrSignatureInvalid)
 }
 
 func TestErrorErrorIncludesCodeAndCause(t *testing.T) {

--- a/jose/internal/cryptoadapter/cryptoadapter_test.go
+++ b/jose/internal/cryptoadapter/cryptoadapter_test.go
@@ -3,7 +3,6 @@ package cryptoadapter
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"errors"
 	"testing"
 
 	jose "github.com/go-jose/go-jose/v4"
@@ -72,7 +71,7 @@ func TestVerifyRejectsKidMismatch(t *testing.T) {
 		AllowedSigAlgs: []jose.SignatureAlgorithm{jose.RS256},
 	})
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrKidMismatch))
+	assert.ErrorIs(t, err, ErrKidMismatch)
 }
 
 func TestDecryptRejectsKidMismatch(t *testing.T) {
@@ -90,7 +89,7 @@ func TestDecryptRejectsKidMismatch(t *testing.T) {
 		AllowedContentEnc: []jose.ContentEncryption{jose.A256GCM},
 	})
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrKidMismatch))
+	assert.ErrorIs(t, err, ErrKidMismatch)
 }
 
 func TestVerifyRejectsDisallowedAlg(t *testing.T) {
@@ -104,7 +103,7 @@ func TestVerifyRejectsDisallowedAlg(t *testing.T) {
 		AllowedSigAlgs: []jose.SignatureAlgorithm{jose.PS256},
 	})
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrParseSigned))
+	assert.ErrorIs(t, err, ErrParseSigned)
 }
 
 func TestVerifyRejectsKidMissing(t *testing.T) {
@@ -118,7 +117,7 @@ func TestVerifyRejectsKidMissing(t *testing.T) {
 		AllowedSigAlgs: []jose.SignatureAlgorithm{jose.RS256},
 	})
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrKidMissing))
+	assert.ErrorIs(t, err, ErrKidMissing)
 }
 
 func TestDecryptRejectsKidMissing(t *testing.T) {
@@ -134,7 +133,7 @@ func TestDecryptRejectsKidMissing(t *testing.T) {
 		AllowedContentEnc: []jose.ContentEncryption{jose.A256GCM},
 	})
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrKidMissing))
+	assert.ErrorIs(t, err, ErrKidMissing)
 }
 
 func TestDecryptRejectsDisallowedKeyAlg(t *testing.T) {
@@ -153,5 +152,5 @@ func TestDecryptRejectsDisallowedKeyAlg(t *testing.T) {
 		AllowedContentEnc: []jose.ContentEncryption{jose.A256GCM},
 	})
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrParseEncrypted))
+	assert.ErrorIs(t, err, ErrParseEncrypted)
 }

--- a/jose/scanner_test.go
+++ b/jose/scanner_test.go
@@ -1,7 +1,6 @@
 package jose
 
 import (
-	"errors"
 	"reflect"
 	"testing"
 
@@ -72,6 +71,6 @@ func TestScanTypeBadKidPropagatesError(t *testing.T) {
 	_, err := ScanType(reflect.TypeOf(taggedRequestWithBadKid{}), DirectionInbound)
 	require.Error(t, err)
 	var jerr *Error
-	require.True(t, errors.As(err, &jerr))
+	require.ErrorAs(t, err, &jerr)
 	assert.Equal(t, "JOSE_TAG_KID_INVALID", jerr.Code)
 }

--- a/jose/sealer_opener_test.go
+++ b/jose/sealer_opener_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
-	"errors"
 	"testing"
 	"time"
 
@@ -125,7 +124,7 @@ func TestOpenTamperedCiphertextFails(t *testing.T) {
 	err = openErr(string(tampered), f.inbound, f.resolver)
 	require.Error(t, err)
 	var jerr *Error
-	require.True(t, errors.As(err, &jerr))
+	require.ErrorAs(t, err, &jerr)
 	assert.True(t,
 		jerr.Code == "JOSE_DECRYPT_FAILED" || jerr.Code == "JOSE_MALFORMED",
 		"unexpected error code: %s", jerr.Code,
@@ -147,7 +146,7 @@ func TestOpenWrongVerifyKeyFails(t *testing.T) {
 	err = openErr(compact, f.inbound, f.resolver)
 	require.Error(t, err)
 	var jerr *Error
-	require.True(t, errors.As(err, &jerr))
+	require.ErrorAs(t, err, &jerr)
 	assert.Equal(t, "JOSE_SIGNATURE_INVALID", jerr.Code)
 	assert.Equal(t, 401, jerr.Status)
 }
@@ -157,7 +156,7 @@ func TestSealRequiresOutboundPolicy(t *testing.T) {
 	_, err := Seal([]byte("x"), f.inbound, f.resolver)
 	require.Error(t, err)
 	var jerr *Error
-	require.True(t, errors.As(err, &jerr))
+	require.ErrorAs(t, err, &jerr)
 	assert.Equal(t, "JOSE_POLICY_DIRECTION_MISMATCH", jerr.Code)
 }
 
@@ -166,7 +165,7 @@ func TestOpenRequiresInboundPolicy(t *testing.T) {
 	err := openErr("x", f.outbound, f.resolver)
 	require.Error(t, err)
 	var jerr *Error
-	require.True(t, errors.As(err, &jerr))
+	require.ErrorAs(t, err, &jerr)
 	assert.Equal(t, "JOSE_POLICY_DIRECTION_MISMATCH", jerr.Code)
 }
 
@@ -175,7 +174,7 @@ func TestOpenMalformedInputFails(t *testing.T) {
 	err := openErr("not.a.compact.jose", f.inbound, f.resolver)
 	require.Error(t, err)
 	var jerr *Error
-	require.True(t, errors.As(err, &jerr))
+	require.ErrorAs(t, err, &jerr)
 	assert.Equal(t, "JOSE_MALFORMED", jerr.Code)
 	assert.Equal(t, 400, jerr.Status)
 }
@@ -211,7 +210,7 @@ func TestSealRejectsNilResolver(t *testing.T) {
 	_, err := Seal([]byte("x"), f.outbound, nil)
 	require.Error(t, err)
 	var jerr *Error
-	require.True(t, errors.As(err, &jerr))
+	require.ErrorAs(t, err, &jerr)
 	assert.Equal(t, "JOSE_KEYSTORE_UNAVAILABLE", jerr.Code)
 }
 
@@ -220,7 +219,7 @@ func TestOpenRejectsNilResolver(t *testing.T) {
 	err := openErr("not-used", f.inbound, nil)
 	require.Error(t, err)
 	var jerr *Error
-	require.True(t, errors.As(err, &jerr))
+	require.ErrorAs(t, err, &jerr)
 	assert.Equal(t, "JOSE_KEYSTORE_UNAVAILABLE", jerr.Code)
 }
 
@@ -232,7 +231,7 @@ func TestSealMissingKid(t *testing.T) {
 	_, err := Seal([]byte("x"), &bad, f.resolver)
 	require.Error(t, err)
 	var jerr *Error
-	require.True(t, errors.As(err, &jerr))
+	require.ErrorAs(t, err, &jerr)
 	assert.Equal(t, "JOSE_KID_UNKNOWN", jerr.Code)
 }
 

--- a/jose/tag_test.go
+++ b/jose/tag_test.go
@@ -1,7 +1,6 @@
 package jose
 
 import (
-	"errors"
 	"testing"
 
 	jose "github.com/go-jose/go-jose/v4"
@@ -71,7 +70,7 @@ func TestParseTagInvalid(t *testing.T) {
 			_, err := ParseTag(tt.tag, tt.dir)
 			require.Error(t, err)
 			var jerr *Error
-			require.True(t, errors.As(err, &jerr))
+			require.ErrorAs(t, err, &jerr)
 			assert.Equal(t, tt.wantCode, jerr.Code, "expected code %q, got %q", tt.wantCode, jerr.Code)
 		})
 	}

--- a/jose/testing/helpers_test.go
+++ b/jose/testing/helpers_test.go
@@ -1,7 +1,6 @@
 package testing_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/gaborage/go-bricks/jose"
@@ -59,7 +58,7 @@ func TestNewTestResolverAcceptsPublicOnly(t *testing.T) {
 	_, err = resolver.PrivateKey("peer-pub")
 	require.Error(t, err)
 	var jerr *jose.Error
-	require.True(t, errors.As(err, &jerr))
+	require.ErrorAs(t, err, &jerr)
 	assert.Equal(t, "JOSE_KID_UNKNOWN", jerr.Code)
 }
 


### PR DESCRIPTION
## Summary

Mixed style across the JOSE test suite:
- **11 sites** of \`require.True(t, errors.As(err, &jerr))\` instead of \`require.ErrorAs(t, err, &jerr)\`
- **8 sites** of \`assert.True/False(t, errors.Is(err, X))\` instead of \`assert.ErrorIs(t, err, X)\` / \`assert.NotErrorIs(t, err, X)\`

The testify idioms produce richer failure messages (showing the unwrapped chain or expected sentinel) and save one wrapper call per assertion. Newer test files (\`jose/policy_test.go\`, \`jose/resolver_test.go\`) already used them.

## Test plan
- [x] \`make check\` green
- [x] All 19 conversions complete; \`grep "require.True(t, errors.As\\|assert.True(t, errors.Is"\` returns zero hits in jose/
- [x] \`/simplify\` ran before push — surfaced the 8 \`errors.Is\` sites as the same idiom upgrade, folded them in to avoid a follow-up PR
- [x] TODO.md updated: entry moved to Completed with the expanded scope documented

## Files changed (7)

| File | Change |
|---|---|
| \`jose/sealer_opener_test.go\` | 8 \`ErrorAs\` conversions, drop \`errors\` import |
| \`jose/tag_test.go\` | 1 \`ErrorAs\`, drop \`errors\` import |
| \`jose/scanner_test.go\` | 1 \`ErrorAs\`, drop \`errors\` import |
| \`jose/testing/helpers_test.go\` | 1 \`ErrorAs\`, drop \`errors\` import |
| \`jose/errors_test.go\` | 2 \`ErrorIs\` (one as \`NotErrorIs\`); \`errors\` import kept (still uses \`errors.New\` for fixtures) |
| \`jose/internal/cryptoadapter/cryptoadapter_test.go\` | 6 \`ErrorIs\`, drop \`errors\` import |
| \`TODO.md\` | move entry to Completed |

Mechanical, zero behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized error assertion patterns across the test suite using dedicated assertion helpers.
  * Improved test code consistency and readability.
  * Cleaned up unused imports from test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->