### PR TITLE
docs(keystore): restore Secret() zeroization example lost in #445 squash

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -2941,6 +2941,7 @@ func (s *Service) Digest(payload []byte) ([]byte, error) {
     if err != nil {
         return nil, fmt.Errorf("get mac key: %w", err)
     }
+    defer func() { clear(key) }()  // caller owns the copy — zeroize after use
     mac := hmac.New(sha256.New, key)
     mac.Write(payload)
     return mac.Sum(nil), nil

--- a/wiki/keystore.md
+++ b/wiki/keystore.md
@@ -95,6 +95,7 @@ func (s *Service) Digest(payload []byte) ([]byte, error) {
     if err != nil {
         return nil, fmt.Errorf("get mac key: %w", err)
     }
+    defer func() { clear(key) }()  // caller owns the copy — zeroize after use
     mac := hmac.New(sha256.New, key)
     mac.Write(payload)
     return mac.Sum(nil), nil


### PR DESCRIPTION
## Summary

Small follow-up to the (closed) #442 keystore symmetric-secret work.

PR #445 was **squash-merged from its first commit only** — the follow-up commit `0a212b7`, which addressed CodeRabbit's nitpick by adding `defer clear(key)` to the `Secret()` usage examples, was dropped from the squash and never reached `main`.

This re-applies that 1-line zeroization step to the HMAC examples in `llms.txt` and `wiki/keystore.md` so the docs match the **caller-ownership / zeroization contract** they explicitly teach (the `Secret()` godoc and wiki both state the caller owns the copy and may zeroize it — the example should demonstrate it).

Uses the Go 1.21+ `clear()` builtin (repo is on Go 1.25).

## Scope

Documentation only — `llms.txt` + `wiki/keystore.md`, 2 insertions, no Go code. The exact change was already reviewed (it *is* CodeRabbit's suggested fix); restoring it, not introducing new logic.

Refs #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Keystore secret handling examples to demonstrate explicit zeroization of sensitive material after use, improving security best practices in code examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->