### PR TITLE
feat(keystore): Secret() accessor, loader, and mock support (#442)

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -395,6 +395,10 @@ func (s *stubKeyStore) PrivateKey(_ string) (*rsa.PrivateKey, error) {
 	return nil, fmt.Errorf("stub")
 }
 
+func (s *stubKeyStore) Secret(_ string) ([]byte, error) {
+	return nil, fmt.Errorf("stub")
+}
+
 type testAppFixture struct {
 	t         *testing.T
 	app       *App

--- a/app/module.go
+++ b/app/module.go
@@ -119,6 +119,12 @@ type KeyStore interface {
 	// PrivateKey returns the parsed RSA private key for the given certificate name.
 	// Returns an error if the name is not configured or no private key was provided.
 	PrivateKey(name string) (*rsa.PrivateKey, error)
+
+	// Secret returns a defensive copy of the raw symmetric key material for the
+	// given name (HMAC/CMAC key, HKDF input). The caller owns the returned slice
+	// and may zeroize it after use. Returns an error if the name is not
+	// configured or the entry holds an RSA pair rather than a secret.
+	Secret(name string) ([]byte, error)
 }
 
 // KeyStoreProvider is an optional interface that modules can implement to provide

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -39,6 +39,7 @@
 package keystore
 
 import (
+	"bytes"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
@@ -48,16 +49,19 @@ import (
 	"github.com/gaborage/go-bricks/config"
 )
 
-// keyPair holds a parsed public/private RSA key pair.
-type keyPair struct {
+// keyEntry holds the parsed material for one logical name: either an RSA pair
+// (public set, private optional) or a symmetric secret. The two are mutually
+// exclusive — the config layer rejects mixed entries before newStore runs.
+type keyEntry struct {
 	public  *rsa.PublicKey
 	private *rsa.PrivateKey // May be nil if only public key is configured
+	secret  []byte          // Non-nil only for symmetric-secret entries
 }
 
 // store implements app.KeyStore.
 // All keys are loaded at construction time; access is read-only and thread-safe.
 type store struct {
-	keys map[string]*keyPair
+	keys map[string]*keyEntry
 }
 
 // PublicKey returns the RSA public key for the given key pair name.
@@ -65,6 +69,9 @@ func (s *store) PublicKey(name string) (*rsa.PublicKey, error) {
 	kp, ok := s.keys[name]
 	if !ok {
 		return nil, fmt.Errorf("keystore: key %q not found", name)
+	}
+	if kp.public == nil {
+		return nil, fmt.Errorf("keystore: key %q has no public key configured", name)
 	}
 	return kp.public, nil
 }
@@ -81,52 +88,95 @@ func (s *store) PrivateKey(name string) (*rsa.PrivateKey, error) {
 	return kp.private, nil
 }
 
-// newStore creates a KeyStore by loading all configured key pairs.
-// Fails fast if any key cannot be loaded or parsed.
-func newStore(keys map[string]config.KeyPairConfig) (*store, error) {
-	parsed := make(map[string]*keyPair, len(keys))
+// Secret returns a defensive copy of the raw symmetric key material for the
+// given name. The caller owns the returned slice and may zeroize it.
+func (s *store) Secret(name string) ([]byte, error) {
+	kp, ok := s.keys[name]
+	if !ok {
+		return nil, fmt.Errorf("keystore: key %q not found", name)
+	}
+	if kp.secret == nil {
+		return nil, fmt.Errorf("keystore: key %q has no symmetric secret configured", name)
+	}
+	return bytes.Clone(kp.secret), nil
+}
+
+// newStore creates a KeyStore by loading all configured entries.
+// secretMinLength is the byte floor for symmetric secrets (0 disables it).
+// Fails fast if any entry cannot be loaded, parsed, or fails the floor.
+func newStore(keys map[string]config.KeyPairConfig, secretMinLength int) (*store, error) {
+	parsed := make(map[string]*keyEntry, len(keys))
 
 	for name, kpCfg := range keys {
-		kp := &keyPair{}
-
-		// Load public key (required)
-		pubDER, err := loadDERBytes(kpCfg.Public, name, "public")
+		entry, err := loadKeyEntry(name, &kpCfg, secretMinLength)
 		if err != nil {
 			return nil, err
 		}
-		if pubDER == nil {
-			return nil, fmt.Errorf("keystore: key %q: public key is required", name)
-		}
-		kp.public, err = parsePublicKey(pubDER, name)
-		if err != nil {
-			return nil, err
-		}
-
-		// Load private key (optional)
-		privDER, err := loadDERBytes(kpCfg.Private, name, "private")
-		if err != nil {
-			return nil, err
-		}
-		if privDER != nil {
-			kp.private, err = parsePrivateKey(privDER, name)
-			if err != nil {
-				return nil, err
-			}
-			// Fail fast if public and private keys don't match
-			if kp.private.E != kp.public.E || kp.private.N.Cmp(kp.public.N) != 0 {
-				return nil, fmt.Errorf("keystore: key %q: public and private keys do not match", name)
-			}
-		}
-
-		parsed[name] = kp
+		parsed[name] = entry
 	}
 
 	return &store{keys: parsed}, nil
 }
 
-// loadDERBytes resolves a KeySourceConfig to raw DER bytes.
-// Returns nil if neither file nor value is set (key not configured).
-func loadDERBytes(src config.KeySourceConfig, keyName, keyType string) ([]byte, error) {
+// loadKeyEntry loads one entry as either a symmetric secret or an RSA pair.
+// The config layer guarantees the two are mutually exclusive.
+func loadKeyEntry(name string, cfg *config.KeyPairConfig, secretMinLength int) (*keyEntry, error) {
+	if cfg.Secret.IsSet() {
+		return loadSecretEntry(name, cfg.Secret, secretMinLength)
+	}
+	return loadRSAEntry(name, cfg)
+}
+
+// loadSecretEntry loads raw symmetric key material and enforces the byte floor.
+func loadSecretEntry(name string, src config.KeySourceConfig, secretMinLength int) (*keyEntry, error) {
+	raw, err := loadKeyBytes(src, name, "secret")
+	if err != nil {
+		return nil, err
+	}
+	// src.IsSet() is true here, so loadKeyBytes never returns nil without error.
+	if secretMinLength > 0 && len(raw) < secretMinLength {
+		return nil, fmt.Errorf("keystore: key %q: secret is %d bytes, minimum is %d", name, len(raw), secretMinLength)
+	}
+	return &keyEntry{secret: raw}, nil
+}
+
+// loadRSAEntry loads an RSA pair: public required, private optional, matched.
+func loadRSAEntry(name string, cfg *config.KeyPairConfig) (*keyEntry, error) {
+	kp := &keyEntry{}
+
+	pubDER, err := loadKeyBytes(cfg.Public, name, "public")
+	if err != nil {
+		return nil, err
+	}
+	if pubDER == nil {
+		return nil, fmt.Errorf("keystore: key %q: public key is required", name)
+	}
+	kp.public, err = parsePublicKey(pubDER, name)
+	if err != nil {
+		return nil, err
+	}
+
+	privDER, err := loadKeyBytes(cfg.Private, name, "private")
+	if err != nil {
+		return nil, err
+	}
+	if privDER != nil {
+		kp.private, err = parsePrivateKey(privDER, name)
+		if err != nil {
+			return nil, err
+		}
+		// Fail fast if public and private keys don't match
+		if kp.private.E != kp.public.E || kp.private.N.Cmp(kp.public.N) != 0 {
+			return nil, fmt.Errorf("keystore: key %q: public and private keys do not match", name)
+		}
+	}
+
+	return kp, nil
+}
+
+// loadKeyBytes resolves a KeySourceConfig to raw bytes — DER for RSA keys,
+// raw key material for secrets. Returns nil if neither file nor value is set.
+func loadKeyBytes(src config.KeySourceConfig, keyName, keyType string) ([]byte, error) {
 	hasFile := src.File != ""
 	hasValue := src.Value != ""
 

--- a/keystore/keystore_test.go
+++ b/keystore/keystore_test.go
@@ -59,7 +59,7 @@ func TestNewStoreWithFileSource(t *testing.T) {
 			Public:  config.KeySourceConfig{File: pubPath},
 			Private: config.KeySourceConfig{File: privPath},
 		},
-	})
+	}, 0)
 
 	require.NoError(t, err)
 
@@ -83,7 +83,7 @@ func TestNewStoreWithBase64Source(t *testing.T) {
 			Public:  config.KeySourceConfig{Value: pubB64},
 			Private: config.KeySourceConfig{Value: privB64},
 		},
-	})
+	}, 0)
 
 	require.NoError(t, err)
 
