### PR TITLE
refactor(database): embed wrapper.Connection for shared delegation methods

### DIFF
--- a/database/internal/wrapper/connection.go
+++ b/database/internal/wrapper/connection.go
@@ -1,0 +1,125 @@
+package wrapper
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/gaborage/go-bricks/config"
+	"github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/logger"
+)
+
+// healthCheckTimeout is the per-call timeout applied to Health()'s PingContext.
+// Matches the pre-W4-C hardcoded value in both vendor connections.
+const healthCheckTimeout = 5 * time.Second
+
+// Connection holds the byte-identical fields and delegation methods that
+// previously lived in both postgresql.Connection and oracle.Connection.
+// Vendor packages embed this struct (typically by pointer) and add only the
+// vendor-specific bits (DatabaseType / MigrationTable / CreateMigrationTable
+// DDL / dialer plumbing).
+//
+// Fields are exported so vendor packages can construct via struct literal in
+// their NewConnection, and so the metrics-registration callback can flip
+// MetricsCleanup after wiring it up. The Name field flows into Close()'s
+// "Closing X database connection" log message — the only previously
+// vendor-specific bit in those nine methods.
+type Connection struct {
+	DB             *sql.DB
+	Config         *config.DatabaseConfig
+	Logger         logger.Logger
+	MetricsCleanup func()
+	Name           string // vendor display name, e.g. "PostgreSQL", "Oracle"
+}
+
+// Query executes a query that returns rows.
+func (c *Connection) Query(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return c.DB.QueryContext(ctx, query, args...)
+}
+
+// QueryRow executes a query that returns at most one row.
+func (c *Connection) QueryRow(ctx context.Context, query string, args ...any) types.Row {
+	return types.NewRowFromSQL(c.DB.QueryRowContext(ctx, query, args...))
+}
+
+// Exec executes a query without returning any rows.
+func (c *Connection) Exec(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return c.DB.ExecContext(ctx, query, args...)
+}
+
+// Prepare creates a prepared statement for later queries or executions.
+func (c *Connection) Prepare(ctx context.Context, query string) (types.Statement, error) {
+	stmt, err := c.DB.PrepareContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return NewStatement(stmt), nil
+}
+
+// Begin starts a transaction with default options.
+func (c *Connection) Begin(ctx context.Context) (types.Tx, error) {
+	tx, err := c.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return NewTransaction(tx), nil
+}
+
+// BeginTx starts a transaction with the given options.
+func (c *Connection) BeginTx(ctx context.Context, opts *sql.TxOptions) (types.Tx, error) {
+	tx, err := c.DB.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return NewTransaction(tx), nil
+}
+
+// Health checks database connectivity with a 5s timeout. The caller's context
+// is honored if it has a shorter deadline.
+func (c *Connection) Health(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, healthCheckTimeout)
+	defer cancel()
+	return c.DB.PingContext(ctx)
+}
+
+// Stats returns database connection statistics in a map suitable for logging
+// or metrics tracking. When Config is non-nil, the configured idle-connection
+// target is included for visibility (Go's sql.DB doesn't enforce a minimum
+// idle count; this is purely a configured target).
+func (c *Connection) Stats() (map[string]any, error) {
+	stats := c.DB.Stats()
+	result := map[string]any{
+		"max_open_connections": stats.MaxOpenConnections,
+		"open_connections":     stats.OpenConnections,
+		"in_use":               stats.InUse,
+		"idle":                 stats.Idle,
+		"wait_count":           stats.WaitCount,
+		"wait_duration":        stats.WaitDuration.String(),
+		"max_idle_closed":      stats.MaxIdleClosed,
+		"max_idle_time_closed": stats.MaxIdleTimeClosed,
+		"max_lifetime_closed":  stats.MaxLifetimeClosed,
+	}
+
+	if c.Config != nil {
+		result["max_idle_connections"] = int(c.Config.Pool.Idle.Connections)
+		result["configured_idle_connections"] = int(c.Config.Pool.Idle.Connections)
+	}
+
+	return result, nil
+}
+
+// Close closes the underlying *sql.DB, unregisters the metrics callback (if
+// any), and logs the shutdown. The Name field is used to render the vendor
+// name into the log message.
+func (c *Connection) Close() error {
+	if c.Logger != nil {
+		c.Logger.Info().Msgf("Closing %s database connection", c.Name)
+	}
+
+	if c.MetricsCleanup != nil {
+		c.MetricsCleanup()
+	}
+
+	return c.DB.Close()
+}

