### PR TITLE
test(database): close coverage gaps in manager.go (Phase 2C-3)

### DIFF
--- a/database/manager_test.go
+++ b/database/manager_test.go
@@ -323,3 +323,121 @@ func TestCloseAggregatesErrors(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), "close b"))
 	assert.True(t, strings.Contains(err.Error(), "close a"))
 }
+
+func TestDbManagerStatsEmptyManager(t *testing.T) {
+	m := NewDbManager(&stubResourceSource{configs: map[string]*config.DatabaseConfig{}}, newTestLogger(), DbManagerOptions{
+		MaxSize: 5,
+		IdleTTL: 10 * time.Minute,
+	}, func(*config.DatabaseConfig, logger.Logger) (Interface, error) { return nil, errors.New("not used") })
+
+	stats := m.Stats()
+	assert.Equal(t, 0, stats["active_connections"])
+	assert.Equal(t, 5, stats["max_connections"])
+	assert.Equal(t, 600, stats["idle_ttl_seconds"])
+	conns, ok := stats["connections"].([]map[string]any)
+	require.True(t, ok, "connections key must be []map[string]any")
+	assert.Empty(t, conns, "empty manager has no connection entries")
+}
+
+func TestDbManagerStatsPopulatedManager(t *testing.T) {
+	stubA := &stubDB{key: "a"}
+	stubB := &stubDB{key: "b"}
+	connector := func(cfg *config.DatabaseConfig, _ logger.Logger) (Interface, error) {
+		if cfg.Host == "host-a" {
+			return stubA, nil
+		}
+		return stubB, nil
+	}
+
+	src := &stubResourceSource{configs: map[string]*config.DatabaseConfig{
+		"a": {Type: "postgresql", Host: "host-a"},
+		"b": {Type: "postgresql", Host: "host-b"},
+	}}
+	m := NewDbManager(src, newTestLogger(), DbManagerOptions{MaxSize: 5, IdleTTL: time.Hour}, connector)
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	_, err := m.Get(ctx, "a")
+	require.NoError(t, err)
+	_, err = m.Get(ctx, "b")
+	require.NoError(t, err)
+
+	stats := m.Stats()
+	assert.Equal(t, 2, stats["active_connections"])
+	conns, ok := stats["connections"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, conns, 2)
+
+	for _, c := range conns {
+		assert.Contains(t, []any{"a", "b"}, c["key"])
+		assert.IsType(t, "", c["last_used"])
+		assert.IsType(t, 0, c["idle_duration"])
+	}
+}
+
+func TestStartCleanupIsIdempotent(t *testing.T) {
+	m := NewDbManager(&stubResourceSource{}, newTestLogger(), DbManagerOptions{
+		MaxSize: 5,
+		IdleTTL: time.Hour,
+	}, func(*config.DatabaseConfig, logger.Logger) (Interface, error) { return &stubDB{}, nil })
+	defer func() { _ = m.Close() }()
+
+	m.StartCleanup(10 * time.Second)
+	// Second call must observe cleanupCh != nil and short-circuit rather
+	// than spawning a duplicate goroutine.
+	require.NotPanics(t, func() {
+		m.StartCleanup(10 * time.Second)
+	})
+
+	m.StopCleanup()
+	// Second StopCleanup hits the early-return path (cleanupCh == nil).
+	require.NotPanics(t, func() {
+		m.StopCleanup()
+	})
+}
+
+func TestStartCleanupAppliesDefaultIntervalForNonPositive(t *testing.T) {
+	m := NewDbManager(&stubResourceSource{}, newTestLogger(), DbManagerOptions{
+		MaxSize: 5,
+		IdleTTL: time.Hour,
+	}, func(*config.DatabaseConfig, logger.Logger) (Interface, error) { return &stubDB{}, nil })
+	defer func() { _ = m.Close() }()
+
+	// Zero substitutes the documented 5-min default; we can't inspect the
+	// ticker directly so the contract is "no panic + clean stop".
+	require.NotPanics(t, func() { m.StartCleanup(0) })
+	m.StopCleanup()
+
+	require.NotPanics(t, func() { m.StartCleanup(-5 * time.Second) })
+	m.StopCleanup()
+}
+
+func TestCleanupIdleConnectionsLogsCloseError(t *testing.T) {
+	failingStub := &stubDB{key: "x", closeErr: errors.New("driver fault on close")}
+	connector := func(*config.DatabaseConfig, logger.Logger) (Interface, error) { return failingStub, nil }
+
+	m := NewDbManager(&stubResourceSource{}, newTestLogger(), DbManagerOptions{
+		MaxSize: 5,
+		IdleTTL: time.Hour,
+	}, connector)
+	defer func() { _ = m.Close() }()
+
+	ctx := context.Background()
+	_, err := m.Get(ctx, "x")
+	require.NoError(t, err)
+
+	// Backdate lastUsed so the cleanup pass sees the entry as idle. Direct
+	// field access under m.mu matches the pattern in
+	// TestCloseAggregatesErrors above.
+	m.mu.Lock()
+	m.conns["x"].lastUsed = time.Now().Add(-2 * time.Hour)
+	m.mu.Unlock()
+
+	m.cleanupIdleConnections()
+
+	assert.Equal(t, 0, m.Size(), "idle connection removed from cache despite Close() error")
+	failingStub.closedMu.Lock()
+	closed := failingStub.closed
+	failingStub.closedMu.Unlock()
+	assert.True(t, closed, "Close was attempted even though it returned an error")
+}


