### PR TITLE
feat(multitenant): add path-based tenant resolver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ go test -bench=.        # Run benchmarks
 - [.golangci.yml](.golangci.yml) — Linting configuration
 
 **Wiki (deep dives — read on demand):**
-- Architecture: [database.md](wiki/database.md) · [cache.md](wiki/cache.md) · [messaging.md](wiki/messaging.md) · [outbox.md](wiki/outbox.md) · [scheduler.md](wiki/scheduler.md) · [httpclient.md](wiki/httpclient.md) · [jose.md](wiki/jose.md) · [observability.md](wiki/observability.md)
+- Architecture: [database.md](wiki/database.md) · [cache.md](wiki/cache.md) · [messaging.md](wiki/messaging.md) · [outbox.md](wiki/outbox.md) · [scheduler.md](wiki/scheduler.md) · [httpclient.md](wiki/httpclient.md) · [jose.md](wiki/jose.md) · [observability.md](wiki/observability.md) · [multi-tenant-resolvers.md](wiki/multi-tenant-resolvers.md)
 - Patterns: [handler-patterns.md](wiki/handler-patterns.md) · [context-deadlines.md](wiki/context-deadlines.md) · [testing.md](wiki/testing.md)
 - Reference: [troubleshooting.md](wiki/troubleshooting.md) · [migrations.md](wiki/migrations.md) (breaking changes) · [startup-defaults.md](wiki/startup-defaults.md)
 - ADRs: [wiki/architecture_decisions.md](wiki/architecture_decisions.md), files `wiki/adr-NNN-*.md`
