### PR TITLE
feat(database): add Regex and JSONContains type-safe filters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -612,7 +612,7 @@ query := qb.Select(cols.Fields("ID", "Number")...).
 // Oracle: SELECT "ID", "NUMBER" FROM accounts WHERE "NUMBER" = :1
 ```
 
-**Type-Safe Methods:** `f.Eq`, `f.NotEq`, `f.Lt/Lte/Gt/Gte`, `f.In/NotIn`, `f.Like`, `f.Null/NotNull`, `f.Between`
+**Type-Safe Methods:** `f.Eq`, `f.NotEq`, `f.Lt/Lte/Gt/Gte`, `f.In/NotIn`, `f.Like`, `f.Regex/RegexI/NotRegex/NotRegexI`, `f.JSONContains` (PostgreSQL only), `f.Null/NotNull`, `f.Between`
 
 **Escape Hatch:** `f.Raw(condition, args...)` (and `jf.Raw(...)` for JOIN conditions) — user must manually quote Oracle reserved words and parameterize all value sides. Every call site MUST carry a `// SECURITY: Manual SQL review completed - <rationale>` comment (see Detailed Security Guidelines).
 

--- a/database/internal/builder/filter.go
+++ b/database/internal/builder/filter.go
@@ -172,6 +172,50 @@ func (ff *FilterFactory) Like(column, pattern string) dbtypes.Filter {
 	return Filter{sqlizer: ff.qb.BuildCaseInsensitiveLike(column, pattern)}
 }
 
+// Regex creates a case-sensitive regex match filter.
+// PostgreSQL emits "column ~ ?", Oracle emits "REGEXP_LIKE(column, ?)".
+// The pattern syntax is the database's POSIX regex; portable patterns should
+// stick to the common subset (anchors, character classes, quantifiers).
+func (ff *FilterFactory) Regex(column, pattern string) dbtypes.Filter {
+	return Filter{sqlizer: ff.qb.BuildRegex(column, pattern, false, false)}
+}
+
+// RegexI creates a case-insensitive regex match filter.
+// PostgreSQL emits "column ~* ?", Oracle emits "REGEXP_LIKE(column, ?, 'i')".
+func (ff *FilterFactory) RegexI(column, pattern string) dbtypes.Filter {
+	return Filter{sqlizer: ff.qb.BuildRegex(column, pattern, true, false)}
+}
+
+// NotRegex creates a case-sensitive negated regex match filter.
+// PostgreSQL emits "column !~ ?", Oracle emits "NOT (REGEXP_LIKE(column, ?))".
+func (ff *FilterFactory) NotRegex(column, pattern string) dbtypes.Filter {
+	return Filter{sqlizer: ff.qb.BuildRegex(column, pattern, false, true)}
+}
+
+// NotRegexI creates a case-insensitive negated regex match filter.
+// PostgreSQL emits "column !~* ?", Oracle emits "NOT (REGEXP_LIKE(column, ?, 'i'))".
+func (ff *FilterFactory) NotRegexI(column, pattern string) dbtypes.Filter {
+	return Filter{sqlizer: ff.qb.BuildRegex(column, pattern, true, true)}
+}
+
+// JSONContains creates a JSON containment filter (PostgreSQL @> operator).
+//
+// On PostgreSQL emits "column @> ?::jsonb" with the value JSON-encoded.
+// Strings, []byte, and json.RawMessage are passed through as-is (assumed
+// already-valid JSON); everything else is marshalled via encoding/json so
+// callers can pass structs, maps, or slices directly.
+//
+// Oracle is not yet supported and returns a filter that surfaces an error
+// at ToSQL() time. See https://github.com/gaborage/go-bricks/issues/341.
+//
+// Example:
+//
+//	f.JSONContains("metadata", map[string]any{"role": "admin"})
+//	// PostgreSQL: metadata @> $1::jsonb  (with arg `{"role":"admin"}`)
+func (ff *FilterFactory) JSONContains(column string, value any) dbtypes.Filter {
+	return Filter{sqlizer: ff.qb.BuildJSONContains(column, value)}
+}
+
 // Null creates an IS NULL filter.
 // Column names are automatically quoted according to database vendor rules.
 func (ff *FilterFactory) Null(column string) dbtypes.Filter {

--- a/database/internal/builder/filter_test.go
+++ b/database/internal/builder/filter_test.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -973,4 +974,189 @@ func TestFilterSubqueryCombinedWithOtherFilters(t *testing.T) {
 		assert.Contains(t, sql, "override =")
 		assert.Equal(t, []any{true, false}, args)
 	})
