### PR TITLE
refactor(messaging): close gosec G104 unhandled-error findings (closes #418)

### DIFF
--- a/messaging/declarations.go
+++ b/messaging/declarations.go
@@ -393,8 +393,8 @@ func (d *Declarations) Hash() uint64 {
 	exchangeKeys := slices.Sorted(maps.Keys(d.Exchanges))
 	for _, name := range exchangeKeys {
 		ex := d.Exchanges[name]
-		h.Write([]byte(ex.Name))
-		h.Write([]byte(ex.Type))
+		writeString(h, ex.Name)
+		writeString(h, ex.Type)
 		writeBool(h, ex.Durable)
 		writeBool(h, ex.AutoDelete)
 		writeBool(h, ex.Internal)
@@ -406,7 +406,7 @@ func (d *Declarations) Hash() uint64 {
 	queueKeys := slices.Sorted(maps.Keys(d.Queues))
 	for _, name := range queueKeys {
 		q := d.Queues[name]
-		h.Write([]byte(q.Name))
+		writeString(h, q.Name)
 		writeBool(h, q.Durable)
 		writeBool(h, q.AutoDelete)
 		writeBool(h, q.Exclusive)
@@ -416,19 +416,19 @@ func (d *Declarations) Hash() uint64 {
 
 	// Hash bindings (already in insertion order)
 	for _, b := range d.Bindings {
-		h.Write([]byte(b.Queue))
-		h.Write([]byte(b.Exchange))
-		h.Write([]byte(b.RoutingKey))
+		writeString(h, b.Queue)
+		writeString(h, b.Exchange)
+		writeString(h, b.RoutingKey)
 		writeBool(h, b.NoWait)
 		writeMapArgs(h, b.Args)
 	}
 
 	// Hash publishers (already in insertion order)
 	for _, p := range d.Publishers {
-		h.Write([]byte(p.Exchange))
-		h.Write([]byte(p.RoutingKey))
-		h.Write([]byte(p.EventType))
-		h.Write([]byte(p.Description))
+		writeString(h, p.Exchange)
+		writeString(h, p.RoutingKey)
+		writeString(h, p.EventType)
+		writeString(h, p.Description)
 		writeBool(h, p.Mandatory)
 		writeBool(h, p.Immediate)
 		writeMapArgs(h, p.Headers)
@@ -437,10 +437,10 @@ func (d *Declarations) Hash() uint64 {
 	// Hash consumers (use consumerOrder for deterministic iteration)
 	for _, key := range d.consumerOrder {
 		c := d.consumerIndex[key]
-		h.Write([]byte(c.Queue))
-		h.Write([]byte(c.Consumer))
-		h.Write([]byte(c.EventType))
-		h.Write([]byte(c.Description))
+		writeString(h, c.Queue)
+		writeString(h, c.Consumer)
+		writeString(h, c.EventType)
+		writeString(h, c.Description)
 		writeBool(h, c.AutoAck)
 		writeBool(h, c.Exclusive)
 		writeBool(h, c.NoLocal)
@@ -451,13 +451,18 @@ func (d *Declarations) Hash() uint64 {
 	return h.Sum64()
 }
 
+// writeString writes s to the hash. hash.Hash.Write never returns an error.
+func writeString(h hash.Hash, s string) {
+	_, _ = h.Write([]byte(s))
+}
+
 // writeBool writes a boolean value to the hash as a single byte
 func writeBool(h hash.Hash, value bool) {
 	var b byte
 	if value {
 		b = 1
 	}
-	h.Write([]byte{b})
+	_, _ = h.Write([]byte{b})
 }
 
 // writeMapArgs writes a map[string]any to the hash in deterministic order
@@ -469,11 +474,11 @@ func writeMapArgs(h hash.Hash, args map[string]any) {
 	// Sort keys for deterministic hashing
 	keys := slices.Sorted(maps.Keys(args))
 	for _, key := range keys {
-		h.Write([]byte(key))
+		writeString(h, key)
 		// Hash the value based on its type
 		switch v := args[key].(type) {
 		case string:
-			h.Write([]byte(v))
+			writeString(h, v)
 		case int:
 			writeInt64(h, int64(v))
 		case int64:
@@ -493,12 +498,12 @@ func writeMapArgs(h hash.Hash, args map[string]any) {
 func writeInt64(h hash.Hash, value int64) {
 	buf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(buf, uint64(value)) //nolint:gosec // G115 - intentional bit reinterpretation for hash
-	h.Write(buf)
+	_, _ = h.Write(buf)
 }
 
 // writeFloat64 writes a float64 to the hash
 func writeFloat64(h hash.Hash, value float64) {
 	buf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(buf, math.Float64bits(value))
-	h.Write(buf)
+	_, _ = h.Write(buf)
 }

--- a/messaging/manager.go
+++ b/messaging/manager.go
@@ -158,20 +158,20 @@ func (m *Manager) ensureConsumersInternal(ctx context.Context, key string, decls
 	// Create registry and replay declarations
 	registry := NewRegistry(client, m.logger)
 	if err := decls.ReplayToRegistry(registry); err != nil {
-		client.Close()
+		m.closeClientOnRollback(client, key, "replay_declarations")
 		return fmt.Errorf("failed to replay messaging declarations: %w", err)
 	}
 
 	// Declare infrastructure
 	if err := registry.DeclareInfrastructure(ctx); err != nil {
-		client.Close()
+		m.closeClientOnRollback(client, key, "declare_infrastructure")
 		return fmt.Errorf("failed to declare messaging infrastructure: %w", err)
 	}
 
 	// Start consumers with tenant-aware context
 	tenantCtx := multitenant.SetTenant(ctx, key)
 	if err := registry.StartConsumers(tenantCtx); err != nil {
-		client.Close()
+		m.closeClientOnRollback(client, key, "start_consumers")
 		return fmt.Errorf("failed to start messaging consumers: %w", err)
 	}
 
@@ -254,7 +254,7 @@ func (m *Manager) createPublisher(ctx context.Context, key string) (AMQPClient, 
 	// Check if publisher was created by another goroutine while we were waiting
 	if existing, exists := m.publishers[key]; exists {
 		// Close our new client and return the existing one
-		client.Close()
+		m.closeClientOnRollback(client, key, "publisher_double_create_race")
 		existing.lastUsed = time.Now()
 		m.pubLru.MoveToFront(existing.element)
 		return existing.client, nil
@@ -297,6 +297,21 @@ func (m *Manager) createAMQPClient(ctx context.Context, key string) (AMQPClient,
 		Msg("Created AMQP client for key")
 
 	return client, nil
+}
+
+// closeClientOnRollback closes an AMQP client during an error-rollback path
+// and logs (but does not propagate) any close failure. The primary error is
+// what the caller cares about; we keep the close failure observable for
+// forensics. The `phase` argument identifies which rollback site triggered
+// the close (e.g. "replay_declarations", "publisher_double_create_race").
+func (m *Manager) closeClientOnRollback(client AMQPClient, key, phase string) {
+	if err := client.Close(); err != nil {
+		m.logger.Error().
+			Err(err).
+			Str("key", key).
+			Str("phase", phase).
+			Msg("Error closing AMQP client during rollback")
+	}
 }
 
 // evictPublisherIfNeeded removes the least recently used publisher if at capacity

--- a/messaging/manager_test.go
+++ b/messaging/manager_test.go
@@ -609,6 +609,34 @@ func TestMessagingManagerCloseSurfacesClientErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), wantErr.Error(), "aggregated error should include the underlying client-close message")
 }
 
+// TestMessagingManagerCloseClientOnRollback verifies the load-bearing
+// invariant: when Close returns an error, the helper logs but does NOT
+// panic or propagate — the caller already has a primary error to return.
+func TestMessagingManagerCloseClientOnRollback(t *testing.T) {
+	log := logger.New("error", false)
+	factory := func(string, logger.Logger) AMQPClient { return &stubAMQPClient{} }
+	manager := NewMessagingManager(&stubMessagingSource{}, log, ManagerOptions{MaxPublishers: 1, IdleTTL: time.Minute}, factory)
+
+	t.Run("close succeeds", func(t *testing.T) {
+		client := &stubAMQPClient{}
+		manager.closeClientOnRollback(client, tenant1ID, "replay_declarations")
+
+		client.closedMu.Lock()
+		defer client.closedMu.Unlock()
+		assert.True(t, client.closed, "closeClientOnRollback must invoke Close")
+	})
+
+	t.Run("close errors are logged not propagated", func(t *testing.T) {
+		client := &stubAMQPClient{closeErr: errors.New("rollback close failed")}
+		// No panic, no return — failure observable via logger only.
+		manager.closeClientOnRollback(client, tenant1ID, "publisher_double_create_race")
+
+		client.closedMu.Lock()
+		defer client.closedMu.Unlock()
+		assert.True(t, client.closed, "Close must still be attempted even when it returns an error")
+	})
+}
+
 func TestMessagingManagerStats(t *testing.T) {
 	ctx := context.Background()
 	log := logger.New("error", false)


### PR DESCRIPTION
Closes #418.

## What

Drives standalone-gosec on the messaging package from 19 findings to 1 (the lone remaining one is a pre-existing G115 at \`declarations.go:500\` already carrying \`//nolint:gosec\` for the intentional int64→uint64 bit reinterpretation in the hash function). The project's \`.golangci.yml\` gate was already at 0 issues on this package — this PR tightens the underlying call sites so the wider gosec ruleset is also clean.

## Coverage of the two finding families

### 14 × G104 on \`hash.Hash.Write\` in declarations.go

Introduce a \`writeString(h hash.Hash, s string)\` helper next to the existing \`writeBool\` / \`writeInt64\` / \`writeFloat64\` family — the established local pattern for hash-write helpers.

- 14 \`h.Write([]byte(...))\` sites in \`Hash()\` → \`writeString(h, ...)\`
- 2 \`h.Write([]byte(...))\` sites in \`writeMapArgs\` (key + string-value branches) → \`writeString(h, ...)\`
- \`writeBool\` / \`writeInt64\` / \`writeFloat64\` byte-slice writes tightened to \`_, _ = h.Write(...)\` for consistent discard-style across the file
- Existing \`//nolint:gosec\` on the G115 int64→uint64 bit reinterpretation in \`writeInt64\` preserved at its call site (already documented)

Hash determinism, allocation profile (320 B/op, 18 allocs/op), and byte-equivalence of \`Hash()\` output all verified preserved (per \`/simplify\` efficiency-review benchmarks).

### 4 × G104 on \`client.Close()\` in manager.go (error-rollback paths)

Introduce a \`closeClientOnRollback(client AMQPClient, key, phase string)\` method on \`*Manager\` that logs Close failures at Error level with structured \`key\` + \`phase\` fields. Log shape matches the existing \`evictPublisherIfNeeded\` (line 333) and \`cleanupIdlePublishers\` (line 414) close-failure sites in the same file.

Callers:
- \`ensureConsumersInternal\` lines 161/167/174 — phases \`replay_declarations\`, \`declare_infrastructure\`, \`start_consumers\`
- \`createPublisher\` line 257 — phase \`publisher_double_create_race\`

Phase values use snake_case to match the codebase's log-field-value convention (\`app/bootstrap.go:105\` \`service_name\`, \`migration/multi_tenant.go:144\` action emission, etc.). The codebase has no prior typed-constant convention for phase-style log fields — these four values are each used exactly once and live within ~100 lines of each other in the same file, so kept as free-form strings rather than promoting to a \`const\` block.

## Scope discussion (\`/simplify\` finding noted but not applied)

The Quality reviewer flagged that the existing inline log-and-discard sites in \`evictPublisherIfNeeded\` and \`cleanupIdlePublishers\` could *also* be folded into \`closeClientOnRollback\` to share the same shape. The Reuse reviewer disagreed, recommending \"keep separate\" because those sites:

1. Run during steady-state lifecycle (LRU eviction / idle TTL sweep), not error-rollback. The new helper's name and log message both frame *rollback* semantics — collapsing them in would either lose that framing or force the helper to take both \`phase\` and \`msg\` parameters, degrading self-documentation.
2. Have meaningfully distinct per-message text (\"Error closing evicted publisher client\" vs. \"Error closing idle publisher client\" vs. the new \"Error closing AMQP client during rollback\") that operators may filter on.

Going with \"keep separate.\" The deciding question: \"does the helper's name still accurately describe its function after the change?\" — for a unified version, it wouldn't.

## Pre-push workflow compliance

- **\`/simplify\`** → SHIP IT after applying convergent findings:
  - 4 phase strings renamed hyphens → underscores to match the codebase log-field-value convention
  - \`writeString\` docstring trimmed (WHY preserved, framing dropped)
  - Reuse-extension to lifecycle sites: noted but not applied (judgment call documented above)
- **\`/security-audit\`** → PASS. \`golangci-lint\` (CI gate) returns 0 issues. Standalone \`gosec ./messaging/...\` drops from 19 → 1 (the intentional G115 already annotated).

## Test plan

- [x] \`go test -race ./messaging/...\` green
- [x] \`make check\` green
- [x] \`golangci-lint run ./messaging/...\` → 0 issues
- [x] \`gosec ./messaging/...\` → 1 issue (pre-existing G115 with annotation)
- [x] Hash() output byte-equivalence preserved (confirmed via \`/simplify\` benchmarks)
- [ ] CI green
- [ ] SonarCloud Quality Gate passes (no behavior change; expect neutral coverage impact since refactor is structural, not new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Internal Improvements**
  * Improved client rollback and cleanup to ensure redundant/outstanding clients are closed and close errors are logged without altering the primary error flow.
  * Made hash computation for message declarations more consistent and robust.

* **Tests**
  * Added a unit test validating rollback always attempts client close and does not propagate close errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/420)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->