### PR TITLE
fix(scheduler): idempotent Shutdown + consolidate test helpers

### DIFF
--- a/scheduler/api_handlers_test.go
+++ b/scheduler/api_handlers_test.go
@@ -18,7 +18,6 @@ const (
 // TestListJobsHandler verifies GET /_sys/job returns job metadata
 func TestListJobsHandler(t *testing.T) {
 	module, registrar := newTestScheduler(t, 5*time.Second)
-	defer module.Shutdown()
 
 	// Register a test job
 	job := &counterJob{}
@@ -70,7 +69,6 @@ func TestListJobsHandlerEmptyScheduler(t *testing.T) {
 // TestTriggerJobHandler verifies POST /_sys/job/:jobId triggers job
 func TestTriggerJobHandler(t *testing.T) {
 	module, registrar := newTestScheduler(t, 5*time.Second)
-	defer module.Shutdown()
 
 	// Register a test job
 	job := &counterJob{}

--- a/scheduler/integration_test.go
+++ b/scheduler/integration_test.go
@@ -139,4 +139,3 @@ func (j *longRunningJob) Completed() bool {
 	defer j.mu.Unlock()
 	return j.completed
 }
-

--- a/scheduler/module.go
+++ b/scheduler/module.go
@@ -183,6 +183,7 @@ func (m *Module) Shutdown() error {
 	}
 
 	scheduler := m.scheduler
+	m.scheduler = nil
 	m.mu.Unlock()
 
 	m.logger.Info().Msg("Initiating graceful scheduler shutdown")

--- a/scheduler/module_test.go
+++ b/scheduler/module_test.go
@@ -32,8 +32,7 @@ func TestSchedulerModuleRegisterRoutes(_ *testing.T) {
 
 // TestJobExecutionFailure verifies job failures are tracked
 func TestJobExecutionFailure(t *testing.T) {
-	module, registrar := newTestScheduler(t, 5*time.Second)
-	defer module.Shutdown()
+	_, registrar := newTestScheduler(t, 5*time.Second)
 
 	// Create a job that always fails
 	job := &failingJob{err: errors.New("intentional failure")}
@@ -47,8 +46,7 @@ func TestJobExecutionFailure(t *testing.T) {
 
 // TestJobExecutionPanic verifies panic recovery
 func TestJobExecutionPanic(t *testing.T) {
-	module, registrar := newTestScheduler(t, 5*time.Second)
-	defer module.Shutdown()
+	_, registrar := newTestScheduler(t, 5*time.Second)
 
 	// Create a job that panics
 	job := &panicJob{}
@@ -62,8 +60,7 @@ func TestJobExecutionPanic(t *testing.T) {
 
 // TestJobExecutionOverlappingPrevention verifies jobs don't overlap
 func TestJobExecutionOverlappingPrevention(t *testing.T) {
-	module, registrar := newTestScheduler(t, 5*time.Second)
-	defer module.Shutdown()
+	_, registrar := newTestScheduler(t, 5*time.Second)
 
 	// Create a slow job that takes longer than the interval
 	job := &slowJob{duration: 500 * time.Millisecond}
@@ -88,7 +85,6 @@ func TestJobExecutionPanicMetrics(t *testing.T) {
 	defer mp.Shutdown(context.Background())
 
 	module, _ := newTestScheduler(t, 5*time.Second, withMeterProvider(mp.MeterProvider))
-	defer module.Shutdown()
 
 	// Register a job that panics
 	job := &panicJob{}
@@ -155,7 +151,6 @@ func TestJobExecutionWithDBGetterError(t *testing.T) {
 	module, _ := newTestScheduler(t, 5*time.Second, withDB(func(_ context.Context) (types.Interface, error) {
 		return nil, errors.New("DB connection failed")
 	}))
-	defer module.Shutdown()
 
 	// Create a job that checks DB is nil
 	job := &dbCheckJob{}
@@ -173,7 +168,6 @@ func TestJobExecutionWithMessagingGetterError(t *testing.T) {
 	module, _ := newTestScheduler(t, 5*time.Second, withMessaging(func(_ context.Context) (messaging.AMQPClient, error) {
 		return nil, errors.New("Messaging connection failed")
 	}))
-	defer module.Shutdown()
 
 	// Create a job that checks messaging is nil
 	job := &messagingCheckJob{}
@@ -189,7 +183,6 @@ func TestJobExecutionWithMessagingGetterError(t *testing.T) {
 // TestSlowJobThresholdWarning verifies slow job detection and WARN severity
 func TestSlowJobThresholdWarning(t *testing.T) {
 	module, _ := newTestScheduler(t, 5*time.Second, withSlowJobThreshold(100*time.Millisecond))
-	defer module.Shutdown()
 
 	// Create a slow job that exceeds threshold
 	job := &slowJob{duration: 150 * time.Millisecond}
@@ -206,7 +199,6 @@ func TestSlowJobThresholdWarning(t *testing.T) {
 // TestJobExecutionWithoutTracer verifies jobs execute successfully when tracer is nil
 func TestJobExecutionWithoutTracer(t *testing.T) {
 	module, _ := newTestScheduler(t, 5*time.Second)
-	defer module.Shutdown()
 
 	// Create a simple job
 	job := &slowJob{duration: 10 * time.Millisecond}
@@ -227,7 +219,6 @@ func TestJobExecutionWithTracer(t *testing.T) {
 	defer tp.Shutdown(context.Background())
 
 	module, _ := newTestScheduler(t, 5*time.Second, withTracer(tp.Tracer("test-scheduler")))
-	defer module.Shutdown()
 
 	// Create a simple job. Use a 1s interval so a second tick cannot race the
 	// assertion window, and stop the scheduler before counting spans.
@@ -258,7 +249,6 @@ func TestJobExecutionWithTracerPropagatesContext(t *testing.T) {
 	defer tp.Shutdown(context.Background())
 
 	module, _ := newTestScheduler(t, 5*time.Second, withTracer(tp.Tracer("test-scheduler")))
-	defer module.Shutdown()
 
 	// Job that creates a child span to verify context propagation. Use a 1s
 	// interval so a second tick cannot race the assertion window, and stop the

--- a/scheduler/module_test.go
+++ b/scheduler/module_test.go
@@ -134,6 +134,22 @@ func TestJobSkippedDuringShutdown(t *testing.T) {
 	assert.Equal(t, 0, job.count(), "Job should not execute after shutdown")
 }
 
+// TestShutdownIdempotent verifies that calling Shutdown more than once is a no-op
+// and does not return an error or fail the underlying gocron scheduler. Regression
+// test for the spurious "Error stopping scheduler" log emitted when a deferred
+// Shutdown ran after an explicit Shutdown.
+func TestShutdownIdempotent(t *testing.T) {
+	module, registrar := newTestScheduler(t, 5*time.Second)
+
+	// Register a job so the gocron scheduler is actually initialized.
+	err := registrar.FixedRate("idempotent-shutdown-job", &slowJob{duration: time.Millisecond}, time.Hour)
+	require.NoError(t, err)
+
+	require.NoError(t, module.Shutdown(), "first shutdown should succeed")
+	require.NoError(t, module.Shutdown(), "second shutdown should be a no-op")
+	require.NoError(t, module.Shutdown(), "subsequent shutdowns should remain no-ops")
+}
+
 // TestJobExecutionWithDBGetterError verifies error handling when DB getter fails
 func TestJobExecutionWithDBGetterError(t *testing.T) {
 	module, _ := newTestScheduler(t, 5*time.Second, withDB(func(_ context.Context) (types.Interface, error) {

--- a/scheduler/registrar_test.go
+++ b/scheduler/registrar_test.go
@@ -16,8 +16,7 @@ const (
 // TestJobRegistrarFixedRate tests fixed-rate job scheduling
 func TestJobRegistrarFixedRate(t *testing.T) {
 	t.Run("registers job with valid interval", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 
 		err := registrar.FixedRate(testJobID, job, 30*time.Second)
@@ -25,8 +24,7 @@ func TestJobRegistrarFixedRate(t *testing.T) {
 	})
 
 	t.Run(rejectDuplicateJobIDErrorMsg, func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job1 := &testJob{}
 		job2 := &testJob{}
 
@@ -40,8 +38,7 @@ func TestJobRegistrarFixedRate(t *testing.T) {
 	})
 
 	t.Run("rejects zero interval", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 
 		err := registrar.FixedRate(testJobID, job, 0)
@@ -50,8 +47,7 @@ func TestJobRegistrarFixedRate(t *testing.T) {
 	})
 
 	t.Run("rejects negative interval", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 
 		err := registrar.FixedRate(testJobID, job, -10*time.Second)
@@ -63,8 +59,7 @@ func TestJobRegistrarFixedRate(t *testing.T) {
 // TestJobRegistrarDailyAt tests daily job scheduling
 func TestJobRegistrarDailyAt(t *testing.T) {
 	t.Run("registers job with valid time", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 		localTime := mustParseTime("03:00")
 
@@ -73,8 +68,7 @@ func TestJobRegistrarDailyAt(t *testing.T) {
 	})
 
 	t.Run(rejectDuplicateJobIDErrorMsg, func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job1 := &testJob{}
 		job2 := &testJob{}
 		localTime := mustParseTime("03:00")
@@ -88,8 +82,7 @@ func TestJobRegistrarDailyAt(t *testing.T) {
 	})
 
 	t.Run("accepts hour 0 (midnight)", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 		localTime := mustParseTime("00:00")
 
@@ -98,8 +91,7 @@ func TestJobRegistrarDailyAt(t *testing.T) {
 	})
 
 	t.Run("accepts hour 23", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 		localTime := mustParseTime("23:59")
 
@@ -111,8 +103,7 @@ func TestJobRegistrarDailyAt(t *testing.T) {
 // TestJobRegistrarWeeklyAt tests weekly job scheduling
 func TestJobRegistrarWeeklyAt(t *testing.T) {
 	t.Run("registers job with valid day and time", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 		localTime := mustParseTime("09:00")
 
@@ -121,8 +112,7 @@ func TestJobRegistrarWeeklyAt(t *testing.T) {
 	})
 
 	t.Run(rejectDuplicateJobIDErrorMsg, func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job1 := &testJob{}
 		job2 := &testJob{}
 		localTime := mustParseTime("09:00")
@@ -136,8 +126,7 @@ func TestJobRegistrarWeeklyAt(t *testing.T) {
 	})
 
 	t.Run("accepts all weekdays", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		localTime := mustParseTime("09:00")
 
 		weekdays := []time.Weekday{
@@ -156,8 +145,7 @@ func TestJobRegistrarWeeklyAt(t *testing.T) {
 // TestJobRegistrarHourlyAt tests hourly job scheduling
 func TestJobRegistrarHourlyAt(t *testing.T) {
 	t.Run("registers job with valid minute", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 
 		err := registrar.HourlyAt(testJobID, job, 15)
@@ -165,8 +153,7 @@ func TestJobRegistrarHourlyAt(t *testing.T) {
 	})
 
 	t.Run(rejectDuplicateJobIDErrorMsg, func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job1 := &testJob{}
 		job2 := &testJob{}
 
@@ -179,8 +166,7 @@ func TestJobRegistrarHourlyAt(t *testing.T) {
 	})
 
 	t.Run("accepts minute 0", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 
 		err := registrar.HourlyAt(testJobID, job, 0)
@@ -188,8 +174,7 @@ func TestJobRegistrarHourlyAt(t *testing.T) {
 	})
 
 	t.Run("accepts minute 59", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 
 		err := registrar.HourlyAt(testJobID, job, 59)
@@ -197,8 +182,7 @@ func TestJobRegistrarHourlyAt(t *testing.T) {
 	})
 
 	t.Run("rejects minute 60", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 
 		err := registrar.HourlyAt(testJobID, job, 60)
@@ -207,8 +191,7 @@ func TestJobRegistrarHourlyAt(t *testing.T) {
 	})
 
 	t.Run("rejects negative minute", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 
 		err := registrar.HourlyAt(testJobID, job, -1)
@@ -220,8 +203,7 @@ func TestJobRegistrarHourlyAt(t *testing.T) {
 // TestJobRegistrarMonthlyAt tests monthly job scheduling
 func TestJobRegistrarMonthlyAt(t *testing.T) {
 	t.Run("registers job with valid day and time", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 		localTime := mustParseTime("00:00")
 
@@ -230,8 +212,7 @@ func TestJobRegistrarMonthlyAt(t *testing.T) {
 	})
 
 	t.Run(rejectDuplicateJobIDErrorMsg, func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job1 := &testJob{}
 		job2 := &testJob{}
 		localTime := mustParseTime("00:00")
@@ -245,8 +226,7 @@ func TestJobRegistrarMonthlyAt(t *testing.T) {
 	})
 
 	t.Run("accepts day 1", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 		localTime := mustParseTime("00:00")
 
@@ -255,8 +235,7 @@ func TestJobRegistrarMonthlyAt(t *testing.T) {
 	})
 
 	t.Run("accepts day 31", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 		localTime := mustParseTime("00:00")
 
@@ -265,8 +244,7 @@ func TestJobRegistrarMonthlyAt(t *testing.T) {
 	})
 
 	t.Run("rejects day 0", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 		localTime := mustParseTime("00:00")
 
@@ -276,8 +254,7 @@ func TestJobRegistrarMonthlyAt(t *testing.T) {
 	})
 
 	t.Run("rejects day 32", func(t *testing.T) {
-		module, registrar := newTestScheduler(t, 5*time.Second)
-		defer module.Shutdown()
+		_, registrar := newTestScheduler(t, 5*time.Second)
 		job := &testJob{}
 		localTime := mustParseTime("00:00")
 

--- a/scheduler/registrar_test.go
+++ b/scheduler/registrar_test.go
@@ -1,15 +1,9 @@
 package scheduler
 
 import (
-	"context"
 	"testing"
 	"time"
 
-	"github.com/gaborage/go-bricks/app"
-	"github.com/gaborage/go-bricks/config"
-	"github.com/gaborage/go-bricks/database/types"
-	"github.com/gaborage/go-bricks/logger"
-	"github.com/gaborage/go-bricks/messaging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +16,8 @@ const (
 // TestJobRegistrarFixedRate tests fixed-rate job scheduling
 func TestJobRegistrarFixedRate(t *testing.T) {
 	t.Run("registers job with valid interval", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 
 		err := registrar.FixedRate(testJobID, job, 30*time.Second)
@@ -30,7 +25,8 @@ func TestJobRegistrarFixedRate(t *testing.T) {
 	})
 
 	t.Run(rejectDuplicateJobIDErrorMsg, func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job1 := &testJob{}
 		job2 := &testJob{}
 
@@ -44,7 +40,8 @@ func TestJobRegistrarFixedRate(t *testing.T) {
 	})
 
 	t.Run("rejects zero interval", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 
 		err := registrar.FixedRate(testJobID, job, 0)
@@ -53,7 +50,8 @@ func TestJobRegistrarFixedRate(t *testing.T) {
 	})
 
 	t.Run("rejects negative interval", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 
 		err := registrar.FixedRate(testJobID, job, -10*time.Second)
@@ -65,7 +63,8 @@ func TestJobRegistrarFixedRate(t *testing.T) {
 // TestJobRegistrarDailyAt tests daily job scheduling
 func TestJobRegistrarDailyAt(t *testing.T) {
 	t.Run("registers job with valid time", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 		localTime := mustParseTime("03:00")
 
@@ -74,7 +73,8 @@ func TestJobRegistrarDailyAt(t *testing.T) {
 	})
 
 	t.Run(rejectDuplicateJobIDErrorMsg, func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job1 := &testJob{}
 		job2 := &testJob{}
 		localTime := mustParseTime("03:00")
@@ -88,7 +88,8 @@ func TestJobRegistrarDailyAt(t *testing.T) {
 	})
 
 	t.Run("accepts hour 0 (midnight)", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 		localTime := mustParseTime("00:00")
 
@@ -97,7 +98,8 @@ func TestJobRegistrarDailyAt(t *testing.T) {
 	})
 
 	t.Run("accepts hour 23", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 		localTime := mustParseTime("23:59")
 
@@ -109,7 +111,8 @@ func TestJobRegistrarDailyAt(t *testing.T) {
 // TestJobRegistrarWeeklyAt tests weekly job scheduling
 func TestJobRegistrarWeeklyAt(t *testing.T) {
 	t.Run("registers job with valid day and time", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 		localTime := mustParseTime("09:00")
 
@@ -118,7 +121,8 @@ func TestJobRegistrarWeeklyAt(t *testing.T) {
 	})
 
 	t.Run(rejectDuplicateJobIDErrorMsg, func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job1 := &testJob{}
 		job2 := &testJob{}
 		localTime := mustParseTime("09:00")
@@ -132,7 +136,8 @@ func TestJobRegistrarWeeklyAt(t *testing.T) {
 	})
 
 	t.Run("accepts all weekdays", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		localTime := mustParseTime("09:00")
 
 		weekdays := []time.Weekday{
@@ -151,7 +156,8 @@ func TestJobRegistrarWeeklyAt(t *testing.T) {
 // TestJobRegistrarHourlyAt tests hourly job scheduling
 func TestJobRegistrarHourlyAt(t *testing.T) {
 	t.Run("registers job with valid minute", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 
 		err := registrar.HourlyAt(testJobID, job, 15)
@@ -159,7 +165,8 @@ func TestJobRegistrarHourlyAt(t *testing.T) {
 	})
 
 	t.Run(rejectDuplicateJobIDErrorMsg, func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job1 := &testJob{}
 		job2 := &testJob{}
 
@@ -172,7 +179,8 @@ func TestJobRegistrarHourlyAt(t *testing.T) {
 	})
 
 	t.Run("accepts minute 0", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 
 		err := registrar.HourlyAt(testJobID, job, 0)
@@ -180,7 +188,8 @@ func TestJobRegistrarHourlyAt(t *testing.T) {
 	})
 
 	t.Run("accepts minute 59", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 
 		err := registrar.HourlyAt(testJobID, job, 59)
@@ -188,7 +197,8 @@ func TestJobRegistrarHourlyAt(t *testing.T) {
 	})
 
 	t.Run("rejects minute 60", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 
 		err := registrar.HourlyAt(testJobID, job, 60)
@@ -197,7 +207,8 @@ func TestJobRegistrarHourlyAt(t *testing.T) {
 	})
 
 	t.Run("rejects negative minute", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 
 		err := registrar.HourlyAt(testJobID, job, -1)
@@ -209,7 +220,8 @@ func TestJobRegistrarHourlyAt(t *testing.T) {
 // TestJobRegistrarMonthlyAt tests monthly job scheduling
 func TestJobRegistrarMonthlyAt(t *testing.T) {
 	t.Run("registers job with valid day and time", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 		localTime := mustParseTime("00:00")
 
@@ -218,7 +230,8 @@ func TestJobRegistrarMonthlyAt(t *testing.T) {
 	})
 
 	t.Run(rejectDuplicateJobIDErrorMsg, func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job1 := &testJob{}
 		job2 := &testJob{}
 		localTime := mustParseTime("00:00")
@@ -232,7 +245,8 @@ func TestJobRegistrarMonthlyAt(t *testing.T) {
 	})
 
 	t.Run("accepts day 1", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 		localTime := mustParseTime("00:00")
 
@@ -241,7 +255,8 @@ func TestJobRegistrarMonthlyAt(t *testing.T) {
 	})
 
 	t.Run("accepts day 31", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 		localTime := mustParseTime("00:00")
 
@@ -250,7 +265,8 @@ func TestJobRegistrarMonthlyAt(t *testing.T) {
 	})
 
 	t.Run("rejects day 0", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 		localTime := mustParseTime("00:00")
 
@@ -260,7 +276,8 @@ func TestJobRegistrarMonthlyAt(t *testing.T) {
 	})
 
 	t.Run("rejects day 32", func(t *testing.T) {
-		registrar := newTestRegistrar()
+		module, registrar := newTestScheduler(t, 5*time.Second)
+		defer module.Shutdown()
 		job := &testJob{}
 		localTime := mustParseTime("00:00")
 
@@ -271,31 +288,6 @@ func TestJobRegistrarMonthlyAt(t *testing.T) {
 }
 
 // Test helpers
-
-// newTestRegistrar creates a test JobRegistrar using the real scheduler Module
-func newTestRegistrar() app.JobRegistrar {
-	module := NewModule()
-
-	// Initialize with minimal dependencies
-	deps := &app.ModuleDeps{
-		Logger:        logger.New("info", false),
-		Config:        &config.Config{},
-		Tracer:        nil,
-		MeterProvider: nil,
-		DB: func(_ context.Context) (types.Interface, error) {
-			return nil, nil
-		},
-		Messaging: func(_ context.Context) (messaging.AMQPClient, error) {
-			return nil, nil
-		},
-	}
-
-	if err := module.Init(deps); err != nil {
-		panic(err) //nolint:S8148 // NOSONAR: Test helper - panic on setup failure is intentional
-	}
-
-	return module
-}
 
 // mustParseTime parses time in "HH:MM" format
 func mustParseTime(s string) time.Time {

--- a/scheduler/test_helpers_test.go
+++ b/scheduler/test_helpers_test.go
@@ -65,6 +65,7 @@ func newTestScheduler(t *testing.T, shutdownTimeout time.Duration, opts ...testS
 	}
 
 	require.NoError(t, module.Init(appDeps), "Module initialization should succeed")
+	t.Cleanup(func() { _ = module.Shutdown() })
 
 	return module, module
 }

--- a/scheduler/test_helpers_test.go
+++ b/scheduler/test_helpers_test.go
@@ -65,7 +65,11 @@ func newTestScheduler(t *testing.T, shutdownTimeout time.Duration, opts ...testS
 	}
 
 	require.NoError(t, module.Init(appDeps), "Module initialization should succeed")
-	t.Cleanup(func() { _ = module.Shutdown() })
+	t.Cleanup(func() {
+		if err := module.Shutdown(); err != nil {
+			t.Errorf("module shutdown failed during cleanup: %v", err)
+		}
+	})
 
 	return module, module
 }


### PR DESCRIPTION
## Summary

Closes #361 and #360 in one PR.

- **`0fd3f3f` — fix(scheduler): make Module.Shutdown idempotent (#361).** Clears `m.scheduler = nil` under the existing lock so a second call hits the early-return path instead of re-entering gocron and triggering `ErrSchedulerNotRunning`. Eliminates the spurious `level=error msg="Error stopping scheduler"` log that fired whenever a deferred Shutdown ran after an explicit one (a pattern used by `TestJobExecutionWithTracer*` to flush spans before assertions).
- **`8089fda` — test(scheduler): consolidate newTestRegistrar into newTestScheduler (#360).** Migrates all 23 `newTestRegistrar()` call sites in `registrar_test.go` to the canonical `newTestScheduler(t, 5*time.Second)` helper added in #353, and deletes the duplicate `ModuleDeps` builder + its `panic(err)` setup-failure shim. Also closes the latent goroutine-leak path in those tests (every site now actually shuts the scheduler down).
- **`d55a285` — refactor(scheduler): centralize Shutdown via t.Cleanup in newTestScheduler.** Surfaced by `/simplify` after the first two commits landed: moves `t.Cleanup(func() { _ = module.Shutdown() })` into the helper, deleting all 35 per-site `defer module.Shutdown()` calls (23 in `registrar_test.go`, 10 in `module_test.go`, 2 in `api_handlers_test.go`). Net `+27 / -61`. Depends on the idempotency fix above — without it, the auto-cleanup would emit spurious ERRORs whenever a test also called `Shutdown()` explicitly.

`TestShutdownIdempotent` is added in commit 1 as a regression test and now exercises 4 sequential `Shutdown()` calls (3 explicit + the cleanup), strengthening the lock.

## Test plan

- [x] `go test -race -count=1 ./scheduler/` — green (30s)
- [x] `make check` — green
- [x] `make lint` — 0 issues
- [x] `TestShutdownIdempotent` passes; log output shows 1 real shutdown + 3 idempotent no-ops, **zero ERROR lines**
- [x] `TestJobExecutionWithTracer` and `TestJobExecutionWithTracerPropagatesContext` (which already pair explicit + deferred Shutdown) no longer emit the spurious "Error stopping scheduler" line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduler shutdown made safe for repeated calls.
  * Fixed long-running job completion tracking.

* **Tests**
  * Added regression test verifying idempotent shutdown.
  * Refactored test helpers and integration tests to use centralized test scheduler and automatic cleanup, simplifying test setup and imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->