### PR TITLE
docs(security): codify // SECURITY: annotation policy for f.Raw/jf.Raw

### DIFF
--- a/.claude/commands/security-audit.md
+++ b/.claude/commands/security-audit.md
@@ -5,7 +5,7 @@ Run a comprehensive security audit of the GoBricks codebase.
 ## Workflow
 
 1. **Static analysis**: Run `golangci-lint run --enable gosec ./...` to find security issues.
-2. **WhereRaw audit**: Search for all `WhereRaw()` usages and verify each has the required security annotation comment: `// SECURITY: Manual SQL review completed - identifier quoting verified`. Flag any missing annotations.
+2. **Raw-SQL escape hatch audit**: Search for all `f.Raw(` and `jf.Raw(` call sites (the FilterFactory / JoinFilterFactory escape hatches) with `git grep -E 'f\.Raw\(|jf\.Raw\('` and verify each has an inline security annotation matching the prefix `// SECURITY: Manual SQL review completed - ` (the rationale after the prefix is per-site). Flag any call site missing the prefix. The annotation may live directly above the call, or above an enclosing dispatch (e.g. a table-driven loop or a multi-call JoinOn chain) when the safety property is uniform across the calls. See CLAUDE.md "Detailed Security Guidelines" and the godoc on `FilterFactory.Raw` for the policy.
 3. **Secrets scan**: Search for patterns that suggest hardcoded secrets (API keys, passwords, tokens, connection strings) in Go files and config files. Exclude `.example` files and test fixtures.
 4. **Input validation**: Check all HTTP handler request structs for `validate` tags. Flag handlers that accept user input without validation.
 5. **Vulnerability check**: Run `govulncheck ./...` to find known vulnerabilities in dependencies.
@@ -31,6 +31,6 @@ Generated: {date}
 
 ## Severity Classification
 - **Critical**: Hardcoded secrets, SQL injection without sanitization, known CVEs with exploits
-- **High**: Missing input validation on public endpoints, unsafe WhereRaw without annotation
+- **High**: Missing input validation on public endpoints, raw-SQL escape hatch (`f.Raw` / `jf.Raw`) without `// SECURITY:` annotation
 - **Medium**: Missing validation tags, outdated dependencies with vulnerabilities
 - **Low**: Informational findings, minor gosec warnings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,14 +111,14 @@ GoBricks is a **production-grade framework for building MVPs fast**. It provides
 - **Composition > Inheritance** → Flexible, simple structures. Use interfaces and embedding over inheritance.
 - **Robustness** → Handle errors idiomatically, wrap once at boundaries. No silent failures.
 - **Patterns, not Over-Design** → Use them only when they solve real problems. Justify abstractions.
-- **Security First** → Input validation mandatory, secrets from env/vault, audit `WhereRaw()` usage.
+- **Security First** → Input validation mandatory, secrets from env/vault, audit raw-SQL escape hatches (see Detailed Security Guidelines below).
 - **Context-First Design** → Always pass `context.Context` as first parameter for tracing, cancellation, deadlines.
 - **Interface Segregation** → Small, focused interfaces for testability (e.g., `Client` vs `AMQPClient`).
 - **Vendor Agnosticism** → Abstract high-cost dependencies (databases), embrace low-cost ones (HTTP frameworks).
 
 #### Detailed Security Guidelines
 - Input validation is **mandatory** at all boundaries (HTTP, messaging, database)
-- `WhereRaw()` requires annotation: `// SECURITY: Manual SQL review completed - identifier quoting verified`
+- Raw-SQL escape hatches (`f.Raw()` and `jf.Raw()` on `FilterFactory` / `JoinFilterFactory`) require an inline `// SECURITY: Manual SQL review completed - <what was verified>` annotation at every call site. The annotation is a forcing function for review — even on "obviously safe" literal SQL — and makes call sites grep-discoverable (`git grep -E 'f\.Raw\(|jf\.Raw\('`). The rationale should name the specific property checked: identifier quoting for vendor reserved words, parameterization of value sides, absence of user-input concatenation, etc.
 - Secrets from environment variables or secret managers (AWS Secrets Manager, HashiCorp Vault)
 - No hardcoded credentials, no secrets in logs or error messages
 - Audit logging for sensitive operations (access control, data modifications)
