### PR TITLE
feat(migration): structured Flyway-JSON Result + CLI fields + tool README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,10 +42,10 @@
 
 !.claude/commands/*
 
-# Test fixtures (JSON / SQL / golden files) live alongside the source they
-# exercise; allowlist common extensions so go test pickups don't break.
-!*.json
-!*.sql
+# Test fixtures (JSON / SQL / golden files) live under testdata/ alongside the
+# source they exercise.
+!**/testdata/**/*.json
+!**/testdata/**/*.sql
 
 # ...even if they are in subdirectories
 !*/

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,11 @@
 
 !.claude/commands/*
 
+# Test fixtures (JSON / SQL / golden files) live alongside the source they
+# exercise; allowlist common extensions so go test pickups don't break.
+!*.json
+!*.sql
+
 # ...even if they are in subdirectories
 !*/
 

--- a/migration/audit_test.go
+++ b/migration/audit_test.go
@@ -298,7 +298,8 @@ func TestMigrateForEmitsAuditEventOnSuccess(t *testing.T) {
 	require.NoError(t, os.WriteFile(mcfg.ConfigPath, []byte(""), 0o644))
 	require.NoError(t, os.MkdirAll(mcfg.MigrationPath, 0o755))
 
-	require.NoError(t, fm.Migrate(context.Background(), mcfg))
+	_, err := fm.Migrate(context.Background(), mcfg)
+	require.NoError(t, err)
 
 	sink.waitForFirst(t, 2*time.Second)
 	events := sink.snapshot()
@@ -362,7 +363,8 @@ func TestAuditTargetFallsBackToMigratorDatabaseWhenAllElseEmpty(t *testing.T) {
 		Username: "user", Password: "longenough-pw",
 		Database: "", // empty — middle fallback yields nothing
 	}
-	require.NoError(t, fm.MigrateFor(context.Background(), emptyDB, mcfg))
+	_, err := fm.MigrateFor(context.Background(), emptyDB, mcfg)
+	require.NoError(t, err)
 
 	sink.waitForFirst(t, 2*time.Second)
 	events := sink.snapshot()
@@ -404,7 +406,7 @@ func TestMigrateForEmitsClassifiedErrorOnFailure(t *testing.T) {
 	require.NoError(t, os.WriteFile(mcfg.ConfigPath, []byte(""), 0o644))
 	require.NoError(t, os.MkdirAll(mcfg.MigrationPath, 0o755))
 
-	err := fm.Migrate(context.Background(), mcfg)
+	_, err := fm.Migrate(context.Background(), mcfg)
 	require.Error(t, err, "stub exits non-zero so Migrate must report failure")
 
 	sink.waitForFirst(t, 2*time.Second)
@@ -456,6 +458,51 @@ func TestInfoAndValidateDoNotEmitMigrationApplied(t *testing.T) {
 
 	assert.Empty(t, sink.snapshot(),
 		"Info/Validate must not emit migration.applied per ADR-019 (only the migrate verb does)")
+}
+
+func TestMigrationAppliedCarriesParsedVersionAndAttributes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+	setupTestTracer(t)
+
+	payload := readFixture(t, "migrate_success.json")
+
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{
+			Type: "postgresql", Host: "h", Port: 15432,
+			Username: "u", Password: "longenough-pw", Database: "db",
+		},
+		App: config.AppConfig{Env: "test"},
+	}
+	sink := newRecordingSink()
+	fm := NewFlywayMigrator(cfg, logger.New("disabled", true)).WithAuditRecorder(sink)
+	t.Cleanup(func() { _ = fm.Close(context.Background()) })
+
+	stub, _ := createCommandCapturingStub(t, payload)
+	mcfg := &Config{
+		FlywayPath:    stub,
+		ConfigPath:    filepath.Join(t.TempDir(), "flyway.conf"),
+		MigrationPath: filepath.Join(t.TempDir(), "migrations"),
+		Timeout:       10 * time.Second,
+		Environment:   cfg.App.Env,
+		Audit:         AuditContext{Principal: "deployer@example.com"},
+	}
+	require.NoError(t, os.WriteFile(mcfg.ConfigPath, []byte(""), 0o644))
+	require.NoError(t, os.MkdirAll(mcfg.MigrationPath, 0o755))
+
+	_, err := fm.Migrate(context.Background(), mcfg)
+	require.NoError(t, err)
+
+	sink.waitForFirst(t, 2*time.Second)
+	events := sink.snapshot()
+	require.Len(t, events, 1)
+
+	ev := events[0]
+	assert.Equal(t, AuditOutcomeSuccess, ev.Outcome)
+	assert.Equal(t, "2", ev.Version, "AuditEvent.Version mirrors Result.EndingVersion")
+	assert.Equal(t, "10.22.0", ev.Attributes["migration.flyway_version"])
+	assert.Equal(t, "1,2", ev.Attributes["migration.applied_versions"])
 }
 
 func TestEmitterCloseIsIdempotent(t *testing.T) {

--- a/migration/flyway.go
+++ b/migration/flyway.go
@@ -21,8 +21,9 @@ import (
 
 const (
 	// Flyway command flag constants
-	flagConfigFiles = "-configFiles="
-	flagLocationsFS = "-locations=filesystem:"
+	flagConfigFiles    = "-configFiles="
+	flagLocationsFS    = "-locations=filesystem:"
+	flagOutputTypeJSON = "-outputType=json"
 
 	flywayExecutable  = "flyway"
 	flywayCmdMigrate  = "migrate"
@@ -194,8 +195,10 @@ func (fm *FlywayMigrator) defaultMigrationConfig() *Config {
 	return fm.DefaultMigrationConfigForVendor(fm.config.Database.Type)
 }
 
-// Migrate executes pending migrations against the migrator's configured database.
-func (fm *FlywayMigrator) Migrate(ctx context.Context, cfg *Config) error {
+// Migrate executes pending migrations against the migrator's configured
+// database. The Result carries the parsed per-target outcome; on parse
+// failure it is zero-valued and the error return is authoritative.
+func (fm *FlywayMigrator) Migrate(ctx context.Context, cfg *Config) (Result, error) {
 	if cfg == nil {
 		cfg = fm.DefaultMigrationConfig()
 	}
@@ -204,7 +207,8 @@ func (fm *FlywayMigrator) Migrate(ctx context.Context, cfg *Config) error {
 
 // MigrateFor executes pending migrations against the supplied database.
 // Used by multi-tenant migrations to target a tenant-specific DatabaseConfig.
-func (fm *FlywayMigrator) MigrateFor(ctx context.Context, db *config.DatabaseConfig, cfg *Config) error {
+// See Migrate for the Result contract.
+func (fm *FlywayMigrator) MigrateFor(ctx context.Context, db *config.DatabaseConfig, cfg *Config) (Result, error) {
 	return fm.runFor(ctx, db, cfg, flywayCmdMigrate)
 }
 
@@ -218,7 +222,8 @@ func (fm *FlywayMigrator) Info(ctx context.Context, cfg *Config) error {
 
 // InfoFor shows migration status for the supplied database.
 func (fm *FlywayMigrator) InfoFor(ctx context.Context, db *config.DatabaseConfig, cfg *Config) error {
-	return fm.runFor(ctx, db, cfg, flywayCmdInfo)
+	_, err := fm.runFor(ctx, db, cfg, flywayCmdInfo)
+	return err
 }
 
 // Validate validates migrations without executing them against the migrator's database.
@@ -231,10 +236,11 @@ func (fm *FlywayMigrator) Validate(ctx context.Context, cfg *Config) error {
 
 // ValidateFor validates migrations for the supplied database.
 func (fm *FlywayMigrator) ValidateFor(ctx context.Context, db *config.DatabaseConfig, cfg *Config) error {
-	return fm.runFor(ctx, db, cfg, flywayCmdValidate)
+	_, err := fm.runFor(ctx, db, cfg, flywayCmdValidate)
+	return err
 }
 
-func (fm *FlywayMigrator) runFor(ctx context.Context, db *config.DatabaseConfig, cfg *Config, verb string) error {
+func (fm *FlywayMigrator) runFor(ctx context.Context, db *config.DatabaseConfig, cfg *Config, verb string) (Result, error) {
 	startedAt := time.Now()
 
 	if cfg == nil {
@@ -247,28 +253,41 @@ func (fm *FlywayMigrator) runFor(ctx context.Context, db *config.DatabaseConfig,
 		Str("action", verb).
 		Msg("Starting Flyway command")
 
+	// Info / validate keep their default pretty-printed output for operators
+	// running them at the CLI; migrate switches to JSON so we can parse a
+	// structured Result for the audit pipeline and CLI consumers.
+	isMigrate := verb == flywayCmdMigrate
 	args := []string{
 		flagConfigFiles + cfg.ConfigPath,
 		flagLocationsFS + cfg.MigrationPath,
-		verb,
 	}
+	if isMigrate {
+		args = append(args, flagOutputTypeJSON)
+	}
+	args = append(args, verb)
 
 	output, runErr := fm.runFlywayCommandFor(ctx, db, cfg, args)
 
-	// ADR-019: migration.applied is emitted only for actual applications
-	// (the migrate verb). Info / validate read state and don't count as
-	// applications even though they invoke Flyway.
-	if verb == flywayCmdMigrate {
-		fm.emitMigrationApplied(ctx, db, cfg, &flywayRunOutcome{
-			Vendor:      vendor,
-			StartedAt:   startedAt,
-			CompletedAt: time.Now(),
-			Output:      output,
-			Err:         runErr,
-		})
+	if !isMigrate {
+		return Result{}, runErr
 	}
 
-	return runErr
+	result, parseErr := parseFlywayJSON(output)
+	if parseErr != nil {
+		fm.logger.Debug().Err(parseErr).Msg("Failed to parse Flyway JSON output")
+	}
+
+	// ADR-019: migration.applied fires only for actual applications.
+	fm.emitMigrationApplied(ctx, db, cfg, &flywayRunOutcome{
+		Vendor:      vendor,
+		StartedAt:   startedAt,
+		CompletedAt: time.Now(),
+		Output:      output,
+		Result:      result,
+		Err:         runErr,
+	})
+
+	return result, runErr
 }
 
 // flywayRunOutcome bundles the result of a single Flyway subprocess
@@ -279,6 +298,7 @@ type flywayRunOutcome struct {
 	StartedAt   time.Time
 	CompletedAt time.Time
 	Output      string
+	Result      Result
 	Err         error
 }
 
@@ -315,9 +335,8 @@ func (fm *FlywayMigrator) runFlywayCommandFor(ctx context.Context, db *config.Da
 
 // emitMigrationApplied composes an AuditEvent of type migration.applied and
 // dispatches it through the configured emitter (always OTel; optionally
-// AuditRecorder). Best-effort error classification via classifyFlywayError.
-// Version remains empty in v1 — populating it requires parsing Flyway's
-// JSON output, deferred to #376's structured-Result work.
+// AuditRecorder). Version maps to the parsed Result.EndingVersion — the
+// schema version after the run, equal on both fresh-apply and no-op reruns.
 func (fm *FlywayMigrator) emitMigrationApplied(ctx context.Context, db *config.DatabaseConfig, cfg *Config, run *flywayRunOutcome) {
 	if fm.audit == nil {
 		return
@@ -336,6 +355,17 @@ func (fm *FlywayMigrator) emitMigrationApplied(ctx context.Context, db *config.D
 		target = fm.config.Database.Database
 	}
 
+	attrs := map[string]string{
+		"migration.vendor":  run.Vendor,
+		"migration.dry_run": strconv.FormatBool(cfg.DryRun),
+	}
+	if run.Result.FlywayVersion != "" {
+		attrs["migration.flyway_version"] = run.Result.FlywayVersion
+	}
+	if applied := run.Result.AppliedVersions; len(applied) > 0 {
+		attrs["migration.applied_versions"] = strings.Join(applied, ",")
+	}
+
 	ev := &AuditEvent{
 		Type:               AuditEventTypeMigrationApplied,
 		Target:             target,
@@ -344,10 +374,8 @@ func (fm *FlywayMigrator) emitMigrationApplied(ctx context.Context, db *config.D
 		CompletedAt:        run.CompletedAt,
 		GitCommitSHA:       cfg.Audit.GitCommitSHA,
 		PipelineRunID:      cfg.Audit.PipelineRunID,
-		Attributes: map[string]string{
-			"migration.vendor":  run.Vendor,
-			"migration.dry_run": strconv.FormatBool(cfg.DryRun),
-		},
+		Version:            run.Result.EndingVersion,
+		Attributes:         attrs,
 	}
 
 	if run.Err != nil {
@@ -503,14 +531,17 @@ func redactPassword(output string, db *config.DatabaseConfig) string {
 	return redacted
 }
 
-// RunMigrationsAtStartup executes migrations automatically at application startup
+// RunMigrationsAtStartup executes migrations automatically at application
+// startup. The structured Result is discarded here; downstream consumers
+// pick it up via the migration.applied audit event.
 func (fm *FlywayMigrator) RunMigrationsAtStartup(ctx context.Context) error {
 	migrationConfig := fm.DefaultMigrationConfig()
 
 	// In development, run migrations automatically
 	if fm.config.App.Env == config.EnvDevelopment {
 		fm.logger.Info().Msg("Running automatic migrations in development environment")
-		return fm.Migrate(ctx, migrationConfig)
+		_, err := fm.Migrate(ctx, migrationConfig)
+		return err
 	}
 
 	// In other environments, only validate

--- a/migration/flyway_test.go
+++ b/migration/flyway_test.go
@@ -406,17 +406,19 @@ func TestRunMigrationsAtStartup(t *testing.T) {
 // createCommandCapturingStub builds a flyway-stub that writes the verbatim
 // arg list to capturePath, then optionally emits stdoutPayload on stdout
 // before exiting 0. Pass an empty stdoutPayload for the args-only variant.
+// Path interpolations are shell-quoted so the script survives $TMPDIR values
+// containing spaces or other shell-metacharacters.
 func createCommandCapturingStub(t *testing.T, stdoutPayload string) (stubPath, capturePath string) {
 	t.Helper()
 	dir := t.TempDir()
 	stubPath = filepath.Join(dir, "flyway-stub.sh")
 	capturePath = filepath.Join(dir, "captured_command")
 
-	script := "#!/bin/sh\necho \"$@\" > " + capturePath + "\n"
+	script := fmt.Sprintf("#!/bin/sh\necho \"$@\" > %q\n", capturePath)
 	if stdoutPayload != "" {
 		payloadPath := filepath.Join(dir, "payload")
 		require.NoError(t, os.WriteFile(payloadPath, []byte(stdoutPayload), 0o644))
-		script += "cat " + payloadPath + "\n"
+		script += fmt.Sprintf("cat %q\n", payloadPath)
 	}
 	script += "exit 0\n"
 	require.NoError(t, os.WriteFile(stubPath, []byte(script), 0o755))

--- a/migration/flyway_test.go
+++ b/migration/flyway_test.go
@@ -154,7 +154,8 @@ func TestRunFlywayCommandSuccessWithEnv(t *testing.T) {
 
 	ctx := context.Background()
 	// Should succeed and validate env variables presence
-	require.NoError(t, fm.Migrate(ctx, mcfg))
+	_, err := fm.Migrate(ctx, mcfg)
+	require.NoError(t, err)
 }
 
 func TestDefaultMigrationConfig(t *testing.T) {
@@ -374,7 +375,7 @@ func TestRunMigrationsAtStartup(t *testing.T) {
 
 			fm := NewFlywayMigrator(cfg, logger.New("disabled", true))
 
-			stub, capturePath := createCommandCapturingStub(t)
+			stub, capturePath := createCommandCapturingStub(t, "")
 			tempDir := t.TempDir()
 			configPath := filepath.Join(tempDir, "flyway.conf")
 			migrationPath := filepath.Join(tempDir, "migrations")
@@ -402,19 +403,24 @@ func TestRunMigrationsAtStartup(t *testing.T) {
 	}
 }
 
-// Helper function to create a stub that captures which command was called
-func createCommandCapturingStub(t *testing.T) (_, _ string) {
+// createCommandCapturingStub builds a flyway-stub that writes the verbatim
+// arg list to capturePath, then optionally emits stdoutPayload on stdout
+// before exiting 0. Pass an empty stdoutPayload for the args-only variant.
+func createCommandCapturingStub(t *testing.T, stdoutPayload string) (stubPath, capturePath string) {
 	t.Helper()
 	dir := t.TempDir()
-	path := filepath.Join(dir, "flyway-capture.sh")
-	capturePath := filepath.Join(dir, "captured_command")
+	stubPath = filepath.Join(dir, "flyway-stub.sh")
+	capturePath = filepath.Join(dir, "captured_command")
 
-	// Create a script that writes the command to a file and exits successfully
-	content := "#!/bin/sh\n" +
-		"echo \"$@\" > " + capturePath + "\n" +
-		"exit 0\n"
-	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
-	return path, capturePath
+	script := "#!/bin/sh\necho \"$@\" > " + capturePath + "\n"
+	if stdoutPayload != "" {
+		payloadPath := filepath.Join(dir, "payload")
+		require.NoError(t, os.WriteFile(payloadPath, []byte(stdoutPayload), 0o644))
+		script += "cat " + payloadPath + "\n"
+	}
+	script += "exit 0\n"
+	require.NoError(t, os.WriteFile(stubPath, []byte(script), 0o755))
+	return stubPath, capturePath
 }
 
 // Helper function to create a failing stub for testing error scenarios
@@ -469,7 +475,7 @@ func TestRunFlywayCommandErrorHandling(t *testing.T) {
 		require.NoError(t, os.MkdirAll(mcfg.MigrationPath, 0o755))
 
 		ctx := context.Background()
-		err := fm.Migrate(ctx, mcfg)
+		_, err := fm.Migrate(ctx, mcfg)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "flyway command failed")
 	})
@@ -483,7 +489,7 @@ func TestRunFlywayCommandErrorHandling(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		err := fm.Migrate(ctx, mcfg)
+		_, err := fm.Migrate(ctx, mcfg)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid flyway path")
 	})
@@ -502,7 +508,7 @@ func TestRunFlywayCommandErrorHandling(t *testing.T) {
 		require.NoError(t, os.MkdirAll(mcfg.MigrationPath, 0o755))
 
 		ctx := context.Background()
-		err := fm.Migrate(ctx, mcfg)
+		_, err := fm.Migrate(ctx, mcfg)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "flyway command failed")
 	})
@@ -769,7 +775,7 @@ func TestMigrateEdgeCases(t *testing.T) {
 	fm := NewFlywayMigrator(cfg, logger.New("disabled", true))
 
 	t.Run("migrate_with_nil_config_uses_default", func(t *testing.T) {
-		stub, capturePath := createCommandCapturingStub(t)
+		stub, capturePath := createCommandCapturingStub(t, "")
 		tempDir := t.TempDir()
 		configPath := filepath.Join(tempDir, "flyway.conf")
 		migrationPath := filepath.Join(tempDir, "migrations")
@@ -787,7 +793,7 @@ func TestMigrateEdgeCases(t *testing.T) {
 			}
 		}
 
-		err := fm.Migrate(context.Background(), nil)
+		_, err := fm.Migrate(context.Background(), nil)
 		assert.NoError(t, err)
 
 		captured, readErr := os.ReadFile(capturePath)
@@ -809,7 +815,7 @@ func TestMigrateEdgeCases(t *testing.T) {
 		require.NoError(t, os.MkdirAll(mcfg.MigrationPath, 0o755))
 
 		ctx := context.Background()
-		err := fm.Migrate(ctx, mcfg)
+		_, err := fm.Migrate(ctx, mcfg)
 		assert.NoError(t, err)
 	})
 }
@@ -827,7 +833,7 @@ func TestInfoEdgeCases(t *testing.T) {
 	fm := NewFlywayMigrator(cfg, logger.New("disabled", true))
 
 	t.Run("info_with_nil_config_executes_command", func(t *testing.T) {
-		stub, capturePath := createCommandCapturingStub(t)
+		stub, capturePath := createCommandCapturingStub(t, "")
 		tempDir := t.TempDir()
 		configPath := filepath.Join(tempDir, "flyway.conf")
 		migrationPath := filepath.Join(tempDir, "migrations")
@@ -885,7 +891,7 @@ func TestValidateEdgeCases(t *testing.T) {
 	})
 
 	t.Run("validate_with_nil_config_executes_command", func(t *testing.T) {
-		stub, capturePath := createCommandCapturingStub(t)
+		stub, capturePath := createCommandCapturingStub(t, "")
 		tempDir := t.TempDir()
 		configPath := filepath.Join(tempDir, "flyway.conf")
 		migrationPath := filepath.Join(tempDir, "migrations")
@@ -976,4 +982,88 @@ func TestRedactPasswordKeepsAlphanumericLongPasswordsRedactedRaw(t *testing.T) {
 	out := redactPassword("error: jdbc:postgresql://user:longalphanumeric1@host/db", db)
 	assert.Contains(t, out, "[REDACTED]")
 	assert.NotContains(t, out, "longalphanumeric1")
+}
+
+func TestMigrateRequestsJSONOutputAndParsesResult(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+
+	payload := readFixture(t, "migrate_success.json")
+
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{
+			Type: "postgresql", Host: "h", Port: 15432,
+			Username: "u", Password: "longenough-pw", Database: "db",
+		},
+		App: config.AppConfig{Env: "test"},
+	}
+	fm := NewFlywayMigrator(cfg, logger.New("disabled", true))
+
+	stub, capturePath := createCommandCapturingStub(t, payload)
+	mcfg := &Config{
+		FlywayPath:    stub,
+		ConfigPath:    filepath.Join(t.TempDir(), "flyway.conf"),
+		MigrationPath: filepath.Join(t.TempDir(), "migrations"),
+		Timeout:       10 * time.Second,
+		Environment:   cfg.App.Env,
+	}
+	require.NoError(t, os.WriteFile(mcfg.ConfigPath, []byte(""), 0o644))
+	require.NoError(t, os.MkdirAll(mcfg.MigrationPath, 0o755))
+
+	result, err := fm.Migrate(context.Background(), mcfg)
+	require.NoError(t, err)
+
+	captured, readErr := os.ReadFile(capturePath)
+	require.NoError(t, readErr)
+	args := string(captured)
+	assert.Contains(t, args, "-outputType=json", "migrate verb must request JSON output to populate Result")
+	assert.Contains(t, args, "migrate")
+
+	assert.True(t, result.Success)
+	assert.Equal(t, []string{"1", "2"}, result.AppliedVersions)
+	assert.Equal(t, "2", result.EndingVersion)
+	assert.Equal(t, int64(8), result.DurationMillis)
+}
+
+func TestInfoAndValidateDoNotRequestJSONOutput(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{
+			Type: "postgresql", Host: "h", Port: 15432,
+			Username: "u", Password: "longenough-pw", Database: "db",
+		},
+		App: config.AppConfig{Env: "test"},
+	}
+	fm := NewFlywayMigrator(cfg, logger.New("disabled", true))
+
+	for _, tc := range []struct {
+		name string
+		call func(*Config) error
+	}{
+		{"info", func(c *Config) error { return fm.Info(context.Background(), c) }},
+		{"validate", func(c *Config) error { return fm.Validate(context.Background(), c) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stub, capturePath := createCommandCapturingStub(t, "")
+			mcfg := &Config{
+				FlywayPath:    stub,
+				ConfigPath:    filepath.Join(t.TempDir(), "flyway.conf"),
+				MigrationPath: filepath.Join(t.TempDir(), "migrations"),
+				Timeout:       10 * time.Second,
+			}
+			require.NoError(t, os.WriteFile(mcfg.ConfigPath, []byte(""), 0o644))
+			require.NoError(t, os.MkdirAll(mcfg.MigrationPath, 0o755))
+
+			require.NoError(t, tc.call(mcfg))
+
+			captured, readErr := os.ReadFile(capturePath)
+			require.NoError(t, readErr)
+			assert.NotContains(t, string(captured), "-outputType=json",
+				"info/validate keep default pretty-printed output for operator-facing sessions")
+		})
+	}
 }

--- a/migration/multi_tenant.go
+++ b/migration/multi_tenant.go
@@ -50,6 +50,10 @@ type TenantResult struct {
 	Vendor   string
 	Err      error
 	Duration time.Duration
+
+	// Result is the parsed Flyway outcome for ActionMigrate. Zero-valued
+	// for Validate / Info, or when Flyway crashed before emitting JSON.
+	Result Result
 }
 
 // MigrateAllResult aggregates per-tenant results from a MigrateAll run.
@@ -64,9 +68,11 @@ func (r *MigrateAllResult) Failed() []TenantResult {
 		return nil
 	}
 	var out []TenantResult
-	for _, res := range r.Results {
-		if res.Err != nil {
-			out = append(out, res)
+	// Index iteration: TenantResult is too large for gocritic's
+	// rangeValCopy threshold (each step would copy the embedded Result).
+	for i := range r.Results {
+		if r.Results[i].Err != nil {
+			out = append(out, r.Results[i])
 		}
 	}
 	return out
@@ -312,7 +318,7 @@ func runOne(
 
 	switch action {
 	case ActionMigrate:
-		res.Err = migrator.MigrateFor(ctx, dbCfg, cfg)
+		res.Result, res.Err = migrator.MigrateFor(ctx, dbCfg, cfg)
 	case ActionValidate:
 		res.Err = migrator.ValidateFor(ctx, dbCfg, cfg)
 	case ActionInfo:

--- a/migration/result.go
+++ b/migration/result.go
@@ -1,0 +1,159 @@
+package migration
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Result captures the structured outcome of a single Flyway migrate
+// invocation, populated from the engine's -outputType=json output. Fields
+// are best-effort: an empty Result is returned when the subprocess crashed
+// before emitting JSON or the payload was malformed. Callers that need an
+// authoritative pass/fail signal should still consult the error returned
+// alongside the Result.
+type Result struct {
+	// Operation is the Flyway verb. Empty on the error envelope.
+	Operation string
+
+	// Success is false whenever Flyway emitted an error envelope, even if
+	// the JSON parsed cleanly.
+	Success bool
+
+	// AppliedVersions enumerates the migration versions Flyway applied in
+	// this run, in the order Flyway reported them. Empty on no-op reruns.
+	AppliedVersions []string
+
+	// StartingVersion is the schema version before this run (Flyway's
+	// initialSchemaVersion). Empty when Flyway reported it as null —
+	// typically on the first migrate against a fresh schema.
+	StartingVersion string
+
+	// EndingVersion is the schema version after this run. Flyway reports
+	// targetSchemaVersion as null on no-op runs; the parser falls back to
+	// StartingVersion in that case so callers always see a usable terminus.
+	EndingVersion string
+
+	// DurationMillis is Flyway's totalMigrationTime in milliseconds.
+	DurationMillis int64
+
+	// FlywayVersion is the engine version that produced this result.
+	FlywayVersion string
+
+	// DatabaseType is Flyway's databaseType field ("PostgreSQL", "Oracle").
+	DatabaseType string
+
+	// ErrorCode is Flyway's errorCode on the failure envelope (e.g.
+	// "VALIDATE_ERROR" for a checksum mismatch). Empty when Success is true.
+	ErrorCode string
+
+	// ErrorMessage is the human-readable error message from Flyway when
+	// Success is false. May contain embedded newlines from Flyway.
+	ErrorMessage string
+}
+
+// flywayJSONEnvelope is the union of Flyway's -outputType=json payload
+// shapes. Success-shape fields and Error-shape fields are mutually exclusive
+// in practice; pointer-typed fields distinguish "present" from "zero-valued".
+type flywayJSONEnvelope struct {
+	Operation            string              `json:"operation"`
+	InitialSchemaVersion *string             `json:"initialSchemaVersion"`
+	TargetSchemaVersion  *string             `json:"targetSchemaVersion"`
+	Migrations           []flywayMigration   `json:"migrations"`
+	Success              *bool               `json:"success"`
+	FlywayVersion        string              `json:"flywayVersion"`
+	DatabaseType         string              `json:"databaseType"`
+	TotalMigrationTime   int64               `json:"totalMigrationTime"`
+	Error                *flywayErrorPayload `json:"error"`
+}
+
+type flywayMigration struct {
+	Version string `json:"version"`
+}
+
+type flywayErrorPayload struct {
+	ErrorCode string `json:"errorCode"`
+	Message   string `json:"message"`
+}
+
+// errEmptyFlywayOutput is returned when parseFlywayJSON receives an empty
+// or whitespace-only payload — typically because the subprocess crashed
+// before Flyway could write its JSON envelope.
+var errEmptyFlywayOutput = errors.New("migration: empty Flyway JSON output")
+
+// parseFlywayJSON parses Flyway's -outputType=json output into a Result.
+// The first JSON object embedded in output is consumed; any leading non-JSON
+// noise (e.g. JVM warnings printed before the envelope) is skipped over
+// rather than treated as a parse error.
+func parseFlywayJSON(output string) (Result, error) {
+	trimmed := skipToObject(output)
+	if trimmed == "" {
+		return Result{}, errEmptyFlywayOutput
+	}
+
+	var env flywayJSONEnvelope
+	dec := json.NewDecoder(strings.NewReader(trimmed))
+	if err := dec.Decode(&env); err != nil {
+		if errors.Is(err, io.EOF) {
+			return Result{}, errEmptyFlywayOutput
+		}
+		return Result{}, fmt.Errorf("migration: parse Flyway JSON: %w", err)
+	}
+
+	res := Result{
+		Operation:      env.Operation,
+		DurationMillis: env.TotalMigrationTime,
+		FlywayVersion:  env.FlywayVersion,
+		DatabaseType:   env.DatabaseType,
+	}
+
+	if env.Success != nil {
+		res.Success = *env.Success
+	}
+	if env.InitialSchemaVersion != nil {
+		res.StartingVersion = *env.InitialSchemaVersion
+	}
+	if env.TargetSchemaVersion != nil {
+		res.EndingVersion = *env.TargetSchemaVersion
+	} else {
+		// No-op rerun: Flyway reports targetSchemaVersion=null but the
+		// schema is still at its initial version. Falling back keeps the
+		// audit pipeline from recording an empty terminus on every benign
+		// rerun.
+		res.EndingVersion = res.StartingVersion
+	}
+	if len(env.Migrations) > 0 {
+		res.AppliedVersions = make([]string, 0, len(env.Migrations))
+		for _, m := range env.Migrations {
+			if m.Version != "" {
+				res.AppliedVersions = append(res.AppliedVersions, m.Version)
+			}
+		}
+	}
+	if env.Error != nil {
+		res.ErrorCode = env.Error.ErrorCode
+		res.ErrorMessage = env.Error.Message
+		// The failure shape omits "success" entirely; force the field so
+		// callers can rely on a single discriminator.
+		res.Success = false
+	}
+
+	return res, nil
+}
+
+// skipToObject returns s sliced from the first '{' onward, or "" when none
+// is present. Lets json.Decoder consume the first object without tripping
+// on JVM / SLF4J chatter that occasionally precedes Flyway's JSON envelope.
+func skipToObject(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	start := strings.IndexByte(s, '{')
+	if start < 0 {
+		return ""
+	}
+	return s[start:]
+}

--- a/migration/result_test.go
+++ b/migration/result_test.go
@@ -1,0 +1,102 @@
+package migration
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readFixture loads a Flyway JSON output fixture from testdata/flyway.
+// Fixtures were captured against Flyway 10.22 via docker run; see the
+// commit history for the capture sequence.
+func readFixture(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", "flyway", name))
+	require.NoError(t, err)
+	return string(b)
+}
+
+func TestParseFlywayJSONMigrateSuccess(t *testing.T) {
+	got, err := parseFlywayJSON(readFixture(t, "migrate_success.json"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "migrate", got.Operation)
+	assert.True(t, got.Success)
+	assert.Equal(t, []string{"1", "2"}, got.AppliedVersions)
+	assert.Equal(t, "", got.StartingVersion, "fresh schema starts at null/empty")
+	assert.Equal(t, "2", got.EndingVersion)
+	assert.Equal(t, int64(8), got.DurationMillis)
+	assert.Equal(t, "10.22.0", got.FlywayVersion)
+	assert.Equal(t, "PostgreSQL", got.DatabaseType)
+	assert.Empty(t, got.ErrorCode)
+	assert.Empty(t, got.ErrorMessage)
+}
+
+func TestParseFlywayJSONMigrateNoop(t *testing.T) {
+	got, err := parseFlywayJSON(readFixture(t, "migrate_noop.json"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "migrate", got.Operation)
+	assert.True(t, got.Success)
+	assert.Empty(t, got.AppliedVersions, "no-op reruns apply nothing")
+	assert.Equal(t, "2", got.StartingVersion)
+	assert.Equal(t, "2", got.EndingVersion, "no-op fallback: EndingVersion mirrors StartingVersion when target is null")
+	assert.Equal(t, int64(0), got.DurationMillis)
+}
+
+func TestParseFlywayJSONChecksumFailure(t *testing.T) {
+	got, err := parseFlywayJSON(readFixture(t, "migrate_checksum_fail.json"))
+	require.NoError(t, err)
+
+	assert.False(t, got.Success)
+	assert.Empty(t, got.Operation, "failure envelope has no top-level operation field")
+	assert.Empty(t, got.AppliedVersions)
+	assert.Equal(t, "VALIDATE_ERROR", got.ErrorCode)
+	assert.Contains(t, got.ErrorMessage, "checksum mismatch")
+}
+
+func TestParseFlywayJSONEmptyOutput(t *testing.T) {
+	_, err := parseFlywayJSON("")
+	assert.ErrorIs(t, err, errEmptyFlywayOutput)
+
+	_, err = parseFlywayJSON("   \n\t  ")
+	assert.ErrorIs(t, err, errEmptyFlywayOutput)
+}
+
+func TestParseFlywayJSONMalformed(t *testing.T) {
+	// Balanced braces but invalid JSON inside — extractJSONObject returns
+	// the (broken) payload, json.Unmarshal then rejects it. The error is
+	// a distinct class from errEmptyFlywayOutput so callers can tell the
+	// "no JSON at all" case apart from "JSON arrived but corrupt".
+	_, err := parseFlywayJSON(`{"success": notabool}`)
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, errEmptyFlywayOutput))
+}
+
+func TestParseFlywayJSONNoJSONObject(t *testing.T) {
+	// Plain text with no { at all — common when Flyway crashes pre-JSON.
+	_, err := parseFlywayJSON("SLF4J: warning\nERROR: cannot connect\n")
+	assert.ErrorIs(t, err, errEmptyFlywayOutput)
+}
+
+func TestParseFlywayJSONIgnoresLeadingNoise(t *testing.T) {
+	// Some classpaths print SLF4J warnings before the JSON envelope.
+	noisy := "SLF4J: defaulting to no-op (NOP) logger implementation\n" + readFixture(t, "migrate_noop.json")
+	got, err := parseFlywayJSON(noisy)
+	require.NoError(t, err)
+	assert.True(t, got.Success)
+	assert.Equal(t, "2", got.EndingVersion)
+}
+
+func TestParseFlywayJSONStopsAtFirstObject(t *testing.T) {
+	// json.Decoder consumes a single object then stops; trailing garbage
+	// after the closing brace must not poison the parse.
+	src := readFixture(t, "migrate_noop.json") + "\nTRAILING NOISE\n"
+	got, err := parseFlywayJSON(src)
+	require.NoError(t, err)
+	assert.True(t, got.Success)
+}

--- a/migration/testdata/flyway/migrate_checksum_fail.json
+++ b/migration/testdata/flyway/migrate_checksum_fail.json
@@ -1,0 +1,10 @@
+{
+  "error" : {
+    "errorCode" : "VALIDATE_ERROR",
+    "message" : "Validate failed: Migrations have failed validation\nMigration checksum mismatch for migration version 1\n-> Applied to database : -722161396\n-> Resolved locally    : -1154033441\nEither revert the changes to the migration, or run repair to update the schema history.\nNeed more flexibility with validation rules? Learn more: https://rd.gt/3AbJUZE",
+    "stackTrace" : null,
+    "lineNumber" : null,
+    "path" : null,
+    "cause" : null
+  }
+}

--- a/migration/testdata/flyway/migrate_noop.json
+++ b/migration/testdata/flyway/migrate_noop.json
@@ -1,0 +1,17 @@
+{
+  "timestamp" : "2026-05-13T20:49:03.519038549",
+  "operation" : "migrate",
+  "exception" : null,
+  "licenseFailed" : false,
+  "initialSchemaVersion" : "2",
+  "targetSchemaVersion" : null,
+  "schemaName" : "",
+  "migrations" : [ ],
+  "migrationsExecuted" : 0,
+  "success" : true,
+  "flywayVersion" : "10.22.0",
+  "database" : "testdb",
+  "warnings" : [ ],
+  "databaseType" : "PostgreSQL",
+  "totalMigrationTime" : 0
+}

--- a/migration/testdata/flyway/migrate_success.json
+++ b/migration/testdata/flyway/migrate_success.json
@@ -1,0 +1,31 @@
+{
+  "timestamp" : "2026-05-13T20:49:02.646391423",
+  "operation" : "migrate",
+  "exception" : null,
+  "licenseFailed" : false,
+  "initialSchemaVersion" : null,
+  "targetSchemaVersion" : "2",
+  "schemaName" : "",
+  "migrations" : [ {
+    "category" : "Versioned",
+    "version" : "1",
+    "description" : "create users",
+    "type" : "SQL",
+    "filepath" : "/flyway/sql/V1__create_users.sql",
+    "executionTime" : 5
+  }, {
+    "category" : "Versioned",
+    "version" : "2",
+    "description" : "create orders",
+    "type" : "SQL",
+    "filepath" : "/flyway/sql/V2__create_orders.sql",
+    "executionTime" : 3
+  } ],
+  "migrationsExecuted" : 2,
+  "success" : true,
+  "flywayVersion" : "10.22.0",
+  "database" : "testdb",
+  "warnings" : [ ],
+  "databaseType" : "PostgreSQL",
+  "totalMigrationTime" : 8
+}

--- a/tools/migration/README.md
+++ b/tools/migration/README.md
@@ -134,8 +134,9 @@ treat absence as "no signal" rather than "zero".
 
 A failed tenant adds `"status": "fail"` and an `"error"` field; the process
 exits non-zero whenever `failed > 0`. Idempotent reruns against already-
-migrated tenants emit `applied_versions: []` (omitted) with
-`ending_version` mirroring `starting_version`.
+migrated tenants omit `applied_versions` (zero-length slices follow the same
+omit-when-empty rule as the other Result-derived keys) with `ending_version`
+mirroring `starting_version`.
 
 ## CI integration
 

--- a/tools/migration/README.md
+++ b/tools/migration/README.md
@@ -1,0 +1,189 @@
+# go-bricks-migrate
+
+Operator and CI CLI for rolling Flyway migrations against a single tenant or a
+fleet of tenants behind a control plane. Wraps `migration.MigrateAll` from the
+go-bricks framework so the runtime engine and the CLI honor the same contract
+(credentials never appear in audit events, vendor-specific defaults applied per
+tenant, advisory-lock concurrency provided by Flyway natively).
+
+Deep dives:
+- [wiki/multi-tenant-migration.md](../../wiki/multi-tenant-migration.md) — full
+  architecture, control-plane response shape, AWS Secrets Manager layout.
+- [wiki/migration-audit.md](../../wiki/migration-audit.md) — `migration.applied`
+  audit event schema, OTel emission, `AuditRecorder` opt-in.
+- [ADR-018](../../wiki/adr-018-multi-tenant-migration-cli.md) — design rationale.
+- [ADR-019](../../wiki/adr-019-migration-audit-delivery.md) — audit delivery
+  guarantees.
+
+## Install
+
+```bash
+cd tools/migration
+make build               # produces ./go-bricks-migrate
+# or
+make install             # go install via $GOBIN
+```
+
+## Quick start
+
+**Single tenant from a YAML config:**
+
+```bash
+go-bricks-migrate migrate \
+    --source-config ./config.yaml \
+    --credentials-from config-file \
+    --tenant tenant_acme
+```
+
+**Fleet rollout from a control-plane API + AWS Secrets Manager:**
+
+```bash
+export GOBRICKS_MIGRATE_SOURCE_TOKEN=$(cat /run/secrets/cp_token)
+go-bricks-migrate migrate \
+    --source-url https://control.internal/v1/tenants \
+    --credentials-from aws-secrets-manager \
+    --secrets-prefix gobricks/migrate/ \
+    --parallel 10 \
+    --continue-on-error \
+    --json
+```
+
+## Subcommands
+
+| Command | Purpose |
+|---|---|
+| `migrate` | Apply pending migrations. Default action for CI/CD rollouts. |
+| `validate` | Validate the locally-checked-in migration set against the schema history without applying anything. |
+| `info` | Print Flyway's migration status table for each target. Operator-facing; not for CI parsing. |
+| `list` | List tenant IDs the configured source would target. Useful for dry-running the rollout shape. |
+| `version` | Print the CLI version. |
+
+## Flag groups
+
+### Tenant selection (mutually exclusive)
+
+| Flag | When to use |
+|---|---|
+| `--tenant ID` | One-shot operator run against a single tenant. |
+| `--source-url URL` | Fleet run; lists tenants from a control-plane API matching the [HTTP listing contract](../../wiki/multi-tenant-migration.md#pre-defined-http-listing-contract). |
+| `--source-config PATH` | Fleet run from a YAML file containing a `multitenant.tenants` block. |
+
+### Credentials
+
+| Flag | Source |
+|---|---|
+| `--credentials-from aws-secrets-manager` (default) | Per-tenant secrets fetched from AWS SM under `--secrets-prefix`. |
+| `--credentials-from config-file` | Per-tenant credentials embedded in the YAML supplied via `--source-config`. |
+
+### Runtime tuning
+
+| Flag | Purpose |
+|---|---|
+| `--parallel N` | Concurrency for fleet runs. `1` = sequential (default). Capped at 32 in the engine. |
+| `--continue-on-error` | Keep iterating after the first per-tenant failure instead of fail-fast. |
+| `--json` | Emit structured per-tenant and summary events on stdout for CI ingestion. |
+| `--flyway-path PATH` | Override the default `flyway` executable lookup. |
+| `--flyway-config PATH` | Override Flyway's `-configFiles=` argument. |
+| `--migrations-dir PATH` | Override Flyway's `-locations=filesystem:` argument. |
+| `--verbose` | Switch the embedded logger from `info` to `debug`. |
+
+### Environment variable overrides
+
+| Variable | Meaning |
+|---|---|
+| `GOBRICKS_MIGRATE_SOURCE_TOKEN` | Bearer token passed to the control-plane API. Used when `--source-url` is set. |
+| `GOBRICKS_MIGRATE_SECRETS_PREFIX` | Default `--secrets-prefix`. An explicit flag still wins. |
+
+## JSON output (for CI consumers)
+
+With `--json`, the CLI streams a JSON object per tenant and a final summary
+object. Both are newline-delimited; pipe through `jq -c .` to consume.
+
+**Per-tenant event:**
+
+```json
+{
+  "event": "tenant_complete",
+  "tenant_id": "tenant_acme",
+  "vendor": "postgresql",
+  "duration": "152ms",
+  "status": "ok",
+  "applied_versions": ["1", "2"],
+  "starting_version": "",
+  "ending_version": "2",
+  "duration_millis": 142,
+  "flyway_version": "10.22.0"
+}
+```
+
+Fields whose underlying `migration.Result` was zero-valued (e.g. for
+`validate`/`info` actions, or when Flyway crashed before emitting its JSON
+envelope) are omitted rather than emitted as empty strings. Consumers should
+treat absence as "no signal" rather than "zero".
+
+**Final summary:**
+
+```json
+{
+  "event": "summary",
+  "action": "migrate",
+  "total": 3,
+  "failed": 0
+}
+```
+
+A failed tenant adds `"status": "fail"` and an `"error"` field; the process
+exits non-zero whenever `failed > 0`. Idempotent reruns against already-
+migrated tenants emit `applied_versions: []` (omitted) with
+`ending_version` mirroring `starting_version`.
+
+## CI integration
+
+GitHub Actions example for a fleet rollout step:
+
+```yaml
+- name: Run migrations
+  env:
+    AWS_REGION: us-east-1
+    GOBRICKS_MIGRATE_SOURCE_TOKEN: ${{ secrets.CP_TOKEN }}
+  run: |
+    go-bricks-migrate migrate \
+      --source-url https://control.internal/v1/tenants \
+      --credentials-from aws-secrets-manager \
+      --secrets-prefix gobricks/migrate/ \
+      --parallel 10 \
+      --continue-on-error \
+      --json > migrate.log
+    cat migrate.log | jq -c 'select(.status=="fail")'
+```
+
+`--continue-on-error` ensures one tenant's failure doesn't strand the rest;
+the post-step `jq` filter surfaces per-tenant failures in the CI log without
+needing a separate parser.
+
+## Audit events
+
+Every `migrate` invocation emits a `migration.applied` event per tenant via
+OpenTelemetry (always-on) and, when configured at the library layer, via the
+optional `AuditRecorder` durable-delivery seam. The event carries
+`Version` (the schema version after the run), `Outcome`, `ErrorClass` on
+failure, and `Attributes` (Flyway engine version, applied versions CSV,
+vendor, dry-run flag). See
+[wiki/migration-audit.md](../../wiki/migration-audit.md) for the full schema.
+
+`--applied-by`, `--git-sha`, and `--pipeline-run-id` CLI flag plumbing for
+ADR-019's `AuditContext` is a separate follow-up; today the audit pipeline
+emits `<unspecified>` for principal when the library caller leaves it empty.
+
+## Development
+
+```bash
+make check               # fmt + lint + test + CLI smoke
+make test                # unit tests only
+make test-coverage       # writes coverage.html
+```
+
+The CLI tests use `httptest` for the control-plane source and a fake AWS SM
+client for credentials; no Docker dependency at the unit-test layer.
+Testcontainers-driven end-to-end coverage against real Postgres + Flyway is
+tracked separately (see the parent issue for the migration epic).

--- a/tools/migration/internal/commands/common.go
+++ b/tools/migration/internal/commands/common.go
@@ -325,14 +325,21 @@ func formatSchemaSummary(r *migration.Result) string {
 	if r.EndingVersion == "" && len(r.AppliedVersions) == 0 {
 		return ""
 	}
+	// Fall back to the last applied version when the parser couldn't read
+	// Flyway's targetSchemaVersion. Keeps the line useful instead of showing
+	// "v→v (N applied)" on engine output we didn't fully recognize.
+	end := r.EndingVersion
+	if end == "" && len(r.AppliedVersions) > 0 {
+		end = r.AppliedVersions[len(r.AppliedVersions)-1]
+	}
 	from := r.StartingVersion
 	if from == "" {
 		from = "∅"
 	}
 	if len(r.AppliedVersions) == 0 {
-		return fmt.Sprintf("schema=v%s (no-op)", r.EndingVersion)
+		return fmt.Sprintf("schema=v%s (no-op)", end)
 	}
-	return fmt.Sprintf("schema=v%s→v%s (%d applied)", from, r.EndingVersion, len(r.AppliedVersions))
+	return fmt.Sprintf("schema=v%s→v%s (%d applied)", from, end, len(r.AppliedVersions))
 }
 
 func vendorOrUnknown(v string) string {

--- a/tools/migration/internal/commands/common.go
+++ b/tools/migration/internal/commands/common.go
@@ -256,6 +256,10 @@ type fixedLister struct{ ids []string }
 func (f *fixedLister) ListTenants(context.Context) ([]string, error) { return f.ids, nil }
 
 // makeHook returns a TenantResult callback that streams progress to out.
+// JSON mode emits the structured per-target fields populated by the engine's
+// Flyway-JSON parser (applied_versions, starting_version, ending_version,
+// duration_millis) so CI consumers can pin assertions on schema terminus
+// without re-parsing Flyway output themselves.
 func makeHook(out io.Writer, asJSON bool) func(migration.TenantResult) {
 	if asJSON {
 		enc := json.NewEncoder(out)
@@ -266,6 +270,7 @@ func makeHook(out io.Writer, asJSON bool) func(migration.TenantResult) {
 				"vendor":    r.Vendor,
 				"duration":  r.Duration.String(),
 			}
+			addResultFields(rec, &r.Result)
 			if r.Err != nil {
 				rec["error"] = r.Err.Error()
 				rec["status"] = "fail"
@@ -281,9 +286,53 @@ func makeHook(out io.Writer, asJSON bool) func(migration.TenantResult) {
 		if r.Err != nil {
 			status = "FAIL"
 			extra = ": " + r.Err.Error()
+		} else if summary := formatSchemaSummary(&r.Result); summary != "" {
+			extra = " " + summary
 		}
 		fmt.Fprintf(out, "  %s (%s) ... %s (%s)%s\n", r.TenantID, vendorOrUnknown(r.Vendor), status, r.Duration.Round(10*time.Millisecond), extra)
 	}
+}
+
+// addResultFields conditionally merges Result fields into the JSON event
+// record. Empty / zero-valued fields are omitted so consumers parsing the
+// stream don't see noise from validate / info actions (which never populate
+// a Result) or from migrate runs where Flyway crashed before emitting JSON.
+func addResultFields(rec map[string]any, r *migration.Result) {
+	if len(r.AppliedVersions) > 0 {
+		rec["applied_versions"] = r.AppliedVersions
+	}
+	if r.StartingVersion != "" {
+		rec["starting_version"] = r.StartingVersion
+	}
+	if r.EndingVersion != "" {
+		rec["ending_version"] = r.EndingVersion
+	}
+	if r.DurationMillis > 0 {
+		rec["duration_millis"] = r.DurationMillis
+	}
+	if r.FlywayVersion != "" {
+		rec["flyway_version"] = r.FlywayVersion
+	}
+	if r.ErrorCode != "" {
+		rec["error_code"] = r.ErrorCode
+	}
+}
+
+// formatSchemaSummary renders the human-readable schema-terminus summary
+// appended to each tenant line ("v0 → v2 (2 applied)" or "v2 (no-op)").
+// Empty when the Result is zero-valued (validate / info actions).
+func formatSchemaSummary(r *migration.Result) string {
+	if r.EndingVersion == "" && len(r.AppliedVersions) == 0 {
+		return ""
+	}
+	from := r.StartingVersion
+	if from == "" {
+		from = "∅"
+	}
+	if len(r.AppliedVersions) == 0 {
+		return fmt.Sprintf("schema=v%s (no-op)", r.EndingVersion)
+	}
+	return fmt.Sprintf("schema=v%s→v%s (%d applied)", from, r.EndingVersion, len(r.AppliedVersions))
 }
 
 func vendorOrUnknown(v string) string {
@@ -311,8 +360,8 @@ func writeSummary(out io.Writer, result *migration.MigrateAllResult, asJSON bool
 	}
 
 	fmt.Fprintf(out, "\n%s summary: %d tenants total, %d failed\n", titleASCII(result.Action.String()), total, len(failed))
-	for _, f := range failed {
-		fmt.Fprintf(out, "  - %s: %v\n", f.TenantID, f.Err)
+	for i := range failed {
+		fmt.Fprintf(out, "  - %s: %v\n", failed[i].TenantID, failed[i].Err)
 	}
 }
 

--- a/tools/migration/internal/commands/constructors_test.go
+++ b/tools/migration/internal/commands/constructors_test.go
@@ -191,6 +191,61 @@ func TestMakeHookPlainText(t *testing.T) {
 	assert.Contains(t, out, "FAIL")
 }
 
+func TestMakeHookJSONIncludesStructuredResultFields(t *testing.T) {
+	// The CLI's JSON-mode hook is the contract consumers (CI pipelines) rely
+	// on. Adding new fields is non-breaking, but they must show up exactly
+	// when the underlying Result was populated — never on Err-only entries.
+	var buf bytes.Buffer
+	hook := makeHook(&buf, true)
+	hook(migration.TenantResult{
+		TenantID: "tenant_acme",
+		Vendor:   "postgresql",
+		Duration: 50 * time.Millisecond,
+		Result: migration.Result{
+			Success:         true,
+			AppliedVersions: []string{"1", "2"},
+			StartingVersion: "",
+			EndingVersion:   "2",
+			DurationMillis:  42,
+			FlywayVersion:   "10.22.0",
+		},
+	})
+	out := buf.String()
+	assert.Contains(t, out, `"applied_versions":["1","2"]`)
+	assert.Contains(t, out, `"ending_version":"2"`)
+	assert.NotContains(t, out, `"starting_version"`, "empty StartingVersion should be omitted, not emitted as \"\"")
+	assert.Contains(t, out, `"duration_millis":42`)
+	assert.Contains(t, out, `"flyway_version":"10.22.0"`)
+}
+
+func TestMakeHookPlainTextRendersSchemaSummary(t *testing.T) {
+	var buf bytes.Buffer
+	hook := makeHook(&buf, false)
+	// Fresh-apply: ∅ → v2 with 2 migrations.
+	hook(migration.TenantResult{
+		TenantID: "fresh",
+		Vendor:   "postgresql",
+		Duration: 10 * time.Millisecond,
+		Result: migration.Result{
+			AppliedVersions: []string{"1", "2"},
+			EndingVersion:   "2",
+		},
+	})
+	// No-op rerun: starting and ending both at v2, zero applied.
+	hook(migration.TenantResult{
+		TenantID: "noop",
+		Vendor:   "postgresql",
+		Duration: 1 * time.Millisecond,
+		Result: migration.Result{
+			StartingVersion: "2",
+			EndingVersion:   "2",
+		},
+	})
+	out := buf.String()
+	assert.Contains(t, out, "schema=v∅→v2 (2 applied)")
+	assert.Contains(t, out, "schema=v2 (no-op)")
+}
+
 func TestWriteSummaryJSON(t *testing.T) {
 	var buf bytes.Buffer
 	result := &migration.MigrateAllResult{

--- a/tools/migration/internal/commands/constructors_test.go
+++ b/tools/migration/internal/commands/constructors_test.go
@@ -246,6 +246,18 @@ func TestMakeHookPlainTextRendersSchemaSummary(t *testing.T) {
 	assert.Contains(t, out, "schema=v2 (no-op)")
 }
 
+func TestFormatSchemaSummaryFallsBackToLastAppliedWhenEndingMissing(t *testing.T) {
+	// Defensive against a Flyway-output shape we didn't fully parse: when
+	// AppliedVersions is populated but EndingVersion came back empty (e.g.
+	// parser tolerated a missing targetSchemaVersion field), the summary
+	// must still render a usable terminus rather than "v→v".
+	got := formatSchemaSummary(&migration.Result{
+		AppliedVersions: []string{"3", "4"},
+		StartingVersion: "2",
+	})
+	assert.Equal(t, "schema=v2→v4 (2 applied)", got)
+}
+
 func TestWriteSummaryJSON(t *testing.T) {
 	var buf bytes.Buffer
 	result := &migration.MigrateAllResult{


### PR DESCRIPTION
## Summary

Closes the production-code and docs gaps on three open issues in the migration epic (parent #375):

- **#376** — `FlywayMigrator.Migrate` / `MigrateFor` now return `(Result, error)`. The new `Result` type carries `AppliedVersions` / `StartingVersion` / `EndingVersion` / `DurationMillis` / `FlywayVersion` / `ErrorCode` / `ErrorMessage` parsed from Flyway's `-outputType=json` output. `AuditEvent.Version` is populated from `Result.EndingVersion`; new `Attributes` keys carry `migration.flyway_version` and `migration.applied_versions` (CSV). This closes the deferred TODO previously documented at `migration/flyway.go::emitMigrationApplied`.
- **#377** — `migration.TenantResult` embeds the per-target `Result`; `multi_tenant.runOne` threads it through both sequential and parallel code paths.
- **#383** — `tools/migration`'s CLI hook surfaces the structured fields in JSON mode (`applied_versions` / `starting_version` / `ending_version` / `duration_millis` / `flyway_version`, omitted when zero) and plain-text mode (`schema=v∅→v2 (2 applied)` / `schema=v2 (no-op)`). New `tools/migration/README.md` covers invocation, flag groups, env vars, JSON output schema, and CI integration.

Parser fixtures (`migration/testdata/flyway/*.json`) captured against real Flyway 10.22 via Docker (no host install required). `.gitignore` allowlist extended to track `*.json` / `*.sql` under the existing allowlist pattern.

## Deferred to a follow-up

The testcontainers Postgres integration tests called for in #376/#377/#383 ACs (checksum-mismatch fail-fast, advisory-lock serialization, parallel non-blocking targets, CLI end-to-end) are NOT in this PR — they're tracked in **#422**, which also covers installing the Flyway CLI in `.github/workflows/ci-v2.yml`'s `framework-integration-test` job. Once #422 lands, that PR plus this one fully close #376/#377/#383.

## Why split

- Production-code review and CI-infra review have different reviewer concerns.
- The parser is fully unit-testable today against captured Flyway fixtures (8 result-parser tests + 2 args-flag tests + 1 audit-Version test); the integration tests are blocked on CI changes outside the PR's scope.
- Per CLAUDE.md workflow rules, ran both `/simplify` and `/security-audit` on the staged diff — simplify produced 6 fixes (state-machine → `json.Decoder`, run-method consolidation, test-stub deduplication, fixture-read deduplication, task-referencing comment removal); security-audit returned 0 findings.

## Test plan

- [x] `make check` green on the framework module
- [x] `make check-all` green (tools/openapi builds against the API change)
- [x] `tools/migration make check` green (separate Go module)
- [x] `golangci-lint --enable gosec` 0 issues on `migration/...` and `tools/migration/...`
- [x] `govulncheck` clean on both modules
- [x] Parser unit tests cover migrate-success, migrate-noop, checksum-failure shapes plus malformed / empty / leading-noise / trailing-noise edges
- [x] New `TestMigrateRequestsJSONOutputAndParsesResult` confirms `-outputType=json` reaches the subprocess for migrate
- [x] New `TestInfoAndValidateDoNotRequestJSONOutput` confirms the flag does NOT reach info/validate (preserves operator-facing pretty output)
- [x] New `TestMigrationAppliedCarriesParsedVersionAndAttributes` confirms `AuditEvent.Version` mirrors `Result.EndingVersion`
- [x] New CLI tests confirm structured fields land in JSON output and the schema-terminus summary in plain text

## Breaking changes

- `FlywayMigrator.Migrate(ctx, cfg)` → returns `(Result, error)` (was `error`)
- `FlywayMigrator.MigrateFor(ctx, db, cfg)` → returns `(Result, error)` (was `error`)
- `RunMigrationsAtStartup` signature unchanged (discards the new Result internally)
- `Info` / `Validate` / `InfoFor` / `ValidateFor` signatures unchanged

The breaking change is justified per the project manifesto's "Type Safety > Dynamic Hacks" principle — making the structured Result a first-class return value preserves compile-time safety and aligns with the original AC's "per-target result includes..." requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migration operations now return structured results with parsed version, applied versions, duration, and Flyway metadata.
  * Audit events and JSON/CLI outputs include richer migration fields and schema summaries.

* **Documentation**
  * Added comprehensive migration tool guide with usage, flags, CI JSON semantics, and examples.

* **Tests**
  * Expanded tests and fixtures for JSON parsing, result parsing, audit emission, and output formatting.

* **Chores**
  * .gitignore updated to allow JSON/SQL test fixtures in testdata directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/421)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->