### PR TITLE
fix(cache): add CacheManager closed-state guard

### DIFF
--- a/cache/errors.go
+++ b/cache/errors.go
@@ -22,6 +22,12 @@ var (
 
 	// ErrInvalidTTL is returned when a TTL value is invalid (e.g., negative).
 	ErrInvalidTTL = errors.New("cache: invalid TTL")
+
+	// ErrManagerClosed is returned by CacheManager operations (Get, Remove)
+	// after Close() has been called. Callers can errors.Is(err, ErrManagerClosed)
+	// to distinguish "manager is gone" from per-cache failures and decide
+	// whether to abort or fall back to a non-cache path.
+	ErrManagerClosed = errors.New("cache: manager closed")
 )
 
 // ConfigError represents a configuration error during cache initialization.

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gaborage/go-bricks/config"
@@ -64,6 +65,11 @@ type CacheManager struct {
 	// Lifecycle
 	closeCh   chan struct{}
 	closeOnce sync.Once
+	// closed flips to true the moment Close() begins. Read on the hot path of
+	// Get/Remove so callers immediately see ErrManagerClosed instead of getting
+	// a handle to a cache instance that is about to be torn down. Atomic so we
+	// don't need to take m.mu on every operation just to consult shutdown state.
+	closed atomic.Bool
 }
 
 // ManagerConfig configures the cache manager's behavior.
@@ -119,7 +125,11 @@ func NewCacheManager(cfg ManagerConfig, connector Connector) (*CacheManager, err
 }
 
 // Get retrieves or creates a cache instance for the given key.
