### PR TITLE
docs: clean up stale references across ADRs and top-level docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,6 @@
 !sonar-project.properties
 
 !.claude/commands/*
-!specs/**/*
 
 # ...even if they are in subdirectories
 !*/

--- a/MULTI_TENANT.md
+++ b/MULTI_TENANT.md
@@ -74,8 +74,8 @@ All resolvers support context propagation and integrate seamlessly with the midd
 
 Modules access tenant-specific resources through function-based injection in `ModuleDeps`:
 
-- `GetDB(ctx context.Context)` - Returns database connection for the tenant in the context
-- `GetMessaging(ctx context.Context)` - Returns messaging client for the tenant in the context
+- `DB(ctx context.Context)` - Returns database connection for the tenant in the context
+- `Messaging(ctx context.Context)` - Returns messaging client for the tenant in the context
 
 The framework automatically resolves the tenant ID from the request context and provides the appropriate isolated resources. Messaging declarations made in `DeclareMessaging()` are validated once at startup and replayed to each tenant's registry, ensuring complete infrastructure isolation.
 

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ type UserService struct {
 }
 
 func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
-    // GetCache resolves tenant from context automatically
+    // Cache(ctx) resolves the tenant from context automatically
     cache, err := s.getCache(ctx)
     if err != nil {
         return nil, err

--- a/wiki/adr-008-database-testing-interface-segregation.md
+++ b/wiki/adr-008-database-testing-interface-segregation.md
@@ -3,6 +3,8 @@
 ## Status
 Accepted (2025-01-10)
 
+> **Note (2026-05-12):** Code examples in this ADR were updated to reflect the S8179 rename (`GetDB` → `DB` field on `ModuleDeps`). The decision, rationale, and test-helper API surface are unchanged. The full rename table lives in [wiki/migrations.md](migrations.md).
+
 ## Context
 Application developers faced testing friction with `database.Interface` requiring ~25 methods across 4 wrapper types (Interface, Tx, Row, Statement). Testing required:
 - **30+ lines of sqlmock boilerplate** per test
@@ -79,7 +81,7 @@ tenants.ForTenant("acme").ExpectQuery("SELECT").WillReturnRows(...)
 tenants.ForTenant("globex").ExpectQuery("SELECT").WillReturnRows(...)
 
 deps := &app.ModuleDeps{
-    GetDB: tenants.AsGetDBFunc(),  // Respects function-based injection
+    DB: tenants.AsGetDBFunc(),  // Respects function-based injection
 }
 ```
 
@@ -96,7 +98,7 @@ AssertTransactionCommitted(t, db)
 - **73% less test boilerplate**: 30+ lines → 8 lines per test
 - **100% backward compatible**: All 32 test suites pass unchanged
 - **Honors SRP**: Separate Querier (execution) from Transactor (transactions)
-- **Multi-tenant ready**: TenantDBMap respects function-based `GetDB(ctx)` pattern
+- **Multi-tenant ready**: TenantDBMap respects function-based `DB(ctx)` pattern
 - **Type-safe**: Compile-time verification of interface compliance
 - **Clearer test intent**: Expectation-based API vs verbose sqlmock regexp patterns
 - **Zero breaking changes**: Existing code unaffected
@@ -181,7 +183,7 @@ db := dbtest.NewTestDB(dbtypes.PostgreSQL).
     WillReturnRows(dbtest.NewRowSet("id", "name").AddRow(1, "Alice"))
 
 deps := &app.ModuleDeps{
-    GetDB: func(ctx context.Context) (database.Interface, error) {
+    DB: func(ctx context.Context) (database.Interface, error) {
         return db, nil
     },
 }

--- a/wiki/adr-010-panic-to-error-conversion.md
+++ b/wiki/adr-010-panic-to-error-conversion.md
@@ -236,4 +236,4 @@ The following S8242 (context-in-struct) patterns are **intentionally retained** 
 - [Effective Go: Errors](https://go.dev/doc/effective_go#errors)
 - [SonarCloud S8148: Functions should follow Go's explicit error handling patterns](https://rules.sonarsource.com/go/RSPEC-8148/)
 - [SonarCloud S8242: context.Context should not be embedded in structs](https://rules.sonarsource.com/go/RSPEC-8242/)
-- [GoBricks Manifesto: Robustness - Handle errors idiomatically](.specify/memory/constitution.md)
+- [GoBricks Manifesto: Robustness - Handle errors idiomatically](../CLAUDE.md#developer-manifesto-mandatory)

--- a/wiki/adr-011-redis-cache.md
+++ b/wiki/adr-011-redis-cache.md
@@ -5,6 +5,8 @@
 **Status:** Accepted
 **Context:** Multi-tenant caching infrastructure and distributed locking support
 
+> **Note (2026-05-12):** Code examples in this ADR were updated to reflect the S8179 rename (`GetCache` → `Cache` field on `ModuleDeps`, mirroring the `GetDB` → `DB` / `GetMessaging` → `Messaging` renames). The decision, rationale, and lifecycle behaviour are unchanged. The full rename table lives in [wiki/migrations.md](migrations.md). Entries in the "Completed PRs" list (further down) are deliberately preserved with their original names as a historical record.
+
 ## Problem Statement
 
 GoBricks applications require:
@@ -158,14 +160,14 @@ cache:
 ```go
 type ModuleDeps struct {
     // ... existing fields
-    GetCache func(context.Context) (cache.Cache, error)  // NEW
+    Cache func(context.Context) (cache.Cache, error)  // NEW
 }
 ```
 
 **Impact:**
 - Minor breaking change (new field on struct)
 - Backward compatible: modules not using cache ignore new field
-- Function-based dependency (matches `GetDB`, `GetMessaging` pattern)
+- Function-based dependency (matches `DB`, `Messaging` pattern)
 
 **Rationale:**
 - Consistent API with existing multi-tenant dependencies
@@ -249,7 +251,7 @@ See main implementation plan for details (CBOR serialization, Redis client, conf
 ### Adoption Path
 ```go
 // Phase 1: Basic caching
-cache, _ := deps.GetCache(ctx)
+cache, _ := deps.Cache(ctx)
 data, _ := cache.Marshal(&user)
 cache.Set(ctx, "user:123", data, 5*time.Minute)
 
@@ -358,7 +360,7 @@ defer cache.Delete(ctx, lockKey)
 - Full observability metrics implementation (cache.hit, cache.miss counters)
 
 **Architectural Highlights:**
-- Follows "Explicit > Implicit" manifesto principle with function-based `deps.GetCache(ctx)`
+- Follows "Explicit > Implicit" manifesto principle with function-based `deps.Cache(ctx)`
 - Lock-free close pattern prevents blocking operations during cache lifecycle events
 - Singleflight prevents duplicate cache creation under concurrent load
 - Defensive validation at multiple layers (app, config, Redis client)

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -190,7 +190,7 @@ When creating a new ADR:
 
 - **[CLAUDE.md](../CLAUDE.md)**: Development guide and quick reference
 - **[llms.txt](../llms.txt)**: Code examples for LLM code generation
-- **[.specify/memory/constitution.md](../.specify/memory/constitution.md)**: Project governance framework
+- **[CLAUDE.md → Developer Manifesto](../CLAUDE.md#developer-manifesto-mandatory)**: Project governance — principles, security guidelines, engineering practices
 - **[Demo Project](https://github.com/gaborage/go-bricks-demo-project)**: Working examples
 
 ---

--- a/wiki/cache.md
+++ b/wiki/cache.md
@@ -8,7 +8,7 @@ GoBricks provides Redis-based caching with type-safe serialization, multi-tenant
 - **Redis Client**: Atomic operations (Get/Set/GetOrSet/CompareAndSet), connection pooling, health monitoring
 - **CacheManager**: Per-tenant cache lifecycle with lazy initialization, LRU eviction, idle cleanup, singleflight
 - **CBOR Serialization**: Type-safe encoding with security limits (max 10k array/map elements)
-- **TenantStore Integration**: Automatic tenant resolution from context via `deps.Cache(ctx)`
+- **Multi-tenant integration**: Automatic tenant resolution from context via `deps.Cache(ctx)`
 
 **Lifecycle Management (CacheManager):**
 - **Lazy Initialization**: Cache created on first access per tenant (no upfront connections)


### PR DESCRIPTION
## Summary

Post-#395/#396 doc sweep. No code changes, no behaviour changes — just unblocking stale references that would mislead readers today.

## Findings

### 1. Dead .gitignore entry
`.gitignore:44` had `!specs/**/*` — an allowlist for a directory deleted in [#173](https://github.com/gaborage/go-bricks/pull/173) (Nov 2025, "Remove job scheduler specification and task documents"). Harmless no-op, but a fossil. Removed.

### 2. Two broken links to a deleted file
The "GoBricks Manifesto" used to live at `.specify/memory/constitution.md`. That file was deleted in the same #173 cleanup. Its content now lives in `CLAUDE.md` under "Developer Manifesto (MANDATORY)". Updated the two remaining links:
- `wiki/architecture_decisions.md` → "Related Documentation" section
- `wiki/adr-010-panic-to-error-conversion.md` → "References" section

### 3. Stale `Get*` getter references in current usage docs
The S8179 rename (`GetX()` → `X()`) is documented in [wiki/migrations.md](wiki/migrations.md), but a few references slipped through to docs that describe *current* API:
- `README.md` cache code comment
- `MULTI_TENANT.md` module-deps method list
- `wiki/cache.md` — "TenantStore Integration" header was ambiguous (the underlying interface was `database.TenantStore` which renamed to `database.DBConfigProvider`; the user-facing `app.TenantStore` composite kept its name per ADR-013). Changed to "Multi-tenant integration" for clarity.

### 4. Stale code examples in ADR-008 and ADR-011
Code blocks using `GetDB: …` / `GetCache: …` field syntax that no longer compiles. Updated the active examples to current API and added a one-line note at the top of each ADR pointing to `wiki/migrations.md` so the rename context is discoverable. Original decisions and rationale are untouched.

## Left alone (deliberately historical)

| Location | Why kept |
|---|---|
| `wiki/adr-004-lazy-messaging-registry.md` (3 refs to GetDB/GetMessaging) | Describes the transition era — essential historical context |
| `wiki/adr-013-interface-naming-conventions.md` (TenantStore, HealthProbe, Job refs) | IS the rename announcement; old names appear deliberately in before/after tables |
| `wiki/adr-011-redis-cache.md` "Completed PRs" list | Historical artifact of what shipped; explicitly preserved per the ADR's new note |
| `CLAUDE.md` migration tables (S8179, S8196, ToSQL) | Intentionally use old names in the "before" columns |
| `wiki/migrations.md` | Migration reference; same posture |

## Additional finding (not fixed here)

`database/testing/multitenant.go:32, 144` — the `TenantDBMap.AsGetDBFunc()` method and its docstring example use the old `GetDB:` field syntax. The method itself is real Go (still works because the field type didn't change), but the example wouldn't compile. This is **source-code** rather than docs scope, so leaving it for a separate small follow-up if desired.

## Test plan

- [x] `make check` green (docs-only)
- [x] All broken `.specify/` links removed (`grep -rn ".specify\\b" .gitignore CLAUDE.md wiki/ README.md MULTI_TENANT.md` returns 0 hits)
- [x] All remaining `GetDB`/`GetCache`/`GetMessaging` references confirmed deliberate (5 in historical ADRs + 3 in migration tables + 2 in the new "rename note" lines at the top of ADR-008/011 explaining the rename)
- [x] `specs/` references: gone from `.gitignore`; remaining matches are external URL (`opentelemetry.io/docs/specs/...`) and the word "specs" in a CLI tool description ("Generate OpenAPI specs")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation to reflect simplified function naming conventions (e.g., `DB()`, `Messaging()`, `Cache()` instead of `Get*` variants).
  * Updated multi-tenant integration examples and references for consistency.
  * Corrected internal documentation links.

* **Chores**
  * Updated `.gitignore` configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/399)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->