### PR TITLE
docs: correct GitHub issue title and label convention in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ go test -bench=.        # Run benchmarks
 **Additional Documentation:**
 - [TESTING.md](TESTING.md) - Testing strategy deep-dive
 - [METRICS.md](METRICS.md) - Observability metrics reference
-- [GitHub Issues](https://github.com/gaborage/go-bricks/issues?q=is%3Aopen%20label%3Aenhancement) - Technical backlog (active enhancement items; titles use `[P1]`/`[P2]`/`[P3]` and `[JOSE]`/area prefixes for filtering)
+- [GitHub Issues](https://github.com/gaborage/go-bricks/issues?q=is%3Aopen%20label%3Akind%2Ffeature) - Technical backlog. Titles use `<area>: <description>` (lowercase, e.g. `jose: add sample module to demo project`); labels combine `area/<package>` (e.g. `area/messaging`, `area/outbox`) with `kind/<type>` (`feature`, `exploration`, `refactor`, `tech-debt`, `security`) or top-level `bug`/`documentation`.
 - [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution guidelines
 - [config.example.yaml](config.example.yaml) - Full configuration template
 


### PR DESCRIPTION
## Summary
- Update the GitHub Issues bullet on `CLAUDE.md:48` to reflect the title and label conventions actually used by recent issues.
- Title format is `<area>: <description>` (lowercase, e.g. `jose: add sample module to demo project`); labels combine `area/<package>` with `kind/<type>` rather than the previously documented `[P1]`/`[P2]`/`[P3]` and `enhancement` scheme.
- Switch the filter URL from `label:enhancement` (deprecated for new issues) to `label:kind/feature` so the link surfaces the live backlog.

Discovered while drafting #366 — the convention drift between docs and live state would have led to a misnamed issue.

## Test plan
- [ ] Render `CLAUDE.md` and confirm the link in the GitHub Issues bullet opens the filtered backlog view.
- [ ] Confirm the example title and label taxonomy match recent issues (e.g. #348, #346, #339, #366).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the GitHub Issues backlog link filter in internal documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->