### PR TITLE
feat(migration): security-hardening bundle from #387 follow-ups

### DIFF
--- a/migration/flyway.go
+++ b/migration/flyway.go
@@ -3,6 +3,7 @@ package migration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -188,7 +189,11 @@ func (fm *FlywayMigrator) runFlywayCommandFor(ctx context.Context, db *config.Da
 	// #nosec G204 -- FlywayPath is validated by validateFlywayPath function
 	cmd := exec.CommandContext(timeoutCtx, cfg.FlywayPath, args...)
 
-	cmd.Env = append(os.Environ(), buildEnvironmentVariables(db)...)
+	envVars, err := buildEnvironmentVariables(db)
+	if err != nil {
+		return fmt.Errorf("build flyway environment: %w", err)
+	}
+	cmd.Env = append(os.Environ(), envVars...)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -209,10 +214,24 @@ func dbVendor(db *config.DatabaseConfig, fallback string) string {
 	return fallback
 }
 
+// ErrEnvFieldHasControlChar is returned when a DatabaseConfig field destined
+// for the Flyway subprocess environment contains a forbidden control character
+// (CR, LF, or NUL). Go's exec.Cmd.Env passes strings to execve(2) verbatim and
+// does not split on newlines, so this isn't a known injection path — but
+// rejecting at the boundary prevents a compromised secret writer from
+// propagating multi-line surprises into downstream logs or env-parsing tools.
+var ErrEnvFieldHasControlChar = errors.New("migration: env field contains forbidden control character (CR/LF/NUL)")
+
 // buildEnvironmentVariables builds Flyway environment variables for the supplied database.
-func buildEnvironmentVariables(db *config.DatabaseConfig) []string {
+// Returns ErrEnvFieldHasControlChar wrapped with the offending field name when
+// any of Host/Username/Password/Database contains CR, LF, or NUL.
+func buildEnvironmentVariables(db *config.DatabaseConfig) ([]string, error) {
 	if db == nil {
-		return nil
+		return nil, nil
+	}
+
+	if err := validateEnvFields(db); err != nil {
+		return nil, err
 	}
 
 	var envVars []string
@@ -236,7 +255,36 @@ func buildEnvironmentVariables(db *config.DatabaseConfig) []string {
 		)
 	}
 
-	return envVars
+	return envVars, nil
+}
+
+const (
+	envFieldHost     = "Host"
+	envFieldUsername = "Username"
+	envFieldPassword = "Password"
+	envFieldDatabase = "Database"
+)
+
+// validateEnvFields rejects any DatabaseConfig string field that would be
+// formatted into the Flyway subprocess environment if it contains CR, LF, or
+// NUL. The error names the offending field but never echoes the value (since
+// it may be the password).
+func validateEnvFields(db *config.DatabaseConfig) error {
+	fields := []struct {
+		name  string
+		value string
+	}{
+		{envFieldHost, db.Host},
+		{envFieldUsername, db.Username},
+		{envFieldPassword, db.Password},
+		{envFieldDatabase, db.Database},
+	}
+	for _, f := range fields {
+		if strings.ContainsAny(f.value, "\r\n\x00") {
+			return fmt.Errorf("%w: %s", ErrEnvFieldHasControlChar, f.name)
+		}
+	}
+	return nil
 }
 
 // validateFlywayPath ensures the Flyway path is non-empty, free of shell

--- a/migration/flyway_test.go
+++ b/migration/flyway_test.go
@@ -82,7 +82,8 @@ func TestBuildEnvironmentVariables(t *testing.T) {
 		Database: "d",
 	}}
 	fm := NewFlywayMigrator(cfg, logger.New("disabled", true))
