### PR TITLE
test(scheduler): fix flaky tracer tests by removing tick-boundary race

### DIFF
--- a/scheduler/module_test.go
+++ b/scheduler/module_test.go
@@ -360,16 +360,16 @@ func TestJobExecutionWithTracer(t *testing.T) {
 	require.NoError(t, err)
 	defer module.Shutdown()
 
-	// Create a simple job
+	// Create a simple job. Use a 1s interval so a second tick cannot race the
+	// assertion window, and stop the scheduler before counting spans.
 	job := &slowJob{duration: 10 * time.Millisecond}
-	err = module.FixedRate("traced-job", job, 100*time.Millisecond)
+	err = module.FixedRate("traced-job", job, 1*time.Second)
 	require.NoError(t, err)
 
-	// Wait for job to execute
-	time.Sleep(200 * time.Millisecond)
+	require.Eventually(t, func() bool { return job.count() >= 1 },
+		2*time.Second, 10*time.Millisecond, "Job should execute at least once")
 
-	// Verify job executed
-	assert.Greater(t, job.count(), 0, "Job should execute")
+	require.NoError(t, module.Shutdown())
 
 	// Verify span was created
 	collector := obtest.NewSpanCollector(t, tp.Exporter)
@@ -412,15 +412,18 @@ func TestJobExecutionWithTracerPropagatesContext(t *testing.T) {
 	require.NoError(t, err)
 	defer module.Shutdown()
 
-	// Job that creates a child span to verify context propagation
+	// Job that creates a child span to verify context propagation. Use a 1s
+	// interval so a second tick cannot race the assertion window, and stop the
+	// scheduler before counting spans.
 	tracer := tp.Tracer("test-child")
 	job := &spanCapturingJob{tracer: tracer}
-	err = module.FixedRate("ctx-propagation-job", job, 100*time.Millisecond)
+	err = module.FixedRate("ctx-propagation-job", job, 1*time.Second)
 	require.NoError(t, err)
 
-	time.Sleep(200 * time.Millisecond)
+	require.Eventually(t, func() bool { return job.count() >= 1 },
+		2*time.Second, 10*time.Millisecond, "Job should execute at least once")
 
-	assert.Greater(t, job.count(), 0, "Job should execute")
+	require.NoError(t, module.Shutdown())
 
 	// Verify both parent and child spans exist
 	collector := obtest.NewSpanCollector(t, tp.Exporter)


### PR DESCRIPTION
## Summary
- `TestJobExecutionWithTracerCreatesSpan` and `TestJobExecutionWithTracerPropagatesContext` were flaking on `framework-integration-test` (3 of the last 5 main-branch runs failed).
- Root cause: both tests scheduled a 100 ms `FixedRate` job and asserted **exact** span counts after a 200 ms sleep. The 200 ms wait landed precisely on the second tick boundary, so under integration-test load (parallel testcontainers + race detector) the second fire often squeaked in before the assertion, producing 2 spans instead of 1.
- Fix: widen the interval to 1 s so a second tick cannot fall inside the wait, replace `time.Sleep` with `require.Eventually(count >= 1, 2s, 10ms)`, and `Shutdown()` the scheduler before counting spans so no further fire can race the assertion.

## Why these are the only two tests changed
The other 100 ms-interval scheduler tests use `waitFor`/`Eventually` boolean checks or range assertions (`>0`, `<10`), which tolerate extra fires. Only these two used exact-`AssertCount(1)` against a tick-boundary-bounded wait.

## Trade-off
Total scheduler test runtime grows by ~3 s (27 s → 30 s in CI). A reviewer flagged that the unexported `executeManualJob` path could keep the tests sub-second, but it sets `job.trigger=\"manual\"` while `TestJobExecutionWithTracerCreatesSpan` asserts `job.trigger=\"scheduled\"`. Routing through the manual path would silently change what's verified, so it was rejected.

## Test plan
- [x] `make check` green locally
- [x] `go test -race -count=20` against both tests = 40 consecutive passes (~22 s)
- [ ] CI passes `framework-integration-test` (the previously flaky job)
- [ ] CI passes the rest of the matrix unchanged

## Follow-up
Filed a separate issue for the duplicated `ModuleDeps` setup block across `TestJobExecutionWithTracer*` (3 near-clones, ~25 lines each). Pre-existing duplication, intentionally out of scope for this flake fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of scheduler tests by implementing more robust polling mechanisms and adjusting timing parameters to reduce intermittent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->