### PR TITLE
fix(logger,httpclient): wave 2 — privacy filter hardening

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -630,8 +630,8 @@ func (c *client) ensureContentTypeHeader(httpReq *nethttp.Request, body []byte) 
 	if body == nil {
 		return
 	}
-	if httpReq.Header.Get("Content-Type") == "" {
-		httpReq.Header.Set("Content-Type", mimeApplicationJSON)
+	if httpReq.Header.Get(headerContentType) == "" {
+		httpReq.Header.Set(headerContentType, mimeApplicationJSON)
 	}
 }
 
@@ -759,6 +759,28 @@ func isJSONContentType(ct string) bool {
 	return ct == mimeApplicationJSON || strings.HasSuffix(ct, "+json")
 }
 
+// logBodyPreview appends body-preview fields to dbg and returns the updated event.
+// JSON object roots are parsed and filter-walked via Interface so SensitiveDataFilter
+// can mask sensitive keys. Non-JSON, JSON primitive/array roots, and parse failures
+// log only metadata (content-type + byte count) — primitive/array roots cannot be
+// key-walked by the filter, so dropping them is the safe default.
+func logBodyPreview(dbg logger.LogEvent, preview []byte, ct string) logger.LogEvent {
+	if !isJSONContentType(ct) {
+		return dbg.Str("body_content_type", ct).Int("body_preview_dropped", len(preview))
+	}
+	var parsed any
+	if err := json.Unmarshal(preview, &parsed); err != nil {
+		return dbg.Str("body_content_type", ct).Str("body_preview_status", "json_parse_failed").Int("body_preview_dropped", len(preview))
+	}
+	m, ok := parsed.(map[string]any)
+	if !ok {
+		// JSON primitive/array root — SensitiveDataFilter can only walk map keys;
+		// drop rather than log a value it cannot inspect.
+		return dbg.Str("body_content_type", ct).Int("body_preview_dropped", len(preview))
+	}
+	return dbg.Interface("body_preview", m)
+}
+
 // logRequest logs the outgoing request
 func (c *client) logRequest(httpReq *nethttp.Request, body []byte, traceID string) {
 	// Info-level: only metadata to avoid leaking PII/secrets
@@ -799,20 +821,7 @@ func (c *client) logRequest(httpReq *nethttp.Request, body []byte, traceID strin
 			}
 			dbg = dbg.Int("body_size", len(body)).
 				Str("body_truncated", strconv.FormatBool(truncated))
-			ct := httpReq.Header.Get("Content-Type")
-			if isJSONContentType(ct) {
-				var parsed any
-				if jsonErr := json.Unmarshal(preview, &parsed); jsonErr == nil {
-					dbg = dbg.Interface("body_preview", parsed)
-				} else {
-					dbg = dbg.Str("body_content_type", ct).Str("body_preview_status", "json_parse_failed")
-				}
-			} else {
-				// Non-JSON bodies (form-urlencoded, multipart, binary) are never emitted —
-				// form-urlencoded encodes credential pairs in plaintext and binary payloads
-				// are not filterable. Log only the content-type and byte count.
-				dbg = dbg.Str("body_content_type", ct).Int("body_preview_dropped", len(preview))
-			}
+			dbg = logBodyPreview(dbg, preview, httpReq.Header.Get(headerContentType))
 		}
 		dbg.Msg("REST client request")
 	}
@@ -854,17 +863,7 @@ func (c *client) logResponse(resp *Response, traceID string) {
 			}
 			dbg = dbg.Int("body_size", len(resp.Body)).
 				Str("body_truncated", strconv.FormatBool(truncated))
-			ct := resp.Headers.Get("Content-Type")
-			if isJSONContentType(ct) {
-				var parsed any
-				if jsonErr := json.Unmarshal(preview, &parsed); jsonErr == nil {
-					dbg = dbg.Interface("body_preview", parsed)
-				} else {
-					dbg = dbg.Str("body_content_type", ct).Str("body_preview_status", "json_parse_failed")
-				}
-			} else {
-				dbg = dbg.Str("body_content_type", ct).Int("body_preview_dropped", len(preview))
-			}
+			dbg = logBodyPreview(dbg, preview, resp.Headers.Get(headerContentType))
 		}
 		// Response headers go through logger filter to mask sensitive keys/values
 		if len(resp.Headers) > 0 {

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	crand "crypto/rand"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +12,8 @@ import (
 	"math/big"
 	"net"
 	nethttp "net/http"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -27,6 +30,8 @@ const (
 
 	// DefaultRetryDelay is the default delay between retries
 	DefaultRetryDelay = 1 * time.Second
+
+	mimeApplicationJSON = "application/json"
 )
 
 // client implements the Client interface
@@ -83,6 +88,25 @@ func (b *Builder) WithTimeout(timeout time.Duration) *Builder {
 func (b *Builder) WithRetries(maxRetries int, retryDelay time.Duration) *Builder {
 	b.config.MaxRetries = maxRetries
 	b.config.RetryDelay = retryDelay
+	return b
+}
+
+// WithLogPayloads enables debug-level logging of request and response bodies.
+// WARNING: enable only in development/staging — even with SensitiveDataFilter active,
+// JSON bodies are parsed and field-masked but the full body surface is widened significantly.
+// Non-JSON bodies (form-urlencoded, binary, etc.) are never emitted; only the content-type
+// and byte count are logged to prevent credential pairs from reaching the log stream.
+func (b *Builder) WithLogPayloads(enabled bool) *Builder {
+	b.config.LogPayloads = enabled
+	return b
+}
+
+// WithMaxPayloadLogBytes caps the number of body bytes inspected per direction when
+// WithLogPayloads is enabled. Values <= 0 are ignored; the built-in fallback (1024) applies.
+func (b *Builder) WithMaxPayloadLogBytes(n int) *Builder {
+	if n > 0 {
+		b.config.MaxPayloadLogBytes = n
+	}
 	return b
 }
 
@@ -607,7 +631,7 @@ func (c *client) ensureContentTypeHeader(httpReq *nethttp.Request, body []byte) 
 		return
 	}
 	if httpReq.Header.Get("Content-Type") == "" {
-		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Content-Type", mimeApplicationJSON)
 	}
 }
 
@@ -725,6 +749,16 @@ func (c *client) runResponseInterceptors(ctx context.Context, req *nethttp.Reque
 	return nil
 }
 
+// isJSONContentType reports whether ct is an application/json or *+json media type.
+// Parameters such as "; charset=utf-8" are stripped before the check.
+func isJSONContentType(ct string) bool {
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = ct[:i]
+	}
+	ct = strings.ToLower(strings.TrimSpace(ct))
+	return ct == mimeApplicationJSON || strings.HasSuffix(ct, "+json")
+}
+
 // logRequest logs the outgoing request
 func (c *client) logRequest(httpReq *nethttp.Request, body []byte, traceID string) {
 	// Info-level: only metadata to avoid leaking PII/secrets
@@ -764,8 +798,21 @@ func (c *client) logRequest(httpReq *nethttp.Request, body []byte, traceID strin
 				truncated = true
 			}
 			dbg = dbg.Int("body_size", len(body)).
-				Str("body_truncated", map[bool]string{true: "true", false: "false"}[truncated]).
-				Bytes("body_preview", preview)
+				Str("body_truncated", strconv.FormatBool(truncated))
+			ct := httpReq.Header.Get("Content-Type")
+			if isJSONContentType(ct) {
+				var parsed any
+				if jsonErr := json.Unmarshal(preview, &parsed); jsonErr == nil {
+					dbg = dbg.Interface("body_preview", parsed)
+				} else {
+					dbg = dbg.Str("body_content_type", ct).Str("body_preview_status", "json_parse_failed")
+				}
+			} else {
+				// Non-JSON bodies (form-urlencoded, multipart, binary) are never emitted —
+				// form-urlencoded encodes credential pairs in plaintext and binary payloads
+				// are not filterable. Log only the content-type and byte count.
+				dbg = dbg.Str("body_content_type", ct).Int("body_preview_dropped", len(preview))
+			}
 		}
 		dbg.Msg("REST client request")
 	}
@@ -806,8 +853,18 @@ func (c *client) logResponse(resp *Response, traceID string) {
 				truncated = true
 			}
 			dbg = dbg.Int("body_size", len(resp.Body)).
