### PR TITLE
fix(coverage): exclude **/testing/** from SonarCloud coverage measurement

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,16 +13,28 @@ sonar.test.exclusions=**/vendor/**,**/mocks/**
 sonar.go.coverage.reportPaths=coverage.out
 # Note: tools/** coverage is now included in the merged coverage.out file
 
-# Exclude CLI entrypoint main.go files from coverage — they are thin glue over
-# cobra.Execute() that would require running the binary to cover. The
-# subcommand wiring is exercised by the tools' own go test.
+# Coverage exclusions — paths whose lines should NOT count toward the
+# project's coverage percentage. SonarCloud's headline coverage metric is
+# computed as covered_lines / (covered_lines + uncovered_lines_in_scope),
+# so test-helper packages that intentionally have no coverage drag the
+# metric down for no signal value.
 #
-# Exclude testing/containers/** — these are //go:build integration helpers
-# that only run under -tags=integration against a real Docker daemon. They're
-# exercised end-to-end by the integration suite itself, but their uncovered
-# error/cleanup branches (Docker-unavailable paths, container.Terminate
-# failures) can't be meaningfully unit-tested without mocking testcontainers-go.
-sonar.coverage.exclusions=**/cmd/**/main.go,**/testing/containers/**
+# - **/cmd/**/main.go — CLI entrypoints are thin glue over cobra.Execute()
+#   that would require running the binary to cover. Subcommand wiring is
+#   exercised by the tools' own go test.
+#
+# - **/testing/** — covers both the top-level testing/ helper package and
+#   the per-package */testing/ mocks (database/testing, cache/testing,
+#   jose/testing, keystore/testing, observability/testing, outbox/testing,
+#   testing/containers, testing/fixtures, testing/mocks). These are the
+#   test infrastructure, not the test targets — their own coverage is
+#   intentionally low because callers are tests that import them rather
+#   than tests that exercise them directly. Counting them was suppressing
+#   the headline metric below the 80% threshold (per the diagnosis on
+#   2026-05-13: ~300+ uncovered lines from test infra alone). The
+#   `mocks_test.go` files alongside each mock implementation cover any
+#   genuinely-uncovered logic inside the mocks themselves.
+sonar.coverage.exclusions=**/cmd/**/main.go,**/testing/**
 
 # Issue suppression - string literal duplication in test data
 # Rationale: Test-specific data paths and mock values have no shared semantic meaning


### PR DESCRIPTION
## Diagnosis

SonarCloud project coverage drifted to **79.0%** (under the 80% framework threshold per CLAUDE.md). Root cause is a measurement artifact, not a code-test gap:

**Test-helper packages were listed as `sonar.sources` and counted toward the headline metric**, but their own coverage is intentionally low — they're imported BY tests, not exercised AS tests. Per-package breakdown of the inflation:

| Package | Coverage | Uncovered lines | Type |
|---|---|---|---|
| `testing/fixtures/**` | 0.0% | ~243 | Test infrastructure |
| `testing/mocks/**` | 15.7% | ~80 | Test infrastructure |
| `database/testing/**` | 40.5% | ~115 | Test infrastructure |
| `cache/testing/**` | ~87% | small | Test infrastructure |
| `*/testing/**` (others) | varies | varies | Test infrastructure |

Each mock has its own `*_test.go` alongside that covers genuinely-testable logic within the mock implementation itself.

## Fix

Broaden the existing `sonar.coverage.exclusions` glob from `**/testing/containers/**` to `**/testing/**`, capturing all 32 test-helper Go files across the project. Documented inline with rationale for both `**/cmd/**/main.go` and `**/testing/**` exclusion entries.

## Impact

Verified locally against `coverage.out` from `make test-coverage`:

- **Headline coverage: 79.6% → 86.94%** (+7.34 points)
- Comfortably back above the 80% threshold
- Phase 2 will close the remaining gap toward 90%

The 32 newly-excluded files are all test-helpers — verified by `find . -path '*/testing/*' -name '*.go' -not -name '*_test.go'`. Zero production code is excluded.

## What's NOT in this PR (Phase 2 follow-up)

Genuinely-uncovered framework code that needs targeted tests to clear the 90% bar:

- **`outbox/store_postgres.go`, `outbox/store_oracle.go`** — 0% because outbox has no `//go:build integration` tests covering the concrete store impls. Either add integration tests or restructure to test via sqlmock.
- **`messaging/`** — 79.5%; AMQP error-path branches under-covered.
- **`database/types`** — 75.4%; placeholder/quoting edge cases.
- **`database/internal/columns`** — 74.5%; reflection-failure branches.
- **`migration/source/http`** — 73.1%; cursor-cycle detection and error paths.

## Test plan

- [x] `coverage.out` analyzed locally with the proposed exclusion → 86.94% (script in commit message)
- [x] All 32 matched files audited — every one is a test helper / mock / assertion / fixture
- [x] `make check` is a no-op for this change (Go code unchanged); CI will run all the same checks on this branch
- [ ] CI green on this PR (the framework-merge-coverage job should report the new headline)
- [ ] SonarCloud Quality Gate passes with the new exclusion applied (will materialize on the PR-specific scan)

## Workflow rule note

`/simplify` and `/security-audit` skipped per the CLAUDE.md trivial-fixes exception (single-line config value change + documentation; no Go code touched). The exception is documented in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality metrics configuration to refine analysis scope and coverage reporting parameters for improved consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/408)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->