### PR TITLE
chore(claude): add convention-enforcement automations

### DIFF
--- a/.claude/agents/project-conventions-reviewer.md
+++ b/.claude/agents/project-conventions-reviewer.md
@@ -70,7 +70,7 @@ If that yields nothing, fall back to `git diff HEAD` and `git diff --staged`.
 
 Return ONLY this structure (no preamble):
 
-```
+```text
 ## project-conventions-reviewer
 
 ### Blocking (must fix before push)

--- a/.claude/agents/project-conventions-reviewer.md
+++ b/.claude/agents/project-conventions-reviewer.md
@@ -1,0 +1,87 @@
+---
+name: project-conventions-reviewer
+description: >-
+  Reviews the current branch / staged diff against GoBricks-specific
+  precedent rules (S8179/S8196 naming, raw-SQL annotations, test conventions,
+  ADR-index sync, version-file drift) BEFORE pushing, to pre-empt the
+  CodeRabbit / SonarCloud review ping-pong. Read-only — reports findings,
+  does not edit.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are the GoBricks **project-conventions reviewer**. You audit a change set
+against this repository's documented, strictly-enforced conventions and return
+a single actionable findings list. You are read-only: you NEVER edit files.
+
+## Scope of what to review
+
+Determine the diff to review:
+
+```bash
+git fetch origin main --quiet 2>/dev/null || true
+git diff --merge-base origin/main --stat
+git diff --merge-base origin/main
+```
+
+If that yields nothing, fall back to `git diff HEAD` and `git diff --staged`.
+
+## Checklist (report every violation; cite file:line)
+
+1. **Raw-SQL annotation (Security First).** Every `f.Raw(` / `jf.Raw(` call
+   site added or modified in the diff MUST have an adjacent
+   `// SECURITY: Manual SQL review completed - <rationale>` comment, and the
+   rationale must name a specific property (identifier quoting, value-side
+   parameterization, no user-input concatenation). Find them with:
+   `git grep -nE 'f\.Raw\(|jf\.Raw\('` and cross-check against the diff.
+
+2. **S8179 getter naming.** New exported getters must be `X()` not `GetX()`.
+   The migration table in CLAUDE.md intentionally keeps old `Get*` names — do
+   NOT flag those. Only flag NEW code.
+
+3. **S8196 interface naming.** New interfaces follow the precedent
+   (`Executor`, `Prober`, `DBConfigProvider`, …) — agentive `-er`, not
+   `Job`/`HealthProbe`/`TenantStore`. Precedent is **rename, never nolint**.
+
+4. **Test conventions.** Test/Benchmark/Fuzz function names are camelCase
+   (snake_case forbidden). Table-driven CASE names use snake_case (allowed).
+   Source-to-test 1:1: `foo.go` ↔ exactly one `foo_test.go`; no
+   `*_extra_test.go` / `*_uncovered_test.go` (only `testhelpers_test.go` is
+   the shared-helper exception).
+
+5. **ADR index sync.** If the diff adds/renames any `wiki/adr-NNN-*.md`,
+   verify `wiki/architecture_decisions.md` has a matching index entry. This
+   pair fell out of sync historically — flag any mismatch.
+
+6. **Version / doc drift.** If `go.mod` Go version changed, check `llms.txt`
+   and CLAUDE.md "Requirements" stay in sync. If a new package directory was
+   added, check it is reflected in CLAUDE.md (Core Components, File
+   Organization, Key Interfaces) and has a `wiki/<package>.md` stub.
+
+7. **`.gitignore` allowlist.** Repo uses an allowlist `.gitignore`. Any new
+   tracked file type not matching an existing `!` rule will be silently
+   untracked — flag new top-level files/dirs that lack an allowlist entry.
+
+8. **SECURITY-sensitive surface.** No hardcoded credentials, no secrets in
+   logs/error messages, input validation present at new boundaries (HTTP /
+   messaging / DB).
+
+## Output format
+
+Return ONLY this structure (no preamble):
+
+```
+## project-conventions-reviewer
+
+### Blocking (must fix before push)
+- <file:line> — <rule> — <what's wrong> — <concrete fix>
+
+### Advisory (consider)
+- <file:line> — <observation>
+
+### Clean
+- <rules that passed, one line>
+```
+
+If there are zero blocking findings, say so explicitly on the first line.
+Be specific and terse: every line must tell the reader what to change.

