### PR TITLE
feat(logger): auto-select console vs JSON output based on TTY and observability

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -165,7 +165,7 @@ func createBootstrapLogger() logger.Logger {
 	// optimistically assume OTLP logs are off. If they turn out to be on,
 	// WithOTelProvider's fail-fast will surface the conflict.
 	pretty := logger.ResolvePretty(
-		os.Getenv("LOG_FORMAT"),
+		os.Getenv("LOG_OUTPUT_FORMAT"),
 		false,
 		false,
 		logger.StdoutIsTerminal(),

--- a/app/app.go
+++ b/app/app.go
@@ -152,22 +152,24 @@ func resolveServer(cfg *config.Config, log logger.Logger, opts *Options) ServerR
 // createBootstrapLogger creates a logger with smart defaults for bootstrap/initialization logging.
 // This logger is available even when configuration loading fails.
 func createBootstrapLogger() logger.Logger {
-	// Smart defaults: debug in dev, info in prod
 	level := logger.LevelInfo
-	pretty := false
-
-	// Check environment for development mode
 	env := strings.TrimSpace(os.Getenv("APP_ENV"))
 	if env == "" || strings.EqualFold(env, "development") || strings.EqualFold(env, "dev") {
 		level = logger.LevelDebug
-		pretty = true
 	}
-
-	// Allow override via environment variable
 	if envLevel := os.Getenv("LOG_LEVEL"); envLevel != "" {
 		level = envLevel
 	}
 
+	// Bootstrap runs before observability config is unmarshaled, so we
+	// optimistically assume OTLP logs are off. If they turn out to be on,
+	// WithOTelProvider's fail-fast will surface the conflict.
+	pretty := logger.ResolvePretty(
+		os.Getenv("LOG_FORMAT"),
+		false,
+		false,
+		logger.StdoutIsTerminal(),
+	)
 	return logger.New(level, pretty)
 }
 

--- a/app/app_builder.go
+++ b/app/app_builder.go
@@ -53,7 +53,13 @@ func (b *Builder) CreateLogger() *Builder {
 		return b
 	}
 
-	b.logger = logger.New(b.cfg.Log.Level, b.cfg.Log.Pretty)
+	pretty := logger.ResolvePretty(
+		b.cfg.Log.Output.Format,
+		b.cfg.Log.Pretty,
+		otlpLogsActive(b.cfg),
+		logger.StdoutIsTerminal(),
+	)
+	b.logger = logger.New(b.cfg.Log.Level, pretty)
 	b.logger.Info().
 		Str("app", b.cfg.App.Name).
 		Str("env", b.cfg.App.Env).
@@ -61,6 +67,17 @@ func (b *Builder) CreateLogger() *Builder {
 		Msg("Starting application")
 
 	return b
+}
+
+// otlpLogsActive reports whether OTLP log export will run after bootstrap.
+// Reads raw koanf keys because observability.Config is unmarshaled later in
+// initializeObservability, and the logger is created first. Mirrors the
+// defaulting rule in observability.Config.applyLogsDefaults: when
+// observability is enabled, logs default to enabled unless explicitly off.
+func otlpLogsActive(cfg *config.Config) bool {
+	return cfg != nil &&
+		cfg.Bool("observability.enabled", false) &&
+		cfg.Bool("observability.logs.enabled", true)
 }
 
 // CreateBootstrap creates the bootstrap helper for dependency resolution.

--- a/app/app_builder_test.go
+++ b/app/app_builder_test.go
@@ -86,6 +86,65 @@ func TestAppBuilderCreateLoggerErrors(t *testing.T) {
 	})
 }
 