-	env := buildEnvironmentVariables(&fm.config.Database)
+	env, err := buildEnvironmentVariables(&fm.config.Database)
+	require.NoError(t, err)
 	joined := "" + (func() string {
 		s := ""
 		for _, e := range env {
@@ -106,7 +107,8 @@ func TestBuildEnvironmentVariables(t *testing.T) {
 		Database: "pdb1",
 	}}
 	fm = NewFlywayMigrator(cfg, logger.New("disabled", true))
-	env = buildEnvironmentVariables(&fm.config.Database)
+	env, err = buildEnvironmentVariables(&fm.config.Database)
+	require.NoError(t, err)
 	joined = "" + (func() string {
 		s := ""
 		for _, e := range env {
@@ -657,11 +659,73 @@ func TestBuildEnvironmentVariablesComprehensiveDrivers(t *testing.T) {
 			}
 
 			fm := NewFlywayMigrator(cfg, logger.New("disabled", true))
-			envVars := buildEnvironmentVariables(&fm.config.Database)
+			envVars, err := buildEnvironmentVariables(&fm.config.Database)
+			require.NoError(t, err)
 			assertEnvVarsContain(t, envVars, tt.expectedVars)
 			assertEnvVarsLackPrefixes(t, envVars, tt.notExpectedVars)
 		})
 	}
+}
+
+func TestBuildEnvironmentVariablesRejectsControlChars(t *testing.T) {
+	t.Run("accepts_equals_in_password", func(t *testing.T) {
+		db := &config.DatabaseConfig{
+			Type:     "postgresql",
+			Host:     "h",
+			Port:     5432,
+			Username: "u",
+			Password: "base64==", // legitimate base64-encoded secret tail
+			Database: "d",
+		}
+		envVars, err := buildEnvironmentVariables(db)
+		require.NoError(t, err)
+		assert.Contains(t, envVars, "DB_PASSWORD=base64==")
+	})
+
+	cases := []struct {
+		name, field, badChar string
+	}{
+		{"host_lf", envFieldHost, "\n"},
+		{"host_cr", envFieldHost, "\r"},
+		{"host_nul", envFieldHost, "\x00"},
+		{"username_lf", envFieldUsername, "\n"},
+		{"username_cr", envFieldUsername, "\r"},
+		{"username_nul", envFieldUsername, "\x00"},
+		{"password_lf", envFieldPassword, "\n"},
+		{"password_cr", envFieldPassword, "\r"},
+		{"password_nul", envFieldPassword, "\x00"},
+		{"database_lf", envFieldDatabase, "\n"},
+		{"database_cr", envFieldDatabase, "\r"},
+		{"database_nul", envFieldDatabase, "\x00"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := &config.DatabaseConfig{Type: "postgresql", Host: "h", Port: 5432, Username: "u", Password: "p", Database: "d"}
+			switch tc.field {
+			case envFieldHost:
+				db.Host += tc.badChar
+			case envFieldUsername:
+				db.Username += tc.badChar
+			case envFieldPassword:
+				db.Password += tc.badChar
+			case envFieldDatabase:
+				db.Database += tc.badChar
+			}
+			_, err := buildEnvironmentVariables(db)
+			require.ErrorIs(t, err, ErrEnvFieldHasControlChar)
+			assert.Contains(t, err.Error(), tc.field, "error should name the offending field")
+		})
+	}
+
+	t.Run("error_does_not_echo_value", func(t *testing.T) {
+		db := &config.DatabaseConfig{
+			Type: "postgresql", Host: "h", Port: 5432, Username: "u",
+			Password: "leakySecret\n", Database: "d",
+		}
+		_, err := buildEnvironmentVariables(db)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "leakySecret", "error message must not echo the offending value")
+	})
 }
 
 func assertEnvVarsContain(t *testing.T, envVars, expected []string) {

--- a/migration/secrets.go
+++ b/migration/secrets.go
@@ -5,11 +5,19 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 
 	"github.com/gaborage/go-bricks/config"
 )
