### PR TITLE
docs(database/testing): update docstring examples to current ModuleDeps.DB field name

### DIFF
--- a/database/testing/fake_db.go
+++ b/database/testing/fake_db.go
@@ -63,7 +63,7 @@ const (
 //	        WillReturnRowsAffected(1)
 //
 //	deps := &app.ModuleDeps{
-//	    GetDB: func(ctx context.Context) (database.Interface, error) {
+//	    DB: func(ctx context.Context) (database.Interface, error) {
 //	        return db, nil
 //	    },
 //	}

--- a/database/testing/multitenant.go
+++ b/database/testing/multitenant.go
@@ -29,7 +29,7 @@ import (
 //
 //	// Inject into ModuleDeps
 //	deps := &app.ModuleDeps{
-//	    GetDB: tenants.AsGetDBFunc(),
+//	    DB: tenants.AsGetDBFunc(),
 //	}
 //
 //	// Test with tenant context
@@ -127,7 +127,7 @@ func (m *TenantDBMap) SetDefaultDB(db *TestDB) *TenantDBMap {
 	return m
 }
 
-// AsGetDBFunc returns a function compatible with ModuleDeps.GetDB.
+// AsGetDBFunc returns a function compatible with ModuleDeps.DB.
 // The returned function extracts the tenant ID from context and returns the corresponding TestDB.
 //
 // Behavior:
@@ -141,11 +141,11 @@ func (m *TenantDBMap) SetDefaultDB(db *TestDB) *TenantDBMap {
 //	tenants.ForTenant("acme").ExpectQuery("SELECT").WillReturnRows(...)
 //
 //	deps := &app.ModuleDeps{
-//	    GetDB: tenants.AsGetDBFunc(),
+//	    DB: tenants.AsGetDBFunc(),
 //	}
 //
 //	ctx := multitenant.SetTenant(context.Background(), "acme")
-//	db, err := deps.GetDB(ctx)  // Returns TestDB for "acme"
+//	db, err := deps.DB(ctx)  // Returns TestDB for "acme"
 func (m *TenantDBMap) AsGetDBFunc() func(context.Context) (dbtypes.Interface, error) {
 	return func(ctx context.Context) (dbtypes.Interface, error) {
 		// Try to get tenant from context


### PR DESCRIPTION
## Summary

Carryover finding from PR #399's docs sweep — flagged there as a follow-up because it touched source code rather than docs.

The docstring examples on `TestDB` (`fake_db.go`) and `TenantDBMap` (`multitenant.go`) still used the pre-S8179 `GetDB:` field syntax that no longer compiles against `app.ModuleDeps` (renamed `GetDB`/`GetCache`/`GetMessaging` → `DB`/`Cache`/`Messaging` per S8179).

Five sites updated to `DB:`. No behaviour change, no signature change, no test change.

## What was NOT changed (deliberately)

The method `TenantDBMap.AsGetDBFunc()` itself is still named after the old field. It has **zero in-tree callers** (grepped across the entire repo, including tests), so renaming to `AsDBFunc()` (matching the existing `NamedDBMap.AsDBFunc()`) would be a small breaking change with very low blast radius — but it's still a public API surface decision worth doing on its own merits. Left for a separate small PR if you want the symmetry.

The method's docstring + examples now consistently use the new field name, so a reader who copy-pastes the example gets compiling code today; the asymmetry is contained to the method name itself.

## Test plan

- [x] `make check` green
- [x] Grep confirms no remaining `GetDB:` field syntax in `database/testing/`
- [x] No code changes — only inline doc comments touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples and comments in the database testing module to reflect current API naming conventions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/400)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->