@@ -114,7 +114,7 @@ func TestNewStoreMultipleKeyPairs(t *testing.T) {
 			Public:  config.KeySourceConfig{Value: pub2B64},
 			Private: config.KeySourceConfig{Value: priv2B64},
 		},
-	})
+	}, 0)
 
 	require.NoError(t, err)
 
@@ -137,7 +137,7 @@ func TestNewStorePrivateKeyOptional(t *testing.T) {
 			Public: config.KeySourceConfig{Value: pubB64},
 			// No private key
 		},
-	})
+	}, 0)
 
 	require.NoError(t, err)
 
@@ -150,14 +150,14 @@ func TestNewStorePrivateKeyOptional(t *testing.T) {
 }
 
 func TestPublicKeyNotFound(t *testing.T) {
-	s := &store{keys: map[string]*keyPair{}}
+	s := &store{keys: map[string]*keyEntry{}}
 
 	_, err := s.PublicKey("nonexistent")
 	assert.ErrorContains(t, err, `key "nonexistent" not found`)
 }
 
 func TestPrivateKeyNotFound(t *testing.T) {
-	s := &store{keys: map[string]*keyPair{}}
+	s := &store{keys: map[string]*keyEntry{}}
 
 	_, err := s.PrivateKey("nonexistent")
 	assert.ErrorContains(t, err, `key "nonexistent" not found`)
@@ -168,7 +168,7 @@ func TestNewStoreFileNotFound(t *testing.T) {
 		"missing": {
 			Public: config.KeySourceConfig{File: "/nonexistent/path.der"},
 		},
-	})
+	}, 0)
 
 	assert.ErrorContains(t, err, "read file")
 }
