### PR TITLE
fix(messaging): stop reconnect goroutine on Close for never-ready clients (fixes flaky -race)

### DIFF
--- a/messaging/amqp_client.go
+++ b/messaging/amqp_client.go
@@ -26,16 +26,26 @@ import (
 // AMQPClientImpl provides an AMQP implementation of the messaging client interface.
 // It includes automatic reconnection, retry logic, and AMQP-specific features.
 type AMQPClientImpl struct {
-	m               *sync.RWMutex
-	brokerURL       string
-	log             logger.Logger
-	connection      amqpConnection
-	channel         amqpChannel
-	done            chan bool
+	m          *sync.RWMutex
+	brokerURL  string
+	log        logger.Logger
+	connection amqpConnection
+	channel    amqpChannel
+	done       chan bool
+	// reconnectDone is closed by handleReconnect when it returns. Close does not
+	// block on it (Close stays non-blocking), but it lets tests confirm the
+	// reconnection goroutine has fully exited so a leaked goroutine can't race
+	// later tests through the shared dial func. Set only when NewAMQPClient
+	// starts the goroutine; nil for manually-constructed test clients.
+	reconnectDone   chan struct{}
 	notifyConnClose chan *amqp.Error
 	notifyChanClose chan *amqp.Error
 	notifyConfirm   chan amqp.Confirmation
 	isReady         bool
+	// closed marks that Close has run. It is distinct from isReady: a client
+	// that never finished connecting is not ready but is also not closed, and
+	// Close must still stop its reconnection goroutine. Guarded by c.m.
+	closed bool
 
 	// pendingPublishes correlates broker confirmations to the in-flight publish
 	// that issued them. Keyed by (channel generation, DeliveryTag) →
@@ -114,6 +124,7 @@ func NewAMQPClient(brokerURL string, log logger.Logger) *AMQPClientImpl {
 		brokerURL:         brokerURL,
 		log:               log,
 		done:              make(chan bool),
+		reconnectDone:     make(chan struct{}),
 		reconnectDelay:    defaultReconnectDelay,
 		reconnectMaxDelay: defaultReconnectMaxDelay,
 		reInitDelay:       defaultReInitDelay,
@@ -489,11 +500,15 @@ func (c *AMQPClientImpl) BindQueue(queue, exchange, routingKey string, noWait bo
 // Close gracefully shuts down the AMQP client.
 func (c *AMQPClientImpl) Close() error {
 	c.m.Lock()
-	defer c.m.Unlock()
 
-	if !c.isReady {
+	// Idempotency is keyed on closed, NOT isReady: a client whose initial
+	// connect never succeeded is still running a reconnection goroutine that
+	// Close must stop, even though it never became ready.
+	if c.closed {
+		c.m.Unlock()
 		return errAlreadyClosed
 	}
+	c.closed = true
 
 	close(c.done)
 	c.isReady = false
@@ -514,14 +529,38 @@ func (c *AMQPClientImpl) Close() error {
 		tracking.RecordConnectionEvent("close", nil)
 	}
 
+	c.m.Unlock()
+
+	// Close stays non-blocking: it signals the reconnection goroutine to stop
+	// (via close(c.done)) but does not wait for it. Waiting here would let an
+	// in-flight, uncancellable dial stall callers — and Manager invokes Close
+	// while holding pubMu/consMu (shutdown, LRU eviction, idle cleanup), so a
+	// blocking Close could wedge the publish path. The goroutine exits on its
+	// own at its next select; reconnectDone lets tests confirm that exit.
 	c.log.Info().Msg("AMQP client closed")
 	return err
 }
 
 // handleReconnect manages connection lifecycle and reconnection logic.
 func (c *AMQPClientImpl) handleReconnect() {
+	// Signal that this goroutine has fully exited (tests wait on reconnectDone
+	// to confirm teardown; Close itself does not block on it). Guarded because
+	// manually-constructed test clients may run handleReconnect without a
+	// reconnectDone channel.
+	if c.reconnectDone != nil {
+		defer close(c.reconnectDone)
+	}
+
 	attempt := 0
 	for {
+		// Stop before starting another connect attempt once Close has fired, so
+		// no connect/changeConnection runs while/after Close is tearing down.
+		select {
+		case <-c.done:
+			return
+		default:
+		}
+
 		c.m.Lock()
 		c.isReady = false
 		c.m.Unlock()
@@ -668,7 +707,11 @@ func (c *AMQPClientImpl) init(conn amqpConnection) error {
 
 	c.changeChannel(ch)
 	c.m.Lock()
-	c.isReady = true
+	// Don't flip back to ready if Close already ran: a concurrent Close sets
+	// closed under c.m, and a closed client must stay not-ready.
+	if !c.closed {
+		c.isReady = true
+	}
 	c.m.Unlock()
 
 	// Record channel create event
@@ -679,10 +722,15 @@ func (c *AMQPClientImpl) init(conn amqpConnection) error {
 }
 
 // changeConnection updates the connection and sets up close notifications.
+// The connection/notify fields are written under c.m so a concurrent Close
+// (which reads c.connection under the same lock) cannot race this write.
 func (c *AMQPClientImpl) changeConnection(connection amqpConnection) {
+	c.m.Lock()
 	c.connection = connection
 	c.notifyConnClose = make(chan *amqp.Error, 1)
-	c.connection.NotifyClose(c.notifyConnClose)
+	notify := c.notifyConnClose
+	c.m.Unlock()
+	connection.NotifyClose(notify)
 }
 
 // confirmKey scopes a pending-publish entry to a single channel incarnation.
@@ -710,14 +758,20 @@ func (c *AMQPClientImpl) changeChannel(channel amqpChannel) {
 	c.generation++
 	newGen := c.generation
 
+	// Publish the channel pointer under c.m so a concurrent Close (which reads
+	// c.channel under c.m to tear it down) and the c.m-guarded readers in
+	// DeclareQueue/ConsumeFromQueue cannot race this write. Lock order is
+	// publishSerial → c.m, matching PublishToExchange.
+	c.m.Lock()
 	c.channel = channel
+	c.m.Unlock()
 	c.notifyChanClose = make(chan *amqp.Error, 1)
 	// Buffer sized for a reasonable concurrent-publish burst. The dispatcher
 	// goroutine drains it; the broker will block PublishWithContext if this
 	// fills up, providing natural backpressure.
 	c.notifyConfirm = make(chan amqp.Confirmation, defaultConfirmBufferSize)
-	c.channel.NotifyClose(c.notifyChanClose)
-	c.channel.NotifyPublish(c.notifyConfirm)
+	channel.NotifyClose(c.notifyChanClose)
+	channel.NotifyPublish(c.notifyConfirm)
 
 	// Start the dispatcher for this channel incarnation, pinned to newGen
 	// so late confirms from a previous channel (read by the previous

--- a/messaging/amqp_client_test.go
+++ b/messaging/amqp_client_test.go
@@ -703,8 +703,10 @@ func TestNewAMQPClientConstructsAndStarts(t *testing.T) {
 	if c == nil {
 		t.Fatalf("expected client instance")
 	}
-	// Ensure background goroutines are stopped
-	t.Cleanup(func() { _ = c.Close() })
+	// Ensure background goroutines are stopped before the test ends (and before
+	// the deferred setAmqpDialFunc restore), so the reconnect goroutine can't
+	// race a later test through the shared dial func.
+	t.Cleanup(func() { closeAndWaitForReconnect(c) })
 }
 
 // ===== Enhanced Connection Management Tests =====
@@ -1193,7 +1195,7 @@ func TestAMQPClientDeclareQueueNotReadyError(t *testing.T) {
 	setAmqpDialFunc(func(_ string) (amqpConnection, error) { return nil, errors.New(dialFailMsg) })
 
 	client := NewAMQPClient(amqpHost, &stubLogger{})
-	defer client.Close() // Prevent goroutine leak
+	defer closeAndWaitForReconnect(client) // Prevent goroutine leak / cross-test race
 
 	// Client not ready
 	err := client.DeclareQueue(testQueue, true, false, false, false)
@@ -1209,7 +1211,7 @@ func TestAMQPClientDeclareExchangeNotReadyError(t *testing.T) {
 	setAmqpDialFunc(func(_ string) (amqpConnection, error) { return nil, errors.New(dialFailMsg) })
 
 	client := NewAMQPClient(amqpHost, &stubLogger{})
-	defer client.Close() // Prevent goroutine leak
+	defer closeAndWaitForReconnect(client) // Prevent goroutine leak / cross-test race
 
 	// Client not ready
 	err := client.DeclareExchange("test-exchange", "topic", true, false, false, false)
@@ -1225,7 +1227,7 @@ func TestAMQPClientBindQueueNotReadyError(t *testing.T) {
 	setAmqpDialFunc(func(_ string) (amqpConnection, error) { return nil, errors.New(dialFailMsg) })
 
 	client := NewAMQPClient(amqpHost, &stubLogger{})
-	defer client.Close() // Prevent goroutine leak
+	defer closeAndWaitForReconnect(client) // Prevent goroutine leak / cross-test race
 
 	// Client not ready
 	err := client.BindQueue(testQueue, "test-exchange", "test.key", false)
@@ -1241,7 +1243,7 @@ func TestAMQPClientConsumeFromQueueNotReadyError(t *testing.T) {
 	setAmqpDialFunc(func(_ string) (amqpConnection, error) { return nil, errors.New(dialFailMsg) })
 
 	client := NewAMQPClient(amqpHost, &stubLogger{})
-	defer client.Close() // Prevent goroutine leak
+	defer closeAndWaitForReconnect(client) // Prevent goroutine leak / cross-test race
 
 	// Client not ready
 	_, err := client.ConsumeFromQueue(context.Background(), ConsumeOptions{
@@ -1278,6 +1280,7 @@ func TestAMQPClientInitChannelCreationFailure(t *testing.T) {
 	setAmqpDialFunc(func(_ string) (amqpConnection, error) { return nil, errors.New(dialFailMsg) })
 
 	client := NewAMQPClient(amqpHost, &stubLogger{})
+	defer closeAndWaitForReconnect(client) // Prevent goroutine leak / cross-test race
 
 	// Test init with a connection that fails to create channels
 	mockConn := &stubConn{}
@@ -1286,4 +1289,21 @@ func TestAMQPClientInitChannelCreationFailure(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no channel")
 	assert.False(t, client.IsReady())
+}
+
+// closeAndWaitForReconnect closes the client and waits for its background
+// reconnection goroutine to fully exit. Without this wait a goroutine leaked
+// from one test can, via the package-global dial func, dial a later test's fake
+// connection and race it. Close itself stays non-blocking in production; this
+// deterministic wait lives only in tests. The timeout is a safety net — with
+// the in-test stub dialers the goroutine exits near-instantly once done closes.
+func closeAndWaitForReconnect(c *AMQPClientImpl) {
+	_ = c.Close()
+	if c.reconnectDone == nil {
+		return
+	}
+	select {
+	case <-c.reconnectDone:
+	case <-time.After(2 * time.Second):
+	}
 }


### PR DESCRIPTION
## Problem

The `messaging` package intermittently failed `go test -race` (~10% per full-suite run, reproducible on `main` at high `-count`). The racing pair shifts between runs (e.g. `TestNewAMQPClientConstructsAndStarts` vs `TestPublishConfirmationTimeoutRecordsError` / `TestPublishToExchangeCreatesSpanWithExchangeAttributes`), but the mechanism is constant.

This is a **pre-existing** flake (not introduced by recent work) — surfaced while verifying #480.

## Root cause

`AMQPClientImpl.Close()` short-circuited on `if !c.isReady { return errAlreadyClosed }`. A client whose **initial connect never succeeded** (e.g. tests using an error dialer) is *not ready* — so `Close()` returned without ever closing `c.done`, and its `handleReconnect` goroutine **ran forever**.

Because the test dial func is a **package-global** (`setAmqpDialFunc`), that leaked goroutine — still looping — would call the dial func a *later* test had since swapped in, obtain that test's `fakeConnAdapter`, and write its `notifyCloseCh` (via `connect → changeConnection → fakeConnAdapter.NotifyClose`) **while the later test was reading the same fake**. Cross-test data race.

The `!isReady` guard wrongly conflated *"never connected"* with *"already closed."*

## Fix

`Close()` stays **non-blocking** — `Manager` calls it while holding `pubMu`/`consMu` (publish hot path LRU eviction, idle cleanup, consumer rollback, shutdown), so it must not wait on an uncancellable in-flight dial. The fix stops the goroutine without making `Close` block:

- **Key `Close()` idempotency on a new `closed` flag** (not `isReady`), so `Close` always closes `c.done` and stops the reconnect goroutine — even for a never-ready client. First `Close` succeeds; second returns `errAlreadyClosed`.
- **`reconnectDone`**, closed by `handleReconnect` on exit, lets **tests** deterministically wait for the goroutine to stop (`closeAndWaitForReconnect`) rather than leaking it into the next test. `Close` itself does not block on it.
- **Top-of-loop `done` check** in `handleReconnect` so it exits promptly after `Close`.
- **`init()` won't flip `isReady` back to true after `Close`** (checks `closed`), so a closed client stays not-ready.
- **`changeChannel`/`changeConnection` publish `c.channel`/`c.connection` under `c.m`**, so `Close`'s `c.m`-guarded teardown read can't race the write (also aligns with the `DeclareQueue`/`ConsumeFromQueue` readers).
- Close the one `NewAMQPClient` test that never closed its client.

## Why non-blocking (not a synchronous join)

An earlier draft made `Close()` *wait* for the goroutine. Review flagged that `Manager` calls `Close()` serially while holding `pubMu`/`consMu`, so a blocking `Close` (bounded or not) could wedge the publish path for all tenants and blow the shutdown budget (`N × timeout`). Non-blocking `Close` + a test-only wait avoids that entirely — no manager-locking changes.

## Verification

`make check` green. `go test ./messaging/ -race -count=50` clean (was ~10%/run failing before). `/code-review` + `/security-audit` run; all findings addressed or rendered moot by keeping `Close` non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced AMQP client shutdown and reconnection lifecycle to safely handle concurrent Close operations and prevent data races during channel and connection setup.
  * Improved connection cleanup to prevent channel readiness states from being flipped during shutdown teardown.

* **Tests**
  * Improved test cleanup procedures to prevent goroutine leaks and eliminate cross-test race conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->