### PR TITLE
ci: skip framework/tool/migrate-tool jobs when no Go files changed

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -28,15 +28,32 @@ jobs:
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         id: filter
         with:
+          # Filters intentionally match only code-affecting paths. Doc-only
+          # changes (`wiki/**`, `CLAUDE.md`, `README.md`, `MULTI_TENANT.md`,
+          # `llms.txt`, etc.) match nothing here, so the test/build/lint/security
+          # jobs gated on these outputs cleanly skip — keeping doc PRs fast.
+          # CI workflow changes still trigger every component so reviewers see
+          # the consequences of pipeline edits.
           filters: |
             framework:
-              - '**'
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - '.golangci.yml'
+              - '.github/workflows/ci-v2.yml'
               - '!tools/**'
             tool:
-              - 'tools/openapi/**'
+              - 'tools/openapi/**/*.go'
+              - 'tools/openapi/go.mod'
+              - 'tools/openapi/go.sum'
+              - 'tools/openapi/Makefile'
               - '.github/workflows/ci-v2.yml'
             migrate_tool:
-              - 'tools/migration/**'
+              - 'tools/migration/**/*.go'
+              - 'tools/migration/go.mod'
+              - 'tools/migration/go.sum'
+              - 'tools/migration/Makefile'
               - '.github/workflows/ci-v2.yml'
 
   # ============================================================================


### PR DESCRIPTION
## Summary

Today's three doc-heavy PRs (#398 ADR-019, #399 cleanup sweep, #400 docstring fix) all triggered the full ~10-min framework integration test suite even though zero `.go` files changed — and the Oracle testcontainer flaked twice in the process. This redefines the paths-filter to gate framework / tool / migrate-tool jobs on **code-affecting** changes only.

## Change

Filter patterns shift from "any change under the component's path" to "code change under the component's path":

| Component | Before | After |
|---|---|---|
| `framework` | `**`, `!tools/**` | `**/*.go`, `go.mod`, `go.sum`, `Makefile`, `.golangci.yml`, `.github/workflows/ci-v2.yml`, `!tools/**` |
| `tool` | `tools/openapi/**`, `.github/workflows/ci-v2.yml` | `tools/openapi/{**/*.go,go.mod,go.sum,Makefile}`, `.github/workflows/ci-v2.yml` |
| `migrate_tool` | `tools/migration/**`, `.github/workflows/ci-v2.yml` | `tools/migration/{**/*.go,go.mod,go.sum,Makefile}`, `.github/workflows/ci-v2.yml` |

All ~20 existing `if: needs.changes.outputs.X == 'true'` gates stay unchanged — only the filter patterns shift. The outputs now semantically mean "code change in this component."

## Behaviour matrix

| Change | Before | After |
|---|---|---|
| `wiki/foo.md` only | Full framework suite (~10 min) | Framework jobs skip |
| `CLAUDE.md` / `README.md` / `MULTI_TENANT.md` / `llms.txt` | Full framework suite | Framework jobs skip |
| `**/foo.go` | Same | Same |
| `go.mod` / `go.sum` bump | Same | Same |
| `.golangci.yml` change | Same | Lint re-runs (tests/build/security also re-run via current filter, since they don't distinguish lint vs. test triggers — acceptable since lint config changes are rare) |
| `.github/workflows/ci-v2.yml` (this PR) | Same | Same — workflow changes re-run all components, validating the new filter end-to-end |
| Both `.go` and `.md` | Same | Same |

## Why this is the right shape

- `golangci-lint` only lints `.go` files, so doc-only changes never surface lint issues.
- `gosec` only scans `.go` files, same.
- `go test` / `go build` are no-ops when no Go code changed.
- The 10-min Oracle integration test is by far the biggest cost; skipping it on doc-only PRs is the highest-value optimization.

The remaining concern is branch protection: GitHub's status-check requirement might treat SKIPPED differently from SUCCESS. The existing workflow already uses this gating pattern (`framework == 'true'` was previously triggered by tool-only changes that were correctly skipping framework jobs), so the pattern is known to work in this repo.

## Test plan

- [x] `make check` green
- [x] YAML still parses
- [ ] This PR itself runs all CI jobs (because `.github/workflows/ci-v2.yml` is in every filter) — proves the filter doesn't break under any state
- [ ] After merge: next doc-only PR (e.g., the carryover #384 runbooks) should complete in under 2 min instead of ~10

## Follow-up

Filing a separate exploration issue (`area/database`, `kind/exploration`) on making the Oracle integration test more reliable/faster — that's the OTHER half of the pain. This PR addresses the "don't run it at all on doc-only PRs" half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflow configuration to use more precise path filtering for build triggers. This refines how the CI pipeline detects relevant code changes, improving build efficiency by reducing unnecessary job executions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/401)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->