### PR DESCRIPTION
## Phase 2C-3 of the coverage push toward 90%

Closes the most impactful gaps in `database/manager.go`. Production code unchanged.

## What's covered

| Function | Before | After | Test |
|---|---|---|---|
| `Stats()` | 0% | 100% | `TestDbManagerStatsEmptyManager`, `TestDbManagerStatsPopulatedManager` |
| `StartCleanup` (idempotency) | 90% | 100% | `TestStartCleanupIsIdempotent` (also covers `StopCleanup`'s symmetric early-return) |
| `StartCleanup` (default interval) | partial | full | `TestStartCleanupAppliesDefaultIntervalForNonPositive` (zero and negative values) |
| `cleanupIdleConnections` (close-error branch) | 92.9% | 100% | `TestCleanupIdleConnectionsLogsCloseError` |
| **Package `database`** | **81.1%** | **91.9%** (+10.8 points) |

## What's NOT covered (deferred — integration territory)

- `NewConnection` (55.6%): success-path branches need a real PostgreSQL/Oracle driver connection. Existing tests already cover via `NewTrackedConnection` directly; the `tracking.NewConnection` wrap + `SetServerInfo` lines are exercised at the integration test level.
- `Get` (77.8%): the singleflight double-check window after acquiring the lock requires deterministic goroutine orchestration to reach.
- `evictIfNeeded` (83.3%): the `oldest == nil` branch is dead defensive code (`len(m.conns) >= maxSize` implies non-empty LRU list).
- `cleanupLoop` (83.3%): the `ticker.C` fire path requires time-based test orchestration; the `done` branch is already covered.

## Source-to-test 1:1 convention

All new tests live in the existing `database/manager_test.go` — no separate `manager_uncovered_test.go` file. The framework convention is strict 1:1 mapping between source files and their companion tests (`foo.go` → `foo_test.go`).

## Pre-push workflow rule compliance

- **`/simplify`** → SHIP AS-IS. No CRITICAL/HIGH findings. One MEDIUM note: `Stats` assertions use concrete-type checks (`assert.IsType(t, "", ...)` for the `last_used` field, `assert.IsType(t, 0, ...)` for `idle_duration`) — this pins the exact Go types rather than the JSON schema. Acceptable since `Stats()` is JSON-marshalled into a health endpoint where the wire shape *is* the contract.
- **`/security-audit`** → PASS. Clean across `golangci-lint`, `gosec` (0 issues, the package-level gosec findings are pre-existing in production code at `query_builder.go:970` and `manager.go:155`), `govulncheck`, raw-SQL grep, secrets scan. Manual threat-model spot-checks confirmed mutex usage (held only across map write, released before assertions) and the close-error contract match `database/manager.go:279-287` production behavior.

## Test plan

- [x] `go test -race ./database/...` green
- [x] `make check` green
- [x] Coverage verified locally: 91.9%
- [ ] CI green
- [ ] SonarCloud Quality Gate passes; per-component coverage reflects the lift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for database connection manager to verify correct behavior for empty and populated states, cleanup lifecycle management, and error handling during idle connection cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/414)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->