+
+// tenantIDPattern enforces a conservative character allowlist on tenant IDs
+// before they are concatenated into secret-store lookup names. AWS Secrets
+// Manager has no path-traversal semantics, so this is defense-in-depth: a
+// compromised control-plane returning malicious tenant IDs cannot craft
+// unexpected secret names (whitespace, control chars, slashes, dots).
+var tenantIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,128}$`)
 
 // DefaultSecretsPrefix is the default name prefix used to look up tenant
 // database credentials in a secret store. The full secret name is
@@ -50,6 +58,11 @@ var ErrNoFetcher = errors.New("migration: SecretsProvider.Fetch is nil")
 // ErrEmptyTenantID is returned when DBConfig is invoked with a blank tenant ID.
 var ErrEmptyTenantID = errors.New("migration: tenantID is empty")
 
+// ErrInvalidTenantID is returned when DBConfig is invoked with a tenant ID
+// that contains characters outside the [A-Za-z0-9_-] allowlist or exceeds
+// the 128-character length bound.
+var ErrInvalidTenantID = errors.New("migration: tenantID contains characters outside [A-Za-z0-9_-] or exceeds 128 characters")
+
 // Validate checks that the provider is wired correctly. Callers may invoke it
 // eagerly at startup; DBConfig also calls it lazily on first lookup so library
 // callers who skip the explicit check still get a clear error before any
@@ -87,6 +100,9 @@ func (p *SecretsProvider) DBConfig(ctx context.Context, tenantID string) (*confi
 	tenantID = strings.TrimSpace(tenantID)
 	if tenantID == "" {
 		return nil, ErrEmptyTenantID
+	}
+	if !tenantIDPattern.MatchString(tenantID) {
+		return nil, ErrInvalidTenantID
 	}
 
 	name := p.SecretName(tenantID)

--- a/migration/secrets_test.go
+++ b/migration/secrets_test.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -237,4 +238,65 @@ func TestSecretsProviderEmptyTenantID(t *testing.T) {
 	}
 	_, err := p.DBConfig(context.Background(), "   ")
 	require.ErrorIs(t, err, ErrEmptyTenantID)
+}
+
+func TestSecretsProviderTenantIDAllowlist(t *testing.T) {
+	validPayload := []byte(`{"type":"postgresql","host":"h","username":"u"}`)
+
+	t.Run("accepts_allowed_characters", func(t *testing.T) {
+		cases := []string{
+			"tenant1",
+			"TENANT-X",
+			"a_b-c_2",
+			"A",                                // 1 char
+			strings.Repeat("a", 128),           // 128 chars (upper bound)
+			"abcdef-ABCDEF-0123456789-_______", // mixed allowed runes
+		}
+		for _, id := range cases {
+			t.Run(id, func(t *testing.T) {
+				p := &SecretsProvider{
+					Fetch: func(context.Context, string) ([]byte, error) { return validPayload, nil },
+				}
+				_, err := p.DBConfig(context.Background(), id)
+				require.NoError(t, err)
+			})
+		}
+	})
+
+	t.Run("rejects_disallowed_inputs", func(t *testing.T) {
+		cases := []struct {
+			name string
+			id   string
+		}{
+			{"space", "tenant 1"},
+			{"slash", "tenant/secret"},
+			{"dot", "tenant.id"},
+			{"colon", "tenant:id"},
+			{"nul", "tenant\x00id"},
+			{"newline", "tenant\nid"},
+			{"unicode", "tenanté"},
+			{"over_128_chars", strings.Repeat("a", 129)},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				p := &SecretsProvider{
+					Fetch: func(context.Context, string) ([]byte, error) {
+						t.Fatal("Fetch should not be called for disallowed tenantID")
+						return nil, nil
+					},
+				}
+				_, err := p.DBConfig(context.Background(), tc.id)
+				require.ErrorIs(t, err, ErrInvalidTenantID)
+			})
+		}
+	})
+
+	t.Run("trims_then_validates", func(t *testing.T) {
+		p := &SecretsProvider{
+			Fetch: func(context.Context, string) ([]byte, error) { return validPayload, nil },
+		}
+		// Leading/trailing whitespace is trimmed; the inner ID must still match.
+		_, err := p.DBConfig(context.Background(), "  tenant-1  ")
+		require.NoError(t, err)
+	})
 }

--- a/migration/source/http/cycle_test.go
+++ b/migration/source/http/cycle_test.go
@@ -38,7 +38,7 @@ func TestListTenantsRejectsRepeatedCursor(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	src, err := New(srv.URL, Options{})
+	src, err := New(srv.URL, Options{AllowInsecureScheme: true})
 	require.NoError(t, err)
 	_, err = src.ListTenants(context.Background())
 	require.Error(t, err)

--- a/migration/source/http/source.go
+++ b/migration/source/http/source.go
@@ -51,7 +51,21 @@ type Options struct {
 	// PageLimit is sent as the ?limit= query parameter on each request.
 	// Servers may cap this. When 0 or negative, DefaultPageLimit is used.
 	PageLimit int
+
+	// AllowInsecureScheme opts in to accepting `http://` base URLs. By default
+	// New() rejects plaintext schemes so an operator-supplied bearer token is
+	// never transmitted in clear text. Set this to true only for LocalStack,
+	// dev loops, or internal-only tooling on private networks.
+	AllowInsecureScheme bool
 }