+}
+
+// ========== Regex Filter Tests ==========
+
+func TestFilterRegex(t *testing.T) {
+	const pattern = `^[a-z]+@example\.com$`
+
+	tests := []struct {
+		name        string
+		vendor      string
+		method      func(ff dbtypes.FilterFactory) dbtypes.Filter
+		expectedSQL string
+	}{
+		// PostgreSQL: ~, ~*, !~, !~*
+		{
+			name:        "postgresql_regex_cs",
+			vendor:      dbtypes.PostgreSQL,
+			method:      func(ff dbtypes.FilterFactory) dbtypes.Filter { return ff.Regex("email", pattern) },
+			expectedSQL: "email ~ ?",
+		},
+		{
+			name:        "postgresql_regex_ci",
+			vendor:      dbtypes.PostgreSQL,
+			method:      func(ff dbtypes.FilterFactory) dbtypes.Filter { return ff.RegexI("email", pattern) },
+			expectedSQL: "email ~* ?",
+		},
+		{
+			name:        "postgresql_not_regex_cs",
+			vendor:      dbtypes.PostgreSQL,
+			method:      func(ff dbtypes.FilterFactory) dbtypes.Filter { return ff.NotRegex("email", pattern) },
+			expectedSQL: "email !~ ?",
+		},
+		{
+			name:        "postgresql_not_regex_ci",
+			vendor:      dbtypes.PostgreSQL,
+			method:      func(ff dbtypes.FilterFactory) dbtypes.Filter { return ff.NotRegexI("email", pattern) },
+			expectedSQL: "email !~* ?",
+		},
+		// Oracle: REGEXP_LIKE, optionally with 'i' flag and NOT prefix
+		{
+			name:        "oracle_regex_cs",
+			vendor:      dbtypes.Oracle,
+			method:      func(ff dbtypes.FilterFactory) dbtypes.Filter { return ff.Regex("email", pattern) },
+			expectedSQL: "REGEXP_LIKE(email, ?)",
+		},
+		{
+			name:        "oracle_regex_ci",
+			vendor:      dbtypes.Oracle,
+			method:      func(ff dbtypes.FilterFactory) dbtypes.Filter { return ff.RegexI("email", pattern) },
+			expectedSQL: "REGEXP_LIKE(email, ?, ?)",
+		},
+		{
+			name:        "oracle_not_regex_cs",
+			vendor:      dbtypes.Oracle,
+			method:      func(ff dbtypes.FilterFactory) dbtypes.Filter { return ff.NotRegex("email", pattern) },
+			expectedSQL: "NOT (REGEXP_LIKE(email, ?))",
+		},
+		{
+			name:        "oracle_not_regex_ci",
+			vendor:      dbtypes.Oracle,
+			method:      func(ff dbtypes.FilterFactory) dbtypes.Filter { return ff.NotRegexI("email", pattern) },
+			expectedSQL: "NOT (REGEXP_LIKE(email, ?, ?))",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qb := NewQueryBuilder(tt.vendor)
+			f := qb.Filter()
+
+			sql, args, err := tt.method(f).ToSQL()
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedSQL, sql)
+			require.NotEmpty(t, args)
+			assert.Equal(t, pattern, args[0])
+			// Oracle case-insensitive variants pass 'i' as the second arg
+			if len(args) == 2 {
+				assert.Equal(t, "i", args[1])
+			}
+		})
+	}
+}
+
+func TestFilterRegexQuotesOracleReservedWords(t *testing.T) {
+	// "number" is an Oracle reserved word and must be auto-quoted.
+	qb := NewQueryBuilder(dbtypes.Oracle)
+	f := qb.Filter()
+
+	sql, args, err := f.Regex("number", `\d+`).ToSQL()
+	require.NoError(t, err)
+	assert.Equal(t, `REGEXP_LIKE("number", ?)`, sql)
+	assert.Equal(t, []any{`\d+`}, args)
+}
+
+func TestFilterRegexUnsupportedVendor(t *testing.T) {
+	qb := NewQueryBuilder(dbtypes.Vendor("mysql"))
+	f := qb.Filter()
+
+	_, _, err := f.Regex("col", "pat").ToSQL()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "regex matching is not supported")
+}
+
+func TestFilterRegexInWhereClause(t *testing.T) {
+	// End-to-end: regex composes with other filters and gets correct placeholders.
+	qb := NewQueryBuilder(dbtypes.PostgreSQL)
+	f := qb.Filter()
+
+	sql, args, err := qb.Select("id").
+		From("users").
+		Where(f.And(
+			f.Eq("status", "active"),
+			f.RegexI("email", `@example\.com$`),
+		)).
+		ToSQL()
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT id FROM users WHERE (status = $1 AND email ~* $2)", sql)
+	assert.Equal(t, []any{"active", `@example\.com$`}, args)
+}
+
+// ========== JSONContains Filter Tests ==========
+
+func TestFilterJSONContainsPostgreSQL(t *testing.T) {
+	qb := NewQueryBuilder(dbtypes.PostgreSQL)
+	f := qb.Filter()
+
+	type doc struct {
+		Role string `json:"role"`
+	}
+
+	tests := []struct {
+		name         string
+		value        any
+		expectedJSON string
+	}{
+		{name: "string_passthrough", value: `{"role":"admin"}`, expectedJSON: `{"role":"admin"}`},
+		{name: "bytes_passthrough", value: []byte(`{"role":"admin"}`), expectedJSON: `{"role":"admin"}`},
+		{name: "raw_message_passthrough", value: json.RawMessage(`{"role":"admin"}`), expectedJSON: `{"role":"admin"}`},
+		{name: "struct_marshal", value: doc{Role: "admin"}, expectedJSON: `{"role":"admin"}`},
+		{name: "map_marshal", value: map[string]any{"role": "admin"}, expectedJSON: `{"role":"admin"}`},
+		{name: "slice_marshal", value: []string{"a", "b"}, expectedJSON: `["a","b"]`},
+		{name: "nil_value", value: nil, expectedJSON: `null`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql, args, err := f.JSONContains("metadata", tt.value).ToSQL()
+			require.NoError(t, err)
+			assert.Equal(t, "metadata @> ?::jsonb", sql)
+			require.Len(t, args, 1)
+			assert.Equal(t, tt.expectedJSON, args[0])
+		})
+	}
+}
+
+func TestFilterJSONContainsOracleNotImplemented(t *testing.T) {
+	qb := NewQueryBuilder(dbtypes.Oracle)
+	f := qb.Filter()
+
+	_, _, err := f.JSONContains("metadata", `{"role":"admin"}`).ToSQL()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Oracle support not implemented")
+}
+
+func TestFilterJSONContainsMarshalError(t *testing.T) {
+	qb := NewQueryBuilder(dbtypes.PostgreSQL)
+	f := qb.Filter()
+
+	// channels are not JSON-marshallable
+	_, _, err := f.JSONContains("metadata", make(chan int)).ToSQL()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "JSONContains:")
+}
+
+func TestFilterJSONContainsInWhereClause(t *testing.T) {
+	qb := NewQueryBuilder(dbtypes.PostgreSQL)
+	f := qb.Filter()
+
+	sql, args, err := qb.Select("id").
+		From("users").
+		Where(f.JSONContains("metadata", map[string]any{"role": "admin"})).
+		ToSQL()
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT id FROM users WHERE metadata @> $1::jsonb", sql)
+	assert.Equal(t, []any{`{"role":"admin"}`}, args)
 }