--- a/.claude/hooks/check-raw-sql.sh
+++ b/.claude/hooks/check-raw-sql.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# PreToolUse guard for GoBricks.
+#
+# Blocks any Edit/Write/MultiEdit that introduces an f.Raw() or jf.Raw()
+# raw-SQL escape hatch WITHOUT the mandatory inline SECURITY annotation
+# required by CLAUDE.md ("Security Guidelines" / Developer Manifesto).
+#
+# Rationale: the annotation is a forcing function for manual SQL review and
+# keeps every call site grep-discoverable. A pre-edit block is strictly
+# better than relying on a human remembering to grep later.
+#
+# Scope note: detection mirrors the canonical discovery grep in CLAUDE.md
+# (git grep -E 'f\.Raw\(|jf\.Raw\(') on purpose — it is tied to the documented
+# convention, not a general static analyzer. Receivers not named f/jf are out
+# of scope by design (the same as the CLAUDE.md grep).
+#
+# Fails CLOSED: a missing dependency or unparseable input blocks rather than
+# silently allowing an unguarded edit.
+#
+# Exit codes: 0 = allow, 2 = block (stderr is shown to Claude).
+set -uo pipefail
+
+command -v jq >/dev/null 2>&1 || {
+  echo "check-raw-sql: jq not found — refusing to allow a potentially unguarded edit." >&2
+  exit 2
+}
+
+input="$(cat)"
+
+# Cheapest guard first: only Go source files can contain f.Raw()/jf.Raw().
+# Extracting just the path keeps the common non-Go edit on a single jq fork.
+file="$(jq -r '.tool_input.file_path // empty' <<<"$input" 2>/dev/null || true)"
+case "$file" in
+  *.go) ;;
+  *) exit 0 ;;
+esac
+
+# The text this edit ADDS, across tool shapes, in one jq pass:
+#   Write      -> .tool_input.content
+#   Edit       -> .tool_input.new_string
+#   MultiEdit  -> joined .tool_input.edits[].new_string  (nulls filtered)
+added="$(jq -r '
+  .tool_input.content
+  // .tool_input.new_string
+  // ([.tool_input.edits[]?.new_string // empty] | join("\n"))
+  // ""' <<<"$input" 2>/dev/null || true)"
+
+# Does this edit introduce a raw-SQL escape hatch?
+if ! grep -Eq '(^|[^A-Za-z0-9_])(f|jf)\.Raw\(' <<<"$added"; then
+  exit 0
+fi
+
+# Is the mandatory annotation present in the SAME edit?
+if grep -q 'SECURITY: Manual SQL review completed' <<<"$added"; then
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+BLOCKED — raw-SQL escape hatch added without its mandatory SECURITY annotation.
+
+CLAUDE.md requires, at EVERY f.Raw()/jf.Raw() call site, an adjacent comment:
+
+    // SECURITY: Manual SQL review completed - <what was verified>
+
+The rationale must name the specific property checked, e.g.:
+  - identifier quoting for vendor reserved words
+  - parameterization of the value side
+  - absence of user-input concatenation
+
+Re-issue this edit with the annotation included in the same new_string /
+content so the call site is review-forced and grep-discoverable.
+
+(If you are editing a file that already has Raw + annotation elsewhere and
+this edit legitimately does not add a new Raw call, include the annotation
+line in the edit anyway, or make the change via a hunk that excludes Raw.)
+EOF
+exit 2

--- a/.claude/hooks/check-raw-sql.sh
+++ b/.claude/hooks/check-raw-sql.sh
@@ -27,9 +27,19 @@ command -v jq >/dev/null 2>&1 || {
 
 input="$(cat)"
 
+block_unparseable() {
+  echo "check-raw-sql: unparseable or unsupported hook payload — refusing to allow a potentially unguarded edit." >&2
+  exit 2
+}
+
+# Fail CLOSED on malformed input: a payload jq cannot parse must block, never
+# fall through as "not a Go file". (Swallowing jq errors with `|| true` would
+# silently break the fail-closed contract this guard advertises.)
+jq -e . >/dev/null 2>&1 <<<"$input" || block_unparseable
+
 # Cheapest guard first: only Go source files can contain f.Raw()/jf.Raw().
 # Extracting just the path keeps the common non-Go edit on a single jq fork.
-file="$(jq -r '.tool_input.file_path // empty' <<<"$input" 2>/dev/null || true)"
+file="$(jq -er '.tool_input.file_path // empty' <<<"$input" 2>/dev/null)" || block_unparseable
 case "$file" in
   *.go) ;;
   *) exit 0 ;;
@@ -39,19 +49,35 @@ esac
 #   Write      -> .tool_input.content
 #   Edit       -> .tool_input.new_string
 #   MultiEdit  -> joined .tool_input.edits[].new_string  (nulls filtered)
