### PR TITLE
feat(migration): PostgreSQL migrator-vs-runtime role separation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ make lint                       # Run golangci-lint
 - **messaging/** — AMQP client for RabbitMQ
 - **scheduler/** — gocron-based job scheduling with observability and CIDR-restricted APIs
 - **server/** — Echo-based HTTP server
-- **migration/** — Flyway integration with single- and multi-tenant runners; pairs with `tools/migration` CLI (`go-bricks-migrate`) for CI/CD fleet rollouts. Emits `migration.applied` audit events on every migrate invocation via OTel by default; opt-in `AuditRecorder` for compliance-grade durable delivery. See [multi-tenant-migration.md](wiki/multi-tenant-migration.md), [migration-audit.md](wiki/migration-audit.md), [ADR-018](wiki/adr-018-multi-tenant-migration-cli.md), and [ADR-019](wiki/adr-019-migration-audit-delivery.md).
+- **migration/** — Flyway integration with single- and multi-tenant runners; pairs with `tools/migration` CLI (`go-bricks-migrate`) for CI/CD fleet rollouts. Emits `migration.applied` audit events on every migrate invocation via OTel by default; opt-in `AuditRecorder` for compliance-grade durable delivery. PostgreSQL migrator-vs-runtime role separation (`ProvisionPGRoles` / `PGRoleProvisioningSQL`) gives auditors a flat *no* to "can the running service alter its own schema?". See [multi-tenant-migration.md](wiki/multi-tenant-migration.md), [migration-roles.md](wiki/migration-roles.md), [migration-audit.md](wiki/migration-audit.md), [ADR-018](wiki/adr-018-multi-tenant-migration-cli.md), and [ADR-019](wiki/adr-019-migration-audit-delivery.md).
 - **observability/** — OpenTelemetry tracing and metrics
 - **outbox/** — Transactional outbox for reliable event publishing (at-least-once delivery)
 - **keystore/** — Named RSA key pair management from DER files or base64 env vars

--- a/migration/flyway_integration_test.go
+++ b/migration/flyway_integration_test.go
@@ -24,7 +24,7 @@ func TestFlywayMigrateFreshSchemaPopulatesResult(t *testing.T) {
 	dbCfg := env.dbConfigFor(env.defaultDB)
 	ctx, cancel := testCtx(t)
 	defer cancel()
-	result, err := env.migrator().MigrateFor(ctx, dbCfg, env.flywayConfig())
+	result, err := env.migrator().MigrateFor(ctx, dbCfg, env.flywayConfig(t))
 	require.NoError(t, err)
 
 	assert.True(t, result.Success)
@@ -58,7 +58,7 @@ func TestFlywayMigrateChecksumMismatchFailsFast(t *testing.T) {
 	defer cancel()
 
 	// First run: applies cleanly.
-	res, err := migrator.MigrateFor(ctx, dbCfg, env.flywayConfig())
+	res, err := migrator.MigrateFor(ctx, dbCfg, env.flywayConfig(t))
 	require.NoError(t, err)
 	require.True(t, res.Success)
 	require.Equal(t, []string{"1"}, res.AppliedVersions)
@@ -71,7 +71,7 @@ func TestFlywayMigrateChecksumMismatchFailsFast(t *testing.T) {
 
 	// Second run: must fail fast on checksum mismatch. Live engine output
 	// is verified to match the parsed error envelope shape.
-	res2, err := migrator.MigrateFor(ctx, dbCfg, env.flywayConfig())
+	res2, err := migrator.MigrateFor(ctx, dbCfg, env.flywayConfig(t))
 	require.Error(t, err, "tampered checksum must surface as an error from MigrateFor")
 	assert.False(t, res2.Success)
 	assert.Equal(t, "VALIDATE_ERROR", res2.ErrorCode,

--- a/migration/integration_helpers_test.go
+++ b/migration/integration_helpers_test.go
@@ -25,6 +25,9 @@ import (
 // pattern in testing/containers/postgresql.go so local runs without Flyway
 // installed degrade to a skip rather than a hard failure. CI's framework-
 // integration-test job installs the binary so this branch is exercised.
+//
+// Called lazily by flywayConfig() / migrator() so PG-only role-separation
+// tests can use the same integrationEnv without requiring Flyway.
 func flywayOrSkip(t *testing.T) string {
 	t.Helper()
 	path, err := exec.LookPath("flyway")
@@ -62,12 +65,11 @@ type integrationEnv struct {
 }
 
 // newIntegrationEnv starts a PG testcontainer + scaffolds a per-test Flyway
-// config and migrations directory. flywayOrSkip is checked first so tests
-// fail-fast on hosts without Flyway rather than spending the testcontainer
-// startup time only to skip afterward.
+// config and migrations directory. The Flyway-or-skip check is deferred
+// until flywayConfig() / migrator() is called so PG-only role-separation
+// tests don't require Flyway on PATH.
 func newIntegrationEnv(t *testing.T) *integrationEnv {
 	t.Helper()
-	flywayPath := flywayOrSkip(t)
 
 	parent, cancelParent := testCtx(t)
 	t.Cleanup(cancelParent)
@@ -101,7 +103,6 @@ func newIntegrationEnv(t *testing.T) *integrationEnv {
 
 	return &integrationEnv{
 		container:     pg,
-		flywayPath:    flywayPath,
 		configPath:    configPath,
 		migrationsDir: migrationsDir,
 		host:          host,
@@ -153,8 +154,14 @@ func (e *integrationEnv) dbConfigFor(dbName string) *config.DatabaseConfig {
 
 // flywayConfig returns a *Config wired with the env's binary + conf +
 // migrations directory. Tests typically copy this and override individual
-// fields (e.g. Timeout, Audit) for their scenario.
-func (e *integrationEnv) flywayConfig() *Config {
+// fields (e.g. Timeout, Audit) for their scenario. Lazily resolves the
+// Flyway binary on PATH and t.Skips when absent so PG-only tests reusing
+// integrationEnv don't require Flyway.
+func (e *integrationEnv) flywayConfig(t *testing.T) *Config {
+	t.Helper()
+	if e.flywayPath == "" {
+		e.flywayPath = flywayOrSkip(t)
+	}
 	return &Config{
 		FlywayPath:    e.flywayPath,
 		ConfigPath:    e.configPath,
@@ -219,4 +226,34 @@ type schemaHistoryRow struct {
 	Version     string
 	Description string
 	Success     bool
+}
+
+// adminDB returns a *sql.DB authenticated as the container admin user against
+// the env's default database. Used by role-provisioning integration tests to
+// create roles and schemas before connecting as the freshly-provisioned roles.
+// The connection is closed automatically when the test ends.
+func (e *integrationEnv) adminDB(t *testing.T) *sql.DB {
+	t.Helper()
+	return e.openAsRole(t, e.adminUser, e.adminPassword)
+}
+
+// openAsRole returns a *sql.DB authenticated as the given PostgreSQL role
+// using the env's default database. Used by role-separation tests to verify
+// that DDL is rejected for runtime roles and that DML is permitted for
+// migrator-owned tables via ALTER DEFAULT PRIVILEGES.
+func (e *integrationEnv) openAsRole(t *testing.T, role, password string) *sql.DB {
+	t.Helper()
+	dsn := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable",
+		role, password, e.host, e.port, e.defaultDB)
+	db, err := sql.Open("pgx", dsn)
+	require.NoError(t, err, "open connection as role %q", role)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Eagerly verify the credential — sql.Open is lazy and a bad password
+	// would otherwise surface inside the test body, masking the credential
+	// problem as a feature failure.
+	ctx, cancel := testCtx(t)
+	defer cancel()
+	require.NoError(t, db.PingContext(ctx), "ping as role %q", role)
+	return db
 }

--- a/migration/multi_tenant_integration_test.go
+++ b/migration/multi_tenant_integration_test.go
@@ -32,7 +32,7 @@ func TestMigrateAllAdvisoryLockSerializesConcurrentRuns(t *testing.T) {
 	configs := newFakeConfigProvider(map[string]*config.DatabaseConfig{tenantID: tenantCfg})
 	migrator := env.migrator()
 
-	opts := MigrateAllOptions{BaseConfig: env.flywayConfig()}
+	opts := MigrateAllOptions{BaseConfig: env.flywayConfig(t)}
 	ctx, cancel := testCtx(t)
 	defer cancel()
 
@@ -106,7 +106,7 @@ func TestMigrateAllParallelNonBlocking(t *testing.T) {
 		tenantB: cfgB,
 	})
 	opts := MigrateAllOptions{
-		BaseConfig:  env.flywayConfig(),
+		BaseConfig:  env.flywayConfig(t),
 		Parallelism: 2,
 	}
 

--- a/migration/roles.go
+++ b/migration/roles.go
@@ -1,0 +1,266 @@
+package migration
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// pgPasswordLiteralPattern matches the `PASSWORD 'literal'` clause emitted by
+// buildRoleCreateAndLockdown / buildPGRoleStatements. Used by summarizeStmt
+// to redact the literal before the SQL fragment is wrapped into any error
+// message — keeps the resolved secret out of error logs and stack traces
+// when ExecContext fails on a password-bearing statement.
+//
+// Matches a single-quoted PostgreSQL string literal: an opening single quote,
+// any number of non-quote characters or escaped doubled-quote pairs, then a
+// closing single quote. Case-insensitive on the PASSWORD keyword for safety.
+// The keyword + whitespace prefix is captured in group 1 so the substitution
+// preserves the original casing and spacing.
+var pgPasswordLiteralPattern = regexp.MustCompile(`(?i)(PASSWORD\s+)'(?:[^']|'')*'`)
+
+// PGRoleSpec describes a PostgreSQL role-pair plus per-tenant schema for the
+// migrator-vs-runtime role-separation model defined in issue #378.
+//
+// Migrator role: owns the per-tenant schema, holds DDL privileges, used
+// exclusively by the migration runner. Created with NOSUPERUSER NOCREATEDB
+// NOCREATEROLE NOBYPASSRLS NOREPLICATION so even a compromised migrator
+// credential cannot escalate itself.
+//
+// Runtime role: per-tenant LOGIN role granted only DML on the tenant schema.
+// Does not own the schema, so PostgreSQL's default ownership model rejects
+// ALTER/CREATE/DROP statements from this role without any explicit REVOKE.
+// Granted SELECT/INSERT/UPDATE/DELETE on existing AND future tables via
+// ALTER DEFAULT PRIVILEGES so subsequent migrations don't need per-script grants.
+type PGRoleSpec struct {
+	// Schema is the per-tenant schema name (e.g. "tenant_a"). Owned by
+	// MigratorRole after provisioning.
+	Schema string
+
+	// MigratorRole owns Schema and is used exclusively by the migration runner.
+	// Must differ from RuntimeRole.
+	MigratorRole string
+
+	// MigratorPassword is optionally assigned to MigratorRole via ALTER ROLE
+	// PASSWORD on every call. Useful for the one-time bootstrap and for
+	// secret rotation. Leave empty when credentials are managed externally
+	// (e.g., the role is created out-of-band and password set via a
+	// privileged migration pipeline).
+	MigratorPassword string
+
+	// RuntimeRole is the per-tenant DML-only role consumed by the running
+	// service. Must differ from MigratorRole.
+	RuntimeRole string
+
+	// RuntimePassword is optionally assigned to RuntimeRole. Same semantics
+	// as MigratorPassword — passing it on every call makes secret rotation a
+	// no-op rerun.
+	RuntimePassword string
+}
+
+// ErrInvalidPGIdentifier is returned by Validate when a role or schema name
+// fails the safe-identifier check enforced by ProvisionPGRoles.
+var ErrInvalidPGIdentifier = errors.New("migration: PostgreSQL identifier rejected")
+
+// Field name constants used in Validate error messages. Exported via
+// ErrInvalidPGIdentifier so callers (including tests) can assert which
+// field failed without coupling to the literal string.
+const (
+	pgRoleFieldSchema       = "Schema"
+	pgRoleFieldMigratorRole = "MigratorRole"
+	pgRoleFieldRuntimeRole  = "RuntimeRole"
+)
+
+// safePGIdentifier matches the conservative ASCII subset of PostgreSQL
+// identifiers permitted in role and schema names: letters, digits, and
+// underscores, starting with a letter or underscore, up to 63 bytes (the
+// NAMEDATALEN-1 default). Tenant IDs sourced from outside should be
+// normalized to this subset upstream; rejecting at the migration boundary
+// gives a single forcing function rather than scattering input filters.
+var safePGIdentifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,62}$`)
+
+// Validate reports whether the spec's identifiers pass the safe-identifier
+// check and the two roles differ. Returns ErrInvalidPGIdentifier wrapped
+// with the offending field name (and value) on failure.
+func (s *PGRoleSpec) Validate() error {
+	for _, f := range []struct{ name, value string }{
+		{pgRoleFieldSchema, s.Schema},
+		{pgRoleFieldMigratorRole, s.MigratorRole},
+		{pgRoleFieldRuntimeRole, s.RuntimeRole},
+	} {
+		if !safePGIdentifier.MatchString(f.value) {
+			return fmt.Errorf("%w: %s=%q", ErrInvalidPGIdentifier, f.name, f.value)
+		}
+	}
+	if s.MigratorRole == s.RuntimeRole {
+		return fmt.Errorf("%w: MigratorRole and RuntimeRole must differ", ErrInvalidPGIdentifier)
+	}
+	return nil
+}
+
+// ProvisionPGRoles applies the role-pair + schema described by spec to the
+// PostgreSQL instance reachable via db. All statements are idempotent: a
+// rerun against an already-provisioned tenant is a no-op, except that
+// MigratorPassword / RuntimePassword (when non-empty) are reapplied on
+// every call to support secret rotation.
+//
+// db MUST be authenticated as a role with CREATEROLE plus the right to
+// CREATE SCHEMA AUTHORIZATION <other> — typically the instance bootstrap
+// superuser or a dedicated provisioner role granted those capabilities.
+// The migrator and runtime roles created here cannot self-provision: they
+// are denied SUPERUSER, CREATEDB, CREATEROLE, BYPASSRLS, and REPLICATION
+// per the deliverables of #378.
+//
+// PostgreSQL is not fully transactional across role + schema boundaries
+// (CREATE ROLE in particular is not transactional), so a partial-progress
+// failure can leak intermediate state. Callers should rerun the same spec
+// to converge; the idempotent template makes that safe.
+func ProvisionPGRoles(ctx context.Context, db *sql.DB, spec *PGRoleSpec) error {
+	if spec == nil {
+		return fmt.Errorf("migration: ProvisionPGRoles requires a non-nil *PGRoleSpec")
+	}
+	if db == nil {
+		return fmt.Errorf("migration: ProvisionPGRoles requires a non-nil *sql.DB")
+	}
+	if err := spec.Validate(); err != nil {
+		return err
+	}
+
+	stmts := buildPGRoleStatements(spec)
+	for i, stmt := range stmts {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("migration: provisioning step %d (%s) failed: %w",
+				i, summarizeStmt(stmt), err)
+		}
+	}
+	return nil
+}
+
+// PGRoleProvisioningSQL returns the SQL statements that ProvisionPGRoles
+// would execute for spec, in order. Use this when operators want to inspect
+// or apply the provisioning manually via psql, or feed it into their own
+// migration runner (Flyway, Liquibase) rather than the Go helper.
+//
+// Returns ErrInvalidPGIdentifier when spec fails Validate. The returned
+// slice does not include trailing semicolons; callers concatenating them
+// into a single script should add separators themselves.
+//
+// SECURITY: when spec.MigratorPassword or spec.RuntimePassword is non-empty,
+// the returned statements include the password as an in-clear SQL literal
+// (`ALTER ROLE "..." PASSWORD '<secret>'`). Treat the returned slice as a
+// sensitive value: do not echo it to logs, CI build artifacts, or anywhere
+// the original credential wouldn't be acceptable. Callers preparing scripts
+// for review should redact the literal before persisting to disk.
+func PGRoleProvisioningSQL(spec *PGRoleSpec) ([]string, error) {
+	if spec == nil {
+		return nil, fmt.Errorf("migration: PGRoleProvisioningSQL requires a non-nil *PGRoleSpec")
+	}
+	if err := spec.Validate(); err != nil {
+		return nil, err
+	}
+	return buildPGRoleStatements(spec), nil
+}
+
+// buildPGRoleStatements composes the ordered statement list. Spec is assumed
+// to be non-nil and Validate()-clean.
+func buildPGRoleStatements(spec *PGRoleSpec) []string {
+	schema := quotePGIdent(spec.Schema)
+	migrator := quotePGIdent(spec.MigratorRole)
+	runtime := quotePGIdent(spec.RuntimeRole)
+
+	roles := []struct {
+		quotedIdent string
+		rolname     string
+		password    string
+	}{
+		{migrator, spec.MigratorRole, spec.MigratorPassword},
+		{runtime, spec.RuntimeRole, spec.RuntimePassword},
+	}
+
+	// Pre-size for the worst case: 2 roles × (create + lockdown + password) + 6 schema/grant statements.
+	stmts := make([]string, 0, 2*3+6)
+	for _, r := range roles {
+		stmts = append(stmts, buildRoleCreateAndLockdown(r.rolname, r.quotedIdent)...)
+		if r.password != "" {
+			stmts = append(stmts, fmt.Sprintf(
+				`ALTER ROLE %s PASSWORD %s`,
+				r.quotedIdent, quotePGStringLiteral(r.password),
+			))
+		}
+	}
+
+	stmts = append(stmts,
+		fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s AUTHORIZATION %s`, schema, migrator),
+		fmt.Sprintf(`GRANT USAGE ON SCHEMA %s TO %s`, schema, runtime),
+		// Existing-object grants — required when reprovisioning a schema
+		// that already contains tables created out-of-band.
+		fmt.Sprintf(`GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %s TO %s`, schema, runtime),
+		fmt.Sprintf(`GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA %s TO %s`, schema, runtime),
+		// Future-object grants — the AC-critical bit: ALTER DEFAULT PRIVILEGES
+		// scoped to the migrator role + the tenant schema so tables created
+		// by future Flyway migrations auto-grant to the runtime role.
+		fmt.Sprintf(`ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %s`, migrator, schema, runtime),
+		fmt.Sprintf(`ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO %s`, migrator, schema, runtime),
+	)
+	return stmts
+}
+
+// buildRoleCreateAndLockdown returns the two-statement idempotent template
+// that creates a role (if missing) and snaps its attribute floor back to the
+// locked-down baseline. Used for both the migrator and runtime roles since
+// both share the same NO* attribute requirements.
+//
+// The CREATE wrapped in DO-block is the canonical idempotent pattern because
+// PostgreSQL has no CREATE ROLE IF NOT EXISTS syntax; the unconditional
+// ALTER on the next statement re-applies the attribute floor on every run
+// so manual drift (e.g. someone ran ALTER ROLE ... SUPERUSER) snaps back.
+func buildRoleCreateAndLockdown(rolname, quotedIdent string) []string {
+	const lockdownAttrs = "NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS"
+	return []string{
+		fmt.Sprintf(`DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = %s) THEN
+    CREATE ROLE %s LOGIN %s;
+  END IF;
+END $$`, quotePGStringLiteral(rolname), quotedIdent, lockdownAttrs),
+		fmt.Sprintf(`ALTER ROLE %s %s`, quotedIdent, lockdownAttrs),
+	}
+}
+
+// quotePGIdent returns the PostgreSQL-safe quoted form of ident. Callers must
+// have verified ident via safePGIdentifier or PGRoleSpec.Validate first;
+// the double-quote escaping here is belt-and-suspenders for the (regex-
+// rejected) embedded-quote case.
+func quotePGIdent(ident string) string {
+	return `"` + strings.ReplaceAll(ident, `"`, `""`) + `"`
+}
+
+// quotePGStringLiteral returns the PostgreSQL-safe quoted form of a string
+// literal under standard_conforming_strings=on (the default since PG 9.1).
+// Doubles embedded single quotes; backslashes are literal under this setting
+// and need no escaping.
+func quotePGStringLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, `'`, `''`) + "'"
+}
+
+// summarizeStmt returns the first line of stmt, trimmed and truncated to 80
+// chars, for use in provisioning error messages. Keeps the wrapping error
+// short while still naming the failing statement.
+//
+// Redacts any `PASSWORD '<literal>'` clause before truncation so a failure
+// on ALTER ROLE ... PASSWORD doesn't leak the resolved secret into the
+// returned error string (which downstream callers may log).
+func summarizeStmt(stmt string) string {
+	first := stmt
+	if idx := strings.IndexByte(stmt, '\n'); idx > 0 {
+		first = stmt[:idx]
+	}
+	first = strings.TrimSpace(first)
+	first = pgPasswordLiteralPattern.ReplaceAllString(first, "${1}'[REDACTED]'")
+	if len(first) > 80 {
+		first = first[:80] + "..."
+	}
+	return first
+}

--- a/migration/roles_integration_test.go
+++ b/migration/roles_integration_test.go
@@ -1,0 +1,210 @@
+//go:build integration
+
+package migration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPGRolesRuntimeRoleRejectedOnDDL verifies the role-separation acceptance
+// criterion: a runtime role attempting CREATE/ALTER/DROP TABLE against its
+// own schema must be rejected by PostgreSQL. The runtime role does not own
+// the schema (the migrator does), so default PG ownership semantics enforce
+// this without explicit REVOKE statements.
+func TestPGRolesRuntimeRoleRejectedOnDDL(t *testing.T) {
+	env := newIntegrationEnv(t)
+	spec := &PGRoleSpec{
+		Schema:           "tenant_ddl",
+		MigratorRole:     "mig_ddl",
+		MigratorPassword: "mig-ddl-pw-1234",
+		RuntimeRole:      "rt_ddl",
+		RuntimePassword:  "rt-ddl-pw-1234",
+	}
+
+	ctx, cancel := testCtx(t)
+	defer cancel()
+
+	admin := env.adminDB(t)
+	require.NoError(t, ProvisionPGRoles(ctx, admin, spec))
+
+	// Pre-seed an existing table via the migrator so we can exercise ALTER
+	// and DROP. CREATE TABLE is exercised separately below — it needs no
+	// pre-existing object.
+	migratorDB := env.openAsRole(t, spec.MigratorRole, spec.MigratorPassword)
+	_, err := migratorDB.ExecContext(ctx,
+		fmt.Sprintf(`CREATE TABLE %s.widgets (id INT PRIMARY KEY, label TEXT)`,
+			quotePGIdent(spec.Schema)))
+	require.NoError(t, err, "migrator must be able to create tables in its own schema")
+
+	runtimeDB := env.openAsRole(t, spec.RuntimeRole, spec.RuntimePassword)
+
+	// CREATE TABLE — rejected because the runtime role lacks CREATE on the schema.
+	_, err = runtimeDB.ExecContext(ctx,
+		fmt.Sprintf(`CREATE TABLE %s.unauthorized (id INT)`, quotePGIdent(spec.Schema)))
+	require.Error(t, err, "runtime role must not be able to CREATE TABLE")
+	assert.True(t, isPermissionDenied(err), "CREATE TABLE should fail with permission denied, got: %v", err)
+
+	// ALTER TABLE — rejected because the runtime role is not the table owner.
+	_, err = runtimeDB.ExecContext(ctx,
+		fmt.Sprintf(`ALTER TABLE %s.widgets ADD COLUMN sneaky TEXT`, quotePGIdent(spec.Schema)))
+	require.Error(t, err, "runtime role must not be able to ALTER TABLE")
+	assert.True(t, isPermissionDenied(err), "ALTER TABLE should fail with permission denied, got: %v", err)
+
+	// DROP TABLE — rejected for the same reason.
+	_, err = runtimeDB.ExecContext(ctx,
+		fmt.Sprintf(`DROP TABLE %s.widgets`, quotePGIdent(spec.Schema)))
+	require.Error(t, err, "runtime role must not be able to DROP TABLE")
+	assert.True(t, isPermissionDenied(err), "DROP TABLE should fail with permission denied, got: %v", err)
+}
+
+// TestPGRolesAlterDefaultPrivilegesAutoGrants verifies the second acceptance
+// criterion: after the migrator creates a new table, the runtime role must
+// automatically have SELECT/INSERT/UPDATE/DELETE on it via ALTER DEFAULT
+// PRIVILEGES — no per-migration grant DDL required.
+func TestPGRolesAlterDefaultPrivilegesAutoGrants(t *testing.T) {
+	env := newIntegrationEnv(t)
+	spec := &PGRoleSpec{
+		Schema:           "tenant_adp",
+		MigratorRole:     "mig_adp",
+		MigratorPassword: "mig-adp-pw-1234",
+		RuntimeRole:      "rt_adp",
+		RuntimePassword:  "rt-adp-pw-1234",
+	}
+
+	ctx, cancel := testCtx(t)
+	defer cancel()
+
+	admin := env.adminDB(t)
+	require.NoError(t, ProvisionPGRoles(ctx, admin, spec))
+
+	// Migrator creates a new table AFTER provisioning ran — this is what
+	// ALTER DEFAULT PRIVILEGES covers (existing-table grants ran during
+	// provisioning, but at that point the schema was empty).
+	migratorDB := env.openAsRole(t, spec.MigratorRole, spec.MigratorPassword)
+	createTable := fmt.Sprintf(
+		`CREATE TABLE %s.gadgets (id INT PRIMARY KEY, name TEXT NOT NULL, qty INT NOT NULL DEFAULT 0)`,
+		quotePGIdent(spec.Schema),
+	)
+	_, err := migratorDB.ExecContext(ctx, createTable)
+	require.NoError(t, err)
+
+	runtimeDB := env.openAsRole(t, spec.RuntimeRole, spec.RuntimePassword)
+	qualified := quotePGIdent(spec.Schema) + ".gadgets"
+
+	// INSERT
+	_, err = runtimeDB.ExecContext(ctx,
+		fmt.Sprintf(`INSERT INTO %s (id, name, qty) VALUES (1, 'widget-a', 5)`, qualified))
+	require.NoError(t, err, "ALTER DEFAULT PRIVILEGES must auto-grant INSERT on future tables")
+
+	// SELECT
+	var name string
+	var qty int
+	err = runtimeDB.QueryRowContext(ctx,
+		fmt.Sprintf(`SELECT name, qty FROM %s WHERE id = 1`, qualified)).Scan(&name, &qty)
+	require.NoError(t, err, "ALTER DEFAULT PRIVILEGES must auto-grant SELECT on future tables")
+	assert.Equal(t, "widget-a", name)
+	assert.Equal(t, 5, qty)
+
+	// UPDATE
+	_, err = runtimeDB.ExecContext(ctx,
+		fmt.Sprintf(`UPDATE %s SET qty = qty + 1 WHERE id = 1`, qualified))
+	require.NoError(t, err, "ALTER DEFAULT PRIVILEGES must auto-grant UPDATE on future tables")
+
+	// DELETE
+	_, err = runtimeDB.ExecContext(ctx,
+		fmt.Sprintf(`DELETE FROM %s WHERE id = 1`, qualified))
+	require.NoError(t, err, "ALTER DEFAULT PRIVILEGES must auto-grant DELETE on future tables")
+}
+
+// TestPGRolesRuntimeRoleHasNoSuperPowers verifies the third acceptance
+// criterion: the runtime role must not carry any privilege-escalation
+// attributes (SUPERUSER, CREATEDB, CREATEROLE, BYPASSRLS, or REPLICATION).
+// The migrator role is verified for the same flat 'no' to give auditors a
+// single answer for the entire role pair.
+func TestPGRolesRuntimeRoleHasNoSuperPowers(t *testing.T) {
+	env := newIntegrationEnv(t)
+	spec := &PGRoleSpec{
+		Schema:          "tenant_caps",
+		MigratorRole:    "mig_caps",
+		RuntimeRole:     "rt_caps",
+		RuntimePassword: "rt-caps-pw-1234",
+	}
+
+	ctx, cancel := testCtx(t)
+	defer cancel()
+
+	admin := env.adminDB(t)
+	require.NoError(t, ProvisionPGRoles(ctx, admin, spec))
+
+	for _, role := range []string{spec.MigratorRole, spec.RuntimeRole} {
+		role := role
+		t.Run(role, func(t *testing.T) {
+			var attrs struct {
+				IsSuperuser, CanCreateDB, CanCreateRole, CanBypassRLS, CanReplicate bool
+			}
+			err := admin.QueryRowContext(ctx,
+				`SELECT rolsuper, rolcreatedb, rolcreaterole, rolbypassrls, rolreplication
+				 FROM pg_catalog.pg_roles WHERE rolname = $1`,
+				role,
+			).Scan(&attrs.IsSuperuser, &attrs.CanCreateDB, &attrs.CanCreateRole, &attrs.CanBypassRLS, &attrs.CanReplicate)
+			require.NoError(t, err)
+
+			assert.False(t, attrs.IsSuperuser, "%s must not be SUPERUSER", role)
+			assert.False(t, attrs.CanCreateDB, "%s must not have CREATEDB", role)
+			assert.False(t, attrs.CanCreateRole, "%s must not have CREATEROLE", role)
+			assert.False(t, attrs.CanBypassRLS, "%s must not have BYPASSRLS", role)
+			assert.False(t, attrs.CanReplicate, "%s must not have REPLICATION", role)
+		})
+	}
+}
+
+// TestPGRolesProvisioningIsIdempotent verifies that running ProvisionPGRoles
+// twice with the same spec is a no-op the second time — required because
+// PostgreSQL DDL isn't transactional across role + schema, so callers must
+// be able to converge by rerunning. Re-runs also exercise the in-place
+// password rotation path.
+func TestPGRolesProvisioningIsIdempotent(t *testing.T) {
+	env := newIntegrationEnv(t)
+	spec := &PGRoleSpec{
+		Schema:           "tenant_idem",
+		MigratorRole:     "mig_idem",
+		MigratorPassword: "mig-idem-pw-1234",
+		RuntimeRole:      "rt_idem",
+		RuntimePassword:  "rt-idem-pw-1234",
+	}
+
+	ctx, cancel := testCtx(t)
+	defer cancel()
+
+	admin := env.adminDB(t)
+	require.NoError(t, ProvisionPGRoles(ctx, admin, spec), "first run")
+	require.NoError(t, ProvisionPGRoles(ctx, admin, spec), "second run must be idempotent")
+
+	// Rotate the runtime password and verify the new credential works while
+	// the old one is rejected.
+	spec.RuntimePassword = "rt-idem-pw-rotated"
+	require.NoError(t, ProvisionPGRoles(ctx, admin, spec), "rotate runtime password")
+
+	rotated := env.openAsRole(t, spec.RuntimeRole, "rt-idem-pw-rotated")
+	require.NoError(t, rotated.PingContext(ctx))
+}
+
+// isPermissionDenied reports whether err looks like a PostgreSQL privilege-
+// rejection error (SQLSTATE 42501). We match on the message because the test
+// uses database/sql + pgx stdlib, which surfaces the SQLSTATE inside the
+// wrapped error string. Substring match is sufficient — the prefix is stable
+// across pgx versions.
+func isPermissionDenied(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "SQLSTATE 42501") ||
+		strings.Contains(msg, "permission denied") ||
+		strings.Contains(msg, "must be owner")
+}

--- a/migration/roles_test.go
+++ b/migration/roles_test.go
@@ -1,0 +1,251 @@
+package migration
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPGRoleSpecValidateAccepts(t *testing.T) {
+	specs := []*PGRoleSpec{
+		{Schema: "tenant_a", MigratorRole: "migrator", RuntimeRole: "tenant_a_app"},
+		{Schema: "TenantA", MigratorRole: "Mig", RuntimeRole: "App"},
+		{Schema: "_underscore_start", MigratorRole: "_m", RuntimeRole: "_r"},
+		// Boundary: 63-char identifier (NAMEDATALEN-1).
+		{
+			Schema:       strings.Repeat("a", 63),
+			MigratorRole: strings.Repeat("b", 63),
+			RuntimeRole:  strings.Repeat("c", 63),
+		},
+	}
+	for _, s := range specs {
+		s := s
+		t.Run(s.Schema, func(t *testing.T) {
+			assert.NoError(t, s.Validate())
+		})
+	}
+}
+
+func TestPGRoleSpecValidateRejects(t *testing.T) {
+	tests := []struct {
+		name string
+		spec *PGRoleSpec
+		// fieldOrReason is a substring expected in the error message so the
+		// caller knows which field failed.
+		fieldOrReason string
+	}{
+		{
+			name:          "empty_schema",
+			spec:          &PGRoleSpec{MigratorRole: "m", RuntimeRole: "r"},
+			fieldOrReason: pgRoleFieldSchema,
+		},
+		{
+			name:          "schema_with_hyphen",
+			spec:          &PGRoleSpec{Schema: "tenant-a", MigratorRole: "m", RuntimeRole: "r"},
+			fieldOrReason: pgRoleFieldSchema,
+		},
+		{
+			name:          "schema_starts_with_digit",
+			spec:          &PGRoleSpec{Schema: "1tenant", MigratorRole: "m", RuntimeRole: "r"},
+			fieldOrReason: pgRoleFieldSchema,
+		},
+		{
+			name:          "schema_with_quote",
+			spec:          &PGRoleSpec{Schema: `bad"quote`, MigratorRole: "m", RuntimeRole: "r"},
+			fieldOrReason: pgRoleFieldSchema,
+		},
+		{
+			name:          "schema_too_long",
+			spec:          &PGRoleSpec{Schema: strings.Repeat("a", 64), MigratorRole: "m", RuntimeRole: "r"},
+			fieldOrReason: pgRoleFieldSchema,
+		},
+		{
+			name:          "migrator_role_empty",
+			spec:          &PGRoleSpec{Schema: "s", RuntimeRole: "r"},
+			fieldOrReason: pgRoleFieldMigratorRole,
+		},
+		{
+			name:          "runtime_role_with_space",
+			spec:          &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "runtime app"},
+			fieldOrReason: pgRoleFieldRuntimeRole,
+		},
+		{
+			name:          "migrator_equals_runtime",
+			spec:          &PGRoleSpec{Schema: "s", MigratorRole: "same", RuntimeRole: "same"},
+			fieldOrReason: "MigratorRole and RuntimeRole must differ",
+		},
+		{
+			name:          "schema_with_null_byte",
+			spec:          &PGRoleSpec{Schema: "tenant\x00a", MigratorRole: "m", RuntimeRole: "r"},
+			fieldOrReason: pgRoleFieldSchema,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.spec.Validate()
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrInvalidPGIdentifier),
+				"want wrapped ErrInvalidPGIdentifier, got %v", err)
+			assert.Contains(t, err.Error(), tt.fieldOrReason)
+		})
+	}
+}
+
+func TestPGRoleProvisioningSQLRejectsInvalidSpec(t *testing.T) {
+	_, err := PGRoleProvisioningSQL(&PGRoleSpec{})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidPGIdentifier))
+}
+
+func TestPGRoleProvisioningSQLRejectsNilSpec(t *testing.T) {
+	_, err := PGRoleProvisioningSQL(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-nil *PGRoleSpec")
+}
+
+func TestPGRoleProvisioningSQLContainsExpectedStatements(t *testing.T) {
+	spec := &PGRoleSpec{
+		Schema:           "tenant_a",
+		MigratorRole:     "migrator",
+		MigratorPassword: "mpw",
+		RuntimeRole:      "tenant_a_app",
+		RuntimePassword:  "rpw",
+	}
+	stmts, err := PGRoleProvisioningSQL(spec)
+	require.NoError(t, err)
+	require.NotEmpty(t, stmts)
+
+	all := strings.Join(stmts, "\n;\n")
+
+	// Role creation in a DO block (idempotent).
+	assert.Contains(t, all, `CREATE ROLE "migrator"`)
+	assert.Contains(t, all, `CREATE ROLE "tenant_a_app"`)
+	assert.Contains(t, all, `pg_catalog.pg_roles WHERE rolname = 'migrator'`)
+	assert.Contains(t, all, `pg_catalog.pg_roles WHERE rolname = 'tenant_a_app'`)
+
+	// Attribute lockdown on both roles.
+	assert.Contains(t, all, `ALTER ROLE "migrator" NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS`)
+	assert.Contains(t, all, `ALTER ROLE "tenant_a_app" NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS`)
+
+	// Passwords applied.
+	assert.Contains(t, all, `ALTER ROLE "migrator" PASSWORD 'mpw'`)
+	assert.Contains(t, all, `ALTER ROLE "tenant_a_app" PASSWORD 'rpw'`)
+
+	// Schema ownership and runtime grants.
+	assert.Contains(t, all, `CREATE SCHEMA IF NOT EXISTS "tenant_a" AUTHORIZATION "migrator"`)
+	assert.Contains(t, all, `GRANT USAGE ON SCHEMA "tenant_a" TO "tenant_a_app"`)
+	assert.Contains(t, all, `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA "tenant_a" TO "tenant_a_app"`)
+
+	// The AC-critical ALTER DEFAULT PRIVILEGES line.
+	assert.Contains(t, all, `ALTER DEFAULT PRIVILEGES FOR ROLE "migrator" IN SCHEMA "tenant_a" GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "tenant_a_app"`)
+}
+
+func TestPGRoleProvisioningSQLOmitsEmptyPasswordALTERs(t *testing.T) {
+	spec := &PGRoleSpec{
+		Schema:       "tenant_b",
+		MigratorRole: "migrator2",
+		RuntimeRole:  "tenant_b_app",
+		// Both passwords intentionally empty.
+	}
+	stmts, err := PGRoleProvisioningSQL(spec)
+	require.NoError(t, err)
+
+	all := strings.Join(stmts, "\n;\n")
+	assert.NotContains(t, all, "PASSWORD '",
+		"empty passwords must not emit ALTER ROLE ... PASSWORD statements")
+}
+
+func TestQuotePGIdent(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"simple", "simple", `"simple"`},
+		{"mixed_case", "Mixed_Case", `"Mixed_Case"`},
+		// Defense-in-depth: even though Validate rejects embedded quotes,
+		// quotePGIdent still doubles them so a direct misuse from inside
+		// the package can't smuggle a quote-break.
+		{"embedded_quote_is_doubled", `weird"name`, `"weird""name"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, quotePGIdent(tt.in))
+		})
+	}
+}
+
+func TestQuotePGStringLiteral(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", "''"},
+		{"simple", "simple", "'simple'"},
+		{"single_quote_is_doubled", "O'Brien", "'O''Brien'"},
+		// Backslashes are literal under standard_conforming_strings=on.
+		{"backslash_is_literal", `back\slash`, `'back\slash'`},
+		{"two_doubles_become_four", "two''doubles", "'two''''doubles'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, quotePGStringLiteral(tt.in))
+		})
+	}
+}
+
+func TestSummarizeStmt(t *testing.T) {
+	assert.Equal(t, "short", summarizeStmt("short"))
+	assert.Equal(t, "first line", summarizeStmt("first line\nsecond line"))
+	assert.Equal(t, "trimmed", summarizeStmt("  trimmed  "))
+
+	long := strings.Repeat("x", 100)
+	got := summarizeStmt(long)
+	assert.Len(t, got, 83, "long statements truncate to 80 chars plus the ellipsis sentinel")
+	assert.True(t, strings.HasSuffix(got, "..."))
+}
+
+// TestSummarizeStmtRedactsPasswordLiteral verifies that the password literal
+// in ALTER ROLE ... PASSWORD '<secret>' is replaced with [REDACTED] before
+// the summary is returned. Without this redaction, a failing password-rotation
+// statement would leak the resolved secret into the wrapped error string.
+func TestSummarizeStmtRedactsPasswordLiteral(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "simple_password",
+			in:   `ALTER ROLE "tenant_a_app" PASSWORD 'super-secret-123'`,
+			want: `ALTER ROLE "tenant_a_app" PASSWORD '[REDACTED]'`,
+		},
+		{
+			name: "password_with_doubled_quote",
+			in:   `ALTER ROLE "x" PASSWORD 'hard''quote'`,
+			want: `ALTER ROLE "x" PASSWORD '[REDACTED]'`,
+		},
+		{
+			name: "lowercase_keyword",
+			in:   `alter role "x" password 'lower-cased'`,
+			want: `alter role "x" password '[REDACTED]'`,
+		},
+		{
+			name: "no_password_unchanged",
+			in:   `CREATE SCHEMA IF NOT EXISTS "tenant_a" AUTHORIZATION "migrator"`,
+			want: `CREATE SCHEMA IF NOT EXISTS "tenant_a" AUTHORIZATION "migrator"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summarizeStmt(tt.in)
+			assert.Equal(t, tt.want, got)
+			assert.NotContains(t, got, "super-secret-123")
+			assert.NotContains(t, got, "lower-cased")
+		})
+	}
+}

--- a/wiki/migration-roles.md
+++ b/wiki/migration-roles.md
@@ -1,0 +1,186 @@
+# PostgreSQL Role Separation for Migrations
+
+This guide documents the migrator-vs-runtime role-separation model that lets
+auditors answer a flat **no** to *"can the running service alter its own
+database schema?"*. Tracked under issue #378; depends on the multi-tenant
+migration runner from #377 (PR #421).
+
+**Scope:** PostgreSQL only in v1. Oracle is tracked separately under #385
+because its user/role/grant model is fundamentally different.
+
+## The model
+
+Two roles per tenant:
+
+| Role | Owns | Privileges | Used by |
+|------|------|-----------|---------|
+| **Migrator** (one per deployment, shared across tenants) | The tenant schema(s) it provisioned | DDL on its own schemas | `go-bricks-migrate` CLI / `migration.MigrateAll` |
+| **Per-tenant runtime** (one per tenant) | Nothing | `USAGE` on the tenant schema; `SELECT/INSERT/UPDATE/DELETE` on all current and future tables; `USAGE/SELECT/UPDATE` on sequences | The running service (`runtime.role` in `database.yaml`) |
+
+Both roles are created with the same locked-down attribute floor:
+`NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS`. The
+attribute lockdown is reapplied on every provisioning call so a misconfigured
+role (e.g., someone ran `ALTER ROLE migrator SUPERUSER` manually) snaps back
+on the next migration run.
+
+The runtime role's DDL rejection is **not** enforced by explicit `REVOKE`
+statements — it falls out of PostgreSQL's default ownership model. The
+runtime role doesn't own the schema and doesn't have `CREATE` on it, so
+`CREATE TABLE`, `ALTER TABLE`, and `DROP TABLE` are rejected with SQLSTATE
+42501 by construction. This means there's no grant arithmetic to audit; the
+proof is **"the runtime role never owns anything"**.
+
+## Future-table auto-grants
+
+The hinge of the model is `ALTER DEFAULT PRIVILEGES`. Every table created by
+the migrator inside a tenant schema is owned by the migrator, so without
+this clause the runtime role would have *no* privilege on tables added by
+future Flyway migrations. The provisioning helper emits:
+
+```sql
+ALTER DEFAULT PRIVILEGES FOR ROLE "migrator" IN SCHEMA "tenant_a"
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "tenant_a_app";
+
+ALTER DEFAULT PRIVILEGES FOR ROLE "migrator" IN SCHEMA "tenant_a"
+  GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO "tenant_a_app";
+```
+
+Result: a Flyway migration adding `CREATE TABLE tenant_a.gadgets (...)` does
+not need a follow-up `GRANT` statement — the table is automatically
+DML-accessible to the runtime role.
+
+## Using the helper
+
+```go
+import "github.com/gaborage/go-bricks/migration"
+
+spec := migration.PGRoleSpec{
+    Schema:           "tenant_a",
+    MigratorRole:     "migrator",
+    MigratorPassword: os.Getenv("MIGRATOR_PASSWORD"), // optional, omit if managed externally
+    RuntimeRole:      "tenant_a_app",
+    RuntimePassword:  os.Getenv("TENANT_A_RUNTIME_PASSWORD"),
+}
+
+// db is an *sql.DB authenticated as a role with CREATEROLE — typically the
+// instance bootstrap superuser or a dedicated provisioner role.
+if err := migration.ProvisionPGRoles(ctx, db, spec); err != nil {
+    return fmt.Errorf("provision tenant %q: %w", spec.Schema, err)
+}
+```
+
+All operations are idempotent — rerunning with the same spec is a no-op
+except that `MigratorPassword` / `RuntimePassword` (when non-empty) are
+reapplied on every call, which makes secret rotation a no-op rerun.
+
+### Operator escape hatch
+
+When you want to inspect or apply the provisioning via `psql` instead, use
+`PGRoleProvisioningSQL` to get the statements:
+
+```go
+stmts, err := migration.PGRoleProvisioningSQL(spec)
+if err != nil { return err }
+for _, s := range stmts {
+    fmt.Println(s + ";")
+}
+```
+
+## Identifier safety
+
+`PGRoleSpec.Schema`, `MigratorRole`, and `RuntimeRole` are validated against
+a conservative ASCII subset: `[A-Za-z_][A-Za-z0-9_]{0,62}` (NAMEDATALEN-1
+maximum). Identifiers that fail this check (hyphens, dots, Unicode, embedded
+quotes, NUL bytes, leading digits, names longer than 63 bytes) are rejected
+with `ErrInvalidPGIdentifier` before any DDL is built.
+
+If your tenant IDs include hyphens or other characters outside this subset,
+normalize them upstream (e.g., `tenant-a` → `tenant_a`) before constructing
+the spec. The migration boundary deliberately enforces a single forcing
+function rather than scattering input filters across the codebase.
+
+## Credential handling
+
+The migrator role holds privileged access to every tenant schema in the
+deployment. Treat its credentials accordingly:
+
+- **Where:** AWS Secrets Manager, HashiCorp Vault, GCP Secret Manager, or
+  equivalent. Never check the password into a config file or environment
+  variable that is broadly readable.
+- **Who:** Only the migration runner (the `go-bricks-migrate` CLI or the
+  in-process `migration.MigrateAll` caller). Runtime services must connect
+  as their per-tenant runtime role, never as the migrator.
+- **Rotation:** Pass the new password as `MigratorPassword` on the next
+  provisioning call. The helper emits `ALTER ROLE ... PASSWORD ...`
+  unconditionally when the field is non-empty, so rerunning with a rotated
+  secret is sufficient.
+
+For the AWS Secrets Manager naming convention used by `go-bricks-migrate`,
+see [multi-tenant-migration.md](multi-tenant-migration.md#aws-secrets-manager-convention).
+
+## Provisioning flow
+
+```text
+              ┌──────────────────────┐
+              │ Provisioner role     │  (bootstrap superuser or dedicated
+              │ (CREATEROLE)         │   role with CREATEROLE granted)
+              └──────────┬───────────┘
+                         │ ProvisionPGRoles(spec)
+                         ▼
+   ┌─────────────────────────────────────────────────┐
+   │ DO $$ BEGIN IF NOT EXISTS CREATE ROLE migrator  │  idempotent role create
+   │ ALTER ROLE migrator NO*                         │  attribute floor lockdown
+   │ DO $$ BEGIN IF NOT EXISTS CREATE ROLE runtime   │
+   │ ALTER ROLE runtime NO*                          │
+   │ ALTER ROLE migrator PASSWORD '...'              │  optional rotation
+   │ ALTER ROLE runtime  PASSWORD '...'              │  optional rotation
+   │ CREATE SCHEMA IF NOT EXISTS tenant_a AUTH...    │  schema owned by migrator
+   │ GRANT USAGE ON SCHEMA tenant_a TO runtime       │
+   │ GRANT SELECT/INSERT/UPDATE/DELETE ON ALL TABLES │  existing-object grants
+   │ ALTER DEFAULT PRIVILEGES ... ON TABLES TO ...   │  future-object grants
+   └─────────────────────────────────────────────────┘
+```
+
+After provisioning:
+- The migration runner connects as `migrator` and applies Flyway migrations.
+  All new tables are owned by `migrator`.
+- The running service connects as `tenant_a_app` and performs DML only. Any
+  attempt to issue DDL is rejected with SQLSTATE 42501.
+
+## Verifying the model
+
+The acceptance tests under `migration/roles_integration_test.go` codify
+three claims that should remain true forever:
+
+1. **`TestPGRolesRuntimeRoleRejectedOnDDL`** — `CREATE/ALTER/DROP TABLE`
+   from the runtime role return SQLSTATE 42501.
+2. **`TestPGRolesAlterDefaultPrivilegesAutoGrants`** — A table created by
+   the migrator *after* provisioning is automatically DML-accessible to the
+   runtime role with no intervening `GRANT`.
+3. **`TestPGRolesRuntimeRoleHasNoSuperPowers`** — Both roles have
+   `rolsuper=false`, `rolcreatedb=false`, `rolcreaterole=false`,
+   `rolbypassrls=false`, and `rolreplication=false` in `pg_catalog.pg_roles`.
+
+Run them with:
+
+```bash
+go test -tags=integration -run TestPGRoles ./migration/
+```
+
+Docker is required (testcontainers spins up a fresh PostgreSQL 17 instance
+per test). Flyway is **not** required for these tests — they exercise the
+role helpers directly against PostgreSQL.
+
+## Limitations & future work
+
+- **Multi-database vs multi-schema.** This model assumes the multi-schema
+  multi-tenant pattern (one database, schema-per-tenant). For
+  database-per-tenant deployments, the same role attributes apply but the
+  helper would need to grow a `CREATE DATABASE ... OWNER` step.
+- **Oracle.** Tracked under #385. Oracle's user-as-schema model and
+  privilege grants are fundamentally different — likely a separate
+  `OracleRoleSpec` and `ProvisionOracleRoles` rather than an extension here.
+- **Provisioning state machine.** #379 will add a durable, crash-recoverable
+  state machine that orchestrates the full per-tenant provisioning flow
+  (schema_created → role_created → migrated → seeded → ready). Today the
+  helper is a single idempotent call; the state machine will wrap it.


### PR DESCRIPTION
## Summary

- Adds `ProvisionPGRoles` and `PGRoleProvisioningSQL` to the `migration/` package, implementing the migrator-owns-DDL / runtime-DML-only role model defined in #378.
- Both roles are created with `NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS`; the runtime role's DDL rejection falls out of PostgreSQL's default ownership model (no explicit `REVOKE` needed). `ALTER DEFAULT PRIVILEGES FOR ROLE migrator IN SCHEMA <t>` grants the runtime role DML on tables created by future migrations.
- Integration tests verify the three acceptance criteria against a real PostgreSQL 17 testcontainer; unit tests cover identifier validation, SQL-literal quoting, and password redaction.

## Design decisions documented

- **Role model:** Migrator owns the schema and holds DDL; runtime role doesn't own anything and is granted DML on existing + future tables via `ALTER DEFAULT PRIVILEGES`. Both roles get the same locked-down attribute floor, re-applied on every provisioning call to snap drift back. See [`wiki/migration-roles.md`](wiki/migration-roles.md).
- **Identifier safety:** Conservative ASCII subset (`[A-Za-z_][A-Za-z0-9_]{0,62}`) enforced via regex; identifiers double-quoted as belt-and-suspenders. Rejects hyphens, dots, Unicode, embedded quotes, leading digits, names > 63 bytes.
- **String literal safety:** `quotePGStringLiteral` doubles single quotes; relies on `standard_conforming_strings=on` (PG 9.1+ default) for literal backslashes.
- **Idempotency:** `DO $$ BEGIN IF NOT EXISTS ... CREATE ROLE ... END $$;` for role creation, `CREATE SCHEMA IF NOT EXISTS ... AUTHORIZATION`, and unconditional `ALTER ROLE PASSWORD` on every call to support secret rotation.
- **Ship as both:** Go helpers (`ProvisionPGRoles`) for the in-process path, exported `PGRoleProvisioningSQL()` for operators who prefer inspecting/applying via psql.

## Security

- gosec scan: 0 issues on the diff
- govulncheck: no vulnerabilities
- SQL injection surface sealed: identifier regex + double-quoting, single-quoted-literal doubling
- **Credential leak path closed:** `summarizeStmt` now redacts `PASSWORD '...'` clauses before they reach error-wrapping output, so a failing `ALTER ROLE ... PASSWORD '<secret>'` doesn't leak the password into the returned error string.
- `PGRoleProvisioningSQL`'s godoc carries an explicit `SECURITY:` note that the returned slice contains password literals when set on the spec.

## Test plan

- [x] `make check` — green
- [x] `go test -tags=integration -run TestPGRoles ./migration/` — four tests pass on PG 17 testcontainer
- [x] Unit tests cover Validate (accept + reject tables), SQL generation, identifier/literal quoting, password redaction
- [ ] CI green on Ubuntu + Windows × Go 1.25

## Compatibility / scope

- **PostgreSQL only** in v1. Oracle is tracked separately under #385 because its user/role/grant model is fundamentally different.
- `flywayConfig()` test helper signature changed to `flywayConfig(t *testing.T)` so it can lazily resolve the Flyway binary — lets PG-only role tests reuse `integrationEnv` without requiring Flyway on PATH. All in-repo callers updated.
- No public framework API breaks; new package-level exports only (`ProvisionPGRoles`, `PGRoleProvisioningSQL`, `PGRoleSpec`, `ErrInvalidPGIdentifier`).

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PostgreSQL role provisioning with migrator and runtime role separation for multi-tenant schemas.
  * Automatic privilege grants and schema ownership configuration.

* **Documentation**
  * Added comprehensive guide for PostgreSQL role-based access patterns and provisioning workflows.
  * Updated migration architecture documentation with role separation details.

* **Tests**
  * Enhanced integration test infrastructure with role provisioning validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/427)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->