### PR TITLE
test(messaging): coverage push 84.7% → 94.5% (Phase 2D)

### DIFF
--- a/messaging/amqp_adapters_test.go
+++ b/messaging/amqp_adapters_test.go
@@ -1,0 +1,48 @@
+package messaging
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAmqpDialFuncRoundTrip verifies set/get round-trip and the substitute
+// is invoked by callers that read through getAmqpDialFunc.
+func TestAmqpDialFuncRoundTrip(t *testing.T) {
+	original := getAmqpDialFunc()
+	t.Cleanup(func() { setAmqpDialFunc(original) })
+
+	called := 0
+	var gotURL string
+	replacement := func(url string) (amqpConnection, error) {
+		called++
+		gotURL = url
+		return stubConn{}, nil
+	}
+	setAmqpDialFunc(replacement)
+
+	dial := getAmqpDialFunc()
+	conn, err := dial(amqpURLIdle)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	assert.Equal(t, 1, called)
+	assert.Equal(t, amqpURLIdle, gotURL)
+}
+
+// TestAmqpDialFuncPropagatesError verifies that errors from the substituted
+// dialer surface through getAmqpDialFunc unchanged.
+func TestAmqpDialFuncPropagatesError(t *testing.T) {
+	original := getAmqpDialFunc()
+	t.Cleanup(func() { setAmqpDialFunc(original) })
+
+	wantErr := errors.New("connection refused")
+	setAmqpDialFunc(func(string) (amqpConnection, error) {
+		return nil, wantErr
+	})
+
+	conn, err := getAmqpDialFunc()(amqpURLIdle)
+	assert.Nil(t, conn)
+	assert.ErrorIs(t, err, wantErr)
+}

--- a/messaging/declarations_test.go
+++ b/messaging/declarations_test.go
@@ -793,3 +793,53 @@ func TestReplayToRegistryPreservesWorkerPoolConfig(t *testing.T) {
 	assert.Equal(t, 48, registry.consumers[0].Workers, "Workers should propagate through ReplayToRegistry")
 	assert.Equal(t, 480, registry.consumers[0].PrefetchCount, "PrefetchCount should propagate through ReplayToRegistry")
 }
+
+// TestDeclarationsIsEmpty covers the IsEmpty fast-path. The function delegates
+// to Stats(), so we only need to verify the empty and non-empty branches.
+func TestDeclarationsIsEmpty(t *testing.T) {
+	t.Run("empty declarations", func(t *testing.T) {
+		d := NewDeclarations()
+		assert.True(t, d.IsEmpty())
+	})
+
+	t.Run("becomes non-empty after a single registration", func(t *testing.T) {
+		d := NewDeclarations()
+		d.RegisterQueue(&QueueDeclaration{Name: testQueue})
+		assert.False(t, d.IsEmpty())
+	})
+}
+
+// TestDeclarationsHashCoversAllArgTypes exercises Hash() with a publisher whose
+// Args map contains every supported value type. This drives writeMapArgs through
+// each typed branch (string/int/int64/bool/float64/default) and exercises
+// writeInt64 / writeFloat64.
+func TestDeclarationsHashCoversAllArgTypes(t *testing.T) {
+	d := NewDeclarations()
+	d.RegisterExchange(&ExchangeDeclaration{Name: testExchange, Type: exchangeTypeTopic, Durable: true})
+	d.RegisterQueue(&QueueDeclaration{
+		Name:    testQueue,
+		Durable: true,
+		Args: map[string]any{
+			"string_arg":  "value",
+			"int_arg":     int(42),
+			"int64_arg":   int64(1024),
+			"bool_arg":    true,
+			"float64_arg": 1.5,
+			"other_arg":   []string{"non-primitive falls to fmt.Fprintf branch"},
+		},
+	})
+	d.RegisterBinding(&BindingDeclaration{Queue: testQueue, Exchange: testExchange, RoutingKey: testRoutingKey})
+	d.RegisterPublisher(&PublisherDeclaration{
+		Exchange:   testExchange,
+		RoutingKey: testRoutingKey,
+		EventType:  eventTestEvent,
+	})
+
+	first := d.Hash()
+	assert.NotZero(t, first, "Hash with multi-typed args must be deterministic and non-zero")
+
+	// Second call must return the same value — confirms map-iteration order is
+	// neutralized by the sorted-keys logic inside writeMapArgs.
+	second := d.Hash()
+	assert.Equal(t, first, second, "Hash must be deterministic across calls regardless of map iteration order")
+}