+func TestAppBuilderCreateLoggerWithFormat(t *testing.T) {
+	// Verify the builder wiring accepts every format value without erroring
+	// and produces a logger. Pretty-mode resolution itself is covered
+	// exhaustively in logger.TestResolvePretty.
+	cases := []string{"", "auto", "console", "json", "pretty", "structured", "AUTO"}
+
+	for _, format := range cases {
+		t.Run("format="+format, func(t *testing.T) {
+			cfg := &config.Config{
+				App: config.AppConfig{Name: "test-app", Env: "test", Version: "1.0.0"},
+				Log: config.LogConfig{
+					Level:  "info",
+					Output: config.OutputConfig{Format: format},
+				},
+			}
+
+			result := NewAppBuilder().WithConfig(cfg, &Options{}).CreateLogger()
+			assert.Nil(t, result.err)
+			assert.NotNil(t, result.logger)
+		})
+	}
+}
+
+func TestOtlpLogsActive(t *testing.T) {
+	t.Run("nil_config_returns_false", func(t *testing.T) {
+		assert.False(t, otlpLogsActive(nil))
+	})
+
+	t.Run("observability_disabled_returns_false", func(t *testing.T) {
+		cfg := loadConfigFromYAML(t, minimumValidConfig+`
+observability:
+  enabled: false
+`)
+		assert.False(t, otlpLogsActive(cfg))
+	})
+
+	t.Run("observability_enabled_logs_default_returns_true", func(t *testing.T) {
+		cfg := loadConfigFromYAML(t, minimumValidConfig+`
+observability:
+  enabled: true
+  service:
+    name: test
+`)
+		assert.True(t, otlpLogsActive(cfg))
+	})
+
+	t.Run("observability_enabled_logs_explicitly_disabled_returns_false", func(t *testing.T) {
+		cfg := loadConfigFromYAML(t, minimumValidConfig+`
+observability:
+  enabled: true
+  service:
+    name: test
+  logs:
+    enabled: false
+`)
+		assert.False(t, otlpLogsActive(cfg))
+	})
+}
+
 func TestAppBuilderCreateBootstrapErrors(t *testing.T) {
 	t.Run("missing logger", func(t *testing.T) {
 		cfg := &config.Config{}

--- a/app/testhelpers_test.go
+++ b/app/testhelpers_test.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaborage/go-bricks/config"
+)
+
+// loadConfigFromYAML writes the given YAML to a temp config.yaml and loads
+// it via config.Load(). It restores the original working directory on cleanup.
+func loadConfigFromYAML(t *testing.T, yaml string) *config.Config {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(yaml), 0o600))
+
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.Chdir(origDir)
+	})
+	require.NoError(t, os.Chdir(tmpDir))
+
+	cfg, err := config.Load()
+	require.NoError(t, err)
+	return cfg
+}
+
+// minimumValidConfig contains the keys config.Load() requires to pass
+// validation (app + server + database). Tests append their own sections.
+const minimumValidConfig = `
+app:
+  name: test-app
+  version: 1.0.0
+  env: development
+server:
+  host: localhost
+  port: 8080
+database:
+  type: postgresql
+  host: localhost
+  port: 5432
+  database: testdb
+  username: testuser
+  password: testpass
+log:
+  level: info
+`

--- a/app/testhelpers_test.go
+++ b/app/testhelpers_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,10 +11,18 @@ import (
 	"github.com/gaborage/go-bricks/config"
 )
 
+// configLoadMu serializes os.Chdir + config.Load() so callers of
+// loadConfigFromYAML are safe under t.Parallel() if anyone adds it later.
+var configLoadMu sync.Mutex
+
 // loadConfigFromYAML writes the given YAML to a temp config.yaml and loads
-// it via config.Load(). It restores the original working directory on cleanup.
+// it via config.Load(). It restores the working directory before returning, so
+// callers are not exposed to the temporary chdir.
 func loadConfigFromYAML(t *testing.T, yaml string) *config.Config {
 	t.Helper()
+
+	configLoadMu.Lock()
+	defer configLoadMu.Unlock()
 
 	tmpDir := t.TempDir()
 	cfgPath := filepath.Join(tmpDir, "config.yaml")
@@ -21,10 +30,8 @@ func loadConfigFromYAML(t *testing.T, yaml string) *config.Config {
 
 	origDir, err := os.Getwd()
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.Chdir(origDir)
-	})
 	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
 
 	cfg, err := config.Load()
 	require.NoError(t, err)