@@ -150,6 +150,7 @@ make lint                       # Run golangci-lint
 - **scheduler/** — gocron-based job scheduling with observability and CIDR-restricted APIs
 - **server/** — Echo-based HTTP server
 - **migration/** — Flyway integration with single- and multi-tenant runners; pairs with `tools/migration` CLI (`go-bricks-migrate`) for CI/CD fleet rollouts. Emits `migration.applied` audit events on every migrate invocation via OTel by default; opt-in `AuditRecorder` for compliance-grade durable delivery. PostgreSQL migrator-vs-runtime role separation (`ProvisionPGRoles` / `PGRoleProvisioningSQL`) gives auditors a flat *no* to "can the running service alter its own schema?". The `migration/provisioning/` subpackage carries a durable, crash-recoverable per-tenant state machine (`pending → schema_created → role_created → migrated → seeded → ready`, with `cleanup → failed` branches) for dynamic tenant provisioning. See [multi-tenant-migration.md](wiki/multi-tenant-migration.md), [migration-roles.md](wiki/migration-roles.md), [migration-provisioning.md](wiki/migration-provisioning.md), [migration-audit.md](wiki/migration-audit.md), [ADR-018](wiki/adr-018-multi-tenant-migration-cli.md), [ADR-019](wiki/adr-019-migration-audit-delivery.md), and [ADR-021](wiki/adr-021-provisioning-state-machine.md).
+- **multitenant/** — Tenant identifier resolution from incoming HTTP requests. Four resolver types: `header` (default `X-Tenant-ID`), `subdomain` (`<tenant>.<domain>`), `path` (1-indexed segment with optional prefix gate; e.g. `/itsp/{tenantID}/...`), and `composite` (header → subdomain → path fallback chain). All run before route matching so the resolved tenant is in `context.Context` for every middleware and handler. Per-tenant DB/cache/messaging accessors (`deps.DB(ctx)`, etc.) consume the value transparently. See [multi-tenant-resolvers.md](wiki/multi-tenant-resolvers.md).
 - **observability/** — OpenTelemetry tracing and metrics
 - **outbox/** — Transactional outbox for reliable event publishing (at-least-once delivery)
 - **keystore/** — Named RSA key pair management from DER files or base64 env vars

--- a/config/types.go
+++ b/config/types.go
@@ -400,10 +400,22 @@ type TenantMessagingConfig struct {
 
 // ResolverConfig holds tenant resolution strategy settings.
 type ResolverConfig struct {
-	Type    string `koanf:"type" json:"type" yaml:"type" toml:"type" mapstructure:"type"`                // header, subdomain, composite
-	Header  string `koanf:"header" json:"header" yaml:"header" toml:"header" mapstructure:"header"`      // default: X-Tenant-ID
-	Domain  string `koanf:"domain" json:"domain" yaml:"domain" toml:"domain" mapstructure:"domain"`      // e.g., api.example.com or .api.example.com (leading dot optional)
-	Proxies bool   `koanf:"proxies" json:"proxies" yaml:"proxies" toml:"proxies" mapstructure:"proxies"` // trust X-Forwarded-Host
+	Type    string             `koanf:"type" json:"type" yaml:"type" toml:"type" mapstructure:"type"`                // header, subdomain, path, composite
+	Header  string             `koanf:"header" json:"header" yaml:"header" toml:"header" mapstructure:"header"`      // default: X-Tenant-ID
+	Domain  string             `koanf:"domain" json:"domain" yaml:"domain" toml:"domain" mapstructure:"domain"`      // e.g., api.example.com or .api.example.com (leading dot optional)
+	Proxies bool               `koanf:"proxies" json:"proxies" yaml:"proxies" toml:"proxies" mapstructure:"proxies"` // trust X-Forwarded-Host
+	Path    PathResolverConfig `koanf:"path" json:"path" yaml:"path" toml:"path" mapstructure:"path"`                // path-segment resolver settings
+}
+
+// PathResolverConfig holds settings for the path-segment tenant resolver.
+//
+// Segment is 1-indexed: 1 = first non-empty path part after the leading slash.
+// Prefix is an optional gate — when set, only requests whose path equals
+// Prefix exactly or starts with "Prefix/" are eligible for extraction (useful
+// when a service hosts both tenant-scoped and non-tenant-scoped routes).
+type PathResolverConfig struct {
+	Segment int    `koanf:"segment" json:"segment" yaml:"segment" toml:"segment" mapstructure:"segment"`
+	Prefix  string `koanf:"prefix" json:"prefix" yaml:"prefix" toml:"prefix" mapstructure:"prefix"`
 }
 
 // LimitsConfig holds resource limits for multi-tenant operation.
@@ -438,6 +450,7 @@ const (
 const (
 	ResolverTypeHeader    = "header"
 	ResolverTypeSubdomain = "subdomain"
+	ResolverTypePath      = "path"
 	ResolverTypeComposite = "composite"
 )
 

--- a/config/validation.go
+++ b/config/validation.go
@@ -929,7 +929,7 @@ func validateNoSingleTenantConflict(db *DatabaseConfig, msg *MessagingConfig) er
 
 // validateMultitenantResolver validates tenant resolver configuration
 func validateMultitenantResolver(cfg *ResolverConfig) error {
-	validTypes := []string{ResolverTypeHeader, ResolverTypeSubdomain, ResolverTypeComposite}
+	validTypes := []string{ResolverTypeHeader, ResolverTypeSubdomain, ResolverTypePath, ResolverTypeComposite}
 	if !slices.Contains(validTypes, cfg.Type) {
 		return NewInvalidFieldError("multitenant.resolver.type", fmt.Sprintf(errNotSupportedFmt, cfg.Type), validTypes)
 	}
@@ -947,6 +947,15 @@ func validateMultitenantResolver(cfg *ResolverConfig) error {
 		// Normalize: leading dot is optional in config
 		if !strings.HasPrefix(cfg.Domain, ".") {
 			cfg.Domain = "." + cfg.Domain
+		}
+	}
+
+	if cfg.Type == ResolverTypePath || (cfg.Type == ResolverTypeComposite && cfg.Path.Segment != 0) {
+		if cfg.Path.Segment <= 0 {
+			return NewValidationError("multitenant.resolver.path.segment", errMustBePositive)
+		}
+		if cfg.Path.Prefix != "" && !strings.HasPrefix(cfg.Path.Prefix, "/") {
+			return NewValidationError("multitenant.resolver.path.prefix", "must start with '/' when set")
 		}
 	}
 

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -2616,6 +2616,50 @@ func TestValidateMultitenantSuccess(t *testing.T) {
 			msgConfig: &MessagingConfig{},
 		},
 		{
+			name: "valid_path_resolver",
+			mtConfig: &MultitenantConfig{
+				Enabled: true,
+				Resolver: ResolverConfig{
+					Type: ResolverTypePath,
+					Path: PathResolverConfig{Segment: 2, Prefix: "/itsp"},
+				},
+				Limits:  LimitsConfig{Tenants: 100},
+				Tenants: makeSampleTenants(),
+			},
+			dbConfig:  &DatabaseConfig{},
+			msgConfig: &MessagingConfig{},
+		},
+		{
+			name: "valid_path_resolver_no_prefix",
+			mtConfig: &MultitenantConfig{
+				Enabled: true,
+				Resolver: ResolverConfig{
+					Type: ResolverTypePath,
+					Path: PathResolverConfig{Segment: 1},
+				},
+				Limits:  LimitsConfig{Tenants: 100},
+				Tenants: makeSampleTenants(),
+			},
+			dbConfig:  &DatabaseConfig{},
+			msgConfig: &MessagingConfig{},
+		},
+		{
+			name: "valid_composite_resolver_with_path",
+			mtConfig: &MultitenantConfig{
+				Enabled: true,
+				Resolver: ResolverConfig{
+					Type:   "composite",
+					Header: testTenantHeader,
+					Domain: testDomain,
+					Path:   PathResolverConfig{Segment: 2, Prefix: "/itsp"},
+				},
+				Limits:  LimitsConfig{Tenants: 100},
+				Tenants: makeSampleTenants(),
+			},
+			dbConfig:  &DatabaseConfig{},
+			msgConfig: &MessagingConfig{},
+		},
+		{
 			name: "tenants_without_messaging",
 			mtConfig: &MultitenantConfig{
 				Enabled: true,
@@ -2687,6 +2731,68 @@ func TestValidateMultitenantFailures(t *testing.T) {
 			dbConfig:      &DatabaseConfig{},
 			msgConfig:     &MessagingConfig{},
 			expectedError: "multitenant.resolver.type",
+		},
+		{
+			name: "path_resolver_missing_segment",
+			mtConfig: &MultitenantConfig{
+				Enabled: true,
+				Resolver: ResolverConfig{
+					Type: ResolverTypePath,
+					Path: PathResolverConfig{Segment: 0},
+				},
+				Limits:  LimitsConfig{Tenants: 100},
+				Tenants: makeSampleTenants(),
+			},
+			dbConfig:      &DatabaseConfig{},
+			msgConfig:     &MessagingConfig{},
+			expectedError: "multitenant.resolver.path.segment",
+		},
+		{
+			name: "path_resolver_negative_segment",
+			mtConfig: &MultitenantConfig{
+				Enabled: true,
+				Resolver: ResolverConfig{
+					Type: ResolverTypePath,
+					Path: PathResolverConfig{Segment: -1},
+				},
+				Limits:  LimitsConfig{Tenants: 100},
+				Tenants: makeSampleTenants(),
+			},
+			dbConfig:      &DatabaseConfig{},
+			msgConfig:     &MessagingConfig{},
+			expectedError: "multitenant.resolver.path.segment",
+		},
+		{
+			name: "path_resolver_prefix_missing_leading_slash",
+			mtConfig: &MultitenantConfig{
+				Enabled: true,
+				Resolver: ResolverConfig{
+					Type: ResolverTypePath,
+					Path: PathResolverConfig{Segment: 2, Prefix: "itsp"},
+				},
+				Limits:  LimitsConfig{Tenants: 100},
+				Tenants: makeSampleTenants(),
+			},
+			dbConfig:      &DatabaseConfig{},
+			msgConfig:     &MessagingConfig{},
+			expectedError: "multitenant.resolver.path.prefix",
+		},
+		{
+			name: "composite_with_invalid_path_segment",
+			mtConfig: &MultitenantConfig{
+				Enabled: true,
+				Resolver: ResolverConfig{
+					Type:   "composite",
+					Header: testTenantHeader,
+					Domain: testDomain,
+					Path:   PathResolverConfig{Segment: -2, Prefix: "/itsp"},
+				},
+				Limits:  LimitsConfig{Tenants: 100},
+				Tenants: makeSampleTenants(),
+			},
+			dbConfig:      &DatabaseConfig{},
+			msgConfig:     &MessagingConfig{},
+			expectedError: "multitenant.resolver.path.segment",
 		},
 		{
 			name: "invalid_limits_too_many_tenants",

--- a/llms.txt
+++ b/llms.txt
@@ -89,7 +89,7 @@ Add observability settings as needed (see Observability & Logging).
 - Declarative messaging defines exchanges, queues, bindings, publishers, and consumers once; the framework replays per tenant.
 - Transactional outbox guarantees at-least-once event delivery: events written atomically with business data, then reliably published by a background relay.
 - Observability hooks (traces, metrics, structured logs) activate when `observability.enabled=true`.
-- Multi-tenant mode resolves tenants (header/host/custom store) and hands each module tenant-specific resources.
+- Multi-tenant mode resolves tenants (header, subdomain, path, or composite chain) and hands each module tenant-specific resources.
 
 ## Module Skeleton & Composition
 
@@ -3243,10 +3243,12 @@ The httpclient JOSE wrapper for outbound calls (sign-then-encrypt the request bo
 
 ## Multi-Tenancy
 - Enable with `multitenant.enabled=true`.
-- Resolution strategies: `header`, `host`, or custom store implementing `multitenant.Store`.
+- Resolution strategies: `header` (default `X-Tenant-ID`), `subdomain` (`<tenant>.<domain>`), `path` (1-indexed segment with optional prefix gate), or `composite` (header → subdomain → path fallback chain).
 - Each tenant gets isolated DB connections, messaging clients, and module lifecycle events.
+- Resolution runs as middleware before route matching, so `deps.DB(ctx)` / `deps.Cache(ctx)` etc. resolve to the tenant-specific instance on every request.
+- Resolved tenant IDs are validated against `^[a-z0-9-]{1,64}$` before landing in context. The composite resolver advances to the next sub-resolver on validation failure.
 
-**Configuration:**
+**Header (default for internal APIs):**
 
 ```yaml
 multitenant:
@@ -3266,6 +3268,45 @@ multitenant:
         host: globex-db.example.com
         name: globex_production
 ```
+
+**Subdomain (for `<tenant>.<root>` deployments):**
+
+```yaml
+multitenant:
+  enabled: true
+  resolver:
+    type: subdomain
+    domain: api.example.com  # leading dot optional
+    proxies: true            # trust X-Forwarded-Host (only behind a trusted proxy)
+```
+
+**Path (for `/<service>/{tenantID}/...` URLs — e.g. NovoPayment ITSP/TRTSP/3DS):**
+
+```yaml
+multitenant:
+  enabled: true
+  resolver:
+    type: path
+    path:
+      segment: 2          # 1-indexed: /itsp/{tenantID}/... → segment 2
+      prefix: /itsp        # optional gate; only paths under here are eligible
+```
+
+**Composite (header → subdomain → path fallback chain):**
+
+```yaml
+multitenant:
+  enabled: true
+  resolver:
+    type: composite
+    header: X-Tenant-ID
+    domain: api.example.com
+    path:
+      segment: 2
+      prefix: /itsp
+```
+
+For the full resolver reference (segment-indexing semantics, prefix-gate behavior, trailing-slash and query-string handling, when to choose each type), see `wiki/multi-tenant-resolvers.md`.
 
 **Multi-Tenant Service Implementation:**
 

--- a/multitenant/resolver.go
+++ b/multitenant/resolver.go
@@ -137,3 +137,44 @@ func (r *ValidatingResolver) ResolveTenant(ctx context.Context, req *http.Reques
 
 	return tenantID, nil
 }
+
+// PathResolver extracts the tenant identifier from a path segment.
+//
+// Segment is 1-indexed (segment 1 is the first non-empty path part after the
+// leading slash). When Prefix is non-empty, the resolver only attempts
+// extraction for requests whose path equals Prefix exactly or starts with
+// "Prefix/" — non-matching paths return ErrTenantResolutionFailed so the
+// composite chain (if any) can fall through to other resolvers.
+type PathResolver struct {
+	Segment int
+	Prefix  string
+}
+
+// ResolveTenant implements TenantResolver.
+func (r *PathResolver) ResolveTenant(ctx context.Context, req *http.Request) (string, error) {
+	_ = ctx
+	if r == nil || req == nil || r.Segment <= 0 || req.URL == nil {
+		return "", ErrTenantResolutionFailed
+	}
+
+	path := req.URL.Path
+	if r.Prefix != "" {
+		prefix := r.Prefix
+		if !strings.HasPrefix(prefix, "/") {
+			prefix = "/" + prefix
+		}
+		if path != prefix && !strings.HasPrefix(path, prefix+"/") {
+			return "", ErrTenantResolutionFailed
+		}
+	}
+
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if r.Segment > len(parts) {
+		return "", ErrTenantResolutionFailed
+	}
+	tenantID := strings.TrimSpace(parts[r.Segment-1])
+	if tenantID == "" {
+		return "", ErrTenantResolutionFailed
+	}
+	return tenantID, nil
+}

--- a/multitenant/resolver.go
+++ b/multitenant/resolver.go
@@ -168,7 +168,19 @@ func (r *PathResolver) ResolveTenant(ctx context.Context, req *http.Request) (st
 		}
 	}
 
-	parts := strings.Split(strings.Trim(path, "/"), "/")
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	// Tolerate trailing slashes by dropping trailing empty segments, then
+	// reject any intermediate empty segment — malformed inputs like
+	// "/foo//bar" must not produce a tenant ID at any segment index, not
+	// just the slot pointing at the empty part.
+	for len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	for _, p := range parts {
+		if p == "" {
+			return "", ErrTenantResolutionFailed
+		}
+	}
 	if r.Segment > len(parts) {
 		return "", ErrTenantResolutionFailed
 	}

--- a/multitenant/resolver_test.go
+++ b/multitenant/resolver_test.go
@@ -556,6 +556,30 @@ func TestPathResolverResolveTenant(t *testing.T) {
 			path:     "/itsp/clientD?foo=bar&baz=qux",
 			expected: "clientD",
 		},
+		{
+			name:     "fragment_isolated_from_segment",
+			resolver: &PathResolver{Segment: 2},
+			path:     "/itsp/clientF#section",
+			expected: "clientF",
+		},
+		{
+			name:        "intermediate_empty_segment_rejected_for_any_index",
+			resolver:    &PathResolver{Segment: 3},
+			path:        "/foo//bar/baz",
+			expectError: true,
+		},
+		{
+			name:        "leading_double_slash_rejected",
+			resolver:    &PathResolver{Segment: 1},
+			path:        "//foo",
+			expectError: true,
+		},
+		{
+			name:     "multiple_trailing_slashes_tolerated",
+			resolver: &PathResolver{Segment: 2, Prefix: "/itsp"},
+			path:     "/itsp/clientE//",
+			expected: "clientE",
+		},
 	}
 
 	for _, tc := range tests {

--- a/multitenant/resolver_test.go
+++ b/multitenant/resolver_test.go
@@ -442,3 +442,194 @@ func TestSubdomainResolverResolveTenant(t *testing.T) {
 		})
 	}
 }
+
+// setupPathRequest creates an HTTP request with a specific URL path for path-resolver tests.
+func setupPathRequest(rawURL string) *http.Request {
+	ctx := context.Background()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://example.com"+rawURL, http.NoBody)
+	return req
+}
+
+func TestPathResolverResolveTenant(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		resolver    *PathResolver
+		path        string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "segment_one_extracted",
+			resolver: &PathResolver{Segment: 1},
+			path:     "/foo/bar/baz",
+			expected: "foo",
+		},
+		{
+			name:     "segment_two_extracted",
+			resolver: &PathResolver{Segment: 2},
+			path:     "/itsp/servitebca/lifecycle",
+			expected: "servitebca",
+		},
+		{
+			name:     "deep_segment_extracted",
+			resolver: &PathResolver{Segment: 4},
+			path:     "/a/b/c/tenant42/d",
+			expected: "tenant42",
+		},
+		{
+			name:     "prefix_match_extracts",
+			resolver: &PathResolver{Segment: 2, Prefix: "/itsp"},
+			path:     "/itsp/clientA/provisioning",
+			expected: "clientA",
+		},
+		{
+			name:        "prefix_exact_match_no_segment",
+			resolver:    &PathResolver{Segment: 2, Prefix: "/itsp"},
+			path:        "/itsp",
+			expectError: true,
+		},
+		{
+			name:        "prefix_mismatch_returns_error",
+			resolver:    &PathResolver{Segment: 2, Prefix: "/itsp"},
+			path:        "/health",
+			expectError: true,
+		},
+		{
+			name:        "prefix_partial_word_match_rejected",
+			resolver:    &PathResolver{Segment: 2, Prefix: "/itsp"},
+			path:        "/itspx/other",
+			expectError: true,
+		},
+		{
+			name:     "trailing_slash_tolerated",
+			resolver: &PathResolver{Segment: 2, Prefix: "/itsp"},
+			path:     "/itsp/clientB/",
+			expected: "clientB",
+		},
+		{
+			name:     "prefix_without_leading_slash_normalized",
+			resolver: &PathResolver{Segment: 2, Prefix: "itsp"},
+			path:     "/itsp/clientC",
+			expected: "clientC",
+		},
+		{
+			name:        "missing_segment_returns_error",
+			resolver:    &PathResolver{Segment: 3},
+			path:        "/only/two",
+			expectError: true,
+		},
+		{
+			name:        "empty_segment_rejected",
+			resolver:    &PathResolver{Segment: 2},
+			path:        "/foo//bar",
+			expectError: true,
+		},
+		{
+			name:        "root_path_with_segment_one_rejected",
+			resolver:    &PathResolver{Segment: 1},
+			path:        "/",
+			expectError: true,
+		},
+		{
+			name:        "empty_path_rejected",
+			resolver:    &PathResolver{Segment: 1},
+			path:        "",
+			expectError: true,
+		},
+		{
+			name:        "segment_zero_invalid",
+			resolver:    &PathResolver{Segment: 0},
+			path:        "/foo/bar",
+			expectError: true,
+		},
+		{
+			name:        "negative_segment_invalid",
+			resolver:    &PathResolver{Segment: -1},
+			path:        "/foo/bar",
+			expectError: true,
+		},
+		{
+			name:     "query_string_isolated_from_segment",
+			resolver: &PathResolver{Segment: 2},
+			path:     "/itsp/clientD?foo=bar&baz=qux",
+			expected: "clientD",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := setupPathRequest(tc.path)
+			tenantID, err := tc.resolver.ResolveTenant(ctx, req)
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Equal(t, ErrTenantResolutionFailed, err)
+				assert.Empty(t, tenantID)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, tenantID)
+			}
+		})
+	}
+}
+
+func TestPathResolverNilSafety(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("nil_resolver", func(t *testing.T) {
+		var r *PathResolver
+		req := setupPathRequest("/foo/bar")
+		tenantID, err := r.ResolveTenant(ctx, req)
+		assert.Equal(t, ErrTenantResolutionFailed, err)
+		assert.Empty(t, tenantID)
+	})
+
+	t.Run("nil_request", func(t *testing.T) {
+		r := &PathResolver{Segment: 1}
+		tenantID, err := r.ResolveTenant(ctx, nil)
+		assert.Equal(t, ErrTenantResolutionFailed, err)
+		assert.Empty(t, tenantID)
+	})
+
+	t.Run("nil_request_url", func(t *testing.T) {
+		r := &PathResolver{Segment: 1}
+		req := &http.Request{} // URL is nil
+		tenantID, err := r.ResolveTenant(ctx, req)
+		assert.Equal(t, ErrTenantResolutionFailed, err)
+		assert.Empty(t, tenantID)
+	})
+}
+
+func TestCompositeResolverWithPathSubresolver(t *testing.T) {
+	ctx := context.Background()
+	composite := &CompositeResolver{
+		Resolvers: []TenantResolver{
+			&PathResolver{Segment: 2, Prefix: "/itsp"},
+			&HeaderResolver{},
+		},
+	}
+
+	t.Run("path_match_wins", func(t *testing.T) {
+		req := setupPathRequest("/itsp/clientA/lifecycle")
+		req.Header.Set(tenantIDHeader, "fallback-tenant")
+		tenantID, err := composite.ResolveTenant(ctx, req)
+		assert.NoError(t, err)
+		assert.Equal(t, "clientA", tenantID)
+	})
+
+	t.Run("path_miss_falls_through_to_header", func(t *testing.T) {
+		req := setupPathRequest("/health")
+		req.Header.Set(tenantIDHeader, "header-tenant")
+		tenantID, err := composite.ResolveTenant(ctx, req)
+		assert.NoError(t, err)
+		assert.Equal(t, "header-tenant", tenantID)
+	})
+
+	t.Run("both_miss_returns_error", func(t *testing.T) {
+		req := setupPathRequest("/health")
+		tenantID, err := composite.ResolveTenant(ctx, req)
+		assert.Equal(t, ErrTenantResolutionFailed, err)
+		assert.Empty(t, tenantID)
+	})
+}

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -156,11 +156,20 @@ func buildTenantResolver(cfg *config.Config) multitenant.TenantResolver {
 		return &multitenant.SubdomainResolver{RootDomain: rootDomain, TrustProxies: resolverCfg.Proxies}
 	}
 
+	newPathResolver := func() multitenant.TenantResolver {
+		if resolverCfg.Path.Segment <= 0 {
+			return nil
+		}
+		return &multitenant.PathResolver{Segment: resolverCfg.Path.Segment, Prefix: resolverCfg.Path.Prefix}
+	}
+
 	switch resolverCfg.Type {
 	case config.ResolverTypeHeader:
 		return wrap(newHeaderResolver())
 	case config.ResolverTypeSubdomain:
 		return wrap(newSubdomainResolver())
+	case config.ResolverTypePath:
+		return wrap(newPathResolver())
 	case config.ResolverTypeComposite:
 		resolvers := []multitenant.TenantResolver{}
 		if header := newHeaderResolver(); header != nil {
@@ -168,6 +177,9 @@ func buildTenantResolver(cfg *config.Config) multitenant.TenantResolver {
 		}
 		if subdomain := newSubdomainResolver(); subdomain != nil {
 			resolvers = append(resolvers, subdomain)
+		}
+		if pathr := newPathResolver(); pathr != nil {
+			resolvers = append(resolvers, pathr)
 		}
 		if len(resolvers) == 0 {
 			return nil

--- a/wiki/multi-tenant-resolvers.md
+++ b/wiki/multi-tenant-resolvers.md
@@ -1,0 +1,122 @@
+# Multi-Tenant Resolvers
+
+> Where tenant identifiers come from on an inbound HTTP request, and how the framework picks one. Settings live under `multitenant.resolver` in your YAML config; the framework wires the active resolver into a request-scoped middleware before module routes run, so handlers and database/cache/messaging accessors see the tenant on every call.
+
+## Resolver types
+
+The `multitenant.resolver.type` field selects one of four strategies:
+
+| Type | Tenant source | Typical shape |
+|---|---|---|
+| `header` | Request header (default `X-Tenant-ID`, configurable) | `X-Tenant-ID: acme` |
+| `subdomain` | Hostname with `.<RootDomain>` suffix | `acme.api.example.com` |
+| `path` | Path segment (1-indexed) | `/itsp/acme/lifecycle/...` |
+| `composite` | Tries header → subdomain → path in order; first non-empty wins | Mix of above |
+
+All resolvers funnel through the same interface (`multitenant.TenantResolver`) and surface the result via `multitenant.SetTenant(ctx, id)` on success. Failure returns `multitenant.ErrTenantResolutionFailed`, which the server middleware maps to a 4xx error response.
+
+## Validation
+
+Every resolved tenant ID is checked against a regex (default `^[a-z0-9-]{1,64}$`) before it lands in context. Reject the request rather than silently masking malformed IDs — tenant strings are used downstream as DB schema names, cache keys, and span attributes, so a strict allowlist closes a class of injection attacks. The composite resolver advances to the next sub-resolver if the validation fails (same as a missing tenant).
+
+## Header resolver
+
+```yaml
+multitenant:
+  enabled: true
+  resolver:
+    type: header
+    header: X-Tenant-ID   # optional; default is X-Tenant-ID
+```
+
+The simplest and most common form for internal APIs where clients can set headers freely. Whitespace is trimmed; empty values fail.
+
+## Subdomain resolver
+
+```yaml
+multitenant:
+  enabled: true
+  resolver:
+    type: subdomain
+    domain: api.example.com   # leading dot optional
+    proxies: true             # trust X-Forwarded-Host
+```
+
+Extracts the part before `.<domain>` from the request `Host`. Use `proxies: true` only behind a trusted reverse proxy that sets `X-Forwarded-Host`; otherwise an attacker can forge it. Ports are stripped from the host; IPv6 literals are preserved correctly.
+
+## Path resolver
+
+```yaml
+multitenant:
+  enabled: true
+  resolver:
+    type: path
+    path:
+      segment: 2          # 1-indexed; segment 1 = first part after leading slash
+      prefix: /itsp        # optional gate; only paths under here are eligible
+```
+
+Use this when downstream clients route by URL path rather than header or hostname. The NovoPayment tokenization services (ITSP, TRTSP, 3DS, Click-to-Pay, Backoffice) are the canonical examples — their public contracts are `/itsp/{clientID}/lifecycle/...`, `/trtsp/{clientID}/provisioning/...`, etc.
+
+**Segment indexing is 1-indexed**: segment 1 is the first non-empty path part after the leading `/`. For `/itsp/acme/lifecycle`, segment 2 yields `acme`.
+
+**Prefix gate** is optional. When set, requests whose path doesn't match `Prefix` exactly or start with `Prefix/` return `ErrTenantResolutionFailed` immediately — useful when a service hosts non-tenanted routes (e.g. `/health`, `/ready`, `/admin`) alongside the tenant-scoped ones. Without a prefix, the resolver always attempts extraction at the configured segment.
+
+**Trailing slashes are tolerated**: `/itsp/acme/` resolves identically to `/itsp/acme`.
+
+**Empty segments are rejected**: `/itsp//foo` is not a valid resolution.
+
+**Query strings and fragments are ignored**: they're isolated from `URL.Path` by the standard library before the resolver sees the request.
+
+### Why path-segment over Echo's `c.Param("tenantID")`?
+
+Route params would only resolve **inside** a route group like `r.Group("/itsp/:tenantID", ...)`. That means framework middleware that needs the tenant before route matching (rate limiting, request logging, OTel span attributes, tenant-scoped DB resolution) wouldn't have it. The path resolver extracts at the URL level, before routing, so the entire framework's tenant-aware machinery has the value from the first middleware onward.
+
+## Composite resolver
+
+```yaml
+multitenant:
+  enabled: true
+  resolver:
+    type: composite
+    header: X-Tenant-ID         # tried first
+    domain: api.example.com     # tried second
+    proxies: true
+    path:
+      segment: 2                # tried third
+      prefix: /itsp
+```
+
+Tries each configured sub-resolver in order until one returns a non-empty, valid tenant ID. Order is fixed: **header → subdomain → path**. A sub-resolver is included only when its config is present (e.g., `path:` is included only when `path.segment > 0`).
+
+The typical use case is migrating from header-based clients to path-based clients gradually: keep header support for legacy callers, add `path` for new ones, no downtime.
+
+## Implementation reference
+
+Resolver implementations live in [`multitenant/resolver.go`](../multitenant/resolver.go). All four implement the same interface:
+
+```go
+type TenantResolver interface {
+    ResolveTenant(ctx context.Context, req *http.Request) (string, error)
+}
+```
+
+The factory that wires `ResolverConfig` to a concrete resolver instance is `buildTenantResolver` in [`server/middleware.go`](../server/middleware.go). The composite resolver wraps each sub-resolver and returns the first non-empty, validation-passing result.
+
+## Programmatic use
+
+If you need to call a resolver directly (in tests, or as a building block in custom middleware):
+
+```go
+import "github.com/gaborage/go-bricks/multitenant"
+
+resolver := &multitenant.PathResolver{Segment: 2, Prefix: "/itsp"}
+tenantID, err := resolver.ResolveTenant(ctx, req)
+if err != nil {
+    // Failure cases: nil request, missing/empty segment, prefix mismatch.
+    return err
+}
+ctx = multitenant.SetTenant(ctx, tenantID)
+```
+
+For the multi-tenant resource resolution that consumes the tenant ID downstream (`deps.DB(ctx)`, `deps.Cache(ctx)`, etc.), see the per-subsystem wiki pages.

--- a/wiki/multi-tenant-resolvers.md
+++ b/wiki/multi-tenant-resolvers.md
@@ -64,7 +64,7 @@ Use this when downstream clients route by URL path rather than header or hostnam
 
 **Trailing slashes are tolerated**: `/itsp/acme/` resolves identically to `/itsp/acme`.
 
-**Empty segments are rejected**: `/itsp//foo` is not a valid resolution.
+**Empty segments are rejected outright**: paths with intermediate empty parts like `/itsp//foo` or a leading double-slash (`//foo`) fail at any segment index — these are malformed inputs that must not produce a tenant ID regardless of which slot is configured.
 
 **Query strings and fragments are ignored**: they're isolated from `URL.Path` by the standard library before the resolver sees the request.
 


### PR DESCRIPTION
## Summary

Adds `path` as a fourth tenant resolver type in `multitenant/resolver.go` alongside `header`, `subdomain`, and `composite`. Extracts a tenant identifier from a 1-indexed segment of `req.URL.Path`, with an optional `prefix` gate that constrains the resolver to a specific URL family (e.g. `/itsp/{tenantID}/...`).

Closes #433.

## Why

Several NovoPayment tokenization services (ITSP, TRTSP, 3DS, Click-to-Pay, Backoffice) route tenants via a path segment rather than a header or subdomain — the canonical shape is `/<service>/{tenantID}/...`. Without an upstream resolver, each consumer service would hand-roll ~30 LOC of middleware duplicating the segment-extraction + validation pattern. This resolver centralizes the logic so the consumer side stays declarative in `config.yaml`, matching the ergonomics of `header` and `subdomain` today.

## Config shape

\`\`\`yaml
multitenant:
  enabled: true
  resolver:
    type: path
    path:
      segment: 2          # 1-indexed: /itsp/{tenantID}/... → segment 2
      prefix: /itsp        # optional gate; only paths under here are eligible
\`\`\`

`composite` mode accepts the path block alongside `header` + `subdomain` for migration scenarios (legacy callers on header, new clients on path).

## Settled open questions

The issue listed three; this PR answers each:

| Question | Decision |
|---|---|
| 1-indexed vs 0-indexed segment | **1-indexed** — matches the natural "second path segment" reading |
| Trailing-slash policy | **Tolerated** — `/itsp/acme/` resolves identically to `/itsp/acme` |
| `Required` flag | **Dropped** — the existing resolver pattern returns `ErrTenantResolutionFailed` uniformly; the composite already handles "try next resolver" via that signal; a separate toggle adds no observable behavior (YAGNI per CLAUDE.md) |

## Acceptance criteria

- [x] `multitenant.resolver.type: path` accepted by config parser with validation (`segment > 0`; prefix must start with `/`; included in composite only when segment is configured)
- [x] `PathResolver` matches the existing `TenantResolver` interface — no changes to downstream tenant-loading code
- [x] `composite` resolver accepts `path` as one of its sub-resolvers (factory + test coverage)
- [x] Unit tests cover: 16 segment/prefix/edge cases + 3 nil-safety cases + 3 composite-with-path cases = 22 new subtests, all passing
- [x] `wiki/multi-tenant-resolvers.md` (new) — deep dive for all four resolver types
- [x] `llms.txt` updated — the previous \"header/host/custom store\" wording was inaccurate; replaced with the actual four resolver types + YAML examples for each
- [x] `CLAUDE.md` — added `multitenant/` to Core Components (previously omitted despite being a non-trivial subsystem)
- [ ] CHANGELOG entry under \"Unreleased\" — **skipped**: repo has no CHANGELOG file (release notes are PR-driven on existing precedent)

## Test plan

- [x] `make check` — fmt + lint + tests (unit + race) for all touched packages
- [x] Tests pass: `TestPathResolverResolveTenant` (16 subtests), `TestPathResolverNilSafety` (3 subtests), `TestCompositeResolverWithPathSubresolver` (3 subtests)
- [x] Config validation: 3 success cases (path standalone, path no-prefix, composite-with-path) + 4 failure cases (missing segment, negative segment, prefix without leading slash, composite with invalid path)
- [x] `/simplify` swept findings: replaced hand-rolled error message with existing `errMustBePositive` constant; removed 4 WHAT-narrating comments
- [x] `/security-audit` results: gosec 0/7145, govulncheck 0 vulnerabilities, no raw-SQL escape hatches, no new secrets. Threat model walked: path traversal (`..`), URL-encoded traversal (`%2E%2E`), null bytes, unicode bypass — all caught by existing `^[a-z0-9-]{1,64}$` regex on `ValidatingResolver`. Partial-prefix bypass caught by the prefix-gate's exact + `prefix/` head check (test: `prefix_partial_word_match_rejected`)

## Implementation notes

- Resolver lives in the existing `multitenant/resolver.go` (single file), not a `multitenant/resolver/` subpackage as the issue body sketched. The existing pattern is followed — no over-engineering.
- The factory closure in `server/middleware.go` returns `nil` when `Path.Segment <= 0`, so composite mode includes path only when configured. Matches the existing `newSubdomainResolver` pattern.
- One follow-up worth filing: `server/route_registrar.go` already has unexported `ensureLeadingSlash` / `normalizePrefix` / `stripPathPrefix` helpers that overlap with the prefix-gate logic. Consolidating into `internal/pathutil` is a separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Path-based tenant resolution: tenants can be extracted from 1-indexed URL path segments with optional prefix gating and validation.

* **Documentation**
  * Expanded multi-tenancy docs covering header, subdomain, path, and composite resolver behaviors and examples.

* **Tests**
  * Added comprehensive tests for path resolver behavior, nil-safety, composite fallthrough, and validation cases.

* **Bug Fixes**
  * Configuration validation now enforces positive segment indices and normalized path prefixes for path-based resolvers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/438)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->