### PR TITLE
chore(ci): pin golangci-lint and gosec versions

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -752,7 +752,7 @@ jobs:
       - name: golangci-lint (migrate tool)
         uses: golangci/golangci-lint-action@36fe29c8f9dc696b104db0f7d49d1a87d2bbcd5b
         with:
-          version: latest
+          version: v2.12.2
           working-directory: tools/migration
           args: --timeout=5m
 
@@ -777,7 +777,7 @@ jobs:
           cache-dependency-path: tools/migration/go.sum
 
       - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
 
       - name: Run Gosec Security Scanner (migrate tool)
         run: |
@@ -813,7 +813,7 @@ jobs:
       - name: golangci-lint (framework)
         uses: golangci/golangci-lint-action@36fe29c8f9dc696b104db0f7d49d1a87d2bbcd5b
         with:
-          version: latest
+          version: v2.12.2
           args: --timeout=5m --skip-dirs=tools
 
   lint-tool:
@@ -836,7 +836,7 @@ jobs:
       - name: golangci-lint (tool)
         uses: golangci/golangci-lint-action@36fe29c8f9dc696b104db0f7d49d1a87d2bbcd5b
         with:
-          version: latest
+          version: v2.12.2
           working-directory: tools/openapi
           args: --timeout=5m
 
@@ -858,7 +858,7 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
 
       - name: Run Gosec Security Scanner (framework)
         run: |
@@ -892,7 +892,7 @@ jobs:
           cache-dependency-path: tools/openapi/go.sum
 
       - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
 
       - name: Run Gosec Security Scanner (tool)
         run: |


### PR DESCRIPTION
## Summary

Pin both lint/security CLI tools to the versions PR #395 just validated against, rather than letting `@latest` drift on every CI run.

| Tool | Before | After | Call sites |
|---|---|---|---|
| `golangci-lint` (via action) | `version: latest` | `version: v2.12.2` | 3 (framework, openapi-tool, migrate-tool) |
| `gosec` (via `go install`) | `@latest` | `@v2.26.1` | 3 (framework, openapi-tool, migrate-tool) |

## Why now

A new upstream release between merges could quietly change lint coverage (or break it) without any code change in this repo. Pinning makes tool upgrades an explicit, bisectable commit instead of an implicit drift. The chosen versions are the ones that `latest` resolved to during PR #395's successful CI run, so this is a no-op behaviour-wise.

This is a tech-debt item carried in `.claude/tasks/multi-tenant-migration-followups.md` from the original #387 review pass.

## Test plan

- [x] \`make check\` green locally
- [x] YAML still parses (verified syntactically)
- [ ] CI runs all 3 lint + 3 security jobs cleanly against the pinned versions
- [ ] No new lint findings vs. the previous \`latest\` run on PR #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to pin specific versions of security and linting tools for improved build consistency and reliability. This ensures more deterministic builds across environments without affecting job logic or test coverage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/396)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->