--- a/config/config.go
+++ b/config/config.go
@@ -138,7 +138,7 @@ func loadDefaults(k *koanf.Koanf) error {
 
 		fieldLogLevel:       logger.LevelInfo,
 		"log.pretty":        false,
-		"log.output.format": "json",
+		"log.output.format": "auto",
 		"log.output.file":   "",
 
 		// Debug endpoints defaults (disabled by default for security)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -63,7 +63,7 @@ func TestLoadWithDefaults(t *testing.T) {
 
 	assert.Equal(t, "info", cfg.Log.Level)
 	assert.False(t, cfg.Log.Pretty)
-	assert.Equal(t, "json", cfg.Log.Output.Format)
+	assert.Equal(t, "auto", cfg.Log.Output.Format)
 	assert.Equal(t, "", cfg.Log.Output.File)
 }
 
@@ -210,7 +210,7 @@ func TestLoadDefaultsInternalFunction(t *testing.T) {
 
 	assert.Equal(t, "info", k.String("log.level"))
 	assert.False(t, k.Bool("log.pretty"))
-	assert.Equal(t, "json", k.String("log.output.format"))
+	assert.Equal(t, "auto", k.String("log.output.format"))
 	assert.Equal(t, "", k.String("log.output.file"))
 }
 

--- a/config/types.go
+++ b/config/types.go
@@ -280,7 +280,8 @@ type RedisConfig struct {
 	MaxRetryBackoff time.Duration `koanf:"maxretrybackoff" json:"maxretrybackoff" yaml:"maxretrybackoff" toml:"maxretrybackoff" mapstructure:"maxretrybackoff"`
 }
 