--- a/database/oracle/connection.go
+++ b/database/oracle/connection.go
@@ -18,12 +18,17 @@ import (
 	"github.com/gaborage/go-bricks/logger"
 )
 
-// Connection implements the types.Interface for Oracle
+// vendorName is the human-readable vendor name used in log messages,
+// errors, and wrapper.Connection.Name.
+const vendorName = "Oracle"
+
+// Connection implements the types.Interface for Oracle. Embeds the
+// vendor-agnostic wrapper.Connection which carries the byte-identical
+// delegation methods (Query, Exec, Prepare, Begin, Health, Stats, Close, etc.)
+// — see database/internal/wrapper. Oracle-only methods (DatabaseType,
+// MigrationTable, CreateMigrationTable PL/SQL block) stay defined here.
 type Connection struct {
-	db             *sql.DB
-	config         *config.DatabaseConfig
-	logger         logger.Logger
-	metricsCleanup func() // Cleanup function for unregistering metrics callback
+	*wrapper.Connection
 }
 
 var (
@@ -118,13 +123,16 @@ func NewConnection(cfg *config.DatabaseConfig, log logger.Logger) (types.Interfa
 	logConnectionSuccess(log, cfg)
 
 	conn := &Connection{
-		db:     db,
-		config: cfg,
-		logger: log,
+		Connection: &wrapper.Connection{
+			DB:     db,
+			Config: cfg,
+			Logger: log,
+			Name:   vendorName,
+		},
 	}
 
 	namespace := tracking.BuildOracleNamespace(cfg.Oracle.Service.Name, cfg.Oracle.Service.SID, cfg.Database)
-	conn.metricsCleanup = tracking.RegisterConnectionPoolMetrics(conn, "oracle", cfg.Host, cfg.Port, namespace)
+	conn.MetricsCleanup = tracking.RegisterConnectionPoolMetrics(conn, "oracle", cfg.Host, cfg.Port, namespace)
 
 	return conn, nil
 }
@@ -295,93 +303,8 @@ func logConnectionSuccess(log logger.Logger, cfg *config.DatabaseConfig) {
 type Statement = wrapper.Statement
 type Transaction = wrapper.Transaction
 
-// Query executes a query that returns rows
-func (c *Connection) Query(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
-	return c.db.QueryContext(ctx, query, args...)
-}
-
-// QueryRow executes a query that returns at most one row
-func (c *Connection) QueryRow(ctx context.Context, query string, args ...any) types.Row {
-	return types.NewRowFromSQL(c.db.QueryRowContext(ctx, query, args...))
-}
-
-// Exec executes a query without returning any rows
-func (c *Connection) Exec(ctx context.Context, query string, args ...any) (sql.Result, error) {
-	return c.db.ExecContext(ctx, query, args...)
-}
-
-// Prepare creates a prepared statement for later queries or executions
-func (c *Connection) Prepare(ctx context.Context, query string) (types.Statement, error) {
-	stmt, err := c.db.PrepareContext(ctx, query)
-	if err != nil {
-		return nil, err
-	}
-	return wrapper.NewStatement(stmt), nil
-}
-
-// Begin starts a transaction
-func (c *Connection) Begin(ctx context.Context) (types.Tx, error) {
-	tx, err := c.db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	return wrapper.NewTransaction(tx), nil
-}
-
-// BeginTx starts a transaction with options
-func (c *Connection) BeginTx(ctx context.Context, opts *sql.TxOptions) (types.Tx, error) {
-	tx, err := c.db.BeginTx(ctx, opts)
-	if err != nil {
-		return nil, err
-	}
-	return wrapper.NewTransaction(tx), nil
-}
-
-// Health checks database connectivity
-func (c *Connection) Health(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	return c.db.PingContext(ctx)
-}
-
-// Stats returns database connection statistics
-func (c *Connection) Stats() (map[string]any, error) {
-	stats := c.db.Stats()
-	result := map[string]any{
-		"max_open_connections": stats.MaxOpenConnections,
-		"open_connections":     stats.OpenConnections,
-		"in_use":               stats.InUse,
-		"idle":                 stats.Idle,
-		"wait_count":           stats.WaitCount,
-		"wait_duration":        stats.WaitDuration.String(),
-		"max_idle_closed":      stats.MaxIdleClosed,
-		"max_idle_time_closed": stats.MaxIdleTimeClosed,
-		"max_lifetime_closed":  stats.MaxLifetimeClosed,
-	}
-
-	// Add configured idle connections if config is available
-	if c.config != nil {
-		result["max_idle_connections"] = int(c.config.Pool.Idle.Connections)
-		// configured_idle_connections represents the target maximum idle connections setting.
-		// Go's sql.DB does not enforce a minimum idle count; this is purely a configured target.
-		result["configured_idle_connections"] = int(c.config.Pool.Idle.Connections)
-	}
-
-	return result, nil
-}
-
-// Close closes the database connection
-func (c *Connection) Close() error {
-	c.logger.Info().Msg("Closing Oracle database connection")
-
-	// Unregister metrics callback to allow garbage collection
-	if c.metricsCleanup != nil {
-		c.metricsCleanup()
-	}
-
-	return c.db.Close()
-}
+// Query, QueryRow, Exec, Prepare, Begin, BeginTx, Health, Stats, Close are
+// inherited from the embedded *wrapper.Connection — see database/internal/wrapper.
 
 // DatabaseType returns the database type
 func (c *Connection) DatabaseType() string {
@@ -495,7 +418,7 @@ func (c *Connection) CreateMigrationTable(ctx context.Context) error {
 // Registration must occur before any queries or procedures use the type.
 // Best practice: register all UDTs during application initialization.
 func (c *Connection) RegisterType(typeName, arrayTypeName string, typeObj any) error {
-	logEvent := c.logger.Info().
+	logEvent := c.Logger.Info().
 		Str("type_name", typeName).
 		Str("array_type_name", arrayTypeName)
 
@@ -505,9 +428,9 @@ func (c *Connection) RegisterType(typeName, arrayTypeName string, typeObj any) e
 		logEvent.Msg("Registering Oracle UDT (object type only)")
 	}
 
-	err := go_ora.RegisterType(c.db, typeName, arrayTypeName, typeObj)
+	err := go_ora.RegisterType(c.DB, typeName, arrayTypeName, typeObj)
 	if err != nil {
-		c.logger.Error().
+		c.Logger.Error().
 			Err(err).
 			Str("type_name", typeName).
 			Str("array_type_name", arrayTypeName).
@@ -515,7 +438,7 @@ func (c *Connection) RegisterType(typeName, arrayTypeName string, typeObj any) e
 		return fmt.Errorf("failed to register Oracle type %s: %w", typeName, err)
 	}
 
-	c.logger.Debug().
+	c.Logger.Debug().
 		Str("type_name", typeName).
 		Str("array_type_name", arrayTypeName).
 		Msg("Successfully registered Oracle UDT")
@@ -545,7 +468,7 @@ func (c *Connection) RegisterType(typeName, arrayTypeName string, typeObj any) e
 //   - arrayTypeName: Oracle collection type name (use "" for single objects)
 //   - typeObj: Go struct instance with udt:"FIELD_NAME" tags
 func (c *Connection) RegisterTypeWithOwner(owner, typeName, arrayTypeName string, typeObj any) error {
-	logEvent := c.logger.Info().
+	logEvent := c.Logger.Info().
 		Str("owner", owner).
 		Str("type_name", typeName).
 		Str("array_type_name", arrayTypeName)
@@ -556,9 +479,9 @@ func (c *Connection) RegisterTypeWithOwner(owner, typeName, arrayTypeName string
 		logEvent.Msg("Registering Oracle UDT with owner (object type only)")
 	}
 
-	err := go_ora.RegisterTypeWithOwner(c.db, owner, typeName, arrayTypeName, typeObj)
+	err := go_ora.RegisterTypeWithOwner(c.DB, owner, typeName, arrayTypeName, typeObj)
 	if err != nil {
-		c.logger.Error().
+		c.Logger.Error().
 			Err(err).
 			Str("owner", owner).
 			Str("type_name", typeName).
@@ -567,7 +490,7 @@ func (c *Connection) RegisterTypeWithOwner(owner, typeName, arrayTypeName string
 		return fmt.Errorf("failed to register Oracle type %s.%s: %w", owner, typeName, err)
 	}
 
-	c.logger.Debug().
+	c.Logger.Debug().
 		Str("owner", owner).
 		Str("type_name", typeName).
 		Str("array_type_name", arrayTypeName).

--- a/database/oracle/connection_integration_test.go
+++ b/database/oracle/connection_integration_test.go
@@ -1050,7 +1050,7 @@ func TestConnectionWithKeepAliveZeroInterval(t *testing.T) {
 func queryOracleSessionTimezone(t *testing.T, ctx context.Context, conn *Connection) string {
 	t.Helper()
 	var tz string
-	row := conn.db.QueryRowContext(ctx, "SELECT SESSIONTIMEZONE FROM dual")
+	row := conn.DB.QueryRowContext(ctx, "SELECT SESSIONTIMEZONE FROM dual")
 	require.NoError(t, row.Scan(&tz))
 	return tz
 }
@@ -1165,7 +1165,7 @@ func TestConnectionSessionTimezoneAppliedToAllPoolMembers(t *testing.T) {
 	}()
 
 	for i := 0; i < concurrency; i++ {
-		c, err := conn.db.Conn(ctx)
+		c, err := conn.DB.Conn(ctx)
 		require.NoError(t, err, "should obtain pool connection #%d", i)
 		pinned = append(pinned, c)
 	}

--- a/database/oracle/connection_test.go
+++ b/database/oracle/connection_test.go
@@ -42,7 +42,7 @@ type ConnectionTestData struct {
 func setupMockConnection(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *Connection) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
-	c := &Connection{db: db, logger: dbtestlog.NewDisabledTestLogger()}
+	c := &Connection{Connection: &wrapper.Connection{DB: db, Logger: dbtestlog.NewDisabledTestLogger(), Name: "Oracle"}}
 	return db, mock, c
 }
 
@@ -1215,9 +1215,12 @@ func TestConnectionStatsWithNilConfig(t *testing.T) {
 
 	// Create connection with nil config
 	c := &Connection{
-		db:     db,
-		logger: dbtestlog.NewDisabledTestLogger(),
-		config: nil, // Explicitly nil config
+		Connection: &wrapper.Connection{
+			DB:     db,
+			Logger: dbtestlog.NewDisabledTestLogger(),
+			Config: nil, // Explicitly nil config
+			Name:   "Oracle",
+		},
 	}
 
 	stats, err := c.Stats()

--- a/database/postgresql/connection.go
+++ b/database/postgresql/connection.go
@@ -18,12 +18,17 @@ import (
 	"github.com/gaborage/go-bricks/logger"
 )
 
-// Connection implements the types.Interface for PostgreSQL
+// vendorName is the human-readable vendor name used in log messages,
+// errors, and wrapper.Connection.Name.
+const vendorName = "PostgreSQL"
+
+// Connection implements the types.Interface for PostgreSQL. Embeds the
+// vendor-agnostic wrapper.Connection which carries the byte-identical
+// delegation methods (Query, Exec, Prepare, Begin, Health, Stats, Close, etc.)
+// — see database/internal/wrapper. PostgreSQL-only methods (DatabaseType,
+// MigrationTable, CreateMigrationTable DDL) stay defined here.
 type Connection struct {
-	db             *sql.DB
-	config         *config.DatabaseConfig
-	logger         logger.Logger
-	metricsCleanup func() // Cleanup function for unregistering metrics callback
+	*wrapper.Connection
 }
 
 var (
@@ -179,15 +184,19 @@ func NewConnection(cfg *config.DatabaseConfig, log logger.Logger) (types.Interfa
 		Msg("Connected to PostgreSQL database")
 
 	conn := &Connection{
-		db:     db,
-		config: cfg,
-		logger: log,
+		Connection: &wrapper.Connection{
+			DB:     db,
+			Config: cfg,
+			Logger: log,
+			Name:   vendorName,
+		},
 	}
 
 	// Register connection pool metrics for observability with server metadata
-	// Store cleanup function to allow proper unregistration during Close()
+	// Store cleanup function on the embedded wrapper.Connection so its Close()
+	// can invoke it during shutdown.
 	namespace := tracking.BuildPostgreSQLNamespace(cfg.Database, cfg.PostgreSQL.Schema)
-	conn.metricsCleanup = tracking.RegisterConnectionPoolMetrics(conn, "postgresql", cfg.Host, cfg.Port, namespace)
+	conn.MetricsCleanup = tracking.RegisterConnectionPoolMetrics(conn, "postgresql", cfg.Host, cfg.Port, namespace)
 
 	return conn, nil
 }
@@ -195,94 +204,6 @@ func NewConnection(cfg *config.DatabaseConfig, log logger.Logger) (types.Interfa
 // PostgreSQL re-exports the vendor-agnostic wrappers; see database/internal/wrapper.
 type Statement = wrapper.Statement
 type Transaction = wrapper.Transaction
-
-// Query executes a query that returns rows
-func (c *Connection) Query(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
-	return c.db.QueryContext(ctx, query, args...)
-}
-
-// QueryRow executes a query that returns at most one row
-func (c *Connection) QueryRow(ctx context.Context, query string, args ...any) types.Row {
-	return types.NewRowFromSQL(c.db.QueryRowContext(ctx, query, args...))
-}
-
-// Exec executes a query without returning any rows
-func (c *Connection) Exec(ctx context.Context, query string, args ...any) (sql.Result, error) {
-	return c.db.ExecContext(ctx, query, args...)
-}
-
-// Prepare creates a prepared statement for later queries or executions
-func (c *Connection) Prepare(ctx context.Context, query string) (types.Statement, error) {
-	stmt, err := c.db.PrepareContext(ctx, query)
-	if err != nil {
-		return nil, err
-	}
-	return wrapper.NewStatement(stmt), nil
-}
-
-// Begin starts a transaction
-func (c *Connection) Begin(ctx context.Context) (types.Tx, error) {
-	tx, err := c.db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	return wrapper.NewTransaction(tx), nil
-}
-
-// BeginTx starts a transaction with options
-func (c *Connection) BeginTx(ctx context.Context, opts *sql.TxOptions) (types.Tx, error) {
-	tx, err := c.db.BeginTx(ctx, opts)
-	if err != nil {
-		return nil, err
-	}
-	return wrapper.NewTransaction(tx), nil
-}
-
-// Health checks database connectivity
-func (c *Connection) Health(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	return c.db.PingContext(ctx)
-}
-
-// Stats returns database connection statistics
-func (c *Connection) Stats() (map[string]any, error) {
-	stats := c.db.Stats()
-	result := map[string]any{
-		"max_open_connections": stats.MaxOpenConnections,
-		"open_connections":     stats.OpenConnections,
-		"in_use":               stats.InUse,
-		"idle":                 stats.Idle,
-		"wait_count":           stats.WaitCount,
-		"wait_duration":        stats.WaitDuration.String(),
-		"max_idle_closed":      stats.MaxIdleClosed,
-		"max_idle_time_closed": stats.MaxIdleTimeClosed,
-		"max_lifetime_closed":  stats.MaxLifetimeClosed,
-	}
-
-	// Add configured idle connections if config is available
-	if c.config != nil {
-		result["max_idle_connections"] = int(c.config.Pool.Idle.Connections)
-		// configured_idle_connections represents the target maximum idle connections setting.
-		// Go's sql.DB does not enforce a minimum idle count; this is purely a configured target.
-		result["configured_idle_connections"] = int(c.config.Pool.Idle.Connections)
-	}
-
-	return result, nil
-}
-
-// Close closes the database connection
-func (c *Connection) Close() error {
-	c.logger.Info().Msg("Closing PostgreSQL database connection")
-
-	// Unregister metrics callback to allow garbage collection
-	if c.metricsCleanup != nil {
-		c.metricsCleanup()
-	}
-
-	return c.db.Close()
-}
 
 // DatabaseType returns the database type
 func (c *Connection) DatabaseType() string {

--- a/database/postgresql/connection_integration_test.go
+++ b/database/postgresql/connection_integration_test.go
@@ -637,7 +637,7 @@ func TestConnectionWithTLSMode(t *testing.T) {
 func queryPostgresTimezone(t *testing.T, ctx context.Context, conn *Connection) string {
 	t.Helper()
 	var tz string
-	row := conn.db.QueryRowContext(ctx, "SELECT current_setting('timezone')")
+	row := conn.DB.QueryRowContext(ctx, "SELECT current_setting('timezone')")
 	require.NoError(t, row.Scan(&tz))
 	return tz
 }
@@ -766,7 +766,7 @@ func TestConnectionSessionTimezoneAppliedToAllPoolMembers(t *testing.T) {
 	}()
 
 	for i := 0; i < concurrency; i++ {
-		c, err := conn.db.Conn(ctx)
+		c, err := conn.DB.Conn(ctx)
 		require.NoError(t, err, "should obtain pool connection #%d", i)
 		pinned = append(pinned, c)
 	}

--- a/database/postgresql/connection_test.go
+++ b/database/postgresql/connection_test.go
@@ -33,7 +33,7 @@ const (
 func setupMockConnection(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *Connection) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
-	c := &Connection{db: db, logger: dbtestlog.NewDisabledTestLogger()}
+	c := &Connection{Connection: &wrapper.Connection{DB: db, Logger: dbtestlog.NewDisabledTestLogger(), Name: "PostgreSQL"}}
 	return db, mock, c
 }
 
@@ -934,9 +934,12 @@ func TestConnectionStatsWithNilConfig(t *testing.T) {
 
 	// Create connection with nil config
 	c := &Connection{
-		db:     db,
-		logger: dbtestlog.NewDisabledTestLogger(),
-		config: nil, // Explicitly nil config
+		Connection: &wrapper.Connection{
+			DB:     db,
+			Logger: dbtestlog.NewDisabledTestLogger(),
+			Config: nil, // Explicitly nil config
+			Name:   "PostgreSQL",
+		},
 	}
 
 	stats, err := c.Stats()
@@ -963,11 +966,14 @@ func TestConnectionCloseWithNilMetricsCleanup(t *testing.T) {
 
 	mock.ExpectClose()
 
-	// Create connection with nil metricsCleanup
+	// Create connection with nil MetricsCleanup
 	c := &Connection{
-		db:             db,
-		logger:         dbtestlog.NewDisabledTestLogger(),
-		metricsCleanup: nil, // Explicitly nil - no metrics registered
+		Connection: &wrapper.Connection{
+			DB:             db,
+			Logger:         dbtestlog.NewDisabledTestLogger(),
+			MetricsCleanup: nil, // Explicitly nil - no metrics registered
+			Name:           "PostgreSQL",
+		},
 	}
 
 	err = c.Close()

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -52,7 +52,7 @@ sonar.coverage.exclusions=**/cmd/**/main.go,**/testing/**
 # Issue suppression - string literal duplication in test data
 # Rationale: Test-specific data paths and mock values have no shared semantic meaning
 # Extracting them creates unnecessary abstraction (YAGNI principle)
-sonar.issue.ignore.multicriteria=e1,e2,e3
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4
 sonar.issue.ignore.multicriteria.e1.ruleKey=go:S1192
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*_test.go
 
@@ -84,3 +84,13 @@ sonar.issue.ignore.multicriteria.e2.ruleKey=godre:S8242
 sonar.issue.ignore.multicriteria.e2.resourceKey=**/scheduler/job.go
 sonar.issue.ignore.multicriteria.e3.ruleKey=godre:S8242
 sonar.issue.ignore.multicriteria.e3.resourceKey=**/scheduler/module.go
+
+# e4 — godre:S8168 ("Add 'defer tx.Rollback()' after checking the error from BeginTx")
+# on database/internal/wrapper/connection.go's Begin and BeginTx methods. These
+# are factory functions that intentionally return the *sql.Tx to the caller —
+# the caller owns the rollback responsibility. The rule fires identically on
+# the same pattern in the postgresql and oracle Connection types pre-W4-C
+# (where the issues were marked false-positive in the SonarCloud UI). After
+# W4-C centralized the methods into wrapper, the suppression needs to follow.
+sonar.issue.ignore.multicriteria.e4.ruleKey=godre:S8168
+sonar.issue.ignore.multicriteria.e4.resourceKey=**/database/internal/wrapper/connection.go


### PR DESCRIPTION
## Summary

Extends W4-B by extracting the **9 byte-identical Connection delegation methods** (Query, QueryRow, Exec, Prepare, Begin, BeginTx, Health, Stats, Close) from postgresql + oracle into a shared \`wrapper.Connection\` that both vendors embed by pointer.

## What was duplicated

Pre-fix, postgresql.Connection and oracle.Connection each defined the same 9 methods (~60 LOC per file) doing pure delegation to \`sql.DB\`, with only Close's log message and the metricsCleanup wiring being vendor-specific.

## How it's structured now

\`database/internal/wrapper/connection.go\` holds the shared struct + methods:

\`\`\`go
type Connection struct {
    DB             *sql.DB
    Config         *config.DatabaseConfig
    Logger         logger.Logger
    MetricsCleanup func()
    Name           string  // vendor name for log messages
}
\`\`\`

Vendor packages now embed by pointer:

\`\`\`go
type Connection struct { *wrapper.Connection }
\`\`\`

All 9 methods promoted automatically. Vendor-specific methods (DatabaseType, MigrationTable, CreateMigrationTable with its vendor DDL or PL/SQL block) stay defined on the outer Connection type.

## Diff stat

**-214 / +192 = net -22 LOC** in this PR, but the real win is the new wrapper.Connection is the single source of truth — behavior changes to the delegation methods now ship in one place instead of two.

## Test plan

- [x] \`make check\` — 43 packages clean with \`-race\`
- [x] \`go build -tags=integration ./database/postgresql/ ./database/oracle/\` clean
- [x] gosec clean, govulncheck clean
- [x] Test fixtures updated to construct via embedded \`*wrapper.Connection\` (about 4 sites per vendor)
- [x] Added \`const vendorName = \"PostgreSQL\"/\"Oracle\"\` per vendor to satisfy goconst (the new Name field literal pushed the per-vendor occurrence count over 3)

## Wave 4 sequencing

- [x] W4-A — delete validation/ ([#461](https://github.com/gaborage/go-bricks/pull/461), merged)
- [x] W4-B — database byte-identical extraction ([#462](https://github.com/gaborage/go-bricks/pull/462), merged)
- [x] **W4-C — database connection methods dedup (this PR)**
- [ ] W4-D — httpclient constants consolidation
- [ ] W4-E — messaging constants consolidation
- [ ] W4-F — scheduler constants consolidation
- [ ] W4-G — dead-API sweep
- [ ] W4-H — trace/ → OTEL replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated database connection behavior into a shared wrapper to centralize querying, transactions, health checks, pool statistics, and shutdown/metrics cleanup across vendors.
* **Tests**
  * Updated unit and integration tests to use the new shared connection shape and to access the underlying DB handle consistently.
* **Chores**
  * Added a static analysis suppression entry for the new wrapper to align linter reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->