### PR TITLE
refactor(messaging): consolidate magic numbers into constants.go

### DIFF
--- a/messaging/constants.go
+++ b/messaging/constants.go
@@ -1,0 +1,44 @@
+package messaging
+
+import "time"
+
+// Consumer concurrency + prefetch tuning. Previously inline literals in
+// helpers.go's worker auto-scaling logic.
+const (
+	// maxWorkersPerConsumer is the safeguard cap on a single consumer's
+	// concurrent worker pool. Set high enough that production workloads
+	// rarely hit it, low enough to prevent runaway resource use from a
+	// typo in DeclareConsumer.Workers.
+	maxWorkersPerConsumer = 200
+
+	// defaultPrefetchMultiplier is the auto-scale factor applied when
+	// PrefetchCount is unset: prefetch = workers * defaultPrefetchMultiplier
+	// (then capped at maxDefaultPrefetch below). 10 keeps the pipeline
+	// full without overloading any single consumer.
+	defaultPrefetchMultiplier = 10
+
+	// maxDefaultPrefetch caps the auto-scaled prefetch (workers *
+	// defaultPrefetchMultiplier) to avoid pulling more unacked messages
+	// from the broker than a worker pool can chew through.
+	maxDefaultPrefetch = 500
+
+	// maxPrefetchCount is the hard upper bound applied AFTER the operator's
+	// PrefetchCount value (whether explicit or auto-scaled), to prevent a
+	// misconfiguration from causing memory exhaustion on consumer hosts.
+	maxPrefetchCount = 1000
+)
+
+// Registry readiness polling. Previously inline literals in registry.go's
+// "wait for AMQP client ready" loop.
+const (
+	// readyTimeoutDuration is how long DeclareConsumers waits for the
+	// AMQP client to enter the isReady state before failing startup.
+	// Long enough to cover broker handshake + channel init; short enough
+	// that misconfigurations surface during deploy rather than hanging.
+	readyTimeoutDuration = 30 * time.Second
+
+	// readinessCheckInterval is the poll interval inside the readiness
+	// wait loop. Tight enough to react quickly to broker connect; loose
+	// enough not to spin the CPU.
+	readinessCheckInterval = 100 * time.Millisecond
+)

--- a/messaging/helpers.go
+++ b/messaging/helpers.go
@@ -186,19 +186,19 @@ func (d *Declarations) DeclareConsumer(opts *ConsumerOptions, queue *QueueDeclar
 		opts.Workers = runtime.NumCPU() * 4
 	}
 
-	// Resource safeguard: Cap workers at 200 per consumer
-	if opts.Workers > 200 {
-		opts.Workers = 200
+	// Resource safeguard: Cap workers per consumer
+	if opts.Workers > maxWorkersPerConsumer {
+		opts.Workers = maxWorkersPerConsumer
 	}
 
-	// PrefetchCount: Default to Workers * 10 for optimal pipeline, capped at 500
+	// PrefetchCount: Default to Workers * multiplier for optimal pipeline, capped at maxDefaultPrefetch
 	if opts.PrefetchCount == 0 {
-		opts.PrefetchCount = min(opts.Workers*10, 500)
+		opts.PrefetchCount = min(opts.Workers*defaultPrefetchMultiplier, maxDefaultPrefetch)
 	}
 
-	// Resource safeguard: Cap prefetch at 1000 to prevent memory exhaustion
-	if opts.PrefetchCount > 1000 {
-		opts.PrefetchCount = 1000
+	// Resource safeguard: Cap prefetch to prevent memory exhaustion
+	if opts.PrefetchCount > maxPrefetchCount {
+		opts.PrefetchCount = maxPrefetchCount
 	}
 
 	consumer := NewConsumer(opts)

--- a/messaging/registry.go
+++ b/messaging/registry.go
@@ -253,10 +253,10 @@ func (r *Registry) DeclareInfrastructure(ctx context.Context) error {
 	}
 
 	// Wait for AMQP client to be ready with timeout
-	timeout := time.NewTimer(30 * time.Second)
+	timeout := time.NewTimer(readyTimeoutDuration)
 	defer timeout.Stop()
 
-	ticker := time.NewTicker(100 * time.Millisecond)
+	ticker := time.NewTicker(readinessCheckInterval)
 	defer ticker.Stop()
 
 	for {


### PR DESCRIPTION
## Summary

W4-E — move scattered numeric literals in \`helpers.go\` (consumer auto-scaling) and \`registry.go\` (AMQP-ready polling) into a dedicated \`messaging/constants.go\`. Mirrors W4-D's httpclient pattern.

## Consolidated

**Consumer concurrency + prefetch (helpers.go):**

| Constant | Value | Previously | Purpose |
|---|---|---|---|
| \`maxWorkersPerConsumer\` | 200 | helpers.go:190-191 inline | Cap on concurrent worker pool |
| \`defaultPrefetchMultiplier\` | 10 | helpers.go:196 inline | workers * this = auto-scaled prefetch |
| \`maxDefaultPrefetch\` | 500 | helpers.go:196 inline | Cap on auto-scaled prefetch |
| \`maxPrefetchCount\` | 1000 | helpers.go:200-201 inline | Hard upper bound on PrefetchCount |

**Registry readiness polling (registry.go):**

| Constant | Value | Previously | Purpose |
|---|---|---|---|
| \`readyTimeoutDuration\` | 30s | registry.go:256 inline | Max wait for isReady state |
| \`readinessCheckInterval\` | 100ms | registry.go:259 inline | Poll interval |

## Test plan

- [x] \`make check\` — 43 packages clean with \`-race\`
- [x] gosec clean, govulncheck clean
- [x] Zero behavior changes — all literals preserved exactly

## Wave 4 sequencing

- [x] W4-A — delete validation/ ([#461](https://github.com/gaborage/go-bricks/pull/461), merged)
- [x] W4-B — database byte-identical ([#462](https://github.com/gaborage/go-bricks/pull/462), merged)
- [x] W4-C — database connection methods ([#463](https://github.com/gaborage/go-bricks/pull/463), merged)
- [x] W4-D — httpclient constants ([#464](https://github.com/gaborage/go-bricks/pull/464), merged)
- [x] **W4-E — messaging constants (this PR)**
- [ ] W4-F — scheduler constants
- [ ] W4-G — dead-API sweep
- [ ] W4-H — trace/ → OTEL replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Refactor**
- Messaging system consumer concurrency and prefetch behavior now utilize fully configurable parameters including per-consumer worker limits, prefetch multiplier defaults, and maximum prefetch capacity values.
- AMQP client readiness polling now uses adjustable timeout and check interval durations instead of previously hardcoded values.
- Consumer declaration and infrastructure initialization logic updated accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->