-// LogConfig holds logging settings.
+// LogConfig holds logging settings. See OutputConfig.Format for the
+// rendering-mode selector (auto/console/json) and the legacy Pretty override.
 type LogConfig struct {
 	Level  string       `koanf:"level" json:"level" yaml:"level" toml:"level" mapstructure:"level"`
 	Pretty bool         `koanf:"pretty" json:"pretty" yaml:"pretty" toml:"pretty" mapstructure:"pretty"`
@@ -288,6 +289,16 @@ type LogConfig struct {
 }
 
 // OutputConfig holds log output settings.
+//
+// Format selects the rendering mode for stdout, evaluated case-insensitively:
+//   - "auto" (default): console output only when stdout is a terminal AND OTLP
+//     log export is not active; otherwise JSON.
+//   - "console" / "pretty": always console (colored).
+//   - "json" / "structured": always JSON.
+//
+// LogConfig.Pretty=true is a legacy override that always forces console output.
+// Console output is incompatible with OTLP log export — that combination
+// panics at startup via logger.WithOTelProvider.
 type OutputConfig struct {
 	Format string `koanf:"format" json:"format" yaml:"format" toml:"format" mapstructure:"format"`
 	File   string `koanf:"file" json:"file" yaml:"file" toml:"file" mapstructure:"file"`

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/term v0.42.0
 	google.golang.org/grpc v1.81.0
 )
 

--- a/llms.txt
+++ b/llms.txt
@@ -76,7 +76,9 @@ observability:
     endpoint: stdout  # stdout | http://collector:4318/v1/traces | collector:4317 (gRPC)
 logger:
   level: info
-  pretty: false  # Must be false when observability is enabled (pretty + OTLP logs = panic)
+  output:
+    format: auto  # auto (default) | console | json — auto colors TTY stdout when OTLP logs are off
+  pretty: false   # Legacy explicit override; must be false when observability.logs.enabled is true
 ```
 
 `Highest precedence first: env vars > config.<env>.yaml > config.yaml > struct defaults.`

--- a/logger/format.go
+++ b/logger/format.go
@@ -1,0 +1,43 @@
+package logger
+
+import (
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// Log format constants used by config.OutputConfig.Format.
+// "pretty" and "structured" are accepted aliases for "console" and "json".
+const (
+	FormatAuto    = "auto"
+	FormatConsole = "console"
+	FormatJSON    = "json"
+)
+
+// ResolvePretty decides whether the logger should run in pretty (console) mode.
+//
+// legacyPretty=true wins over format because users opting in via the older
+// log.pretty boolean expect their preference to stick. Combined with
+// otlpLogsActive=true it will panic at startup via WithOTelProvider — that
+// fail-fast is intentional: silently muting the log shipping pipeline would
+// be a worse outcome than a clear startup error.
+func ResolvePretty(format string, legacyPretty, otlpLogsActive, isTerminal bool) bool {
+	if legacyPretty {
+		return true
+	}
+
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case FormatConsole, "pretty":
+		return true
+	case FormatJSON, "structured":
+		return false
+	default:
+		return isTerminal && !otlpLogsActive
+	}
+}
+
+// StdoutIsTerminal reports whether os.Stdout is attached to a terminal.
+func StdoutIsTerminal() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}

--- a/logger/format_test.go
+++ b/logger/format_test.go
@@ -1,0 +1,147 @@
+package logger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolvePretty(t *testing.T) {
+	tests := []struct {
+		name           string
+		format         string
+		legacyPretty   bool
+		otlpLogsActive bool
+		isTerminal     bool
+		want           bool
+	}{
+		{
+			name:           "legacy_pretty_true_wins_over_format_json",
+			format:         FormatJSON,
+			legacyPretty:   true,
+			otlpLogsActive: false,
+			isTerminal:     false,
+			want:           true,
+		},
+		{
+			name:           "legacy_pretty_true_wins_over_obs_active",
+			format:         FormatAuto,
+			legacyPretty:   true,
+			otlpLogsActive: true,
+			isTerminal:     true,
+			want:           true,
+		},
+		{
+			name:           "format_console_always_pretty",
+			format:         FormatConsole,
+			legacyPretty:   false,
+			otlpLogsActive: false,
+			isTerminal:     false,
+			want:           true,
+		},
+		{
+			name:           "format_pretty_alias_is_console",
+			format:         "pretty",
+			legacyPretty:   false,
+			otlpLogsActive: false,
+			isTerminal:     false,
+			want:           true,
+		},
+		{
+			name:           "format_console_case_insensitive",
+			format:         "CONSOLE",
+			legacyPretty:   false,
+			otlpLogsActive: false,
+			isTerminal:     false,
+			want:           true,
+		},
+		{
+			name:           "format_json_always_structured",
+			format:         FormatJSON,
+			legacyPretty:   false,
+			otlpLogsActive: false,
+			isTerminal:     true,
+			want:           false,
+		},
+		{
+			name:           "format_structured_alias_is_json",
+			format:         "structured",
+			legacyPretty:   false,
+			otlpLogsActive: false,
+			isTerminal:     true,
+			want:           false,
+		},
+		{
+			name:           "auto_tty_no_otlp_pretty",
+			format:         FormatAuto,
+			legacyPretty:   false,
+			otlpLogsActive: false,
+			isTerminal:     true,
+			want:           true,
+		},
+		{
+			name:           "auto_tty_with_otlp_json",
+			format:         FormatAuto,
+			legacyPretty:   false,
+			otlpLogsActive: true,
+			isTerminal:     true,
+			want:           false,
+		},
+		{
+			name:           "auto_no_tty_no_otlp_json",
+			format:         FormatAuto,
+			legacyPretty:   false,
+			otlpLogsActive: false,
+			isTerminal:     false,
+			want:           false,
+		},
+		{
+			name:           "empty_format_treated_as_auto_tty",
+			format:         "",
+			legacyPretty:   false,
+			otlpLogsActive: false,
+			isTerminal:     true,
+			want:           true,
+		},
+		{
+			name:           "whitespace_format_treated_as_auto",
+			format:         "   ",
+			legacyPretty:   false,
+			otlpLogsActive: false,
+			isTerminal:     true,
+			want:           true,
+		},
+		{
+			name:           "unknown_format_falls_back_to_auto",
+			format:         "yaml",
+			legacyPretty:   false,
+			otlpLogsActive: false,
+			isTerminal:     true,
+			want:           true,
+		},
+		{
+			name:           "unknown_format_no_tty_is_json",
+			format:         "yaml",
+			legacyPretty:   false,
+			otlpLogsActive: false,
+			isTerminal:     false,
+			want:           false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolvePretty(tc.format, tc.legacyPretty, tc.otlpLogsActive, tc.isTerminal)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestStdoutIsTerminalDoesNotPanic(t *testing.T) {
+	// Under `go test`, stdout is usually not a TTY (it's a pipe to the test
+	// runner). We don't care about the exact return value — we only verify
+	// the function is safe to call and returns a bool without crashing.
+	assert.NotPanics(t, func() {
+		_ = StdoutIsTerminal()
+	})
+}

--- a/wiki/observability.md
+++ b/wiki/observability.md
@@ -38,6 +38,8 @@ Span helpers: `AssertSpanName`, `AssertSpanAttribute`, `AssertSpanStatus`, `Asse
 
 **Common Issues:** Spans not appearing (check `observability.enabled`, wait for batch timeout), logs not exported (verify `observability.logs.enabled`, set `logger.pretty: false`), pretty mode conflict (fails fast at startup). See the Troubleshooting section in [CLAUDE.md](../CLAUDE.md#troubleshooting) for details
 
+**Log format selection (`log.output.format`):** Defaults to `auto`, which resolves to console (colored) output when stdout is a terminal AND OTLP log export is not active; otherwise structured JSON. Explicit values: `console` / `pretty` (always colored), `json` / `structured` (always JSON). The legacy `log.pretty: true` still works and overrides `log.output.format`. Combining pretty output with `observability.logs.enabled: true` still panics at startup — `auto` is the safe default that keeps local dev colored and production JSON without manual configuration.
+
 ## Custom Metrics
 
 GoBricks exposes `MeterProvider` via `ModuleDeps` for creating application-specific metrics. When `observability.enabled: false`, a no-op provider is used with zero overhead.

--- a/wiki/observability.md
+++ b/wiki/observability.md
@@ -36,7 +36,7 @@ Span helpers: `AssertSpanName`, `AssertSpanAttribute`, `AssertSpanStatus`, `Asse
 
 **Debug Mode:** Set `GOBRICKS_DEBUG=true` for `[OBSERVABILITY]` logs (provider init, exporter setup, span lifecycle)
 
-**Common Issues:** Spans not appearing (check `observability.enabled`, wait for batch timeout), logs not exported (verify `observability.logs.enabled`, set `logger.pretty: false`), pretty mode conflict (fails fast at startup). See the Troubleshooting section in [CLAUDE.md](../CLAUDE.md#troubleshooting) for details
+**Common Issues:** Spans not appearing (check `observability.enabled`, wait for batch timeout), logs not exported (verify `observability.logs.enabled`, set `log.pretty: false`), pretty mode conflict (fails fast at startup). See the Troubleshooting section in [CLAUDE.md](../CLAUDE.md#troubleshooting) for details
 
 **Log format selection (`log.output.format`):** Defaults to `auto`, which resolves to console (colored) output when stdout is a terminal AND OTLP log export is not active; otherwise structured JSON. Explicit values: `console` / `pretty` (always colored), `json` / `structured` (always JSON). The legacy `log.pretty: true` still works and overrides `log.output.format`. Combining pretty output with `observability.logs.enabled: true` still panics at startup — `auto` is the safe default that keeps local dev colored and production JSON without manual configuration.
 

--- a/wiki/troubleshooting.md
+++ b/wiki/troubleshooting.md
@@ -120,11 +120,11 @@ database:
 
 ```bash
 # "cannot use OTLP logs with pretty=true"
-# → Set logger.pretty: false when observability.logs.enabled: true
-# → Or omit logger.pretty entirely and rely on log.output.format: auto (default)
+# → Set log.pretty: false when observability.logs.enabled: true
+# → Or omit log.pretty entirely and rely on log.output.format: auto (default)
 #   which picks JSON automatically when OTLP logs are active.
 
-# Local logs are uncolored
+# Local logs are not colored as expected
 # → Default is log.output.format: auto, which colors stdout only when it's a TTY
 #   AND OTLP logs aren't active. Force colors via log.output.format: console
 #   (incompatible with observability.logs.enabled: true).

--- a/wiki/troubleshooting.md
+++ b/wiki/troubleshooting.md
@@ -121,6 +121,13 @@ database:
 ```bash
 # "cannot use OTLP logs with pretty=true"
 # → Set logger.pretty: false when observability.logs.enabled: true
+# → Or omit logger.pretty entirely and rely on log.output.format: auto (default)
+#   which picks JSON automatically when OTLP logs are active.
+
+# Local logs are uncolored
+# → Default is log.output.format: auto, which colors stdout only when it's a TTY
+#   AND OTLP logs aren't active. Force colors via log.output.format: console
+#   (incompatible with observability.logs.enabled: true).
 
 # Spans not appearing in collector
 # → Check observability.enabled: true


### PR DESCRIPTION
## Summary
- Local dev without observability now renders **colored console output** by default. New `log.output.format` (default `auto`) picks console when stdout is a TTY and OTLP log export is off, otherwise JSON.
- Explicit values: `console` / `pretty` → always colored, `json` / `structured` → always JSON. Legacy `log.pretty: true` still overrides the format (and still panics at startup when combined with `observability.logs.enabled: true`, matching prior behavior).
- Implementation: pure `logger.ResolvePretty(format, legacyPretty, otlpLogsActive, isTerminal)` helper + `logger.StdoutIsTerminal()`. App builder + bootstrap logger call it instead of reading `cfg.Log.Pretty` directly.
- Repurposed the previously-unused `LogConfig.Output.Format` field rather than adding a new `log.format` key, to avoid two `format` knobs under `log:`.

## Why
Previously the framework defaulted to `pretty: false` so the same default worked under OTLP (JSON-required) and elsewhere. That left local dev with uncolored JSON logs unless users explicitly opted into `log.pretty: true`. The new `auto` default does the right thing in both contexts without manual configuration — local terminals get colored output; Docker/CI/observability-on environments stay JSON.

## Behavior matrix
| Scenario | Old default | New default |
| --- | --- | --- |
| `go run` on a TTY, observability off | JSON | **Console (colored)** |
| Docker / piped stdout, observability off | JSON | JSON (TTY check fails) |
| Observability + OTLP logs on | JSON | JSON (`otlpLogsActive` forces it) |
| Explicit `log.pretty: true` | Console | Console (unchanged) |

## Test plan
- [x] `make check` (framework `fmt + lint + test`) green
- [x] 14 unit tests in `logger.TestResolvePretty` covering the resolution matrix (legacy override, format aliases, case-insensitivity, TTY × OTLP × auto interactions, unknown values fall back to auto)
- [x] `app.TestAppBuilderCreateLoggerWithFormat` exercises the builder wiring for every format value
- [x] `app.TestOtlpLogsActive` covers nil cfg, observability off, observability+logs default, observability+logs explicitly off
- [x] `gosec` clean on changed packages
- [x] `govulncheck` clean

## Follow-ups (not in this PR)
- The existing `OutputConfig.File` field is still dead code. Wiring file output would be a natural next step.
- `loadConfigFromYAML(t, yaml)` test helper in `app/testhelpers_test.go` consolidates a pattern that `app/bootstrap_test.go` open-codes 4 times — those call sites could migrate in a separate cleanup PR.
- `otlpLogsActive` mirrors `observability.Config.applyLogsDefaults`. Exposing a single helper (e.g. `observability.LogsEnabledFromKoanf`) would centralize the rule across all 3 call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Log output defaults to "auto", auto-selecting console (colored) or JSON based on terminal and export state.
  * Added explicit log format options for console/pretty and JSON/structured outputs.

* **Improvements**
  * Smarter detection for when pretty/console output is safe (considers terminal and log export activity).
  * Improved OTLP log export compatibility.

* **Tests**
  * Added coverage validating log-format and OTLP-related behaviors.

* **Documentation**
  * Updated guidance and troubleshooting for log format and OTLP configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/424)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->