### PR TITLE
fix(app): fail-fast when MessagingDeclarer modules require unconfigured messaging (#366)

### DIFF
--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -12,6 +12,9 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v5"
+
+	"github.com/gaborage/go-bricks/config"
+	"github.com/gaborage/go-bricks/messaging"
 )
 
 // startMaintenanceLoops starts background cleanup processes for managers
@@ -34,6 +37,10 @@ func (a *App) prepareRuntime() error {
 	}
 
 	decls := a.messagingDeclarations
+
+	if err := a.assertMessagingConfiguredIfDeclared(decls); err != nil {
+		return err
+	}
 
 	if a.messagingInitializer != nil && a.messagingInitializer.IsAvailable() && decls != nil {
 		a.messagingInitializer.LogDeploymentMode()
@@ -68,6 +75,26 @@ func (a *App) prepareRuntime() error {
 	a.startMaintenanceLoops()
 
 	return nil
+}
+
+// assertMessagingConfiguredIfDeclared fails-fast in single-tenant mode when
+// a module has declared messaging infrastructure but no broker URL is set —
+// without this check the declarations would be silently dropped (issue #366).
+// Multi-tenant mode resolves messaging per-tenant via the resource source, so
+// the static check is skipped there.
+func (a *App) assertMessagingConfiguredIfDeclared(decls *messaging.Declarations) error {
+	if a.cfg.Multitenant.Enabled || decls == nil || decls.IsEmpty() {
+		return nil
+	}
+	if config.IsMessagingConfigured(&a.cfg.Messaging) {
+		return nil
+	}
+	s := decls.Stats()
+	return fmt.Errorf("messaging declarations were registered "+
+		"(publishers=%d, consumers=%d, exchanges=%d, queues=%d, bindings=%d) "+
+		"but messaging is not configured; "+
+		"set messaging.broker.url (or env MESSAGING_BROKER_URL)",
+		s.Publishers, s.Consumers, s.Exchanges, s.Queues, s.Bindings)
 }
 
 // registerDebugHandlers sets up debug endpoints if enabled in configuration

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -6,9 +6,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gaborage/go-bricks/config"
 	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/messaging"
 )
 
 const (
@@ -110,4 +112,104 @@ func TestPrepareRuntimeWithScheduler(t *testing.T) {
 	// Verify RegisterJobs was called on the provider
 	jobProvider.AssertExpectations(t)
 	scheduler.AssertExpectations(t)
+}
+
+// publisherDeclaringModule registers a single publisher during DeclareMessaging.
+// Used to drive the structural fail-fast check in prepareRuntime — see issue #366.
+type publisherDeclaringModule struct{}
+
+func (publisherDeclaringModule) Name() string             { return "publisher-declaring-module" }
+func (publisherDeclaringModule) Init(_ *ModuleDeps) error { return nil }
+func (publisherDeclaringModule) Shutdown() error          { return nil }
+func (publisherDeclaringModule) DeclareMessaging(decls *messaging.Declarations) {
+	decls.RegisterExchange(&messaging.ExchangeDeclaration{
+		Name:    "test.exchange",
+		Type:    "topic",
+		Durable: true,
+	})
+	decls.RegisterPublisher(&messaging.PublisherDeclaration{
+		Exchange:   "test.exchange",
+		RoutingKey: "test.routing",
+		EventType:  "test.event",
+	})
+}
+
+// newLifecycleCheckApp builds a minimal App suitable for exercising prepareRuntime's
+// fail-fast check without standing up the full bootstrap pipeline.
+func newLifecycleCheckApp(t *testing.T, cfg *config.Config) *App {
+	t.Helper()
+	testLogger := logger.New("info", false)
+	deps := &ModuleDeps{Logger: testLogger, Config: cfg}
+	return &App{
+		cfg:      cfg,
+		logger:   testLogger,
+		registry: NewModuleRegistry(deps),
+		server:   newMockServer(),
+		closers:  []namedCloser{},
+	}
+}
+
+// TestPrepareRuntimeFailsWhenDeclarationsExistAndMessagingUnconfigured guards
+// the structural half of issue #366: declarations from MessagingDeclarer modules
+// must not be silently dropped when messaging is unset.
+func TestPrepareRuntimeFailsWhenDeclarationsExistAndMessagingUnconfigured(t *testing.T) {
+	cfg := &config.Config{
+		App:         config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"},
+		Multitenant: config.MultitenantConfig{Enabled: false},
+		// Messaging.Broker.URL intentionally empty.
+	}
+	app := newLifecycleCheckApp(t, cfg)
+	require.NoError(t, app.RegisterModule(publisherDeclaringModule{}))
+
+	err := app.prepareRuntime()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "messaging is not configured")
+	assert.Contains(t, err.Error(), "publishers=1")
+}
+
+// TestPrepareRuntimeAllowsEmptyDeclarationsWithMessagingUnconfigured verifies
+// that the check does not fire when no module declared messaging — startup
+// without messaging configured remains valid for apps that don't use AMQP.
+func TestPrepareRuntimeAllowsEmptyDeclarationsWithMessagingUnconfigured(t *testing.T) {
+	cfg := &config.Config{
+		App:         config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"},
+		Multitenant: config.MultitenantConfig{Enabled: false},
+		// Messaging.Broker.URL intentionally empty; no MessagingDeclarer module registered.
+	}
+	app := newLifecycleCheckApp(t, cfg)
+
+	require.NoError(t, app.prepareRuntime())
+}
+
+// TestPrepareRuntimeSkipsCheckInMultiTenantMode verifies that the static check
+// is skipped when multitenant.enabled=true — each tenant supplies its own
+// broker URL via the resource source, so a global check would yield false
+// positives.
+func TestPrepareRuntimeSkipsCheckInMultiTenantMode(t *testing.T) {
+	cfg := &config.Config{
+		App:         config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"},
+		Multitenant: config.MultitenantConfig{Enabled: true},
+		// Messaging.Broker.URL intentionally empty.
+	}
+	app := newLifecycleCheckApp(t, cfg)
+	require.NoError(t, app.RegisterModule(publisherDeclaringModule{}))
+
+	require.NoError(t, app.prepareRuntime())
+}
+
+// TestPrepareRuntimeSucceedsWithDeclarationsAndConfiguredMessaging is the
+// regression guard for the happy path: messaging configured, declarations
+// present, prepareRuntime proceeds.
+func TestPrepareRuntimeSucceedsWithDeclarationsAndConfiguredMessaging(t *testing.T) {
+	cfg := &config.Config{
+		App:         config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"},
+		Multitenant: config.MultitenantConfig{Enabled: false},
+		Messaging: config.MessagingConfig{
+			Broker: config.BrokerConfig{URL: "amqp://localhost"},
+		},
+	}
+	app := newLifecycleCheckApp(t, cfg)
+	require.NoError(t, app.RegisterModule(publisherDeclaringModule{}))
+
+	require.NoError(t, app.prepareRuntime())
 }