@@ -591,7 +591,7 @@ query := qb.Select(cols.Fields("ID", "Number")...).
 
 **Type-Safe Methods:** `f.Eq`, `f.NotEq`, `f.Lt/Lte/Gt/Gte`, `f.In/NotIn`, `f.Like`, `f.Null/NotNull`, `f.Between`
 
-**Escape Hatch:** `WhereRaw(condition, args...)` - user must manually quote Oracle reserved words
+**Escape Hatch:** `f.Raw(condition, args...)` (and `jf.Raw(...)` for JOIN conditions) — user must manually quote Oracle reserved words and parameterize all value sides. Every call site MUST carry a `// SECURITY: Manual SQL review completed - <rationale>` comment (see Detailed Security Guidelines).
 
 #### Table Aliases
 
@@ -2007,7 +2007,7 @@ golangci-lint run
 
 ```bash
 # Oracle: ORA-00936 "missing expression"
-# → Use type-safe WHERE methods (.WhereEq) instead of .WhereRaw() for auto-quoting
+# → Use type-safe filter methods (f.Eq, f.Lt, f.In, etc.) instead of f.Raw() for auto-quoting
 
 # PostgreSQL: "syntax error at or near $1"
 # → Check placeholder numbering (PostgreSQL: $1,$2; Oracle: :1,:2)

--- a/TODO.md
+++ b/TODO.md
@@ -12,32 +12,7 @@ This document tracks future enhancements, technical improvements, and nice-to-ha
 
 ## P0 - Critical
 
-### Security Audit Annotations for WhereRaw()
-**Status:** Planned
-**Context:** `WhereRaw()` bypasses SQL safety mechanisms. All usage should require explicit security review annotation.
-
-**Requirements:**
-- Audit all existing `WhereRaw()` usage in codebase
-- Add linting rule or pre-commit hook to require annotation
-- Document annotation format in CLAUDE.md
-
-**Annotation Format:**
-```go
-// SECURITY: Manual SQL review completed - identifier quoting verified for Oracle
-query := qb.Select("id", "number").
-    From("accounts").
-    WhereRaw(`"number" = ? AND ROWNUM <= ?`, value, 10)
-```
-
-**Tasks:**
-- [ ] Search codebase for all `WhereRaw()` usage
-- [ ] Add annotations to existing usage
-- [ ] Document in CLAUDE.md security section
-- [ ] Consider custom linter rule (optional)
-
-**Related:**
-- ADR-005: Type-Safe WHERE Clause Construction
-- [database/internal/builder/](database/internal/builder/)
+_(no open P0 items)_
 
 ---
 
@@ -321,6 +296,31 @@ go-bricks generate handler --name CreateUser --method POST --path /users
 ---
 
 ## Completed / Won't Do
+
+### ~~Security Audit Annotations for Raw-SQL Escape Hatches~~
+**Status:** ✅ Completed (2026-04-30)
+**Context:** Originally filed against `WhereRaw()`, the pre-v0.15.0 escape hatch on the query builder. The struct-based column work in v0.15.0+ (ADR-007) shifted the escape hatch onto the filter factories: `f.Raw()` (on `FilterFactory`) and `jf.Raw()` (on `JoinFilterFactory`). The audit and policy landed against the current API; documentation references to `WhereRaw()` in CLAUDE.md and llms.txt were also a stale-doc bug — fixed in the same change.
+
+**Audit findings:**
+- **Zero production usage** of any raw-SQL escape hatch in the framework. All callers use the type-safe filter methods (`f.Eq`, `f.In`, `f.Between`, etc.).
+- **9 call sites total**, all in `_test.go` files under `database/internal/builder/`: `filter_test.go` (4), `oracle_test.go` (table-driven, 1 annotation covering both branches), `join_filter_test.go` (2), `query_builder_test.go` (3 in one test).
+- One additional documentation example in `llms.txt` (a tenant-isolation `f.Raw("1 = 0")` safety fallback).
+
+**Resolution:**
+- Added `// SECURITY: Manual SQL review completed - <rationale>` annotations to every call site, with the rationale tailored to each site's risk profile (literal column comparison, parameterized values, Oracle reserved-word quoting, etc.). For the Oracle table-driven test, a single annotation above the dispatch documents the safety property of the entire fixture.
+- Codified the annotation requirement in CLAUDE.md "Detailed Security Guidelines" — the comment is a forcing function for review even on "obviously safe" literal SQL, and makes call sites grep-discoverable via `git grep -E 'f\.Raw\(|jf\.Raw\('`.
+- Added an "Escape hatch" row to the API quick-reference table in `llms.txt` so LLM-generated code picks up the annotation requirement.
+- Skipped the optional custom linter: with zero production usage and the API being short and grep-able, a linter would be YAGNI. If raw escape-hatch usage starts appearing in production code, revisit at that point.
+
+**Why the API drift mattered for this work:** The TODO entry, CLAUDE.md, and llms.txt were all referencing `WhereRaw()` as if it still existed on the query builder. It does not — only `f.Raw()` and `jf.Raw()` on the filter factories. Fixing the doc references alongside the annotation work prevents future contributors (human or LLM) from looking for a method that doesn't exist.
+
+**Related:**
+- ADR-005: Type-Safe WHERE Clause Construction
+- ADR-007: Struct-Based Column Extraction (introduced the FilterFactory split)
+- [database/internal/builder/filter.go](database/internal/builder/filter.go), [database/internal/builder/join_filter.go](database/internal/builder/join_filter.go) — `Raw()` method definitions
+- [CLAUDE.md](CLAUDE.md) — Detailed Security Guidelines, Escape Hatch reference, Database Issues troubleshooting
+
+---
 
 ### ~~Raw String WHERE Clauses~~
 **Status:** ❌ Won't Do

