### PR TITLE
fix(sonar): suppress godre:S8242 on scheduler's unavoidable context fields

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -39,6 +39,35 @@ sonar.coverage.exclusions=**/cmd/**/main.go,**/testing/**
 # Issue suppression - string literal duplication in test data
 # Rationale: Test-specific data paths and mock values have no shared semantic meaning
 # Extracting them creates unnecessary abstraction (YAGNI principle)
-sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria=e1,e2,e3
 sonar.issue.ignore.multicriteria.e1.ruleKey=go:S1192
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go
+
+# e2, e3 — godre:S8242 ("don't store context.Context in a struct") on the
+# scheduler module's two unavoidable context fields. SonarCloud's
+# directive engine doesn't honour the inline `//nolint:S8242 // NOSONAR:`
+# annotations that golangci-lint reads, so we suppress at the project
+# level here with the rationale recorded inline.
+#
+# - scheduler/job.go    — jobContextImpl embeds context.Context because
+#                         the public scheduler.JobContext interface does.
+#                         The embed is what allows callers to pass a
+#                         JobContext anywhere a context.Context is
+#                         expected (OTel propagation, db/messaging ops).
+#                         Removing the embed would change the public API
+#                         contract.
+#
+# - scheduler/module.go — Module.shutdownCtx is a lifecycle context, not
+#                         a request context. It's a parent for derived
+#                         contexts in multiple goroutines (scheduling
+#                         loop, per-job spawn, shutdown coordination) and
+#                         lives the entire process lifetime. The standard
+#                         Go service pattern uses a stored
+#                         context+cancel pair here; making it a function
+#                         parameter would require threading it through
+#                         every goroutine spawn site for negative
+#                         architectural payoff.
+sonar.issue.ignore.multicriteria.e2.ruleKey=godre:S8242
+sonar.issue.ignore.multicriteria.e2.resourceKey=**/scheduler/job.go
+sonar.issue.ignore.multicriteria.e3.ruleKey=godre:S8242
+sonar.issue.ignore.multicriteria.e3.resourceKey=**/scheduler/module.go


### PR DESCRIPTION
## Diagnosis

SonarCloud's `godre:S8242` rule ("Remove this 'context.Context' field and pass context as a parameter to methods that need it") has two MAJOR maintainability issues currently in **REOPENED** status:

| Key | File | Why it's flagged | Why it can't be refactored |
|---|---|---|---|
| `AZrF-o8hR7TGIJ0nygrl` | `scheduler/job.go:73` | `jobContextImpl` embeds `context.Context` | The public `scheduler.JobContext` interface itself embeds `context.Context` — the impl MUST mirror that. The embed is what lets callers pass a `JobContext` anywhere a `context.Context` is expected (OTel propagation, DB / messaging ops). |
| `AZrF-o85R7TGIJ0nygrn` | `scheduler/module.go:69` | `Module.shutdownCtx` stored field | `shutdownCtx` is a lifecycle context (not a request context) used as a parent for derived contexts in multiple goroutines: scheduling loop (`:489`), per-job spawn (`:517`), and shutdown coordination (`:369`). Making it a function parameter would require threading it through every goroutine spawn site for negative architectural payoff. This is the standard Go service-pattern shape. |

Both files already have inline `//nolint:S8242 // NOSONAR:` annotations documenting the rationale, but **SonarCloud's directive engine doesn't honour them** — golangci-lint and SonarCloud are independent scanners with independent suppression syntax. SonarCloud only honours the project-level `sonar.issue.ignore.multicriteria` mechanism, which `sonar-project.properties` already uses for `go:S1192` in test files.

## Fix

Add two entries (e2, e3) to the existing `multicriteria` block in `sonar-project.properties`, each suppressing `godre:S8242` for one of the two scheduler files. Inline rationale comments document why each suppression is structural rather than oversight.

The inline `//nolint:S8242` Go comments stay in place as in-source documentation; they're functionally a no-op (golangci-lint's rule set doesn't include `S8242` either — it's a SonarSource Go plugin rule), but they record the design intent at the field declaration site.

## Verification

`make check` green locally — no Go code touched, only `sonar-project.properties`. The SonarCloud rescan on this PR's branch should move both issues from `REOPENED` to `CLOSED` (suppressed by configuration).

## Why this is a separate PR

- Independent from PR #408 (coverage exclusion) and PR #409 (outbox tests). All three touch SonarCloud-related concerns but in non-overlapping ways.
- Small, mechanically reviewable diff — one config file, well-documented suppression entries.
- The structural nature of both fields means there's no realistic alternative; review here is just "does the suppression rationale make sense", not "is there a better refactor."

## Workflow rule note

`/simplify` and `/security-audit` skipped per the CLAUDE.md trivial-fixes exception. Config-only change, no code or tests changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality configuration settings for internal quality checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/410)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->