@@ -178,7 +178,7 @@ func TestNewStoreInvalidBase64(t *testing.T) {
 		"bad": {
 			Public: config.KeySourceConfig{Value: "not-valid-base64!!!"},
 		},
-	})
+	}, 0)
 
 	assert.ErrorContains(t, err, "base64 decode")
 }
@@ -190,7 +190,7 @@ func TestNewStoreInvalidDER(t *testing.T) {
 		"corrupt": {
 			Public: config.KeySourceConfig{Value: badB64},
 		},
-	})
+	}, 0)
 
 	assert.ErrorContains(t, err, "ParsePKIXPublicKey")
 }
@@ -205,7 +205,7 @@ func TestNewStoreInvalidPrivateKeyDER(t *testing.T) {
 			Public:  config.KeySourceConfig{Value: pubB64},
 			Private: config.KeySourceConfig{Value: badPrivB64},
 		},
-	})
+	}, 0)
 
 	assert.ErrorContains(t, err, "PKCS1 fallback also failed")
 }
@@ -224,7 +224,7 @@ func TestNewStorePKCS1Fallback(t *testing.T) {
 			Public:  config.KeySourceConfig{Value: pubB64},
 			Private: config.KeySourceConfig{Value: privB64},
 		},
-	})
+	}, 0)
 
 	require.NoError(t, err)
 
@@ -239,7 +239,7 @@ func TestNewStorePublicKeyRequired(t *testing.T) {
 			// No public key configured
 			Private: config.KeySourceConfig{Value: "dW51c2Vk"},
 		},
-	})
+	}, 0)
 
 	assert.ErrorContains(t, err, "public key is required")
 }
@@ -257,32 +257,133 @@ func TestNewStoreMismatchedKeyPair(t *testing.T) {
 			Public:  config.KeySourceConfig{Value: pub1B64},
 			Private: config.KeySourceConfig{Value: priv2B64},
 		},
-	})
+	}, 0)
 
 	assert.ErrorContains(t, err, "public and private keys do not match")
 }
 
