### PR TITLE
refactor(jose): drop dormant Typ field from diagnostic Header

### DIFF
--- a/jose/internal/cryptoadapter/cryptoadapter.go
+++ b/jose/internal/cryptoadapter/cryptoadapter.go
@@ -31,7 +31,6 @@ type Header struct {
 	Kid string
 	Alg string
 	Enc string
-	Typ string
 	Cty string
 }
 
@@ -54,7 +53,6 @@ func Decrypt(compact string, key *rsa.PrivateKey, opts *DecryptOptions) ([]byte,
 		Kid: jwe.Header.KeyID,
 		Alg: jwe.Header.Algorithm,
 		Enc: extractStringExtra(jwe.Header.ExtraHeaders, "enc"),
-		Typ: extractStringExtra(jwe.Header.ExtraHeaders, jose.HeaderType),
 		Cty: extractStringExtra(jwe.Header.ExtraHeaders, jose.HeaderContentType),
 	}
 
@@ -94,7 +92,6 @@ func Verify(compact string, key *rsa.PublicKey, opts *VerifyOptions) ([]byte, He
 	hdr := Header{
 		Kid: sig.Protected.KeyID,
 		Alg: sig.Protected.Algorithm,
-		Typ: extractStringExtra(sig.Protected.ExtraHeaders, jose.HeaderType),
 		Cty: extractStringExtra(sig.Protected.ExtraHeaders, jose.HeaderContentType),
 	}
 

--- a/jose/opener.go
+++ b/jose/opener.go
@@ -97,12 +97,11 @@ type Header struct {
 	Kid string
 	Alg string
 	Enc string
-	Typ string
 	Cty string
 }
 
 func cryptoHeaderToOpen(h *cryptoadapter.Header) Header {
-	return Header{Kid: h.Kid, Alg: h.Alg, Enc: h.Enc, Typ: h.Typ, Cty: h.Cty}
+	return Header{Kid: h.Kid, Alg: h.Alg, Enc: h.Enc, Cty: h.Cty}
 }
 
 func mapDecryptError(err error, _ *Policy, hdr *cryptoadapter.Header) *Error {


### PR DESCRIPTION
## Summary

- Closes #349 via Path 2 (drop). The issue's own decision rule said *"Pick Path 2 at the next opportunistic cleanup if nobody touches it"* — that's the situation: every `jose.Open()` caller in the framework discards the `OpenHeader` return value (`server/jose.go`, `httpclient/jose_transport.go`, `jose/testing/helpers.go`), no test asserts on `Typ`, and no triage issue ever surfaced needing it.
- Removes `Typ string` from both `cryptoadapter.Header` (internal) and `jose.Header` (public, exposed via `OpenHeader{JWE, JWS}` from `jose.Open`), plus the two `extractStringExtra(..., jose.HeaderType)` calls that populated it.
- Net diff: 5 lines removed across 2 files.

## API impact

Minor. `jose.Header` is part of `OpenHeader`, returned by the public `jose.Open()`. External code that read `hdr.JWE.Typ` or `hdr.JWS.Typ` would no longer compile. Inside this repo, all three callers discard the header — no internal break.

## Path 1 vs Path 2 rationale

The issue offered two paths: (1) wire `typ` into `jose.decode_request` span attributes and request-log fields, or (2) drop it. I chose Path 2 because:

1. The issue's explicit decision rule favors Path 2 absent triage evidence — and there's been none.
2. The project's YAGNI principle (CLAUDE.md → Developer Manifesto) discourages carrying dead surface "in case someone wants it."
3. Even the test helper docstring at `jose/testing/helpers.go:25-27` documents that "the diagnostic header is dropped because tests rarely care about it" — strong evidence the dormancy is by design, not oversight.

## Follow-up surfaced during review

`/simplify` review flagged that `hdr.Cty` on the **JWE layer** is also dead surface (only the **JWS layer's** `Cty` is read in `opener.go:72` for cty enforcement). Keeping this PR scoped strictly to #349; will file a separate exploration issue mirroring #349's structure if the same opportunistic-cleanup case applies.

## Test plan

- [x] `make check` passes (fmt + lint + race-tested unit tests, all packages green)
- [x] `go build ./...` clean — no orphaned references
- [x] `/simplify` reviewed for reuse, quality, efficiency — clean
- [x] Repo-wide grep confirms zero remaining `\.Typ\b` or `HeaderType` references in non-archive paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the `Typ` field from the public JOSE header structure. The header now only exposes `Kid`, `Alg`, `Enc`, and `Cty`. Consumers relying on `Typ` in decrypted or verified messages must update their integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->