-				Str("body_truncated", map[bool]string{true: "true", false: "false"}[truncated]).
-				Bytes("body_preview", preview)
+				Str("body_truncated", strconv.FormatBool(truncated))
+			ct := resp.Headers.Get("Content-Type")
+			if isJSONContentType(ct) {
+				var parsed any
+				if jsonErr := json.Unmarshal(preview, &parsed); jsonErr == nil {
+					dbg = dbg.Interface("body_preview", parsed)
+				} else {
+					dbg = dbg.Str("body_content_type", ct).Str("body_preview_status", "json_parse_failed")
+				}
+			} else {
+				dbg = dbg.Str("body_content_type", ct).Int("body_preview_dropped", len(preview))
+			}
 		}
 		// Response headers go through logger filter to mask sensitive keys/values
 		if len(resp.Headers) > 0 {

--- a/httpclient/logging_test.go
+++ b/httpclient/logging_test.go
@@ -650,6 +650,73 @@ func TestClientLogRequestJSONBodyParsedAsMap(t *testing.T) {
 	assert.Contains(t, preview, "password", "parsed map must contain all JSON keys")
 }
 
+// TestLogBodyPreviewPrimitiveRootDropped verifies that JSON bodies whose root is a
+// primitive or array are never emitted as body_preview. SensitiveDataFilter can only
+// walk map[string]any keys, so logging a raw string/number/bool/array would bypass
+// filtering entirely. The fix gates on map[string]any and drops everything else.
+func TestLogBodyPreviewPrimitiveRootDropped(t *testing.T) {
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{name: "json_string", body: []byte(`"secret-token"`)},
+		{name: "json_number", body: []byte(`123456789`)},
+		{name: "json_bool", body: []byte(`true`)},
+		{name: "json_array", body: []byte(`["item1","item2"]`)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeLog := &fakeLogger{}
+			c := &client{
+				logger: fakeLog,
+				config: &Config{LogPayloads: true, MaxPayloadLogBytes: 512},
+			}
+
+			req, err := http.NewRequestWithContext(context.Background(), "POST", "https://api.example.com/x", http.NoBody)
+			assert.NoError(t, err)
+			req.Header.Set(testContentTypeHeader, testContentType)
+
+			c.logRequest(req, tc.body, "trace-123")
+
+			debugEvents := fakeLog.eventsByLevel("debug")
+			assert.Len(t, debugEvents, 1)
+
+			ev := debugEvents[0]
+			assert.Nil(t, ev.fields["body_preview"], "primitive/array JSON root must not appear as body_preview")
+			assert.Equal(t, len(tc.body), ev.fields["body_preview_dropped"], "byte count must be logged for dropped body")
+		})
+	}
+}
+
+// TestLogBodyPreviewMalformedJSONLogsDroppedCount verifies that when a JSON body
+// fails to parse (e.g., truncated mid-token by MaxPayloadLogBytes), the log event
+// contains both body_preview_status and body_preview_dropped so operators can
+// distinguish truncation-induced errors from server-side malformed JSON.
+func TestLogBodyPreviewMalformedJSONLogsDroppedCount(t *testing.T) {
+	fakeLog := &fakeLogger{}
+	c := &client{
+		logger: fakeLog,
+		config: &Config{LogPayloads: true, MaxPayloadLogBytes: 10},
+	}
+
+	// A 10-byte truncation of valid JSON produces invalid JSON (cut mid-token)
+	body := []byte(`{"username": "alice", "password": "s3cr3t"}`)
+	req, err := http.NewRequestWithContext(context.Background(), "POST", "https://api.example.com/x", http.NoBody)
+	assert.NoError(t, err)
+	req.Header.Set(testContentTypeHeader, testContentType)
+
+	c.logRequest(req, body, "trace-123")
+
+	debugEvents := fakeLog.eventsByLevel("debug")
+	assert.Len(t, debugEvents, 1)
+
+	ev := debugEvents[0]
+	assert.Equal(t, "json_parse_failed", ev.fields["body_preview_status"], "status must indicate parse failure")
+	assert.Equal(t, 10, ev.fields["body_preview_dropped"], "byte count must be logged even on parse failure")
+	assert.Nil(t, ev.fields["body_preview"], "raw body bytes must never appear in log output")
+}
+
 // TestIsJSONContentTypeEdgeCases verifies that isJSONContentType handles
 // edge-case Content-Type values that occur with proxies or custom transports.
 func TestIsJSONContentTypeEdgeCases(t *testing.T) {

--- a/httpclient/logging_test.go
+++ b/httpclient/logging_test.go
@@ -242,6 +242,7 @@ func TestClientLogRequest(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), "PUT", "https://api.example.com/resource", http.NoBody)
 		assert.NoError(t, err)
 		req.Header.Set("X-API-Key", "secret")
+		req.Header.Set(testContentTypeHeader, testContentType)
 
 		body := []byte(`{"data": "some content for testing"}`)
 		c.logRequest(req, body, "trace-789")
