### PR TITLE
httpclient: add OpenTelemetry metrics for outbound HTTP calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ make lint                       # Run golangci-lint
 - **config/** — Configuration management (Koanf: YAML + env vars)
 - **database/** — Multi-database interface with query builder
 - **cache/** — Redis caching with type-safe CBOR serialization
-- **httpclient/** — HTTP client with retries, W3C trace propagation, and interceptors
+- **httpclient/** — HTTP client with retries, W3C trace propagation, and interceptors. OpenTelemetry metrics: see [wiki/httpclient.md#metrics](wiki/httpclient.md#metrics).
 - **logger/** — Structured logging (zerolog)
 - **messaging/** — AMQP client for RabbitMQ
 - **scheduler/** — gocron-based job scheduling with observability and CIDR-restricted APIs
@@ -309,6 +309,7 @@ client := httpclient.NewBuilder(logger).
     WithTimeout(10 * time.Second).
     WithRetries(3, 500 * time.Millisecond).
     WithW3CTrace(true).
+    WithPeerName("downstream-service").
     Build()
 
 resp, err := client.Get(ctx, &httpclient.Request{URL: "https://api.example.com/users"})

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	crand "crypto/rand"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"math/big"
 	"net"
 	nethttp "net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -19,6 +21,8 @@ import (
 
 	"github.com/gaborage/go-bricks/jose"
 	"github.com/gaborage/go-bricks/logger"
+
+	"github.com/gaborage/go-bricks/httpclient/internal/tracking"
 )
 
 const (
@@ -155,6 +159,16 @@ func (b *Builder) WithW3CTrace(enabled bool) *Builder {
 	return b
 }
 
+// WithPeerName sets a low-cardinality logical service name attached to every
+// metric emitted by this client. Intended for SLO attribution (e.g., "stripe",
+// "visa-vts"). When unset, only the high-cardinality server.address is recorded.
+func (b *Builder) WithPeerName(name string) *Builder {
+	if name != "" {
+		b.config.PeerName = name
+	}
+	return b
+}
+
 // WithHTTPClient allows providing a custom *http.Client instance.
 // If the provided client's Timeout is zero, the builder applies its configured Timeout; otherwise it is used as-is.
 // The client's Transport is preserved unless explicitly overridden via WithTransport.
@@ -264,6 +278,7 @@ func deepCopyConfig(src *Config) *Config {
 		MaxPayloadLogBytes: src.MaxPayloadLogBytes,
 		TraceIDHeader:      src.TraceIDHeader,
 		EnableW3CTrace:     src.EnableW3CTrace,
+		PeerName:           src.PeerName,
 	}
 
 	// Copy BasicAuth
@@ -327,18 +342,23 @@ func (c *client) Delete(ctx context.Context, req *Request) (*Response, error) {
 }
 
 type attemptResult struct {
-	response *Response
-	err      error
-	retry    bool
+	response    *Response
+	err         error
+	retry       bool
+	retryReason string
 }
 
 // responseProcessingContext groups the metadata needed when handling an HTTP response.
 type responseProcessingContext struct {
-	attempt    int
-	maxRetries int
-	start      time.Time
-	callCount  int64
-	traceID    string
+	attempt      int
+	maxRetries   int
+	start        time.Time
+	callCount    int64
+	traceID      string
+	attemptStart time.Time
+	method       string
+	requestBytes int
+	httpReqURL   *url.URL
 }
 
 // Do performs an HTTP request with the specified method
@@ -351,9 +371,21 @@ func (c *client) Do(ctx context.Context, method string, req *Request) (*Response
 	callCount := atomic.AddInt64(&c.callCount, 1)
 	maxRetries := c.config.MaxRetries
 
+	// Pre-extract host once for active_requests attribute. URL parse failures
+	// surface in buildRequest, not here — leave addr empty if parse fails so
+	// the attribute is omitted rather than crashing the gauge.
+	addr := ""
+	if parsed, err := url.Parse(req.URL); err == nil {
+		addr = parsed.Hostname()
+	}
+
+	tracking.IncActiveRequests(ctx, c.config.PeerName, method, addr)
+	defer tracking.DecActiveRequests(ctx, c.config.PeerName, method, addr)
+
 	for attempt := 0; ; attempt++ {
 		result := c.executeAttempt(ctx, method, req, attempt, maxRetries, start, callCount)
 		if result.retry {
+			tracking.IncRetry(ctx, c.config.PeerName, method, result.retryReason)
 			continue
 		}
 		return result.response, result.err
@@ -370,6 +402,7 @@ func (c *client) executeAttempt(
 ) attemptResult {
 	httpReq, err := c.buildRequest(ctx, method, req)
 	if err != nil {
+		// Pre-roundtrip build failure: do NOT record a metric observation.
 		return attemptResult{err: err}
 	}
 
@@ -378,20 +411,37 @@ func (c *client) executeAttempt(
 
 	c.logRequest(httpReq, req.Body, traceIDForLog)
 
+	attemptStart := time.Now()
 	httpResp, err := c.httpClient.Do(httpReq)
 	if err != nil {
 		if httpResp != nil && httpResp.Body != nil {
 			httpResp.Body.Close()
 		}
+		// Transport error: record metric with status 0 and classified error type.
+		m := tracking.HTTPClientMeasurement{
+			PeerName:     c.config.PeerName,
+			Method:       method,
+			URL:          httpReq.URL,
+			StatusCode:   0,
+			ErrorType:    classifyError(err),
+			ResendCount:  attempt,
+			Elapsed:      time.Since(attemptStart),
+			RequestBytes: len(req.Body),
+		}
+		tracking.RecordHTTPClientMetrics(ctx, &m)
 		return c.handleExecutionError(ctx, err, attempt, maxRetries)
 	}
 
-	respCtx := responseProcessingContext{
-		attempt:    attempt,
-		maxRetries: maxRetries,
-		start:      start,
-		callCount:  callCount,
-		traceID:    traceIDForLog,
+	respCtx := &responseProcessingContext{
+		attempt:      attempt,
+		maxRetries:   maxRetries,
+		start:        start,
+		callCount:    callCount,
+		traceID:      traceIDForLog,
+		attemptStart: attemptStart,
+		method:       method,
+		requestBytes: len(req.Body),
+		httpReqURL:   httpReq.URL,
 	}
 	return c.processHTTPResponse(ctx, httpReq, httpResp, respCtx)
 }
@@ -402,7 +452,11 @@ func (c *client) handleExecutionError(ctx context.Context, err error, attempt, m
 		return attemptResult{err: handledErr}
 	}
 	if retry {
-		return attemptResult{retry: true}
+		reason := retryReasonNetwork
+		if c.isTimeout(err) {
+			reason = retryReasonTimeout
+		}
+		return attemptResult{retry: true, retryReason: reason}
 	}
 	return attemptResult{err: NewNetworkError("request execution failed", err)}
 }
@@ -411,12 +465,25 @@ func (c *client) processHTTPResponse(
 	ctx context.Context,
 	httpReq *nethttp.Request,
 	httpResp *nethttp.Response,
-	respCtx responseProcessingContext,
+	respCtx *responseProcessingContext,
 ) attemptResult {
 	resp, err := c.buildResponse(ctx, respCtx.start, respCtx.callCount, httpReq, httpResp)
 	if err != nil {
 		return c.handleResponseBuildError(ctx, err, respCtx.attempt, respCtx.maxRetries)
 	}
+	// Record per-attempt metric for successful roundtrip (including HTTP error status codes).
+	m := tracking.HTTPClientMeasurement{
+		PeerName:      c.config.PeerName,
+		Method:        respCtx.method,
+		URL:           respCtx.httpReqURL,
+		StatusCode:    resp.StatusCode,
+		ErrorType:     classifyError(nil),
+		ResendCount:   respCtx.attempt,
+		Elapsed:       time.Since(respCtx.attemptStart),
+		RequestBytes:  respCtx.requestBytes,
+		ResponseBytes: len(resp.Body),
+	}
+	tracking.RecordHTTPClientMetrics(ctx, &m)
 	return c.finalizeResponse(ctx, resp, respCtx.attempt, respCtx.maxRetries, respCtx.traceID)
 }
 
@@ -426,7 +493,7 @@ func (c *client) handleResponseBuildError(ctx context.Context, err error, attemp
 		return attemptResult{err: handledErr}
 	}
 	if retry {
-		return attemptResult{retry: true}
+		return attemptResult{retry: true, retryReason: retryReasonBuildResponse}
 	}
 	return attemptResult{err: err}
 }
@@ -442,7 +509,7 @@ func (c *client) finalizeResponse(ctx context.Context, resp *Response, attempt, 
 		return attemptResult{response: resp, err: err}
 	}
 	if retry {
-		return attemptResult{retry: true}
+		return attemptResult{retry: true, retryReason: retryReason5xx}
 	}
 
 	c.logResponse(resp, traceID)
@@ -726,6 +793,55 @@ func (c *client) isTimeout(err error) bool {
 
 func (c *client) isRetryableStatus(code int) bool {
 	return code >= httpStatusServerErrorMin && code < httpStatusServerErrorMax
+}
+
+// classifyError maps a typed/wrapped error to the OTel error.type enum value.
+// Returns "" when err is nil (including for HTTP error status codes — those carry
+// the signal via http.response.status_code, not error.type, per OTel guidance).
+func classifyError(err error) string {
+	if err == nil {
+		return ""
+	}
+	// Timeout: framework timeout type, context deadline, or net.Error.Timeout().
+	if IsErrorType(err, TimeoutError) || errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return "timeout"
+	}
+	// Context canceled.
+	if errors.Is(err, context.Canceled) {
+		return "context_canceled"
+	}
+	// DNS resolution failure.
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return "name_resolution_error"
+	}
+	// TLS errors.
+	var tlsRecordErr *tls.RecordHeaderError
+	if errors.As(err, &tlsRecordErr) {
+		return "tls_error"
+	}
+	var tlsCertErr *tls.CertificateVerificationError
+	if errors.As(err, &tlsCertErr) {
+		return "tls_error"
+	}
+	// Dial connection failure.
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr.Op == "dial" {
+		return "connection_error"
+	}
+	// Interceptor failure.
+	if IsErrorType(err, InterceptorError) {
+		return "interceptor_failed"
+	}
+	// Any other wrapped network error.
+	if IsErrorType(err, NetworkError) {
+		return "_OTHER"
+	}
+	return "_OTHER"
 }
 
 // runRequestInterceptors executes all request interceptors

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -452,8 +452,14 @@ func (c *client) handleExecutionError(ctx context.Context, err error, attempt, m
 		return attemptResult{err: handledErr}
 	}
 	if retry {
+		// Derive retry.reason from classifyError so it agrees with the
+		// error.type attribute recorded on the duration histogram. Using a
+		// separate isTimeout call here previously caused divergence: a dial
+		// timeout was labelled error.type="connection_error" but
+		// retry.reason="timeout" because isTimeout matches net.Error.Timeout().
+		errType := classifyError(err)
 		reason := retryReasonNetwork
-		if c.isTimeout(err) {
+		if errType == errorTypeTimeout || errType == errorTypeContextCanceled {
 			reason = retryReasonTimeout
 		}
 		return attemptResult{retry: true, retryReason: reason}
@@ -814,6 +820,24 @@ func (c *client) isRetryableStatus(code int) bool {
 // classifyError maps a typed/wrapped error to the OTel error.type enum value.
 // Returns "" when err is nil (including for HTTP error status codes — those carry
 // the signal via http.response.status_code, not error.type, per OTel guidance).
+//
+// Check ordering rationale:
+//  1. nil → ""
+//  2. context.Canceled → "context_canceled"
+//  3. Framework TimeoutError / context.DeadlineExceeded → "timeout"
+//  4. InterceptorError — checked BEFORE all errors.As chains because
+//     interceptorError.Unwrap() exposes its cause; without this guard,
+//     errors.As would traverse the chain and match the wrapped net type
+//     (e.g. *net.DNSError inside an interceptor failure would be
+//     mis-labelled "name_resolution_error" instead of "interceptor_failed").
+//  5. *net.DNSError — must precede the generic net.Error.Timeout() check
+//     because *net.DNSError implements net.Error and Timeout() can return
+//     true for timed-out lookups; matching it here keeps the label specific.
+//  6. TLS errors.
+//  7. Dial OpError — must precede the generic net.Error.Timeout() check so
+//     a dial that times out is labelled "connection_error", not "timeout".
+//  8. Generic net.Error.Timeout() — read-deadline exceeded and similar.
+//  9. Catch-all → "_OTHER".
 func classifyError(err error) string {
 	if err == nil {
 		return ""
@@ -825,6 +849,12 @@ func classifyError(err error) string {
 	// Framework-typed timeout or context deadline exceeded.
 	if IsErrorType(err, TimeoutError) || errors.Is(err, context.DeadlineExceeded) {
 		return errorTypeTimeout
+	}
+	// Interceptor failure — must precede all errors.As network-type checks so
+	// that an interceptor wrapping a *net.DNSError/*net.OpError/tls error is
+	// labelled "interceptor_failed", not the wrapped cause's type.
+	if IsErrorType(err, InterceptorError) {
+		return errorTypeInterceptorFailed
 	}
 	// DNS resolution failure — must precede the generic net.Error.Timeout() check
 	// because *net.DNSError implements net.Error and Timeout() can return true for
@@ -845,7 +875,7 @@ func classifyError(err error) string {
 	// Dial connection failure — must precede the generic net.Error.Timeout() check
 	// so a dial that times out is labelled "connection_error", not "timeout".
 	var opErr *net.OpError
-	if errors.As(err, &opErr) && opErr.Op == "dial" {
+	if errors.As(err, &opErr) && opErr.Op == netOpDial {
 		return errorTypeConnection
 	}
 	// Generic net-layer timeout (e.g. read deadline exceeded) that did not match
@@ -853,10 +883,6 @@ func classifyError(err error) string {
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {
 		return errorTypeTimeout
-	}
-	// Interceptor failure.
-	if IsErrorType(err, InterceptorError) {
-		return errorTypeInterceptorFailed
 	}
 	// Any other wrapped network error or unknown error.
 	return errorTypeOther

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -818,46 +818,48 @@ func classifyError(err error) string {
 	if err == nil {
 		return ""
 	}
-	// Timeout: framework timeout type, context deadline, or net.Error.Timeout().
-	if IsErrorType(err, TimeoutError) || errors.Is(err, context.DeadlineExceeded) {
-		return "timeout"
-	}
-	var netErr net.Error
-	if errors.As(err, &netErr) && netErr.Timeout() {
-		return "timeout"
-	}
-	// Context canceled.
+	// Context canceled (check before deadline so Canceled isn't shadowed).
 	if errors.Is(err, context.Canceled) {
-		return "context_canceled"
+		return errorTypeContextCanceled
 	}
-	// DNS resolution failure.
+	// Framework-typed timeout or context deadline exceeded.
+	if IsErrorType(err, TimeoutError) || errors.Is(err, context.DeadlineExceeded) {
+		return errorTypeTimeout
+	}
+	// DNS resolution failure — must precede the generic net.Error.Timeout() check
+	// because *net.DNSError implements net.Error and Timeout() can return true for
+	// timed-out lookups; matching it here keeps the label specific.
 	var dnsErr *net.DNSError
 	if errors.As(err, &dnsErr) {
-		return "name_resolution_error"
+		return errorTypeNameResolution
 	}
 	// TLS errors.
 	var tlsRecordErr *tls.RecordHeaderError
 	if errors.As(err, &tlsRecordErr) {
-		return "tls_error"
+		return errorTypeTLS
 	}
 	var tlsCertErr *tls.CertificateVerificationError
 	if errors.As(err, &tlsCertErr) {
-		return "tls_error"
+		return errorTypeTLS
 	}
-	// Dial connection failure.
+	// Dial connection failure — must precede the generic net.Error.Timeout() check
+	// so a dial that times out is labelled "connection_error", not "timeout".
 	var opErr *net.OpError
 	if errors.As(err, &opErr) && opErr.Op == "dial" {
-		return "connection_error"
+		return errorTypeConnection
+	}
+	// Generic net-layer timeout (e.g. read deadline exceeded) that did not match
+	// any of the more specific types above.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return errorTypeTimeout
 	}
 	// Interceptor failure.
 	if IsErrorType(err, InterceptorError) {
-		return "interceptor_failed"
+		return errorTypeInterceptorFailed
 	}
-	// Any other wrapped network error.
-	if IsErrorType(err, NetworkError) {
-		return "_OTHER"
-	}
-	return "_OTHER"
+	// Any other wrapped network error or unknown error.
+	return errorTypeOther
 }
 
 // runRequestInterceptors executes all request interceptors

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -469,6 +469,22 @@ func (c *client) processHTTPResponse(
 ) attemptResult {
 	resp, err := c.buildResponse(ctx, respCtx.start, respCtx.callCount, httpReq, httpResp)
 	if err != nil {
+		// The wire was hit and the server returned a status code, but the response
+		// could not be successfully assembled (interceptor error or body-read failure).
+		// Per the "exactly once per attempt that reaches the wire" rule, record the
+		// histogram observation here before delegating to the error handler.
+		m := tracking.HTTPClientMeasurement{
+			PeerName:      c.config.PeerName,
+			Method:        respCtx.method,
+			URL:           respCtx.httpReqURL,
+			StatusCode:    httpResp.StatusCode,
+			ErrorType:     classifyError(err),
+			ResendCount:   respCtx.attempt,
+			Elapsed:       time.Since(respCtx.attemptStart),
+			RequestBytes:  respCtx.requestBytes,
+			ResponseBytes: 0,
+		}
+		tracking.RecordHTTPClientMetrics(ctx, &m)
 		return c.handleResponseBuildError(ctx, err, respCtx.attempt, respCtx.maxRetries)
 	}
 	// Record per-attempt metric for successful roundtrip (including HTTP error status codes).

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -976,11 +976,14 @@ func TestTraceIDUtilities(t *testing.T) {
 // provider for metric collection and a cleanup function that must be deferred.
 func setupClientTestMeterProvider(t *testing.T) (mp *obtest.TestMeterProvider, cleanup func()) {
 	t.Helper()
+	prev := otel.GetMeterProvider()
 	mp = obtest.NewTestMeterProvider()
 	otel.SetMeterProvider(mp)
 	tracking.ResetMeterForTesting()
 	tracking.InitHTTPMeter()
 	return mp, func() {
+		otel.SetMeterProvider(prev)
+		tracking.ResetMeterForTesting()
 		require.NoError(t, mp.Shutdown(context.Background()))
 	}
 }
@@ -1055,13 +1058,12 @@ func TestHTTPClientMetricsSuccessPath(t *testing.T) {
 	activeMetric := obtest.FindMetric(rm, "http.client.active_requests")
 	require.NotNil(t, activeMetric, "http.client.active_requests must be emitted")
 	sumData, ok := activeMetric.Data.(metricdata.Sum[int64])
-	if ok {
-		var netTotal int64
-		for _, dp := range sumData.DataPoints {
-			netTotal += dp.Value
-		}
-		assert.Equal(t, int64(0), netTotal, "net active requests must be 0 after the call completes")
+	require.True(t, ok, "http.client.active_requests data must be Sum[int64]")
+	var netTotal int64
+	for _, dp := range sumData.DataPoints {
+		netTotal += dp.Value
 	}
+	assert.Equal(t, int64(0), netTotal, "net active requests must be 0 after the call completes")
 }
 
 // TestHTTPClientMetricsRetryOn503 verifies that when the server returns 503 then 200
@@ -1228,13 +1230,12 @@ func TestHTTPClientMetricsBuildResponseFailureRecorded(t *testing.T) {
 	activeMetric := obtest.FindMetric(rm, "http.client.active_requests")
 	require.NotNil(t, activeMetric, "http.client.active_requests must be emitted")
 	sumData, ok := activeMetric.Data.(metricdata.Sum[int64])
-	if ok {
-		var netTotal int64
-		for _, dp := range sumData.DataPoints {
-			netTotal += dp.Value
-		}
-		assert.Equal(t, int64(0), netTotal, "net active requests must be 0 after the call completes")
+	require.True(t, ok, "http.client.active_requests data must be Sum[int64]")
+	var netTotal int64
+	for _, dp := range sumData.DataPoints {
+		netTotal += dp.Value
 	}
+	assert.Equal(t, int64(0), netTotal, "net active requests must be 0 after the call completes")
 }
 
 // TestBackoffDelayFallbacks covers the three defensive fallback branches in

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -1340,7 +1340,7 @@ func TestClassifyError(t *testing.T) {
 		},
 		{
 			name:     "tcp_dial_failure",
-			err:      &net.OpError{Op: "dial", Err: errors.New("connection refused")},
+			err:      &net.OpError{Op: netOpDial, Err: errors.New("connection refused")},
 			expected: errorTypeConnection,
 		},
 		{
@@ -1353,6 +1353,22 @@ func TestClassifyError(t *testing.T) {
 		{
 			name:     "interceptor_failure",
 			err:      NewInterceptorError("interceptor failed", "request", errors.New("upstream")),
+			expected: errorTypeInterceptorFailed,
+		},
+		{
+			// Regression: an interceptor wrapping a *net.DNSError must be
+			// "interceptor_failed", not "name_resolution_error". Without the
+			// InterceptorError guard before the errors.As chains, errors.As
+			// would traverse Unwrap() and match the wrapped *net.DNSError.
+			name:     "interceptor_wrapping_dns_error",
+			err:      NewInterceptorError("validate", "response", &net.DNSError{Err: "no such host", IsNotFound: true}),
+			expected: errorTypeInterceptorFailed,
+		},
+		{
+			// Regression: an interceptor wrapping a *net.OpError (dial) must be
+			// "interceptor_failed", not "connection_error".
+			name:     "interceptor_wrapping_dial_error",
+			err:      NewInterceptorError("validate", "response", &net.OpError{Op: netOpDial, Err: errors.New("connection refused")}),
 			expected: errorTypeInterceptorFailed,
 		},
 		{
@@ -1371,6 +1387,66 @@ func TestClassifyError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := classifyError(tc.err)
 			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+// TestClassifyErrorRetryReasonCoherence verifies that the retry.reason derived
+// from classifyError agrees with the error.type label — i.e., errors that are
+// NOT classified as timeout or context_canceled must produce retryReasonNetwork,
+// not retryReasonTimeout. This is the regression guard for Bug 2: a dial timeout
+// previously produced error.type="connection_error" but retry.reason="timeout"
+// because handleExecutionError called isTimeout separately from classifyError.
+func TestClassifyErrorRetryReasonCoherence(t *testing.T) {
+	tests := []struct {
+		name            string
+		err             error
+		wantErrType     string
+		wantRetryReason string
+	}{
+		{
+			name:            "dial_timeout_connection_not_timeout",
+			err:             &net.OpError{Op: netOpDial, Err: errors.New("connection refused")},
+			wantErrType:     errorTypeConnection,
+			wantRetryReason: retryReasonNetwork,
+		},
+		{
+			name:            "dns_timeout_name_resolution_not_timeout",
+			err:             &net.DNSError{Err: "i/o timeout", IsTimeout: true},
+			wantErrType:     errorTypeNameResolution,
+			wantRetryReason: retryReasonNetwork,
+		},
+		{
+			name:            "context_deadline_exceeded_is_timeout",
+			err:             context.DeadlineExceeded,
+			wantErrType:     errorTypeTimeout,
+			wantRetryReason: retryReasonTimeout,
+		},
+		{
+			name:            "framework_timeout_is_timeout",
+			err:             NewTimeoutError("request timed out", 5*time.Second),
+			wantErrType:     errorTypeTimeout,
+			wantRetryReason: retryReasonTimeout,
+		},
+		{
+			name:            "interceptor_wrapping_dns_is_network",
+			err:             NewInterceptorError("validate", "response", &net.DNSError{Err: "no such host", IsNotFound: true}),
+			wantErrType:     errorTypeInterceptorFailed,
+			wantRetryReason: retryReasonNetwork,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errType := classifyError(tc.err)
+			assert.Equal(t, tc.wantErrType, errType, "classifyError mismatch")
+
+			// Mirror the retry-reason logic from handleExecutionError.
+			reason := retryReasonNetwork
+			if errType == errorTypeTimeout || errType == errorTypeContextCanceled {
+				reason = retryReasonTimeout
+			}
+			assert.Equal(t, tc.wantRetryReason, reason, "retry.reason mismatch for error.type=%q", errType)
 		})
 	}
 }

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -1169,6 +1169,74 @@ func TestHTTPClientMetricsTimeoutClassification(t *testing.T) {
 	assert.True(t, foundTimeout, "at least one datapoint must have error.type='timeout'")
 }
 
+// TestHTTPClientMetricsBuildResponseFailureRecorded verifies that when a response
+// interceptor returns an error — a post-roundtrip failure where the wire was hit and
+// the server returned a status — the duration histogram still records exactly one
+// observation. The datapoint must carry the wire status code (200) and
+// error.type="interceptor_failed", and active_requests must be net 0 after the call.
+func TestHTTPClientMetricsBuildResponseFailureRecorded(t *testing.T) {
+	mp, cleanup := setupClientTestMeterProvider(t)
+	defer cleanup()
+
+	server := newIPv4TestServer(t, nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.WriteHeader(nethttp.StatusOK)
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("server write failed: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	respInterceptor := func(_ context.Context, _ *nethttp.Request, _ *nethttp.Response) error {
+		return fmt.Errorf("interceptor boom")
+	}
+
+	log := createTestLogger()
+	c := NewBuilder(log).
+		WithPeerName("interceptor-fail-peer").
+		WithResponseInterceptor(respInterceptor).
+		Build()
+
+	_, err := c.Get(context.Background(), &Request{URL: server.URL})
+	require.Error(t, err)
+	assert.True(t, IsErrorType(err, InterceptorError))
+
+	rm := mp.Collect(t)
+
+	// Duration histogram must have exactly 1 datapoint — the build-response failure.
+	durationMetric := obtest.FindMetric(rm, "http.client.request.duration")
+	require.NotNil(t, durationMetric, "http.client.request.duration must be emitted on buildResponse failure")
+	histData, ok := durationMetric.Data.(metricdata.Histogram[float64])
+	require.True(t, ok, "expected Histogram[float64]")
+
+	var totalCount uint64
+	for _, dp := range histData.DataPoints {
+		totalCount += dp.Count
+	}
+	assert.Equal(t, uint64(1), totalCount, "expected 1 histogram observation for the build-response failure attempt")
+
+	// The datapoint must carry the wire status code (200) and error.type="interceptor_failed".
+	require.NotEmpty(t, histData.DataPoints)
+	dp0 := histData.DataPoints[0]
+	attrs := dp0.Attributes.ToSlice()
+	assert.True(t, hasAttrKey(attrs, "http.response.status_code"),
+		"http.response.status_code must be present — server returned 200 before interceptor failed")
+	assert.True(t, hasStringAttr(attrs, "error.type", "interceptor_failed"),
+		"error.type must be 'interceptor_failed' for response interceptor errors")
+
+	// Active requests must be net 0 after the call returns.
+	activeMetric := obtest.FindMetric(rm, "http.client.active_requests")
+	if activeMetric != nil {
+		sumData, ok := activeMetric.Data.(metricdata.Sum[int64])
+		if ok {
+			var netTotal int64
+			for _, dp := range sumData.DataPoints {
+				netTotal += dp.Value
+			}
+			assert.Equal(t, int64(0), netTotal, "net active requests must be 0 after the call completes")
+		}
+	}
+}
+
 // TestBackoffDelayFallbacks covers the three defensive fallback branches in
 // backoffDelay that the existing retry-path tests don't reach: zero RetryDelay
 // (uses defaultBackoffBase), attempt exceeding maxBackoffAttempt (clamped),

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -2,6 +2,8 @@ package httpclient
 
 import (
 	"context"
+	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	nethttp "net/http"
@@ -1051,15 +1053,14 @@ func TestHTTPClientMetricsSuccessPath(t *testing.T) {
 
 	// Active requests must be net 0 after the call returns (defer fired before we reach here).
 	activeMetric := obtest.FindMetric(rm, "http.client.active_requests")
-	if activeMetric != nil {
-		sumData, ok := activeMetric.Data.(metricdata.Sum[int64])
-		if ok {
-			var netTotal int64
-			for _, dp := range sumData.DataPoints {
-				netTotal += dp.Value
-			}
-			assert.Equal(t, int64(0), netTotal, "net active requests must be 0 after the call completes")
+	require.NotNil(t, activeMetric, "http.client.active_requests must be emitted")
+	sumData, ok := activeMetric.Data.(metricdata.Sum[int64])
+	if ok {
+		var netTotal int64
+		for _, dp := range sumData.DataPoints {
+			netTotal += dp.Value
 		}
+		assert.Equal(t, int64(0), netTotal, "net active requests must be 0 after the call completes")
 	}
 }
 
@@ -1225,15 +1226,14 @@ func TestHTTPClientMetricsBuildResponseFailureRecorded(t *testing.T) {
 
 	// Active requests must be net 0 after the call returns.
 	activeMetric := obtest.FindMetric(rm, "http.client.active_requests")
-	if activeMetric != nil {
-		sumData, ok := activeMetric.Data.(metricdata.Sum[int64])
-		if ok {
-			var netTotal int64
-			for _, dp := range sumData.DataPoints {
-				netTotal += dp.Value
-			}
-			assert.Equal(t, int64(0), netTotal, "net active requests must be 0 after the call completes")
+	require.NotNil(t, activeMetric, "http.client.active_requests must be emitted")
+	sumData, ok := activeMetric.Data.(metricdata.Sum[int64])
+	if ok {
+		var netTotal int64
+		for _, dp := range sumData.DataPoints {
+			netTotal += dp.Value
 		}
+		assert.Equal(t, int64(0), netTotal, "net active requests must be 0 after the call completes")
 	}
 }
 
@@ -1275,4 +1275,102 @@ func TestBackoffDelayFallbacks(t *testing.T) {
 				maxBackoffDuration, got)
 		}
 	})
+}
+
+// netTimeoutErr is a minimal net.Error implementation used to exercise the
+// generic net.Error.Timeout() branch in classifyError without matching any of
+// the more specific error types (DNSError, OpError, etc.).
+type netTimeoutErr struct{}
+
+func (netTimeoutErr) Error() string   { return "simulated net timeout" }
+func (netTimeoutErr) Timeout() bool   { return true }
+func (netTimeoutErr) Temporary() bool { return true }
+
+// TestClassifyError is a white-box table-driven test that verifies every branch
+// of classifyError, including the DNS-timeout regression (a timed-out
+// *net.DNSError must yield "name_resolution_error", not "timeout").
+func TestClassifyError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "nil_error",
+			err:      nil,
+			expected: "",
+		},
+		{
+			name:     "context_canceled",
+			err:      context.Canceled,
+			expected: errorTypeContextCanceled,
+		},
+		{
+			name:     "context_deadline_exceeded",
+			err:      context.DeadlineExceeded,
+			expected: errorTypeTimeout,
+		},
+		{
+			name:     "framework_timeout",
+			err:      NewTimeoutError("request timed out", 5*time.Second),
+			expected: errorTypeTimeout,
+		},
+		{
+			name:     "dns_error_nxdomain",
+			err:      &net.DNSError{Err: "no such host", IsNotFound: true},
+			expected: errorTypeNameResolution,
+		},
+		{
+			// Regression: a timed-out DNS lookup must be errorTypeNameResolution,
+			// not errorTypeTimeout. Previously the generic net.Error.Timeout() check
+			// fired first because *net.DNSError implements net.Error with Timeout()==true.
+			name:     "dns_error_timeout_regression",
+			err:      &net.DNSError{Err: "i/o timeout", IsTimeout: true},
+			expected: errorTypeNameResolution,
+		},
+		{
+			name:     "tls_record_header_error",
+			err:      &tls.RecordHeaderError{Msg: "bad record header"},
+			expected: errorTypeTLS,
+		},
+		{
+			name:     "tls_cert_verification_error",
+			err:      &tls.CertificateVerificationError{Err: errors.New("cert expired")},
+			expected: errorTypeTLS,
+		},
+		{
+			name:     "tcp_dial_failure",
+			err:      &net.OpError{Op: "dial", Err: errors.New("connection refused")},
+			expected: errorTypeConnection,
+		},
+		{
+			// A read-deadline net.Error (not a DNSError or dial OpError) must fall
+			// through to the generic net.Error.Timeout() branch → errorTypeTimeout.
+			name:     "generic_net_timeout",
+			err:      netTimeoutErr{},
+			expected: errorTypeTimeout,
+		},
+		{
+			name:     "interceptor_failure",
+			err:      NewInterceptorError("interceptor failed", "request", errors.New("upstream")),
+			expected: errorTypeInterceptorFailed,
+		},
+		{
+			name:     "generic_network_error",
+			err:      NewNetworkError("network failure", errors.New("connection reset")),
+			expected: errorTypeOther,
+		},
+		{
+			name:     "unknown_error",
+			err:      errors.New("mystery error"),
+			expected: errorTypeOther,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyError(tc.err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
 }

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -13,7 +13,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
+	obtest "github.com/gaborage/go-bricks/observability/testing"
+
+	"github.com/gaborage/go-bricks/httpclient/internal/tracking"
 	"github.com/gaborage/go-bricks/logger"
 )
 
@@ -961,6 +967,206 @@ func TestTraceIDUtilities(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "existing-trace", req.Header.Get(HeaderXRequestID))
 	})
+}
+
+// setupClientTestMeterProvider creates a TestMeterProvider, sets it as the global OTel
+// provider, resets tracking meter state, and initialises the instruments. Returns the
+// provider for metric collection and a cleanup function that must be deferred.
+func setupClientTestMeterProvider(t *testing.T) (mp *obtest.TestMeterProvider, cleanup func()) {
+	t.Helper()
+	mp = obtest.NewTestMeterProvider()
+	otel.SetMeterProvider(mp)
+	tracking.ResetMeterForTesting()
+	tracking.InitHTTPMeter()
+	return mp, func() {
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}
+}
+
+// hasStringAttr returns true when an attribute with the given key and value appears in attrs.
+func hasStringAttr(attrs []attribute.KeyValue, key, val string) bool {
+	for _, a := range attrs {
+		if string(a.Key) == key && a.Value.AsString() == val {
+			return true
+		}
+	}
+	return false
+}
+
+// hasAttrKey returns true when any attribute with the given key appears in attrs.
+func hasAttrKey(attrs []attribute.KeyValue, key string) bool {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return true
+		}
+	}
+	return false
+}
+
+// TestHTTPClientMetricsSuccessPath verifies that a successful request emits the
+// duration histogram with peer.service and status_code attributes, no error.type
+// attribute, and that active_requests returns to 0 after the call completes.
+func TestHTTPClientMetricsSuccessPath(t *testing.T) {
+	mp, cleanup := setupClientTestMeterProvider(t)
+	defer cleanup()
+
+	server := newIPv4TestServer(t, nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.WriteHeader(nethttp.StatusOK)
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("server write failed: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	log := createTestLogger()
+	c := NewBuilder(log).
+		WithPeerName("test-peer").
+		Build()
+
+	resp, err := c.Get(context.Background(), &Request{URL: server.URL})
+	require.NoError(t, err)
+	assert.Equal(t, nethttp.StatusOK, resp.StatusCode)
+
+	rm := mp.Collect(t)
+
+	// Duration histogram must have exactly 1 datapoint.
+	durationMetric := obtest.FindMetric(rm, "http.client.request.duration")
+	require.NotNil(t, durationMetric, "http.client.request.duration metric must be emitted")
+	histData, ok := durationMetric.Data.(metricdata.Histogram[float64])
+	require.True(t, ok, "expected Histogram[float64]")
+
+	var totalCount uint64
+	for _, dp := range histData.DataPoints {
+		totalCount += dp.Count
+	}
+	assert.Equal(t, uint64(1), totalCount, "expected 1 histogram observation for a single successful request")
+
+	// Verify peer.service and status_code attributes, absent error.type.
+	require.NotEmpty(t, histData.DataPoints)
+	dp0 := histData.DataPoints[0]
+	attrs := dp0.Attributes.ToSlice()
+	assert.True(t, hasStringAttr(attrs, "peer.service", "test-peer"), "peer.service attribute should be 'test-peer'")
+	assert.True(t, hasAttrKey(attrs, "http.response.status_code"), "http.response.status_code attribute must be present")
+	assert.False(t, hasAttrKey(attrs, "error.type"), "error.type attribute must be absent on success")
+
+	// Active requests must be net 0 after the call returns (defer fired before we reach here).
+	activeMetric := obtest.FindMetric(rm, "http.client.active_requests")
+	if activeMetric != nil {
+		sumData, ok := activeMetric.Data.(metricdata.Sum[int64])
+		if ok {
+			var netTotal int64
+			for _, dp := range sumData.DataPoints {
+				netTotal += dp.Value
+			}
+			assert.Equal(t, int64(0), netTotal, "net active requests must be 0 after the call completes")
+		}
+	}
+}
+
+// TestHTTPClientMetricsRetryOn503 verifies that when the server returns 503 then 200
+// the duration histogram records one observation per attempt and the retries counter
+// is incremented with retry.reason="5xx".
+func TestHTTPClientMetricsRetryOn503(t *testing.T) {
+	mp, cleanup := setupClientTestMeterProvider(t)
+	defer cleanup()
+
+	var callCount atomic.Int32
+	server := newIPv4TestServer(t, nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		if callCount.Add(1) == 1 {
+			w.WriteHeader(nethttp.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(nethttp.StatusOK)
+		if _, err := w.Write([]byte(`{"ok":true}`)); err != nil {
+			t.Errorf("server write failed: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	log := createTestLogger()
+	c := NewBuilder(log).
+		WithPeerName("retry-peer").
+		WithRetries(2, 1*time.Millisecond).
+		Build()
+
+	resp, err := c.Get(context.Background(), &Request{URL: server.URL})
+	require.NoError(t, err)
+	assert.Equal(t, nethttp.StatusOK, resp.StatusCode)
+
+	rm := mp.Collect(t)
+
+	// Duration histogram must have 2 total observations (one per attempt).
+	durationMetric := obtest.FindMetric(rm, "http.client.request.duration")
+	require.NotNil(t, durationMetric, "http.client.request.duration must be emitted")
+	histData, ok := durationMetric.Data.(metricdata.Histogram[float64])
+	require.True(t, ok, "expected Histogram[float64]")
+
+	var totalCount uint64
+	for _, dp := range histData.DataPoints {
+		totalCount += dp.Count
+	}
+	assert.Equal(t, uint64(2), totalCount, "expected 2 histogram observations (one per attempt)")
+
+	// Retries counter must be 1 with retry.reason="5xx".
+	retryMetric := obtest.FindMetric(rm, "http.client.retries.total")
+	require.NotNil(t, retryMetric, "http.client.retries.total must be emitted")
+	sumData, ok := retryMetric.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "expected Sum[int64] for retries.total")
+
+	var totalRetries int64
+	foundFiveXX := false
+	for _, dp := range sumData.DataPoints {
+		totalRetries += dp.Value
+		if hasStringAttr(dp.Attributes.ToSlice(), "retry.reason", "5xx") {
+			foundFiveXX = true
+		}
+	}
+	assert.Equal(t, int64(1), totalRetries, "expected exactly 1 retry")
+	assert.True(t, foundFiveXX, "retry.reason='5xx' attribute must be present on retry counter")
+}
+
+// TestHTTPClientMetricsTimeoutClassification verifies that when the server delays
+// beyond the client timeout the duration histogram datapoint carries error.type="timeout"
+// and no http.response.status_code attribute.
+func TestHTTPClientMetricsTimeoutClassification(t *testing.T) {
+	mp, cleanup := setupClientTestMeterProvider(t)
+	defer cleanup()
+
+	server := newIPv4TestServer(t, nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(nethttp.StatusOK)
+	}))
+	defer server.Close()
+
+	log := createTestLogger()
+	c := NewBuilder(log).
+		WithPeerName("timeout-peer").
+		WithTimeout(10 * time.Millisecond).
+		Build()
+
+	_, err := c.Get(context.Background(), &Request{URL: server.URL})
+	require.Error(t, err)
+	assert.True(t, IsErrorType(err, TimeoutError))
+
+	rm := mp.Collect(t)
+
+	durationMetric := obtest.FindMetric(rm, "http.client.request.duration")
+	require.NotNil(t, durationMetric, "http.client.request.duration must be emitted on timeout")
+	histData, ok := durationMetric.Data.(metricdata.Histogram[float64])
+	require.True(t, ok, "expected Histogram[float64]")
+	require.NotEmpty(t, histData.DataPoints)
+
+	// Find the datapoint that has error.type="timeout".
+	foundTimeout := false
+	for _, dp := range histData.DataPoints {
+		attrs := dp.Attributes.ToSlice()
+		if hasStringAttr(attrs, "error.type", "timeout") {
+			foundTimeout = true
+			assert.False(t, hasAttrKey(attrs, "http.response.status_code"),
+				"http.response.status_code must be absent when status is 0 (transport error)")
+		}
+	}
+	assert.True(t, foundTimeout, "at least one datapoint must have error.type='timeout'")
 }
 
 // TestBackoffDelayFallbacks covers the three defensive fallback branches in

--- a/httpclient/constants.go
+++ b/httpclient/constants.go
@@ -50,3 +50,31 @@ const (
 	retryReasonBuildResponse = "build_response"
 	retryReason5xx           = "5xx"
 )
+
+// OTel error.type attribute values returned by classifyError. These are the
+// canonical string values emitted on the http.client.request.duration histogram
+// and http.client.request.failed counter — kept as named constants so that
+// both classifyError and its tests can reference them without duplication.
+const (
+	// errorTypeContextCanceled indicates the request was cancelled by the caller.
+	errorTypeContextCanceled = "context_canceled"
+
+	// errorTypeTimeout covers framework TimeoutError, context.DeadlineExceeded,
+	// and generic net.Error timeouts that are not more specifically classified.
+	errorTypeTimeout = "timeout"
+
+	// errorTypeNameResolution indicates a DNS lookup failure (including timeouts).
+	errorTypeNameResolution = "name_resolution_error"
+
+	// errorTypeTLS indicates a TLS handshake or certificate verification failure.
+	errorTypeTLS = "tls_error"
+
+	// errorTypeConnection indicates a TCP dial failure.
+	errorTypeConnection = "connection_error"
+
+	// errorTypeInterceptorFailed indicates a request or response interceptor returned an error.
+	errorTypeInterceptorFailed = "interceptor_failed"
+
+	// errorTypeOther is the catch-all for unclassified errors.
+	errorTypeOther = "_OTHER"
+)

--- a/httpclient/constants.go
+++ b/httpclient/constants.go
@@ -41,3 +41,12 @@ const (
 	// from filling log storage during high-volume request capture.
 	defaultMaxPayloadLogBytes = 1024
 )
+
+// Retry reason labels passed to tracking.IncRetry. These values match the
+// retry.reason attribute values defined in the tracking package.
+const (
+	retryReasonTimeout       = "timeout"
+	retryReasonNetwork       = "network"
+	retryReasonBuildResponse = "build_response"
+	retryReason5xx           = "5xx"
+)

--- a/httpclient/constants.go
+++ b/httpclient/constants.go
@@ -51,6 +51,10 @@ const (
 	retryReason5xx           = "5xx"
 )
 
+// netOpDial is the net.OpError.Op value for TCP dial operations. Centralised
+// as a constant because classifyError and its tests reference it in four places.
+const netOpDial = "dial"
+
 // OTel error.type attribute values returned by classifyError. These are the
 // canonical string values emitted on the http.client.request.duration histogram
 // and http.client.request.failed counter — kept as named constants so that

--- a/httpclient/interface.go
+++ b/httpclient/interface.go
@@ -82,6 +82,10 @@ type Config struct {
 	TraceIDExtractor func(_ context.Context) (traceID string, ok bool)
 	// EnableW3CTrace enables W3C Trace Context (traceparent/tracestate) propagation and generation
 	EnableW3CTrace bool
+	// PeerName is a low-cardinality logical service name attached to every metric emitted
+	// by this client. Intended for SLO attribution (e.g., "stripe", "visa-vts").
+	// When unset, only the high-cardinality server.address is recorded.
+	PeerName string
 }
 
 // Trace ID utility functions

--- a/httpclient/internal/tracking/metrics.go
+++ b/httpclient/internal/tracking/metrics.go
@@ -77,12 +77,8 @@ func logMetricError(metricName string, err error) {
 }
 
 // initHTTPMeter performs the one-time meter and instrument initialization.
-// It is called via sync.Once and is protected by meterInitMu to prevent
-// races between a reset (in tests) and concurrent callers.
+// Caller MUST hold meterInitMu.
 func initHTTPMeter() {
-	meterInitMu.Lock()
-	defer meterInitMu.Unlock()
-
 	if httpMeter != nil {
 		return
 	}
@@ -134,9 +130,11 @@ func initHTTPMeter() {
 }
 
 // InitHTTPMeter initializes the HTTP client meter idempotently.
-// Subsequent calls after the first are no-ops. The meter is pulled from
-// otel.GetMeterProvider() lazily via sync.Once.
+// Subsequent calls after the first are no-ops. Holds meterInitMu so that
+// concurrent calls and ResetMeterForTesting cannot race on meterOnce.
 func InitHTTPMeter() {
+	meterInitMu.Lock()
+	defer meterInitMu.Unlock()
 	meterOnce.Do(initHTTPMeter)
 }
 

--- a/httpclient/internal/tracking/metrics.go
+++ b/httpclient/internal/tracking/metrics.go
@@ -1,0 +1,311 @@
+package tracking
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	// httpMeterName is the meter name following the go-bricks/<module> convention.
+	httpMeterName = "go-bricks/httpclient"
+
+	// Metric names per OTel semantic conventions for HTTP clients.
+	metricRequestDuration  = "http.client.request.duration"
+	metricActiveRequests   = "http.client.active_requests"
+	metricRequestBodySize  = "http.client.request.body.size"
+	metricResponseBodySize = "http.client.response.body.size"
+	metricRetriesTotal     = "http.client.retries.total"
+
+	// Attribute keys per OTel semantic conventions (semconv v1.37.0 equivalents).
+	// peer.service and http.request.resend_count are not in v1.37.0 constants but are
+	// defined in the OTel spec — declared here as local constants for consistency.
+	attrPeerService     = "peer.service"
+	attrServerAddress   = "server.address"
+	attrServerPort      = "server.port"
+	attrURLScheme       = "url.scheme"
+	attrHTTPMethod      = "http.request.method"
+	attrHTTPStatusCode  = "http.response.status_code"
+	attrErrorType       = "error.type"
+	attrHTTPResendCount = "http.request.resend_count"
+	attrRetryReason     = "reason"
+
+	// Sentinel value for unknown HTTP methods per OTel spec.
+	methodOther = "_OTHER"
+
+	// Well-known HTTP method strings used in canonicalMethod.
+	methodGET     = "GET"
+	methodHEAD    = "HEAD"
+	methodPOST    = "POST"
+	methodPUT     = "PUT"
+	methodDELETE  = "DELETE"
+	methodCONNECT = "CONNECT"
+	methodOPTIONS = "OPTIONS"
+	methodTRACE   = "TRACE"
+	methodPATCH   = "PATCH"
+)
+
+var (
+	// Singleton meter initialization guards.
+	httpMeter   metric.Meter
+	meterOnce   sync.Once
+	meterInitMu sync.Mutex
+
+	// Metric instruments.
+	requestDuration  metric.Float64Histogram
+	activeRequests   metric.Int64UpDownCounter
+	requestBodySize  metric.Int64Histogram
+	responseBodySize metric.Int64Histogram
+	retriesTotal     metric.Int64Counter
+)
+
+// logMetricError logs a metric initialization error to stderr.
+// Metric failures are best-effort and must not crash the application.
+func logMetricError(metricName string, err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: Failed to initialize metric %s: %v\n", metricName, err)
+	}
+}
+
+// initHTTPMeter performs the one-time meter and instrument initialization.
+// It is called via sync.Once and is protected by meterInitMu to prevent
+// races between a reset (in tests) and concurrent callers.
+func initHTTPMeter() {
+	meterInitMu.Lock()
+	defer meterInitMu.Unlock()
+
+	if httpMeter != nil {
+		return
+	}
+
+	httpMeter = otel.Meter(httpMeterName)
+
+	var err error
+
+	// Duration histogram — explicit buckets per OTel HTTP client semconv recommendation.
+	requestDuration, err = httpMeter.Float64Histogram(
+		metricRequestDuration,
+		metric.WithDescription("Duration of HTTP client requests"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10),
+	)
+	logMetricError(metricRequestDuration, err)
+
+	// Up-down counter for in-flight requests.
+	activeRequests, err = httpMeter.Int64UpDownCounter(
+		metricActiveRequests,
+		metric.WithDescription("Number of in-flight HTTP client requests"),
+		metric.WithUnit("{request}"),
+	)
+	logMetricError(metricActiveRequests, err)
+
+	// Histogram for outgoing request body size.
+	requestBodySize, err = httpMeter.Int64Histogram(
+		metricRequestBodySize,
+		metric.WithDescription("Size of HTTP client request bodies"),
+		metric.WithUnit("By"),
+	)
+	logMetricError(metricRequestBodySize, err)
+
+	// Histogram for incoming response body size.
+	responseBodySize, err = httpMeter.Int64Histogram(
+		metricResponseBodySize,
+		metric.WithDescription("Size of HTTP client response bodies"),
+		metric.WithUnit("By"),
+	)
+	logMetricError(metricResponseBodySize, err)
+
+	// Counter for client-side retries.
+	retriesTotal, err = httpMeter.Int64Counter(
+		metricRetriesTotal,
+		metric.WithDescription("Total number of HTTP client retry attempts"),
+		metric.WithUnit("{retry}"),
+	)
+	logMetricError(metricRetriesTotal, err)
+}
+
+// InitHTTPMeter initializes the HTTP client meter idempotently.
+// Subsequent calls after the first are no-ops. The meter is pulled from
+// otel.GetMeterProvider() lazily via sync.Once.
+func InitHTTPMeter() {
+	meterOnce.Do(initHTTPMeter)
+}
+
+// HTTPClientMeasurement carries all per-request data needed to emit OTel metrics.
+type HTTPClientMeasurement struct {
+	// PeerName is the logical peer service name (peer.service). Omitted when empty.
+	PeerName string
+	// Method is the HTTP method (uppercase canonical; unknown methods → "_OTHER").
+	Method string
+	// URL is the request URL, used to extract server.address, server.port, and url.scheme.
+	URL *url.URL
+	// StatusCode is the HTTP response status code. 0 means a transport error (no response).
+	StatusCode int
+	// ErrorType is the OTel error.type enum value. Empty string on success.
+	ErrorType string
+	// ResendCount is the number of prior attempts (0 = first attempt).
+	ResendCount int
+	// Elapsed is the total request duration, recorded as seconds in the histogram.
+	Elapsed time.Duration
+	// RequestBytes is the request body size in bytes. Skipped when 0.
+	RequestBytes int
+	// ResponseBytes is the response body size in bytes. Skipped when 0.
+	ResponseBytes int
+}
+
+// RecordHTTPClientMetrics records all per-request OTel metrics after a request completes.
+// It emits:
+//   - http.client.request.duration (seconds)
+//   - http.client.request.body.size (bytes, when > 0)
+//   - http.client.response.body.size (bytes, when > 0)
+func RecordHTTPClientMetrics(ctx context.Context, m *HTTPClientMeasurement) {
+	InitHTTPMeter()
+
+	method := canonicalMethod(m.Method)
+	addr, port := serverAddressPort(m.URL)
+	scheme := urlScheme(m.URL)
+
+	// Base attributes shared across all instruments.
+	base := baseAttrs(m.PeerName, method, addr, port, scheme)
+
+	// Duration histogram — extended with status code, error type, resend count.
+	durationAttrs := make([]attribute.KeyValue, 0, len(base)+3)
+	durationAttrs = append(durationAttrs, base...)
+	if m.StatusCode != 0 {
+		durationAttrs = append(durationAttrs, attribute.Int(attrHTTPStatusCode, m.StatusCode))
+	}
+	if m.ErrorType != "" {
+		durationAttrs = append(durationAttrs, attribute.String(attrErrorType, m.ErrorType))
+	}
+	durationAttrs = append(durationAttrs, attribute.Int(attrHTTPResendCount, m.ResendCount))
+
+	if requestDuration != nil {
+		secs := float64(m.Elapsed.Nanoseconds()) / 1e9
+		requestDuration.Record(ctx, secs, metric.WithAttributes(durationAttrs...))
+	}
+
+	// Body-size histograms — only when bytes > 0.
+	if requestBodySize != nil && m.RequestBytes > 0 {
+		requestBodySize.Record(ctx, int64(m.RequestBytes), metric.WithAttributes(base...))
+	}
+	if responseBodySize != nil && m.ResponseBytes > 0 {
+		responseBodySize.Record(ctx, int64(m.ResponseBytes), metric.WithAttributes(base...))
+	}
+}
+
+// IncActiveRequests increments the http.client.active_requests counter.
+// Call this immediately before sending a request.
+// peer is the peer.service value (omitted when empty); method is the HTTP method.
+func IncActiveRequests(ctx context.Context, peer, method string) {
+	InitHTTPMeter()
+	if activeRequests == nil {
+		return
+	}
+	attrs := activeRequestAttrs(peer, canonicalMethod(method))
+	activeRequests.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+// DecActiveRequests decrements the http.client.active_requests counter.
+// Call this after the request completes (in a defer alongside IncActiveRequests).
+func DecActiveRequests(ctx context.Context, peer, method string) {
+	InitHTTPMeter()
+	if activeRequests == nil {
+		return
+	}
+	attrs := activeRequestAttrs(peer, canonicalMethod(method))
+	activeRequests.Add(ctx, -1, metric.WithAttributes(attrs...))
+}
+
+// IncRetry increments the http.client.retries.total counter.
+// reason should be one of: "timeout", "5xx", "network", "build_response".
+func IncRetry(ctx context.Context, peer, reason string) {
+	InitHTTPMeter()
+	if retriesTotal == nil {
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String(attrRetryReason, reason),
+	}
+	if peer != "" {
+		attrs = append([]attribute.KeyValue{attribute.String(attrPeerService, peer)}, attrs...)
+	}
+	retriesTotal.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+// baseAttrs builds the attribute set common to all instruments.
+func baseAttrs(peer, method, addr string, port int, scheme string) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 5)
+	if peer != "" {
+		attrs = append(attrs, attribute.String(attrPeerService, peer))
+	}
+	attrs = append(attrs,
+		attribute.String(attrHTTPMethod, method),
+		attribute.String(attrServerAddress, addr),
+		attribute.Int(attrServerPort, port),
+		attribute.String(attrURLScheme, scheme),
+	)
+	return attrs
+}
+
+// activeRequestAttrs builds the minimal attribute set for the active_requests counter.
+func activeRequestAttrs(peer, method string) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 2)
+	if peer != "" {
+		attrs = append(attrs, attribute.String(attrPeerService, peer))
+	}
+	attrs = append(attrs, attribute.String(attrHTTPMethod, method))
+	return attrs
+}
+
+// canonicalMethod returns the uppercase canonical HTTP method, or "_OTHER" for
+// methods not in the OTel-defined set of well-known HTTP methods.
+func canonicalMethod(method string) string {
+	upper := strings.ToUpper(method)
+	switch upper {
+	case methodGET, methodHEAD, methodPOST, methodPUT, methodDELETE,
+		methodCONNECT, methodOPTIONS, methodTRACE, methodPATCH:
+		return upper
+	default:
+		return methodOther
+	}
+}
+
+// serverAddressPort extracts the server.address and server.port from a URL.
+// When the port is blank it defaults to 80 for http and 443 for https.
+func serverAddressPort(u *url.URL) (addr string, port int) {
+	if u == nil {
+		return "", 0
+	}
+	addr = u.Hostname()
+	portStr := u.Port()
+	if portStr != "" {
+		p, err := strconv.Atoi(portStr)
+		if err == nil {
+			port = p
+		}
+		return addr, port
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "https":
+		return addr, 443
+	default:
+		return addr, 80
+	}
+}
+
+// urlScheme returns the URL scheme string, or "" when the URL is nil.
+func urlScheme(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	return u.Scheme
+}

--- a/httpclient/internal/tracking/metrics.go
+++ b/httpclient/internal/tracking/metrics.go
@@ -37,7 +37,7 @@ const (
 	attrHTTPStatusCode  = "http.response.status_code"
 	attrErrorType       = "error.type"
 	attrHTTPResendCount = "http.request.resend_count"
-	attrRetryReason     = "reason"
+	attrRetryReason     = "retry.reason"
 
 	// Sentinel value for unknown HTTP methods per OTel spec.
 	methodOther = "_OTHER"
@@ -204,24 +204,26 @@ func RecordHTTPClientMetrics(ctx context.Context, m *HTTPClientMeasurement) {
 
 // IncActiveRequests increments the http.client.active_requests counter.
 // Call this immediately before sending a request.
-// peer is the peer.service value (omitted when empty); method is the HTTP method.
-func IncActiveRequests(ctx context.Context, peer, method string) {
+// peer is the peer.service value (omitted when empty); method is the HTTP method;
+// addr is the server hostname (server.address, omitted when empty).
+func IncActiveRequests(ctx context.Context, peer, method, addr string) {
 	InitHTTPMeter()
 	if activeRequests == nil {
 		return
 	}
-	attrs := activeRequestAttrs(peer, canonicalMethod(method))
+	attrs := activeRequestAttrs(peer, canonicalMethod(method), addr)
 	activeRequests.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 // DecActiveRequests decrements the http.client.active_requests counter.
 // Call this after the request completes (in a defer alongside IncActiveRequests).
-func DecActiveRequests(ctx context.Context, peer, method string) {
+// addr is the server hostname (server.address, omitted when empty).
+func DecActiveRequests(ctx context.Context, peer, method, addr string) {
 	InitHTTPMeter()
 	if activeRequests == nil {
 		return
 	}
-	attrs := activeRequestAttrs(peer, canonicalMethod(method))
+	attrs := activeRequestAttrs(peer, canonicalMethod(method), addr)
 	activeRequests.Add(ctx, -1, metric.WithAttributes(attrs...))
 }
 
@@ -261,12 +263,17 @@ func baseAttrs(peer, method, addr string, port int, scheme string) []attribute.K
 }
 
 // activeRequestAttrs builds the minimal attribute set for the active_requests counter.
-func activeRequestAttrs(peer, method string) []attribute.KeyValue {
-	attrs := make([]attribute.KeyValue, 0, 2)
+// Per OTel spec, active_requests carries: peer.service, server.address, http.request.method.
+// peer and addr are omitted when empty.
+func activeRequestAttrs(peer, method, addr string) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 3)
 	if peer != "" {
 		attrs = append(attrs, attribute.String(attrPeerService, peer))
 	}
 	attrs = append(attrs, attribute.String(attrHTTPMethod, method))
+	if addr != "" {
+		attrs = append(attrs, attribute.String(attrServerAddress, addr))
+	}
 	return attrs
 }
 

--- a/httpclient/internal/tracking/metrics.go
+++ b/httpclient/internal/tracking/metrics.go
@@ -226,18 +226,22 @@ func DecActiveRequests(ctx context.Context, peer, method string) {
 }
 
 // IncRetry increments the http.client.retries.total counter.
-// reason should be one of: "timeout", "5xx", "network", "build_response".
-func IncRetry(ctx context.Context, peer, reason string) {
+// peer is the peer.service value (omitted when empty); method is the HTTP method
+// (normalized via canonicalMethod); reason should be one of: "timeout", "5xx", "network",
+// "build_response".
+func IncRetry(ctx context.Context, peer, method, reason string) {
 	InitHTTPMeter()
 	if retriesTotal == nil {
 		return
 	}
-	attrs := []attribute.KeyValue{
-		attribute.String(attrRetryReason, reason),
-	}
+	attrs := make([]attribute.KeyValue, 0, 3)
 	if peer != "" {
-		attrs = append([]attribute.KeyValue{attribute.String(attrPeerService, peer)}, attrs...)
+		attrs = append(attrs, attribute.String(attrPeerService, peer))
 	}
+	attrs = append(attrs,
+		attribute.String(attrHTTPMethod, canonicalMethod(method)),
+		attribute.String(attrRetryReason, reason),
+	)
 	retriesTotal.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 

--- a/httpclient/internal/tracking/metrics_test.go
+++ b/httpclient/internal/tracking/metrics_test.go
@@ -3,7 +3,6 @@ package tracking
 import (
 	"context"
 	"net/url"
-	"sync"
 	"testing"
 	"time"
 
@@ -17,15 +16,10 @@ import (
 	obtest "github.com/gaborage/go-bricks/observability/testing"
 )
 
-// resetMeterForTesting resets package-level meter state so each test starts clean.
+// resetMeterForTesting is a package-internal alias for the exported ResetMeterForTesting
+// kept for test-file readability. Uses the exported function to avoid duplication.
 func resetMeterForTesting() {
-	meterOnce = sync.Once{}
-	httpMeter = nil
-	requestDuration = nil
-	activeRequests = nil
-	requestBodySize = nil
-	responseBodySize = nil
-	retriesTotal = nil
+	ResetMeterForTesting()
 }
 
 // setupTestMeterProvider creates a test meter provider, sets it as the global provider,

--- a/httpclient/internal/tracking/metrics_test.go
+++ b/httpclient/internal/tracking/metrics_test.go
@@ -16,12 +16,6 @@ import (
 	obtest "github.com/gaborage/go-bricks/observability/testing"
 )
 
-// resetMeterForTesting is a package-internal alias for the exported ResetMeterForTesting
-// kept for test-file readability. Uses the exported function to avoid duplication.
-func resetMeterForTesting() {
-	ResetMeterForTesting()
-}
-
 // setupTestMeterProvider creates a test meter provider, sets it as the global provider,
 // resets meter state, and initialises the instruments. Returns the provider for metric
 // collection and a cleanup function.
@@ -29,7 +23,7 @@ func setupTestMeterProvider(t *testing.T) (mp *obtest.TestMeterProvider, cleanup
 	t.Helper()
 	mp = obtest.NewTestMeterProvider()
 	otel.SetMeterProvider(mp)
-	resetMeterForTesting()
+	ResetMeterForTesting()
 	InitHTTPMeter()
 	cleanup = func() {
 		require.NoError(t, mp.Shutdown(context.Background()))
@@ -463,13 +457,13 @@ func TestNoopMeterProviderPath(t *testing.T) {
 	original := otel.GetMeterProvider()
 	t.Cleanup(func() {
 		otel.SetMeterProvider(original)
-		resetMeterForTesting()
+		ResetMeterForTesting()
 		// Re-initialize with real provider so other tests are unaffected.
 	})
 
 	// Install noop provider and reset cached meter.
 	otel.SetMeterProvider(metricnoop.NewMeterProvider())
-	resetMeterForTesting()
+	ResetMeterForTesting()
 
 	ctx := context.Background()
 

--- a/httpclient/internal/tracking/metrics_test.go
+++ b/httpclient/internal/tracking/metrics_test.go
@@ -298,7 +298,7 @@ func TestIncDecActiveRequestsBalanced(t *testing.T) {
 }
 
 // TestIncRetryWithVariousReasons verifies that IncRetry increments the retry counter
-// with the correct reason attribute for each call.
+// with the correct reason and http.request.method attributes for each call.
 func TestIncRetryWithVariousReasons(t *testing.T) {
 	mp, cleanup := setupTestMeterProvider(t)
 	defer cleanup()
@@ -306,7 +306,7 @@ func TestIncRetryWithVariousReasons(t *testing.T) {
 	ctx := context.Background()
 	reasons := []string{"timeout", "5xx", "network", "build_response"}
 	for _, r := range reasons {
-		IncRetry(ctx, "svc", r)
+		IncRetry(ctx, "svc", "POST", r)
 	}
 
 	rm := mp.Collect(t)
@@ -323,17 +323,54 @@ func TestIncRetryWithVariousReasons(t *testing.T) {
 	reasonsFound := make(map[string]bool)
 	for _, dp := range sumData.DataPoints {
 		total += dp.Value
-		for _, a := range dp.Attributes.ToSlice() {
+		attrs := dp.Attributes.ToSlice()
+		for _, a := range attrs {
 			if string(a.Key) == attrRetryReason {
 				reasonsFound[a.Value.AsString()] = true
 			}
 		}
+		// Every datapoint must carry http.request.method canonicalized to "POST".
+		assertHasAttribute(t, attrs, attrHTTPMethod, "POST")
 	}
 
 	assert.Equal(t, int64(4), total, "expected 4 total retries (one per reason)")
 	for _, r := range reasons {
 		assert.True(t, reasonsFound[r], "reason %q not found in retry attributes", r)
 	}
+}
+
+// TestIncRetryMethodCanonicalization verifies that IncRetry canonicalizes the HTTP method:
+// lowercase "get" → "GET", unknown "WEIRD" → "_OTHER".
+func TestIncRetryMethodCanonicalization(t *testing.T) {
+	mp, cleanup := setupTestMeterProvider(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Lowercase method must be uppercased.
+	IncRetry(ctx, "svc", "get", "timeout")
+	// Unknown method must become _OTHER.
+	IncRetry(ctx, "svc", "WEIRD", "5xx")
+
+	rm := mp.Collect(t)
+
+	retryMetric := obtest.FindMetric(rm, metricRetriesTotal)
+	require.NotNil(t, retryMetric)
+
+	sumData, ok := retryMetric.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "expected Sum[int64] for retries.total")
+
+	methodsFound := make(map[string]bool)
+	for _, dp := range sumData.DataPoints {
+		for _, a := range dp.Attributes.ToSlice() {
+			if string(a.Key) == attrHTTPMethod {
+				methodsFound[a.Value.AsString()] = true
+			}
+		}
+	}
+
+	assert.True(t, methodsFound["GET"], "lowercase 'get' should be canonicalized to 'GET'")
+	assert.True(t, methodsFound[methodOther], "unknown 'WEIRD' should be canonicalized to '_OTHER'")
 }
 
 // TestEmptyPeerNameOmitsPeerServiceAttribute verifies that when PeerName is empty the
@@ -356,7 +393,7 @@ func TestEmptyPeerNameOmitsPeerServiceAttribute(t *testing.T) {
 	})
 	IncActiveRequests(ctx, "", "GET")
 	DecActiveRequests(ctx, "", "GET")
-	IncRetry(ctx, "", "timeout")
+	IncRetry(ctx, "", "GET", "timeout")
 
 	rm := mp.Collect(t)
 
@@ -373,6 +410,13 @@ func TestEmptyPeerNameOmitsPeerServiceAttribute(t *testing.T) {
 	reqHistData := reqBodyMetric.Data.(metricdata.Histogram[int64])
 	require.NotEmpty(t, reqHistData.DataPoints)
 	assertNoAttribute(t, reqHistData.DataPoints[0].Attributes.ToSlice(), attrPeerService)
+
+	// Response body size — no peer.service.
+	respBodyMetric := obtest.FindMetric(rm, metricResponseBodySize)
+	require.NotNil(t, respBodyMetric)
+	respHistData := respBodyMetric.Data.(metricdata.Histogram[int64])
+	require.NotEmpty(t, respHistData.DataPoints)
+	assertNoAttribute(t, respHistData.DataPoints[0].Attributes.ToSlice(), attrPeerService)
 
 	// Active requests — no peer.service.
 	activeMetric := obtest.FindMetric(rm, metricActiveRequests)

--- a/httpclient/internal/tracking/metrics_test.go
+++ b/httpclient/internal/tracking/metrics_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	obtest "github.com/gaborage/go-bricks/observability/testing"
@@ -272,14 +273,14 @@ func TestRecordHTTPClientMetricsWithZeroBodySizes(t *testing.T) {
 }
 
 // TestIncDecActiveRequestsBalanced verifies that a paired Inc/Dec results in a net zero
-// active-request count.
+// active-request count and that the server.address attribute is present on the datapoint.
 func TestIncDecActiveRequestsBalanced(t *testing.T) {
 	mp, cleanup := setupTestMeterProvider(t)
 	defer cleanup()
 
 	ctx := context.Background()
-	IncActiveRequests(ctx, "svc", "GET")
-	DecActiveRequests(ctx, "svc", "GET")
+	IncActiveRequests(ctx, "svc", "GET", "api.example.com")
+	DecActiveRequests(ctx, "svc", "GET", "api.example.com")
 
 	rm := mp.Collect(t)
 	obtest.AssertMetricExists(t, rm, metricActiveRequests)
@@ -295,6 +296,10 @@ func TestIncDecActiveRequestsBalanced(t *testing.T) {
 		total += dp.Value
 	}
 	assert.Equal(t, int64(0), total, "net active requests should be 0 after balanced inc/dec")
+
+	// server.address must be present on the datapoint.
+	require.NotEmpty(t, sumData.DataPoints)
+	assertHasAttribute(t, sumData.DataPoints[0].Attributes.ToSlice(), attrServerAddress, "api.example.com")
 }
 
 // TestIncRetryWithVariousReasons verifies that IncRetry increments the retry counter
@@ -391,8 +396,8 @@ func TestEmptyPeerNameOmitsPeerServiceAttribute(t *testing.T) {
 		RequestBytes:  100,
 		ResponseBytes: 50,
 	})
-	IncActiveRequests(ctx, "", "GET")
-	DecActiveRequests(ctx, "", "GET")
+	IncActiveRequests(ctx, "", "GET", "")
+	DecActiveRequests(ctx, "", "GET", "")
 	IncRetry(ctx, "", "GET", "timeout")
 
 	rm := mp.Collect(t)
@@ -455,4 +460,131 @@ func TestUnknownMethodNormalizedToOther(t *testing.T) {
 	require.NotEmpty(t, histData.DataPoints)
 
 	assertHasAttribute(t, histData.DataPoints[0].Attributes.ToSlice(), attrHTTPMethod, methodOther)
+}
+
+// TestNoopMeterProviderPath verifies that when the global meter provider is a noop provider
+// all tracking functions execute without panicking and no instruments are registered.
+func TestNoopMeterProviderPath(t *testing.T) {
+	// Save original provider so we can restore it.
+	original := otel.GetMeterProvider()
+	t.Cleanup(func() {
+		otel.SetMeterProvider(original)
+		resetMeterForTesting()
+		// Re-initialize with real provider so other tests are unaffected.
+	})
+
+	// Install noop provider and reset cached meter.
+	otel.SetMeterProvider(metricnoop.NewMeterProvider())
+	resetMeterForTesting()
+
+	ctx := context.Background()
+
+	// All functions must complete without panicking.
+	assert.NotPanics(t, func() {
+		RecordHTTPClientMetrics(ctx, &HTTPClientMeasurement{
+			Method:     "GET",
+			URL:        mustParseURL("https://api.example.com/ping"),
+			StatusCode: 200,
+			Elapsed:    1 * time.Millisecond,
+		})
+	})
+	assert.NotPanics(t, func() { IncActiveRequests(ctx, "svc", "GET", "api.example.com") })
+	assert.NotPanics(t, func() { DecActiveRequests(ctx, "svc", "GET", "api.example.com") })
+	assert.NotPanics(t, func() { IncRetry(ctx, "svc", "GET", "timeout") })
+}
+
+// TestRecordHTTPClientMetricsHTTPErrorStatusOmitsErrorType verifies that a 503 response
+// does not automatically set error.type — 4xx/5xx status codes alone do not imply an error type.
+func TestRecordHTTPClientMetricsHTTPErrorStatusOmitsErrorType(t *testing.T) {
+	mp, cleanup := setupTestMeterProvider(t)
+	defer cleanup()
+
+	RecordHTTPClientMetrics(context.Background(), &HTTPClientMeasurement{
+		Method:     "GET",
+		URL:        mustParseURL("https://api.example.com/health"),
+		StatusCode: 503,
+		ErrorType:  "", // explicitly empty — no transport-level error
+		Elapsed:    8 * time.Millisecond,
+	})
+
+	rm := mp.Collect(t)
+
+	durationMetric := obtest.FindMetric(rm, metricRequestDuration)
+	require.NotNil(t, durationMetric, "duration histogram must be emitted for 503 responses")
+
+	histData, ok := durationMetric.Data.(metricdata.Histogram[float64])
+	require.True(t, ok, "expected Histogram[float64]")
+	require.NotEmpty(t, histData.DataPoints, "duration histogram must have datapoints")
+
+	attrs := histData.DataPoints[0].Attributes.ToSlice()
+	// 503 must produce a status code attribute.
+	assertHasIntAttribute(t, attrs, attrHTTPStatusCode, 503)
+	// 5xx without an explicit ErrorType must NOT produce an error.type attribute.
+	assertNoAttribute(t, attrs, attrErrorType)
+}
+
+// TestServerAddressPort exercises the defensive branches of serverAddressPort directly.
+func TestServerAddressPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawURL   string
+		nilURL   bool
+		wantAddr string
+		wantPort int
+	}{
+		{
+			name:     "nil_url",
+			nilURL:   true,
+			wantAddr: "",
+			wantPort: 0,
+		},
+		{
+			name:     "http_no_explicit_port",
+			rawURL:   "http://example.com/path",
+			wantAddr: "example.com",
+			wantPort: 80,
+		},
+		{
+			name:     "https_no_explicit_port",
+			rawURL:   "https://example.com/path",
+			wantAddr: "example.com",
+			wantPort: 443,
+		},
+		{
+			name:     "explicit_port_overrides_scheme_default",
+			rawURL:   "https://example.com:8443/path",
+			wantAddr: "example.com",
+			wantPort: 8443,
+		},
+		{
+			name:     "http_explicit_port",
+			rawURL:   "http://example.com:9090/path",
+			wantAddr: "example.com",
+			wantPort: 9090,
+		},
+		{
+			name:     "ipv6_with_explicit_port",
+			rawURL:   "http://[::1]:8080/path",
+			wantAddr: "::1", // url.URL.Hostname() strips brackets
+			wantPort: 8080,
+		},
+		{
+			name:     "unknown_scheme_falls_back_to_80",
+			rawURL:   "ftp://example.com/files",
+			wantAddr: "example.com",
+			wantPort: 80,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var u *url.URL
+			if !tc.nilURL {
+				u = mustParseURL(tc.rawURL)
+			}
+			addr, port := serverAddressPort(u)
+			assert.Equal(t, tc.wantAddr, addr, "addr mismatch")
+			assert.Equal(t, tc.wantPort, port, "port mismatch")
+		})
+	}
 }

--- a/httpclient/internal/tracking/metrics_test.go
+++ b/httpclient/internal/tracking/metrics_test.go
@@ -1,0 +1,414 @@
+package tracking
+
+import (
+	"context"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	obtest "github.com/gaborage/go-bricks/observability/testing"
+)
+
+// resetMeterForTesting resets package-level meter state so each test starts clean.
+func resetMeterForTesting() {
+	meterOnce = sync.Once{}
+	httpMeter = nil
+	requestDuration = nil
+	activeRequests = nil
+	requestBodySize = nil
+	responseBodySize = nil
+	retriesTotal = nil
+}
+
+// setupTestMeterProvider creates a test meter provider, sets it as the global provider,
+// resets meter state, and initialises the instruments. Returns the provider for metric
+// collection and a cleanup function.
+func setupTestMeterProvider(t *testing.T) (mp *obtest.TestMeterProvider, cleanup func()) {
+	t.Helper()
+	mp = obtest.NewTestMeterProvider()
+	otel.SetMeterProvider(mp)
+	resetMeterForTesting()
+	InitHTTPMeter()
+	cleanup = func() {
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}
+	return mp, cleanup
+}
+
+// mustParseURL is a test helper that panics if the URL string is invalid.
+func mustParseURL(raw string) *url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+// assertHasAttribute asserts that a string attribute with the given key exists and
+// equals the expected value in the provided attribute slice.
+func assertHasAttribute(t *testing.T, attrs []attribute.KeyValue, key, expected string) {
+	t.Helper()
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			assert.Equal(t, expected, a.Value.AsString(), "attribute %s value mismatch", key)
+			return
+		}
+	}
+	t.Errorf("attribute %s not found in attribute set", key)
+}
+
+// assertHasIntAttribute asserts that an integer attribute with the given key exists and
+// equals the expected value in the provided attribute slice.
+func assertHasIntAttribute(t *testing.T, attrs []attribute.KeyValue, key string, expected int64) {
+	t.Helper()
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			assert.Equal(t, expected, a.Value.AsInt64(), "attribute %s value mismatch", key)
+			return
+		}
+	}
+	t.Errorf("attribute %s not found in attribute set", key)
+}
+
+// assertNoAttribute asserts that no attribute with the given key appears in the slice.
+func assertNoAttribute(t *testing.T, attrs []attribute.KeyValue, key string) {
+	t.Helper()
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			t.Errorf("attribute %s should be absent but found value %v", key, a.Value)
+			return
+		}
+	}
+}
+
+// TestRecordHTTPClientMetricsSuccessPath verifies that a successful request emits the
+// duration histogram with all expected attributes and no error.type attribute.
+func TestRecordHTTPClientMetricsSuccessPath(t *testing.T) {
+	mp, cleanup := setupTestMeterProvider(t)
+	defer cleanup()
+
+	m := HTTPClientMeasurement{
+		PeerName:    "payments-api",
+		Method:      "GET",
+		URL:         mustParseURL("https://api.example.com/v1/users"),
+		StatusCode:  200,
+		ErrorType:   "",
+		ResendCount: 0,
+		Elapsed:     150 * time.Millisecond,
+	}
+
+	RecordHTTPClientMetrics(context.Background(), &m)
+
+	rm := mp.Collect(t)
+	obtest.AssertMetricExists(t, rm, metricRequestDuration)
+
+	durationMetric := obtest.FindMetric(rm, metricRequestDuration)
+	require.NotNil(t, durationMetric)
+
+	histData, ok := durationMetric.Data.(metricdata.Histogram[float64])
+	require.True(t, ok, "expected Histogram[float64]")
+	require.NotEmpty(t, histData.DataPoints)
+
+	dp := histData.DataPoints[0]
+	assert.InDelta(t, 0.15, dp.Sum, 0.01, "duration should be ~0.15 seconds")
+	assert.Equal(t, uint64(1), dp.Count)
+
+	attrs := dp.Attributes.ToSlice()
+	assertHasAttribute(t, attrs, attrPeerService, "payments-api")
+	assertHasAttribute(t, attrs, attrHTTPMethod, "GET")
+	assertHasAttribute(t, attrs, attrServerAddress, "api.example.com")
+	assertHasAttribute(t, attrs, attrURLScheme, "https")
+	assertHasIntAttribute(t, attrs, attrHTTPStatusCode, 200)
+	assertHasIntAttribute(t, attrs, attrHTTPResendCount, 0)
+	assertNoAttribute(t, attrs, attrErrorType)
+}
+
+// TestRecordHTTPClientMetricsPerAttemptSemantics verifies that three sequential calls with
+// resend_count 0, 1, 2 each emit a separate OTel datapoint (distinct attribute sets),
+// for a total of 3 recorded measurements across all datapoints.
+func TestRecordHTTPClientMetricsPerAttemptSemantics(t *testing.T) {
+	mp, cleanup := setupTestMeterProvider(t)
+	defer cleanup()
+
+	u := mustParseURL("https://api.example.com/orders")
+	ctx := context.Background()
+
+	for i := range 3 {
+		RecordHTTPClientMetrics(ctx, &HTTPClientMeasurement{
+			Method:      "POST",
+			URL:         u,
+			StatusCode:  200,
+			ResendCount: i,
+			Elapsed:     10 * time.Millisecond,
+		})
+	}
+
+	rm := mp.Collect(t)
+
+	durationMetric := obtest.FindMetric(rm, metricRequestDuration)
+	require.NotNil(t, durationMetric)
+
+	histData, ok := durationMetric.Data.(metricdata.Histogram[float64])
+	require.True(t, ok, "expected Histogram[float64]")
+
+	// Each resend_count value (0, 1, 2) produces a distinct attribute set → distinct datapoint.
+	// Sum their counts to get the total number of recorded measurements.
+	var totalCount uint64
+	for _, dp := range histData.DataPoints {
+		totalCount += dp.Count
+	}
+	assert.Equal(t, uint64(3), totalCount, "expected 3 total measurements, one per attempt")
+}
+
+// TestRecordHTTPClientMetricsTransportError verifies that when StatusCode is 0 (transport
+// error) the http.response.status_code attribute is omitted from all instruments.
+func TestRecordHTTPClientMetricsTransportError(t *testing.T) {
+	mp, cleanup := setupTestMeterProvider(t)
+	defer cleanup()
+
+	RecordHTTPClientMetrics(context.Background(), &HTTPClientMeasurement{
+		Method:      "GET",
+		URL:         mustParseURL("https://api.example.com"),
+		StatusCode:  0, // transport error — no response received
+		ErrorType:   "network_error",
+		ResendCount: 0,
+		Elapsed:     5 * time.Millisecond,
+	})
+
+	rm := mp.Collect(t)
+
+	durationMetric := obtest.FindMetric(rm, metricRequestDuration)
+	require.NotNil(t, durationMetric)
+	histData := durationMetric.Data.(metricdata.Histogram[float64])
+	require.NotEmpty(t, histData.DataPoints)
+
+	attrs := histData.DataPoints[0].Attributes.ToSlice()
+	assertNoAttribute(t, attrs, attrHTTPStatusCode)
+}
+
+// TestRecordHTTPClientMetricsWithTimeout verifies that a timeout error sets the
+// error.type attribute and omits http.response.status_code when StatusCode is 0.
+func TestRecordHTTPClientMetricsWithTimeout(t *testing.T) {
+	mp, cleanup := setupTestMeterProvider(t)
+	defer cleanup()
+
+	RecordHTTPClientMetrics(context.Background(), &HTTPClientMeasurement{
+		Method:      "GET",
+		URL:         mustParseURL("https://api.example.com"),
+		StatusCode:  0,
+		ErrorType:   "timeout",
+		ResendCount: 0,
+		Elapsed:     30 * time.Second,
+	})
+
+	rm := mp.Collect(t)
+
+	durationMetric := obtest.FindMetric(rm, metricRequestDuration)
+	require.NotNil(t, durationMetric)
+	histData := durationMetric.Data.(metricdata.Histogram[float64])
+	require.NotEmpty(t, histData.DataPoints)
+
+	attrs := histData.DataPoints[0].Attributes.ToSlice()
+	assertHasAttribute(t, attrs, attrErrorType, "timeout")
+	assertNoAttribute(t, attrs, attrHTTPStatusCode)
+}
+
+// TestRecordHTTPClientMetricsWithNonZeroBodySizes verifies that non-zero request and
+// response body sizes emit the corresponding body-size histograms.
+func TestRecordHTTPClientMetricsWithNonZeroBodySizes(t *testing.T) {
+	mp, cleanup := setupTestMeterProvider(t)
+	defer cleanup()
+
+	RecordHTTPClientMetrics(context.Background(), &HTTPClientMeasurement{
+		Method:        "POST",
+		URL:           mustParseURL("https://api.example.com/data"),
+		StatusCode:    201,
+		Elapsed:       20 * time.Millisecond,
+		RequestBytes:  512,
+		ResponseBytes: 1024,
+	})
+
+	rm := mp.Collect(t)
+
+	obtest.AssertMetricExists(t, rm, metricRequestBodySize)
+	obtest.AssertMetricExists(t, rm, metricResponseBodySize)
+
+	reqCount, err := obtest.GetMetricHistogramCount(rm, metricRequestBodySize)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), reqCount)
+
+	respCount, err := obtest.GetMetricHistogramCount(rm, metricResponseBodySize)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), respCount)
+}
+
+// TestRecordHTTPClientMetricsWithZeroBodySizes verifies that body-size histograms are
+// not emitted when RequestBytes and ResponseBytes are both 0.
+func TestRecordHTTPClientMetricsWithZeroBodySizes(t *testing.T) {
+	mp, cleanup := setupTestMeterProvider(t)
+	defer cleanup()
+
+	RecordHTTPClientMetrics(context.Background(), &HTTPClientMeasurement{
+		Method:        "GET",
+		URL:           mustParseURL("https://api.example.com/status"),
+		StatusCode:    200,
+		Elapsed:       5 * time.Millisecond,
+		RequestBytes:  0,
+		ResponseBytes: 0,
+	})
+
+	rm := mp.Collect(t)
+
+	// Body-size metrics must not appear when sizes are 0.
+	assert.Nil(t, obtest.FindMetric(rm, metricRequestBodySize), "request body size metric should not be emitted when 0")
+	assert.Nil(t, obtest.FindMetric(rm, metricResponseBodySize), "response body size metric should not be emitted when 0")
+}
+
+// TestIncDecActiveRequestsBalanced verifies that a paired Inc/Dec results in a net zero
+// active-request count.
+func TestIncDecActiveRequestsBalanced(t *testing.T) {
+	mp, cleanup := setupTestMeterProvider(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	IncActiveRequests(ctx, "svc", "GET")
+	DecActiveRequests(ctx, "svc", "GET")
+
+	rm := mp.Collect(t)
+	obtest.AssertMetricExists(t, rm, metricActiveRequests)
+
+	activeMetric := obtest.FindMetric(rm, metricActiveRequests)
+	require.NotNil(t, activeMetric)
+
+	sumData, ok := activeMetric.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "expected Sum[int64] for active_requests")
+	// Paired inc/dec → net 0, meaning the sum across datapoints is 0.
+	var total int64
+	for _, dp := range sumData.DataPoints {
+		total += dp.Value
+	}
+	assert.Equal(t, int64(0), total, "net active requests should be 0 after balanced inc/dec")
+}
+
+// TestIncRetryWithVariousReasons verifies that IncRetry increments the retry counter
+// with the correct reason attribute for each call.
+func TestIncRetryWithVariousReasons(t *testing.T) {
+	mp, cleanup := setupTestMeterProvider(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	reasons := []string{"timeout", "5xx", "network", "build_response"}
+	for _, r := range reasons {
+		IncRetry(ctx, "svc", r)
+	}
+
+	rm := mp.Collect(t)
+	obtest.AssertMetricExists(t, rm, metricRetriesTotal)
+
+	retryMetric := obtest.FindMetric(rm, metricRetriesTotal)
+	require.NotNil(t, retryMetric)
+
+	sumData, ok := retryMetric.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "expected Sum[int64] for retries.total")
+
+	// Count total and collect distinct reasons seen.
+	var total int64
+	reasonsFound := make(map[string]bool)
+	for _, dp := range sumData.DataPoints {
+		total += dp.Value
+		for _, a := range dp.Attributes.ToSlice() {
+			if string(a.Key) == attrRetryReason {
+				reasonsFound[a.Value.AsString()] = true
+			}
+		}
+	}
+
+	assert.Equal(t, int64(4), total, "expected 4 total retries (one per reason)")
+	for _, r := range reasons {
+		assert.True(t, reasonsFound[r], "reason %q not found in retry attributes", r)
+	}
+}
+
+// TestEmptyPeerNameOmitsPeerServiceAttribute verifies that when PeerName is empty the
+// peer.service attribute is omitted across all instruments (duration, body size, active
+// requests, retries).
+func TestEmptyPeerNameOmitsPeerServiceAttribute(t *testing.T) {
+	mp, cleanup := setupTestMeterProvider(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	RecordHTTPClientMetrics(ctx, &HTTPClientMeasurement{
+		PeerName:      "", // must be omitted
+		Method:        "GET",
+		URL:           mustParseURL("https://api.example.com/ping"),
+		StatusCode:    200,
+		Elapsed:       10 * time.Millisecond,
+		RequestBytes:  100,
+		ResponseBytes: 50,
+	})
+	IncActiveRequests(ctx, "", "GET")
+	DecActiveRequests(ctx, "", "GET")
+	IncRetry(ctx, "", "timeout")
+
+	rm := mp.Collect(t)
+
+	// Duration histogram — no peer.service.
+	durationMetric := obtest.FindMetric(rm, metricRequestDuration)
+	require.NotNil(t, durationMetric)
+	histData := durationMetric.Data.(metricdata.Histogram[float64])
+	require.NotEmpty(t, histData.DataPoints)
+	assertNoAttribute(t, histData.DataPoints[0].Attributes.ToSlice(), attrPeerService)
+
+	// Request body size — no peer.service.
+	reqBodyMetric := obtest.FindMetric(rm, metricRequestBodySize)
+	require.NotNil(t, reqBodyMetric)
+	reqHistData := reqBodyMetric.Data.(metricdata.Histogram[int64])
+	require.NotEmpty(t, reqHistData.DataPoints)
+	assertNoAttribute(t, reqHistData.DataPoints[0].Attributes.ToSlice(), attrPeerService)
+
+	// Active requests — no peer.service.
+	activeMetric := obtest.FindMetric(rm, metricActiveRequests)
+	require.NotNil(t, activeMetric)
+	sumData := activeMetric.Data.(metricdata.Sum[int64])
+	if len(sumData.DataPoints) > 0 {
+		assertNoAttribute(t, sumData.DataPoints[0].Attributes.ToSlice(), attrPeerService)
+	}
+
+	// Retries — no peer.service.
+	retryMetric := obtest.FindMetric(rm, metricRetriesTotal)
+	require.NotNil(t, retryMetric)
+	retrySumData := retryMetric.Data.(metricdata.Sum[int64])
+	require.NotEmpty(t, retrySumData.DataPoints)
+	assertNoAttribute(t, retrySumData.DataPoints[0].Attributes.ToSlice(), attrPeerService)
+}
+
+// TestUnknownMethodNormalizedToOther verifies that an unrecognised HTTP method is
+// normalised to "_OTHER" in the http.request.method attribute.
+func TestUnknownMethodNormalizedToOther(t *testing.T) {
+	mp, cleanup := setupTestMeterProvider(t)
+	defer cleanup()
+
+	RecordHTTPClientMetrics(context.Background(), &HTTPClientMeasurement{
+		Method:     "WEIRD",
+		URL:        mustParseURL("https://api.example.com/op"),
+		StatusCode: 200,
+		Elapsed:    10 * time.Millisecond,
+	})
+
+	rm := mp.Collect(t)
+
+	durationMetric := obtest.FindMetric(rm, metricRequestDuration)
+	require.NotNil(t, durationMetric)
+	histData := durationMetric.Data.(metricdata.Histogram[float64])
+	require.NotEmpty(t, histData.DataPoints)
+
+	assertHasAttribute(t, histData.DataPoints[0].Attributes.ToSlice(), attrHTTPMethod, methodOther)
+}

--- a/httpclient/internal/tracking/testing.go
+++ b/httpclient/internal/tracking/testing.go
@@ -4,10 +4,12 @@ import "sync"
 
 // ResetMeterForTesting resets the package-level meter state so each test starts
 // with a fresh meter. This is intended for use by httpclient package tests that
-// cannot access the unexported resetMeterForTesting helper directly.
-// It is safe to call from any test goroutine, but must not be called concurrently
-// with InitHTTPMeter or any metric-recording function.
+// cannot access the unexported meter state directly. Safe to call concurrently
+// with InitHTTPMeter — the mutex serializes both paths.
 func ResetMeterForTesting() {
+	meterInitMu.Lock()
+	defer meterInitMu.Unlock()
+
 	meterOnce = sync.Once{}
 	httpMeter = nil
 	requestDuration = nil

--- a/httpclient/internal/tracking/testing.go
+++ b/httpclient/internal/tracking/testing.go
@@ -1,0 +1,18 @@
+package tracking
+
+import "sync"
+
+// ResetMeterForTesting resets the package-level meter state so each test starts
+// with a fresh meter. This is intended for use by httpclient package tests that
+// cannot access the unexported resetMeterForTesting helper directly.
+// It is safe to call from any test goroutine, but must not be called concurrently
+// with InitHTTPMeter or any metric-recording function.
+func ResetMeterForTesting() {
+	meterOnce = sync.Once{}
+	httpMeter = nil
+	requestDuration = nil
+	activeRequests = nil
+	requestBodySize = nil
+	responseBodySize = nil
+	retriesTotal = nil
+}

--- a/llms.txt
+++ b/llms.txt
@@ -3941,7 +3941,7 @@ client := httpclient.NewBuilder(log).
 resp, err := client.Get(ctx, &httpclient.Request{URL: "https://api.stripe.com/v1/charges"})
 ```
 
-`WithPeerName` sets the `peer.service` attribute on all emitted metrics (`http.client.request.duration`, `http.client.active_requests`, `http.client.request.body.size`, `http.client.response.body.size`, `http.client.request.resend.count`). Use it to attribute SLO budget consumption per upstream: `"stripe"`, `"visa-vts"`, `"payments-core"`, etc. When omitted the attribute is absent — metrics aggregate across all upstreams.
+`WithPeerName` sets the `peer.service` attribute on all emitted metrics (`http.client.request.duration`, `http.client.active_requests`, `http.client.request.body.size`, `http.client.response.body.size`, `http.client.retries.total`). Use it to attribute SLO budget consumption per upstream: `"stripe"`, `"visa-vts"`, `"payments-core"`, etc. When omitted the attribute is absent — metrics aggregate across all upstreams.
 
 ## Observability & Logging
 

--- a/llms.txt
+++ b/llms.txt
@@ -3929,6 +3929,20 @@ _ = fm.Migrate(ctx, mcfg)  // → AuditEvent fires on both OTel and sink paths
 
 Full guide: [wiki/migration-audit.md](wiki/migration-audit.md). Decision rationale: [ADR-019](wiki/adr-019-migration-audit-delivery.md).
 
+## Outbound HTTP Client
+
+```go
+// Outbound HTTP client with OpenTelemetry metrics (SLO attribution via peer.service)
+client := httpclient.NewBuilder(log).
+    WithTimeout(10 * time.Second).
+    WithPeerName("stripe").
+    Build()
+
+resp, err := client.Get(ctx, &httpclient.Request{URL: "https://api.stripe.com/v1/charges"})
+```
+
+`WithPeerName` sets the `peer.service` attribute on all emitted metrics (`http.client.request.duration`, `http.client.active_requests`, `http.client.request.body.size`, `http.client.response.body.size`, `http.client.request.resend.count`). Use it to attribute SLO budget consumption per upstream: `"stripe"`, `"visa-vts"`, `"payments-core"`, etc. When omitted the attribute is absent — metrics aggregate across all upstreams.
+
 ## Observability & Logging
 
 GoBricks ships **OpenTelemetry traces, metrics, and structured logs out of the box** — flip `observability.enabled: true` and the framework auto-instruments every external boundary (HTTP, database, AMQP, cache, outbound HTTP). No application code is required for the auto-instrumentation; custom spans/metrics/logs slot in on top.

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -29,6 +29,95 @@ resp, err := client.Get(ctx, &httpclient.Request{
 
 **Interface:** `Get`, `Post`, `Put`, `Patch`, `Delete`, `Do` — all accept `context.Context` and `*Request`, return `*Response` and `error`.
 
+## Metrics
+
+### Overview
+
+The `httpclient` package emits five OpenTelemetry instruments under the meter name `go-bricks/httpclient`. All instruments are initialized lazily on first use via `otel.GetMeterProvider()` and governed by `observability.enabled` — when observability is disabled a no-op provider is active and there is zero overhead.
+
+### Instrument Reference
+
+| Name | Kind | Unit | Description |
+|---|---|---|---|
+| `http.client.request.duration` | `Float64Histogram` | `s` | Duration of HTTP client requests |
+| `http.client.active_requests` | `Int64UpDownCounter` | `{request}` | Number of in-flight HTTP client requests |
+| `http.client.request.body.size` | `Int64Histogram` | `By` | Size of HTTP client request bodies |
+| `http.client.response.body.size` | `Int64Histogram` | `By` | Size of HTTP client response bodies |
+| `http.client.retries.total` | `Int64Counter` | `{retry}` | Total number of HTTP client retry attempts |
+
+> **Duration histogram bucket boundaries (explicit):** `0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10` (seconds). These follow the OTel HTTP client semconv recommendation.
+
+### Attribute Reference
+
+**Base attributes** (present on `http.client.request.duration`, `http.client.request.body.size`, and `http.client.response.body.size`):
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `peer.service` | string | Logical peer name set via `WithPeerName`. Omitted when not configured. |
+| `server.address` | string | Hostname extracted from the request URL. |
+| `server.port` | int | Port extracted from URL; defaults to 80 (http) or 443 (https) when absent. |
+| `url.scheme` | string | URL scheme (e.g. `"https"`). |
+| `http.request.method` | string | Uppercase canonical HTTP method. Non-standard methods emit `"_OTHER"`. |
+
+**Duration-only additional attributes** (on `http.client.request.duration` only):
+
+| Attribute | Notes |
+|---|---|
+| `http.response.status_code` | Integer status code. Omitted on transport errors (no response received). |
+| `error.type` | OTel error type enum. Omitted on success and on 4xx/5xx responses — only set for transport-level failures. See `error.type` Enum below. |
+| `http.request.resend_count` | Number of prior attempts. `0` on the first (non-retry) attempt. |
+
+**`http.client.active_requests` attributes:**
+
+| Attribute | Notes |
+|---|---|
+| `peer.service` | Omitted when `WithPeerName` is not set. |
+| `http.request.method` | Canonical HTTP method. |
+| `server.address` | Omitted when not available. |
+
+**`http.client.retries.total` attributes:**
+
+| Attribute | Notes |
+|---|---|
+| `peer.service` | Omitted when `WithPeerName` is not set. |
+| `http.request.method` | Canonical HTTP method. |
+| `retry.reason` | One of `"timeout"`, `"network"`, `"5xx"`, `"build_response"`. |
+
+### `error.type` Enum
+
+| Value | Condition |
+|---|---|
+| `"timeout"` | Framework `TimeoutError`, `context.DeadlineExceeded`, or any `net.Error` where `Timeout() == true` (after more-specific classifiers below are checked). |
+| `"context_canceled"` | `context.Canceled` |
+| `"name_resolution_error"` | `*net.DNSError` (DNS lookup failure, including DNS timeouts) |
+| `"tls_error"` | `*tls.RecordHeaderError` or `*tls.CertificateVerificationError` |
+| `"connection_error"` | `*net.OpError` with `Op == "dial"` (TCP connection refused / unreachable) |
+| `"interceptor_failed"` | `InterceptorError` from a request or response interceptor |
+| `"_OTHER"` | Any other `NetworkError` or unclassified error |
+
+### `WithPeerName` Example
+
+Set a low-cardinality logical service name at client construction time. It populates the `peer.service` attribute on all five instruments and is the recommended primary dimension for SLO dashboards.
+
+```go
+client := httpclient.NewBuilder(log).
+    WithTimeout(10 * time.Second).
+    WithPeerName("visa-vts").
+    Build()
+```
+
+### Cardinality Guidance
+
+Prefer `peer.service` over `server.address` when writing SLO queries and alerts. `peer.service` is a short, stable string set at builder construction time, so cardinality is bounded by the number of downstream services your application calls. `server.address` is the actual hostname resolved at request time and can explode for webhook-dispatcher or fan-out clients that call arbitrary external URLs. No URL path or query string is ever emitted as an attribute.
+
+### JOSE Body-Size Caveat
+
+For clients constructed with `WithJOSE(...)`, the `http.client.request.body.size` and `http.client.response.body.size` histograms measure the plaintext (application-level) body before encryption and after decryption respectively — not the encrypted wire size. A JOSE-aware variant that also records wire sizes is a possible follow-up.
+
+### Test Utilities
+
+The internal `tracking` package (at `httpclient/internal/tracking`) exposes `ResetMeterForTesting()` in `testing.go` for tests that need to swap meter providers between sub-tests. It resets all package-level instrument state to nil so the next `InitHTTPMeter()` call re-registers with whatever provider is active at that point. Because the package is under `internal/`, it is only importable by code within the `httpclient` package boundary.
+
 ## Payload Logging
 
 > **Warning:** payload logging is a debug aid for development/staging only. Enabling it in production widens the audit-log surface and may expose sensitive data to log pipelines.

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -35,6 +35,8 @@ resp, err := client.Get(ctx, &httpclient.Request{
 
 The `httpclient` package emits five OpenTelemetry instruments under the meter name `go-bricks/httpclient`. All instruments are initialized lazily on first use via `otel.GetMeterProvider()` and governed by `observability.enabled` — when observability is disabled a no-op provider is active and there is zero overhead.
 
+**Meter scope:** `go-bricks/httpclient`
+
 ### Instrument Reference
 
 | Name | Kind | Unit | Description |
@@ -69,19 +71,19 @@ The `httpclient` package emits five OpenTelemetry instruments under the meter na
 
 **`http.client.active_requests` attributes:**
 
-| Attribute | Notes |
-|---|---|
-| `peer.service` | Omitted when `WithPeerName` is not set. |
-| `http.request.method` | Canonical HTTP method. |
-| `server.address` | Omitted when not available. |
+| Attribute | Type | Notes |
+|---|---|---|
+| `peer.service` | string | Omitted when `WithPeerName` is not set. |
+| `http.request.method` | string | Canonical HTTP method. |
+| `server.address` | string | Omitted when URL parsing fails or the URL has no hostname. |
 
 **`http.client.retries.total` attributes:**
 
-| Attribute | Notes |
-|---|---|
-| `peer.service` | Omitted when `WithPeerName` is not set. |
-| `http.request.method` | Canonical HTTP method. |
-| `retry.reason` | One of `"timeout"`, `"network"`, `"5xx"`, `"build_response"`. |
+| Attribute | Type | Notes |
+|---|---|---|
+| `peer.service` | string | Omitted when `WithPeerName` is not set. |
+| `http.request.method` | string | Canonical HTTP method. |
+| `retry.reason` | string | One of `"timeout"`, `"network"`, `"5xx"`, `"build_response"`. |
 
 ### `error.type` Enum
 
@@ -116,7 +118,29 @@ For clients constructed with `WithJOSE(...)`, the `http.client.request.body.size
 
 ### Test Utilities
 
-The internal `tracking` package (at `httpclient/internal/tracking`) exposes `ResetMeterForTesting()` in `testing.go` for tests that need to swap meter providers between sub-tests. It resets all package-level instrument state to nil so the next `InitHTTPMeter()` call re-registers with whatever provider is active at that point. Because the package is under `internal/`, it is only importable by code within the `httpclient` package boundary.
+**External module tests (the common case):** Use the `observability/testing` helpers to install an in-memory meter provider, exercise code that calls httpclient, then assert instruments were recorded:
+
+```go
+import (
+    "github.com/gaborage/go-bricks/httpclient"
+    obtest "github.com/gaborage/go-bricks/observability/testing"
+    "go.opentelemetry.io/otel"
+)
+
+func TestMyService(t *testing.T) {
+    mp := obtest.NewTestMeterProvider()
+    prev := otel.GetMeterProvider()
+    otel.SetMeterProvider(mp)
+    t.Cleanup(func() { otel.SetMeterProvider(prev) })
+
+    // ... exercise code that uses httpclient ...
+
+    rm := mp.Collect(t)
+    obtest.AssertMetricExists(t, rm, "http.client.request.duration")
+}
+```
+
+**Internal httpclient tests only:** `tracking.ResetMeterForTesting()` (in `httpclient/internal/tracking/testing.go`) resets cached instrument state so the next `InitHTTPMeter()` re-registers against whichever provider is active. The `internal/` boundary limits this to code within the `httpclient/**` package tree.
 
 ## Payload Logging
 

--- a/wiki/observability.md
+++ b/wiki/observability.md
@@ -6,6 +6,8 @@ GoBricks provides production-grade observability built on OpenTelemetry: distrib
 
 **Key Features:** W3C traceparent propagation, OpenTelemetry metrics (database/HTTP/AMQP/Go runtime), health endpoints (`/health`, `/ready`), dual-mode logging with conditional sampling, environment-aware batching (500ms dev, 5s prod), environment-aware export timeouts (10s dev, 60s prod)
 
+**Per-Subsystem Instrumented Meters:** The framework ships three automatically-instrumented meters alongside the Go runtime meter. `go-bricks/database` records query durations and pool utilisation. `go-bricks/messaging` records AMQP publish and consume durations. `go-bricks/httpclient` records five outbound HTTP instruments: `http.client.request.duration`, `http.client.active_requests`, `http.client.request.body.size`, `http.client.response.body.size`, and `http.client.retries.total`. All three meters are governed by `observability.enabled` and are no-ops when disabled. See [httpclient.md#metrics](httpclient.md#metrics) for the full attribute reference.
+
 **Go Runtime Metrics:** Auto-exports memory, goroutines, CPU, scheduler latency, GC config when `observability.enabled: true`. Follows [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/runtime/go-metrics/)
 
 **Export Timeout Configuration:** GoBricks uses environment-aware export timeouts to balance fail-fast feedback (development) with network resilience (production):


### PR DESCRIPTION
Closes #469.

## Summary

Adds OpenTelemetry metrics to `httpclient/` so operators get aggregate visibility into outbound HTTP latency, error rate, in-flight load, retry pressure, and per-peer SLO attribution. Follows the framework's established `<package>/internal/tracking/metrics.go` pattern (database, messaging precedent) — same meter init via `sync.Once`, same no-op behavior when `observability.enabled=false`.

## What shipped

**5 instruments under meter scope `go-bricks/httpclient`:**

| Instrument | Kind | Unit |
|---|---|---|
| `http.client.request.duration` | Float64Histogram | s |
| `http.client.active_requests` | Int64UpDownCounter | {request} |
| `http.client.request.body.size` | Int64Histogram | By |
| `http.client.response.body.size` | Int64Histogram | By |
| `http.client.retries.total` | Int64Counter | {retry} |

**New builder option:** `httpclient.NewBuilder(log).WithPeerName("stripe").Build()` — attaches `peer.service` (low-cardinality SLO label) alongside OTel-standard `server.address` / `server.port` / `url.scheme` / `http.request.method`.

**Semantics:** one duration observation per attempt (with `http.request.resend_count`); transport errors and post-roundtrip response-build failures both emit metrics ("exactly once per attempt that reaches the wire"); pre-roundtrip build failures correctly do NOT emit (those are application errors, not transport failures).

**Error classification:** `classifyError` maps typed/wrapped errors to OTel `error.type` (`timeout`, `context_canceled`, `name_resolution_error`, `tls_error`, `connection_error`, `interceptor_failed`, `_OTHER`). 4xx/5xx responses leave `error.type` empty — `status_code` carries the signal (per OTel guidance).

## Files changed

- `httpclient/internal/tracking/metrics.go` (new, 322 lines) + `metrics_test.go` (new, 578 lines, 93.1% coverage, 15+ tests) + `testing.go` (new, 20 lines, exports `ResetMeterForTesting`)
- `httpclient/client.go` (+170): `WithPeerName`, `classifyError`, tracking calls in `Do` / `executeAttempt`, retry-reason wiring
- `httpclient/interface.go` (+5): `Config.PeerName`
- `httpclient/constants.go` (+37): retry-reason + error-type constants
- `httpclient/client_test.go` (+372): 4 e2e metric tests + classifyError unit table + retry-reason coherence test
- `wiki/httpclient.md` (+113): new Metrics section (instrument table, attribute reference, error.type enum, WithPeerName example, cardinality guidance, JOSE caveat, test utilities)
- `wiki/observability.md` (+2): note new meter scope
- `CLAUDE.md` (+3): stub line + WithPeerName in example
- `llms.txt` (+14): outbound-HTTP-with-metrics snippet

## Review trail

The branch was built via a multi-agent fleet (subagent-driven-development): 3 tasks × (implementer + spec-compliance + code-quality) + final project-conventions review + xhigh-effort code-review recall pass + security-audit. Key correctness fixes that landed during review:

- `classifyError` ordering: specific error types (DNSError, TLS, OpError dial) now precede the generic `net.Error.Timeout()` fallback; **InterceptorError check moved to the top** so it isn't shadowed when wrapping a net error
- `handleExecutionError` retry-reason now derives from `classifyError` rather than a separate `isTimeout` call — duration histogram's `error.type` and retries counter's `retry.reason` agree on what counts as a timeout
- `buildResponse` failures (response interceptor / body-read errors) emit a histogram observation — post-roundtrip failures count per the "exactly once per attempt that reaches the wire" rule
- `IncRetry` carries `http.request.method`; `IncActiveRequests`/`Dec` carry `server.address`; retry-counter attribute key aligned with messaging precedent (`retry.reason`, not `reason`)
- `ResetMeterForTesting` holds `meterInitMu` to avoid racing with `InitHTTPMeter`

## Tradeoffs / known limitations

- **Body-size measurements for JOSE-wrapped clients** reflect plaintext app bytes, not encrypted wire bytes. Documented in `wiki/httpclient.md` Metrics → JOSE Body-Size Caveat. A JOSE-aware variant is a possible follow-up.
- **`active_requests` `server.address` vs duration histogram `server.address`** can theoretically diverge if a request interceptor rewrites `httpReq.URL.Host` — `Do()` pre-extracts hostname from the caller's URL string, while `RecordHTTPClientMetrics` uses `httpReq.URL` (post-interceptor). Edge case (no framework interceptor rewrites the host today); noted here for future awareness.
- **Tracing (spans per outbound request) is out of scope** — separate follow-up. Sampling, URL redaction in span names, and span-link semantics across retries deserve their own design pass.

## Test plan

- [ ] `make check` passes (✅ confirmed locally)
- [ ] `go test ./httpclient/... -race -count=1` passes (✅ confirmed locally)
- [ ] `go test -cover ./httpclient/internal/tracking/` reports ≥90% (✅ 93.1% locally)
- [ ] CI: Ubuntu + Windows × Go 1.25 green
- [ ] SonarCloud quality gate green; PR-scoped NEW issues addressed (per CLAUDE.md workflow rule)
- [ ] CodeRabbit findings addressed (nitpicks included)
- [ ] Manual smoke (optional): build a small demo binary, point it at an httptest server, export OTLP to a local collector, verify `http.client.*` metrics with the documented attribute set


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP client supports peer name configuration for metrics attribution
  * Added OpenTelemetry metrics for outbound HTTP requests: duration, active requests, body/response sizes, and retry counts

* **Documentation**
  * Added HTTP client metrics docs and an "Outbound HTTP Client" example
  * Updated observability docs to include per-subsystem metrics info

* **Tests**
  * Added extensive tests for HTTP client metrics, retries, and error classification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->