### PR TITLE
docs(observability): fix LogsConfig.Insecure inheritance comment

### DIFF
--- a/observability/config.go
+++ b/observability/config.go
@@ -515,7 +515,10 @@ type LogsConfig struct {
 	Protocol string `mapstructure:"protocol"`
 
 	// Insecure controls whether to use insecure connections (no TLS).
-	// Only applicable for OTLP endpoints (http/grpc). Falls back to trace setting when unset.
+	// Only applicable for OTLP endpoints (http/grpc). Independent of Trace.Insecure:
+	// when unset, defaults to false (TLS-secure) via applyLogsDefaults — it does NOT
+	// inherit from the trace setting. Operators running a plaintext local OTLP
+	// collector for logs must opt in by setting logs.insecure: true explicitly.
 	Insecure *bool `mapstructure:"insecure"`
 
 	// DisableStdout controls whether to disable stdout logging when OTLP is enabled.


### PR DESCRIPTION
## Summary
- `LogsConfig.Insecure`'s doc comment claimed it falls back to `Trace.Insecure` when unset, but `applyLogsDefaults()` independently defaults it to `false` (TLS-secure). The inherit behavior was intentionally removed (see existing explanatory block at lines 271–276 of `observability/config.go`) to avoid coupling an unrelated endpoint's transport choice into the logs pipeline.
- Comment-only change — no behavior change. Per CLAUDE.md, this falls under the narrowly-defined trivial-fixes exception that exempts comment-only edits from `/code-review` and `/security-audit`.

## Why this matters
Security-relevant doc fix, not cosmetic. The stale comment left operators with the old mental model: "stdout traces means stdout-style insecure logs by default." With the new behavior, operators running a plaintext local OTLP collector for logs **must** set `logs.insecure: true` explicitly. A misleading field doc would silently push them toward a broken config.

## Test plan
- [x] `make check` — fmt + lint + race-detected unit tests across all framework packages passes locally
- [x] No behavior change — observability tests already cover `applyLogsDefaults()` default of `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified logs configuration documentation to explain that the insecure setting operates independently of trace settings, defaults to TLS-secure mode, and requires explicit configuration when using plaintext collectors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/455?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->