### PR TITLE
fix(outbox): fail-fast at Init when messaging is not configured (#366)

### DIFF
--- a/outbox/module.go
+++ b/outbox/module.go
@@ -82,6 +82,15 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 		return fmt.Errorf("outbox: messaging resolver (deps.Messaging) is required when outbox is enabled")
 	}
 
+	// Fail fast: in single-tenant mode the broker URL must be set at startup,
+	// otherwise the relay job logs "messaging not available" every poll cycle (issue #366).
+	// Multi-tenant resolves messaging per-tenant via the resource source, so a static
+	// check would yield false positives — skip it there.
+	if m.config != nil && !m.config.Multitenant.Enabled && !config.IsMessagingConfigured(&m.config.Messaging) {
+		return fmt.Errorf("outbox: messaging is not configured but outbox.enabled=true; " +
+			"set messaging.broker.url (or env MESSAGING_BROKER_URL) or set outbox.enabled=false")
+	}
+
 	// Store creation is deferred until first use (lazy init like scheduler)
 	// because we need to know the database vendor type, which requires a DB connection.
 	// The publisher wraps the store and handles lazy initialization.

--- a/outbox/module_test.go
+++ b/outbox/module_test.go
@@ -74,6 +74,9 @@ func TestModuleInitEnabledWithBothResolvers(t *testing.T) {
 		Logger: logger.New("info", false),
 		Config: &config.Config{
 			Outbox: config.OutboxConfig{Enabled: true},
+			Messaging: config.MessagingConfig{
+				Broker: config.BrokerConfig{URL: "amqp://localhost"},
+			},
 		},
 		DB: func(_ context.Context) (dbtypes.Interface, error) {
 			return nil, nil
@@ -101,4 +104,53 @@ func TestModuleInitDisabledAllowsNilResolvers(t *testing.T) {
 
 	err := m.Init(deps)
 	require.NoError(t, err, "Nil resolvers should be allowed when outbox is disabled")
+}
+
+// TestModuleInitEnabledMessagingUnconfiguredSingleTenant guards issue #366:
+// outbox.enabled=true with no messaging.broker.url must fail at startup
+// instead of letting the relay job log "messaging not available" each poll.
+func TestModuleInitEnabledMessagingUnconfiguredSingleTenant(t *testing.T) {
+	m := NewModule()
+	deps := &app.ModuleDeps{
+		Logger: logger.New("info", false),
+		Config: &config.Config{
+			Outbox: config.OutboxConfig{Enabled: true},
+			// Messaging.Broker.URL intentionally empty.
+		},
+		DB: func(_ context.Context) (dbtypes.Interface, error) {
+			return nil, nil
+		},
+		Messaging: func(_ context.Context) (messaging.AMQPClient, error) {
+			return nil, nil
+		},
+	}
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "messaging is not configured")
+}
+
+// TestModuleInitEnabledMessagingUnconfiguredMultiTenant verifies the static
+// check is skipped when multitenant.enabled=true — each tenant supplies its
+// own broker URL via the resource source, so a global check would be wrong.
+func TestModuleInitEnabledMessagingUnconfiguredMultiTenant(t *testing.T) {
+	m := NewModule()
+	deps := &app.ModuleDeps{
+		Logger: logger.New("info", false),
+		Config: &config.Config{
+			Outbox:      config.OutboxConfig{Enabled: true},
+			Multitenant: config.MultitenantConfig{Enabled: true},
+			// Messaging.Broker.URL intentionally empty.
+		},
+		DB: func(_ context.Context) (dbtypes.Interface, error) {
+			return nil, nil
+		},
+		Messaging: func(_ context.Context) (messaging.AMQPClient, error) {
+			return nil, nil
+		},
+	}
+
+	err := m.Init(deps)
+	require.NoError(t, err)
+	assert.NotNil(t, m.publisher, "Publisher should be initialized in multi-tenant mode even with empty global broker URL")
 }


### PR DESCRIPTION
## Summary

Closes the visible-symptom half of #366. When `outbox.enabled=true` but `messaging.broker.url` is unset, the relay job logged `"outbox relay: messaging not available"` every poll cycle (~17k errors/day per instance) and at-least-once delivery was silently broken — events accumulated in the outbox table forever. This change makes `outbox.Module.Init()` return an error so the application refuses to start instead.

The check uses the existing `config.IsMessagingConfigured` helper. Multi-tenant mode is exempted because each tenant supplies its own broker URL via the resource source — a global check would be wrong there.

This is the first of two PRs implementing the structural direction from #366. The follow-up PR adds an app-level cross-cutting check after `buildMessagingDeclarations` so that `MessagingDeclarer` modules also fail-fast (the silent half of the issue) — that case is not addressed here.

## Test plan

- [x] `go test -race ./outbox/...` — all green, including new cases
- [x] `golangci-lint run ./outbox/...` — 0 issues
- [x] Existing tests updated where required (`TestModuleInitEnabledWithBothResolvers` now sets `Messaging.Broker.URL`)
- [x] New tests:
  - `TestModuleInitEnabledMessagingUnconfiguredSingleTenant` — fails with clear error
  - `TestModuleInitEnabledMessagingUnconfiguredMultiTenant` — succeeds (per-tenant semantics)
- [ ] Hand-test: run a single-tenant binary with `outbox.enabled=true` and no `messaging.broker.url` — confirm app refuses to start

Refs: #366

https://claude.ai/code/session_01WrgqYHFEuTUbh5hJJPxVfF

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrgqYHFEuTUbh5hJJPxVfF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Outbox startup validation improved: In single-tenant mode, when outbox is enabled but messaging broker is not configured, the system now fails immediately at startup with a clear error message, eliminating repeated "messaging not available" log entries from polling cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->