-added="$(jq -r '
+added="$(jq -er '
   .tool_input.content
   // .tool_input.new_string
   // ([.tool_input.edits[]?.new_string // empty] | join("\n"))
-  // ""' <<<"$input" 2>/dev/null || true)"
+  // ""' <<<"$input" 2>/dev/null)" || block_unparseable
 
 # Does this edit introduce a raw-SQL escape hatch?
 if ! grep -Eq '(^|[^A-Za-z0-9_])(f|jf)\.Raw\(' <<<"$added"; then
   exit 0
 fi
 
-# Is the mandatory annotation present in the SAME edit?
-if grep -q 'SECURITY: Manual SQL review completed' <<<"$added"; then
+# Is the mandatory annotation present AND positioned to cover the calls?
+#
+# Stronger than "annotation appears anywhere in the blob": every (f|jf).Raw(
+# occurrence must be preceded (same line or any earlier line in this edit) by
+# a SECURITY annotation. This rejects the "annotation pasted after the calls"
+# and "bare call, no annotation" cases.
+#
+# It deliberately does NOT enforce strict line-N-1 adjacency: CLAUDE.md /
+# the security-audit policy explicitly permit ONE annotation above an
+# enclosing dispatch (table-driven loop, multi-call JoinOn chain) covering
+# several Raw calls. A pre-edit hook only sees a string fragment, so strict
+# per-call adjacency would false-block that sanctioned pattern. Semantic
+# adjacency review remains the job of /security-audit + human review.
+if awk '
+  /SECURITY: Manual SQL review completed/ { seen = 1 }
+  /(^|[^A-Za-z0-9_])(f|jf)\.Raw\(/      { if (!seen) { missing = 1 } }
+  END                                    { exit (missing ? 1 : 0) }
+' <<<"$added"; then
   exit 0
 fi
 

--- a/.claude/hooks/check-test-conventions.sh
+++ b/.claude/hooks/check-test-conventions.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# PostToolUse linter for GoBricks *_test.go files.
+#
+# Enforces two strict, frequently-violated CLAUDE.md conventions that
+# otherwise only get caught by a SonarCloud / CodeRabbit round-trip:
+#
+#   1. camelCase test function names (snake_case forbidden; 100% compliance).
+#   2. Source-to-test 1:1 file naming (no foo_extra_test.go / foo_uncovered_test.go;
+#      testhelpers_test.go is the documented shared-helper exception).
+#
+# The file is already written (PostToolUse), so this cannot block — it exits 2
+# with a message on stderr, which is fed back to Claude so it self-corrects in
+# the same turn. No violation -> silent exit 0 (no noise on every test edit).
+set -uo pipefail
+
+# Can't lint without jq; PostToolUse can't block anyway, so warn (for
+# debuggability) and exit 0 rather than nagging on every edit.
+command -v jq >/dev/null 2>&1 || {
+  echo "check-test-conventions: jq not found — test-convention linting skipped." >&2
+  exit 0
+}
+
+input="$(cat)"
+file="$(jq -r '.tool_input.file_path // empty' <<<"$input" 2>/dev/null || true)"
+
+case "$file" in
+  *_test.go) ;;
+  *) exit 0 ;;
+esac
+
+[ -f "$file" ] || exit 0
+
+problems=""
+base="$(basename -- "$file")"
+
+case "$base" in
+  testhelpers_test.go)
+    : # documented shared-helper exception — allowed
+    ;;
+  *_extra_test.go|*_uncovered_test.go|*_additional_test.go|*_more_test.go|*_extra2_test.go|*_uncovered2_test.go)
+    problems+="- Filename '$base' violates source-to-test 1:1 naming."$'\n'
+    problems+="  'foo.go' has exactly one companion 'foo_test.go'. Append gap-closing"$'\n'
+    problems+="  tests to the existing companion instead of creating a new *_extra/_uncovered file."$'\n'
+    ;;
+esac
+
+# Snake_case in Test/Benchmark/Fuzz function names is forbidden. The optional
+# (\[[^]]*\])? tolerates a Go 1.25 generic type-param list before the args,
+# e.g. func TestFoo_Bar[T any](...). Example functions are intentionally
+# excluded: Go's ExampleFoo_method form legitimately uses underscores.
+bad_funcs="$(grep -nE '^func[[:space:]]+(Test|Benchmark|Fuzz)[A-Za-z0-9]*_[A-Za-z0-9_]*(\[[^]]*\])?\(' -- "$file" || true)"
+if [ -n "$bad_funcs" ]; then
+  problems+="- Snake_case test function name(s) found (camelCase is MANDATORY):"$'\n'
+  while IFS= read -r line; do
+    problems+="    $line"$'\n'
+  done <<<"$bad_funcs"
+  problems+="  Rename e.g. TestUserService_CreateUser -> TestUserServiceCreateUser."$'\n'
+  problems+="  (Table-driven test CASE names still use snake_case — only func names are camelCase.)"$'\n'
+fi
+
+if [ -n "$problems" ]; then
+  printf 'GoBricks test-convention violations in %s:\n\n' "$file" >&2
+  printf '%s' "$problems" >&2
+  printf '\nFix before continuing — see CLAUDE.md "Testing Conventions".\n' >&2
+  exit 2
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+  {
+    "$schema": "https://json.schemastore.org/claude-code-settings.json",
+    "hooks": {
+      "PreToolUse": [
+        { "matcher": "Edit|Write|MultiEdit",
+          "hooks": [{ "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-raw-sql.sh" }] }
+      ],
+      "PostToolUse": [
+        { "matcher": "Edit|Write|MultiEdit",
+          "hooks": [{ "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-test-conventions.sh" }] }
+      ]
+    }
+  }