@@ -260,8 +261,11 @@ func TestClientLogRequest(t *testing.T) {
 		assert.Equal(t, "trace-789", debugEvent.fields["request_id"])
 		assert.NotNil(t, debugEvent.fields["headers"])
 		assert.Equal(t, len(body), debugEvent.fields["body_size"])
-		assert.Equal(t, "false", debugEvent.fields["body_truncated"]) // Body is small, not truncated
-		assert.Equal(t, body, debugEvent.fields["body_preview"])
+		assert.Equal(t, "false", debugEvent.fields["body_truncated"])
+		// JSON body is parsed and logged via Interface (not raw bytes)
+		preview, ok := debugEvent.fields["body_preview"].(map[string]any)
+		assert.True(t, ok, "JSON body_preview should be a parsed map")
+		assert.Equal(t, "some content for testing", preview["data"])
 	})
 
 	t.Run("request with large body truncation", func(t *testing.T) {
@@ -286,7 +290,10 @@ func TestClientLogRequest(t *testing.T) {
 		debugEvent := debugEvents[0]
 		assert.Equal(t, len(largeBody), debugEvent.fields["body_size"])
 		assert.Equal(t, "true", debugEvent.fields["body_truncated"])
-		assert.Equal(t, largeBody[:10], debugEvent.fields["body_preview"])
+		// Plain text body (no Content-Type) → bytes dropped, not logged
+		assert.Equal(t, "", debugEvent.fields["body_content_type"])
+		assert.Equal(t, 10, debugEvent.fields["body_preview_dropped"])
+		assert.Nil(t, debugEvent.fields["body_preview"])
 	})
 
 	t.Run("request with zero MaxPayloadLogBytes uses default", func(t *testing.T) {
@@ -316,7 +323,10 @@ func TestClientLogRequest(t *testing.T) {
 		debugEvent := debugEvents[0]
 		assert.Equal(t, len(largeBody), debugEvent.fields["body_size"])
 		assert.Equal(t, "true", debugEvent.fields["body_truncated"])
-		assert.Equal(t, largeBody[:1024], debugEvent.fields["body_preview"]) // Should use 1024 default
+		// Plain text body (no Content-Type) → bytes dropped, not logged; preview size is capped at default 1024
+		assert.Equal(t, "", debugEvent.fields["body_content_type"])
+		assert.Equal(t, 1024, debugEvent.fields["body_preview_dropped"])
+		assert.Nil(t, debugEvent.fields["body_preview"])
 	})
 }
 
@@ -404,7 +414,7 @@ func TestClientLogResponse(t *testing.T) {
 		response := &Response{
 			StatusCode: 201,
 			Body:       []byte(`{"id": 123, "created": true}`),
-			Headers:    http.Header{"X-Rate-Limit": []string{"100"}},
+			Headers:    http.Header{"X-Rate-Limit": []string{"100"}, testContentTypeHeader: []string{testContentType}},
 			Stats: Stats{
 				ElapsedTime: 300 * time.Millisecond,
 				CallCount:   2,
@@ -428,7 +438,11 @@ func TestClientLogResponse(t *testing.T) {
 		assert.NotNil(t, debugEvent.fields["headers"])
 		assert.Equal(t, len(response.Body), debugEvent.fields["body_size"])
 		assert.Equal(t, "false", debugEvent.fields["body_truncated"])
-		assert.Equal(t, response.Body, debugEvent.fields["body_preview"])
+		// JSON response body is parsed and logged via Interface (filter can walk keys)
+		preview, ok := debugEvent.fields["body_preview"].(map[string]any)
+		assert.True(t, ok, "JSON body_preview should be a parsed map")
+		assert.Equal(t, float64(123), preview["id"])
+		assert.Equal(t, true, preview["created"])
 	})
 
 	t.Run("response with large body truncation", func(t *testing.T) {
@@ -460,7 +474,10 @@ func TestClientLogResponse(t *testing.T) {
 		debugEvent := debugEvents[0]
 		assert.Equal(t, len(largeResponseBody), debugEvent.fields["body_size"])
 		assert.Equal(t, "true", debugEvent.fields["body_truncated"])
-		assert.Equal(t, largeResponseBody[:15], debugEvent.fields["body_preview"])
+		// No Content-Type on response headers → bytes dropped, not logged
+		assert.Equal(t, "", debugEvent.fields["body_content_type"])
+		assert.Equal(t, 15, debugEvent.fields["body_preview_dropped"])
+		assert.Nil(t, debugEvent.fields["body_preview"])
 	})
 
 	t.Run("response error scenarios", func(t *testing.T) {
@@ -548,7 +565,112 @@ func TestLoggingIntegration(t *testing.T) {
 		assert.Len(t, fakeLog.eventsByLevel("debug"), 1)
 
 		debugEvent := fakeLog.eventsByLevel("debug")[0]
-		assert.Contains(t, debugEvent.fields, "body_preview")
+		// Plain text body (no Content-Type) → bytes dropped, not logged
+		assert.Equal(t, "", debugEvent.fields["body_content_type"])
+		assert.Equal(t, len(body), debugEvent.fields["body_preview_dropped"])
+		assert.Nil(t, debugEvent.fields["body_preview"])
 		assert.Equal(t, "false", debugEvent.fields["body_truncated"])
 	})
+}
+
+// TestBuilderPayloadLoggingSetters verifies that WithLogPayloads and WithMaxPayloadLogBytes
+// propagate correctly into the built client config.
+func TestBuilderPayloadLoggingSetters(t *testing.T) {
+	t.Run("WithLogPayloads enables payload logging", func(t *testing.T) {
+		fakeLog := &fakeLogger{}
+		builtClient := NewBuilder(fakeLog).
+			WithLogPayloads(true).
+			Build()
+		c := builtClient.(*client)
+		assert.True(t, c.config.LogPayloads)
+	})
+
+	t.Run("WithLogPayloads false disables payload logging", func(t *testing.T) {
+		fakeLog := &fakeLogger{}
+		builtClient := NewBuilder(fakeLog).
+			WithLogPayloads(false).
+			Build()
+		c := builtClient.(*client)
+		assert.False(t, c.config.LogPayloads)
+	})
+
+	t.Run("WithMaxPayloadLogBytes sets limit", func(t *testing.T) {
+		fakeLog := &fakeLogger{}
+		builtClient := NewBuilder(fakeLog).
+			WithLogPayloads(true).
+			WithMaxPayloadLogBytes(2048).
+			Build()
+		c := builtClient.(*client)
+		assert.True(t, c.config.LogPayloads)
+		assert.Equal(t, 2048, c.config.MaxPayloadLogBytes)
+	})
+
+	t.Run("WithMaxPayloadLogBytes ignores zero or negative", func(t *testing.T) {
+		fakeLog := &fakeLogger{}
+		builtClient := NewBuilder(fakeLog).
+			WithMaxPayloadLogBytes(0).
+			Build()
+		c := builtClient.(*client)
+		// Should retain the default (1024), not override with zero
+		assert.Equal(t, 1024, c.config.MaxPayloadLogBytes)
+	})
+}
+
+// TestClientLogRequestJSONBodyParsedAsMap verifies that JSON request bodies are parsed
+// into map[string]any before being passed to Interface() — this is what enables the
+// SensitiveDataFilter to walk nested keys and mask sensitive fields. Actual masking
+// is tested at the logger layer (logger/adapter_test.go, logger/filter_test.go).
+func TestClientLogRequestJSONBodyParsedAsMap(t *testing.T) {
+	fakeLog := &fakeLogger{}
+	c := &client{
+		logger: fakeLog,
+		config: &Config{
+			LogPayloads:        true,
+			MaxPayloadLogBytes: 512,
+		},
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "POST", "https://api.example.com/auth", http.NoBody)
+	assert.NoError(t, err)
+	req.Header.Set(testContentTypeHeader, testContentType)
+
+	body := []byte(`{"username": "alice", "password": "s3cr3t!", "amount": 100}`)
+	c.logRequest(req, body, "trace-sensitive")
+
+	debugEvents := fakeLog.eventsByLevel("debug")
+	assert.Len(t, debugEvents, 1)
+
+	debugEvent := debugEvents[0]
+	// JSON body_preview must be map[string]any so the SensitiveDataFilter can walk its keys.
+	// If it were []byte, the filter would see an opaque blob and masking could not occur.
+	preview, ok := debugEvent.fields["body_preview"].(map[string]any)
+	assert.True(t, ok, "JSON body_preview must be a parsed map[string]any to enable filter walking")
+	assert.Equal(t, "alice", preview["username"])
+	assert.Equal(t, float64(100), preview["amount"])
+	assert.Contains(t, preview, "password", "parsed map must contain all JSON keys")
+}
+
+// TestIsJSONContentTypeEdgeCases verifies that isJSONContentType handles
+// edge-case Content-Type values that occur with proxies or custom transports.
+func TestIsJSONContentTypeEdgeCases(t *testing.T) {
+	cases := []struct {
+		ct   string
+		want bool
+	}{
+		{ct: "application/json", want: true},
+		{ct: "application/json; charset=utf-8", want: true},
+		{ct: "  application/json  ", want: true},             // leading/trailing whitespace
+		{ct: " application/json; charset=utf-8", want: true}, // leading space before semicolon
+		{ct: "application/vnd.api+json", want: true},
+		{ct: "APPLICATION/JSON", want: true},
+		{ct: "text/plain", want: false},
+		{ct: "", want: false},
+		{ct: "text/html; charset=utf-8", want: false},
+	}
+	for _, tc := range cases {
+		got := isJSONContentType(tc.ct)
+		if got != tc.want {
+			t.Errorf("isJSONContentType(%q) = %v, want %v", tc.ct, got, tc.want)
+		}
+	}
 }

--- a/logger/adapter.go
+++ b/logger/adapter.go
@@ -20,6 +20,16 @@ func (lea *LogEventAdapter) wrapEvent(e *zerolog.Event) *LogEventAdapter {
 	return &LogEventAdapter{event: e, filter: lea.filter, level: lea.level, hook: lea.hook}
 }
 
+// maskIfSensitive returns a masked adapter when the key is sensitive, signalling via ok.
+// Centralizes the typed-method mask check so adding a new typed slot (e.g. Float64) cannot
+// silently bypass the privacy boundary by forgetting to wire the same conditional.
+func (lea *LogEventAdapter) maskIfSensitive(key string) (LogEvent, bool) {
+	if lea.filter != nil && lea.filter.isSensitiveField(key) {
+		return lea.wrapEvent(lea.event.Interface(key, lea.filter.config.MaskValue)), true
+	}
+	return nil, false
+}
+
 // Msg logs the message
 func (lea *LogEventAdapter) Msg(msg string) {
 	lea.trackSeverity()
@@ -47,32 +57,32 @@ func (lea *LogEventAdapter) Str(key, value string) LogEvent {
 
 // Int adds an integer field to the log event
 func (lea *LogEventAdapter) Int(key string, value int) LogEvent {
-	if lea.filter != nil && lea.filter.isSensitiveField(key) {
-		return lea.wrapEvent(lea.event.Interface(key, lea.filter.config.MaskValue))
+	if masked, ok := lea.maskIfSensitive(key); ok {
+		return masked
 	}
 	return lea.wrapEvent(lea.event.Int(key, value))
 }
 
 // Int64 adds an int64 field to the log event
 func (lea *LogEventAdapter) Int64(key string, value int64) LogEvent {
-	if lea.filter != nil && lea.filter.isSensitiveField(key) {
-		return lea.wrapEvent(lea.event.Interface(key, lea.filter.config.MaskValue))
+	if masked, ok := lea.maskIfSensitive(key); ok {
+		return masked
 	}
 	return lea.wrapEvent(lea.event.Int64(key, value))
 }
 
 // Uint64 adds a uint64 field to the log event
 func (lea *LogEventAdapter) Uint64(key string, value uint64) LogEvent {
-	if lea.filter != nil && lea.filter.isSensitiveField(key) {
-		return lea.wrapEvent(lea.event.Interface(key, lea.filter.config.MaskValue))
+	if masked, ok := lea.maskIfSensitive(key); ok {
+		return masked
 	}
 	return lea.wrapEvent(lea.event.Uint64(key, value))
 }
 
 // Dur adds a duration field to the log event
 func (lea *LogEventAdapter) Dur(key string, d time.Duration) LogEvent {
-	if lea.filter != nil && lea.filter.isSensitiveField(key) {
-		return lea.wrapEvent(lea.event.Interface(key, lea.filter.config.MaskValue))
+	if masked, ok := lea.maskIfSensitive(key); ok {
+		return masked
 	}
 	return lea.wrapEvent(lea.event.Dur(key, d))
 }
@@ -87,8 +97,8 @@ func (lea *LogEventAdapter) Interface(key string, i any) LogEvent {
 
 // Bytes adds a byte slice field to the log event
 func (lea *LogEventAdapter) Bytes(key string, val []byte) LogEvent {
-	if lea.filter != nil && lea.filter.isSensitiveField(key) {
-		return lea.wrapEvent(lea.event.Interface(key, lea.filter.config.MaskValue))
+	if masked, ok := lea.maskIfSensitive(key); ok {
+		return masked
 	}
 	return lea.wrapEvent(lea.event.Bytes(key, val))
 }

--- a/logger/adapter.go
+++ b/logger/adapter.go
@@ -42,21 +42,33 @@ func (lea *LogEventAdapter) Str(key, value string) LogEvent {
 
 // Int adds an integer field to the log event
 func (lea *LogEventAdapter) Int(key string, value int) LogEvent {
+	if lea.filter != nil && lea.filter.isSensitiveField(key) {
+		return &LogEventAdapter{event: lea.event.Interface(key, lea.filter.config.MaskValue), filter: lea.filter, level: lea.level, hook: lea.hook}
+	}
 	return &LogEventAdapter{event: lea.event.Int(key, value), filter: lea.filter, level: lea.level, hook: lea.hook}
 }
 
 // Int64 adds an int64 field to the log event
 func (lea *LogEventAdapter) Int64(key string, value int64) LogEvent {
+	if lea.filter != nil && lea.filter.isSensitiveField(key) {
+		return &LogEventAdapter{event: lea.event.Interface(key, lea.filter.config.MaskValue), filter: lea.filter, level: lea.level, hook: lea.hook}
+	}
 	return &LogEventAdapter{event: lea.event.Int64(key, value), filter: lea.filter, level: lea.level, hook: lea.hook}
 }
 
 // Uint64 adds a uint64 field to the log event
 func (lea *LogEventAdapter) Uint64(key string, value uint64) LogEvent {
+	if lea.filter != nil && lea.filter.isSensitiveField(key) {
+		return &LogEventAdapter{event: lea.event.Interface(key, lea.filter.config.MaskValue), filter: lea.filter, level: lea.level, hook: lea.hook}
+	}
 	return &LogEventAdapter{event: lea.event.Uint64(key, value), filter: lea.filter, level: lea.level, hook: lea.hook}
 }
 
 // Dur adds a duration field to the log event
 func (lea *LogEventAdapter) Dur(key string, d time.Duration) LogEvent {
+	if lea.filter != nil && lea.filter.isSensitiveField(key) {
+		return &LogEventAdapter{event: lea.event.Interface(key, lea.filter.config.MaskValue), filter: lea.filter, level: lea.level, hook: lea.hook}
+	}
 	return &LogEventAdapter{event: lea.event.Dur(key, d), filter: lea.filter, level: lea.level, hook: lea.hook}
 }
 
@@ -70,6 +82,9 @@ func (lea *LogEventAdapter) Interface(key string, i any) LogEvent {
 
 // Bytes adds a byte slice field to the log event
 func (lea *LogEventAdapter) Bytes(key string, val []byte) LogEvent {
+	if lea.filter != nil && lea.filter.isSensitiveField(key) {
+		return &LogEventAdapter{event: lea.event.Interface(key, lea.filter.config.MaskValue), filter: lea.filter, level: lea.level, hook: lea.hook}
+	}
 	return &LogEventAdapter{event: lea.event.Bytes(key, val), filter: lea.filter, level: lea.level, hook: lea.hook}
 }
 

--- a/logger/adapter.go
+++ b/logger/adapter.go
@@ -15,6 +15,11 @@ type LogEventAdapter struct {
 	hook   func(zerolog.Level)
 }
 
+// wrapEvent creates a new LogEventAdapter reusing the current filter/level/hook.
+func (lea *LogEventAdapter) wrapEvent(e *zerolog.Event) *LogEventAdapter {
+	return &LogEventAdapter{event: e, filter: lea.filter, level: lea.level, hook: lea.hook}
+}
+
 // Msg logs the message
 func (lea *LogEventAdapter) Msg(msg string) {
 	lea.trackSeverity()
@@ -29,7 +34,7 @@ func (lea *LogEventAdapter) Msgf(format string, args ...any) {
 
 // Err adds an error to the log event
 func (lea *LogEventAdapter) Err(err error) LogEvent {
-	return &LogEventAdapter{event: lea.event.Err(err), filter: lea.filter, level: lea.level, hook: lea.hook}
+	return lea.wrapEvent(lea.event.Err(err))
 }
 
 // Str adds a string field to the log event
@@ -37,39 +42,39 @@ func (lea *LogEventAdapter) Str(key, value string) LogEvent {
 	if lea.filter != nil {
 		value = lea.filter.FilterString(key, value)
 	}
-	return &LogEventAdapter{event: lea.event.Str(key, value), filter: lea.filter, level: lea.level, hook: lea.hook}
+	return lea.wrapEvent(lea.event.Str(key, value))
 }
 
 // Int adds an integer field to the log event
 func (lea *LogEventAdapter) Int(key string, value int) LogEvent {
 	if lea.filter != nil && lea.filter.isSensitiveField(key) {
-		return &LogEventAdapter{event: lea.event.Interface(key, lea.filter.config.MaskValue), filter: lea.filter, level: lea.level, hook: lea.hook}
+		return lea.wrapEvent(lea.event.Interface(key, lea.filter.config.MaskValue))
 	}
-	return &LogEventAdapter{event: lea.event.Int(key, value), filter: lea.filter, level: lea.level, hook: lea.hook}
+	return lea.wrapEvent(lea.event.Int(key, value))
 }
 
 // Int64 adds an int64 field to the log event
 func (lea *LogEventAdapter) Int64(key string, value int64) LogEvent {
 	if lea.filter != nil && lea.filter.isSensitiveField(key) {
-		return &LogEventAdapter{event: lea.event.Interface(key, lea.filter.config.MaskValue), filter: lea.filter, level: lea.level, hook: lea.hook}
+		return lea.wrapEvent(lea.event.Interface(key, lea.filter.config.MaskValue))
 	}
-	return &LogEventAdapter{event: lea.event.Int64(key, value), filter: lea.filter, level: lea.level, hook: lea.hook}
+	return lea.wrapEvent(lea.event.Int64(key, value))
 }
 
 // Uint64 adds a uint64 field to the log event
 func (lea *LogEventAdapter) Uint64(key string, value uint64) LogEvent {
 	if lea.filter != nil && lea.filter.isSensitiveField(key) {
-		return &LogEventAdapter{event: lea.event.Interface(key, lea.filter.config.MaskValue), filter: lea.filter, level: lea.level, hook: lea.hook}
+		return lea.wrapEvent(lea.event.Interface(key, lea.filter.config.MaskValue))
 	}
-	return &LogEventAdapter{event: lea.event.Uint64(key, value), filter: lea.filter, level: lea.level, hook: lea.hook}
+	return lea.wrapEvent(lea.event.Uint64(key, value))
 }
 
 // Dur adds a duration field to the log event
 func (lea *LogEventAdapter) Dur(key string, d time.Duration) LogEvent {
 	if lea.filter != nil && lea.filter.isSensitiveField(key) {
-		return &LogEventAdapter{event: lea.event.Interface(key, lea.filter.config.MaskValue), filter: lea.filter, level: lea.level, hook: lea.hook}
+		return lea.wrapEvent(lea.event.Interface(key, lea.filter.config.MaskValue))
 	}
-	return &LogEventAdapter{event: lea.event.Dur(key, d), filter: lea.filter, level: lea.level, hook: lea.hook}
+	return lea.wrapEvent(lea.event.Dur(key, d))
 }
 
 // Interface adds an any field to the log event
@@ -77,15 +82,15 @@ func (lea *LogEventAdapter) Interface(key string, i any) LogEvent {
 	if lea.filter != nil {
 		i = lea.filter.FilterValue(key, i)
 	}
-	return &LogEventAdapter{event: lea.event.Interface(key, i), filter: lea.filter, level: lea.level, hook: lea.hook}
+	return lea.wrapEvent(lea.event.Interface(key, i))
 }
 
 // Bytes adds a byte slice field to the log event
 func (lea *LogEventAdapter) Bytes(key string, val []byte) LogEvent {
 	if lea.filter != nil && lea.filter.isSensitiveField(key) {
-		return &LogEventAdapter{event: lea.event.Interface(key, lea.filter.config.MaskValue), filter: lea.filter, level: lea.level, hook: lea.hook}
+		return lea.wrapEvent(lea.event.Interface(key, lea.filter.config.MaskValue))
 	}
-	return &LogEventAdapter{event: lea.event.Bytes(key, val), filter: lea.filter, level: lea.level, hook: lea.hook}
+	return lea.wrapEvent(lea.event.Bytes(key, val))
 }
 
 // Bool adds a boolean field to the log event
@@ -93,12 +98,12 @@ func (lea *LogEventAdapter) Bool(key string, value bool) LogEvent {
 	if lea.filter != nil {
 		filtered := lea.filter.FilterValue(key, value)
 		if b, ok := filtered.(bool); ok {
-			return &LogEventAdapter{event: lea.event.Bool(key, b), filter: lea.filter, level: lea.level, hook: lea.hook}
+			return lea.wrapEvent(lea.event.Bool(key, b))
 		}
 		// Sensitive field was masked to a string — fall back to Interface to preserve the mask
-		return &LogEventAdapter{event: lea.event.Interface(key, filtered), filter: lea.filter, level: lea.level, hook: lea.hook}
+		return lea.wrapEvent(lea.event.Interface(key, filtered))
 	}
-	return &LogEventAdapter{event: lea.event.Bool(key, value), filter: lea.filter, level: lea.level, hook: lea.hook}
+	return lea.wrapEvent(lea.event.Bool(key, value))
 }
 
 func (lea *LogEventAdapter) trackSeverity() {

--- a/logger/adapter_test.go
+++ b/logger/adapter_test.go
@@ -519,6 +519,16 @@ func TestLogEventAdapterTypedMethodsMaskSensitiveKeys(t *testing.T) {
 		assert.Equal(t, "[MASKED]", entry["password"])
 	})
 
+	t.Run("Int64_non_sensitive_preserved", func(t *testing.T) {
+		var buf bytes.Buffer
+		zl := zerolog.New(&buf)
+		logger := &ZeroLogger{zlog: &zl, filter: NewSensitiveDataFilter(filterConfig)}
+		logger.Info().Int64("user_id", 9876543210).Msg("x")
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+		assert.Equal(t, float64(9876543210), entry["user_id"], "Int64 non-sensitive must not be masked")
+	})
+
 	t.Run("Uint64_sensitive_masked", func(t *testing.T) {
 		var buf bytes.Buffer
 		zl := zerolog.New(&buf)
@@ -529,6 +539,16 @@ func TestLogEventAdapterTypedMethodsMaskSensitiveKeys(t *testing.T) {
 		assert.Equal(t, "[MASKED]", entry["api_key"])
 	})
 
+	t.Run("Uint64_non_sensitive_preserved", func(t *testing.T) {
+		var buf bytes.Buffer
+		zl := zerolog.New(&buf)
+		logger := &ZeroLogger{zlog: &zl, filter: NewSensitiveDataFilter(filterConfig)}
+		logger.Info().Uint64("file_size", 1024).Msg("x")
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+		assert.Equal(t, float64(1024), entry["file_size"], "Uint64 non-sensitive must not be masked")
+	})
+
 	t.Run("Dur_sensitive_masked", func(t *testing.T) {
 		var buf bytes.Buffer
 		zl := zerolog.New(&buf)
@@ -537,6 +557,16 @@ func TestLogEventAdapterTypedMethodsMaskSensitiveKeys(t *testing.T) {
 		var entry map[string]any
 		require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
 		assert.Equal(t, "[MASKED]", entry["token"])
+	})
+
+	t.Run("Dur_non_sensitive_preserved", func(t *testing.T) {
+		var buf bytes.Buffer
+		zl := zerolog.New(&buf)
+		logger := &ZeroLogger{zlog: &zl, filter: NewSensitiveDataFilter(filterConfig)}
+		logger.Info().Dur("elapsed", 250*time.Millisecond).Msg("x")
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+		assert.Equal(t, float64(250), entry["elapsed"], "Dur non-sensitive must not be masked")
 	})
 
 	t.Run("Bytes_sensitive_masked", func(t *testing.T) {

--- a/logger/adapter_test.go
+++ b/logger/adapter_test.go
@@ -472,6 +472,96 @@ func TestLogEventAdapterSpecialCharacters(t *testing.T) {
 	assert.Equal(t, "special characters test", logEntry["message"])
 }
 
+// TestLogEventAdapterTypedMethodsMaskSensitiveKeys verifies that Int, Int64, Uint64,
+// Dur, and Bytes emit the mask string (via Interface) when the key is sensitive, not the
+// raw numeric/byte value. This is the typed-method bypass regression guard: before the
+// fix, log.Bytes("api_key", rawKey) or log.Int64("password_hash", h) leaked verbatim.
+func TestLogEventAdapterTypedMethodsMaskSensitiveKeys(t *testing.T) {
+	filterConfig := &FilterConfig{
+		SensitiveFields: []string{"password", "token", "api_key", "secret"},
+		MaskValue:       "[MASKED]",
+	}
+
+	sensitiveKeys := []string{"password", "token", "api_key", "my_secret_field"}
+	nonSensitiveKeys := []string{"count", "size", "elapsed", "user_id"}
+
+	t.Run("Int_sensitive_masked", func(t *testing.T) {
+		for _, key := range sensitiveKeys {
+			var buf bytes.Buffer
+			zl := zerolog.New(&buf)
+			logger := &ZeroLogger{zlog: &zl, filter: NewSensitiveDataFilter(filterConfig)}
+			logger.Info().Int(key, 12345).Msg("x")
+			var entry map[string]any
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+			assert.Equal(t, "[MASKED]", entry[key], "Int(%q) must be masked", key)
+		}
+	})
+
+	t.Run("Int_non_sensitive_preserved", func(t *testing.T) {
+		for _, key := range nonSensitiveKeys {
+			var buf bytes.Buffer
+			zl := zerolog.New(&buf)
+			logger := &ZeroLogger{zlog: &zl, filter: NewSensitiveDataFilter(filterConfig)}
+			logger.Info().Int(key, 42).Msg("x")
+			var entry map[string]any
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+			assert.Equal(t, float64(42), entry[key], "Int(%q) must not be masked", key)
+		}
+	})
+
+	t.Run("Int64_sensitive_masked", func(t *testing.T) {
+		var buf bytes.Buffer
+		zl := zerolog.New(&buf)
+		logger := &ZeroLogger{zlog: &zl, filter: NewSensitiveDataFilter(filterConfig)}
+		logger.Info().Int64("password", 9876543210).Msg("x")
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+		assert.Equal(t, "[MASKED]", entry["password"])
+	})
+
+	t.Run("Uint64_sensitive_masked", func(t *testing.T) {
+		var buf bytes.Buffer
+		zl := zerolog.New(&buf)
+		logger := &ZeroLogger{zlog: &zl, filter: NewSensitiveDataFilter(filterConfig)}
+		logger.Info().Uint64("api_key", 1234567890).Msg("x")
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+		assert.Equal(t, "[MASKED]", entry["api_key"])
+	})
+
+	t.Run("Dur_sensitive_masked", func(t *testing.T) {
+		var buf bytes.Buffer
+		zl := zerolog.New(&buf)
+		logger := &ZeroLogger{zlog: &zl, filter: NewSensitiveDataFilter(filterConfig)}
+		logger.Info().Dur("token", 5*time.Second).Msg("x")
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+		assert.Equal(t, "[MASKED]", entry["token"])
+	})
+
+	t.Run("Bytes_sensitive_masked", func(t *testing.T) {
+		var buf bytes.Buffer
+		zl := zerolog.New(&buf)
+		logger := &ZeroLogger{zlog: &zl, filter: NewSensitiveDataFilter(filterConfig)}
+		rawKey := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE}
+		logger.Info().Bytes("api_key", rawKey).Msg("x")
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+		assert.Equal(t, "[MASKED]", entry["api_key"], "Bytes with sensitive key must not leak raw bytes")
+	})
+
+	t.Run("Bytes_non_sensitive_preserved", func(t *testing.T) {
+		var buf bytes.Buffer
+		zl := zerolog.New(&buf)
+		logger := &ZeroLogger{zlog: &zl, filter: NewSensitiveDataFilter(filterConfig)}
+		logger.Info().Bytes("payload", []byte("hello")).Msg("x")
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+		assert.NotEqual(t, "[MASKED]", entry["payload"], "non-sensitive Bytes must not be masked")
+		assert.NotEmpty(t, entry["payload"])
+	})
+}
+
 func TestLogEventAdapterReturnedTypes(t *testing.T) {
 	logger, _ := createTestLogger()
 

--- a/logger/filter.go
+++ b/logger/filter.go
@@ -2,12 +2,11 @@
 package logger
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
 	"strings"
 	"unsafe"
-
-	"github.com/rs/zerolog"
 )
 
 const (
@@ -46,7 +45,9 @@ func DefaultFilterConfig() *FilterConfig {
 	}
 }
 
-// SensitiveDataFilter implements zerolog.Hook to filter sensitive data from logs
+// SensitiveDataFilter filters sensitive data from logs. Filtering is enforced by the
+// adapter layer (LogEventAdapter) — never add a Zerolog() accessor to ZeroLogger as
+// that would create a bypass path around this filter boundary.
 type SensitiveDataFilter struct {
 	config *FilterConfig
 }
@@ -60,17 +61,6 @@ func NewSensitiveDataFilter(config *FilterConfig) *SensitiveDataFilter {
 		config.MaskValue = DefaultMaskValue
 	}
 	return &SensitiveDataFilter{config: config}
-}
-
-// Run implements zerolog.Hook interface to filter sensitive data
-func (f *SensitiveDataFilter) Run(_ *zerolog.Event, _ zerolog.Level, _ string) {
-	// Note: zerolog's Event doesn't expose its internal fields directly,
-	// so we need to work with the event through its methods.
-	// The filtering will be applied when fields are added to the event.
-
-	// This hook serves as a placeholder for the filtering mechanism.
-	// The actual filtering happens in the FilterString and FilterValue methods
-	// that are called by the enhanced logger methods.
 }
 
 // FilterString filters sensitive data from string values
@@ -97,9 +87,12 @@ func (f *SensitiveDataFilter) filterValueWithProtection(key string, value any, v
 		return nil
 	}
 
-	// Check depth limit
+	// Check depth limit — fail-closed: mask the subtree rather than leaking sensitive
+	// leaves the recursion budget didn't reach. Contrast with cycle detection (below)
+	// which returns value because masking a cycle root discards the rest of the tree;
+	// depth exhaustion can always safely substitute the mask.
 	if maxDepth <= 0 {
-		return value
+		return f.config.MaskValue
 	}
 
 	return f.filterByTypeWithProtection(key, value, visited, maxDepth)
@@ -123,6 +116,28 @@ func (f *SensitiveDataFilter) filterByTypeWithProtection(key string, value any, 
 			return f.filterStructWithProtection(value, visited, maxDepth)
 		}
 		return value
+	case reflect.Map:
+		// Covers map[string]string, map[string][]string (http.Header), map[string]int, etc.
+		// map[string]any is handled by the fast-path type-assertion above; this arm catches
+		// every other concrete map type. Keys are stringified so non-string-keyed maps still
+		// get their keys sensitivity-checked. Output is always map[string]any — the log
+		// consumer does not require the original value type.
+		if rv.IsNil() {
+			// A typed nil map (e.g. var h http.Header = nil) must stay nil in the log output.
+			// Without this guard, rv.Len()==0 would produce {} instead of null.
+			return nil
+		}
+		result := make(map[string]any, rv.Len())
+		for _, k := range rv.MapKeys() {
+			var keyStr string
+			if k.Kind() == reflect.String {
+				keyStr = k.String()
+			} else {
+				keyStr = fmt.Sprintf("%v", k.Interface())
+			}
+			result[keyStr] = f.filterValueWithProtection(keyStr, rv.MapIndex(k).Interface(), visited, maxDepth-1)
+		}
+		return result
 	default:
 		// All other types pass through unchanged
 		return value
@@ -279,21 +294,15 @@ func (f *SensitiveDataFilter) buildMaskedURL(parsed *url.URL, username string) s
 	return b.String()
 }
 
-// filterStruct filters sensitive fields in struct values using reflection
-func (f *SensitiveDataFilter) filterStruct(value any) any {
-	visited := make(map[uintptr]struct{})
-	return f.filterStructWithProtection(value, visited, DefaultMaxDepth)
-}
-
 // filterStructWithProtection filters sensitive fields with cycle detection and depth limiting
 func (f *SensitiveDataFilter) filterStructWithProtection(value any, visited map[uintptr]struct{}, maxDepth int) any {
 	if value == nil {
 		return nil
 	}
 
-	// Check depth limit
+	// Check depth limit — fail-closed; see filterValueWithProtection for rationale.
 	if maxDepth <= 0 {
-		return value
+		return f.config.MaskValue
 	}
 
 	structVal, structType, ptr := f.extractStructValueWithPointer(value)

--- a/logger/filter.go
+++ b/logger/filter.go
@@ -102,6 +102,11 @@ func (f *SensitiveDataFilter) filterValueWithProtection(key string, value any, v
 func (f *SensitiveDataFilter) filterByTypeWithProtection(key string, value any, visited map[uintptr]struct{}, maxDepth int) any {
 	// Handle typed map first (most common case)
 	if m, ok := value.(map[string]any); ok {
+		if m == nil {
+			// Preserve typed-nil parity with the reflect.Map branch below
+			// (filterStringMapWithProtection would otherwise return {} via make).
+			return nil
+		}
 		return f.filterStringMapWithProtection(m, visited, maxDepth)
 	}
 

--- a/logger/filter_test.go
+++ b/logger/filter_test.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"net/http"
 	"slices"
 	"testing"
 )
@@ -172,16 +173,6 @@ func TestMaskURL(t *testing.T) {
 // =============================================================================
 // Enhanced Sensitive Data Filtering Tests
 // =============================================================================
-
-func TestSensitiveDataFilterRunHook(_ *testing.T) {
-	filter := NewSensitiveDataFilter(nil)
-
-	// Test that Run method can be called without panic
-	// This is primarily a placeholder method but should work safely
-	filter.Run(nil, 0, "test message")
-
-	// The method should not panic or error, it's a no-op placeholder
-}
 
 func TestFilterValueStructFiltering(t *testing.T) {
 	filter := NewSensitiveDataFilter(&FilterConfig{
@@ -389,11 +380,12 @@ func TestFilterValueNonStructType(t *testing.T) {
 		t.Errorf("Expected slice to pass through unchanged")
 	}
 
-	stringMap := map[string]string{"key": "value"}
+	// Non-sensitive key: should pass through (now returns map[string]any after reflect.Map fix)
+	stringMap := map[string]string{"username": "alice"}
 	mapResult := filter.FilterValue("field", stringMap)
-	mapResultTyped, ok := mapResult.(map[string]string)
-	if !ok || mapResultTyped["key"] != "value" {
-		t.Errorf("Expected string map to pass through unchanged")
+	mapResultTyped, ok := mapResult.(map[string]any)
+	if !ok || mapResultTyped["username"] != "alice" {
+		t.Errorf("Expected non-sensitive string map field to pass through unchanged")
 	}
 }
 
@@ -556,6 +548,126 @@ var completeFieldCoverageFilter = NewSensitiveDataFilter(&FilterConfig{
 
 const completeCoverageTestName = "test"
 
+func TestFilterValueMapStringStringSensitiveKeyMasked(t *testing.T) {
+	filter := NewSensitiveDataFilter(&FilterConfig{
+		SensitiveFields: []string{"password", "token"},
+		MaskValue:       DefaultMaskValue,
+	})
+
+	cases := []struct {
+		name     string
+		in       map[string]string
+		key      string
+		wantMask bool
+	}{
+		{name: "sensitive_key_masked", in: map[string]string{"password": "s3cr3t", "user": "bob"}, key: "password", wantMask: true},
+		{name: "non_sensitive_preserved", in: map[string]string{"username": "bob"}, key: "username", wantMask: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := filter.FilterValue("data", tc.in)
+			resultMap, ok := result.(map[string]any)
+			if !ok {
+				t.Fatalf("Expected map[string]any, got %T", result)
+			}
+			got := resultMap[tc.key]
+			if tc.wantMask && got != DefaultMaskValue {
+				t.Errorf("Expected %q to be masked, got %v", tc.key, got)
+			}
+			if !tc.wantMask && got != tc.in[tc.key] {
+				t.Errorf("Expected %q to be %q, got %v", tc.key, tc.in[tc.key], got)
+			}
+		})
+	}
+}
+
+func TestFilterValueNilMapPreservesNil(t *testing.T) {
+	filter := NewSensitiveDataFilter(DefaultFilterConfig())
+
+	// A typed-nil map must remain nil in the output, not become an empty {}.
+	// Without an rv.IsNil() guard, typed nils bypass the interface nil check.
+	var h http.Header // nil map of type map[string][]string
+	result := filter.FilterValue("headers", h)
+	if result != nil {
+		t.Errorf("Expected typed-nil http.Header to filter as nil, got %T %v", result, result)
+	}
+
+	var m map[string]string // nil map of type map[string]string
+	result2 := filter.FilterValue("data", m)
+	if result2 != nil {
+		t.Errorf("Expected typed-nil map[string]string to filter as nil, got %T %v", result2, result2)
+	}
+}
+
+func TestFilterValueHTTPHeaderMasksSensitiveKeys(t *testing.T) {
+	filter := NewSensitiveDataFilter(&FilterConfig{
+		SensitiveFields: []string{"authorization", "token"},
+		MaskValue:       DefaultMaskValue,
+	})
+
+	headers := map[string][]string{
+		"Authorization": {"Bearer eyJhbGciOiJSUzI1NiJ9"},
+		"Content-Type":  {"application/json"},
+	}
+	result := filter.FilterValue("headers", headers)
+	resultMap, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("Expected map[string]any, got %T", result)
+	}
+	if resultMap["Authorization"] != DefaultMaskValue {
+		t.Errorf("Expected Authorization header to be masked, got %v", resultMap["Authorization"])
+	}
+	if resultMap["Content-Type"] == DefaultMaskValue {
+		t.Error("Expected Content-Type header to be preserved")
+	}
+}
+
+func TestFilterValueDepthExhaustionMasks(t *testing.T) {
+	filter := NewSensitiveDataFilter(&FilterConfig{
+		SensitiveFields: []string{"password"},
+		MaskValue:       DefaultMaskValue,
+	})
+
+	// Build a map nested deeper than DefaultMaxDepth (8).
+	// The "password" field lives at depth 10 — previously leaked due to fail-open;
+	// after the fix, the entire subtree at depth 0 is replaced with the mask.
+	var buildDeep func(depth int) map[string]any
+	buildDeep = func(depth int) map[string]any {
+		if depth == 0 {
+			return map[string]any{"password": "s3cr3t", "name": "leaf"}
+		}
+		return map[string]any{"next": buildDeep(depth - 1)}
+	}
+	deep := buildDeep(DefaultMaxDepth + 2)
+
+	result := filter.FilterValue("data", deep)
+	resultMap, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("Expected map[string]any, got %T", result)
+	}
+	// Top-level key is non-sensitive; the nested subtree exceeds depth limit.
+	// The subtree is replaced with the mask rather than leaking its contents.
+	if resultMap["next"] == nil {
+		t.Error("Expected 'next' key to be present")
+	}
+	// Walk as deep as possible and confirm we never get a plain "s3cr3t" string.
+	var checkNoLeak func(v any)
+	checkNoLeak = func(v any) {
+		switch val := v.(type) {
+		case string:
+			if val == "s3cr3t" {
+				t.Error("Sensitive password leaked despite depth exhaustion")
+			}
+		case map[string]any:
+			for _, inner := range val {
+				checkNoLeak(inner)
+			}
+		}
+	}
+	checkNoLeak(result)
+}
+
 func TestFilterStructWithInterfaceField(t *testing.T) {
 	type TestStruct struct {
 		Username string `json:"username"`
@@ -659,7 +771,6 @@ func TestFilterStructPointerToValidStruct(t *testing.T) {
 }
 
 func TestFilterStructDirectPointerHandling(t *testing.T) {
-	// Test the pointer handling within filterStruct directly
 	type TestStruct struct {
 		Name     string `json:"name"`
 		Password string `json:"password"`
@@ -670,8 +781,7 @@ func TestFilterStructDirectPointerHandling(t *testing.T) {
 		Password: "secret",
 	}
 
-	// Call filterStruct directly to test pointer dereferencing
-	result := completeFieldCoverageFilter.filterStruct(input)
+	result := completeFieldCoverageFilter.FilterValue(completeCoverageTestName, input)
 	resultMap, ok := result.(map[string]any)
 	if !ok {
 		t.Fatal(expectedMaskedMapMsg)

--- a/logger/filter_test.go
+++ b/logger/filter_test.go
@@ -598,6 +598,14 @@ func TestFilterValueNilMapPreservesNil(t *testing.T) {
 	if result2 != nil {
 		t.Errorf("Expected typed-nil map[string]string to filter as nil, got %T %v", result2, result2)
 	}
+
+	// map[string]any is handled by the fast-path type assertion (not reflect.Map),
+	// so it needs its own nil guard. Locks in regression coverage for the fast path.
+	var ma map[string]any
+	result3 := filter.FilterValue("payload", ma)
+	if result3 != nil {
+		t.Errorf("Expected typed-nil map[string]any to filter as nil, got %T %v", result3, result3)
+	}
 }
 
 func TestFilterValueHTTPHeaderMasksSensitiveKeys(t *testing.T) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -31,38 +31,7 @@ var callerMarshalOnce sync.Once
 // New creates a new ZeroLogger instance with the specified log level and formatting options.
 // If pretty is true, output will be formatted for human readability.
 func New(level string, pretty bool) *ZeroLogger {
-	callerMarshalOnce.Do(func() {
-		zerolog.CallerMarshalFunc = func(_ uintptr, file string, line int) string {
-			base := filepath.Base(file)
-			parent := filepath.Base(filepath.Dir(file))
-			if parent != "." && parent != "" {
-				return parent + "/" + base + ":" + strconv.Itoa(line)
-			}
-			return base + ":" + strconv.Itoa(line)
-		}
-	})
-
-	var l zerolog.Logger
-
-	if pretty {
-		l = zerolog.New(zerolog.ConsoleWriter{
-			Out:        os.Stdout,
-			TimeFormat: time.RFC3339,
-		}).With().Timestamp().CallerWithSkipFrameCount(3).Logger()
-	} else {
-		l = zerolog.New(os.Stdout).With().Timestamp().CallerWithSkipFrameCount(3).Logger()
-	}
-
-	zLevel, err := zerolog.ParseLevel(level)
-	if err != nil {
-		zLevel = zerolog.InfoLevel
-	}
-	l = l.Level(zLevel)
-
-	// Initialize the sensitive data filter with default configuration
-	filter := NewSensitiveDataFilter(DefaultFilterConfig())
-
-	return &ZeroLogger{zlog: &l, filter: filter, pretty: pretty}
+	return NewWithFilter(level, pretty, DefaultFilterConfig())
 }
 
 // NewWithFilter creates a new ZeroLogger instance with custom filter configuration.

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -528,17 +528,6 @@ func TestNewWithFilterEdgeCases(t *testing.T) {
 	})
 }
 
-func TestSensitiveDataFilterRun(_ *testing.T) {
-	// Test the Run method that currently has 0% coverage
-	filter := NewSensitiveDataFilter(nil)
-
-	// The Run method is a no-op placeholder, but we need to call it for coverage
-	filter.Run(nil, zerolog.InfoLevel, testMessage)
-
-	// No assertions needed since it's a placeholder method
-	// But this covers the 0% coverage method
-}
-
 func TestFilterValueEdgeCases(t *testing.T) {
 	config := &FilterConfig{
 		SensitiveFields: []string{"password", "secret", "token"},
@@ -635,16 +624,6 @@ func TestFilterStructEdgeCases(t *testing.T) {
 		result := filter.FilterValue("empty", data)
 		assert.NotNil(t, result)
 	})
-}
-
-func TestSensitiveDataFilterRunMethodCoverage(t *testing.T) {
-	filter := NewSensitiveDataFilter(DefaultFilterConfig())
-
-	// Test Run method directly (currently 0% coverage)
-	filter.Run(nil, zerolog.InfoLevel, testMessage)
-
-	// The Run method is a placeholder implementation, so just ensuring it doesn't panic
-	assert.NotNil(t, filter)
 }
 
 func TestCallerMarshalFuncCoverage(t *testing.T) {

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -46,7 +46,7 @@ client := httpclient.NewBuilder(logger).
 
 | Content-Type | Behaviour |
 |---|---|
-| `application/json` or `*+json` | Body is parsed with `json.Unmarshal` and logged as `body_preview` (`map[string]any`). The framework's `SensitiveDataFilter` walks the parsed map and masks keys that match the sensitive field list (`password`, `token`, `api_key`, …). |
+| `application/json` or `*+json` | Body is parsed with `json.Unmarshal`. If the root is a JSON object, it is logged as `body_preview` after `SensitiveDataFilter` walks it to mask sensitive keys (`password`, `token`, `api_key`, …). Primitive/array roots are dropped — the filter can only walk map keys. |
 | Everything else (form-urlencoded, binary, multipart, missing/unknown) | Bytes are **not** logged. Instead `body_content_type` and `body_preview_dropped` (byte count) appear in the log. Form-urlencoded bodies often carry credential pairs; multipart and binary blobs are not filterable. |
 
 **JSON parse failure:** If the Content-Type is JSON but the body is malformed (e.g. truncated by `MaxPayloadLogBytes`), `body_content_type` and `body_preview_status: json_parse_failed` are logged instead of raw bytes.

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -32,6 +32,8 @@ resp, err := client.Get(ctx, &httpclient.Request{
 ## Payload Logging
 
 > **Warning:** payload logging is a debug aid for development/staging only. Enabling it in production widens the audit-log surface and may expose sensitive data to log pipelines.
+>
+> **PCI/PII workloads must extend the default sensitive-field list.** The framework ships defaults like `password`, `token`, `api_key`, `authorization`, but workload-specific fields (`pan`, `cvv2`, `cvv`, `otp`, `ssn`, …) need to be added via `log.sensitive_fields` in YAML or `app.Options.LoggerFilterConfig` in code before enabling payload logging — see [observability.md](observability.md#sensitive-data-filtering) for the full field list and customization seams.
 
 By default the client logs only request/response metadata (method, URL, status, elapsed, body size). Debug-level payload logging can be enabled via the builder:
 
@@ -46,7 +48,7 @@ client := httpclient.NewBuilder(logger).
 
 | Content-Type | Behaviour |
 |---|---|
-| `application/json` or `*+json` | Body is parsed with `json.Unmarshal`. If the root is a JSON object, it is logged as `body_preview` after `SensitiveDataFilter` walks it to mask sensitive keys (`password`, `token`, `api_key`, …). Primitive/array roots are dropped — the filter can only walk map keys. |
+| `application/json` or `*+json` | Body is parsed with `json.Unmarshal`. If the root is a JSON object, it is logged as `body_preview` after `SensitiveDataFilter` walks it to mask sensitive keys (`password`, `token`, `api_key`, …); nested maps and arrays inside that object root are processed recursively. Primitive and array roots are dropped — the filter requires a top-level JSON object with keys to walk and mask, so root-level scalars (`"secret-token"`, `123456`) and bare arrays would land verbatim without one. |
 | Everything else (form-urlencoded, binary, multipart, missing/unknown) | Bytes are **not** logged. Instead `body_content_type` and `body_preview_dropped` (byte count) appear in the log. Form-urlencoded bodies often carry credential pairs; multipart and binary blobs are not filterable. |
 
 **JSON parse failure:** If the Content-Type is JSON but the body is malformed (e.g. truncated by `MaxPayloadLogBytes`), `body_content_type` and `body_preview_status: json_parse_failed` are logged instead of raw bytes.

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -28,3 +28,27 @@ resp, err := client.Get(ctx, &httpclient.Request{
 ```
 
 **Interface:** `Get`, `Post`, `Put`, `Patch`, `Delete`, `Do` — all accept `context.Context` and `*Request`, return `*Response` and `error`.
+
+## Payload Logging
+
+> **Warning:** payload logging is a debug aid for development/staging only. Enabling it in production widens the audit-log surface and may expose sensitive data to log pipelines.
+
+By default the client logs only request/response metadata (method, URL, status, elapsed, body size). Debug-level payload logging can be enabled via the builder:
+
+```go
+client := httpclient.NewBuilder(logger).
+    WithLogPayloads(true).
+    WithMaxPayloadLogBytes(2048). // default 1024; must be > 0
+    Build()
+```
+
+**Content-type-aware logging:** Request and response bodies are handled differently depending on the `Content-Type` header:
+
+| Content-Type | Behaviour |
+|---|---|
+| `application/json` or `*+json` | Body is parsed with `json.Unmarshal` and logged as `body_preview` (`map[string]any`). The framework's `SensitiveDataFilter` walks the parsed map and masks keys that match the sensitive field list (`password`, `token`, `api_key`, …). |
+| Everything else (form-urlencoded, binary, multipart, missing/unknown) | Bytes are **not** logged. Instead `body_content_type` and `body_preview_dropped` (byte count) appear in the log. Form-urlencoded bodies often carry credential pairs; multipart and binary blobs are not filterable. |
+
+**JSON parse failure:** If the Content-Type is JSON but the body is malformed (e.g. truncated by `MaxPayloadLogBytes`), `body_content_type` and `body_preview_status: json_parse_failed` are logged instead of raw bytes.
+
+**Recommendation:** Keep `WithLogPayloads` disabled in production configs. If you need body inspection in production, log only the specific fields you need at the application layer (before or after the HTTP call) rather than enabling blanket payload logging.

--- a/wiki/observability.md
+++ b/wiki/observability.md
@@ -121,7 +121,7 @@ fw, err = app.NewWithOptions(&app.Options{
 
 - **Field names**, not field values. The filter never scans string contents for PAN-shaped digit sequences or Luhn-valid numbers. Value scanning is a defense-in-depth concern that belongs in application code (see *Defense in depth*, below).
 - **Case-insensitive substring**. `pan` matches `pan`, `PAN`, `Pan`, `card_pan`, `primary_account_number`. This is intentional — it survives typos, naming-convention drift, and underscored-vs-camelCase variants in different modules.
-- **Recursive into structures**. Direct `Str/Int/Interface(...)` fields, nested `map[string]any`, struct fields (using `json` tags when present), and slice/array elements are all walked. Recursion is bounded (`logger.DefaultMaxDepth = 8`) and cycle-safe (visited pointer set).
+- **Recursive into structures**. All log-event methods are covered — `Str`, `Int`, `Int64`, `Uint64`, `Dur`, `Bytes`, and `Interface(...)` — as well as nested `map[string]any`, `map[string]string`, `http.Header` (`map[string][]string`), struct fields (using `json` tags when present), and slice/array elements. Recursion is bounded (`logger.DefaultMaxDepth = 8`) and cycle-safe (visited pointer set). Depth exhaustion fails **closed** — values past the depth limit are replaced with the mask rather than logged verbatim.
 - **URLs as a special case**. If a masked field's value is an HTTP/AMQP URL with `user:password@host`, only the password component is replaced — the rest of the URL stays readable. This keeps `database_url` and `broker_url` actionable in error logs.
 
 ### What this does *not* do
@@ -137,7 +137,7 @@ Field-name masking is *one* layer. A complete PCI-DSS 3.3/3.4/3.5 posture combin
 1. **Don't log raw payloads.** Use validated DTOs in handlers, mask at the source: `log.Str("pan_last4", req.PAN[len(req.PAN)-4:])` is safer than relying on field-name masking to catch a `log.Interface("payload", req)` call.
 2. **Mask in error wrapping.** When wrapping errors that may include sensitive context, redact before `fmt.Errorf`. Helper pattern: `func MaskPAN(s string) string`.
 3. **Scrub free-text values.** Outside of structured logging, regex-scan any `log.Msg("...")` argument for digit sequences with Luhn validity. Implement as a `LogFilter` wrapper if your compliance auditor requires evidence.
-4. **Audit your default list.** Run `git grep -E 'Str|Int64|Interface\("([^"]+)"' --include='*.go'` periodically. Anything that looks PII-shaped should be in the allowlist.
+4. **Audit your default list.** Run `git grep -E '\.(Str|Int|Int64|Uint64|Dur|Bytes|Interface)\("([^"]+)"' --include='*.go'` periodically. Anything that looks PII-shaped should be in the allowlist. All these typed methods pass through the filter when the field name is sensitive.
 5. **Test that masking is active.** Add at least one integration test that emits a sensitive value and asserts the captured log line contains `***` (or your configured mask value). See `logger.TestNewWithFilter` for the pattern.
 
 ### Migration notes


### PR DESCRIPTION
## Summary

Closes six reachable privacy boundary bypasses in `SensitiveDataFilter` and the httpclient body-preview path, identified in the 2026-05-23 fleet review.

- **`logger/adapter.go`** — Wire `Int`, `Int64`, `Uint64`, `Dur`, `Bytes` through `isSensitiveField` (mirrors existing `Bool` precedent). `log.Int64("password_hash", h)` now emits the mask string instead of the raw value.
- **`logger/filter.go`** — Add `reflect.Map` case so `map[string]string`, `http.Header` (`map[string][]string`), `map[string]int` etc. are filtered; previously fell through `default` unfiltered. Add `rv.IsNil()` guard so typed-nil maps stay `nil` in output (not `{}`). Change depth exhaustion from fail-open to fail-closed (subtrees at depth > 8 are now masked rather than returned verbatim). Delete `Run` no-op (was claiming `zerolog.Hook` compliance but never registered). Collapse `New` into one-liner wrapper. Delete `filterStruct` shim.
- **`httpclient/client.go`** — Replace `dbg.Bytes("body_preview", preview)` with content-type-aware branch: JSON bodies are parsed → `Interface()` so the filter can walk nested keys; non-JSON bodies (form-urlencoded, binary) emit only `body_content_type + body_preview_dropped`, never raw bytes. Fix `isJSONContentType` to trim leading/trailing whitespace. Add `WithLogPayloads(bool)` and `WithMaxPayloadLogBytes(int)` Builder setters.
- **`wiki/`** — Update observability.md (typed-method coverage, depth semantics, audit grep) and httpclient.md (payload logging docs with PCI hazard warning).

## Security surface closed

| Bypass | Vector |
|--------|--------|
| Typed numeric methods | `log.Int64("password_hash", h)` leaked raw int64 |
| Map type gap | `map[string]string{"password":"x"}` passed through unfiltered |
| HTTP header gap | `http.Header{"Authorization":{"Bearer …"}}` passed through unfiltered |
| Fail-open depth | Values at nesting depth > 8 were returned verbatim even if sensitive |
| Typed-nil map | `var h http.Header = nil` became `{}` instead of `null` |
| httpclient bytes bypass | `body_preview` emitted raw bytes regardless of content type |

## Test plan

- [ ] `make check` passes (fmt + lint + race detection across 43 packages) ✅
- [ ] `golangci-lint run --enable gosec ./...` → 0 issues ✅
- [ ] `govulncheck ./...` → no vulnerabilities ✅
- [ ] New regression tests: `TestLogEventAdapterTypedMethodsMaskSensitiveKeys`, `TestFilterValueMapStringStringSensitiveKeyMasked`, `TestFilterValueHTTPHeaderMasksSensitiveKeys`, `TestFilterValueDepthExhaustionMasks`, `TestFilterValueNilMapPreservesNil`
- [ ] New httpclient tests: `TestBuilderPayloadLoggingSetters`, `TestClientLogRequestJSONBodyParsedAsMap`, `TestIsJSONContentTypeEdgeCases`
- [ ] `/code-review` findings applied (typed-nil map guard, isJSONContentType whitespace) ✅
- [ ] `/security-audit` clean ✅

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debug payload logging with configurable max preview bytes; JSON bodies parsed and previewed when safe.

* **Improvements**
  * Sensitive-data masking extended to numeric, duration, byte and nested fields; recursion now “fail-closed” at depth limits.
  * Non-JSON payloads and JSON roots that are primitives/arrays no longer emit raw previews; dropped-byte and parse-status metadata are logged.

* **Tests**
  * Expanded unit tests covering payload-logging behavior, content-type edge cases, and sensitive-field masking.

* **Documentation**
  * Added guidance on payload logging and masking semantics, usage cautions, and observability notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->