--- a/database/internal/builder/filter.go
+++ b/database/internal/builder/filter.go
@@ -291,14 +291,24 @@ func (ff *FilterFactory) Not(filter dbtypes.Filter) dbtypes.Filter {
 //   - Ensure the SQL fragment is valid for the target database
 //   - Never concatenate user input directly into the condition string
 //
+// REQUIRED: Every call site MUST carry an inline annotation of the form
+// `// SECURITY: Manual SQL review completed - <rationale>` documenting the
+// specific safety property checked (e.g. identifier quoting for vendor reserved
+// words, parameterization of value sides, absence of user input). The annotation
+// is a forcing function for review and makes call sites grep-discoverable via
+// `git grep -E 'f\.Raw\(|jf\.Raw\('`. See CLAUDE.md "Detailed Security Guidelines".
+//
 // Use this method ONLY when the type-safe methods cannot express your condition.
 // For Oracle, remember to quote reserved words: Raw(`"number" = ?`, value)
 //
 // Examples:
 //
-//	f.Raw(`"number" = ?`, accountNumber)  // Oracle reserved word
-//	f.Raw(`ROWNUM <= ?`, 10)              // Oracle-specific syntax
-//	f.Raw(`ST_Distance(location, ?) < ?`, point, radius) // Spatial queries
+//	// SECURITY: Manual SQL review completed - "number" pre-quoted for Oracle, value parameterized
+//	f.Raw(`"number" = ?`, accountNumber)
+//	// SECURITY: Manual SQL review completed - ROWNUM is a pseudo-column, value parameterized
+//	f.Raw(`ROWNUM <= ?`, 10)
+//	// SECURITY: Manual SQL review completed - both args parameterized; spatial fn is a built-in
+//	f.Raw(`ST_Distance(location, ?) < ?`, point, radius)
 func (ff *FilterFactory) Raw(condition string, args ...any) dbtypes.Filter {
 	return Filter{sqlizer: squirrel.Expr(condition, args...)}
 }

--- a/database/internal/builder/filter_test.go
+++ b/database/internal/builder/filter_test.go
@@ -427,6 +427,7 @@ func TestFilterRaw(t *testing.T) {
 	f := qb.Filter()
 
 	// Test Raw filter in a full query to verify placeholder formatting
+	// SECURITY: Manual SQL review completed - test fixture uses literal column "name" and a parameterized value, no user input concatenation
 	query := qb.Select("*").From("users").Where(f.Raw("UPPER(name) = ?", "JOHN"))
 	sql, args, err := query.ToSQL()
 
@@ -440,6 +441,7 @@ func TestFilterRawOracleReservedWord(t *testing.T) {
 	f := qb.Filter()
 
 	// Test Raw filter with Oracle reserved words in a full query
+	// SECURITY: Manual SQL review completed - "number" is double-quoted for Oracle reserved-word handling; ROWNUM is a pseudo-column; both placeholders are parameterized
 	query := qb.Select("*").From("accounts").Where(f.Raw(`"number" = ? AND ROWNUM <= ?`, "12345", 10))
 	sql, args, err := query.ToSQL()
 
@@ -858,6 +860,9 @@ func TestFilterNestedSubqueries(t *testing.T) {
 		qb := NewQueryBuilder(dbtypes.PostgreSQL)
 		f := qb.Filter()
 
+		// SECURITY: Manual SQL review completed - both f.Raw calls below are correlated-subquery
+		// joins on literal qualified column identifiers; no user input, no identifiers requiring
+		// vendor quoting (PostgreSQL fixture).
 		// Inner EXISTS: check for reviews
 		reviewSubquery := qb.Select("1").
 			From("reviews").

--- a/database/internal/builder/join_filter.go
+++ b/database/internal/builder/join_filter.go
@@ -409,12 +409,19 @@ func (jff *JoinFilterFactory) Or(filters ...dbtypes.JoinFilter) dbtypes.JoinFilt
 //   - Ensure the SQL fragment is valid for the target database
 //   - Never concatenate user input directly into the condition string
 //
+// REQUIRED: Every call site MUST carry an inline annotation of the form
+// `// SECURITY: Manual SQL review completed - <rationale>` documenting the
+// specific safety property checked. See FilterFactory.Raw for details and
+// CLAUDE.md "Detailed Security Guidelines".
+//
 // Use this method ONLY when the type-safe methods cannot express your JOIN condition.
 //
 // Examples:
 //
-//	jf.Raw(`users.id = profiles.user_id AND profiles."type" = ?`, "primary")  // Mixed column comparison + value
-//	jf.Raw(`ST_Distance(users.location, stores.location) < 1000`)            // Spatial functions
+//	// SECURITY: Manual SQL review completed - literal qualified identifiers; value side parameterized
+//	jf.Raw(`users.id = profiles.user_id AND profiles."type" = ?`, "primary")
+//	// SECURITY: Manual SQL review completed - column-to-column comparison only, no user input
+//	jf.Raw(`ST_Distance(users.location, stores.location) < 1000`)
 func (jff *JoinFilterFactory) Raw(condition string, args ...any) dbtypes.JoinFilter {
 	return JoinFilter{sqlizer: squirrel.Expr(condition, args...)}
 }

--- a/database/internal/builder/join_filter_test.go
+++ b/database/internal/builder/join_filter_test.go
@@ -144,6 +144,7 @@ func TestJoinFilterRaw(t *testing.T) {
 	jf := qb.JoinFilter()
 
 	t.Run("Raw without args", func(t *testing.T) {
+		// SECURITY: Manual SQL review completed - test fixture string is a literal column-to-column comparison, no user input
 		filter := jf.Raw(testExpectedJoinSQL)
 		sql, args, err := filter.ToSQL()
 		require.NoError(t, err)
@@ -152,6 +153,7 @@ func TestJoinFilterRaw(t *testing.T) {
 	})
 
 	t.Run("Raw with args (mixed column comparison + value)", func(t *testing.T) {
+		// SECURITY: Manual SQL review completed - column comparison uses literal qualified identifiers; value side is parameterized via ?
 		filter := jf.Raw(`users.id = profiles.user_id AND profiles.type = ?`, "primary")
 		sql, args, err := filter.ToSQL()
 		require.NoError(t, err)

--- a/database/internal/builder/oracle_test.go
+++ b/database/internal/builder/oracle_test.go
@@ -511,6 +511,9 @@ func TestWhereRawForComplexOracleQueries(t *testing.T) {
 		},
 	}
 
+	// SECURITY: Manual SQL review completed - all `tt.condition` values are literal strings from the
+	// static fixture above; identifier quoting verified for Oracle reserved words ("number", "level",
+	// "size", "name") and ROWNUM is a pseudo-column; placeholders are parameterized.
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var query dbtypes.SelectQueryBuilder

--- a/database/internal/builder/query_builder_test.go
+++ b/database/internal/builder/query_builder_test.go
@@ -820,6 +820,7 @@ func TestTableAliasMultipleJoins(t *testing.T) {
 		jf := qb.JoinFilter()
 		f := qb.Filter()
 
+		// SECURITY: Manual SQL review completed - all jf.Raw conditions below use literal qualified column identifiers and Oracle's TO_NUMBER built-in; the only value side ("p.status = ?") is parameterized
 		query := qb.Select(selectAll).
 			From(dbtypes.MustTable(tableOrders).MustAs("o")).
 			JoinOn(dbtypes.MustTable("customers").MustAs("c"),

--- a/llms.txt
+++ b/llms.txt
@@ -807,6 +807,7 @@ rows, err := db.Query(ctx, sql, args...)
 | Mutations           | `qb.Insert`, `qb.Update`, `qb.Delete`, then `db.Exec`                  |
 | Joins               | `qb.JoinOn` with `qb.JoinFilter()`                                     |
 | Subqueries          | Compose another builder clause then `f.Exists(subQuery)`               |
+| Raw escape hatch    | `f.Raw(cond, args...)` / `jf.Raw(cond, args...)` — REQUIRES `// SECURITY: Manual SQL review completed - <rationale>` comment at every call site (manual identifier quoting + parameterized values; never concatenate user input) |
 | Transactions        | `tx, err := db.Begin(ctx); if err != nil { return err }; defer tx.Rollback(ctx); /* work */; if err := tx.Commit(ctx); err != nil { return err }` |
 
 **Mutation Examples (INSERT/UPDATE/DELETE):**
@@ -2956,6 +2957,7 @@ func WithTenantFilter(ctx context.Context, f *builder.Filter, cols dbtypes.Colum
     if !ok || tenantID == "" {
         // Return always-false condition to prevent returning any data
         // This is a safety fallback - callers should validate tenant first
+        // SECURITY: Manual SQL review completed - literal constant "1 = 0" with no identifiers, parameters, or user input; risk-free by construction but annotated to comply with the f.Raw audit policy
         return f.Raw("1 = 0")  // No rows will match
     }
     return f.Eq(cols.Col("TenantID"), tenantID)

--- a/wiki/adr-005-type-safe-where-clauses.md
+++ b/wiki/adr-005-type-safe-where-clauses.md
@@ -4,6 +4,8 @@
 **Status:** Accepted
 **Context:** Oracle identifier quoting reliability and SQL injection prevention
 
+> **API Drift Note (2026-04-30):** The original implementation placed the type-safe methods (`WhereEq`, `WhereLt`, …) and the escape hatch (`WhereRaw`) directly on `SelectQueryBuilder`. ADR-007 (Struct-Based Column Extraction) refactored these onto two filter factories: `FilterFactory` (`f.Eq`, `f.Lt`, …, `f.Raw`) returned by `qb.Filter()`, and `JoinFilterFactory` (`jf.Raw`, `jf.EqColumn`, …) returned by `qb.JoinFilter()`. The body below documents the original v0.x design intent and remains accurate as a historical record. When applying this ADR to current code, mentally substitute `f.Raw` / `jf.Raw` for `WhereRaw`, and the type-safe methods now live on `f.*` rather than `*SelectQueryBuilder`. The annotation policy (`// SECURITY: Manual SQL review completed - <rationale>` at every escape-hatch call site) applies to both `f.Raw` and `jf.Raw`; see CLAUDE.md "Detailed Security Guidelines".
+
 ## Problem Statement
 
 The framework's query builder allowed raw string WHERE clauses that could bypass Oracle identifier quoting, leading to runtime SQL errors when reserved words were used unquoted:


### PR DESCRIPTION
## Summary

Audits the raw-SQL escape hatches on \`FilterFactory\` and \`JoinFilterFactory\` and requires an inline \`// SECURITY: Manual SQL review completed - <rationale>\` annotation at every call site. The annotation is a forcing function for review — even on "obviously safe" literal SQL — and makes call sites grep-discoverable via \`git grep -E 'f\.Raw\(|jf\.Raw\('\`.

The TODO entry was originally filed against \`WhereRaw()\` (the pre-v0.15.0 escape hatch on the query builder). The struct-based column work in v0.15.0+ (ADR-007) shifted that escape hatch onto \`f.Raw()\` / \`jf.Raw()\` on the filter factories. The audit and policy land against the *current* API, and the stale \`WhereRaw\` references in CLAUDE.md, llms.txt, ADR-005, and the \`security-audit\` slash command are fixed in the same change.

**Audit findings:**
- **Zero production usage** of any raw-SQL escape hatch in the framework. All callers use the type-safe filter methods (\`f.Eq\`, \`f.In\`, \`f.Between\`, …).
- **9 call sites total**, all in \`_test.go\` files under \`database/internal/builder/\`.
- One additional \`f.Raw("1 = 0")\` documentation example in \`llms.txt\` (tenant-isolation safety fallback).

## Test plan
- [x] \`make check\` green (fmt + lint + test with race detection)
- [x] All 9 \`f.Raw\` / \`jf.Raw\` call sites annotated; \`git grep -E 'f\.Raw\(|jf\.Raw\('\` shows every site preceded by a \`// SECURITY:\` comment (directly or via an enclosing dispatch comment for table-driven loops / multi-call chains)
- [x] \`/simplify\` ran before push — surfaced 5 missed targets (godoc on \`Raw()\`, \`security-audit\` slash command, duplicated annotation in nested-EXISTS test, redundant CLAUDE.md manifesto bullet, stale ADR-005 references), all folded in
- [x] godoc on \`FilterFactory.Raw\` / \`JoinFilterFactory.Raw\` carries the policy so IDE / \`go doc\` users see it without reading CLAUDE.md
- [x] \`security-audit\` slash command updated — future audits grep the correct method names
- [x] ADR-005 carries an "API Drift Note" pointing readers to the current filter-factory API
- [x] TODO.md P0 entry moved to Completed with full resolution summary

## Files changed (11)

| File | Change |
|---|---|
| \`database/internal/builder/filter.go\` | godoc on \`FilterFactory.Raw\` requires \`// SECURITY:\` annotation; annotated examples |
| \`database/internal/builder/join_filter.go\` | godoc on \`JoinFilterFactory.Raw\` mirrors policy |
| \`database/internal/builder/filter_test.go\` | 4 sites annotated; nested-EXISTS duplicate consolidated into single hoisted comment |
| \`database/internal/builder/join_filter_test.go\` | 2 sites annotated |
| \`database/internal/builder/oracle_test.go\` | Table-driven loop covered by single hoisted comment above dispatch |
| \`database/internal/builder/query_builder_test.go\` | Multi-JOIN chain covered by single comment that enumerates each call's safety profile |
| \`CLAUDE.md\` | Manifesto bullet → pointer to Detailed Security Guidelines; full policy paragraph there; troubleshooting reference fixed |
| \`llms.txt\` | New "Raw escape hatch" row in API quick-ref; existing \`f.Raw("1 = 0")\` example annotated |
| \`.claude/commands/security-audit.md\` | Slash command greps \`f.Raw\`/\`jf.Raw\` instead of stale \`WhereRaw\` |
| \`wiki/adr-005-type-safe-where-clauses.md\` | "API Drift Note (2026-04-30)" pointer to current API; historical body preserved |
| \`TODO.md\` | P0 entry moved to Completed with resolution summary |

Comment-and-doc-heavy: +69/-37 across 11 files. No executable logic change.

## Why no linter

The optional linter from the original TODO is YAGNI: zero production usage today, and the API (\`f.Raw\`, \`jf.Raw\`) is short and grep-able. If raw escape-hatch usage starts appearing in production code, revisit at that point. The godoc + slash-command updates already provide automation reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security audit policies and guidance for raw SQL escape hatches, requiring inline security review annotations at all call sites.
  * Removed outdated manual review requirements and replaced with current, stricter annotation standards.
  * Aligned escape hatch documentation across audit workflows and API references.
  * Added security review comments to test cases demonstrating safe raw SQL usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->