--- a/messaging/manager_test.go
+++ b/messaging/manager_test.go
@@ -2,6 +2,7 @@ package messaging
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -30,6 +31,7 @@ type stubAMQPClient struct {
 	lastPublish   PublishOptions
 	consumers     int
 	closeCallback func()
+	closeErr      error
 }
 
 func (s *stubAMQPClient) Publish(ctx context.Context, destination string, data []byte) error {
@@ -70,7 +72,7 @@ func (s *stubAMQPClient) Close() error {
 	if s.closeCallback != nil {
 		s.closeCallback()
 	}
-	return nil
+	return s.closeErr
 }
 
 func (s *stubAMQPClient) IsReady() bool {
@@ -432,4 +434,204 @@ func TestMessagingManagerHashBasedIdempotency(t *testing.T) {
 		assert.NotZero(t, hash, "Hash should not be zero")
 		assert.Equal(t, decls.Hash(), hash, "Recorded hash should match declarations hash")
 	})
+}
+
+// TestMessagingManagerStartCleanupZeroIntervalDefaults verifies StartCleanup
+// substitutes the default 2-minute interval when given a non-positive value.
+// We can't assert the exact ticker period without timing flakiness, but we can
+// confirm StartCleanup wires up the loop (cleanupCh non-nil) and StopCleanup
+// then tears it down cleanly.
+func TestMessagingManagerStartCleanupZeroIntervalDefaults(t *testing.T) {
+	log := logger.New("error", false)
+	factory := func(string, logger.Logger) AMQPClient { return &stubAMQPClient{} }
+	manager := NewMessagingManager(&stubMessagingSource{}, log, ManagerOptions{MaxPublishers: 1, IdleTTL: time.Minute}, factory)
+
+	manager.StartCleanup(0)
+	manager.cleanupMu.Lock()
+	assert.NotNil(t, manager.cleanupCh, "StartCleanup should arm the cleanup loop even with interval=0 (defaults applied)")
+	manager.cleanupMu.Unlock()
+
+	manager.StopCleanup()
+}
+
+func TestMessagingManagerStartCleanupIdempotent(t *testing.T) {
+	log := logger.New("error", false)
+	factory := func(string, logger.Logger) AMQPClient { return &stubAMQPClient{} }
+	manager := NewMessagingManager(&stubMessagingSource{}, log, ManagerOptions{MaxPublishers: 1, IdleTTL: time.Minute}, factory)
+
+	manager.StartCleanup(50 * time.Millisecond)
+	manager.cleanupMu.Lock()
+	first := manager.cleanupCh
+	manager.cleanupMu.Unlock()
+	require.NotNil(t, first)
+
+	manager.StartCleanup(50 * time.Millisecond)
+	manager.cleanupMu.Lock()
+	second := manager.cleanupCh
+	manager.cleanupMu.Unlock()
+	assert.True(t, first == second, "second StartCleanup must be a no-op while a loop is already running (cleanupCh unchanged)")
+
+	manager.StopCleanup()
+}
+
+func TestMessagingManagerStopCleanupBeforeStartIsNoOp(t *testing.T) {
+	log := logger.New("error", false)
+	factory := func(string, logger.Logger) AMQPClient { return &stubAMQPClient{} }
+	manager := NewMessagingManager(&stubMessagingSource{}, log, ManagerOptions{MaxPublishers: 1, IdleTTL: time.Minute}, factory)
+
+	manager.StopCleanup()
+	manager.cleanupMu.Lock()
+	assert.Nil(t, manager.cleanupCh)
+	manager.cleanupMu.Unlock()
+}
+
+// TestMessagingManagerCleanupLoopEvictsOnTick exercises the cleanupLoop goroutine
+// end-to-end: arm a short interval, seed an idle publisher, wait for at least
+// one tick, then verify the entry was cleaned up.
+func TestMessagingManagerCleanupLoopEvictsOnTick(t *testing.T) {
+	ctx := context.Background()
+	log := logger.New("error", false)
+
+	var closed int
+	var mu sync.Mutex
+	factory := func(string, logger.Logger) AMQPClient {
+		return &stubAMQPClient{closeCallback: func() {
+			mu.Lock()
+			defer mu.Unlock()
+			closed++
+		}}
+	}
+
+	manager := NewMessagingManager(
+		&stubMessagingSource{urls: map[string]string{"idle": amqpURLIdle}},
+		log,
+		ManagerOptions{MaxPublishers: 5, IdleTTL: 10 * time.Millisecond},
+		factory,
+	)
+	_, err := manager.Publisher(ctx, "idle")
+	require.NoError(t, err)
+
+	manager.StartCleanup(20 * time.Millisecond)
+	t.Cleanup(manager.StopCleanup)
+
+	// Wait long enough for IdleTTL (10ms) + at least one cleanup tick (20ms).
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return closed >= 1
+	}, time.Second, 10*time.Millisecond, "cleanup loop should evict the idle publisher within a few ticks")
+}
+
+func TestMessagingManagerCloseClosesPublishersAndConsumers(t *testing.T) {
+	ctx := context.Background()
+	log := logger.New("error", false)
+
+	var closedCount int
+	var mu sync.Mutex
+	factory := func(string, logger.Logger) AMQPClient {
+		return &stubAMQPClient{closeCallback: func() {
+			mu.Lock()
+			defer mu.Unlock()
+			closedCount++
+		}}
+	}
+
+	manager := NewMessagingManager(
+		&stubMessagingSource{urls: map[string]string{tenant1ID: amqpURLTenant1, tenant2ID: amqpURLTenant2}},
+		log,
+		ManagerOptions{MaxPublishers: 5, IdleTTL: time.Minute},
+		factory,
+	)
+	manager.StartCleanup(time.Minute)
+
+	// Seed two publishers and a consumer registry.
+	_, err := manager.Publisher(ctx, tenant1ID)
+	require.NoError(t, err)
+	_, err = manager.Publisher(ctx, tenant2ID)
+	require.NoError(t, err)
+
+	decls := NewDeclarations()
+	decls.RegisterQueue(&QueueDeclaration{Name: genericQueue})
+	decls.RegisterConsumer(&ConsumerDeclaration{Queue: genericQueue, Consumer: genericConsumer, Handler: &mockMessageHandler{}})
+	require.NoError(t, manager.EnsureConsumers(ctx, tenant1ID, decls))
+
+	require.NoError(t, manager.Close())
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.GreaterOrEqual(t, closedCount, 2, "Close should close at least the publisher clients")
+
+	// Cleanup loop should be stopped after Close.
+	manager.cleanupMu.Lock()
+	assert.Nil(t, manager.cleanupCh, "Close must stop the cleanup loop")
+	manager.cleanupMu.Unlock()
+
+	// Internal maps are reset.
+	manager.pubMu.RLock()
+	assert.Empty(t, manager.publishers)
+	manager.pubMu.RUnlock()
+	manager.consMu.RLock()
+	assert.Empty(t, manager.consumers)
+	manager.consMu.RUnlock()
+}
+
+// TestMessagingManagerCloseSurfacesClientErrors checks the aggregated-error path
+// when a publisher Close() returns an error.
+func TestMessagingManagerCloseSurfacesClientErrors(t *testing.T) {
+	ctx := context.Background()
+	log := logger.New("error", false)
+
+	factory := func(string, logger.Logger) AMQPClient {
+		return &stubAMQPClient{closeCallback: func() {}}
+	}
+
+	manager := NewMessagingManager(
+		&stubMessagingSource{urls: map[string]string{tenant1ID: amqpURLTenant1}},
+		log,
+		ManagerOptions{MaxPublishers: 5, IdleTTL: time.Minute},
+		factory,
+	)
+	_, err := manager.Publisher(ctx, tenant1ID)
+	require.NoError(t, err)
+
+	// Swap in a failing client behind the cache so Close() surfaces an aggregated error.
+	wantErr := errors.New("client close failed")
+	manager.pubMu.Lock()
+	for key, entry := range manager.publishers {
+		entry.client = &stubAMQPClient{closeErr: wantErr}
+		manager.publishers[key] = entry
+	}
+	manager.pubMu.Unlock()
+
+	err = manager.Close()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "errors closing messaging clients")
+	assert.Contains(t, err.Error(), wantErr.Error(), "aggregated error should include the underlying client-close message")
+}
+
+func TestMessagingManagerStats(t *testing.T) {
+	ctx := context.Background()
+	log := logger.New("error", false)
+
+	factory := func(string, logger.Logger) AMQPClient { return &stubAMQPClient{} }
+	manager := NewMessagingManager(
+		&stubMessagingSource{urls: map[string]string{tenant1ID: amqpURLTenant1, tenant2ID: amqpURLTenant2}},
+		log,
+		ManagerOptions{MaxPublishers: 7, IdleTTL: 90 * time.Second},
+		factory,
+	)
+
+	stats := manager.Stats()
+	assert.Equal(t, 0, stats["active_publishers"])
+	assert.Equal(t, 7, stats["max_publishers"])
+	assert.Equal(t, 0, stats["active_consumers"])
+	assert.Equal(t, 90, stats["idle_ttl_seconds"])
+
+	_, err := manager.Publisher(ctx, tenant1ID)
+	require.NoError(t, err)
+	_, err = manager.Publisher(ctx, tenant2ID)
+	require.NoError(t, err)
+
+	stats = manager.Stats()
+	assert.Equal(t, 2, stats["active_publishers"])
 }

