### PR TITLE
fix(ci): drop !tools/** from framework filter so doc-only PRs skip

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -34,6 +34,16 @@ jobs:
           # jobs gated on these outputs cleanly skip — keeping doc PRs fast.
           # CI workflow changes still trigger every component so reviewers see
           # the consequences of pipeline edits.
+          #
+          # NOTE: do not add `!tools/**` (or any other `!pattern`) here. Under
+          # dorny/paths-filter's default `predicate-quantifier: some`, a `!`
+          # entry is OR'd as its own positive predicate matching every file
+          # outside the inner glob — it does NOT subtract from the list. Adding
+          # `!tools/**` would make the filter true for every non-tools file
+          # (including all of `wiki/**`), defeating the doc-only skip. The
+          # `**/*.go` pattern below already matches `tools/**/*.go`, so tool
+          # Go-file changes correctly re-run the framework matrix without help
+          # from a negation.
           filters: |
             framework:
               - '**/*.go'
@@ -42,7 +52,6 @@ jobs:
               - 'Makefile'
               - '.golangci.yml'
               - '.github/workflows/ci-v2.yml'
-              - '!tools/**'
             tool:
               - 'tools/openapi/**/*.go'
               - 'tools/openapi/go.mod'


### PR DESCRIPTION
## Summary

PR #401 was supposed to make doc-only PRs skip the framework matrix, but it didn't work — #403 (two `wiki/*.md` files, zero `.go` changes) ran the full ~10-min framework suite anyway. Root cause: `!tools/**` is not subtractive under `dorny/paths-filter`'s default `predicate-quantifier: some`.

## Diagnosis

The `changes` job in run [25752079464](https://github.com/gaborage/go-bricks/actions/runs/25752079464/job/75630766923) emitted:

```
Filter framework = true
Matching files:
  wiki/adr-020-oracle-integration-test-container-reuse.md [added]
  wiki/architecture_decisions.md [modified]
```

Neither file matches `**/*.go`, `go.mod`, `go.sum`, `Makefile`, `.golangci.yml`, or `.github/workflows/ci-v2.yml`. The only remaining pattern was `!tools/**` — which under picomatch + `predicate-quantifier: some` is itself a *positive* predicate: it returns true for every path that doesn't start with `tools/`. OR'd with the rest of the list, that's "every non-tools file in the repo," which made the filter universal-minus-tools instead of code-only.

Pre-#401 the same negation existed but was harmless: the filter was `['**', '!tools/**']`, and `**` already matched everything, so `!tools/**` was redundant. #401 dropped `**` to gate on code-affecting paths, which is what exposed `!tools/**` as the new universal matcher.

This is a well-known footgun in `dorny/paths-filter` (issue #225) — `!` patterns only subtract when `predicate-quantifier: every` is set; under the default `some` they're OR'd as ordinary predicates.

## Change

One line removed from the `framework` filter, plus an inline NOTE so this isn't re-introduced by a future "let me clean this up" pass.

```diff
 framework:
   - '**/*.go'
   - 'go.mod'
   - 'go.sum'
   - 'Makefile'
   - '.golangci.yml'
   - '.github/workflows/ci-v2.yml'
-  - '!tools/**'
```

## Behaviour matrix

| Change | Before (#401 as merged) | After |
|---|---|---|
| `wiki/foo.md` only | Framework matrix runs (~10 min) — **bug** | Framework jobs skip |
| `CLAUDE.md` / `README.md` / `llms.txt` | Framework matrix runs — **bug** | Framework jobs skip |
| `**/foo.go` in framework root | Runs | Runs |
| `tools/openapi/foo.go` only | Runs (matched both `**/*.go` and `!tools/**`) | Runs (still matches `**/*.go`) |
| `.github/workflows/ci-v2.yml` (this PR) | Runs | Runs — full-matrix validation under the new filter |
| Both `.go` and `.md` | Runs | Runs |

Tool-only `.go` changes will continue to trigger the framework matrix because `**/*.go` matches `tools/**/*.go`. That's the long-standing pre-#401 behavior; eliminating it would require enumerating the 19 framework code roots (`app/, cache/, …, validation/`), which adds ongoing maintenance burden whenever a new top-level package lands. I think that's worth doing only if tool-only PRs become a measurable CI cost — separate decision.

## Test plan

- [x] `make check` passes locally (framework lint + race tests green).
- [x] Ruby YAML parse confirms the workflow still parses.
- [ ] This PR itself runs all CI jobs (`.github/workflows/ci-v2.yml` is in every filter), so the new filter is end-to-end validated.
- [ ] After merge: re-run #403 — the `framework-*` checks should report SKIPPED rather than running for ~10 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to improve path filtering logic and add documentation guidance for workflow maintenance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/405)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->