### PR TITLE
docs: add Context Deadlines & Timeouts section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ go test -bench=.        # Run benchmarks
 - [Database Architecture](#database-architecture) - Query builder, vendors
 - [Messaging Architecture](#messaging-architecture) - AMQP patterns
 - [Observability](#observability) - Tracing, metrics, logging
+- [Context Deadlines & Timeouts](#context-deadlines--timeouts) - Budget hierarchy, propagation, common patterns
 
 **Development:**
 - [Testing Guidelines](#testing-guidelines) - Unit, integration, coverage
@@ -112,7 +113,7 @@ GoBricks is a **production-grade framework for building MVPs fast**. It provides
 - **Robustness** → Handle errors idiomatically, wrap once at boundaries. No silent failures.
 - **Patterns, not Over-Design** → Use them only when they solve real problems. Justify abstractions.
 - **Security First** → Input validation mandatory, secrets from env/vault, audit raw-SQL escape hatches (see Detailed Security Guidelines below).
-- **Context-First Design** → Always pass `context.Context` as first parameter for tracing, cancellation, deadlines.
+- **Context-First Design** → Always pass `context.Context` as first parameter for tracing, cancellation, deadlines. Inherited deadlines propagate through the framework — see [Context Deadlines & Timeouts](#context-deadlines--timeouts) for the budget hierarchy and per-operation guidance.
 - **Interface Segregation** → Small, focused interfaces for testability (e.g., `Client` vs `AMQPClient`).
 - **Vendor Agnosticism** → Abstract high-cost dependencies (databases), embrace low-cost ones (HTTP frameworks).
 
@@ -1443,6 +1444,131 @@ For high-volume production, use an OTEL Collector as a vendor-agnostic proxy. Be
 **Deployment patterns:** Sidecar (per-pod), DaemonSet (per-node), Gateway (centralized). When using a collector, the GoBricks app points to the collector endpoint with `insecure: true` and no vendor headers.
 
 For deployment patterns, collector configs, and when-to-use guidance, see [wiki/otel-collector.md](wiki/otel-collector.md).
+
+## Context Deadlines & Timeouts
+
+> **Mental model:** GoBricks treats `context.Context` as the primary carrier of deadlines and cancellation. The framework configures timeouts at every external boundary — HTTP server, HTTP client, database pool, AMQP, Redis, observability exporter, startup — and lets those deadlines propagate through the call stack. Inside business logic, **the default is to use the inherited deadline**: do not introduce new timeouts unless you have a specific reason to *shorten* what's already in flight (or, rarely, to *detach* from the request lifecycle for fire-and-forget work).
+
+### Where deadlines come from
+
+Every operation that crosses an external boundary already has a configured timeout. Module authors do not need to wrap these themselves. The table below covers timeouts that shape **runtime, request-scoped behavior** — the budgets your handler context observes:
+
+| Boundary | Config key | Default | Notes |
+|---|---|---|---|
+| HTTP request handler (deadline applied to `c.Request().Context()`) | `server.timeout.middleware` | **5s** | Set by the framework's `Timeout` middleware. This is the budget every handler inherits. |
+| HTTP server read | `server.timeout.read` | 15s | Time to read the request body |
+| HTTP server write | `server.timeout.write` | 30s | Time to write the response (must exceed `middleware`) |
+| HTTP server idle | `server.timeout.idle` | 60s | Keep-alive idle |
+| HTTP server graceful shutdown | `server.timeout.shutdown` | 10s | Drain inflight requests on SIGTERM |
+| Outbound HTTP client | `httpclient.NewBuilder(...).WithTimeout(d)` | 30s | Per-request timeout on the underlying `http.Client` |
+| Cache (Redis) dial / read / write | `cache.redis.{dialtimeout,readtimeout,writetimeout}` | 5s / 3s / 3s | Per-operation socket timeouts |
+| AMQP connection establishment | `messaging.reconnect.connection_timeout` | 30s | Includes publish confirmation |
+| Scheduler — slow job warning | `scheduler.timeout.slowjob` | 25s | Logs WARN if a job exceeds this; does not cancel |
+| Scheduler — graceful shutdown | `scheduler.timeout.shutdown` | 30s | Wait for in-flight jobs on shutdown |
+| Observability export | `observability.trace.export.timeout` | 10s (dev) / 60s (prod) | OTLP export RPC |
+
+**Boundary maintenance / pool hygiene timeouts** — connection lifetime caps, idle eviction TTLs, and reconnect backoff caps don't propagate as deadlines on a request `ctx`. They live in the per-component reference sections: [Connection Pool Defaults](#connection-pool-defaults) (`pool.idle.time`, `pool.lifetime.max`, `pool.keepalive.interval`), [Cache Manager Defaults](#cache-manager-defaults) (`manager.idle_ttl`), [Messaging Reconnection Defaults](#messaging-reconnection-defaults) (`reconnect.max_delay`, `publisher.idle_ttl`), [Outbox Defaults](#outbox-defaults), and [Startup Timeout Defaults](#startup-timeout-defaults) (one-shot bootstrap deadlines).
+
+### The default pattern: do nothing
+
+Inside a handler, the request context already carries a 5-second deadline (the configured `server.timeout.middleware`). The deadline propagates through every operation that takes a `context.Context`:
+
+```go
+func (h *Handler) getOrder(req GetOrderReq, ctx server.HandlerContext) (server.Result[Order], server.IAPIError) {
+    reqCtx := ctx.Echo.Request().Context()  // inherits the 5s deadline
+
+    // All of these inherit the deadline — no manual wrapping needed:
+    cached, _ := h.cache.Get(reqCtx, fmt.Sprintf("order:%d", req.ID))
+    order, err := h.svc.FindByID(reqCtx, req.ID)            // DB query
+    pricing, err := h.pricingClient.Get(reqCtx, order.SKU)  // outbound HTTP
+
+    return server.OK(order), nil
+}
+```
+
+When the deadline fires, every in-flight operation observes `ctx.Done()` and returns `context.DeadlineExceeded` — the framework's central error handler then surfaces a `503` envelope. Wrapping any of those calls with another `context.WithTimeout` would either be redundant (same duration) or would *shorten* the already-tight 5s budget, which is rarely what you want by default.
+
+### When to shorten the inherited deadline
+
+The legitimate use case is when one sub-operation should fail fast so the rest of the request budget can do something else. The canonical example is a cache-then-DB lookup, where the cache check should be capped tightly so a Redis hiccup doesn't burn the whole 5s budget:
+
+```go
+func (s *UserService) Get(ctx context.Context, id int64) (*User, error) {
+    // Cap the cache lookup at 200ms; if Redis is slow we'd rather fall through to DB.
+    cacheCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+    defer cancel()
+
+    if data, err := s.cache.Get(cacheCtx, fmt.Sprintf("user:%d", id)); err == nil {
+        return cache.Unmarshal[*User](data)
+    }
+
+    // DB query keeps the rest of the request budget (~4.8s).
+    return s.queryDatabase(ctx, id)
+}
+```
+
+Recommended budgets when shortening (these are *upper bounds*, not floors):
+
+| Operation | Recommended cap | Rationale |
+|---|---|---|
+| Hot-path cache lookup before DB fallback | **200–500 ms** | If Redis is slow, fall through fast |
+| Idempotency-key check / dedup lookup | **100–300 ms** | Short by design; fall through to actual work on miss |
+| Optional enrichment (recommendations, A/B flags) | **500 ms – 1 s** | Best-effort augmentation; degrade on timeout |
+| Internal HTTP RPC to a known-fast service | **1–2 s** | Tighter than the default 30s on `httpclient.WithTimeout` |
+| External partner API (e.g. payments, KYC) | **5–10 s** | Use the default `httpclient` timeout; tune per partner SLA |
+| Background job step inside a scheduler `Executor` | **per-job** | Scheduler doesn't cancel slow jobs — it logs at `slowjob` (25s) and reports duration. Apply your own deadline if the step has a known SLO. |
+
+**Always pair `context.WithTimeout` with `defer cancel()`** — the linter (`govet`/`lostcancel`) will flag missing cancels, but the discipline matters because leaked cancel functions hold context references and can prevent goroutines from exiting.
+
+### When to detach from the request lifecycle
+
+For fire-and-forget background work that must outlive the request (e.g. sending a webhook from a handler that's returning 202 Accepted), use `context.WithoutCancel` (Go 1.21+) to inherit context *values* — trace IDs, tenant ID, logger — while *severing* the parent's cancellation/deadline:
+
+```go
+func (h *Handler) acceptJob(req JobReq, ctx server.HandlerContext) (server.Result[Receipt], server.IAPIError) {
+    reqCtx := ctx.Echo.Request().Context()
+
+    bgCtx := context.WithoutCancel(reqCtx)              // inherits values, sheds deadline
+    bgCtx, cancel := context.WithTimeout(bgCtx, 30*time.Second)  // re-apply a budget
+
+    go func() {
+        defer cancel()
+        if err := h.worker.Process(bgCtx, req); err != nil {
+            h.logger.WithContext(bgCtx).Error().Err(err).Msg("background job failed")
+        }
+    }()
+
+    return server.Accepted(Receipt{ID: req.ID}), nil
+}
+```
+
+**Why not `context.Background()`?** It severs *everything* — trace ID, tenant ID, request ID, custom logger fields. The job's logs and spans become unattributable. `context.WithoutCancel` is almost always the right tool for "outlive the request, keep the context values."
+
+For scheduler jobs, the `JobContext` passed to `Executor.Execute` carries a context that lives for the job's run and is cancelled on scheduler graceful shutdown (`scheduler.timeout.shutdown`). Jobs SHOULD honor `ctx.Done()` so a SIGTERM doesn't get blocked by a slow job — see [scheduler/module.go](scheduler/module.go).
+
+### Common pitfalls
+
+| Pitfall | Symptom | Fix |
+|---|---|---|
+| Forgetting `defer cancel()` on `context.WithTimeout` | `lostcancel` lint failure; goroutine leaks under load | Always pair `cancel` with `defer` on the next line |
+| Calling `context.Background()` mid-handler | Logs and spans missing trace/tenant attribution; broken trace tree | Use the inherited `ctx` or `context.WithoutCancel(ctx)` |
+| Wrapping with timeout *longer* than the inherited deadline | The longer timeout is silently ignored — the parent's earlier deadline still fires | Don't wrap; the inherited deadline is the cap. If you need longer, see "detach" above |
+| Long loops without `ctx.Err()` checks | Handler keeps running after deadline fires; wasted CPU; eventual `503` from middleware | Check `ctx.Err()` (or `select { case <-ctx.Done(): return ctx.Err(); default: }`) at every iteration boundary in long loops |
+
+### Why context-only timeouts (not `http.TimeoutHandler`)
+
+GoBricks' [`server.Timeout`](server/timeout.go) middleware applies a deadline by wrapping `c.Request().Context()` with `context.WithTimeout` — it does **not** swap the response writer the way Echo's stock `middleware.TimeoutWithConfig` (which wraps `net/http.TimeoutHandler`) would. The trade-off is deliberate: the response-writer swap invalidates `c.Response()` mid-handler, which in turn panics any logging/observability middleware that reads response headers or status. Context-only timeouts let the handler observe cancellation via `ctx.Done()` while keeping the response object valid; the framework's central error handler then renders a standardized 503 envelope. Module authors don't need to do anything special to get this behavior — just use the inherited context.
+
+### Related configuration
+
+- HTTP server timeouts: [`config/types.go`](config/types.go) `TimeoutConfig` (read/write/idle/middleware/shutdown)
+- HTTP client builder: [`httpclient/client.go`](httpclient/client.go) `NewBuilder(...).WithTimeout`
+- Database pool: [Connection Pool Defaults](#connection-pool-defaults)
+- Cache: [Cache Manager Defaults](#cache-manager-defaults), `RedisConfig` in [`config/types.go`](config/types.go)
+- Messaging: [Messaging Reconnection Defaults](#messaging-reconnection-defaults)
+- Scheduler: `scheduler.timeout.{shutdown,slowjob}` in [`config/config.go`](config/config.go)
+- Startup: [Startup Timeout Defaults](#startup-timeout-defaults)
+- Observability export: [`observability.trace.export.timeout`](#observability)
 
 ## Testing Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1477,12 +1477,15 @@ Inside a handler, the request context already carries a 5-second deadline (the c
 func (h *Handler) getOrder(req GetOrderReq, ctx server.HandlerContext) (server.Result[Order], server.IAPIError) {
     reqCtx := ctx.Echo.Request().Context()  // inherits the 5s deadline
 
-    // All of these inherit the deadline — no manual wrapping needed:
-    cached, _ := h.cache.Get(reqCtx, fmt.Sprintf("order:%d", req.ID))
-    order, err := h.svc.FindByID(reqCtx, req.ID)            // DB query
-    pricing, err := h.pricingClient.Get(reqCtx, order.SKU)  // outbound HTTP
+    // Each call below observes the inherited deadline — no manual wrapping needed:
+    _, _ = h.cache.Get(reqCtx, fmt.Sprintf("order:%d", req.ID))  // Redis dial/read/write
+    order, err := h.svc.FindByID(reqCtx, req.ID)                 // DB query
+    if err != nil {
+        return server.Result[Order]{}, server.NewInternalServerError(err.Error())
+    }
+    _, _ = h.pricingClient.Get(reqCtx, order.SKU)                // outbound HTTP
 
-    return server.OK(order), nil
+    return server.NewResult(http.StatusOK, order), nil
 }
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -39,30 +39,6 @@ _(no open P0 items)_
 
 ---
 
-### Context Timeout Defaults
-**Status:** Planned
-**Context:** Framework requires `context.Context` everywhere but doesn't enforce timeout best practices.
-
-**Requirements:**
-- Document recommended timeout values for common operations
-- Consider helper functions for context creation with sensible defaults
-- Add examples in CLAUDE.md
-
-**Example:**
-```go
-// Potential helpers in a new package: context/defaults.go
-func NewHTTPRequestContext(parent context.Context) (context.Context, context.CancelFunc) {
-    return context.WithTimeout(parent, 30*time.Second)
-}
-
-func NewDatabaseQueryContext(parent context.Context) (context.Context, context.CancelFunc) {
-    return context.WithTimeout(parent, 10*time.Second)
-}
-```
-
-**Related:**
-- Context-First Design principle (to be added to CLAUDE.md)
-
 ---
 
 ### ~~Go Runtime Metrics Export via OTLP~~
@@ -296,6 +272,22 @@ go-bricks generate handler --name CreateUser --method POST --path /users
 ---
 
 ## Completed / Won't Do
+
+### ~~Context Timeout Defaults~~
+**Status:** ✅ Completed (2026-04-30)
+**Context:** Framework already configures timeouts at every external boundary (HTTP server `middleware: 5s`, HTTP client `30s`, Redis `dial 5s / read 3s / write 3s`, AMQP `connection_timeout: 30s`, startup per-component, etc.) and propagates deadlines via `context.Context`. The original TODO proposed wrapper helpers (`NewHTTPRequestContext`, `NewDatabaseQueryContext`); audit revealed the gap was *guidance*, not *helpers* — module authors had no single document explaining how the existing knobs compose into a request budget hierarchy or when to manually apply `context.WithTimeout` inside business logic.
+
+**Resolution (docs-only scope):** Added a new top-level `## Context Deadlines & Timeouts` section to CLAUDE.md (mental model, request-scoped boundary table, default/shorten/detach patterns, recommended-cap budgets, pitfalls), and a matching `## Context Timeouts` snippet section to llms.txt. Cross-referenced from the "Context-First Design" principle line and the Table of Contents.
+
+**Why no helper package:** The proposed `NewDatabaseQueryContext(parent)` / `NewHTTPRequestContext(parent)` wrappers would each save one line of `context.WithTimeout(parent, duration)` over the stdlib form, while introducing a new package the framework would need to maintain. The actual gap was *knowledge of recommended values*, which a docs section solves without an abstraction. If duplicated `context.WithTimeout(...)` magic numbers start appearing across modules, revisit with a tiny `internal/timeouts` constants file (named durations only, no wrapper functions) — but that's YAGNI today.
+
+**Related:**
+- [CLAUDE.md](CLAUDE.md) — "Context Deadlines & Timeouts" section
+- [llms.txt](llms.txt) — "Context Timeouts" section
+- [server/timeout.go](server/timeout.go) — context-only middleware
+- [config/types.go](config/types.go) — `TimeoutConfig`, `StartupConfig`, `RedisConfig`, `ReconnectConfig`
+
+---
 
 ### ~~Security Audit Annotations for Raw-SQL Escape Hatches~~
 **Status:** ✅ Completed (2026-04-30)

--- a/llms.txt
+++ b/llms.txt
@@ -645,6 +645,73 @@ func (h *Handler) updateLegacyUser(req GetUserReq, ctx server.HandlerContext) (s
 
 **When to use:** Strangler Fig migration, third-party API compatibility, webhook callbacks requiring specific shapes.
 
+## Context Timeouts
+
+The framework configures timeouts at every external boundary; **inherited deadlines are usually the right answer** inside a handler. See [CLAUDE.md "Context Deadlines & Timeouts"](CLAUDE.md#context-deadlines--timeouts) for the full guide.
+
+```go
+// === DEFAULT: do nothing, inherit the request deadline ===
+// HTTP middleware applies a 5s deadline (server.timeout.middleware) to every handler.
+// All framework operations (DB, cache, HTTP client, AMQP) propagate it automatically.
+
+func (h *Handler) getOrder(req GetOrderReq, ctx server.HandlerContext) (server.Result[Order], server.IAPIError) {
+    reqCtx := ctx.Echo.Request().Context()  // already has the 5s deadline
+
+    // No wrapping needed — every call below observes the inherited deadline:
+    cached, _ := h.cache.Get(reqCtx, key)
+    order, err := h.svc.FindByID(reqCtx, req.ID)
+    pricing, err := h.pricing.Get(reqCtx, order.SKU)
+
+    return server.OK(order), nil
+}
+
+// === SHORTEN: cap one sub-operation so a slow path doesn't burn the budget ===
+func (s *UserService) Get(ctx context.Context, id int64) (*User, error) {
+    // Cap cache lookup at 200ms; fall through to DB on miss/timeout.
+    cacheCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+    defer cancel()
+    if data, err := s.cache.Get(cacheCtx, fmt.Sprintf("user:%d", id)); err == nil {
+        return cache.Unmarshal[*User](data)
+    }
+    return s.queryDatabase(ctx, id) // keeps remaining ~4.8s of inherited budget
+}
+
+// === DETACH: fire-and-forget background work that must outlive the request ===
+// context.WithoutCancel inherits VALUES (trace ID, tenant, logger fields) but
+// sheds the parent's cancellation/deadline. Always re-apply a fresh budget.
+
+func (h *Handler) acceptJob(req JobReq, ctx server.HandlerContext) (server.Result[Receipt], server.IAPIError) {
+    reqCtx := ctx.Echo.Request().Context()
+    bgCtx := context.WithoutCancel(reqCtx)
+    bgCtx, cancel := context.WithTimeout(bgCtx, 30*time.Second)
+    go func() {
+        defer cancel()
+        if err := h.worker.Process(bgCtx, req); err != nil {
+            h.logger.WithContext(bgCtx).Error().Err(err).Msg("background job failed")
+        }
+    }()
+    return server.Accepted(Receipt{ID: req.ID}), nil
+}
+// Anti-pattern: context.Background() severs trace/tenant attribution.
+// Use context.WithoutCancel for "outlive the request, keep observability."
+```
+
+**Recommended caps when shortening** (upper bounds, not floors):
+
+| Operation | Cap |
+|---|---|
+| Hot-path cache lookup before DB fallback | 200–500 ms |
+| Idempotency / dedup lookup | 100–300 ms |
+| Optional enrichment (recommendations, flags) | 500 ms – 1 s |
+| Internal RPC to known-fast service | 1–2 s |
+| External partner API | 5–10 s (tune per SLA) |
+
+**Pitfalls:**
+- Forgetting `defer cancel()` → goroutine leaks (lint catches via `lostcancel`)
+- `context.Background()` mid-handler → orphaned trace, missing tenant
+- Wrapping with timeout *longer* than inherited deadline → silently ignored
+- Long loops without `ctx.Err()` checks → wasted work after deadline fires
+
 ## HTTP Middleware
 
 ```go

--- a/llms.txt
+++ b/llms.txt
@@ -658,11 +658,14 @@ func (h *Handler) getOrder(req GetOrderReq, ctx server.HandlerContext) (server.R
     reqCtx := ctx.Echo.Request().Context()  // already has the 5s deadline
 
     // No wrapping needed — every call below observes the inherited deadline:
-    cached, _ := h.cache.Get(reqCtx, key)
+    _, _ = h.cache.Get(reqCtx, fmt.Sprintf("order:%d", req.ID))
     order, err := h.svc.FindByID(reqCtx, req.ID)
-    pricing, err := h.pricing.Get(reqCtx, order.SKU)
+    if err != nil {
+        return server.Result[Order]{}, server.NewInternalServerError(err.Error())
+    }
+    _, _ = h.pricing.Get(reqCtx, order.SKU)
 
-    return server.OK(order), nil
+    return server.NewResult(http.StatusOK, order), nil
 }
 
 // === SHORTEN: cap one sub-operation so a slow path doesn't burn the budget ===


### PR DESCRIPTION
## Summary

Adds a top-level \`## Context Deadlines & Timeouts\` section to CLAUDE.md and a matching \`## Context Timeouts\` snippet section to llms.txt. Closes the P1 "Context Timeout Defaults" item in TODO.md.

**Scope is docs-only.** The original TODO proposed wrapper helpers (\`NewHTTPRequestContext\`, \`NewDatabaseQueryContext\`) but an audit revealed the gap was *guidance*, not *helpers*: the framework already configures timeouts at every external boundary (HTTP server \`middleware: 5s\`, HTTP client \`30s\`, Redis \`dial:5s / read:3s / write:3s\`, AMQP \`connection_timeout: 30s\`, startup per-component, etc.) and propagates deadlines via \`context.Context\`. What was missing was a single document explaining how those knobs compose into a request budget hierarchy and when module authors should manually apply \`context.WithTimeout\` inside business logic.

**Why no helper package:** \`NewDatabaseQueryContext(parent)\` would save one stdlib line over \`context.WithTimeout(parent, duration)\` while introducing a new package the framework has to maintain. The actual gap is *knowledge of recommended values*, which a docs section solves without an abstraction. If duplicated magic-number \`context.WithTimeout\` calls start appearing across modules, revisit with a tiny \`internal/timeouts\` constants file — but that's YAGNI today.

## What's in the new section

**CLAUDE.md** \`## Context Deadlines & Timeouts\`:
- Mental model: framework configures timeouts at boundaries; modules inherit and propagate
- "Where deadlines come from" table — request-scoped budgets only, with config keys and defaults
- "The default pattern: do nothing" — show inherited 5s deadline propagating through DB/cache/HTTP-client calls
- "When to shorten the inherited deadline" — cache-then-DB example + recommended-cap budgets table (200–500ms hot-path cache, 100–300ms idempotency check, etc.)
- "When to detach from the request lifecycle" — \`context.WithoutCancel\` for fire-and-forget; \`context.Background()\` anti-pattern callout
- Common pitfalls table (4 rows)
- "Why context-only timeouts (not \`http.TimeoutHandler\`)" — explains the \`server.Timeout\` design
- Related-configuration footer

**llms.txt** \`## Context Timeouts\`:
- Three labelled patterns (default / shorten / detach) as copy-paste snippets
- Recommended-cap budgets table
- Pitfalls list
- Link back to CLAUDE.md as source of truth

**CLAUDE.md** "Context-First Design" manifesto line and Table of Contents updated to cross-reference.

## Test plan
- [x] \`make check\` green (no Go code changed; lint + test pass)
- [x] All anchor links verified (\`#context-deadlines--timeouts\`, \`#connection-pool-defaults\`, \`#cache-manager-defaults\`, \`#messaging-reconnection-defaults\`, \`#outbox-defaults\`, \`#startup-timeout-defaults\`, \`#observability\`)
- [x] All cited config defaults verified against source: \`config/config.go\`, \`config/types.go\`, \`config/validation.go\`, \`httpclient/client.go\`
- [x] All API references in code examples checked against current public surface (\`server.HandlerContext\`, \`server.Result[R]\`, \`server.Accepted\`, \`cache.Unmarshal[*T]\`, \`httpclient.NewBuilder\`, \`logger.WithContext\`)
- [x] \`/simplify\` ran before push and caught three factual errors that landed in fixes:
  - \`JobContext\` was incorrectly described as "non-cancelling" — it's \`context.WithCancel(m.shutdownCtx)\` (scheduler/module.go:516), cancelled on graceful shutdown. Corrected.
  - \`cache.Unmarshal[User](data)\` example didn't compile against \`(*User, error)\` return — fixed to \`Unmarshal[*User]\`.
  - "Validation panic" should be "config validation fails at startup" — the validator returns \`ConfigError\`, surfaced as a startup error.
- [x] Trimmed the deadline-source table to focus on request-scoped budgets (separate pointer paragraph for pool/cache/broker hygiene timeouts that don't propagate as request \`ctx\` deadlines)

## Files changed (3)

| File | Change |
|---|---|
| \`CLAUDE.md\` | New \`## Context Deadlines & Timeouts\` section (+128 lines); TOC entry; cross-ref from "Context-First Design" principle |
| \`llms.txt\` | New \`## Context Timeouts\` section (+67 lines) with copy-paste handler patterns |
| \`TODO.md\` | Move "Context Timeout Defaults" from P1 to Completed with docs-only scope rationale |

Total: +210 / -25 lines, no executable code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Context Deadlines & Timeouts" chapter explaining the framework’s deadline/budget model and where timeouts apply at external boundaries.
  * Included explicit patterns for shortening sub-operations, detaching background work, and handling inherited deadlines.
  * Called out common pitfalls (missing cancellation, improper background context, timeout caps, and error checks) and updated the Developer Manifesto reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->