--- a/.claude/skills/sonar-pr/SKILL.md
+++ b/.claude/skills/sonar-pr/SKILL.md
@@ -41,7 +41,7 @@ Use when reviewing or fixing a PR. The argument is the PR number (e.g.
 
 4. Output a table grouped by severity:
 
-   ```
+   ```text
    ## SonarCloud — PR #N  (X issues, Y hotspots)
 
    | Severity | Rule | Location | Message | Disposition |

--- a/.claude/skills/sonar-pr/SKILL.md
+++ b/.claude/skills/sonar-pr/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: sonar-pr
+description: >-
+  Fetch and triage the SonarCloud NEW-issue list for a GoBricks pull request.
+  SonarCloud's "Quality Gate passed" banner hides the per-PR issue list; this
+  pulls it via the public API and triages every OPEN/CONFIRMED finding.
+disable-model-invocation: true
+---
+
+# sonar-pr
+
+Use when reviewing or fixing a PR. The argument is the PR number (e.g.
+`/sonar-pr 447`). If no number is given, infer it from the current branch via
+`gh pr view --json number -q .number`.
+
+## Steps
+
+1. Resolve the PR number `N` (from the argument, else `gh pr view`).
+
+2. Fetch the NEW issues (public endpoint, no auth needed):
+
+   ```bash
+   curl -sS "https://sonarcloud.io/api/issues/search?componentKeys=gaborage_go-bricks&pullRequest=N&statuses=OPEN,CONFIRMED&ps=500" \
+     | jq -r '.issues[] | "\(.severity)\t\(.rule)\t\(.component | sub("^gaborage_go-bricks:";""))#\(.line // 0)\t\(.message)"' \
+     | sort
+   ```
+
+   Also fetch security hotspots, which the issues endpoint omits:
+
+   ```bash
+   curl -sS "https://sonarcloud.io/api/hotspots/search?projectKey=gaborage_go-bricks&pullRequest=N&ps=500" \
+     | jq -r '.hotspots[]? | "HOTSPOT\t\(.securityCategory)\t\(.component | sub("^gaborage_go-bricks:";""))#\(.line // 0)\t\(.message)"'
+   ```
+
+3. Triage every finding. Apply the CLAUDE.md standard: this is **all-or-nothing**
+   — fix each MAJOR/MINOR/BLOCKER or document the skip in the commit message.
+   For framework-precedent rules (S8179 getter naming, S8196 interface naming,
+   etc.) the precedent is **rename/refactor, never nolint** (see ADR-013).
+   Note known false positives already dispositioned in SonarCloud (e.g. the 6
+   S8168 Begin/BeginTx transaction-factory issues) and do not re-flag them.
+
+4. Output a table grouped by severity:
+
+   ```
+   ## SonarCloud — PR #N  (X issues, Y hotspots)
+
+   | Severity | Rule | Location | Message | Disposition |
+   |----------|------|----------|---------|-------------|
+   ```
+
+   `Disposition` = `fix` | `skip: <reason>` | `false-positive: <ref>`.
+
+5. End with a one-line verdict: how many require code changes before the PR is
+   merge-ready, and whether any need a documented skip in the commit message.

--- a/.claude/skills/sonar-pr/SKILL.md
+++ b/.claude/skills/sonar-pr/SKILL.md
@@ -20,7 +20,7 @@ Use when reviewing or fixing a PR. The argument is the PR number (e.g.
 2. Fetch the NEW issues (public endpoint, no auth needed):
 
    ```bash
-   curl -sS "https://sonarcloud.io/api/issues/search?componentKeys=gaborage_go-bricks&pullRequest=N&statuses=OPEN,CONFIRMED&ps=500" \
+   curl -fsSL "https://sonarcloud.io/api/issues/search?componentKeys=gaborage_go-bricks&pullRequest=N&statuses=OPEN,CONFIRMED&ps=500" \
      | jq -r '.issues[] | "\(.severity)\t\(.rule)\t\(.component | sub("^gaborage_go-bricks:";""))#\(.line // 0)\t\(.message)"' \
      | sort
    ```
@@ -28,7 +28,7 @@ Use when reviewing or fixing a PR. The argument is the PR number (e.g.
    Also fetch security hotspots, which the issues endpoint omits:
 
    ```bash
-   curl -sS "https://sonarcloud.io/api/hotspots/search?projectKey=gaborage_go-bricks&pullRequest=N&ps=500" \
+   curl -fsSL "https://sonarcloud.io/api/hotspots/search?projectKey=gaborage_go-bricks&pullRequest=N&ps=500" \
      | jq -r '.hotspots[]? | "HOTSPOT\t\(.securityCategory)\t\(.component | sub("^gaborage_go-bricks:";""))#\(.line // 0)\t\(.message)"'
    ```
 

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@
 !sonar-project.properties
 
 !.claude/commands/*
+!.claude/settings.json
+!.claude/hooks/*
+!.claude/agents/*
+!.claude/skills/**
 
 # Test fixtures (JSON / SQL / golden files) live under testdata/ alongside the
 # source they exercise.


### PR DESCRIPTION
## What

Four Claude Code automations that operationalize the strict, frequently-violated conventions documented in `CLAUDE.md`, converting review-cycle ping-pong into deterministic local guardrails.

| Automation | Type | Enforces |
|---|---|---|
| `.claude/hooks/check-raw-sql.sh` | PreToolUse hook | Blocks `f.Raw()`/`jf.Raw()` edits missing the mandatory `// SECURITY: Manual SQL review completed` annotation. **Fails closed.** |
| `.claude/hooks/check-test-conventions.sh` | PostToolUse hook | Flags snake_case `Test*` func names + forbidden `*_extra_test.go`-style filenames |
| `.claude/agents/project-conventions-reviewer.md` | Subagent | Read-only pre-push reviewer (S8179/S8196 naming, raw-SQL annotations, ADR-index sync, version drift) |
| `.claude/skills/sonar-pr/SKILL.md` | Skill (`/sonar-pr <N>`) | Fetches + triages the SonarCloud per-PR issue list the "Quality Gate passed" banner hides |

`.gitignore` allowlists the new `.claude/` paths (the repo uses an allowlist-style ignore).

## Pre-push review applied

Both mandatory gates (`/simplify` + `/security-audit`) were run before pushing:

- **raw-sql:** `jq` probe now fails *closed* (was: silent allow if `jq` missing — a security guard that fails open); MultiEdit `null` `new_string` filtered; 3 `jq` forks → 2 (extension checked first for the non-Go fast path; per-tool `case` removed).
- **test-conv:** `printf '%b'` → `'%s'` (backslashes in the *linted source* no longer corrupt the message); regex tolerates Go 1.25 generic type params so `TestFoo_Bar[T any]` is still caught.
- **security:** `basename`/`grep` hardened with `--` (argv-injection defense for leading-dash file paths). No Go files changed → gosec/govulncheck N/A. No secrets (`sonar-pr` uses the public unauthenticated SonarCloud endpoint).
- **Accepted by design:** the `f`/`jf`-receiver-only Raw regex intentionally mirrors the canonical `CLAUDE.md` discovery grep (`git grep -E 'f\.Raw\(|jf\.Raw\('`), not a general static analyzer.

## Test evidence

Both hooks verified with a 13-case matrix using **`jq`-serialized** fixtures (matching real harness input — naive `echo` fixtures produce invalid JSON and were silently masking results): Edit/Write/MultiEdit shapes, multi-line content, annotation present/absent, non-Go skip, false-positive `Raw(` substring, generic-type-param funcs, and leading-dash filename hardening. All pass; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated pre-edit and post-edit checks that block unannotated raw SQL edits and enforce test filename/function naming conventions.
  * Updated ignore rules to allow repository tooling assets to be tracked.

* **Documentation**
  * Added guidance for branch/diff convention reviews and a workflow to triage external analysis findings with standardized dispositions and merge-readiness reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/448?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->