### PR TITLE
docs(keystore): document symmetric secret support (#442)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ go test -bench=.        # Run benchmarks
 - [.golangci.yml](.golangci.yml) — Linting configuration
 
 **Wiki (deep dives — read on demand):**
-- Architecture: [database.md](wiki/database.md) · [cache.md](wiki/cache.md) · [messaging.md](wiki/messaging.md) · [outbox.md](wiki/outbox.md) · [scheduler.md](wiki/scheduler.md) · [httpclient.md](wiki/httpclient.md) · [jose.md](wiki/jose.md) · [observability.md](wiki/observability.md) · [multi-tenant-resolvers.md](wiki/multi-tenant-resolvers.md)
+- Architecture: [database.md](wiki/database.md) · [cache.md](wiki/cache.md) · [messaging.md](wiki/messaging.md) · [outbox.md](wiki/outbox.md) · [scheduler.md](wiki/scheduler.md) · [httpclient.md](wiki/httpclient.md) · [jose.md](wiki/jose.md) · [keystore.md](wiki/keystore.md) · [observability.md](wiki/observability.md) · [multi-tenant-resolvers.md](wiki/multi-tenant-resolvers.md)
 - Patterns: [handler-patterns.md](wiki/handler-patterns.md) · [context-deadlines.md](wiki/context-deadlines.md) · [testing.md](wiki/testing.md)
 - Reference: [troubleshooting.md](wiki/troubleshooting.md) · [migrations.md](wiki/migrations.md) (breaking changes) · [startup-defaults.md](wiki/startup-defaults.md)
 - ADRs: [wiki/architecture_decisions.md](wiki/architecture_decisions.md), files `wiki/adr-NNN-*.md`
@@ -153,7 +153,7 @@ make lint                       # Run golangci-lint
 - **multitenant/** — Tenant identifier resolution from incoming HTTP requests. Four resolver types: `header` (default `X-Tenant-ID`), `subdomain` (`<tenant>.<domain>`), `path` (1-indexed segment with optional prefix gate; e.g. `/itsp/{tenantID}/...`), and `composite` (header → subdomain → path fallback chain). All run before route matching so the resolved tenant is in `context.Context` for every middleware and handler. Per-tenant DB/cache/messaging accessors (`deps.DB(ctx)`, etc.) consume the value transparently. See [multi-tenant-resolvers.md](wiki/multi-tenant-resolvers.md).
 - **observability/** — OpenTelemetry tracing and metrics
 - **outbox/** — Transactional outbox for reliable event publishing (at-least-once delivery)
-- **keystore/** — Named RSA key pair management from DER files or base64 env vars
+- **keystore/** — Named key-material management: RSA key pairs and raw symmetric secrets (HMAC/HKDF) from files or base64 env vars; per-entry RSA-or-secret with a startup mutual-exclusivity check. See [keystore.md](wiki/keystore.md)
 - **jose/** — Nested JWE-of-JWS protection on HTTP request and response bodies
 
 ### Module System
@@ -561,7 +561,7 @@ GoBricks has shipped several breaking changes for idiomatic Go conventions. Gree
 - **observability/testing/** — Test utilities for spans and metrics.
 - **outbox/** — Transactional outbox pattern (Publisher, Relay, Store, multi-vendor).
 - **outbox/testing/** — Outbox-specific testing (MockOutbox, assertion helpers).
-- **keystore/** — Named RSA key pair management (DER files + base64 env vars).
+- **keystore/** — Named RSA key pairs + symmetric secrets (DER/raw files + base64 env vars).
 - **keystore/testing/** — KeyStore-specific testing (MockKeyStore, assertion helpers).
 - **tools/** — Development tooling (OpenAPI generator).
 - **wiki/** — Architecture documentation and ADRs.
@@ -606,6 +606,7 @@ type OutboxPublisher interface {
 type KeyStore interface {
     PublicKey(name string) (*rsa.PublicKey, error)
     PrivateKey(name string) (*rsa.PrivateKey, error)
+    Secret(name string) ([]byte, error) // raw symmetric key material (defensive copy)
 }
 ```
 

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -1,20 +1,28 @@
-// Package keystore provides named RSA key pair management for GoBricks applications.
+// Package keystore provides named key-material management for GoBricks
+// applications: RSA key pairs and raw symmetric secrets (HMAC/CMAC keys,
+// HKDF input).
 //
-// Keys are loaded at startup from DER-encoded files or base64-encoded values
-// (typically injected via environment variables for Kubernetes/EKS deployments).
-// Once loaded, the store is read-only and safe for concurrent access.
+// Material is loaded at startup from files or base64-encoded values (typically
+// injected via environment variables for Kubernetes/EKS deployments). Once
+// loaded, the store is read-only and safe for concurrent access. Each entry is
+// either an RSA pair or a symmetric secret — a mixed entry is rejected by the
+// config layer at startup (structural detection, no explicit discriminator).
 //
 // # Configuration
 //
 // Keys are configured in YAML under the "keystore" section:
 //
 //	keystore:
+//	  secret_min_length: 32                        # default 32; 0 disables
 //	  keys:
 //	    signing:
 //	      public:
 //	        file: "certs/signing_public.der"       # Local dev
 //	      private:
 //	        value: "${SIGNING_PRIVATE_KEY_BASE64}"  # EKS (base64-encoded DER)
+//	    mac-key:
+//	      secret:
+//	        value: "${MAC_KEY_BASE64}"              # base64 raw key material
 //
 // # Usage
 //
@@ -36,6 +44,11 @@
 //	}
 //
 //	privKey, err := m.keyStore.PrivateKey("signing")
+//
+// Secret returns a defensive copy of symmetric key material; the caller owns
+// the slice and may zeroize it after use:
+//
+//	macKey, err := m.keyStore.Secret("mac-key")
 package keystore
 
 import (

--- a/llms.txt
+++ b/llms.txt
@@ -2871,10 +2871,12 @@ curl -X POST http://localhost:8080/_sys/job/outbox-relay
 SELECT count(*) FROM gobricks_outbox WHERE status = 'pending';
 ```
 
-## KeyStore (Named RSA Key Pairs)
+## KeyStore (Named RSA Keys & Symmetric Secrets)
 
-Load DER-encoded RSA keys from files (local dev) or base64-encoded env vars (EKS).
-Keys are loaded once at startup and held in memory — no caching or synchronization needed.
+Load DER-encoded RSA keys or raw symmetric secrets (HMAC/CMAC keys, HKDF input)
+from files (local dev) or base64-encoded env vars (EKS). Each entry is **either**
+an RSA pair **or** a secret — a mixed entry fails fast at startup. Keys are loaded
+once and held in memory — no caching or synchronization needed.
 
 ### Configuration
 
@@ -2890,12 +2892,19 @@ keystore:
 
 # EKS deployment (base64-encoded DER via env vars)
 keystore:
+  secret_min_length: 32          # default 32; 0 disables the floor
   keys:
     signing:
       public:
         value: "${SIGNING_PUBLIC_KEY_BASE64}"
       private:
         value: "${SIGNING_PRIVATE_KEY_BASE64}"
+    mac-key:                     # symmetric secret entry
+      secret:
+        file: "certs/mac-key.bin"        # local dev: raw key bytes
+    mac-key-deployed:
+      secret:
+        value: "${MAC_KEY_BASE64}"       # deployed: base64 raw key
 ```
 
 ### Module Setup
@@ -2925,6 +2934,17 @@ func (s *Service) DecryptJWE(ctx context.Context, token string) ([]byte, error) 
     }
     return DecryptJWECompact(token, privKey)
 }
+
+// Symmetric secret — Secret returns a defensive copy the caller owns.
+func (s *Service) Digest(payload []byte) ([]byte, error) {
+    key, err := s.keyStore.Secret("mac-key")
+    if err != nil {
+        return nil, fmt.Errorf("get mac key: %w", err)
+    }
+    mac := hmac.New(sha256.New, key)
+    mac.Write(payload)
+    return mac.Sum(nil), nil
+}
 ```
 
 ### Testing
@@ -2951,16 +2971,27 @@ func TestServiceDecryption(t *testing.T) {
 mock := kstest.NewMockKeyStore().
     WithPrivateKeyError(fmt.Errorf("key unavailable"))
 
+// Symmetric secret mock + error injection
+mock := kstest.NewMockKeyStore().
+    WithSecret("mac-key", []byte("32-byte-symmetric-mac-key-mater!")).
+    WithPrivateKeyError(fmt.Errorf("key unavailable"))
+
 // Assertion helpers
 kstest.AssertPublicKeyAvailable(t, mock, "signing")
 kstest.AssertPrivateKeyAvailable(t, mock, "signing")
+kstest.AssertSecretAvailable(t, mock, "mac-key")
 kstest.AssertKeyNotFound(t, mock, "nonexistent")
 ```
 
 **Key Points:**
-- Public key required per pair, private key optional (verification-only services)
-- Exactly one source per key: `file` (DER path) or `value` (base64 string)
-- Fails fast at startup if any key cannot be loaded or parsed
+- Public key required per RSA pair, private key optional (verification-only services)
+- Symmetric `secret` entries are mutually exclusive with `public`/`private` — a
+  mixed entry is a startup config error (structural detection, no discriminator)
+- `Secret(name)` returns a **defensive copy**; the caller owns it and may zeroize
+- `keystore.secret_min_length` (default 32) enforces a byte floor at startup; an
+  explicit `0` disables it
+- Exactly one source per key: `file` (raw/DER path) or `value` (base64 string)
+- Fails fast at startup if any key cannot be loaded, parsed, or is too short
 - PKCS8 with PKCS1 fallback for private keys (handles legacy formats)
 
 ## JOSE Middleware (Nested JWE-of-JWS)

--- a/wiki/keystore.md
+++ b/wiki/keystore.md
@@ -1,0 +1,143 @@
+# KeyStore (Deep Dive)
+
+The `keystore` package provides named key-material management for GoBricks
+applications: **RSA key pairs** (signing/encryption, consumed by the JOSE
+middleware) and **raw symmetric secrets** (HMAC/CMAC keys, HKDF input keying
+material). Both live under one custody and rotation story — a file in local
+dev, a base64 env var / secrets-manager value in deployed environments, loaded
+once at startup and held read-only in memory.
+
+**Key Features:**
+- **One custody story** for asymmetric and symmetric material — no parallel,
+  un-audited secret path, no deriving a MAC key off an RSA private key
+- **Per-entry RSA *or* secret**, never both — a mixed entry is a startup config
+  error via structural detection (no `kind:` discriminator needed)
+- **Defensive copies**: `Secret` returns a fresh slice the caller owns and may
+  zeroize; the in-memory master is never handed out
+- **Fail-fast minimum length** for secrets (default 32 bytes) so a too-short
+  key is rejected at startup rather than silently weakening a digest
+- **Fail-fast at startup**: any entry that cannot be loaded, parsed, mismatched
+  (RSA pair), or is below the floor (secret) aborts boot
+
+## Configuration
+
+```yaml
+keystore:
+  secret_min_length: 32          # default 32; explicit 0 disables the floor
+  keys:
+    signing:                     # RSA pair (public required, private optional)
+      public:
+        file: "certs/signing_public.der"        # local dev
+      private:
+        value: "${SIGNING_PRIVATE_KEY_BASE64}"  # deployed (base64 DER)
+    mac-key:                     # symmetric secret entry
+      secret:
+        file: "certs/mac-key.bin"               # local dev: raw key bytes
+    mac-key-deployed:
+      secret:
+        value: "${MAC_KEY_BASE64}"              # deployed: base64 raw key
+```
+
+Each `keys.<name>` entry resolves to **exactly one** of:
+
+| Shape | Required | Notes |
+|---|---|---|
+| `public` (+ optional `private`) | `public` | RSA pair. PKCS8 with PKCS1 fallback for private; public/private mismatch is a startup error |
+| `secret` | the source | Raw symmetric bytes. Mutually exclusive with `public`/`private` |
+
+Within any source, set **exactly one** of `file` (path) or `value`
+(base64-encoded bytes). Setting both, or setting a `secret` alongside
+`public`/`private`, is rejected by the config validation layer at startup with
+a clear `ConfigError`.
+
+### Minimum-length floor
+
+`keystore.secret_min_length` (default **32**) is the byte floor enforced for
+every symmetric secret after decoding. It is a defensive control against
+silently weak HMAC/HKDF keys. Set it to an explicit `0` to opt out (documented,
+deliberate); negative values are rejected at config validation.
+
+## API
+
+```go
+type KeyStore interface {
+    PublicKey(name string) (*rsa.PublicKey, error)
+    PrivateKey(name string) (*rsa.PrivateKey, error)
+    Secret(name string) ([]byte, error)
+}
+```
+
+- `PublicKey` / `PrivateKey` — unchanged RSA behavior. Calling either on a
+  secret-only entry returns a clear `"has no public/private key configured"`
+  error rather than a nil key.
+- `Secret` — returns a **defensive copy** (`bytes.Clone`) of the raw material.
+  The caller owns the slice and may zeroize it after use. Calling `Secret` on
+  an RSA entry returns `"has no symmetric secret configured"`; an unknown name
+  returns `"key %q not found"`.
+
+The store's master copy lives for the process lifetime (consistent with how RSA
+private keys are already held). Zeroization is scoped to the caller's returned
+copy — the keystore does not wipe its own master.
+
+### Usage
+
+```go
+func (m *Module) Init(deps *app.ModuleDeps) error {
+    if deps.KeyStore == nil {
+        return fmt.Errorf("KeyStore required but not configured")
+    }
+    m.keyStore = deps.KeyStore
+    return nil
+}
+
+func (s *Service) Digest(payload []byte) ([]byte, error) {
+    key, err := s.keyStore.Secret("mac-key")
+    if err != nil {
+        return nil, fmt.Errorf("get mac key: %w", err)
+    }
+    mac := hmac.New(sha256.New, key)
+    mac.Write(payload)
+    return mac.Sum(nil), nil
+}
+```
+
+Register `keystore.NewModule()` **before** any module that needs key material
+(JOSE-tagged routes, services using `deps.KeyStore`). The framework wires the
+store into `deps.KeyStore` via the `app.KeyStoreProvider` interface; a second
+KeyStore provider is rejected at registration.
+
+## Testing
+
+```go
+import kstest "github.com/gaborage/go-bricks/keystore/testing"
+
+mock := kstest.NewMockKeyStore().
+    WithPublicKey("signing", &priv.PublicKey).
+    WithPrivateKey("signing", priv).
+    WithSecret("mac-key", []byte("a-32-byte-symmetric-mac-key!!!!!"))
+
+// Error injection
+mock.WithSecretError(fmt.Errorf("key unavailable"))
+
+// Assertion helpers
+kstest.AssertPublicKeyAvailable(t, mock, "signing")
+kstest.AssertPrivateKeyAvailable(t, mock, "signing")
+kstest.AssertSecretAvailable(t, mock, "mac-key")
+kstest.AssertKeyNotFound(t, mock, "nonexistent")
+```
+
+`WithSecret` copies its input and `Secret` returns a defensive copy, mirroring
+the real store so tests exercise the same ownership contract.
+
+## Security Notes
+
+- Secrets come from files (local dev) or base64 env vars / secrets managers
+  (deployed) — never hardcoded, one audited path, one rotation runbook.
+- No key material appears in logs or error messages: load/parse errors carry
+  the logical name, key type, and file path only; the framework logger's
+  `SensitiveDataFilter` covers any incidental log lines.
+- The minimum-length floor is on by default — keep it on for HMAC/HKDF keys;
+  only disable it (`secret_min_length: 0`) with a deliberate, documented reason.
+- Derivation (HKDF expansion, etc.) is left to the consumer — the keystore
+  intentionally exposes raw material rather than a built-in derive helper
+  (smallest viable surface; can layer on later if demand appears).


### PR DESCRIPTION
## Summary

Final of three small PRs for keystore symmetric/MAC key support (#442). **Documentation only** — the `keystore.go` change is package-godoc comment text, no logic.

- **New `wiki/keystore.md` deep dive** — entry model, RSA-or-secret mutual exclusivity, the `secret_min_length` floor, the `Secret()` defensive-copy / zeroization ownership contract, testing utilities, and security notes. Linked from the CLAUDE.md Quick Reference wiki index and Core Components (keystore had no wiki page before).
- **`llms.txt`** KeyStore section: secret config example, `Secret()`/HMAC usage snippet, `WithSecret`/`AssertSecretAvailable`, refreshed Key Points.
- **keystore package godoc** now covers secret config + usage.
- **CLAUDE.md** Key Interfaces snippet adds `Secret(name) ([]byte, error)`.

## On the CHANGELOG acceptance criterion

The issue asks for a "CHANGELOG entry under Unreleased", but this repo has **no `CHANGELOG.md`** (verified). Per the project's actual doc conventions I substituted the equivalent surfaces — `llms.txt`, package godoc, and a wiki deep dive.

## Acceptance criteria (#442) — now complete across #443 / #444 / this PR

- [x] `secret.{file,value}` parsed; base64-decoded; same conventions as RSA (#443)
- [x] `Secret(name) ([]byte, error)` defensive copy; RSA paths unchanged (#444)
- [x] Mixed entry fails at startup with a clear config error (#443)
- [x] `keystore/testing` mock `WithSecret` + `AssertSecretAvailable` (#444)
- [x] Minimum-length validation, default-on (32) with `0` override (#443/#444)
- [x] Documentation (CHANGELOG substitute) — this PR

## Verification

All documented claims cross-checked against merged code. `make check` green; `/simplify` (accuracy review — docs match implementation) and `/security-audit` (no real secrets in examples) clean.

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended keystore to support both RSA key pairs and symmetric secrets under unified management with startup validation.

* **Documentation**
  * Updated configuration documentation with symmetric secret setup examples and validation rules.
  * Added comprehensive keystore package documentation with API reference, usage patterns, and security practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->