-func TestLoadDERBytesFromFile(t *testing.T) {
+func TestLoadKeyBytesFromFile(t *testing.T) {
 	dir := t.TempDir()
 	expected := []byte("test-der-content")
 	path := writeDERFile(t, dir, "test.der", expected)
 
-	data, err := loadDERBytes(config.KeySourceConfig{File: path}, "test", "public")
+	data, err := loadKeyBytes(config.KeySourceConfig{File: path}, "test", "public")
 	require.NoError(t, err)
 	assert.Equal(t, expected, data)
 }
 
-func TestLoadDERBytesFromBase64(t *testing.T) {
+func TestLoadKeyBytesFromBase64(t *testing.T) {
 	expected := []byte("test-der-content")
 	b64 := base64.StdEncoding.EncodeToString(expected)
 
-	data, err := loadDERBytes(config.KeySourceConfig{Value: b64}, "test", "public")
+	data, err := loadKeyBytes(config.KeySourceConfig{Value: b64}, "test", "public")
 	require.NoError(t, err)
 	assert.Equal(t, expected, data)
 }
 
-func TestLoadDERBytesNeitherSet(t *testing.T) {
-	data, err := loadDERBytes(config.KeySourceConfig{}, "test", "public")
+func TestLoadKeyBytesNeitherSet(t *testing.T) {
+	data, err := loadKeyBytes(config.KeySourceConfig{}, "test", "public")
 	require.NoError(t, err)
 	assert.Nil(t, data)
+}
+
+// =============================================================================
+// Symmetric secret tests
+// =============================================================================
+
+func TestNewStoreWithSecretFileSource(t *testing.T) {
+	dir := t.TempDir()
+	want := []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+	path := writeDERFile(t, dir, "mac.bin", want)
+
+	s, err := newStore(map[string]config.KeyPairConfig{
+		"mac": {Secret: config.KeySourceConfig{File: path}},
+	}, 32)
+	require.NoError(t, err)
+
+	got, err := s.Secret("mac")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestNewStoreWithSecretBase64Source(t *testing.T) {
+	want := []byte("an-explicitly-32-byte-mac-key!!!")
+	s, err := newStore(map[string]config.KeyPairConfig{
+		"mac": {Secret: config.KeySourceConfig{Value: base64.StdEncoding.EncodeToString(want)}},
+	}, 32)
+	require.NoError(t, err)
+
+	got, err := s.Secret("mac")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestSecretReturnsDefensiveCopy(t *testing.T) {
+	want := []byte("0123456789abcdef0123456789abcdef")
+	s, err := newStore(map[string]config.KeyPairConfig{
+		"mac": {Secret: config.KeySourceConfig{Value: base64.StdEncoding.EncodeToString(want)}},
+	}, 32)
+	require.NoError(t, err)
+
+	first, err := s.Secret("mac")
+	require.NoError(t, err)
+	first[0] ^= 0xFF // caller mutates its copy
+
+	second, err := s.Secret("mac")
+	require.NoError(t, err)
+	assert.Equal(t, want, second, "store must not be affected by caller mutation")
+}
+
+func TestNewStoreSecretBelowMinLength(t *testing.T) {
+	_, err := newStore(map[string]config.KeyPairConfig{
+		"weak": {Secret: config.KeySourceConfig{Value: base64.StdEncoding.EncodeToString([]byte("short"))}},
+	}, 32)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, `key "weak"`)
+	assert.ErrorContains(t, err, "minimum is 32")
+}
+
+func TestNewStoreSecretMinLengthDisabled(t *testing.T) {
+	want := []byte("short")
+	s, err := newStore(map[string]config.KeyPairConfig{
+		"weak": {Secret: config.KeySourceConfig{Value: base64.StdEncoding.EncodeToString(want)}},
+	}, 0) // 0 disables the floor
+	require.NoError(t, err)
+
+	got, err := s.Secret("weak")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestSecretNotFound(t *testing.T) {
+	s := &store{keys: map[string]*keyEntry{}}
+	_, err := s.Secret("nope")
+	assert.ErrorContains(t, err, `key "nope" not found`)
+}
+
+func TestSecretOnRSAEntryRejected(t *testing.T) {
+	_, pub := generateTestKeys(t)
+	s, err := newStore(map[string]config.KeyPairConfig{
+		"signing": {Public: config.KeySourceConfig{
+			Value: base64.StdEncoding.EncodeToString(marshalPublicKeyDER(t, pub)),
+		}},
+	}, 32)
+	require.NoError(t, err)
+
+	_, err = s.Secret("signing")
+	assert.ErrorContains(t, err, "has no symmetric secret configured")
+}
+
+func TestPublicKeyOnSecretEntryRejected(t *testing.T) {
+	s, err := newStore(map[string]config.KeyPairConfig{
+		"mac": {Secret: config.KeySourceConfig{
+			Value: base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef")),
+		}},
+	}, 32)
+	require.NoError(t, err)
+
+	_, pubErr := s.PublicKey("mac")
+	assert.ErrorContains(t, pubErr, "has no public key configured")
+	_, privErr := s.PrivateKey("mac")
+	assert.ErrorContains(t, privErr, "has no private key configured")
 }

--- a/keystore/module.go
+++ b/keystore/module.go
@@ -40,7 +40,7 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 		return nil
 	}
 
-	s, err := newStore(cfg.Keys)
+	s, err := newStore(cfg.Keys, cfg.SecretMinLength)
 	if err != nil {
 		return err
 	}

--- a/keystore/module_test.go
+++ b/keystore/module_test.go
@@ -67,6 +67,36 @@ func TestKeystoreModuleInitWithValidKeys(t *testing.T) {
 	assert.True(t, privKey.PublicKey.Equal(gotPub))
 }
 
+func TestKeystoreModuleInitWithSecret(t *testing.T) {
+	secret := []byte("a-32-byte-symmetric-mac-key!!!!!")
+	deps := newTestDeps(t, config.KeyStoreConfig{
+		SecretMinLength: 32,
+		Keys: map[string]config.KeyPairConfig{
+			"mac": {Secret: config.KeySourceConfig{Value: base64.StdEncoding.EncodeToString(secret)}},
+		},
+	})
+
+	m := NewModule()
+	require.NoError(t, m.Init(deps))
+
+	got, err := m.store.Secret("mac")
+	require.NoError(t, err)
+	assert.Equal(t, secret, got)
+}
+
+func TestKeystoreModuleInitSecretBelowMinLengthFails(t *testing.T) {
+	deps := newTestDeps(t, config.KeyStoreConfig{
+		SecretMinLength: 32,
+		Keys: map[string]config.KeyPairConfig{
+			"mac": {Secret: config.KeySourceConfig{Value: base64.StdEncoding.EncodeToString([]byte("short"))}},
+		},
+	})
+
+	err := NewModule().Init(deps)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "minimum is 32")
+}
+
 func TestKeystoreModuleInitFileNotFound(t *testing.T) {
 	deps := newTestDeps(t, config.KeyStoreConfig{
 		Keys: map[string]config.KeyPairConfig{

--- a/keystore/testing/assertions.go
+++ b/keystore/testing/assertions.go
@@ -26,6 +26,15 @@ func AssertPrivateKeyAvailable(t *testing.T, ks app.KeyStore, name string) {
 	assert.NotNil(t, key, "private key %q should not be nil", name)
 }
 
+// AssertSecretAvailable verifies that a non-empty symmetric secret with the
+// given name can be successfully retrieved from the KeyStore.
+func AssertSecretAvailable(t *testing.T, ks app.KeyStore, name string) {
+	t.Helper()
+	secret, err := ks.Secret(name)
+	require.NoError(t, err, "secret %q should be available", name)
+	assert.NotEmpty(t, secret, "secret %q should not be empty", name)
+}
+
 // AssertKeyNotFound verifies that retrieving a key with the given name returns an error
 // from both PublicKey and PrivateKey. Note that this does not distinguish between
 // "key name not found" and "no private key configured" — it only asserts that both

--- a/keystore/testing/assertions_test.go
+++ b/keystore/testing/assertions_test.go
@@ -1,0 +1,8 @@
+package testing
+
+import "testing"
+
+func TestAssertSecretAvailablePasses(t *testing.T) {
+	m := NewMockKeyStore().WithSecret("mac", []byte("non-empty-secret"))
+	AssertSecretAvailable(t, m, "mac")
+}

--- a/keystore/testing/mock_keystore.go
+++ b/keystore/testing/mock_keystore.go
@@ -3,6 +3,7 @@
 package testing
 
 import (
+	"bytes"
 	"crypto/rsa"
 	"fmt"
 	"sync"
@@ -24,8 +25,10 @@ type MockKeyStore struct {
 	mu          sync.RWMutex
 	publicKeys  map[string]*rsa.PublicKey
 	privateKeys map[string]*rsa.PrivateKey
+	secrets     map[string][]byte
 	publicErr   error
 	privateErr  error
+	secretErr   error
 }
 
 // NewMockKeyStore creates an empty MockKeyStore.
@@ -33,6 +36,7 @@ func NewMockKeyStore() *MockKeyStore {
 	return &MockKeyStore{
 		publicKeys:  make(map[string]*rsa.PublicKey),
 		privateKeys: make(map[string]*rsa.PrivateKey),
+		secrets:     make(map[string][]byte),
 	}
 }
 
@@ -49,6 +53,23 @@ func (m *MockKeyStore) WithPrivateKey(name string, key *rsa.PrivateKey) *MockKey
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.privateKeys[name] = key
+	return m
+}
+
+// WithSecret adds raw symmetric key material for the given name. The slice is
+// copied so later caller mutations do not bleed into the mock.
+func (m *MockKeyStore) WithSecret(name string, secret []byte) *MockKeyStore {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.secrets[name] = bytes.Clone(secret)
+	return m
+}
+
+// WithSecretError configures all Secret calls to return this error.
+func (m *MockKeyStore) WithSecretError(err error) *MockKeyStore {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.secretErr = err
 	return m
 }
 
@@ -94,4 +115,19 @@ func (m *MockKeyStore) PrivateKey(name string) (*rsa.PrivateKey, error) {
 		return nil, fmt.Errorf("mock keystore: private key %q not found", name)
 	}
 	return key, nil
+}
+
+// Secret implements app.KeyStore. It returns a defensive copy, mirroring the
+// real store so tests exercise the same ownership contract.
+func (m *MockKeyStore) Secret(name string) ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.secretErr != nil {
+		return nil, m.secretErr
+	}
+	secret, ok := m.secrets[name]
+	if !ok {
+		return nil, fmt.Errorf("mock keystore: secret %q not found", name)
+	}
+	return bytes.Clone(secret), nil
 }

--- a/keystore/testing/mock_keystore_test.go
+++ b/keystore/testing/mock_keystore_test.go
@@ -1,0 +1,44 @@
+package testing
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockKeyStoreSecretRoundTrip(t *testing.T) {
+	want := []byte("symmetric-mac-key-material")
+	m := NewMockKeyStore().WithSecret("mac", want)
+
+	got, err := m.Secret("mac")
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestMockKeyStoreSecretNotFound(t *testing.T) {
+	_, err := NewMockKeyStore().Secret("missing")
+	assert.ErrorContains(t, err, `secret "missing" not found`)
+}
+
+func TestMockKeyStoreWithSecretError(t *testing.T) {
+	sentinel := errors.New("boom")
+	_, err := NewMockKeyStore().WithSecret("mac", []byte("x")).WithSecretError(sentinel).Secret("mac")
+	assert.ErrorIs(t, err, sentinel)
+}
+
+func TestMockKeyStoreSecretIsolatedFromCallerMutation(t *testing.T) {
+	src := []byte("original-key")
+	m := NewMockKeyStore().WithSecret("mac", src)
+	src[0] ^= 0xFF // mutate the input after storing
+
+	got, err := m.Secret("mac")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("original-key"), got, "WithSecret must copy its input")
+
+	got[1] ^= 0xFF // mutate the returned slice
+	again, err := m.Secret("mac")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("original-key"), again, "Secret must return a defensive copy")
+}


### PR DESCRIPTION
## Summary

Second of three small PRs for keystore symmetric/MAC key support (#442). Builds on the config schema in #443 (merged).

- `app.KeyStore` gains `Secret(name) ([]byte, error)` returning a **defensive copy** (`bytes.Clone`) the caller owns and may zeroize.
- `keystore.store` loads symmetric material via the renamed `loadKeyBytes` (was `loadDERBytes` — it resolves non-DER bytes too). `newStore` takes `secretMinLength` and enforces the byte floor **at startup**. `loadKeyEntry` dispatches to `loadSecretEntry`/`loadRSAEntry` to keep cognitive complexity low (S3776). `keyPair` → `keyEntry` (RSA pair *or* secret; mutual exclusivity enforced by the config layer from #443).
- `PublicKey` now returns a clear error for a secret-only entry instead of a nil key.
- `keystore/testing` `MockKeyStore` gains `WithSecret`/`WithSecretError`/`Secret` (defensive copies mirroring the real store) and `AssertSecretAvailable`, with their first test companions.

## Acceptance criteria progress (#442)

- [x] `Secret(name) ([]byte, error)` returns a defensive copy; `PublicKey`/`PrivateKey` behavior unchanged for RSA entries
- [x] Min-length validation, default-on (32, from #443), `0` disables
- [x] `keystore/testing` mock `WithSecret` + `AssertSecretAvailable`, mirroring `WithPrivateKey`/`AssertPrivateKeyAvailable`
- [ ] Docs (no `CHANGELOG.md` in repo; substituting llms.txt/godoc + new wiki page) -> PR3

## Security / quality notes

`/simplify` + `/security-audit` run on the diff: gosec 0 issues; no secret leakage in logs or wrapped base64 errors; defensive-copy + fail-fast-min-length posture verified. `make check` green; keystore at 97.1%.

Refs #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended keystore to support symmetric secrets alongside RSA key pairs.
  * Symmetric secrets can now be configured with enforced minimum length requirements.
  * Secret values are returned as defensive copies to prevent unintended mutations.
  * Added validation to reject incompatible key type access attempts.

* **Tests**
  * Added comprehensive test coverage for secret configuration, validation, retrieval, and isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->