--- a/messaging/declarations.go
+++ b/messaging/declarations.go
@@ -280,6 +280,13 @@ func (d *Declarations) Stats() DeclarationStats {
 	}
 }
 
+// IsEmpty reports whether no declarations have been registered.
+func (d *Declarations) IsEmpty() bool {
+	s := d.Stats()
+	return s.Exchanges == 0 && s.Queues == 0 && s.Bindings == 0 &&
+		s.Publishers == 0 && s.Consumers == 0
+}
+
 // Clone creates a deep copy of the declarations.
 // This is useful for creating per-tenant copies during replay.
 func (d *Declarations) Clone() *Declarations {


### PR DESCRIPTION
## Summary

Closes the silent half of #366. When a module implements `MessagingDeclarer` (registers publishers/consumers/exchanges/queues/bindings) but `messaging.broker.url` is unset, the framework collected the declarations, validated them, and then silently dropped them — `MessagingInitializer.IsAvailable()` was vacuous because the manager is always non-nil even when no broker URL is configured. The first runtime `Publish()` then failed.

This adds a cross-cutting fail-fast check in `prepareRuntime()` immediately after `buildMessagingDeclarations`. If declarations are non-empty and `config.IsMessagingConfigured(&cfg.Messaging)` is false (single-tenant), the app returns a clear error listing what was declared. Multi-tenant mode is exempted — each tenant supplies its own broker URL via the resource source.

This is the second of two PRs implementing the structural direction from #366. PR #368 plugs the loud half (outbox enabled but messaging unset). Together they ensure no module's runtime contract for messaging is silently violated at startup.

## Changes

- `messaging/declarations.go`: tiny `IsEmpty()` helper next to existing `Stats()`.
- `app/lifecycle.go`: new `assertMessagingConfiguredIfDeclared` helper called from `prepareRuntime`. Extracted into a helper to keep `prepareRuntime` under the `gocyclo` complexity threshold.
- `app/lifecycle_test.go`: four new tests covering the fail path, the no-declarations path, the multi-tenant exemption, and the configured-messaging happy path.

## Test plan

- [x] `go test -race ./app/... ./messaging/...` — all green
- [x] `go test -race ./...` — full unit suite green (no regressions)
- [x] `golangci-lint run ./app/... ./messaging/...` — 0 issues (extracted helper to satisfy `gocyclo`)
- [x] New tests:
  - `TestPrepareRuntimeFailsWhenDeclarationsExistAndMessagingUnconfigured` — error mentions `"messaging is not configured"` + `publishers=1`
  - `TestPrepareRuntimeAllowsEmptyDeclarationsWithMessagingUnconfigured` — succeeds (apps without AMQP can still start without messaging)
  - `TestPrepareRuntimeSkipsCheckInMultiTenantMode` — succeeds (per-tenant resolution semantics preserved)
  - `TestPrepareRuntimeSucceedsWithDeclarationsAndConfiguredMessaging` — happy-path regression guard
- [ ] Hand-test: register a tiny `MessagingDeclarer` module without `messaging.broker.url` — confirm the app refuses to start

Refs: #366
Related: #368

https://claude.ai/code/session_01WrgqYHFEuTUbh5hJJPxVfF

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrgqYHFEuTUbh5hJJPxVfF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Messaging configuration validation now enforces that broker configuration is present when messaging declarations exist in single-tenant mode. Startup will fail with detailed feedback if this requirement is not met.

* **Tests**
  * Added comprehensive test coverage for messaging validation, including scenarios with no declarations, configured broker setup, and multi-tenant mode handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->