### PR TITLE
feat(keystore): symmetric secret config schema and validation (#442)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -159,6 +159,10 @@ func loadDefaults(k *koanf.Koanf) error {
 		"scheduler.timeout.slowjob":         "25s",
 		"scheduler.security.cidrallowlist":  []string{},
 		"scheduler.security.trustedproxies": []string{},
+
+		// KeyStore defaults — symmetric secret floor (32 bytes). Set to 0 to
+		// disable the minimum-length check explicitly.
+		"keystore.secret_min_length": 32,
 	}
 
 	return k.Load(confmap.Provider(defaults, "."), nil)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -212,6 +212,9 @@ func TestLoadDefaultsInternalFunction(t *testing.T) {
 	assert.False(t, k.Bool("log.pretty"))
 	assert.Equal(t, "auto", k.String("log.output.format"))
 	assert.Equal(t, "", k.String("log.output.file"))
+
+	// KeyStore symmetric-secret floor defaults to 32 bytes.
+	assert.Equal(t, 32, k.Int("keystore.secret_min_length"))
 }
 
 func TestLoadEdgeCases(t *testing.T) {

--- a/config/types.go
+++ b/config/types.go
@@ -534,27 +534,48 @@ type SchedulerTimeoutConfig struct {
 	SlowJob time.Duration `koanf:"slowjob" json:"slowjob" yaml:"slowjob" toml:"slowjob" mapstructure:"slowjob"`
 }
 
-// KeyStoreConfig holds named RSA key pair configuration.
-// Keys can be loaded from DER files (local dev) or base64-encoded values (EKS deployment).
+// KeyStoreConfig holds named key material configuration.
+// Keys can be loaded from files (local dev) or base64-encoded values (EKS deployment).
 type KeyStoreConfig struct {
-	// Keys maps logical names to key pair configurations.
-	// Example names: "signing", "encryption", "legacy".
+	// Keys maps logical names to key material configurations. Each entry is
+	// either an RSA pair (public/private) or a symmetric secret — never both.
+	// Example names: "signing", "encryption", "legacy", "my-mac-key".
 	Keys map[string]KeyPairConfig `koanf:"keys" json:"keys" yaml:"keys" toml:"keys" mapstructure:"keys"`
+
+	// SecretMinLength is the minimum byte length enforced for symmetric secret
+	// entries at startup. The default (32) is applied via loadDefaults; an
+	// explicit 0 disables the check (opt-out for callers with a deliberate
+	// reason to allow shorter keys). Negative values are rejected at validation.
+	SecretMinLength int `koanf:"secret_min_length" json:"secret_min_length" yaml:"secret_min_length" toml:"secret_min_length" mapstructure:"secret_min_length"`
 }
 
-// KeyPairConfig holds a public/private RSA key pair configuration.
-// Public key is required; private key is optional (e.g., verification-only services).
+// KeyPairConfig holds key material for one logical name. An entry is either an
+// RSA key pair (Public required, Private optional) or a symmetric Secret —
+// never a mix. A mixed entry is rejected at startup (structural detection; no
+// explicit discriminator needed).
 type KeyPairConfig struct {
 	Public  KeySourceConfig `koanf:"public" json:"public" yaml:"public" toml:"public" mapstructure:"public"`
 	Private KeySourceConfig `koanf:"private" json:"private" yaml:"private" toml:"private" mapstructure:"private"`
+	// Secret holds raw symmetric key material (HMAC/CMAC key, HKDF input).
+	// Mutually exclusive with Public/Private.
+	Secret KeySourceConfig `koanf:"secret" json:"secret" yaml:"secret" toml:"secret" mapstructure:"secret"`
 }
 
-// KeySourceConfig specifies where to load a DER-encoded RSA key from.
+// KeySourceConfig specifies where to load a key from.
 // For required keys (e.g., public), exactly one of File or Value must be set.
 // For optional keys (e.g., private in verification-only services), both may be empty.
-//   - File: path to a .der file (local development)
-//   - Value: base64-encoded DER bytes (EKS deployment via env vars)
+//   - File: path to a key file — DER bytes for RSA, raw key bytes for a secret
+//     (local development)
+//   - Value: base64-encoded bytes — DER for RSA, raw key material for a secret
+//     (EKS deployment via env vars)
 type KeySourceConfig struct {
 	File  string `koanf:"file" json:"file" yaml:"file" toml:"file" mapstructure:"file"`
 	Value string `koanf:"value" json:"value" yaml:"value" toml:"value" mapstructure:"value"`
+}
+
+// IsSet reports whether this source has any material configured (file or
+// value). It is the single source of truth for "is a key source populated",
+// shared by config validation and the keystore loader.
+func (s *KeySourceConfig) IsSet() bool {
+	return s.File != "" || s.Value != ""
 }

--- a/config/validation.go
+++ b/config/validation.go
@@ -732,10 +732,15 @@ func validateOracleFields(cfg *DatabaseConfig) error {
 	return nil
 }
 
-// validateKeyStore validates keystore configuration.
-// Returns nil if no keys are configured. Each key pair must have a public key
-// with exactly one source (file or value). Private keys are optional.
+// validateKeyStore validates keystore configuration. Returns nil if no keys
+// are configured. SecretMinLength must be non-negative. Each entry is either
+// an RSA pair (public required with exactly one source, private optional) or a
+// symmetric secret — a mixed entry is rejected.
 func validateKeyStore(cfg *KeyStoreConfig) error {
+	if cfg.SecretMinLength < 0 {
+		return NewValidationError("keystore.secret_min_length", errMustBeNonNegative)
+	}
+
 	if len(cfg.Keys) == 0 {
 		return nil
 	}
@@ -749,14 +754,37 @@ func validateKeyStore(cfg *KeyStoreConfig) error {
 
 	for _, name := range names {
 		kp := cfg.Keys[name]
-		if err := validateKeySource(kp.Public, name, "public", true); err != nil {
-			return err
-		}
-		if err := validateKeySource(kp.Private, name, "private", false); err != nil {
+		if err := validateKeyEntry(&kp, name); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// validateKeyEntry validates a single keystore entry. An entry is either an
+// RSA pair (public required, private optional) or a symmetric secret — a mixed
+// entry is a structural error detected here without an explicit discriminator.
+func validateKeyEntry(kp *KeyPairConfig, name string) error {
+	hasSecret := kp.Secret.IsSet()
+	hasAsymmetric := kp.Public.IsSet() || kp.Private.IsSet()
+
+	if hasSecret && hasAsymmetric {
+		return &ConfigError{
+			Category: errCategoryInvalid,
+			Field:    fmt.Sprintf("keystore.keys.%s", name),
+			Message:  "entry has both a symmetric 'secret' and asymmetric 'public'/'private' material",
+			Action:   "configure an entry as either a 'secret' or an RSA pair, not both",
+		}
+	}
+
+	if hasSecret {
+		return validateKeySource(kp.Secret, name, "secret", true)
+	}
+
+	if err := validateKeySource(kp.Public, name, "public", true); err != nil {
+		return err
+	}
+	return validateKeySource(kp.Private, name, "private", false)
 }
 
 // validateKeySource checks that a key source has exactly one of file or value set.
@@ -773,7 +801,7 @@ func validateKeySource(src KeySourceConfig, keyName, keyType string, required bo
 			Action:   "use exactly one of 'file' or 'value'",
 		}
 	}
-	if required && !hasFile && !hasValue {
+	if required && !src.IsSet() {
 		return &ConfigError{
 			Category: errCategoryMissing,
 			Field:    fmt.Sprintf("keystore.keys.%s.%s", keyName, keyType),

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -3693,3 +3693,79 @@ func TestValidateKeyStoreWiredIntoValidate(t *testing.T) {
 	assert.ErrorContains(t, err, "keystore config")
 	assert.ErrorContains(t, err, "both 'file' and 'value' set")
 }
+
+func TestValidateKeyStoreSecretValid(t *testing.T) {
+	cfg := &KeyStoreConfig{
+		Keys: map[string]KeyPairConfig{
+			"mac-file":  {Secret: KeySourceConfig{File: "mac.bin"}},
+			"mac-value": {Secret: KeySourceConfig{Value: "base64data"}},
+		},
+	}
+	assert.NoError(t, validateKeyStore(cfg))
+}
+
+func TestValidateKeyStoreSecretRequiresSource(t *testing.T) {
+	cfg := &KeyStoreConfig{
+		Keys: map[string]KeyPairConfig{
+			"empty-secret": {Secret: KeySourceConfig{}},
+		},
+	}
+	// An entry with no material at all falls back to the public-key path.
+	err := validateKeyStore(cfg)
+	assert.ErrorContains(t, err, "key source required")
+}
+
+func TestValidateKeyStoreSecretBothSourcesSet(t *testing.T) {
+	cfg := &KeyStoreConfig{
+		Keys: map[string]KeyPairConfig{
+			"mac": {Secret: KeySourceConfig{File: "mac.bin", Value: "also"}},
+		},
+	}
+	err := validateKeyStore(cfg)
+	assert.ErrorContains(t, err, "both 'file' and 'value' set")
+	assert.ErrorContains(t, err, "keystore.keys.mac.secret")
+}
+
+func TestValidateKeyStoreMixedEntrySecretPlusPublic(t *testing.T) {
+	cfg := &KeyStoreConfig{
+		Keys: map[string]KeyPairConfig{
+			"mixed": {
+				Public: KeySourceConfig{File: "pub.der"},
+				Secret: KeySourceConfig{File: "mac.bin"},
+			},
+		},
+	}
+	err := validateKeyStore(cfg)
+	assert.ErrorContains(t, err, "both a symmetric 'secret' and asymmetric")
+	assert.ErrorContains(t, err, "keystore.keys.mixed")
+}
+
+func TestValidateKeyStoreMixedEntrySecretPlusPrivate(t *testing.T) {
+	cfg := &KeyStoreConfig{
+		Keys: map[string]KeyPairConfig{
+			"mixed": {
+				Private: KeySourceConfig{Value: "privb64"},
+				Secret:  KeySourceConfig{Value: "macb64"},
+			},
+		},
+	}
+	err := validateKeyStore(cfg)
+	assert.ErrorContains(t, err, "both a symmetric 'secret' and asymmetric")
+}
+
+func TestValidateKeyStoreSecretMinLengthNegative(t *testing.T) {
+	cfg := &KeyStoreConfig{SecretMinLength: -1}
+	err := validateKeyStore(cfg)
+	assert.ErrorContains(t, err, "keystore.secret_min_length")
+	assert.ErrorContains(t, err, "must be non-negative")
+}
+
+func TestValidateKeyStoreSecretMinLengthZeroAllowed(t *testing.T) {
+	cfg := &KeyStoreConfig{
+		SecretMinLength: 0,
+		Keys: map[string]KeyPairConfig{
+			"mac": {Secret: KeySourceConfig{File: "mac.bin"}},
+		},
+	}
+	assert.NoError(t, validateKeyStore(cfg))
+}


### PR DESCRIPTION
## Summary

First of three small PRs implementing keystore symmetric/MAC key support (#442). **Config layer only — no behavior change to existing RSA paths or their tests.**

- `KeyPairConfig` gains a `secret` `KeySourceConfig` (`file`/`value`), mutually exclusive with `public`/`private`. A mixed entry fails at startup via **structural detection** (no `kind:` discriminator, per the issue's preferred resolution).
- `KeyStoreConfig` gains `secret_min_length` (default **32**, applied in `loadDefaults`). Negative values are rejected; an explicit `0` disables the floor (documented opt-out).
- Consolidated the "is a key source populated" predicate into one exported `KeySourceConfig.IsSet()` — reused by `validateKeySource` and the new `validateKeyEntry` (and the keystore loader in PR2).

## Why this slice

Decoded-secret length **enforcement** needs the raw bytes, so it lands in PR2 (keystore loader). This PR is the schema + startup validation foundation and is independently green.

## Acceptance criteria progress (#442)

- [x] `keystore.keys.<name>.secret.{file,value}` schema parsed
- [x] Mixed entry (`secret` + `public`/`private`) fails at startup with a clear config error
- [x] Min-length knob with default-on (32) + override (`0` disables)
- [ ] `Secret(name) ([]byte, error)` accessor + defensive copy + decoded-length enforcement -> PR2
- [ ] `keystore/testing` mock `WithSecret` + assertion -> PR2
- [ ] Docs (no CHANGELOG.md exists in repo; substituting llms.txt/godoc/wiki) -> PR3

## Testing

`make check` green. Added 7 validation tests + a defaults assertion, appended to existing companion test files (1:1 source-to-test).

Refs #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keystore now supports symmetric secret key material alongside RSA key pairs.
  * Added `keystore.secret_min_length` configuration option (defaults to 32) to enforce minimum symmetric secret length validation.

* **Improvements**
  * Enhanced keystore validation to prevent mixing symmetric and asymmetric keys in the same entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->