--- a/database/internal/builder/filter_test.go
+++ b/database/internal/builder/filter_test.go
@@ -1115,7 +1115,11 @@ func TestFilterJSONContainsPostgreSQL(t *testing.T) {
 		{name: "struct_marshal", value: doc{Role: "admin"}, expectedJSON: `{"role":"admin"}`},
 		{name: "map_marshal", value: map[string]any{"role": "admin"}, expectedJSON: `{"role":"admin"}`},
 		{name: "slice_marshal", value: []string{"a", "b"}, expectedJSON: `["a","b"]`},
-		{name: "nil_value", value: nil, expectedJSON: `null`},
+		{name: "nil_value", value: nil, expectedJSON: jsonLiteralNull},
+		// Typed-nil byte slices map to the JSON literal "null" rather than
+		// silently sending an empty parameter.
+		{name: "nil_bytes", value: []byte(nil), expectedJSON: jsonLiteralNull},
+		{name: "nil_raw_message", value: json.RawMessage(nil), expectedJSON: jsonLiteralNull},
 	}
 
 	for _, tt := range tests {
@@ -1146,6 +1150,29 @@ func TestFilterJSONContainsMarshalError(t *testing.T) {
 	_, _, err := f.JSONContains("metadata", make(chan int)).ToSQL()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "JSONContains:")
+}
+
+func TestFilterJSONContainsRejectsInvalidPreEncodedJSON(t *testing.T) {
+	qb := NewQueryBuilder(dbtypes.PostgreSQL)
+	f := qb.Filter()
+
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "string_garbage", value: `{not json`},
+		{name: "string_empty", value: ""},
+		{name: "bytes_garbage", value: []byte(`{not json`)},
+		{name: "raw_message_garbage", value: json.RawMessage(`{not json`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := f.JSONContains("metadata", tt.value).ToSQL()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid pre-encoded JSON")
+		})
+	}
 }
 
 func TestFilterJSONContainsInWhereClause(t *testing.T) {

--- a/database/internal/builder/query_builder.go
+++ b/database/internal/builder/query_builder.go
@@ -16,6 +16,9 @@ import (
 const (
 	joinOnPlaceholder = "%s ON %s"
 	sqlFuncNow        = "NOW()"
+	// jsonLiteralNull is the JSON literal sent for nil/typed-nil JSONContains
+	// payloads, matching encoding/json's representation of nil values.
+	jsonLiteralNull = "null"
 )
 
 // QueryBuilder provides vendor-specific SQL query building.
@@ -494,18 +497,32 @@ func (qb *QueryBuilder) BuildJSONContains(column string, value any) squirrel.Sql
 }
 
 // jsonContainsPayload converts the caller-supplied value into a JSON string.
-// Strings, []byte, and json.RawMessage are trusted as already-encoded JSON.
-// Everything else routes through encoding/json.
+//
+// Strings, []byte, and json.RawMessage are treated as already-encoded JSON
+// payloads but are still validated via json.Valid so malformed input fails at
+// query-build time rather than at the database. Typed-nil byte slices map to
+// the JSON literal "null" (matching the explicit nil case). Everything else
+// routes through encoding/json.
 func jsonContainsPayload(value any) (string, error) {
+	validateBytes := func(data []byte) (string, error) {
+		if data == nil {
+			return jsonLiteralNull, nil
+		}
+		if !json.Valid(data) {
+			return "", fmt.Errorf("invalid pre-encoded JSON")
+		}
+		return string(data), nil
+	}
+
 	switch v := value.(type) {
 	case nil:
-		return "null", nil
+		return jsonLiteralNull, nil
 	case string:
-		return v, nil
+		return validateBytes([]byte(v))
 	case json.RawMessage:
-		return string(v), nil
+		return validateBytes([]byte(v))
 	case []byte:
-		return string(v), nil
+		return validateBytes(v)
 	default:
 		data, err := json.Marshal(value)
 		if err != nil {

--- a/database/internal/builder/query_builder.go
+++ b/database/internal/builder/query_builder.go
@@ -4,6 +4,7 @@
 package builder
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -424,6 +425,93 @@ func (qb *QueryBuilder) BuildCaseInsensitiveLike(column, value string) squirrel.
 	default:
 		// Default to standard LIKE
 		return squirrel.Like{column: likeValue}
+	}
+}
+
+// BuildRegex creates a vendor-specific regex match expression.
+//
+// PostgreSQL emits the POSIX-regex operators: ~ (CS), ~* (CI), !~ (NOT CS),
+// !~* (NOT CI). Oracle emits REGEXP_LIKE with an optional 'i' match flag,
+// wrapped in NOT(...) when negated.
+//
+// Pattern syntax differs slightly between vendors (POSIX ERE vs Oracle's
+// extended POSIX); callers writing vendor-portable regexes should stick to
+// the common subset (anchors, character classes, quantifiers).
+func (qb *QueryBuilder) BuildRegex(column, pattern string, caseInsensitive, negated bool) squirrel.Sqlizer {
+	quotedColumn := qb.quoteColumnForQuery(column)
+
+	switch qb.vendor {
+	case dbtypes.PostgreSQL:
+		op := "~"
+		if negated {
+			op = "!~"
+		}
+		if caseInsensitive {
+			op += "*"
+		}
+		return squirrel.Expr(quotedColumn+" "+op+" ?", pattern)
+	case dbtypes.Oracle:
+		expr := "REGEXP_LIKE(" + quotedColumn + ", ?"
+		args := []any{pattern}
+		if caseInsensitive {
+			expr += ", ?"
+			args = append(args, "i")
+		}
+		expr += ")"
+		if negated {
+			expr = "NOT (" + expr + ")"
+		}
+		return squirrel.Expr(expr, args...)
+	default:
+		return errorSqlizer{err: fmt.Errorf("regex matching is not supported for vendor %q", qb.vendor)}
+	}
+}
+
+// BuildJSONContains creates a JSON containment expression.
+//
+// PostgreSQL emits "column @> ?::jsonb" with the value marshalled to JSON.
+// Strings, []byte, and json.RawMessage values are passed through as-is
+// (caller-provided JSON); other values are marshalled via encoding/json so
+// that callers can pass structs, maps, or slices directly.
+//
+// Oracle has no clean equivalent (JSON_EQUAL is exact-equality, JSON_EXISTS
+// requires a path predicate) so it returns an error filter for now. See
+// https://github.com/gaborage/go-bricks/issues/341 for follow-up.
+func (qb *QueryBuilder) BuildJSONContains(column string, value any) squirrel.Sqlizer {
+	switch qb.vendor {
+	case dbtypes.PostgreSQL:
+		jsonStr, err := jsonContainsPayload(value)
+		if err != nil {
+			return errorSqlizer{err: fmt.Errorf("JSONContains: %w", err)}
+		}
+		quotedColumn := qb.quoteColumnForQuery(column)
+		return squirrel.Expr(quotedColumn+" @> ?::jsonb", jsonStr)
+	case dbtypes.Oracle:
+		return errorSqlizer{err: fmt.Errorf("JSONContains: Oracle support not implemented; see https://github.com/gaborage/go-bricks/issues/341")}
+	default:
+		return errorSqlizer{err: fmt.Errorf("JSONContains: unsupported vendor %q", qb.vendor)}
+	}
+}
+
+// jsonContainsPayload converts the caller-supplied value into a JSON string.
+// Strings, []byte, and json.RawMessage are trusted as already-encoded JSON.
+// Everything else routes through encoding/json.
+func jsonContainsPayload(value any) (string, error) {
+	switch v := value.(type) {
+	case nil:
+		return "null", nil
+	case string:
+		return v, nil
+	case json.RawMessage:
+		return string(v), nil
+	case []byte:
+		return string(v), nil
+	default:
+		data, err := json.Marshal(value)
+		if err != nil {
+			return "", fmt.Errorf("marshal value to JSON: %w", err)
+		}
+		return string(data), nil
 	}
 }
 

--- a/database/types/interfaces.go
+++ b/database/types/interfaces.go
@@ -46,6 +46,18 @@ type FilterFactory interface {
 	NotNull(column string) Filter
 	Between(column string, lowerBound, upperBound any) Filter
 
+	// Regex matching (vendor-specific):
+	//   PostgreSQL: ~ (CS), ~* (CI), !~ (NOT CS), !~* (NOT CI)
+	//   Oracle:     REGEXP_LIKE(col, pat[, 'i']), optionally negated with NOT
+	Regex(column, pattern string) Filter
+	RegexI(column, pattern string) Filter
+	NotRegex(column, pattern string) Filter
+	NotRegexI(column, pattern string) Filter
+
+	// JSONContains tests JSON containment (PostgreSQL @>). Currently
+	// PostgreSQL-only; calling on Oracle yields an error filter.
+	JSONContains(column string, value any) Filter
+
 	// Logical operators
 	And(filters ...Filter) Filter
 	Or(filters ...Filter) Filter

--- a/llms.txt
+++ b/llms.txt
@@ -873,6 +873,8 @@ rows, err := db.Query(ctx, sql, args...)
 | Need                | Builder call / API usage                                               |
 |---------------------|------------------------------------------------------------------------|
 | Filtering           | `f.Eq`, `f.And`, `f.Or`, `f.In`, `f.Between`                           |
+| Pattern matching    | `f.Like` (case-insensitive), `f.Regex`/`f.RegexI`/`f.NotRegex`/`f.NotRegexI` (POSIX regex; PG `~`/`~*`/`!~`/`!~*`, Oracle `REGEXP_LIKE` with `'i'` flag) |
+| JSON containment    | `f.JSONContains(col, value)` — PostgreSQL `@>` on `jsonb`; pass struct/map/slice (auto JSON-marshalled) or pre-encoded `string`/`[]byte`/`json.RawMessage`. Oracle is not yet supported. |
 | Sorting / grouping  | `qb.Select(...).From("...").OrderBy(qb.Expr("created_at DESC")).GroupBy("tenant_id")` |
 | Mutations           | `qb.Insert`, `qb.Update`, `qb.Delete`, then `db.Exec`                  |
 | Joins               | `qb.JoinOn` with `qb.JoinFilter()`                                     |
@@ -906,6 +908,44 @@ result, err := db.Exec(ctx, sql, args...)
 ```
 
 Access to vendor quirks (Oracle quoting) routes through the same interface; switching drivers requires config only.
+
+**Regex Matching (vendor-aware):**
+
+```go
+f := qb.Filter()
+
+// Case-sensitive: PG "email ~ ?", Oracle "REGEXP_LIKE(email, ?)"
+sql, args := qb.Select("*").From("users").
+    Where(f.Regex("email", `^admin@`)).ToSQL()
+
+// Case-insensitive: PG "email ~* ?", Oracle "REGEXP_LIKE(email, ?, 'i')"
+qb.Select("*").From("users").Where(f.RegexI("email", `@example\.com$`))
+
+// Negation: f.NotRegex / f.NotRegexI
+//   PG: "email !~ ?" / "email !~* ?"
+//   Oracle: "NOT (REGEXP_LIKE(email, ?))" / "NOT (REGEXP_LIKE(email, ?, 'i'))"
+```
+
+Pattern syntax differs slightly (POSIX ERE vs Oracle's extended POSIX); for vendor-portable patterns stick to the common subset (anchors, character classes, quantifiers).
+
+**JSON Containment (PostgreSQL only):**
+
+```go
+f := qb.Filter()
+
+// Pass any JSON-marshallable value; structs/maps/slices auto-encode.
+sql, args := qb.Select("id").From("users").
+    Where(f.JSONContains("metadata", map[string]any{"role": "admin"})).
+    ToSQL()
+// SQL: SELECT id FROM users WHERE metadata @> $1::jsonb
+// args: [`{"role":"admin"}`]
+
+// Pre-encoded JSON (string, []byte, json.RawMessage) is passed through as-is:
+f.JSONContains("metadata", `{"role":"admin"}`)
+f.JSONContains("metadata", json.RawMessage(`{"role":"admin"}`))
+```
+
+Oracle is not yet supported (`@>` has no clean equivalent — `JSON_EXISTS` requires a path predicate, `JSON_EQUAL` is exact-equality). Calling `JSONContains` on an Oracle `QueryBuilder` produces a filter whose `ToSQL()` returns an explanatory error. Track Oracle support in [issue #341](https://github.com/gaborage/go-bricks/issues/341).
 
 **Struct-Based Columns (v0.15.0+):**
 

--- a/llms.txt
+++ b/llms.txt
@@ -912,37 +912,52 @@ Access to vendor quirks (Oracle quoting) routes through the same interface; swit
 **Regex Matching (vendor-aware):**
 
 ```go
+type User struct {
+    ID    int64  `db:"id"`
+    Email string `db:"email"`
+}
+
+cols := qb.Columns(&User{})
 f := qb.Filter()
 
 // Case-sensitive: PG "email ~ ?", Oracle "REGEXP_LIKE(email, ?)"
-sql, args := qb.Select("*").From("users").
-    Where(f.Regex("email", `^admin@`)).ToSQL()
+sql, args := qb.Select(cols.All()...).From("users").
+    Where(f.Regex(cols.Col("Email"), `^admin@`)).ToSQL()
 
 // Case-insensitive: PG "email ~* ?", Oracle "REGEXP_LIKE(email, ?, 'i')"
-qb.Select("*").From("users").Where(f.RegexI("email", `@example\.com$`))
+qb.Select(cols.All()...).From("users").
+    Where(f.RegexI(cols.Col("Email"), `@example\.com$`))
 
 // Negation: f.NotRegex / f.NotRegexI
 //   PG: "email !~ ?" / "email !~* ?"
 //   Oracle: "NOT (REGEXP_LIKE(email, ?))" / "NOT (REGEXP_LIKE(email, ?, 'i'))"
 ```
 
-Pattern syntax differs slightly (POSIX ERE vs Oracle's extended POSIX); for vendor-portable patterns stick to the common subset (anchors, character classes, quantifiers).
+Pattern syntax differs slightly (POSIX ERE vs Oracle's extended POSIX); for vendor-portable patterns stick to the common subset (anchors, character classes, quantifiers). Using `cols.Col("Email")` rather than the raw string `"email"` keeps Oracle reserved-word quoting and refactor safety — same rule that applies elsewhere in the query builder.
 
 **JSON Containment (PostgreSQL only):**
 
 ```go
+type User struct {
+    ID       int64           `db:"id"`
+    Metadata json.RawMessage `db:"metadata"`
+}
+
+cols := qb.Columns(&User{})
 f := qb.Filter()
 
 // Pass any JSON-marshallable value; structs/maps/slices auto-encode.
-sql, args := qb.Select("id").From("users").
-    Where(f.JSONContains("metadata", map[string]any{"role": "admin"})).
+sql, args := qb.Select(cols.Col("ID")).From("users").
+    Where(f.JSONContains(cols.Col("Metadata"), map[string]any{"role": "admin"})).
     ToSQL()
 // SQL: SELECT id FROM users WHERE metadata @> $1::jsonb
 // args: [`{"role":"admin"}`]
 
-// Pre-encoded JSON (string, []byte, json.RawMessage) is passed through as-is:
-f.JSONContains("metadata", `{"role":"admin"}`)
-f.JSONContains("metadata", json.RawMessage(`{"role":"admin"}`))
+// Pre-encoded JSON (string, []byte, json.RawMessage) is passed through as-is.
+// Inputs are validated via json.Valid() — malformed JSON fails at query-build
+// time, and typed-nil byte slices map to the JSON literal "null".
+f.JSONContains(cols.Col("Metadata"), `{"role":"admin"}`)
+f.JSONContains(cols.Col("Metadata"), json.RawMessage(`{"role":"admin"}`))
 ```
 
 Oracle is not yet supported (`@>` has no clean equivalent — `JSON_EXISTS` requires a path predicate, `JSON_EQUAL` is exact-equality). Calling `JSONContains` on an Oracle `QueryBuilder` produces a filter whose `ToSQL()` returns an explanatory error. Track Oracle support in [issue #341](https://github.com/gaborage/go-bricks/issues/341).

--- a/testing/mocks/query_builder_test.go
+++ b/testing/mocks/query_builder_test.go
@@ -71,6 +71,31 @@ func (m *MockFilterFactory) Like(column, pattern string) types.Filter {
 	return args.Get(0).(types.Filter)
 }
 
+func (m *MockFilterFactory) Regex(column, pattern string) types.Filter {
+	args := m.MethodCalled("Regex", column, pattern)
+	return args.Get(0).(types.Filter)
+}
+
+func (m *MockFilterFactory) RegexI(column, pattern string) types.Filter {
+	args := m.MethodCalled("RegexI", column, pattern)
+	return args.Get(0).(types.Filter)
+}
+
+func (m *MockFilterFactory) NotRegex(column, pattern string) types.Filter {
+	args := m.MethodCalled("NotRegex", column, pattern)
+	return args.Get(0).(types.Filter)
+}
+
+func (m *MockFilterFactory) NotRegexI(column, pattern string) types.Filter {
+	args := m.MethodCalled("NotRegexI", column, pattern)
+	return args.Get(0).(types.Filter)
+}
+
+func (m *MockFilterFactory) JSONContains(column string, value any) types.Filter {
+	args := m.MethodCalled("JSONContains", column, value)
+	return args.Get(0).(types.Filter)
+}
+
 func (m *MockFilterFactory) Null(column string) types.Filter {
 	args := m.MethodCalled("Null", column)
 	return args.Get(0).(types.Filter)


### PR DESCRIPTION
## Summary

Closes #341.

Extends `FilterFactory` with two new categories of type-safe predicates per ADR-005:

- **Regex matching**, fully vendor-aware:
  - `f.Regex` / `f.RegexI` / `f.NotRegex` / `f.NotRegexI`
  - PostgreSQL emits POSIX-regex operators (`~`, `~*`, `!~`, `!~*`).
  - Oracle emits `REGEXP_LIKE(col, pat[, 'i'])`, wrapped in `NOT (...)` when negated.
  - Unsupported vendors surface an error at `ToSQL()` time (consistent with the existing `errorSqlizer` pattern).

- **JSON containment**, PostgreSQL-only initially:
  - `f.JSONContains(col, value)` emits `col @> ?::jsonb`.
  - `string`, `[]byte`, and `json.RawMessage` pass through as already-encoded JSON. Anything else marshals via `encoding/json`, so callers can pass structs / maps / slices directly.
  - Oracle returns an explanatory error filter — the `@>` operator has no clean Oracle equivalent (`JSON_EQUAL` is exact-equality, `JSON_EXISTS` requires a path predicate). Tracked back to this same issue.

Vendor dispatch lives on `QueryBuilder` (`BuildRegex`, `BuildJSONContains`) alongside the existing `BuildCaseInsensitiveLike`, so the FilterFactory methods are thin wrappers that match the pattern of `f.Like`.

## Why one PR for both features

They're the two open items called out in #341 itself ("JSON containment operations (PostgreSQL)" and "Regex matching (vendor-specific)"), they share the same dispatch infrastructure (`QueryBuilder` switch on vendor), and the test plan is identical. Splitting would just double the review cost.

## Test plan

- [x] `go test -race -count=1 ./database/...` — all packages green
- [x] `make check` — fmt + lint + test, 0 lint issues
- [x] `/simplify` run before push (3-agent fan-out) — one finding fixed (vacuous test deleted), other findings declined as out-of-scope or not-an-issue
- [x] Table-driven coverage: 8 vendor × mode combinations for Regex (PG ~/~*/!~/!~* and Oracle REGEXP_LIKE × CS/CI/negated)
- [x] Table-driven coverage: 7 value-type cases for JSONContains (string / []byte / json.RawMessage / struct / map / slice / nil)
- [x] Negative paths: unsupported vendor for Regex, Oracle for JSONContains, JSON-marshal failure (channel value)
- [x] Composition: end-to-end SELECT...WHERE...AND tests verify placeholder numbering with sibling filters
- [x] Oracle reserved-word quoting verified for Regex (`number` → `"number"`)
- [x] `MockFilterFactory` updated to satisfy the new interface methods
- [x] `llms.txt` and `CLAUDE.md` updated with examples and the type-safe methods reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added vendor-aware regex filters (case-sensitive, case-insensitive, and negation variants).
  * Added PostgreSQL-only JSON containment filter.

* **Documentation**
  * Updated docs with examples and guidance for regex and JSON containment usage, inputs, and vendor differences (Oracle not supported for JSONContains).

* **Tests**
  * Added comprehensive tests covering regex and JSON containment behavior, error cases, and integration in queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->