### PR TITLE
refactor(scheduler): consolidate magic numbers into constants.go

### DIFF
--- a/scheduler/constants.go
+++ b/scheduler/constants.go
@@ -1,0 +1,24 @@
+package scheduler
+
+import "time"
+
+// Lifecycle and observability defaults. Previously inline literals scattered
+// across module.go.
+const (
+	// defaultShutdownTimeout is the wall-clock budget for in-flight jobs to
+	// complete during graceful shutdown when cfg.Scheduler.Timeout.Shutdown
+	// is unset or non-positive. Per ASSUME-010 the framework assumes ~30s
+	// is "long enough for cleanup, short enough for orchestrators."
+	defaultShutdownTimeout = 30 * time.Second
+
+	// defaultSlowJobThreshold is the duration above which a job execution
+	// gets logged at WARN even on success — a visibility cue that the job
+	// is running close to its scheduled interval. Applies when
+	// cfg.Scheduler.Timeout.SlowJob is unset.
+	defaultSlowJobThreshold = 30 * time.Second
+)
+
+// Time parsing format used by helpers.ParseTime — HH:MM (24h). Matches Go's
+// reference-time pattern (Mon Jan 2 15:04:05 MST 2006); centralized so a
+// future addition (e.g. seconds support) lives next to its only caller.
+const timeOfDayFormat = "15:04"

--- a/scheduler/helpers.go
+++ b/scheduler/helpers.go
@@ -21,7 +21,7 @@ import (
 //
 // Panics on invalid input (wrong format, invalid hour/minute values).
 func ParseTime(timeStr string) time.Time {
-	t, err := time.Parse("15:04", timeStr)
+	t, err := time.Parse(timeOfDayFormat, timeStr)
 	if err != nil {
 		panic(fmt.Sprintf("scheduler: invalid time format '%s' - expected HH:MM (24-hour), error: %v", timeStr, err)) //nolint:S8148 // NOSONAR: Fail-fast on invalid time format (configuration error)
 	}

--- a/scheduler/module.go
+++ b/scheduler/module.go
@@ -188,8 +188,8 @@ func (m *Module) Shutdown() error {
 
 	m.logger.Info().Msg("Initiating graceful scheduler shutdown")
 
-	// Get shutdown timeout from config (default 30s per ASSUME-010)
-	timeout := 30 * time.Second
+	// Get shutdown timeout from config (default per ASSUME-010, see constants.go)
+	timeout := defaultShutdownTimeout
 	if m.config != nil && m.config.Scheduler.Timeout.Shutdown > 0 {
 		timeout = m.config.Scheduler.Timeout.Shutdown
 	}
@@ -750,7 +750,7 @@ func (m *Module) determineJobSeverity(duration time.Duration, err error) (logLev
 	}
 
 	// WARN: Slow job (succeeded but exceeded threshold)
-	threshold := 30 * time.Second // default
+	threshold := defaultSlowJobThreshold
 	if m.config != nil && m.config.Scheduler.Timeout.SlowJob > 0 {
 		threshold = m.config.Scheduler.Timeout.SlowJob
 	}


### PR DESCRIPTION
## Summary

W4-F — move scattered numeric literals in scheduler into a dedicated \`scheduler/constants.go\`. Completes the constants-consolidation trio started in W4-D (httpclient) and W4-E (messaging).

## Consolidated

| Constant | Value | Previously | Purpose |
|---|---|---|---|
| \`defaultShutdownTimeout\` | 30s | \`module.go:192\` inline | In-flight job budget during graceful shutdown (per ASSUME-010) |
| \`defaultSlowJobThreshold\` | 30s | \`module.go:753\` inline | Duration above which a job log flips to WARN even on success |
| \`timeOfDayFormat\` | \`\"15:04\"\` | \`helpers.go:24\` inline | HH:MM 24-hour format for \`ParseTime\` |

## Test plan

- [x] \`make check\` — 43 packages clean with \`-race\`
- [x] gosec clean, govulncheck clean
- [x] Zero behavior changes — all literals preserved exactly

## Wave 4 sequencing

- [x] W4-A — delete validation/ ([#461](https://github.com/gaborage/go-bricks/pull/461), merged)
- [x] W4-B — database byte-identical ([#462](https://github.com/gaborage/go-bricks/pull/462), merged)
- [x] W4-C — database connection methods ([#463](https://github.com/gaborage/go-bricks/pull/463), merged)
- [x] W4-D — httpclient constants ([#464](https://github.com/gaborage/go-bricks/pull/464), merged)
- [x] W4-E — messaging constants ([#465](https://github.com/gaborage/go-bricks/pull/465), merged)
- [x] **W4-F — scheduler constants (this PR)**
- [ ] W4-G — dead-API sweep
- [ ] W4-H — trace/ → OTEL replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized scheduler default constants (30-second shutdown timeout and slow-job threshold) into a dedicated configuration module, replacing previously hardcoded values while maintaining existing configuration overrides and time parsing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->