+
+// ErrInsecureScheme is returned by New when the supplied base URL uses a
+// plaintext scheme (`http://`) and Options.AllowInsecureScheme is false.
+var ErrInsecureScheme = errors.New("migration/source/http: http:// scheme requires Options.AllowInsecureScheme=true (defense-in-depth: bearer token would be transmitted in clear text)")
+
+// ErrUnsupportedScheme is returned by New when the supplied base URL uses a
+// scheme other than http or https.
+var ErrUnsupportedScheme = errors.New("migration/source/http: unsupported URL scheme (expected http or https)")
 
 // TenantSource implements migration.TenantLister against an HTTP control-plane API.
 type TenantSource struct {
@@ -62,7 +76,8 @@ type TenantSource struct {
 }
 
 // New constructs a TenantSource. baseURL must be parseable; the /tenants
-// path is appended automatically.
+// path is appended automatically. Plaintext `http://` URLs are rejected unless
+// opts.AllowInsecureScheme is true (defense-in-depth around the bearer token).
 func New(baseURL string, opts Options) (*TenantSource, error) {
 	if strings.TrimSpace(baseURL) == "" {
 		return nil, errors.New("migration/source/http: baseURL is empty")
@@ -73,6 +88,17 @@ func New(baseURL string, opts Options) (*TenantSource, error) {
 	}
 	if u.Scheme == "" || u.Host == "" {
 		return nil, fmt.Errorf("migration/source/http: baseURL must include scheme and host: %q", baseURL)
+	}
+	// url.Parse lowercases the scheme per RFC 3986, so a direct equality check
+	// is sufficient here.
+	switch u.Scheme {
+	case "https":
+	case "http":
+		if !opts.AllowInsecureScheme {
+			return nil, ErrInsecureScheme
+		}
+	default:
+		return nil, fmt.Errorf("%w: %q", ErrUnsupportedScheme, u.Scheme)
 	}
 
 	client := opts.Client

--- a/migration/source/http/source_test.go
+++ b/migration/source/http/source_test.go
@@ -27,20 +27,32 @@ func TestHTTPTenantSourceNewValidation(t *testing.T) {
 	tests := []struct {
 		name    string
 		base    string
+		opts    Options
 		wantErr bool
+		errIs   error
 	}{
 		{name: "valid_https", base: "https://api.example.com"},
-		{name: "valid_http", base: "http://localhost:8080/"},
+		{name: "https_with_insecure_flag_still_works", base: "https://api.example.com", opts: Options{AllowInsecureScheme: true}},
+		{name: "http_rejected_by_default", base: "http://localhost:8080/", wantErr: true, errIs: ErrInsecureScheme},
+		{name: "http_allowed_with_opt_out", base: "http://localhost:8080/", opts: Options{AllowInsecureScheme: true}},
 		{name: "empty_url", base: "", wantErr: true},
 		{name: "missing_scheme", base: "api.example.com", wantErr: true},
 		{name: "missing_host", base: "https://", wantErr: true},
+		{name: "ftp_scheme_rejected", base: "ftp://api.example.com", wantErr: true, errIs: ErrUnsupportedScheme},
+		{name: "file_scheme_rejected", base: "file://server/path", wantErr: true, errIs: ErrUnsupportedScheme},
+		// url.Parse lowercases the scheme per RFC 3986; document that here so a
+		// future Go change that drops normalization fails this test.
+		{name: "uppercase_http_rejected", base: "HTTP://localhost", wantErr: true, errIs: ErrInsecureScheme},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := New(tt.base, Options{})
+			_, err := New(tt.base, tt.opts)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
+				if tt.errIs != nil {
+					assert.ErrorIs(t, err, tt.errIs)
+				}
 				return
 			}
 			assert.NoError(t, err)
@@ -65,7 +77,7 @@ func TestHTTPTenantSourceListTenantsSinglePage(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	src, err := New(srv.URL, Options{})
+	src, err := New(srv.URL, Options{AllowInsecureScheme: true})
 	require.NoError(t, err)
 
 	got, err := src.ListTenants(context.Background())
@@ -102,7 +114,7 @@ func TestHTTPTenantSourceListTenantsPagination(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	src, err := New(srv.URL, Options{})
+	src, err := New(srv.URL, Options{AllowInsecureScheme: true})
 	require.NoError(t, err)
 
 	got, err := src.ListTenants(context.Background())
@@ -121,7 +133,7 @@ func TestHTTPTenantSourceBearerTokenForwarded(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	src, err := New(srv.URL, Options{BearerToken: "secret-token"})
+	src, err := New(srv.URL, Options{BearerToken: "secret-token", AllowInsecureScheme: true})
 	require.NoError(t, err)
 
 	_, err = src.ListTenants(context.Background())
@@ -137,7 +149,7 @@ func TestHTTPTenantSourceContractErrorWithEnvelope(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	src, err := New(srv.URL, Options{})
+	src, err := New(srv.URL, Options{AllowInsecureScheme: true})
 	require.NoError(t, err)
 
 	_, err = src.ListTenants(context.Background())
@@ -157,7 +169,7 @@ func TestHTTPTenantSourceContractErrorWithoutEnvelope(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	src, err := New(srv.URL, Options{})
+	src, err := New(srv.URL, Options{AllowInsecureScheme: true})
 	require.NoError(t, err)
 
 	_, err = src.ListTenants(context.Background())
@@ -175,7 +187,8 @@ func TestHTTPTenantSourceContextCancellation(t *testing.T) {
 	defer srv.Close()
 
 	src, err := New(srv.URL, Options{
-		Client: &stdhttp.Client{Timeout: 5 * time.Second},
+		Client:              &stdhttp.Client{Timeout: 5 * time.Second},
+		AllowInsecureScheme: true,
 	})
 	require.NoError(t, err)
 
@@ -199,7 +212,7 @@ func TestHTTPTenantSourcePageLimitOverride(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	src, err := New(srv.URL, Options{PageLimit: 25})
+	src, err := New(srv.URL, Options{PageLimit: 25, AllowInsecureScheme: true})
 	require.NoError(t, err)
 
 	_, err = src.ListTenants(context.Background())
@@ -212,7 +225,7 @@ func TestHTTPTenantSourceMissingDataField(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	src, err := New(srv.URL, Options{})
+	src, err := New(srv.URL, Options{AllowInsecureScheme: true})
 	require.NoError(t, err)
 
 	_, err = src.ListTenants(context.Background())
@@ -231,7 +244,7 @@ func TestHTTPTenantSourceSkipsEmptyIDs(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	src, err := New(srv.URL, Options{})
+	src, err := New(srv.URL, Options{AllowInsecureScheme: true})
 	require.NoError(t, err)
 
 	got, err := src.ListTenants(context.Background())

--- a/tools/migration/internal/commands/common.go
+++ b/tools/migration/internal/commands/common.go
@@ -93,7 +93,8 @@ func buildLister(flags *CommonFlags, fileStore *config.TenantStore) (migration.T
 
 	if flags.SourceURL != "" {
 		return httpsource.New(flags.SourceURL, httpsource.Options{
-			BearerToken: flags.SourceToken,
+			BearerToken:         flags.SourceToken,
+			AllowInsecureScheme: flags.AllowInsecureScheme,
 		})
 	}
 

--- a/tools/migration/internal/commands/list_test.go
+++ b/tools/migration/internal/commands/list_test.go
@@ -30,6 +30,7 @@ func TestListCommandHTTPSourceText(t *testing.T) {
 	cmd := NewListCommand()
 	cmd.SetArgs([]string{
 		"--source-url", srv.URL,
+		"--allow-insecure-scheme",
 	})
 
 	var stdout bytes.Buffer
@@ -59,6 +60,7 @@ func TestListCommandHTTPSourceJSON(t *testing.T) {
 	cmd := NewListCommand()
 	cmd.SetArgs([]string{
 		"--source-url", srv.URL,
+		"--allow-insecure-scheme",
 		"--json",
 	})
 

--- a/tools/migration/internal/commands/migrate_test.go
+++ b/tools/migration/internal/commands/migrate_test.go
@@ -123,6 +123,7 @@ func TestMigrateCommandSuccessAcrossPagesAndShapes(t *testing.T) {
 	cmd := NewMigrateCommand()
 	cmd.SetArgs([]string{
 		"--source-url", listSrv.URL,
+		"--allow-insecure-scheme",
 		"--aws-endpoint", smSrv.URL,
 		"--aws-region", "us-east-1",
 		"--flyway-path", flyway,
@@ -167,6 +168,7 @@ func TestMigrateCommandFailFastStopsAfterFirstFailure(t *testing.T) {
 	cmd := NewMigrateCommand()
 	cmd.SetArgs([]string{
 		"--source-url", listSrv.URL,
+		"--allow-insecure-scheme",
 		"--aws-endpoint", smSrv.URL,
 		"--aws-region", "us-east-1",
 		"--flyway-path", flyway,
@@ -212,6 +214,7 @@ func TestMigrateCommandContinueOnErrorListsAllFailures(t *testing.T) {
 	cmd := NewMigrateCommand()
 	cmd.SetArgs([]string{
 		"--source-url", listSrv.URL,
+		"--allow-insecure-scheme",
 		"--aws-endpoint", smSrv.URL,
 		"--aws-region", "us-east-1",
 		"--flyway-path", flyway,
@@ -255,6 +258,7 @@ func TestMigrateCommandMalformedSecretMentionsTenant(t *testing.T) {
 	cmd := NewMigrateCommand()
 	cmd.SetArgs([]string{
 		"--source-url", listSrv.URL,
+		"--allow-insecure-scheme",
 		"--aws-endpoint", smSrv.URL,
 		"--aws-region", "us-east-1",
 		"--flyway-path", flyway,

--- a/tools/migration/internal/commands/root.go
+++ b/tools/migration/internal/commands/root.go
@@ -10,9 +10,10 @@ import (
 // CommonFlags holds flags shared by every action subcommand.
 type CommonFlags struct {
 	// Listing source.
-	SourceURL    string
-	SourceToken  string
-	SourceConfig string
+	SourceURL           string
+	SourceToken         string
+	SourceConfig        string
+	AllowInsecureScheme bool
 
 	// Credential resolution.
 	SecretsPrefix   string
@@ -67,6 +68,7 @@ func addCommonFlags(cmd *cobra.Command) *CommonFlags {
 	cmd.Flags().StringVar(&flags.SourceURL, "source-url", "", "Base URL of the control-plane tenant-listing API")
 	cmd.Flags().StringVar(&flags.SourceToken, "source-token", "", "Bearer token for the control-plane API (env: GOBRICKS_MIGRATE_SOURCE_TOKEN)")
 	cmd.Flags().StringVar(&flags.SourceConfig, "source-config", "", "Path to a YAML config file with multitenant.tenants block (alternative to --source-url)")
+	cmd.Flags().BoolVar(&flags.AllowInsecureScheme, "allow-insecure-scheme", false, "Allow http:// (plaintext) base URLs for --source-url; rejected by default to keep the bearer token off the wire")
 
 	// Credential resolution.
 	cmd.Flags().StringVar(&flags.SecretsPrefix, "secrets-prefix", migration.DefaultSecretsPrefix, "Prefix for AWS Secrets Manager secret names (final name = prefix + tenant_id)")


### PR DESCRIPTION
## Summary

Three small defense-in-depth hardening items deferred from PR #387's `/simplify` and security-review pass. None of these fix a known-exploitable issue today — each one tightens a trust boundary so a future compromise (malicious control-plane, malicious secret writer, operator typo) doesn't propagate.

- **HTTPS-only by default for the HTTP tenant source** (`migration/source/http`): bearer token no longer transmitted in plaintext if the operator accidentally passes a `http://` base URL. Opt out with the new `--allow-insecure-scheme` CLI flag (or `Options.AllowInsecureScheme: true` library field) for LocalStack / private-network use. Closes #392.
- **Env-var control-char rejection** in `migration.buildEnvironmentVariables`: rejects `\r`, `\n`, `\x00` in `Host`/`Username`/`Password`/`Database` before the Flyway subprocess is spawned. New sentinel `ErrEnvFieldHasControlChar`; error names the offending field but never echoes the value. Closes #393.
- **Tenant-ID character allowlist** in `migration.SecretsProvider.DBConfig`: rejects tenant IDs outside `^[A-Za-z0-9_-]{1,128}$` via a precompiled regex. New sentinel `ErrInvalidTenantID`. Closes #394.

## Notes

- Three new sentinel errors (`ErrInsecureScheme`, `ErrUnsupportedScheme`, `ErrEnvFieldHasControlChar`, `ErrInvalidTenantID`) so library callers can distinguish the new rejection modes from existing ones.
- `buildEnvironmentVariables` signature changes from `func(...) []string` to `func(...) ([]string, error)` — internal (unexported) function, only callers are inside the package.
- CLI tests (`tools/migration/internal/commands/{list,migrate}_test.go`) updated to pass `--allow-insecure-scheme` because `httptest.NewServer` returns `http://` URLs.
- `/simplify` pass applied two findings before push: removed a WHAT-comment justifying `goconst` constants, and flattened a 12-closure test fixture in `flyway_test.go` to a plain switch dispatch.

Closes #392
Closes #393
Closes #394

## Test plan

- [x] \`make check\` green (framework: fmt + lint + race tests)
- [x] \`make check\` green in \`tools/migration/\` (CLI: fmt + lint + race tests + build + --help smoke)
- [x] New unit tests for each hardening item (positive + negative cases)
- [x] Existing tests still pass with the signature change to \`buildEnvironmentVariables\` and the new \`--allow-insecure-scheme\` requirement
- [ ] CI green (paths-filter triggers framework + migrate-tool jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--allow-insecure-scheme` flag for migration commands to permit plaintext HTTP connection sources.

* **Improvements**
  * Enhanced validation for tenant identifiers (alphanumeric, underscore, and hyphen characters only; max 128 characters).
  * Added validation to prevent control characters in database configuration fields.
  * HTTP connections now rejected by default unless explicitly enabled.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/395)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->