+// Returns ErrManagerClosed if Close() has been called.
 func (m *CacheManager) Get(ctx context.Context, key string) (Cache, error) {
+	if m.closed.Load() {
+		return nil, ErrManagerClosed
+	}
 	// Fast path: check if cache already exists
 	if cache := m.getExisting(key); cache != nil {
 		return cache, nil
@@ -214,7 +224,11 @@ func (m *CacheManager) evictIfNeeded() *cacheEntry {
 }
 
 // Remove explicitly removes a cache instance from the manager.
+// Returns ErrManagerClosed if Close() has been called.
 func (m *CacheManager) Remove(key string) error {
+	if m.closed.Load() {
+		return ErrManagerClosed
+	}
 	m.mu.Lock()
 	entry := m.removeEntryLocked(key)
 	m.mu.Unlock()
@@ -295,10 +309,19 @@ func (m *CacheManager) cleanupIdleCaches() {
 }
 
 // Close shuts down all managed cache instances and stops the cleanup goroutine.
+// After Close() returns, subsequent calls to Get() and Remove() return ErrManagerClosed.
 func (m *CacheManager) Close() error {
 	var closeErr error
 
 	m.closeOnce.Do(func() {
+		// Flip closed BEFORE doing any teardown work so concurrent Get/Remove
+		// callers immediately see ErrManagerClosed rather than racing against
+		// half-torn-down state (e.g. getting a cache instance that's already
+		// in the toClose slice below). atomic.Bool is the right primitive here:
+		// it's lock-free on the hot path of every Get, and the memory ordering
+		// guarantees that any subsequent Load reads the final true value.
+		m.closed.Store(true)
+
 		// Signal cleanup goroutine to stop
 		close(m.closeCh)
 

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -651,6 +651,86 @@ func TestCacheManagerClose(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestCacheManagerGetAfterCloseReturnsErrManagerClosed locks in the W3-C
+// closed-state guard. Pre-fix, Get() could race against Close() and return a
+// cache instance that was about to be torn down (still in m.caches but
+// queued in Close's toClose slice). Post-fix, Get() consults the atomic
+// `closed` flag at the very top and returns ErrManagerClosed immediately.
+func TestCacheManagerGetAfterCloseReturnsErrManagerClosed(t *testing.T) {
+	connector := func(_ context.Context, key string) (cache.Cache, error) {
+		return newMockCache(key), nil
+	}
+	mgr, err := cache.NewCacheManager(cache.DefaultManagerConfig(), connector)
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.Close())
+
+	_, err = mgr.Get(context.Background(), tenantOne)
+	assert.ErrorIs(t, err, cache.ErrManagerClosed)
+}
+
+// TestCacheManagerRemoveAfterCloseReturnsErrManagerClosed mirrors the Get
+// test for the Remove() operational path.
+func TestCacheManagerRemoveAfterCloseReturnsErrManagerClosed(t *testing.T) {
+	connector := func(_ context.Context, key string) (cache.Cache, error) {
+		return newMockCache(key), nil
+	}
+	mgr, err := cache.NewCacheManager(cache.DefaultManagerConfig(), connector)
+	require.NoError(t, err)
+
+	// Seed an entry first so we can prove the closed-state check fires BEFORE
+	// the lookup — without the guard, Remove would happily delete from a
+	// half-torn-down map.
+	_, err = mgr.Get(context.Background(), tenantOne)
+	require.NoError(t, err)
+
+	require.NoError(t, mgr.Close())
+
+	err = mgr.Remove(tenantOne)
+	assert.ErrorIs(t, err, cache.ErrManagerClosed)
+}
+
+// TestCacheManagerGetRacesCloseReturnsErrOrSuccess stress-tests the
+// closed-state guard under concurrent Close + Get. Each Get must either
+// succeed (closed wasn't yet observed) or return ErrManagerClosed — it
+// must NEVER return a different error or panic with a use-after-close.
+// Run under -race to catch any unsynchronized access to the manager's
+// internal maps during shutdown.
+func TestCacheManagerGetRacesCloseReturnsErrOrSuccess(t *testing.T) {
+	connector := func(_ context.Context, key string) (cache.Cache, error) {
+		return newMockCache(key), nil
+	}
+	mgr, err := cache.NewCacheManager(cache.DefaultManagerConfig(), connector)
+	require.NoError(t, err)
+
+	const N = 64
+	results := make(chan error, N)
+	start := make(chan struct{})
+
+	for i := 0; i < N; i++ {
+		go func(id int) {
+			<-start
+			_, err := mgr.Get(context.Background(), fmt.Sprintf("tenant-%d", id))
+			results <- err
+		}(i)
+	}
+
+	// Fire concurrent Close from another goroutine; let them race.
+	go func() {
+		<-start
+		_ = mgr.Close()
+	}()
+
+	close(start)
+
+	for i := 0; i < N; i++ {
+		err := <-results
+		if err != nil && !errors.Is(err, cache.ErrManagerClosed) {
+			t.Errorf("Get during Close returned unexpected error: %v (want nil or ErrManagerClosed)", err)
+		}
+	}
+}
+
 // TestCacheManagerStats tests statistics reporting.
 func TestCacheManagerStats(t *testing.T) {
 	connector := func(_ context.Context, key string) (cache.Cache, error) {


### PR DESCRIPTION
## Summary

Add a closed-state guard to `CacheManager` so concurrent `Get()` / `Remove()` calls during shutdown return `ErrManagerClosed` immediately instead of racing against the teardown sequence and potentially handing back a soon-to-be-invalid cache instance.

## The bug

`CacheManager.Close()` collects cache instances into a `toClose` slice under `m.mu`, releases the lock, then closes each one outside the lock. A scheduled job firing during graceful shutdown could:

1. Call `manager.Get(ctx, tenant)` — the entry is still in `m.caches`, so `getExisting` returns it
2. The returned cache instance is queued in Close's `toClose` slice
3. Close calls `cacheInstance.Close()` while the caller is mid-`Set` or mid-`CAS`

The Redis client has its own closed-state guard (returns `ErrClosed`), so the call doesn't panic — but the operation is wasted, the caller's error path runs unnecessarily, and structured logs show confusing per-operation `ErrClosed` errors instead of one clear `ErrManagerClosed`.

## The fix

`closed atomic.Bool` on the manager. `Close()` flips it to `true` at the very start of `closeOnce.Do` (before any teardown). `Get()` and `Remove()` consult it on entry and return `ErrManagerClosed` immediately.

`atomic.Bool` is lock-free on the hot path of every `Get` (avoiding a `mu.RLock` just to check shutdown state) and has memory ordering guarantees so any subsequent `Load` reads the final `true` value.

`Stats()` is left unchanged — read-only metadata; calling on a closed manager is harmless and returns the final state.

## Test plan

- [x] `TestCacheManagerGetAfterCloseReturnsErrManagerClosed` — close + Get → ErrManagerClosed
- [x] `TestCacheManagerRemoveAfterCloseReturnsErrManagerClosed` — close + Remove → ErrManagerClosed (with seeded entry to prove guard fires before lookup)
- [x] `TestCacheManagerGetRacesCloseReturnsErrOrSuccess` — 64 concurrent Gets racing concurrent Close; each must either succeed (closed not yet observed) or return ErrManagerClosed; never a different error or panic. Verified 15/15 passes under `-race`
- [x] `make check` — 43 packages clean with `-race`
- [x] gosec + govulncheck clean

## Wave 3 sequencing

- [x] W3-A — app shutdown honors config ([#457](https://github.com/gaborage/go-bricks/pull/457), merged)
- [x] W3-B — scheduler lifecycle hygiene ([#458](https://github.com/gaborage/go-bricks/pull/458), merged)
- [x] W3-D — messaging at-least-once trio ([#459](https://github.com/gaborage/go-bricks/pull/459), merged)
- [ ] **W3-C — cache manager closed-state guard (this PR)** — last Wave 3 item

After this lands, moving to Wave 4 (architectural cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)