### PR TITLE
refactor(ADR-017): standardize on ToSQL() across all query builders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,28 @@ var job scheduler.Executor = &MyJob{}
 var probe app.Prober = myProbe
 ```
 
+### Breaking Change: Standardized `ToSQL()` Across Query Builders (S8179)
+
+Per [ADR-017](wiki/adr-017-insert-query-builder.md), `qb.Insert*` constructors now return `types.InsertQueryBuilder` (a go-bricks-owned interface) instead of `squirrel.InsertBuilder` directly. The render method is renamed from `ToSql()` (squirrel-style) to `ToSQL()` (idiomatic Go, S8179) — matching `Select`/`Update`/`Delete`.
+
+| Constructor | Old return | New return | Render method |
+|---|---|---|---|
+| `qb.Insert(table)` | `squirrel.InsertBuilder` | `types.InsertQueryBuilder` | `ToSQL()` |
+| `qb.InsertWithColumns(table, cols...)` | `squirrel.InsertBuilder` | `types.InsertQueryBuilder` | `ToSQL()` |
+| `qb.InsertStruct(table, instance)` | `squirrel.InsertBuilder` | `types.InsertQueryBuilder` | `ToSQL()` |
+| `qb.InsertFields(table, instance, fields...)` | `squirrel.InsertBuilder` | `types.InsertQueryBuilder` | `ToSQL()` |
+
+**Example Migration:**
+```go
+// ❌ OLD
+sql, args, err := qb.Insert("users").Columns("name").Values("Alice").ToSql()
+
+// ✅ NEW
+sql, args, err := qb.Insert("users").Columns("name").Values("Alice").ToSQL()
+```
+
+The new interface preserves all common chaining methods (`Columns`, `Values`, `SetMap`, `Options`, `Prefix`, `Suffix`, `Select`). For specialized squirrel-only methods (e.g., `RunWith`, `PlaceholderFormat`), keep the rendered SQL via `ToSQL()` and execute with `db.Exec(ctx, sql, args...)`.
+
 ## Architecture
 
 ### Core Components

--- a/database/internal/builder/postgres.go
+++ b/database/internal/builder/postgres.go
@@ -9,7 +9,7 @@ import (
 // buildPostgreSQLUpsert creates a PostgreSQL ON CONFLICT DO UPDATE statement.
 // PostgreSQL uses INSERT ... ON CONFLICT (columns) DO UPDATE SET ... syntax.
 func (qb *QueryBuilder) buildPostgreSQLUpsert(table string, conflictColumns []string, insertColumns, updateKeys map[string]any) (query string, args []any, err error) {
-	// Build the base INSERT statement
+	// Build the base INSERT statement using the public API for consistency.
 	insertQuery := qb.Insert(table)
 
 	// Create deterministic column order for consistent SQL generation
@@ -45,7 +45,7 @@ func (qb *QueryBuilder) buildPostgreSQLUpsert(table string, conflictColumns []st
 	}
 
 	// Generate the final SQL with conflict resolution
-	sql, args, err := insertQuery.ToSql()
+	sql, args, err := insertQuery.ToSQL()
 	if err != nil {
 		return "", nil, err
 	}

--- a/database/internal/builder/query_builder.go
+++ b/database/internal/builder/query_builder.go
@@ -45,6 +45,7 @@ var _ dbtypes.SelectQueryBuilder = (*SelectQueryBuilder)(nil)
 // see a consistent ToSQL()-based surface across SELECT/INSERT/UPDATE/DELETE.
 type InsertQueryBuilder struct {
 	insertBuilder squirrel.InsertBuilder
+	err           error // deferred error surfaced by ToSQL()
 }
 
 // check if InsertQueryBuilder implements dbtypes.InsertQueryBuilder
@@ -1031,17 +1032,28 @@ func (iqb *InsertQueryBuilder) Suffix(sql string, args ...any) dbtypes.InsertQue
 	return iqb
 }
 
-// Select panics if sb is not the concrete *SelectQueryBuilder from this package —
-// silent fall-through would produce a malformed INSERT...SELECT at runtime.
+// Select uses sb as the source rows for INSERT...SELECT. Squirrel's InsertBuilder.Select
+// requires the concrete *SelectQueryBuilder so pagination state (limit/offset) and captured
+// filter errors are preserved via buildSelectBuilder()/ValidateForSubquery(). Foreign
+// SelectQueryBuilder implementations cannot be plumbed into squirrel's Select clause — for
+// those, the error is deferred to ToSQL() rather than panicking.
 func (iqb *InsertQueryBuilder) Select(sb dbtypes.SelectQueryBuilder) dbtypes.InsertQueryBuilder {
+	if err := dbtypes.ValidateSubquery(sb); err != nil {
+		iqb.err = fmt.Errorf("InsertQueryBuilder.Select: %w", err)
+		return iqb
+	}
 	concrete, ok := sb.(*SelectQueryBuilder)
 	if !ok {
-		panic(fmt.Sprintf("InsertQueryBuilder.Select: expected *SelectQueryBuilder, got %T", sb))
+		iqb.err = fmt.Errorf("InsertQueryBuilder.Select: unsupported subquery type %T", sb)
+		return iqb
 	}
-	iqb.insertBuilder = iqb.insertBuilder.Select(concrete.selectBuilder)
+	iqb.insertBuilder = iqb.insertBuilder.Select(concrete.buildSelectBuilder())
 	return iqb
 }
 
 func (iqb *InsertQueryBuilder) ToSQL() (sql string, args []any, err error) {
+	if iqb.err != nil {
+		return "", nil, iqb.err
+	}
 	return iqb.insertBuilder.ToSql()
 }

--- a/database/internal/builder/query_builder.go
+++ b/database/internal/builder/query_builder.go
@@ -38,6 +38,18 @@ type SelectQueryBuilder struct {
 // check if SelectQueryBuilder implements dbtypes.SelectQueryBuilder
 var _ dbtypes.SelectQueryBuilder = (*SelectQueryBuilder)(nil)
 
+// InsertQueryBuilder wraps squirrel.InsertBuilder so the public API exposes
+// idiomatic ToSQL() (uppercase, per S8179) instead of squirrel's ToSql().
+//
+// All chaining methods return the dbtypes.InsertQueryBuilder interface so users
+// see a consistent ToSQL()-based surface across SELECT/INSERT/UPDATE/DELETE.
+type InsertQueryBuilder struct {
+	insertBuilder squirrel.InsertBuilder
+}
+
+// check if InsertQueryBuilder implements dbtypes.InsertQueryBuilder
+var _ dbtypes.InsertQueryBuilder = (*InsertQueryBuilder)(nil)
+
 // UpdateQueryBuilder provides a type-safe interface for building UPDATE queries
 // with Filter API support and vendor-specific column quoting.
 type UpdateQueryBuilder struct {
@@ -222,15 +234,19 @@ func (qb *QueryBuilder) Select(columns ...any) *SelectQueryBuilder {
 	}
 }
 
-// Insert creates an INSERT query builder for the specified table
-func (qb *QueryBuilder) Insert(table string) squirrel.InsertBuilder {
-	return qb.statementBuilder.Insert(table)
+// Insert creates an INSERT query builder for the specified table.
+// The returned InsertQueryBuilder exposes ToSQL() (idiomatic Go, per S8179)
+// consistent with Select/Update/Delete builders.
+func (qb *QueryBuilder) Insert(table string) dbtypes.InsertQueryBuilder {
+	return &InsertQueryBuilder{insertBuilder: qb.statementBuilder.Insert(table)}
 }
 
 // InsertWithColumns creates an INSERT query builder with pre-specified columns.
 // It applies vendor-specific column quoting to the provided column list.
-func (qb *QueryBuilder) InsertWithColumns(table string, columns ...string) squirrel.InsertBuilder {
-	return qb.statementBuilder.Insert(table).Columns(qb.quoteColumnsForDML(columns...)...)
+func (qb *QueryBuilder) InsertWithColumns(table string, columns ...string) dbtypes.InsertQueryBuilder {
+	return &InsertQueryBuilder{
+		insertBuilder: qb.statementBuilder.Insert(table).Columns(qb.quoteColumnsForDML(columns...)...),
+	}
 }
 
 // InsertStruct creates an INSERT query by extracting all fields from a struct instance.
@@ -250,7 +266,7 @@ func (qb *QueryBuilder) InsertWithColumns(table string, columns ...string) squir
 //	// INSERT INTO users (name, email) VALUES (?, ?)
 //
 // Panics if instance is not a struct or pointer to struct with db tags.
-func (qb *QueryBuilder) InsertStruct(table string, instance any) squirrel.InsertBuilder {
+func (qb *QueryBuilder) InsertStruct(table string, instance any) dbtypes.InsertQueryBuilder {
 	cols := qb.Columns(instance)
 	fieldMap := cols.FieldMap(instance)
 
@@ -267,9 +283,11 @@ func (qb *QueryBuilder) InsertStruct(table string, instance any) squirrel.Insert
 		values = append(values, val)
 	}
 
-	return qb.statementBuilder.Insert(table).
-		Columns(qb.quoteColumnsForDML(columns...)...).
-		Values(values...)
+	return &InsertQueryBuilder{
+		insertBuilder: qb.statementBuilder.Insert(table).
+			Columns(qb.quoteColumnsForDML(columns...)...).
+			Values(values...),
+	}
 }
 
 // InsertFields creates an INSERT query by extracting only specified fields from a struct instance.
@@ -282,7 +300,7 @@ func (qb *QueryBuilder) InsertStruct(table string, instance any) squirrel.Insert
 //	// INSERT INTO users (name, email) VALUES (?, ?)
 //
 // Panics if instance is not a struct or any field name is invalid.
-func (qb *QueryBuilder) InsertFields(table string, instance any, fields ...string) squirrel.InsertBuilder {
+func (qb *QueryBuilder) InsertFields(table string, instance any, fields ...string) dbtypes.InsertQueryBuilder {
 	cols := qb.Columns(instance)
 	fieldMap := cols.FieldMap(instance)
 
@@ -300,9 +318,11 @@ func (qb *QueryBuilder) InsertFields(table string, instance any, fields ...strin
 		}
 	}
 
-	return qb.statementBuilder.Insert(table).
-		Columns(qb.quoteColumnsForDML(columns...)...).
-		Values(values...)
+	return &InsertQueryBuilder{
+		insertBuilder: qb.statementBuilder.Insert(table).
+			Columns(qb.quoteColumnsForDML(columns...)...).
+			Values(values...),
+	}
 }
 
 // extractTerminalIdentifier extracts the final identifier from a column name,
@@ -977,4 +997,51 @@ func (dqb *DeleteQueryBuilder) OrderBy(orderBys ...string) dbtypes.DeleteQueryBu
 // ToSQL generates the final SQL query and arguments.
 func (dqb *DeleteQueryBuilder) ToSQL() (sql string, args []any, err error) {
 	return dqb.deleteBuilder.ToSql()
+}
+
+// ========== InsertQueryBuilder Methods ==========
+
+func (iqb *InsertQueryBuilder) Columns(columns ...string) dbtypes.InsertQueryBuilder {
+	iqb.insertBuilder = iqb.insertBuilder.Columns(columns...)
+	return iqb
+}
+
+func (iqb *InsertQueryBuilder) Values(values ...any) dbtypes.InsertQueryBuilder {
+	iqb.insertBuilder = iqb.insertBuilder.Values(values...)
+	return iqb
+}
+
+func (iqb *InsertQueryBuilder) SetMap(clauses map[string]any) dbtypes.InsertQueryBuilder {
+	iqb.insertBuilder = iqb.insertBuilder.SetMap(clauses)
+	return iqb
+}
+
+func (iqb *InsertQueryBuilder) Options(options ...string) dbtypes.InsertQueryBuilder {
+	iqb.insertBuilder = iqb.insertBuilder.Options(options...)
+	return iqb
+}
+
+func (iqb *InsertQueryBuilder) Prefix(sql string, args ...any) dbtypes.InsertQueryBuilder {
+	iqb.insertBuilder = iqb.insertBuilder.Prefix(sql, args...)
+	return iqb
+}
+
+func (iqb *InsertQueryBuilder) Suffix(sql string, args ...any) dbtypes.InsertQueryBuilder {
+	iqb.insertBuilder = iqb.insertBuilder.Suffix(sql, args...)
+	return iqb
+}
+
+// Select panics if sb is not the concrete *SelectQueryBuilder from this package —
+// silent fall-through would produce a malformed INSERT...SELECT at runtime.
+func (iqb *InsertQueryBuilder) Select(sb dbtypes.SelectQueryBuilder) dbtypes.InsertQueryBuilder {
+	concrete, ok := sb.(*SelectQueryBuilder)
+	if !ok {
+		panic(fmt.Sprintf("InsertQueryBuilder.Select: expected *SelectQueryBuilder, got %T", sb))
+	}
+	iqb.insertBuilder = iqb.insertBuilder.Select(concrete.selectBuilder)
+	return iqb
+}
+
+func (iqb *InsertQueryBuilder) ToSQL() (sql string, args []any, err error) {
+	return iqb.insertBuilder.ToSql()
 }

--- a/database/internal/builder/query_builder_test.go
+++ b/database/internal/builder/query_builder_test.go
@@ -261,7 +261,7 @@ func TestInsertWithColumns(t *testing.T) {
 	qb := NewQueryBuilder(dbtypes.PostgreSQL)
 
 	builder := qb.InsertWithColumns(tableUsers, colName, colEmail).Values(testJohn, testEmail)
-	sql, _, err := builder.ToSql()
+	sql, _, err := builder.ToSQL()
 	require.NoError(t, err)
 	assert.Contains(t, sql, `INSERT INTO users (name,email)`)
 	assert.Contains(t, sql, `VALUES ($1,$2)`)
@@ -1397,7 +1397,7 @@ func TestColumnsInsert(t *testing.T) {
 		query := qb.InsertWithColumns(tableUsers, cols.Cols(fieldName, fieldEmail, fieldStatus)...).
 			Values("John Doe", testEmail, statusActive)
 
-		sql, args, err := query.ToSql()
+		sql, args, err := query.ToSQL()
 		require.NoError(t, err)
 		assert.Equal(t, "INSERT INTO users (name,email,status) VALUES ($1,$2,$3)", sql)
 		assert.Equal(t, []any{"John Doe", testEmail, statusActive}, args)
@@ -1413,7 +1413,7 @@ func TestColumnsInsert(t *testing.T) {
 		query := qb.InsertWithColumns(tableAccounts, cols.Cols(fieldNumber, fieldLevel, "Size")...).
 			Values(testAccountID, 3, "large")
 
-		sql, args, err := query.ToSql()
+		sql, args, err := query.ToSQL()
 		require.NoError(t, err)
 		// Oracle should quote reserved words in column list
 		assert.Contains(t, sql, `"number"`)
@@ -1432,7 +1432,7 @@ func TestColumnsInsert(t *testing.T) {
 		query := qb.InsertWithColumns(tableProducts, cols.All()...).
 			Values(1, "Widget", "9.99")
 
-		sql, args, err := query.ToSql()
+		sql, args, err := query.ToSQL()
 		require.NoError(t, err)
 		assert.Equal(t, "INSERT INTO products (id,name,price) VALUES ($1,$2,$3)", sql)
 		assert.Equal(t, []any{1, "Widget", "9.99"}, args)
@@ -1762,7 +1762,7 @@ func TestInsertStructAllFields(t *testing.T) {
 	}
 
 	query := qb.InsertStruct(tableUsers, &user)
-	sql, args, err := query.ToSql()
+	sql, args, err := query.ToSQL()
 
 	require.NoError(t, err)
 	assert.Contains(t, sql, "INSERT INTO users")
@@ -1786,7 +1786,7 @@ func TestInsertStructWithNonZeroID(t *testing.T) {
 	}
 
 	query := qb.InsertStruct(tableUsers, &user)
-	sql, args, err := query.ToSql()
+	sql, args, err := query.ToSQL()
 
 	require.NoError(t, err)
 	assert.Contains(t, sql, colID) // Non-zero ID included
@@ -1876,7 +1876,7 @@ func TestInsertStructColumnsWithIDSubstring(t *testing.T) {
 	}
 
 	query := qb.InsertStruct("payments", &payment)
-	sql, args, err := query.ToSql()
+	sql, args, err := query.ToSQL()
 
 	require.NoError(t, err)
 	assert.Contains(t, sql, "INSERT INTO payments")
@@ -1910,7 +1910,7 @@ func TestInsertFieldsSelectiveFields(t *testing.T) {
 
 	// Insert only Name and Email
 	query := qb.InsertFields(tableUsers, &user, fieldName, fieldEmail)
-	sql, args, err := query.ToSql()
+	sql, args, err := query.ToSQL()
 
 	require.NoError(t, err)
 	assert.Contains(t, sql, "INSERT INTO users")
@@ -1941,7 +1941,7 @@ func TestInsertStructOracleReservedWords(t *testing.T) {
 	}
 
 	query := qb.InsertStruct(tableAccounts, &account)
-	sql, args, err := query.ToSql()
+	sql, args, err := query.ToSQL()
 
 	require.NoError(t, err)
 	// Oracle should quote reserved words

--- a/database/internal/builder/query_builder_test.go
+++ b/database/internal/builder/query_builder_test.go
@@ -287,7 +287,9 @@ func TestInsertSelectPreservesPagination(t *testing.T) {
 // fallback when squirrel's InsertBuilder.Select cannot accept the type directly.
 type foreignSelect struct{ dbtypes.SelectQueryBuilder }
 
-func (foreignSelect) ToSQL() (string, []any, error) { return "SELECT 1", nil, nil }
+func (foreignSelect) ToSQL() (sql string, args []any, err error) {
+	return "SELECT 1", nil, nil
+}
 
 func TestInsertSelectForeignImplDefersError(t *testing.T) {
 	qb := NewQueryBuilder(dbtypes.PostgreSQL)

--- a/database/internal/builder/query_builder_test.go
+++ b/database/internal/builder/query_builder_test.go
@@ -267,6 +267,49 @@ func TestInsertWithColumns(t *testing.T) {
 	assert.Contains(t, sql, `VALUES ($1,$2)`)
 }
 
+func TestInsertSelectPreservesPagination(t *testing.T) {
+	qb := NewQueryBuilder(dbtypes.PostgreSQL)
+	source := qb.Select(colName, colEmail).From(tableUsers).Paginate(10, 5)
+
+	sql, args, err := qb.InsertWithColumns("users_archive", colName, colEmail).
+		Select(source).
+		ToSQL()
+
+	require.NoError(t, err)
+	assert.Contains(t, sql, "INSERT INTO users_archive (name,email)")
+	assert.Contains(t, sql, "SELECT name, email FROM users")
+	assert.Contains(t, sql, "LIMIT 10")
+	assert.Contains(t, sql, "OFFSET 5")
+	assert.Empty(t, args)
+}
+
+// foreignSelect is a non-package SelectQueryBuilder used to verify deferred-error
+// fallback when squirrel's InsertBuilder.Select cannot accept the type directly.
+type foreignSelect struct{ dbtypes.SelectQueryBuilder }
+
+func (foreignSelect) ToSQL() (string, []any, error) { return "SELECT 1", nil, nil }
+
+func TestInsertSelectForeignImplDefersError(t *testing.T) {
+	qb := NewQueryBuilder(dbtypes.PostgreSQL)
+
+	sql, args, err := qb.Insert("users_archive").Select(foreignSelect{}).ToSQL()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported subquery type")
+	assert.Empty(t, sql)
+	assert.Nil(t, args)
+}
+
+func TestInsertSelectNilSubqueryDefersError(t *testing.T) {
+	qb := NewQueryBuilder(dbtypes.PostgreSQL)
+
+	sql, args, err := qb.Insert("users_archive").Select(nil).ToSQL()
+
+	require.Error(t, err)
+	assert.Empty(t, sql)
+	assert.Nil(t, args)
+}
+
 func TestUpdate(t *testing.T) {
 	qb := NewQueryBuilder(dbtypes.PostgreSQL)
 	f := qb.Filter()

--- a/database/query_builder.go
+++ b/database/query_builder.go
@@ -52,8 +52,10 @@ var _ types.QueryBuilderInterface = (*QueryBuilder)(nil)
 //
 // - Vendor() string
 // - JoinFilter() types.JoinFilterFactory
-// - Insert(table string) squirrel.InsertBuilder
-// - InsertWithColumns(table string, columns ...string) squirrel.InsertBuilder
+// - Insert(table string) types.InsertQueryBuilder
+// - InsertWithColumns(table string, columns ...string) types.InsertQueryBuilder
+// - InsertStruct(table string, instance any) types.InsertQueryBuilder
+// - InsertFields(table string, instance any, fields ...string) types.InsertQueryBuilder
 // - BuildCaseInsensitiveLike(column, value string) squirrel.Sqlizer
 // - BuildUpsert(table string, conflictColumns []string, insertColumns, updateColumns map[string]any) (query string, args []any, err error)
 // - BuildCurrentTimestamp() string

--- a/database/query_builder_test.go
+++ b/database/query_builder_test.go
@@ -150,7 +150,7 @@ func TestQueryBuilderInsert(t *testing.T) {
 			qb := NewQueryBuilder(tt.vendor)
 			query := qb.Insert(tt.table).Columns("name").Values("test")
 
-			sql, _, err := query.ToSql()
+			sql, _, err := query.ToSQL()
 			require.NoError(t, err)
 			assert.Contains(t, sql, tt.expected)
 		})
@@ -195,7 +195,7 @@ func TestQueryBuilderInsertWithColumnsOracleReserved(t *testing.T) {
 
 	// Build an INSERT with a reserved column name for Oracle
 	query := qb.InsertWithColumns("accounts", "id", "number", "name").Values(1, "123", "John")
-	sql, _, err := query.ToSql()
+	sql, _, err := query.ToSQL()
 	require.NoError(t, err)
 
 	// Should quote the reserved column and use Oracle-style placeholders
@@ -805,7 +805,7 @@ func TestQueryBuilderInsertWithSqlmock(t *testing.T) {
 
 	// Build an INSERT query
 	query := qb.Insert("users").Columns("name", "email").Values("John", "john@example.com")
-	sql, args, err := query.ToSql()
+	sql, args, err := query.ToSQL()
 	require.NoError(t, err)
 
 	// Set up mock expectation

--- a/database/types/interfaces.go
+++ b/database/types/interfaces.go
@@ -152,6 +152,27 @@ type SelectQueryBuilder interface {
 	ToSQL() (sql string, args []any, err error)
 }
 
+// InsertQueryBuilder defines the interface for INSERT query building.
+// Wraps squirrel.InsertBuilder so the public API exposes ToSQL() (S8179)
+// consistently with SelectQueryBuilder/UpdateQueryBuilder/DeleteQueryBuilder.
+// See ADR-017 for the rationale and migration path.
+type InsertQueryBuilder interface {
+	// Columns passes names through unchanged. For Oracle reserved-word quoting,
+	// use qb.InsertWithColumns or pre-quote via a Columns helper.
+	Columns(columns ...string) InsertQueryBuilder
+
+	Values(values ...any) InsertQueryBuilder
+	SetMap(clauses map[string]any) InsertQueryBuilder
+	Options(options ...string) InsertQueryBuilder
+	Prefix(sql string, args ...any) InsertQueryBuilder
+	Suffix(sql string, args ...any) InsertQueryBuilder
+
+	// Select panics if sb is not the concrete *SelectQueryBuilder from this package.
+	Select(sb SelectQueryBuilder) InsertQueryBuilder
+
+	ToSQL() (sql string, args []any, err error)
+}
+
 // UpdateQueryBuilder defines the interface for UPDATE query building with type-safe filtering.
 // This interface wraps squirrel.UpdateBuilder with Filter API support and vendor-specific quoting.
 type UpdateQueryBuilder interface {
@@ -424,17 +445,17 @@ type QueryBuilderInterface interface {
 
 	// Query builders
 	Select(columns ...any) SelectQueryBuilder
-	Insert(table string) squirrel.InsertBuilder
-	InsertWithColumns(table string, columns ...string) squirrel.InsertBuilder
+	Insert(table string) InsertQueryBuilder
+	InsertWithColumns(table string, columns ...string) InsertQueryBuilder
 
 	// Struct-based INSERT (v2.4+)
 	// InsertStruct extracts all fields from a struct instance and creates an INSERT query.
 	// Zero-value ID fields (int64/string) are automatically excluded to support auto-increment.
-	InsertStruct(table string, instance any) squirrel.InsertBuilder
+	InsertStruct(table string, instance any) InsertQueryBuilder
 
 	// InsertFields extracts only specified fields from a struct instance for INSERT.
 	// Useful for partial inserts or when you need explicit control over included fields.
-	InsertFields(table string, instance any, fields ...string) squirrel.InsertBuilder
+	InsertFields(table string, instance any, fields ...string) InsertQueryBuilder
 
 	Update(table string) UpdateQueryBuilder
 	Delete(table string) DeleteQueryBuilder

--- a/testing/mocks/query_builder.go
+++ b/testing/mocks/query_builder.go
@@ -75,30 +75,30 @@ func (m *MockQueryBuilder) Select(columns ...any) types.SelectQueryBuilder {
 }
 
 // Insert implements types.QueryBuilderInterface
-func (m *MockQueryBuilder) Insert(table string) squirrel.InsertBuilder {
+func (m *MockQueryBuilder) Insert(table string) types.InsertQueryBuilder {
 	args := m.MethodCalled("Insert", table)
-	return args.Get(0).(squirrel.InsertBuilder)
+	return args.Get(0).(types.InsertQueryBuilder)
 }
 
 // InsertWithColumns implements types.QueryBuilderInterface
-func (m *MockQueryBuilder) InsertWithColumns(table string, columns ...string) squirrel.InsertBuilder {
+func (m *MockQueryBuilder) InsertWithColumns(table string, columns ...string) types.InsertQueryBuilder {
 	callArgs := make([]any, len(columns)+1)
 	callArgs[0] = table
 	for i, col := range columns {
 		callArgs[i+1] = col
 	}
 	args := m.MethodCalled("InsertWithColumns", callArgs...)
-	return args.Get(0).(squirrel.InsertBuilder)
+	return args.Get(0).(types.InsertQueryBuilder)
 }
 
 // InsertStruct implements types.QueryBuilderInterface
-func (m *MockQueryBuilder) InsertStruct(table string, instance any) squirrel.InsertBuilder {
+func (m *MockQueryBuilder) InsertStruct(table string, instance any) types.InsertQueryBuilder {
 	args := m.MethodCalled("InsertStruct", table, instance)
-	return args.Get(0).(squirrel.InsertBuilder)
+	return args.Get(0).(types.InsertQueryBuilder)
 }
 
 // InsertFields implements types.QueryBuilderInterface
-func (m *MockQueryBuilder) InsertFields(table string, instance any, fields ...string) squirrel.InsertBuilder {
+func (m *MockQueryBuilder) InsertFields(table string, instance any, fields ...string) types.InsertQueryBuilder {
 	callArgs := make([]any, len(fields)+2)
 	callArgs[0] = table
 	callArgs[1] = instance
@@ -106,7 +106,7 @@ func (m *MockQueryBuilder) InsertFields(table string, instance any, fields ...st
 		callArgs[i+2] = field
 	}
 	args := m.MethodCalled("InsertFields", callArgs...)
-	return args.Get(0).(squirrel.InsertBuilder)
+	return args.Get(0).(types.InsertQueryBuilder)
 }
 
 // Update implements types.QueryBuilderInterface
@@ -178,7 +178,7 @@ func (m *MockQueryBuilder) ExpectSelect(columns []string, builder types.SelectQu
 }
 
 // ExpectInsert sets up an insert expectation with the provided builder
-func (m *MockQueryBuilder) ExpectInsert(table string, builder squirrel.InsertBuilder) *mock.Call {
+func (m *MockQueryBuilder) ExpectInsert(table string, builder types.InsertQueryBuilder) *mock.Call {
 	return m.On("Insert", table).Return(builder)
 }
 

--- a/testing/mocks/query_builder_test.go
+++ b/testing/mocks/query_builder_test.go
@@ -238,6 +238,67 @@ func (m *MockDeleteQueryBuilder) ToSQL() (sql string, args []any, err error) {
 
 var _ types.DeleteQueryBuilder = (*MockDeleteQueryBuilder)(nil)
 
+// MockInsertQueryBuilder provides a mock implementation of types.InsertQueryBuilder for testing
+type MockInsertQueryBuilder struct {
+	mock.Mock
+}
+
+func (m *MockInsertQueryBuilder) Columns(columns ...string) types.InsertQueryBuilder {
+	callArgs := make([]any, len(columns))
+	for i, col := range columns {
+		callArgs[i] = col
+	}
+	args := m.MethodCalled("Columns", callArgs...)
+	return args.Get(0).(types.InsertQueryBuilder)
+}
+
+func (m *MockInsertQueryBuilder) Values(values ...any) types.InsertQueryBuilder {
+	args := m.MethodCalled("Values", values...)
+	return args.Get(0).(types.InsertQueryBuilder)
+}
+
+func (m *MockInsertQueryBuilder) SetMap(clauses map[string]any) types.InsertQueryBuilder {
+	args := m.MethodCalled("SetMap", clauses)
+	return args.Get(0).(types.InsertQueryBuilder)
+}
+
+func (m *MockInsertQueryBuilder) Options(options ...string) types.InsertQueryBuilder {
+	callArgs := make([]any, len(options))
+	for i, o := range options {
+		callArgs[i] = o
+	}
+	args := m.MethodCalled("Options", callArgs...)
+	return args.Get(0).(types.InsertQueryBuilder)
+}
+
+func (m *MockInsertQueryBuilder) Prefix(sql string, args ...any) types.InsertQueryBuilder {
+	callArgs := append([]any{sql}, args...)
+	mockArgs := m.MethodCalled("Prefix", callArgs...)
+	return mockArgs.Get(0).(types.InsertQueryBuilder)
+}
+
+func (m *MockInsertQueryBuilder) Suffix(sql string, args ...any) types.InsertQueryBuilder {
+	callArgs := append([]any{sql}, args...)
+	mockArgs := m.MethodCalled("Suffix", callArgs...)
+	return mockArgs.Get(0).(types.InsertQueryBuilder)
+}
+
+func (m *MockInsertQueryBuilder) Select(sb types.SelectQueryBuilder) types.InsertQueryBuilder {
+	args := m.MethodCalled("Select", sb)
+	return args.Get(0).(types.InsertQueryBuilder)
+}
+
+func (m *MockInsertQueryBuilder) ToSQL() (sql string, args []any, err error) {
+	mockArgs := m.MethodCalled("ToSQL")
+	var outArgs []any
+	if v := mockArgs.Get(1); v != nil {
+		outArgs = v.([]any)
+	}
+	return mockArgs.String(0), outArgs, mockArgs.Error(2)
+}
+
+var _ types.InsertQueryBuilder = (*MockInsertQueryBuilder)(nil)
+
 func (m *MockSelectQueryBuilder) From(from ...any) types.SelectQueryBuilder {
 	args := m.MethodCalled("From", from...)
 	return args.Get(0).(types.SelectQueryBuilder)
@@ -406,18 +467,18 @@ func TestMockQueryBuilderEmptySearchTerm(t *testing.T) {
 func TestMockQueryBuilderHelperMethods(t *testing.T) {
 	mockQB := &MockQueryBuilder{}
 	mockSelectBuilder := &MockSelectQueryBuilder{}
+	mockInsertBuilder := &MockInsertQueryBuilder{}
 	mockUpdateBuilder := &MockUpdateQueryBuilder{}
 	mockDeleteBuilder := &MockDeleteQueryBuilder{}
 	defer mockQB.AssertExpectations(t)
 
 	// Test helper methods
-	insertBuilder := squirrel.Insert("users")
 	likeCondition := squirrel.ILike{"name": "%test%"}
 
 	// Use helper methods to set expectations
 	mockQB.ExpectVendor("postgresql")
 	mockQB.ExpectSelect([]string{"*"}, mockSelectBuilder)
-	mockQB.ExpectInsert("users", insertBuilder)
+	mockQB.ExpectInsert("users", mockInsertBuilder)
 	mockQB.ExpectUpdate("users", mockUpdateBuilder)
 	mockQB.ExpectDelete("users", mockDeleteBuilder)
 	mockQB.ExpectCaseInsensitiveLike("name", "test", likeCondition)
@@ -429,7 +490,7 @@ func TestMockQueryBuilderHelperMethods(t *testing.T) {
 	// Call the methods
 	assert.Equal(t, "postgresql", mockQB.Vendor())
 	assert.Equal(t, mockSelectBuilder, mockQB.Select("*"))
-	assert.Equal(t, insertBuilder, mockQB.Insert("users"))
+	assert.Equal(t, mockInsertBuilder, mockQB.Insert("users"))
 	assert.Equal(t, mockUpdateBuilder, mockQB.Update("users"))
 	assert.Equal(t, mockDeleteBuilder, mockQB.Delete("users"))
 	assert.Equal(t, likeCondition, mockQB.BuildCaseInsensitiveLike("name", "test"))

--- a/testing/mocks/query_builder_test.go
+++ b/testing/mocks/query_builder_test.go
@@ -742,3 +742,43 @@ func TestMockSelectQueryBuilderNilSafeToSQL(t *testing.T) {
 		mockSelect.AssertExpectations(t)
 	})
 }
+
+// TestMockInsertQueryBuilderNilSafeToSQL tests that ToSQL handles nil args safely
+func TestMockInsertQueryBuilderNilSafeToSQL(t *testing.T) {
+	t.Run(TestToSQLWithNilArgs, func(t *testing.T) {
+		mockInsert := &MockInsertQueryBuilder{}
+		mockInsert.On("ToSQL").Return("INSERT INTO users(name) VALUES(?)", nil, nil)
+
+		sql, args, err := mockInsert.ToSQL()
+
+		assert.Equal(t, "INSERT INTO users(name) VALUES(?)", sql)
+		assert.Nil(t, args)
+		assert.NoError(t, err)
+		mockInsert.AssertExpectations(t)
+	})
+
+	t.Run(TestToSQLWithAnyArgs, func(t *testing.T) {
+		mockInsert := &MockInsertQueryBuilder{}
+		expectedArgs := []any{"Alice", "alice@example.com"}
+		mockInsert.On("ToSQL").Return("INSERT INTO users(name,email) VALUES(?,?)", expectedArgs, nil)
+
+		sql, args, err := mockInsert.ToSQL()
+
+		assert.Equal(t, "INSERT INTO users(name,email) VALUES(?,?)", sql)
+		assert.Equal(t, expectedArgs, args)
+		assert.NoError(t, err)
+		mockInsert.AssertExpectations(t)
+	})
+
+	t.Run(TestToSQLWithErrors, func(t *testing.T) {
+		mockInsert := &MockInsertQueryBuilder{}
+		mockInsert.On("ToSQL").Return("", nil, assert.AnError)
+
+		sql, args, err := mockInsert.ToSQL()
+
+		assert.Empty(t, sql)
+		assert.Nil(t, args)
+		assert.Error(t, err)
+		mockInsert.AssertExpectations(t)
+	})
+}

--- a/wiki/adr-017-insert-query-builder.md
+++ b/wiki/adr-017-insert-query-builder.md
@@ -1,0 +1,113 @@
+# ADR-017: Standardize on `ToSQL()` Across All Query Builders
+
+**Status:** Accepted
+**Date:** 2026-05-01
+
+## Context
+
+Three of the four mutation entry points on `QueryBuilder` returned a go-bricks-owned interface (`SelectQueryBuilder`, `UpdateQueryBuilder`, `DeleteQueryBuilder`) that exposed `ToSQL()` (uppercase, idiomatic Go per [SonarCloud rule S8179](https://rules.sonarsource.com/go/RSPEC-8179/)). The fourth — `Insert` — leaked the upstream `squirrel.InsertBuilder` directly, whose only render method is the lowercase `ToSql()` defined by `squirrel.Sqlizer`.
+
+| Builder | Previous return | Render method |
+|---|---|---|
+| `qb.Select(...)` | `types.SelectQueryBuilder` | `ToSQL()` ✅ |
+| `qb.Update(...)` | `types.UpdateQueryBuilder` | `ToSQL()` ✅ |
+| `qb.Delete(...)` | `types.DeleteQueryBuilder` | `ToSQL()` ✅ |
+| `qb.Insert(...)` | `squirrel.InsertBuilder` | `ToSql()` ❌ |
+| `qb.InsertWithColumns(...)` | `squirrel.InsertBuilder` | `ToSql()` ❌ |
+| `qb.InsertStruct(...)` | `squirrel.InsertBuilder` | `ToSql()` ❌ |
+| `qb.InsertFields(...)` | `squirrel.InsertBuilder` | `ToSql()` ❌ |
+
+End users had to remember a different casing depending on the mutation — a small but persistent paper-cut that contradicts the project's "Explicit > Implicit" principle and the same S8179 rationale that drove the recent `Get*` → `*` rename across the framework (see CLAUDE.md "Breaking Change: Go Naming Conventions").
+
+The inconsistency had already started leaking into the codebase:
+
+- `llms.txt:890` documented an INSERT example calling `.ToSQL()` against the (then-) `squirrel.InsertBuilder` return — code that wouldn't have compiled.
+- `database/query_builder_test.go` mixed `ToSql()` (3 sites) and `ToSQL()` (12 sites) in the same file.
+- `database/internal/builder/query_builder_test.go` had 9 `ToSql()` calls on the four `Insert*` constructors.
+
+`Filter` and `JoinFilter` had already solved this exact pattern by implementing **both** methods and routing `ToSQL()` → `ToSql()` (see `database/internal/builder/filter.go:39-46` and `database/internal/builder/join_filter.go:23-30`). INSERT just hadn't gotten the same treatment.
+
+## Decision
+
+Introduce `types.InsertQueryBuilder`, a go-bricks-owned interface that wraps `squirrel.InsertBuilder` and exposes only `ToSQL()` on the public surface. Re-point all four `Insert*` constructors to return it.
+
+```go
+// database/types/interfaces.go
+type InsertQueryBuilder interface {
+    Columns(columns ...string) InsertQueryBuilder
+    Values(values ...any) InsertQueryBuilder
+    SetMap(clauses map[string]any) InsertQueryBuilder
+    Options(options ...string) InsertQueryBuilder
+    Prefix(sql string, args ...any) InsertQueryBuilder
+    Suffix(sql string, args ...any) InsertQueryBuilder
+    Select(sb SelectQueryBuilder) InsertQueryBuilder
+
+    ToSQL() (sql string, args []any, err error)
+}
+```
+
+The concrete `*builder.InsertQueryBuilder` holds the underlying `squirrel.InsertBuilder` and delegates each chaining method to it. `ToSQL()` calls the wrapped builder's `ToSql()`. The existing pattern from `Filter`/`JoinFilter` is reused verbatim.
+
+### Why these methods (and not the rest of `squirrel.InsertBuilder`)
+
+The interface exposes the chaining methods that real callers in the framework, tests, and demo project use, plus a small set of common SQL-level features:
+
+- `Columns`, `Values`, `SetMap` — covered every existing call site in the framework
+- `Prefix`, `Suffix` — needed for `WITH` clauses and `ON CONFLICT`/`RETURNING` (see `BuildUpsert`)
+- `Options` — needed for vendor-specific INSERT options like `OR IGNORE`/`OR REPLACE`
+- `Select` — needed for `INSERT INTO ... SELECT` patterns
+
+Squirrel-only knobs that don't belong on a vendor-aware go-bricks API (`RunWith`, `PlaceholderFormat`) are deliberately omitted: callers needing them can drop down to `ToSQL()` and execute via `db.Exec(ctx, sql, args...)`.
+
+### What stays the same
+
+- `BuildUpsert` in `database/internal/builder/postgres.go` continues to construct INSERTs internally; it now consumes the new wrapper via the public API. The wrapped squirrel builder is unchanged, so generated SQL is byte-identical.
+- `Filter`/`JoinFilter` keep both `ToSql()` (for `squirrel.Sqlizer` compatibility) and `ToSQL()` — those are filter-side, not the mutation surface this ADR addresses.
+- `MockQueryBuilder.BuildCaseInsensitiveLike` still returns `squirrel.Sqlizer` — that's an internal Squirrel type used inside Where clauses, not a top-level builder.
+
+## Consequences
+
+### Breaking change
+
+Any caller of `qb.Insert(...)`, `qb.InsertWithColumns(...)`, `qb.InsertStruct(...)`, or `qb.InsertFields(...)` that called `.ToSql()` on the returned builder must rename to `.ToSQL()`:
+
+```go
+// ❌ OLD
+sql, args, err := qb.Insert("users").Columns("name").Values("Alice").ToSql()
+
+// ✅ NEW
+sql, args, err := qb.Insert("users").Columns("name").Values("Alice").ToSQL()
+```
+
+Mechanical fix (`s/\.ToSql()/\.ToSQL()/g` against insert chains). The compiler catches every site at upgrade time — no silent runtime drift is possible.
+
+Code that previously type-asserted the return as `squirrel.InsertBuilder` (e.g., to call `RunWith`) must now render via `ToSQL()` and execute through `database.Interface`. This is a deliberate scope-tightening: vendor abstraction is one of GoBricks' core principles, and `RunWith` would couple application code back to Squirrel.
+
+### Mocks
+
+`testing/mocks.MockQueryBuilder.Insert*(...)` returns `types.InsertQueryBuilder` rather than `squirrel.InsertBuilder`. A new `MockInsertQueryBuilder` (in `testing/mocks/query_builder_test.go`) implements the interface for tests that need to assert on chained calls.
+
+### Positive
+
+- One render method across the public mutation surface — no more "is it `ToSql` or `ToSQL` for this one?"
+- Removes a footgun where docs and tests disagreed about the method name.
+- Establishes the wrapping pattern for any future operations that might leak through `squirrel.*Builder` (e.g., `MERGE` if vendors add support).
+
+### Negative
+
+- Breaking change for downstream applications calling `.ToSql()` on insert chains.
+- One additional indirection: insert chains now go through `*builder.InsertQueryBuilder` before reaching `squirrel.InsertBuilder`. The cost is a single pointer dereference per chained call — negligible against query execution.
+
+### Neutral
+
+- No behavioral change to generated SQL. The wrapper is a pass-through; vendor-specific quoting (Oracle reserved words, etc.) still happens at the same point.
+
+## Migration
+
+Single mechanical rename: `.ToSql()` → `.ToSQL()` on insert builder chains. CLAUDE.md gains an entry under "Breaking Change" sections matching the precedent set by S8179 / S8196.
+
+## Related ADRs
+
+- [ADR-005: Type-Safe WHERE Clause Construction](adr-005-type-safe-where-clauses.md) — established the `Filter`/`JoinFilter` pattern of wrapping squirrel with go-bricks-owned interfaces.
+- [ADR-007: Struct-Based Column Extraction](adr-007-struct-based-columns.md) — introduced the `Columns` helper used heavily with `InsertStruct`/`InsertFields`.
+- [ADR-013: Interface Naming Conventions (S8196)](adr-013-interface-naming-conventions.md) — the parallel public-API consistency push for interface names.

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -138,6 +138,15 @@ Slims the `app.Module` interface from 5 methods to 3, making `RegisterRoutes` an
 
 ---
 
+### [ADR-017: Standardize on `ToSQL()` Across All Query Builders](adr-017-insert-query-builder.md)
+**Date:** 2026-05-01 | **Status:** Accepted
+
+Introduces `types.InsertQueryBuilder` so `qb.Insert*` constructors return a go-bricks-owned interface exposing idiomatic `ToSQL()` (S8179) instead of the upstream `squirrel.InsertBuilder` with lowercase `ToSql()`. Aligns the INSERT surface with `Select`/`Update`/`Delete`.
+
+**Key Benefits:** Consistent public API, S8179-compliant naming, removes docs-vs-code drift
+
+---
+
 ## ADR Lifecycle
 
 - **Proposed**: Under discussion, not yet implemented


### PR DESCRIPTION
## Summary

Introduces `types.InsertQueryBuilder` interface to standardize the public API across all query builders. The four `Insert*` constructors now return a go-bricks-owned interface exposing idiomatic `ToSQL()` (uppercase, per S8179) instead of leaking the upstream `squirrel.InsertBuilder` with lowercase `ToSql()`. This aligns INSERT with SELECT/UPDATE/DELETE builders and resolves inconsistencies in documentation and test code.

## Key Changes

- **New Interface**: Added `types.InsertQueryBuilder` interface in `database/types/interfaces.go` with methods: `Columns`, `Values`, `SetMap`, `Options`, `Prefix`, `Suffix`, `Select`, and `ToSQL()`

- **Concrete Implementation**: Created `*builder.InsertQueryBuilder` struct in `database/internal/builder/query_builder.go` that wraps `squirrel.InsertBuilder` and delegates all chaining methods while exposing `ToSQL()` instead of `ToSql()`

- **Constructor Updates**: Modified all four INSERT constructors to return `types.InsertQueryBuilder`:
  - `QueryBuilder.Insert(table string)`
  - `QueryBuilder.InsertWithColumns(table string, columns ...string)`
  - `QueryBuilder.InsertStruct(table string, instance any)`
  - `QueryBuilder.InsertFields(table string, instance any, fields ...string)`

- **Mock Support**: Added `MockInsertQueryBuilder` in `testing/mocks/query_builder_test.go` for test assertions on chained calls

- **Test Updates**: Updated all test files to call `.ToSQL()` instead of `.ToSql()` on insert builder chains (mechanical rename across ~15 test sites)

- **Documentation**: Added ADR-017 explaining the rationale, consequences, and migration path; updated CLAUDE.md with breaking change notice and migration example

## Implementation Details

- The wrapper follows the established pattern from `Filter`/`JoinFilter` (ADR-005), delegating to the underlying squirrel builder while controlling the public surface
- `Select()` method includes a runtime panic if passed a non-`*SelectQueryBuilder` to prevent silent SQL generation errors
- All chaining methods return the interface type, enabling fluent API usage
- No behavioral change to generated SQL; vendor-specific quoting still happens at the same point
- The cost is a single pointer dereference per chained call — negligible against query execution

## Breaking Change

Callers must rename `.ToSql()` to `.ToSQL()` on insert builder chains. The compiler catches every site at upgrade time. Code that type-asserted the return as `squirrel.InsertBuilder` must now render via `ToSQL()` and execute through `database.Interface`.

https://claude.ai/code/session_015gP991HjX2U8W26ojwAC1q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Insert* query builder methods now return a standardized InsertQueryBuilder interface.
  * SQL generation method renamed from ToSql() to ToSQL(); update call sites.

* **Documentation**
  * Added ADR and migration guidance describing the new InsertQueryBuilder and ToSQL() rename.

* **Tests**
  * Updated and added tests and mocks to use InsertQueryBuilder and ToSQL().
<!-- end of auto-generated comment: release notes by coderabbit.ai -->