### PR TITLE
fix(messaging): auto-resubscribe consumers after AMQP reconnect

### DIFF
--- a/messaging/constants.go
+++ b/messaging/constants.go
@@ -28,6 +28,15 @@ const (
 	maxPrefetchCount = 1000
 )
 
+// Consumer log-field names. Shared by the consumer session, worker, and
+// re-subscribe log contexts so the structured field keys stay consistent
+// (and to satisfy goconst now that they appear in 3+ field maps).
+const (
+	genericQueue     = "queue"
+	genericConsumer  = "consumer"
+	genericEventType = "event_type"
+)
+
 // Registry readiness polling. Previously inline literals in registry.go's
 // "wait for AMQP client ready" loop.
 const (

--- a/messaging/manager_test.go
+++ b/messaging/manager_test.go
@@ -53,9 +53,21 @@ func (s *stubAMQPClient) ConsumeFromQueue(_ context.Context, _ ConsumeOptions) (
 	s.closedMu.Lock()
 	s.consumers++
 	s.closedMu.Unlock()
-	ch := make(chan amqp.Delivery)
-	close(ch)
-	return ch, nil
+	// Return an open delivery channel (never closed) so the consumer supervisor
+	// parks waiting for deliveries instead of treating an immediately-closed
+	// channel as a flap and re-subscribing — which would make consumerCount()
+	// non-deterministic. Tests stop the supervisor via manager.Close().
+	return make(chan amqp.Delivery), nil
+}
+
+// consumerCount returns the number of ConsumeFromQueue calls observed, read
+// under the same lock the counter is written with. The registry's per-consumer
+// supervisor calls ConsumeFromQueue from a background goroutine, so tests must
+// not read s.consumers directly.
+func (s *stubAMQPClient) consumerCount() int {
+	s.closedMu.Lock()
+	defer s.closedMu.Unlock()
+	return s.consumers
 }
 
 func (s *stubAMQPClient) DeclareQueue(string, bool, bool, bool, bool) error            { return nil }
@@ -213,6 +225,7 @@ func TestMessagingManagerEnsureConsumersIdempotent(t *testing.T) {
 	client := &stubAMQPClient{}
 	factory := func(string, logger.Logger) AMQPClient { return client }
 	manager := NewMessagingManager(&stubMessagingSource{urls: map[string]string{tenantID: amqpHost}}, log, ManagerOptions{MaxPublishers: 5, IdleTTL: time.Minute}, factory)
+	defer func() { _ = manager.Close() }() // stop supervisor goroutines
 
 	decls := NewDeclarations()
 	decls.RegisterQueue(&QueueDeclaration{Name: genericQueue})
@@ -223,7 +236,7 @@ func TestMessagingManagerEnsureConsumersIdempotent(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	assert.Equal(t, 1, client.consumers)
+	assert.Equal(t, 1, client.consumerCount())
 }
 
 type mockMessageHandler struct{}
@@ -252,6 +265,7 @@ func TestMessagingManagerInjectsTenantIntoConsumerContext(t *testing.T) {
 	client := &stubAMQPClient{}
 	factory := func(string, logger.Logger) AMQPClient { return client }
 	manager := NewMessagingManager(&stubMessagingSource{urls: map[string]string{testTenantID: amqpHost}}, log, ManagerOptions{MaxPublishers: 5, IdleTTL: time.Minute}, factory)
+	defer func() { _ = manager.Close() }() // stop supervisor goroutines
 
 	decls := NewDeclarations()
 	decls.RegisterQueue(&QueueDeclaration{Name: testQueue})
@@ -261,7 +275,7 @@ func TestMessagingManagerInjectsTenantIntoConsumerContext(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that consumer was started
-	assert.Equal(t, 1, client.consumers)
+	assert.Equal(t, 1, client.consumerCount())
 
 	// The actual verification of tenant context injection would require
 	// importing multitenant package and checking the context in the handler

--- a/messaging/registry.go
+++ b/messaging/registry.go
@@ -15,6 +15,14 @@ import (
 	gobrickstrace "github.com/gaborage/go-bricks/trace"
 )
 
+// defaultConsumerResubscribeDelay is the wait between consumer re-subscribe
+// attempts after the broker closes the delivery channel (a connection or
+// channel flap). It mirrors the AMQP client's reconnect delay so consumers do
+// not hammer ConsumeFromQueue while the client is still re-establishing its
+// connection. Overridable per-registry (see Registry.resubscribeDelay) for
+// fast test iteration.
+const defaultConsumerResubscribeDelay = 5 * time.Second
+
 // RegistryInterface defines the contract for messaging infrastructure management.
 // This interface allows for easy mocking and testing of messaging infrastructure.
 type RegistryInterface interface {
@@ -61,6 +69,10 @@ type Registry struct {
 	declared        bool
 	consumersActive bool
 	cancelConsumers context.CancelFunc
+	// resubscribeDelay is the backoff between consumer re-subscribe attempts
+	// after a delivery-channel close. Defaults to defaultConsumerResubscribeDelay;
+	// tests lower it for fast iteration.
+	resubscribeDelay time.Duration
 }
 
 // ExchangeDeclaration defines an exchange to be declared
@@ -122,14 +134,15 @@ type ConsumerDeclaration struct {
 // NewRegistry creates a new messaging registry
 func NewRegistry(client AMQPClient, log logger.Logger) *Registry {
 	return &Registry{
-		client:        client,
-		logger:        log,
-		exchanges:     make(map[string]*ExchangeDeclaration),
-		queues:        make(map[string]*QueueDeclaration),
-		bindings:      make([]*BindingDeclaration, 0),
-		publishers:    make([]*PublisherDeclaration, 0),
-		consumerIndex: make(map[consumerKey]*ConsumerDeclaration),
-		consumerOrder: make([]consumerKey, 0),
+		client:           client,
+		logger:           log,
+		exchanges:        make(map[string]*ExchangeDeclaration),
+		queues:           make(map[string]*QueueDeclaration),
+		bindings:         make([]*BindingDeclaration, 0),
+		publishers:       make([]*PublisherDeclaration, 0),
+		consumerIndex:    make(map[consumerKey]*ConsumerDeclaration),
+		consumerOrder:    make([]consumerKey, 0),
+		resubscribeDelay: defaultConsumerResubscribeDelay,
 	}
 }
 
@@ -433,9 +446,12 @@ func (r *Registry) StopConsumers() {
 	r.logger.Info().Msg("All consumers stopped")
 }
 
-// startSingleConsumer starts a consumer for a specific queue and routes messages to the handler.
-func (r *Registry) startSingleConsumer(ctx context.Context, consumer *ConsumerDeclaration) error {
-	deliveries, err := r.client.ConsumeFromQueue(ctx, ConsumeOptions{
+// consumeOptionsFor builds the ConsumeOptions for a consumer declaration. It is
+// shared by the initial subscription and every re-subscription so the broker
+// re-applies identical settings (QoS/prefetch, consumer tag, ack mode) on the
+// new channel after a reconnect.
+func (r *Registry) consumeOptionsFor(consumer *ConsumerDeclaration) ConsumeOptions {
+	return ConsumeOptions{
 		Queue:         consumer.Queue,
 		Consumer:      consumer.Consumer,
 		AutoAck:       consumer.AutoAck,
@@ -443,32 +459,145 @@ func (r *Registry) startSingleConsumer(ctx context.Context, consumer *ConsumerDe
 		NoLocal:       consumer.NoLocal,
 		NoWait:        consumer.NoWait,
 		PrefetchCount: consumer.PrefetchCount,
-	})
+	}
+}
+
+// startSingleConsumer starts a consumer for a specific queue and routes messages to the handler.
+// The first subscription is established synchronously so an unreachable broker
+// fails startup (fail-fast); the supervisor goroutine then keeps the consumer
+// alive across broker reconnects (see superviseConsumer).
+func (r *Registry) startSingleConsumer(ctx context.Context, consumer *ConsumerDeclaration) error {
+	deliveries, err := r.client.ConsumeFromQueue(ctx, r.consumeOptionsFor(consumer))
 	if err != nil {
 		return fmt.Errorf("failed to start consuming from queue %s: %w", consumer.Queue, err)
 	}
 
-	// Start goroutine to handle messages
-	go r.handleMessages(ctx, consumer, deliveries)
+	// Supervise the subscription so it survives AMQP reconnects: when the broker
+	// closes the delivery channel (connection/channel flap), superviseConsumer
+	// re-subscribes on the client's new channel instead of leaving the queue
+	// with zero consumers until a process restart.
+	go r.superviseConsumer(ctx, consumer, deliveries)
 
 	return nil
 }
 
-// handleMessages processes messages from a consumer and routes them to the handler.
-// v0.17+: Spawns a worker pool for concurrent message processing.
-func (r *Registry) handleMessages(ctx context.Context, consumer *ConsumerDeclaration, deliveries <-chan amqp.Delivery) {
+// superviseConsumer runs consumer sessions back-to-back, re-subscribing after
+// the broker drops the delivery channel, until the consumer context is
+// cancelled (StopConsumers / shutdown). This is the consumer-side counterpart
+// to the client's reconnection supervisor: the publisher path recovers because
+// every publish re-reads the live channel under lock, whereas a consumer
+// captures its delivery channel once, so it needs an explicit re-subscribe.
+func (r *Registry) superviseConsumer(ctx context.Context, consumer *ConsumerDeclaration, deliveries <-chan amqp.Delivery) {
+	for {
+		// Run one subscription session until the delivery channel closes
+		// (reconnect needed) or the context is cancelled (stop for good).
+		sessionStart := time.Now()
+		if !r.handleMessages(ctx, consumer, deliveries) {
+			return // context cancelled → stop for good
+		}
+
+		// Rapid-flap guard: if the session barely lasted, the broker is handing
+		// back channels that close almost immediately. Pace re-subscribes by the
+		// backoff floor so this can't become a tight loop. A healthy (long-lived)
+		// session falls through and re-subscribes immediately for fast recovery.
+		if elapsed := time.Since(sessionStart); elapsed < r.resubscribeDelay {
+			if !sleepCtx(ctx, r.resubscribeDelay-elapsed) {
+				return
+			}
+		}
+
+		next, ok := r.resubscribe(ctx, consumer)
+		if !ok {
+			return // context cancelled while waiting to re-subscribe
+		}
+		deliveries = next
+	}
+}
+
+// sleepCtx waits for d, or until ctx is cancelled, whichever comes first. It
+// returns true if the full duration elapsed and false if ctx was cancelled.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+// consumerLogFields returns the base structured-log fields identifying a
+// consumer, shared by the session, worker, and re-subscribe log contexts so the
+// field keys are defined in exactly one place.
+func consumerLogFields(consumer *ConsumerDeclaration) map[string]any {
+	return map[string]any{
+		genericQueue:     consumer.Queue,
+		genericConsumer:  consumer.Consumer,
+		genericEventType: consumer.EventType,
+	}
+}
+
+// resubscribe re-establishes a consumer subscription after the delivery channel
+// closed. It attempts immediately so a routine channel-only flap (the client's
+// connection is still up) recovers without added downtime, then on failure
+// backs off with full jitter before retrying, until ConsumeFromQueue succeeds
+// or the context is cancelled. Returns (channel, true) on success and
+// (nil, false) on cancellation.
+//
+// A success-then-immediately-closing channel cannot become a tight spin: the
+// client only hands out a fresh usable channel via its own reconnect supervisor
+// (handleReInit, paced by reInitDelay), and while the client is not ready
+// ConsumeFromQueue returns errNotConnected, which takes the backoff path below.
+func (r *Registry) resubscribe(ctx context.Context, consumer *ConsumerDeclaration) (<-chan amqp.Delivery, bool) {
+	log := r.logger.WithFields(consumerLogFields(consumer))
+
+	for attempt := 1; ; attempt++ {
+		// Stop promptly if we're shutting down before trying again.
+		if ctx.Err() != nil {
+			return nil, false
+		}
+
+		deliveries, err := r.client.ConsumeFromQueue(ctx, r.consumeOptionsFor(consumer))
+		if err == nil {
+			log.Info().Int("attempt", attempt).
+				Msg("Consumer re-subscribed after delivery channel closed")
+			return deliveries, true
+		}
+
+		// errNotConnected is expected while the client is still reconnecting;
+		// log at debug to avoid noise during a flap. Full-jitter backoff (the
+		// client's own computeBackoff) bounds the loop and, on a broker restart
+		// that drops every consumer at once, spreads the herd of re-subscribe
+		// attempts instead of having all consumers retry in lockstep.
+		backoff := computeBackoff(r.resubscribeDelay, defaultReconnectMaxDelay, attempt)
+		log.Debug().Err(err).Int("attempt", attempt).Dur("backoff", backoff).
+			Msg("Consumer re-subscribe attempt failed, will retry")
+		select {
+		case <-ctx.Done():
+			return nil, false
+		case <-time.After(backoff):
+		}
+	}
+}
+
+// handleMessages runs a single consumer session: it spawns a worker pool
+// (v0.17+) and feeds deliveries to it until the session ends. It returns true
+// when the broker closed the delivery channel (the caller should re-subscribe)
+// and false when the context was cancelled (shut down for good).
+func (r *Registry) handleMessages(ctx context.Context, consumer *ConsumerDeclaration, deliveries <-chan amqp.Delivery) bool {
 	workers := consumer.Workers
 	if workers <= 0 {
 		workers = 1 // Fallback (should not happen with smart defaults)
 	}
 
-	log := r.logger.WithFields(map[string]any{
-		"queue":      consumer.Queue,
-		"consumer":   consumer.Consumer,
-		"event_type": consumer.EventType,
-		"workers":    workers,
-		"prefetch":   consumer.PrefetchCount,
-	})
+	fields := consumerLogFields(consumer)
+	fields["workers"] = workers
+	fields["prefetch"] = consumer.PrefetchCount
+	log := r.logger.WithFields(fields)
 
 	log.Info().Msg("Message handler started with worker pool")
 
@@ -486,24 +615,34 @@ func (r *Registry) handleMessages(ctx context.Context, consumer *ConsumerDeclara
 		go r.worker(ctx, consumer, jobs, i, &wg)
 	}
 
-	// Main loop: feed jobs to worker pool
-	func() {
+	// Main loop: feed jobs to worker pool. reconnect=true means the broker
+	// closed the delivery channel (the caller should re-subscribe); false means
+	// the context was cancelled (shut down for good).
+	reconnect := func() bool {
 		for {
 			select {
 			case <-ctx.Done():
 				log.Info().Msg("Consumer context cancelled, stopping message handler")
-				return
+				return false
 
 			case delivery, ok := <-deliveries:
 				if !ok {
-					log.Warn().Msg("Delivery channel closed, stopping message handler")
-					return
+					log.Warn().Msg("Delivery channel closed, will re-subscribe")
+					return true
 				}
 
 				// Create local copy to avoid pointer capture bug (loop variable reuse)
 				d := delivery
-				// Send to worker pool (blocks if all workers busy)
-				jobs <- &d
+				// Send to the worker pool, but also honor cancellation: without
+				// the ctx.Done() arm the feed loop could block forever on a full
+				// buffer after workers have already exited on shutdown, leaking
+				// this goroutine (and the supervisor that owns it).
+				select {
+				case jobs <- &d:
+				case <-ctx.Done():
+					log.Info().Msg("Consumer context cancelled, stopping message handler")
+					return false
+				}
 			}
 		}
 	}()
@@ -512,6 +651,7 @@ func (r *Registry) handleMessages(ctx context.Context, consumer *ConsumerDeclara
 	close(jobs)
 	wg.Wait()
 	log.Info().Msg("All workers stopped gracefully")
+	return reconnect
 }
 
 // worker processes messages from the jobs channel concurrently.
@@ -519,12 +659,9 @@ func (r *Registry) handleMessages(ctx context.Context, consumer *ConsumerDeclara
 func (r *Registry) worker(ctx context.Context, consumer *ConsumerDeclaration, jobs <-chan *amqp.Delivery, workerID int, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	log := r.logger.WithFields(map[string]any{
-		"queue":      consumer.Queue,
-		"consumer":   consumer.Consumer,
-		"event_type": consumer.EventType,
-		"worker_id":  workerID,
-	})
+	fields := consumerLogFields(consumer)
+	fields["worker_id"] = workerID
+	log := r.logger.WithFields(fields)
 
 	log.Debug().Msg("Worker started")
 

--- a/messaging/registry_test.go
+++ b/messaging/registry_test.go
@@ -802,22 +802,21 @@ func TestRegistryHandleMessagesContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Use synchronization channels instead of sleep
-	handlerDone := make(chan struct{})
+	handlerDone := make(chan bool, 1)
 	handlerStarted := make(chan struct{})
 	go func() {
 		close(handlerStarted) // Signal handler is about to start
-		registry.handleMessages(ctx, consumer, deliveries)
-		close(handlerDone)
+		handlerDone <- registry.handleMessages(ctx, consumer, deliveries)
 	}()
 
 	// Wait for handler to start, then cancel context immediately
 	<-handlerStarted
 	cancel()
 
-	// Handler should stop
+	// Handler should stop and report "no re-subscribe" (shutdown, not a flap).
 	select {
-	case <-handlerDone:
-		// Expected
+	case reconnect := <-handlerDone:
+		assert.False(t, reconnect, "context cancellation must not signal re-subscribe")
 	case <-time.After(1 * time.Second):
 		t.Fatal("Handler did not stop after context cancellation")
 	}
@@ -842,22 +841,22 @@ func TestRegistryHandleMessagesChannelClosure(t *testing.T) {
 	ctx := context.Background()
 
 	// Use synchronization channels instead of sleep
-	handlerDone := make(chan struct{})
+	handlerDone := make(chan bool, 1)
 	handlerStarted := make(chan struct{})
 	go func() {
 		close(handlerStarted) // Signal handler is about to start
-		registry.handleMessages(ctx, consumer, deliveries)
-		close(handlerDone)
+		handlerDone <- registry.handleMessages(ctx, consumer, deliveries)
 	}()
 
 	// Wait for handler to start, then close delivery channel immediately
 	<-handlerStarted
 	close(deliveries)
 
-	// Handler should stop
+	// Handler should stop and report "re-subscribe" (the broker closed the
+	// delivery channel; this is a flap, not a shutdown).
 	select {
-	case <-handlerDone:
-		// Expected
+	case reconnect := <-handlerDone:
+		assert.True(t, reconnect, "delivery-channel close must signal re-subscribe")
 	case <-time.After(1 * time.Second):
 		t.Fatal("Handler did not stop after channel closure")
 	}
@@ -1995,4 +1994,198 @@ func BenchmarkSequentialVsConcurrent(b *testing.B) {
 			registry.handleMessages(ctx, consumer, deliveries)
 		}
 	})
+}
+
+// ===== Consumer Re-subscribe After Reconnect Tests =====
+
+// consumeResult is one scripted return value for resubscribingMockClient.
+type consumeResult struct {
+	ch  <-chan amqp.Delivery
+	err error
+}
+
+// resubscribingMockClient hands out scripted ConsumeFromQueue results on
+// successive calls, so a test can simulate an AMQP flap by closing the active
+// delivery channel and assert the registry re-subscribes onto the next one.
+// Once the script is exhausted it returns exhaustedErr (keeping the supervisor
+// in the retry/backoff loop) or, if that is nil, a never-closing open channel.
+type resubscribingMockClient struct {
+	*simpleMockAMQPClient
+	callMu       sync.Mutex
+	results      []consumeResult
+	calls        int
+	exhaustedErr error
+}
+
+var _ AMQPClient = (*resubscribingMockClient)(nil)
+
+func (m *resubscribingMockClient) ConsumeFromQueue(_ context.Context, _ ConsumeOptions) (<-chan amqp.Delivery, error) {
+	m.callMu.Lock()
+	defer m.callMu.Unlock()
+	idx := m.calls
+	m.calls++
+	if idx < len(m.results) {
+		return m.results[idx].ch, m.results[idx].err
+	}
+	if m.exhaustedErr != nil {
+		return nil, m.exhaustedErr // keep the supervisor in the retry/backoff loop
+	}
+	return make(chan amqp.Delivery), nil // park: open channel that never closes
+}
+
+func (m *resubscribingMockClient) consumeCallCount() int {
+	m.callMu.Lock()
+	defer m.callMu.Unlock()
+	return m.calls
+}
+
+// TestRegistryConsumerResubscribesAfterDeliveryChannelCloses is the regression
+// test for the consumer-not-resubscribing-after-reconnect bug: when the broker
+// closes the active delivery channel (a connection/channel flap), the registry
+// must acquire a fresh subscription instead of leaving the queue with zero
+// consumers until a process restart.
+func TestRegistryConsumerResubscribesAfterDeliveryChannelCloses(t *testing.T) {
+	ch1 := make(chan amqp.Delivery)
+	ch2 := make(chan amqp.Delivery, 1) // buffered so the post-reconnect send never blocks
+	client := &resubscribingMockClient{
+		simpleMockAMQPClient: &simpleMockAMQPClient{isReady: true},
+		results:              []consumeResult{{ch: ch1}, {ch: ch2}},
+	}
+	registry := NewRegistry(client, &stubLogger{})
+	registry.resubscribeDelay = 5 * time.Millisecond // fast re-subscribe for the test
+
+	handler := &countingTestHandler{}
+	registry.RegisterConsumer(&ConsumerDeclaration{
+		Queue:     testQueueName,
+		EventType: testEventType,
+		Workers:   1,
+		Handler:   handler,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, registry.StartConsumers(ctx))
+
+	// Simulate an AMQP flap: the broker closes the active delivery channel.
+	close(ch1)
+
+	// The consumer must re-subscribe (acquire ch2) without a process restart.
+	require.Eventually(t, func() bool {
+		return client.consumeCallCount() >= 2
+	}, time.Second, 2*time.Millisecond, "consumer did not re-subscribe after delivery channel close")
+
+	// Prove the new subscription is live: a delivery on ch2 is processed.
+	ch2 <- amqp.Delivery{
+		MessageId:    testMessageID,
+		Body:         []byte(testMessageBody),
+		Headers:      amqp.Table{},
+		Acknowledger: &mockAcknowledger{},
+	}
+	require.Eventually(t, func() bool {
+		return handler.CallCount() >= 1
+	}, time.Second, 2*time.Millisecond, "delivery after re-subscribe was not processed")
+
+	registry.StopConsumers()
+}
+
+// TestRegistryConsumerResubscribeRetriesUntilClientReady verifies the
+// re-subscribe loop backs off and retries while the AMQP client is still
+// re-establishing its connection (ConsumeFromQueue returns errNotConnected),
+// then succeeds once the client is ready again.
+func TestRegistryConsumerResubscribeRetriesUntilClientReady(t *testing.T) {
+	ch1 := make(chan amqp.Delivery)
+	ch2 := make(chan amqp.Delivery, 1)
+	client := &resubscribingMockClient{
+		simpleMockAMQPClient: &simpleMockAMQPClient{isReady: true},
+		results: []consumeResult{
+			{ch: ch1},              // initial subscription
+			{err: errNotConnected}, // client still reconnecting
+			{err: errNotConnected}, // still reconnecting
+			{ch: ch2},              // client ready again
+		},
+	}
+	registry := NewRegistry(client, &stubLogger{})
+	registry.resubscribeDelay = 5 * time.Millisecond
+
+	handler := &countingTestHandler{}
+	registry.RegisterConsumer(&ConsumerDeclaration{
+		Queue:     testQueueName,
+		EventType: testEventType,
+		Workers:   1,
+		Handler:   handler,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, registry.StartConsumers(ctx))
+
+	close(ch1) // flap
+
+	// Must keep retrying through the two errNotConnected results to the success.
+	require.Eventually(t, func() bool {
+		return client.consumeCallCount() >= 4
+	}, 2*time.Second, 2*time.Millisecond, "consumer did not retry re-subscribe until client ready")
+
+	ch2 <- amqp.Delivery{
+		MessageId:    testMessageID,
+		Body:         []byte(testMessageBody),
+		Headers:      amqp.Table{},
+		Acknowledger: &mockAcknowledger{},
+	}
+	require.Eventually(t, func() bool {
+		return handler.CallCount() >= 1
+	}, time.Second, 2*time.Millisecond, "delivery after re-subscribe was not processed")
+
+	registry.StopConsumers()
+}
+
+// TestRegistryConsumerSupervisorStopsOnContextCancel verifies the consumer
+// supervisor exits cleanly when StopConsumers cancels the context mid-backoff,
+// and does not keep re-subscribing afterwards (no zombie goroutine).
+func TestRegistryConsumerSupervisorStopsOnContextCancel(t *testing.T) {
+	ch1 := make(chan amqp.Delivery)
+	client := &resubscribingMockClient{
+		simpleMockAMQPClient: &simpleMockAMQPClient{isReady: true},
+		results:              []consumeResult{{ch: ch1}},
+		// After the first session every re-subscribe attempt fails, so the
+		// supervisor stays in the retry/backoff loop (rather than parking on a
+		// success channel) and we can cancel while it is actively retrying.
+		exhaustedErr: errNotConnected,
+	}
+	registry := NewRegistry(client, &stubLogger{})
+	registry.resubscribeDelay = 5 * time.Millisecond
+
+	registry.RegisterConsumer(&ConsumerDeclaration{
+		Queue:     testQueueName,
+		EventType: testEventType,
+		Workers:   1,
+		Handler:   &countingTestHandler{},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, registry.StartConsumers(ctx))
+
+	// Flap, then wait until the supervisor is actively retrying (it has called
+	// ConsumeFromQueue again and is failing into backoff) before cancelling, so
+	// this exercises cancellation from inside the retry/backoff path.
+	close(ch1)
+	require.Eventually(t, func() bool {
+		return client.consumeCallCount() >= 2
+	}, time.Second, 2*time.Millisecond, "supervisor did not enter the re-subscribe retry loop")
+
+	registry.StopConsumers() // cancel while the supervisor is retrying
+
+	// Cancellation interrupts resubscribe's backoff select immediately (it
+	// selects on ctx.Done alongside the backoff timer), so the supervisor exits
+	// after at most one already-dispatched ConsumeFromQueue rather than waiting
+	// out a backoff. Let that in-flight call settle, then require the count to
+	// stay frozen across a window much larger than the re-subscribe backoff: a
+	// still-alive supervisor would keep incrementing it. This avoids a
+	// re-polling check that could land inside a single jittered backoff gap.
+	time.Sleep(10 * registry.resubscribeDelay)
+	settled := client.consumeCallCount()
+	time.Sleep(20 * registry.resubscribeDelay)
+	assert.Equal(t, settled, client.consumeCallCount(),
+		"supervisor kept re-subscribing after StopConsumers")
 }

--- a/messaging/testconsts_test.go
+++ b/messaging/testconsts_test.go
@@ -100,11 +100,12 @@ const (
 	tenant2ID    = "tenant2"
 	testTenantID = "test-tenant"
 
-	// Generic identifiers (short forms)
-	genericQueue    = "queue"
-	genericConsumer = "consumer"
-	genericError    = "error"
-	genericEx       = "ex"
+	// Generic identifiers (short forms). genericQueue, genericConsumer, and
+	// genericEventType now live in constants.go (production) so registry.go
+	// shares the same structured-log field keys; tests still reference them via
+	// package scope.
+	genericError = "error"
+	genericEx    = "ex"
 
 	// Event types
 	eventTestEvent = "TestEvent"


### PR DESCRIPTION
## Problem

Consumers started via `messaging.Registry.StartConsumers` do **not** re-subscribe after an AMQP reconnect. On any RabbitMQ flap or restart, amqp091 closes the consumer's delivery channel, `handleMessages` logged *"Delivery channel closed, stopping message handler"* and the goroutine returned **permanently** — leaving the queue with `consumers=0` until a process restart. Meanwhile the relay publisher recovers fine, so outbox rows keep getting republished into a queue nobody is draining.

This was reported downstream as a consumer that never recovers after an RMQ flap (queue piles up, `consumers=0`, only an API restart fixes it). Verified against **v0.37.0** — `messaging/` at that tag is byte-identical to current `main`.

## Root cause — a publisher/consumer lifecycle asymmetry

The AMQP client has a full reconnection supervisor (`handleReconnect` → `handleReInit` → `init` → `changeChannel`) that rebuilds the connection + channel and restarts the **publish-confirm dispatcher**. The **publisher** rides this for free: every `Publish` re-reads `c.channel` under lock and gates on `isReady`.

The **consumer** captures its `<-chan amqp.Delivery` exactly once at startup and has no re-acquisition path. The reconnect supervisor never calls back into the `Registry` to re-`Consume` on the new channel. `StartConsumers` has exactly one non-test caller (`manager.go`), invoked once per tenant at setup.

## Fix

A per-consumer supervisor that re-subscribes on the client's new channel after a flap — **entirely within `messaging/registry.go`**, with no changes to the publish-confirm / `changeChannel` machinery:

- `startSingleConsumer` keeps the first `ConsumeFromQueue` **synchronous** (preserves fail-fast startup), then spawns `superviseConsumer`.
- `handleMessages` now returns whether the delivery channel **closed** (re-subscribe) vs the **context was cancelled** (stop). It is strictly sequential per consumer, so it cannot double-subscribe.
- `resubscribe` attempts immediately (a routine channel-only flap recovers with no added downtime), then on failure backs off with **full jitter** — reusing the client's own `computeBackoff` so a broker restart that drops every consumer at once doesn't stampede `ConsumeFromQueue` in lockstep.

### Hardening from self-review (`/code-review` + `/security-audit`)

- The worker-pool feed now selects on `ctx.Done()` when handing off a delivery, so it can no longer block forever on a full buffer after workers exit on shutdown (a latent **goroutine leak**, now reachable via the supervisor).
- Shared consumer log fields via `consumerLogFields`; promoted the field-name constants to `constants.go` (also satisfies goconst) and removed the now-duplicate test-only copies.

In-flight deliveries abandoned on shutdown are redelivered by the broker (`AutoAck=false`), preserving **at-least-once**.

## Tests

- `TestRegistryConsumerResubscribesAfterDeliveryChannelCloses` — regression test: close the active delivery channel → consumer re-subscribes onto the next one and processes a post-reconnect message. **Fails on `main`, passes here.**
- `TestRegistryConsumerResubscribeRetriesUntilClientReady` — backs off and retries through `errNotConnected` until the client is ready.
- `TestRegistryConsumerSupervisorStopsOnContextCancel` — supervisor exits cleanly on `StopConsumers` (no zombie goroutine).
- Updated the two direct `handleMessages` tests to assert the new `bool` contract.

`make check` green; `go test ./messaging/ -race -count=3` green.

## Follow-ups (out of scope)

- Wire the re-subscribe cadence to a YAML config key (`messaging.reconnect.*`) once those are actually plumbed into `NewAMQPClient`/`NewRegistry` (today neither the client's reconnect delays nor this one are operator-tunable). Default mirrors the client's reconnect delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic, paced consumer re-subscription with backoff/jitter for resilient message processing.
  * Centralized structured-log field keys and worker identifiers surfaced for consistent logging.

* **Bug Fixes**
  * Safer shutdown and cancellation-aware job feeding to prevent blocked goroutines and leaks during restarts.

* **Tests**
  * Deterministic tests, mocks, and synchronized helpers added/updated to validate resubscribe, retry/backoff, and supervisor shutdown.

* **Documentation**
  * Tests updated to reference shared logging-key comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->