--- a/messaging/tenant_publisher_test.go
+++ b/messaging/tenant_publisher_test.go
@@ -1,0 +1,223 @@
+package messaging
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingAMQPClient implements AMQPClient and records every call so the
+// tenantAwarePublisher wrapper's delegation can be verified.
+type recordingAMQPClient struct {
+	publishCalls         []PublishOptions
+	publishErr           error
+	consumeCalls         []string
+	consumeErr           error
+	consumeFromQueue     []ConsumeOptions
+	consumeFromQueueErr  error
+	declareQueueCalls    []string
+	declareQueueErr      error
+	declareExchangeCalls []string
+	declareExchangeErr   error
+	bindQueueCalls       [][3]string
+	bindQueueErr         error
+	closeErr             error
+	closed               bool
+	ready                bool
+}
+
+func (r *recordingAMQPClient) Publish(ctx context.Context, destination string, data []byte) error {
+	return r.PublishToExchange(ctx, PublishOptions{Exchange: "", RoutingKey: destination}, data)
+}
+
+func (r *recordingAMQPClient) PublishToExchange(_ context.Context, options PublishOptions, _ []byte) error {
+	r.publishCalls = append(r.publishCalls, options)
+	return r.publishErr
+}
+
+func (r *recordingAMQPClient) Consume(_ context.Context, destination string) (<-chan amqp.Delivery, error) {
+	r.consumeCalls = append(r.consumeCalls, destination)
+	if r.consumeErr != nil {
+		return nil, r.consumeErr
+	}
+	ch := make(chan amqp.Delivery)
+	close(ch)
+	return ch, nil
+}
+
+func (r *recordingAMQPClient) ConsumeFromQueue(_ context.Context, options ConsumeOptions) (<-chan amqp.Delivery, error) {
+	r.consumeFromQueue = append(r.consumeFromQueue, options)
+	if r.consumeFromQueueErr != nil {
+		return nil, r.consumeFromQueueErr
+	}
+	ch := make(chan amqp.Delivery)
+	close(ch)
+	return ch, nil
+}
+
+func (r *recordingAMQPClient) DeclareQueue(name string, _, _, _, _ bool) error {
+	r.declareQueueCalls = append(r.declareQueueCalls, name)
+	return r.declareQueueErr
+}
+
+func (r *recordingAMQPClient) DeclareExchange(name, _ string, _, _, _, _ bool) error {
+	r.declareExchangeCalls = append(r.declareExchangeCalls, name)
+	return r.declareExchangeErr
+}
+
+func (r *recordingAMQPClient) BindQueue(queue, exchange, routingKey string, _ bool) error {
+	r.bindQueueCalls = append(r.bindQueueCalls, [3]string{queue, exchange, routingKey})
+	return r.bindQueueErr
+}
+
+func (r *recordingAMQPClient) Close() error {
+	r.closed = true
+	return r.closeErr
+}
+
+func (r *recordingAMQPClient) IsReady() bool {
+	return r.ready
+}
+
+func TestNewTenantAwarePublisherEmptyKeyReturnsBase(t *testing.T) {
+	base := &recordingAMQPClient{}
+	got := newTenantAwarePublisher(base, "")
+	assert.Same(t, AMQPClient(base), got, "empty key should bypass wrapping")
+}
+
+func TestNewTenantAwarePublisherNonEmptyKeyWraps(t *testing.T) {
+	base := &recordingAMQPClient{}
+	got := newTenantAwarePublisher(base, tenant1ID)
+	wrapper, ok := got.(*tenantAwarePublisher)
+	require.True(t, ok, "non-empty key should return *tenantAwarePublisher")
+	assert.Equal(t, tenant1ID, wrapper.key)
+	assert.Same(t, AMQPClient(base), wrapper.base)
+}
+
+func TestTenantAwarePublisherPublishInjectsTenantHeader(t *testing.T) {
+	base := &recordingAMQPClient{}
+	pub := newTenantAwarePublisher(base, tenant1ID)
+
+	require.NoError(t, pub.Publish(context.Background(), testRoutingKey, []byte("body")))
+	require.Len(t, base.publishCalls, 1)
+	got := base.publishCalls[0]
+	assert.Equal(t, "", got.Exchange, "Publish targets the default exchange")
+	assert.Equal(t, testRoutingKey, got.RoutingKey)
+	assert.Equal(t, tenant1ID, got.Headers[tenantHeader])
+}
+
+func TestTenantAwarePublisherPublishToExchangeAddsHeaderWhenNil(t *testing.T) {
+	base := &recordingAMQPClient{}
+	pub := newTenantAwarePublisher(base, tenant1ID)
+
+	opts := PublishOptions{Exchange: testExchange, RoutingKey: testRoutingKey}
+	require.Nil(t, opts.Headers)
+	require.NoError(t, pub.PublishToExchange(context.Background(), opts, []byte("body")))
+
+	require.Len(t, base.publishCalls, 1)
+	assert.Equal(t, tenant1ID, base.publishCalls[0].Headers[tenantHeader])
+	assert.Nil(t, opts.Headers, "caller's Headers map must not be mutated")
+}
+
+func TestTenantAwarePublisherPublishToExchangeClonesExistingHeaders(t *testing.T) {
+	base := &recordingAMQPClient{}
+	pub := newTenantAwarePublisher(base, tenant1ID)
+
+	original := map[string]any{testKey: testValue}
+	opts := PublishOptions{Exchange: testExchange, RoutingKey: testRoutingKey, Headers: original}
+	require.NoError(t, pub.PublishToExchange(context.Background(), opts, []byte("body")))
+
+	require.Len(t, base.publishCalls, 1)
+	got := base.publishCalls[0]
+	assert.Equal(t, tenant1ID, got.Headers[tenantHeader])
+	assert.Equal(t, testValue, got.Headers[testKey])
+
+	_, hadTenantInOriginal := original[tenantHeader]
+	assert.False(t, hadTenantInOriginal, "the caller's headers map must not gain a tenant entry (must be cloned)")
+}
+
+func TestTenantAwarePublisherPublishToExchangePropagatesError(t *testing.T) {
+	wantErr := errors.New("publish failed")
+	base := &recordingAMQPClient{publishErr: wantErr}
+	pub := newTenantAwarePublisher(base, tenant1ID)
+
+	err := pub.PublishToExchange(context.Background(), PublishOptions{Exchange: testExchange, RoutingKey: testRoutingKey}, []byte("body"))
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestTenantAwarePublisherConsumeDelegates(t *testing.T) {
+	base := &recordingAMQPClient{}
+	pub := newTenantAwarePublisher(base, tenant1ID)
+
+	ch, err := pub.Consume(context.Background(), testQueue)
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+	assert.Equal(t, []string{testQueue}, base.consumeCalls)
+}
+
+func TestTenantAwarePublisherConsumeFromQueueDelegates(t *testing.T) {
+	base := &recordingAMQPClient{}
+	pub := newTenantAwarePublisher(base, tenant1ID)
+
+	opts := ConsumeOptions{Queue: testQueue, Consumer: testConsumer}
+	ch, err := pub.ConsumeFromQueue(context.Background(), opts)
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+	require.Len(t, base.consumeFromQueue, 1)
+	assert.Equal(t, opts, base.consumeFromQueue[0])
+}
+
+func TestTenantAwarePublisherDeclareQueueDelegates(t *testing.T) {
+	base := &recordingAMQPClient{}
+	pub := newTenantAwarePublisher(base, tenant1ID)
+
+	require.NoError(t, pub.DeclareQueue(testQueue, true, false, false, false))
+	assert.Equal(t, []string{testQueue}, base.declareQueueCalls)
+}
+
+func TestTenantAwarePublisherDeclareExchangeDelegates(t *testing.T) {
+	base := &recordingAMQPClient{}
+	pub := newTenantAwarePublisher(base, tenant1ID)
+
+	require.NoError(t, pub.DeclareExchange(testExchange, exchangeTypeTopic, true, false, false, false))
+	assert.Equal(t, []string{testExchange}, base.declareExchangeCalls)
+}
+
+func TestTenantAwarePublisherBindQueueDelegates(t *testing.T) {
+	base := &recordingAMQPClient{}
+	pub := newTenantAwarePublisher(base, tenant1ID)
+
+	require.NoError(t, pub.BindQueue(testQueue, testExchange, testRoutingKey, false))
+	require.Len(t, base.bindQueueCalls, 1)
+	assert.Equal(t, [3]string{testQueue, testExchange, testRoutingKey}, base.bindQueueCalls[0])
+}
+
+func TestTenantAwarePublisherCloseDelegates(t *testing.T) {
+	base := &recordingAMQPClient{}
+	pub := newTenantAwarePublisher(base, tenant1ID)
+
+	require.NoError(t, pub.Close())
+	assert.True(t, base.closed)
+}
+
+func TestTenantAwarePublisherCloseError(t *testing.T) {
+	wantErr := errors.New("close failed")
+	base := &recordingAMQPClient{closeErr: wantErr}
+	pub := newTenantAwarePublisher(base, tenant1ID)
+
+	err := pub.Close()
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestTenantAwarePublisherIsReadyDelegates(t *testing.T) {
+	base := &recordingAMQPClient{ready: true}
+	pub := newTenantAwarePublisher(base, tenant1ID)
+	assert.True(t, pub.IsReady())
+
+	base.ready = false
+	assert.False(t, pub.IsReady())
+}


### PR DESCRIPTION
## Phase 2D — messaging coverage push

Closes the biggest remaining single-package coverage gap among the production packages. Three previously-uncovered source files now exercised end-to-end, plus a few helper functions in \`declarations.go\` brought to 100%.

## Coverage impact

| Package | Before | After |
|---|---|---|
| \`messaging/\` | 84.7% | **94.5%** |

Targeted gap closures:

| Source | Function(s) | Before | After |
|---|---|---|---|
| tenant_publisher.go | all 7 wrapper methods | 0% | 100% |
| amqp_adapters.go | setAmqpDialFunc / getAmqpDialFunc round-trip | 0% | 100% |
| manager.go | StartCleanup, StopCleanup, cleanupLoop, Close, Stats | 0% | 100% |
| declarations.go | IsEmpty, Hash, writeMapArgs, writeInt64, writeFloat64 | 0–73% | 100% |

## What's added

**NEW** \`messaging/tenant_publisher_test.go\` (223 LOC, 13 tests):
- New \`recordingAMQPClient\` stub that captures per-method call slices and configurable errors
- Empty-key bypass, non-empty wraps, tenant header injection (nil + cloned-map cases)
- Headers map cloning verification (caller's map must not be mutated)
- Pure delegation tests for Consume / ConsumeFromQueue / DeclareQueue / DeclareExchange / BindQueue / Close / IsReady
- Close error propagation

**NEW** \`messaging/amqp_adapters_test.go\` (45 LOC, 2 tests):
- Reuses existing \`stubConn\` from amqp_client_test.go (no new fake type needed)
- Dial-func substitution round-trip + error propagation

**APPEND** \`messaging/manager_test.go\` (+205 LOC, 7 tests):
- StartCleanup zero-interval default substitution
- StartCleanup idempotency (channel reference preserved across calls)
- StopCleanup-before-Start no-op
- cleanupLoop goroutine evicts idle publisher on tick (uses \`require.Eventually\` polling — bounded 1s, typical resolution 20–40ms)
- Close drains both publisher and consumer maps + halts cleanup loop
- Close aggregates client-close errors via the \`closeErr\` field on stubAMQPClient
- Stats returns expected per-instance counts

**APPEND** \`messaging/declarations_test.go\` (+50 LOC, 2 tests):
- IsEmpty empty + non-empty cases
- Hash with multi-typed Args (string / int / int64 / bool / float64 / non-primitive) drives writeMapArgs through every typed branch and asserts deterministic-hashing across two calls

## Refactor included (per \`/simplify\` findings)

All three \`/simplify\` review agents independently flagged the same consolidation opportunity. Applied in-PR:

- **Drop \`failingCloseClient\`** — replaced by extending the existing \`stubAMQPClient\` with an optional \`closeErr error\` field. Net: -22 LOC of duplicate AMQPClient surface, one place to look for stub features.
- **Drop \`fakeAmqpConnection\`** — reuse existing \`stubConn\` from \`amqp_client_test.go\` (same package, identical purpose).
- **\`testKey\`/\`testValue\` constants** instead of raw \`\"foo\"\`/\`\"bar\"\` in the clone-headers test.

## Follow-up

Filed **#418** for the gosec G104 unhandled-error sweep in declarations.go (14 \`hash.Hash.Write\` sites — stdlib guarantees no error) and manager.go (4 client-Close error-rollback sites — intentional but currently silent). The project's \`.golangci.yml\` gate exempts these as baseline, but with messaging now in the 94.5% tier most of those calls are newly test-covered, so tightening them is the right next step. Kept out of this PR to preserve the test-only diff story.

## Pre-push workflow compliance

- **\`/simplify\`** → SHIP IT after three findings applied (failingCloseClient → stubAMQPClient{closeErr}, fakeAmqpConnection → stubConn, raw-string constants). Coverage held at 94.5% through the refactor.
- **\`/security-audit\`** → PASS. \`golangci-lint\` (the CI gate) returns 0 issues. Standalone gosec findings are all in untouched production source files and pre-existing baseline noise — tracked in #418.

## Test plan

- [x] \`go test -race ./messaging/...\` green
- [x] \`make check\` green
- [x] Coverage verified: 94.5%
- [ ] CI green
- [ ] SonarCloud Quality Gate passes (expect notable positive bump on the framework-wide coverage number)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for messaging infrastructure, including AMQP connection handling, message declarations, manager lifecycle operations, cleanup routines, and tenant-aware publisher functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/419)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->