### PR TITLE
test(database/types): close remaining coverage gaps to 100% (Phase 2C-2)

### DIFF
--- a/database/types/uncovered_branches_test.go
+++ b/database/types/uncovered_branches_test.go
@@ -1,0 +1,119 @@
+package types
+
+import (
+	"errors"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// NewRowFromSQL / sqlRowAdapter — covers the previously-0% wrapper + the
+// nil-safety branches in Scan() and Err(), plus the delegation paths using
+// sqlmock to produce a real *sql.Row.
+// ---------------------------------------------------------------------------
+
+func TestNewRowFromSQLReturnsNilWhenInputIsNil(t *testing.T) {
+	assert.Nil(t, NewRowFromSQL(nil),
+		"contract: a nil *sql.Row produces a nil Row so callers can short-circuit")
+}
+
+func TestNewRowFromSQLWrapsNonNilRow(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectQuery("SELECT 1").WillReturnRows(sqlmock.NewRows([]string{"n"}).AddRow(42))
+	row := db.QueryRowContext(t.Context(), "SELECT 1")
+
+	wrapped := NewRowFromSQL(row)
+	require.NotNil(t, wrapped)
+
+	var got int
+	require.NoError(t, wrapped.Scan(&got))
+	assert.Equal(t, 42, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlRowAdapterScanReturnsErrorWhenReceiverIsNil(t *testing.T) {
+	var r *sqlRowAdapter // typed nil receiver
+	err := r.Scan(new(int))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "underlying sql.Row is nil")
+}
+
+func TestSqlRowAdapterScanReturnsErrorWhenInnerRowIsNil(t *testing.T) {
+	r := &sqlRowAdapter{row: nil}
+	err := r.Scan(new(int))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "underlying sql.Row is nil")
+}
+
+func TestSqlRowAdapterErrReturnsErrorWhenReceiverIsNil(t *testing.T) {
+	var r *sqlRowAdapter
+	err := r.Err()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "underlying sql.Row is nil")
+}
+
+func TestSqlRowAdapterErrDelegatesToUnderlyingSQLRow(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Use a query error (not a row error) so sql.Row.Err() reports it on
+	// the first Err() call without needing a prior Scan. This exercises
+	// the r.row.Err() delegation branch directly.
+	mock.ExpectQuery("SELECT err").WillReturnError(errors.New("driver fault"))
+	row := db.QueryRowContext(t.Context(), "SELECT err")
+	wrapped := NewRowFromSQL(row)
+	require.NotNil(t, wrapped)
+
+	assert.Error(t, wrapped.Err(), "deferred query error must surface through Err() delegation")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// ---------------------------------------------------------------------------
+// ValidateSubquery — covers the previously-uncovered subqueryValidator
+// fast-path branches (success and error). Existing tests cover the
+// nil/invalid-ToSQL/empty-SQL paths via plain mocks; here we use mocks
+// that ALSO implement subqueryValidator to exercise the early-return
+// code path before ToSQL is even called.
+// ---------------------------------------------------------------------------
+
+// mockValidatingSubquery implements both SelectQueryBuilder and the unexported
+// subqueryValidator interface. ValidateForSubquery is wired by the caller.
+type mockValidatingSubquery struct {
+	mockValidSubquery // reuse the existing valid-mock for the SelectQueryBuilder surface
+	validateErr       error
+}
+
+func (m *mockValidatingSubquery) ValidateForSubquery() error { return m.validateErr }
+
+func TestValidateSubqueryReturnsEarlyOnValidatorInterfaceSuccess(t *testing.T) {
+	subquery := &mockValidatingSubquery{validateErr: nil}
+	require.NoError(t, ValidateSubquery(subquery))
+}
+
+func TestValidateSubqueryWrapsValidatorInterfaceError(t *testing.T) {
+	subquery := &mockValidatingSubquery{validateErr: errors.New("missing FROM clause")}
+	err := ValidateSubquery(subquery)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidSubquery),
+		"validator error must be wrapped as ErrInvalidSubquery for caller pattern-matching")
+	assert.Contains(t, err.Error(), "missing FROM clause")
+}
+
+// ---------------------------------------------------------------------------
+// TableRef.As — covers the previously-uncovered nil-receiver branch.
+// ---------------------------------------------------------------------------
+
+func TestTableRefAsReturnsErrorOnNilReceiver(t *testing.T) {
+	var t1 *TableRef // typed-nil receiver
+	_, err := t1.As("x")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNilTableRef),
+		"nil receiver must fail with ErrNilTableRef rather than panic")
+}


### PR DESCRIPTION
## Phase 2C-2 of the coverage push toward 90%

Closes the 5 remaining coverage gaps in `database/types`, lifting the package from **77.6% → 100.0%**.

## What's covered

**`interfaces.go`** — `NewRowFromSQL` + `sqlRowAdapter.Scan`/`Err`:
- `NewRowFromSQL(nil)` returns nil (early-return contract)
- `NewRowFromSQL(non-nil)` produces a working wrapper around a real `*sql.Row` (via sqlmock)
- `(*sqlRowAdapter)(nil).Scan(...)` returns the documented "underlying sql.Row is nil" error rather than panicking
- `&sqlRowAdapter{row: nil}.Scan(...)` same defensive return
- `(*sqlRowAdapter)(nil).Err()` same defensive return
- The `r.row.Err()` delegation path via a sqlmock query-time error (avoids the ordering hazard of needing a prior Scan)

**`subquery.go`** — `ValidateSubquery` validator-interface fast-path:
- The success branch (validator returns nil → ValidateSubquery returns nil early, before `ToSQL()` is called)
- The error branch (validator returns error → wrapped as `ErrInvalidSubquery` for caller pattern-matching)
- Uses a new `mockValidatingSubquery` that embeds the existing `mockValidSubquery` from `subquery_test.go` for the `SelectQueryBuilder` surface and adds `ValidateForSubquery` — no duplicate 16-method stubs

**`table.go`** — `TableRef.As` nil-receiver:
- `var t *TableRef; t.As("x")` returns `ErrNilTableRef` rather than panicking

## Coverage delta

| | Before | After |
|---|---|---|
| `database/types` package | 77.6% | **100.0%** |

## Pre-push workflow rule compliance

- **`/simplify`** → SHIP IT. No LOW+ findings.
- **`/security-audit`** → BLOCKED initially on 2 `golangci-lint noctx` violations: `db.QueryRow(...)` flagged for missing context (`(*database/sql.DB).QueryRow must not be called. use (*database/sql.DB).QueryRowContext`). Switched both call sites to `db.QueryRowContext(t.Context(), ...)` per Go 1.25's testing API. This is exactly the kind of catch the mandatory pre-push rule exists for — without `/security-audit` this PR would have failed CI.

After fix: `make check` green, gosec clean, govulncheck clean, raw-SQL grep clean, secrets scan clean. Manual threat-model spot-checks confirmed the defensive-nil contracts are pinned correctly and the `mockValidatingSubquery` embedding correctly exposes `ValidateForSubquery` via Go's method-set resolution.

## Test plan

- [x] `go test -race ./database/types/...` green
- [x] `make check` green (after the `QueryRowContext` fix)
- [x] Coverage verified locally: 100.0%
- [ ] CI green on this PR
- [ ] SonarCloud Quality Gate passes; per-component coverage reflects the lift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests covering previously untested code paths to improve reliability, including validation of edge cases such as nil input handling, error propagation in database operations, subquery validation, and table reference operations. Tests ensure proper error handling and prevent panics in critical scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/413)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->