### PR TITLE
feat(database/testing): add TestTx.WillReturnError + drop outbox errorTx stub

### DIFF
--- a/database/testing/fake_db_test.go
+++ b/database/testing/fake_db_test.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -574,4 +575,116 @@ func TestConvertAssignTimePointer(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Nil(t, deletedAt)
 	})
+}
+
+// TestTestTxWillReturnErrorOnQuery verifies that WillReturnError targets the most
+// recently added query expectation and that the configured error surfaces through
+// both Query and QueryRow.
+func TestTestTxWillReturnErrorOnQuery(t *testing.T) {
+	wantErr := errors.New("query exploded")
+
+	t.Run("surfaces via Query", func(t *testing.T) {
+		db := NewTestDB(dbtypes.PostgreSQL)
+		db.ExpectTransaction().
+			ExpectQuery("SELECT").WillReturnError(wantErr)
+
+		tx, err := db.Begin(context.Background())
+		assert.NoError(t, err)
+		defer tx.Rollback(context.Background())
+
+		rows, err := tx.Query(context.Background(), "SELECT 1")
+		assert.Nil(t, rows)
+		assert.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("surfaces via QueryRow", func(t *testing.T) {
+		db := NewTestDB(dbtypes.PostgreSQL)
+		db.ExpectTransaction().
+			ExpectQuery("SELECT").WillReturnError(wantErr)
+
+		tx, err := db.Begin(context.Background())
+		assert.NoError(t, err)
+		defer tx.Rollback(context.Background())
+
+		var dst int
+		err = tx.QueryRow(context.Background(), "SELECT 1").Scan(&dst)
+		assert.ErrorIs(t, err, wantErr)
+	})
+}
+
+// TestTestTxWillReturnErrorOnExec verifies that WillReturnError targets the most
+// recently added exec expectation and surfaces through Exec.
+func TestTestTxWillReturnErrorOnExec(t *testing.T) {
+	wantErr := errors.New("exec exploded")
+
+	db := NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction().
+		ExpectExec("INSERT").WillReturnError(wantErr)
+
+	tx, err := db.Begin(context.Background())
+	assert.NoError(t, err)
+	defer tx.Rollback(context.Background())
+
+	result, err := tx.Exec(context.Background(), "INSERT INTO t VALUES (1)")
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// TestTestTxWillReturnErrorTargetsMostRecent verifies that in a mixed chain
+// (queries and execs interleaved), WillReturnError binds to whichever Expect*
+// was called most recently, leaving earlier expectations untouched.
+func TestTestTxWillReturnErrorTargetsMostRecent(t *testing.T) {
+	queryErr := errors.New("query target")
+	execErr := errors.New("exec target")
+
+	t.Run("binds to last when last was exec", func(t *testing.T) {
+		db := NewTestDB(dbtypes.PostgreSQL)
+		db.ExpectTransaction().
+			ExpectQuery("SELECT").WillReturnRows(NewRowSet("id").AddRow(int64(1))).
+			ExpectExec("INSERT").WillReturnError(execErr)
+
+		tx, err := db.Begin(context.Background())
+		assert.NoError(t, err)
+		defer tx.Rollback(context.Background())
+
+		// Query still succeeds — error landed on the exec.
+		var id int64
+		assert.NoError(t, tx.QueryRow(context.Background(), "SELECT 1").Scan(&id))
+		assert.Equal(t, int64(1), id)
+
+		// Exec returns the error.
+		_, err = tx.Exec(context.Background(), "INSERT INTO t VALUES (1)")
+		assert.ErrorIs(t, err, execErr)
+	})
+
+	t.Run("binds to last when last was query", func(t *testing.T) {
+		db := NewTestDB(dbtypes.PostgreSQL)
+		db.ExpectTransaction().
+			ExpectExec("INSERT").WillReturnRowsAffected(1).
+			ExpectQuery("SELECT").WillReturnError(queryErr)
+
+		tx, err := db.Begin(context.Background())
+		assert.NoError(t, err)
+		defer tx.Rollback(context.Background())
+
+		// Exec still succeeds — error landed on the query.
+		result, err := tx.Exec(context.Background(), "INSERT INTO t VALUES (1)")
+		assert.NoError(t, err)
+		affected, _ := result.RowsAffected()
+		assert.Equal(t, int64(1), affected)
+
+		// QueryRow returns the error.
+		var dst int
+		err = tx.QueryRow(context.Background(), "SELECT 1").Scan(&dst)
+		assert.ErrorIs(t, err, queryErr)
+	})
+}
+
+// TestTestTxWillReturnErrorNoOpWhenEmpty verifies that calling WillReturnError
+// before any ExpectQuery or ExpectExec is a safe no-op (matches the existing
+// WillReturnRows / WillReturnRowsAffected behavior).
+func TestTestTxWillReturnErrorNoOpWhenEmpty(t *testing.T) {
+	db := NewTestDB(dbtypes.PostgreSQL)
+	tx := db.ExpectTransaction().WillReturnError(errors.New("ignored"))
+	assert.NotNil(t, tx)
 }

--- a/database/testing/fake_tx.go
+++ b/database/testing/fake_tx.go
@@ -29,16 +29,17 @@ import (
 //	// Assert transaction was committed
 //	AssertCommitted(t, tx)
 type TestTx struct {
-	parent     *TestDB
-	queries    []*QueryExpectation
-	execs      []*ExecExpectation
-	lastQuery  *QueryExpectation
-	lastExec   *ExecExpectation
-	queryLog   []QueryCall
-	execLog    []ExecCall
-	committed  bool
-	rolledBack bool
-	mu         sync.RWMutex
+	parent      *TestDB
+	queries     []*QueryExpectation
+	execs       []*ExecExpectation
+	lastQuery   *QueryExpectation
+	lastExec    *ExecExpectation
+	lastWasExec bool
+	queryLog    []QueryCall
+	execLog     []ExecCall
+	committed   bool
+	rolledBack  bool
+	mu          sync.RWMutex
 }
 
 // ExpectQuery sets up an expectation for Query or QueryRow calls within the transaction.
@@ -55,6 +56,7 @@ func (tx *TestTx) ExpectQuery(sqlPattern string) *TestTx {
 	exp := &QueryExpectation{sql: sqlPattern}
 	tx.queries = append(tx.queries, exp)
 	tx.lastQuery = exp
+	tx.lastWasExec = false
 	return tx
 }
 
@@ -88,6 +90,7 @@ func (tx *TestTx) ExpectExec(sqlPattern string) *TestTx {
 	exp := &ExecExpectation{sql: sqlPattern}
 	tx.execs = append(tx.execs, exp)
 	tx.lastExec = exp
+	tx.lastWasExec = true
 	return tx
 }
 
@@ -103,6 +106,30 @@ func (tx *TestTx) WillReturnRowsAffected(n int64) *TestTx {
 	defer tx.mu.Unlock()
 	if tx.lastExec != nil {
 		tx.lastExec.rowsAffected = n
+	}
+
+	return tx
+}
+
+// WillReturnError configures the most-recently-added expectation (Query or Exec)
+// to return the specified error. The target is whichever ExpectQuery or ExpectExec
+// was called most recently on this TestTx; calling WillReturnError before any
+// expectation has been added is a no-op.
+// Returns the TestTx for method chaining.
+//
+// Example:
+//
+//	tx.ExpectExec("INSERT INTO orders").WillReturnError(errConstraintViolation)
+//	tx.ExpectQuery("SELECT FOR UPDATE").WillReturnError(errLockTimeout)
+func (tx *TestTx) WillReturnError(err error) *TestTx {
+	tx.mu.Lock()
+	defer tx.mu.Unlock()
+	if tx.lastWasExec {
+		if tx.lastExec != nil {
+			tx.lastExec.err = err
+		}
+	} else if tx.lastQuery != nil {
+		tx.lastQuery.err = err
 	}
 
 	return tx

--- a/outbox/store_oracle_test.go
+++ b/outbox/store_oracle_test.go
@@ -39,9 +39,15 @@ func TestOracleStoreInsertSuccess(t *testing.T) {
 func TestOracleStoreInsertExecError(t *testing.T) {
 	store := newOracleTestStore(t)
 	wantErr := errors.New("ORA-00001 unique constraint")
-	tx := &errorTx{execErr: wantErr}
+	db := dbtesting.NewTestDB(dbtypes.Oracle)
+	db.ExpectTransaction().
+		ExpectExec(`INSERT INTO GOBRICKS_OUTBOX`).
+		WillReturnError(wantErr)
 
-	err := store.Insert(t.Context(), tx, sampleRecord())
+	tx, err := db.Begin(t.Context())
+	require.NoError(t, err)
+
+	err = store.Insert(t.Context(), tx, sampleRecord())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, wantErr)
 	assert.Contains(t, err.Error(), "insert failed")

--- a/outbox/store_postgres_test.go
+++ b/outbox/store_postgres_test.go
@@ -1,8 +1,6 @@
 package outbox
 
 import (
-	"context"
-	"database/sql"
 	"errors"
 	"testing"
 	"time"
@@ -40,28 +38,6 @@ func sampleRecord() *Record {
 	}
 }
 
-// errorTx is a minimal dbtypes.Tx that returns a fixed error from Exec.
-// dbtesting.TestTx doesn't expose WillReturnError on its ExecExpectation
-// (the field is unexported), so we use this local stub for Insert-error paths.
-type errorTx struct {
-	execErr error
-}
-
-func (tx *errorTx) Query(context.Context, string, ...any) (*sql.Rows, error) {
-	return nil, errors.New("errorTx.Query not used")
-}
-func (tx *errorTx) QueryRow(context.Context, string, ...any) dbtypes.Row {
-	return nil
-}
-func (tx *errorTx) Exec(context.Context, string, ...any) (sql.Result, error) {
-	return nil, tx.execErr
-}
-func (tx *errorTx) Prepare(context.Context, string) (dbtypes.Statement, error) {
-	return nil, errors.New("errorTx.Prepare not used")
-}
-func (tx *errorTx) Commit(context.Context) error   { return nil }
-func (tx *errorTx) Rollback(context.Context) error { return nil }
-
 // --- Insert -----------------------------------------------------------------
 
 func TestPostgresStoreInsertSuccess(t *testing.T) {
@@ -80,9 +56,15 @@ func TestPostgresStoreInsertSuccess(t *testing.T) {
 func TestPostgresStoreInsertExecError(t *testing.T) {
 	store := newPostgresTestStore(t)
 	wantErr := errors.New("constraint violation")
-	tx := &errorTx{execErr: wantErr}
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction().
+		ExpectExec(`INSERT INTO gobricks_outbox`).
+		WillReturnError(wantErr)
 
-	err := store.Insert(t.Context(), tx, sampleRecord())
+	tx, err := db.Begin(t.Context())
+	require.NoError(t, err)
+
+	err = store.Insert(t.Context(), tx, sampleRecord())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, wantErr)
 	assert.Contains(t, err.Error(), "insert failed")


### PR DESCRIPTION
## Why

Closes the follow-up filed during PR #415.

The outbox store tests in #415 carried a 25-LOC local `errorTx` stub implementing `dbtypes.Tx`, with this comment:

> `dbtesting.TestTx doesn't expose WillReturnError on its ExecExpectation` (the field is unexported), so we use this local stub for Insert-error paths.

That's exactly the kind of workaround that should land back in the framework: every consumer of `database/testing` that needs to test "Exec returns an error inside a transaction" would need its own stub. This PR adds the missing API and converges the outbox tests on the standard fluent chain.

## What

**`database/testing/fake_tx.go`** — `WillReturnError(err error) *TestTx`:
- Mirrors the existing `WillReturnRows` / `WillReturnRowsAffected` convenience methods (which target `lastQuery` / `lastExec` respectively).
- Targets whichever `ExpectQuery` or `ExpectExec` was added most recently to the tx, dispatched via a new `lastWasExec bool` discriminator field on `TestTx`. The bool is necessary because `lastQuery` and `lastExec` are independent slots — once both are set in a mixed chain, neither alone tells you "which was last."
- Empty-chain no-op (matches existing `WillReturnRows` / `WillReturnRowsAffected` behavior).
- Holds `tx.mu.Lock()` like its siblings.

**`database/testing/fake_db_test.go`** — 4 new test functions / 6 subtests:
- `TestTestTxWillReturnErrorOnQuery` — surfaces via both `Query` and `QueryRow`
- `TestTestTxWillReturnErrorOnExec` — surfaces via `Exec`
- `TestTestTxWillReturnErrorTargetsMostRecent` — both directions (last-was-exec vs last-was-query) in mixed chains
- `TestTestTxWillReturnErrorNoOpWhenEmpty` — safe before any `Expect*`

Tests appended to `fake_db_test.go` (where all existing `TestTx` tests live, since `TestTx` is created via `db.ExpectTransaction()` — source-to-test 1:1 convention respected per the package's primary-actor pattern).

**`outbox/store_postgres_test.go`, `outbox/store_oracle_test.go`** — drop the `errorTx` stub:
- Delete the 25-LOC `errorTx` struct from `store_postgres_test.go`
- Rewrite `TestPostgresStoreInsertExecError` and `TestOracleStoreInsertExecError` to use `db.ExpectTransaction().ExpectExec(...).WillReturnError(...)` — same shape as every other test in those files
- Imports cleaned: `context` and `database/sql` no longer needed in `store_postgres_test.go`
- Test count parity preserved (28 == 28 on outbox side)

## Design note (judgment call, intentionally deferred)

The Quality reviewer flagged a larger refactor: collapse `lastQuery`/`lastExec`/`lastWasExec` into a single `lastExpectation` slot typed as `interface{ setErr(error) }`. That's cleaner conceptually but would require widening the interface to also cover `setRows` (query-only) and `setRowsAffected` (exec-only) — operations that are *type-specific*. The current shape lets each `WillReturn*` convenience method stay statically typed to its concrete struct, which is a small API-safety win. Marking this as an explicit non-goal for this PR.

## Pre-push workflow compliance

- **`/simplify`** → SHIP IT. Three review agents (reuse, quality, efficiency) all returned clean or "judgment-call only." One WHAT-style inline comment removed (the test name + assertion already conveyed intent). The `lastExpectation` interface refactor explicitly flagged as acceptable-as-is and out of scope.
- **`/security-audit`** → PASS. golangci-lint 0 issues on changed packages; gosec 0 issues; no raw-SQL escape hatches introduced; no secret-shaped strings (test fixtures are all `"query exploded"`/`"exec exploded"`/`"constraint violation"` etc.); no HTTP handlers touched.

## Test plan

- [x] `go test -race ./database/testing/ ./outbox/...` green
- [x] `make check` green
- [ ] CI green
- [ ] SonarCloud Quality Gate passes (expect mild positive bump on `database/testing` per-package coverage and zero regression on `outbox` since both `errorTx` and its replacement exercise the same Insert error branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test database mocking with improved error handling for transaction-based database operations
  * Expanded test coverage for error scenarios in database queries and executions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/417)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->