### PR TITLE
fix(app): shutdown honors cfg.Server.Timeout.Shutdown

### DIFF
--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -162,23 +162,28 @@ func (a *App) waitForShutdownOrServerError(serverErrCh <-chan error) (bool, erro
 	}
 }
 
+// shutdownTimeouts returns the inner timeout (passed to module Shutdown calls)
+// and the outer hard-stop deadline (inner + 5s headroom). Falls back to 10s/15s
+// when cfg is nil or the configured value is non-positive — matching the
+// documented server.timeout.shutdown default. Reading both values from a single
+// helper keeps drainServerError and the main shutdown sequence in lockstep.
+func (a *App) shutdownTimeouts() (inner, outer time.Duration) {
+	inner = 10 * time.Second
+	if a.cfg != nil && a.cfg.Server.Timeout.Shutdown > 0 {
+		inner = a.cfg.Server.Timeout.Shutdown
+	}
+	outer = inner + 5*time.Second
+	return inner, outer
+}
+
 // drainServerError drains any remaining error from the server error channel
 func (a *App) drainServerError(ch <-chan error) error {
 	if ch == nil {
 		return nil
 	}
 
-	// Derive from configured shutdown timeout with headroom
-	timeoutDur := 15 * time.Second // default timeout
-	if a.cfg != nil {
-		timeoutDur = a.cfg.Server.Timeout.Shutdown
-		if timeoutDur <= 0 {
-			timeoutDur = 15 * time.Second
-		} else {
-			timeoutDur += 5 * time.Second
-		}
-	}
-	timeout := time.After(timeoutDur)
+	_, outer := a.shutdownTimeouts()
+	timeout := time.After(outer)
 
 	if a.logger != nil {
 		a.logger.Debug().Msg("Draining server error channel")
@@ -223,7 +228,8 @@ func (a *App) Run() error {
 		a.logger.Error().Err(serverErr).Msg("Server stopped unexpectedly")
 	}
 
-	ctx, cancel := a.timeoutProvider.WithTimeout(context.Background(), 10*time.Second)
+	inner, outer := a.shutdownTimeouts()
+	ctx, cancel := a.timeoutProvider.WithTimeout(context.Background(), inner)
 
 	a.logger.Info().Msg("Shutting down application")
 
@@ -234,13 +240,13 @@ func (a *App) Run() error {
 		close(shutdownComplete)
 	}()
 
-	// Wait for shutdown with hard timeout
+	// Wait for shutdown with hard timeout (5s headroom over inner via shutdownTimeouts)
 	var shutdownErr error
 	select {
 	case shutdownErr = <-shutdownComplete:
 		a.logger.Info().Msg("Graceful shutdown completed")
 		cancel()
-	case <-time.After(15 * time.Second): // 5 seconds longer than shutdown context
+	case <-time.After(outer):
 		a.logger.Error().Msg("Shutdown timed out, forcing exit")
 		cancel()
 		return fmt.Errorf("shutdown timed out")

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -17,6 +17,56 @@ const (
 	testApp = "test-app"
 )
 
+func TestShutdownTimeouts(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       *config.Config
+		wantInner time.Duration
+		wantOuter time.Duration
+	}{
+		{
+			name:      "nil_cfg_uses_documented_defaults",
+			cfg:       nil,
+			wantInner: 10 * time.Second,
+			wantOuter: 15 * time.Second,
+		},
+		{
+			name:      "positive_config_overrides_default",
+			cfg:       &config.Config{Server: config.ServerConfig{Timeout: config.TimeoutConfig{Shutdown: 30 * time.Second}}},
+			wantInner: 30 * time.Second,
+			wantOuter: 35 * time.Second,
+		},
+		{
+			name:      "small_positive_config_keeps_5s_headroom",
+			cfg:       &config.Config{Server: config.ServerConfig{Timeout: config.TimeoutConfig{Shutdown: 1 * time.Second}}},
+			wantInner: 1 * time.Second,
+			wantOuter: 6 * time.Second,
+		},
+		{
+			name:      "zero_config_falls_back_to_default",
+			cfg:       &config.Config{Server: config.ServerConfig{Timeout: config.TimeoutConfig{Shutdown: 0}}},
+			wantInner: 10 * time.Second,
+			wantOuter: 15 * time.Second,
+		},
+		{
+			name:      "negative_config_falls_back_to_default",
+			cfg:       &config.Config{Server: config.ServerConfig{Timeout: config.TimeoutConfig{Shutdown: -5 * time.Second}}},
+			wantInner: 10 * time.Second,
+			wantOuter: 15 * time.Second,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app := &App{cfg: tc.cfg}
+			gotInner, gotOuter := app.shutdownTimeouts()
+			assert.Equal(t, tc.wantInner, gotInner, "inner timeout")
+			assert.Equal(t, tc.wantOuter, gotOuter, "outer timeout")
+			assert.Equal(t, gotInner+5*time.Second, gotOuter, "outer must equal inner + 5s headroom")
+		})
+	}
+}
+
 func TestShutdownTiming(t *testing.T) {
 	// Test that the shutdown process completes within reasonable time
 	cfg := &config.Config{


### PR DESCRIPTION
## Summary

- Replace two hardcoded shutdown timeouts in `app/lifecycle.go` (`10s` inner + `15s` outer) with values derived from `cfg.Server.Timeout.Shutdown`
- Extract a `shutdownTimeouts()` helper used by `drainServerError()`, the inner `context.WithTimeout`, and the outer `time.After` hard stop — three sites that previously duplicated the same logic
- Behavior preserved for the default config: `inner=10s, outer=15s` matches the prior hardcoded values; operators who set `server.timeout.shutdown: 30s` now actually get a 30s graceful drain instead of being silently capped at 10s

## Background

Wave 3-A of the lifecycle / at-least-once reliability sweep. The 2026-05-23 fleet review surfaced 8 lifecycle defects; this PR addresses the smallest, most isolated one. The same hardcoded-vs-configured pattern was already implemented correctly in `drainServerError()` (lines 167-178 pre-diff) — the helper consolidates that pattern across all three sites and makes the inner+5s headroom invariant explicit.

## Verification

- ✅ `make check` — 43 packages clean with `-race`
- ✅ `/code-review` (extra-high effort, 5 inline angles) — 0 findings
- ✅ `/security-audit` (gosec + govulncheck + raw-SQL + secrets scan) — 0 findings
- ✅ New table-driven test `TestShutdownTimeouts` covers 5 paths: nil cfg, positive override, small positive (asserts +5s headroom invariant), zero, negative — all pass under race
- ✅ Existing `TestShutdownTiming` still passes (uses cfg with zero `Shutdown` → helper returns the same defaults the test originally asserted against)

## Test plan

- [x] `go test -race -run TestShutdownTimeouts ./app/` — all 5 subtests pass
- [x] `make check` — full framework suite passes
- [ ] Manual: configure `server.timeout.shutdown: 30s` in a downstream app, send SIGTERM, observe shutdown context honors 30s budget

## Wave 3 sequencing

Next up (after this merges):
- W3-B: scheduler lifecycle hygiene (`wg.Add` race + CIDR-parse visibility)
- W3-C: cache manager closed-state guard
- W3-D: messaging at-least-once trio (silent `Publish` nil + linear backoff + uncorrelated confirms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced graceful shutdown mechanism with configurable timeout management, replacing fixed hardcoded values for improved control and reliability during application shutdown.

* **Tests**
  * Added comprehensive test coverage for shutdown timeout behavior across various configuration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->