### PR TITLE
fix(outbox): propagate trace context HTTP→outbox→consumer

### DIFF
--- a/outbox/publisher.go
+++ b/outbox/publisher.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/gaborage/go-bricks/app"
 	dbtypes "github.com/gaborage/go-bricks/database/types"
+	gobrickstrace "github.com/gaborage/go-bricks/trace"
 	"github.com/google/uuid"
 )
 
@@ -49,13 +51,20 @@ func (p *outboxPublisher) Publish(ctx context.Context, tx dbtypes.Tx, event *app
 		return "", fmt.Errorf("outbox: failed to marshal payload: %w", err)
 	}
 
-	// Marshal headers (if any)
-	var headers []byte
-	if len(event.Headers) > 0 {
-		headers, err = json.Marshal(event.Headers)
-		if err != nil {
-			return "", fmt.Errorf("outbox: failed to marshal headers: %w", err)
-		}
+	// Capture trace context (traceparent / X-Request-ID / tracestate) from the
+	// publish context into the persisted headers. The relay runs later as a
+	// detached scheduled job whose context carries no trace, so Publish — the
+	// only point where the originating request context is still live — must
+	// snapshot it. Persisting it here lets the relay replay the SAME trace to
+	// the broker (messaging.preparePublishing honors an existing traceparent
+	// header), so the consumer's message-scoped logger reports the originating
+	// trace id instead of a freshly generated one. Mirrors the injection the
+	// direct AMQP fast-path performs, keeping outbox + direct publishes
+	// trace-equivalent. Untraced publishes (no trace in context) are left as-is
+	// so background events don't accrue synthetic trace headers.
+	headers, err := marshalHeaders(ctx, event.Headers)
+	if err != nil {
+		return "", fmt.Errorf("outbox: failed to marshal headers: %w", err)
 	}
 
 	// Resolve exchange
@@ -90,6 +99,58 @@ func (p *outboxPublisher) Publish(ctx context.Context, tx dbtypes.Tx, event *app
 	}
 
 	return eventID, nil
+}
+
+// marshalHeaders JSON-encodes the AMQP headers, first capturing the trace
+// context from ctx so it survives to the relay and consumer. The caller's map
+// is never mutated — trace keys are written to a fresh copy. Returns nil (a SQL
+// NULL) when there are neither caller headers nor a trace context to persist.
+func marshalHeaders(ctx context.Context, eventHeaders map[string]any) ([]byte, error) {
+	traced := hasTraceContext(ctx)
+
+	// Common path: an untraced publish with no caller headers (every
+	// background/non-HTTP event). Store SQL NULL without allocating a map.
+	if len(eventHeaders) == 0 && !traced {
+		return nil, nil
+	}
+
+	// +3 leaves room for the trace keys (X-Request-ID, traceparent, tracestate).
+	headers := make(map[string]any, len(eventHeaders)+3)
+	maps.Copy(headers, eventHeaders)
+	if traced {
+		gobrickstrace.InjectIntoHeaders(ctx, &mapHeaderAccessor{headers: headers})
+	}
+	return json.Marshal(headers)
+}
+
+// hasTraceContext reports whether ctx carries an inbound trace identity worth
+// persisting (a W3C traceparent or an X-Request-ID derived trace id).
+func hasTraceContext(ctx context.Context) bool {
+	if _, ok := gobrickstrace.ParentFromContext(ctx); ok {
+		return true
+	}
+	_, ok := gobrickstrace.IDFromContext(ctx)
+	return ok
+}
+
+// mapHeaderAccessor adapts a map[string]any to trace.HeaderAccessor, letting the
+// publisher reuse the same centralized trace injection the AMQP client uses.
+type mapHeaderAccessor struct {
+	headers map[string]any
+}
+
+func (m *mapHeaderAccessor) Get(key string) any {
+	if m.headers == nil {
+		return nil
+	}
+	return m.headers[key]
+}
+
+func (m *mapHeaderAccessor) Set(key string, value any) {
+	if m.headers == nil {
+		m.headers = make(map[string]any)
+	}
+	m.headers[key] = value
 }
 
 // marshalPayload converts the payload to []byte.

--- a/outbox/publisher_test.go
+++ b/outbox/publisher_test.go
@@ -321,6 +321,34 @@ func TestPublisherPublishPreservesCallerHeadersWithTrace(t *testing.T) {
 	assert.False(t, mutated, "Publish must not mutate the caller-supplied headers map")
 }
 
+// TestPublisherPublishPersistsTracestate verifies the optional W3C tracestate
+// rides along with the traceparent into the persisted row when the inbound
+// request carries it — matching the behavior documented in wiki/outbox.md.
+func TestPublisherPublishPersistsTracestate(t *testing.T) {
+	store := &mockStore{}
+	pub := newPublisher(store, "")
+
+	const tracestate = "vendor1=opaqueValue1,vendor2=opaqueValue2"
+	ctx := gobrickstrace.WithTraceState(
+		gobrickstrace.WithTraceParent(context.Background(), inboundTraceparent),
+		tracestate,
+	)
+
+	event := &app.OutboxEvent{
+		EventType:   eventTypeOrderCreated,
+		AggregateID: aggregateOrderID,
+		Payload:     []byte("{}"),
+	}
+	_, err := pub.Publish(ctx, &mockTx{}, event)
+	require.NoError(t, err)
+
+	var headers map[string]any
+	require.NoError(t, json.Unmarshal(store.insertedRecords[0].Headers, &headers))
+	assert.Equal(t, inboundTraceparent, headers[gobrickstrace.HeaderTraceParent])
+	assert.Equal(t, tracestate, headers[gobrickstrace.HeaderTraceState],
+		"optional tracestate must be persisted alongside traceparent")
+}
+
 // TestPublisherPublishNoTraceLeavesHeadersUnchanged guards the untraced path:
 // a background publish with no trace context must not gain generated trace
 // headers, preserving existing behavior (nil headers for header-less events).

--- a/outbox/publisher_test.go
+++ b/outbox/publisher_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"maps"
 	"testing"
 	"time"
 
 	"github.com/gaborage/go-bricks/app"
 	dbtypes "github.com/gaborage/go-bricks/database/types"
+	gobrickstrace "github.com/gaborage/go-bricks/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -247,6 +249,140 @@ func TestPublisherPublishNilTransaction(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "transaction must not be nil")
+}
+
+// The tests reuse the production mapHeaderAccessor (same package) to drive the
+// centralized trace inject/extract helpers exactly as the AMQP layer does. An
+// amqp.Delivery's Headers are an amqp.Table (also a map[string]any), so this is
+// faithful to the real relay/consumer path.
+
+// inboundTraceparent / inboundTraceID model an inbound W3C trace context: the
+// trace-id is the 32-hex middle segment that the HTTP handler logs (site 1).
+const (
+	inboundTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	inboundTraceID     = "4bf92f3577b34da6a3ce929d0e0e4736"
+)
+
+// TestPublisherPublishPersistsTraceContext asserts that when the publish context
+// carries an inbound W3C traceparent (as placed by server.TraceContext), Publish
+// persists it into the outbox row's headers — the only place the originating
+// request context is still live. Without this, the detached relay job has no
+// trace to replay and the consumer sees a freshly generated id.
+func TestPublisherPublishPersistsTraceContext(t *testing.T) {
+	store := &mockStore{}
+	pub := newPublisher(store, "")
+
+	ctx := gobrickstrace.WithTraceParent(context.Background(), inboundTraceparent)
+
+	event := &app.OutboxEvent{
+		EventType:   eventTypeOrderCreated,
+		AggregateID: aggregateOrderID,
+		Payload:     []byte("{}"),
+	}
+	_, err := pub.Publish(ctx, &mockTx{}, event)
+	require.NoError(t, err)
+
+	require.Len(t, store.insertedRecords, 1)
+	record := store.insertedRecords[0]
+	require.NotEmpty(t, record.Headers, "trace context must be persisted in the outbox row")
+
+	var headers map[string]any
+	require.NoError(t, json.Unmarshal(record.Headers, &headers))
+	assert.Equal(t, inboundTraceparent, headers[gobrickstrace.HeaderTraceParent],
+		"persisted traceparent must match the inbound request traceparent")
+	assert.Equal(t, inboundTraceID, headers[gobrickstrace.HeaderXRequestID],
+		"persisted X-Request-ID must be force-aligned to the traceparent trace-id")
+}
+
+// TestPublisherPublishPreservesCallerHeadersWithTrace verifies trace capture does
+// not clobber application-supplied headers and does not mutate the caller's map.
+func TestPublisherPublishPreservesCallerHeadersWithTrace(t *testing.T) {
+	store := &mockStore{}
+	pub := newPublisher(store, "")
+
+	callerHeaders := map[string]any{"x-priority": "high"}
+	event := &app.OutboxEvent{
+		EventType:   eventTypeTest,
+		AggregateID: aggregateTest,
+		Payload:     []byte("{}"),
+		Headers:     callerHeaders,
+	}
+	ctx := gobrickstrace.WithTraceParent(context.Background(), inboundTraceparent)
+	_, err := pub.Publish(ctx, &mockTx{}, event)
+	require.NoError(t, err)
+
+	var headers map[string]any
+	require.NoError(t, json.Unmarshal(store.insertedRecords[0].Headers, &headers))
+	assert.Equal(t, "high", headers["x-priority"], "caller headers must survive trace capture")
+	assert.Equal(t, inboundTraceparent, headers[gobrickstrace.HeaderTraceParent])
+
+	// The caller's map must not gain framework keys as a side effect.
+	_, mutated := callerHeaders[gobrickstrace.HeaderTraceParent]
+	assert.False(t, mutated, "Publish must not mutate the caller-supplied headers map")
+}
+
+// TestPublisherPublishNoTraceLeavesHeadersUnchanged guards the untraced path:
+// a background publish with no trace context must not gain generated trace
+// headers, preserving existing behavior (nil headers for header-less events).
+func TestPublisherPublishNoTraceLeavesHeadersUnchanged(t *testing.T) {
+	store := &mockStore{}
+	pub := newPublisher(store, "")
+
+	event := &app.OutboxEvent{
+		EventType:   eventTypeTest,
+		AggregateID: aggregateTest,
+		Payload:     []byte("{}"),
+	}
+	_, err := pub.Publish(context.Background(), &mockTx{}, event)
+	require.NoError(t, err)
+
+	assert.Nil(t, store.insertedRecords[0].Headers,
+		"untraced publish must not persist generated trace headers")
+}
+
+// TestOutboxTracePropagationContinuityAcrossThreeSites is the end-to-end
+// continuity regression: the same trace id must appear at all three sites —
+// (1) the HTTP handler's context, (2) the persisted outbox row, and (3) the
+// consumer's message-scoped logger — even though the relay republishes from a
+// detached background context with no ambient trace. This reproduces the bug:
+// before the fix the consumer's correlation_id is a freshly generated random id.
+func TestOutboxTracePropagationContinuityAcrossThreeSites(t *testing.T) {
+	// Site 1 — HTTP handler: server.TraceContext places the inbound W3C
+	// traceparent into the request context; server logs its trace-id.
+	ctx := gobrickstrace.WithTraceParent(context.Background(), inboundTraceparent)
+
+	// Site 2 — outbox publish persists the trace into the row.
+	store := &mockStore{}
+	pub := newPublisher(store, "")
+	_, err := pub.Publish(ctx, &mockTx{}, &app.OutboxEvent{
+		EventType:   eventTypeOrderCreated,
+		AggregateID: aggregateOrderID,
+		Payload:     []byte("{}"),
+	})
+	require.NoError(t, err)
+	require.Len(t, store.insertedRecords, 1)
+	record := store.insertedRecords[0]
+
+	// Relay replay: decode the persisted headers, add outbox metadata, then
+	// publish from a DETACHED background context. This mirrors
+	// outbox.Relay.publishRecord -> messaging.preparePublishing ->
+	// trace.InjectIntoHeaders, where the relay job carries no ambient trace.
+	stored := map[string]any{}
+	if len(record.Headers) > 0 {
+		require.NoError(t, json.Unmarshal(record.Headers, &stored))
+	}
+	wire := map[string]any{}
+	maps.Copy(wire, stored)
+	wire["x-outbox-event-id"] = record.ID
+	gobrickstrace.InjectIntoHeaders(context.Background(), &mapHeaderAccessor{headers: wire})
+
+	// Site 3 — consumer: messaging.Registry.processMessage derives the
+	// per-message logger's correlation_id via ExtractFromHeaders + EnsureTraceID.
+	consumerCtx := gobrickstrace.ExtractFromHeaders(context.Background(), &mapHeaderAccessor{headers: wire})
+	consumerCorrelationID := gobrickstrace.EnsureTraceID(consumerCtx)
+
+	assert.Equal(t, inboundTraceID, consumerCorrelationID,
+		"consumer correlation_id must equal the inbound traceparent trace-id, not a fresh random id")
 }
 
 func TestMarshalPayloadStruct(t *testing.T) {

--- a/outbox/relay.go
+++ b/outbox/relay.go
@@ -8,6 +8,7 @@ import (
 	dbtypes "github.com/gaborage/go-bricks/database/types"
 	"github.com/gaborage/go-bricks/messaging"
 	"github.com/gaborage/go-bricks/scheduler"
+	gobrickstrace "github.com/gaborage/go-bricks/trace"
 )
 
 // Relay is a scheduler.Executor that polls for pending outbox events
@@ -83,13 +84,20 @@ func (r *Relay) publishRecord(ctx scheduler.JobContext, db dbtypes.Interface, ms
 	headers["x-outbox-event-id"] = record.ID
 	headers["x-outbox-event-type"] = record.EventType
 
+	// Rehydrate the originating trace context (persisted by Publish) into the
+	// publish context. The relay job runs detached with no ambient trace, so
+	// without this the downstream preparePublishing would stamp a freshly
+	// generated CorrelationId — which the consumer's failure-path logger and
+	// consume span surface — breaking trace continuity on the error path.
+	pubCtx := gobrickstrace.ExtractFromHeaders(ctx, &mapHeaderAccessor{headers: headers})
+
 	opts := messaging.PublishOptions{
 		Exchange:   record.Exchange,
 		RoutingKey: record.RoutingKey,
 		Headers:    headers,
 	}
 
-	if err := msgClient.PublishToExchange(ctx, opts, record.Payload); err != nil {
+	if err := msgClient.PublishToExchange(pubCtx, opts, record.Payload); err != nil {
 		r.markRecordFailed(ctx, db, record.ID, err.Error())
 		return false
 	}

--- a/outbox/relay_test.go
+++ b/outbox/relay_test.go
@@ -11,6 +11,7 @@ import (
 	dbtesting "github.com/gaborage/go-bricks/database/testing"
 	"github.com/gaborage/go-bricks/messaging"
 	"github.com/gaborage/go-bricks/scheduler"
+	gobrickstrace "github.com/gaborage/go-bricks/trace"
 )
 
 func TestDecodeHeadersEmpty(t *testing.T) {
@@ -221,6 +222,37 @@ func TestPublishRecordReturnsFalseWhenMarkPublishedFails(t *testing.T) {
 	assert.Equal(t, 1, amqp.PublishCalls)
 	assert.Equal(t, 1, store.MarkPublishedCalls)
 	assert.Equal(t, 0, store.MarkFailedCalls, "MarkFailed not called when only MarkPublished failed")
+}
+
+// TestPublishRecordRehydratesTraceContextForPublish asserts that the relay
+// reconstructs the originating trace context from the persisted row headers and
+// publishes with it. Without this, preparePublishing runs under the relay's
+// trace-less background context and stamps the AMQP CorrelationId (which the
+// consumer's failure-path logger and consume span surface as correlation_id)
+// with a freshly generated UUID, breaking continuity precisely on the error path.
+func TestPublishRecordRehydratesTraceContextForPublish(t *testing.T) {
+	store := &fakeStore{}
+	amqp := newFakeAMQP()
+	r := newRelayWithFakes(store, amqp)
+	db := dbtesting.NewTestDB("postgresql")
+	ctx := newFakeJobCtx(db, amqp)
+
+	// A row as persisted by Publish: headers carry the originating trace context.
+	rec := &Record{
+		ID:         "evt-trace",
+		EventType:  "order.created",
+		Exchange:   "orders",
+		RoutingKey: "created",
+		Headers:    []byte(`{"traceparent":"` + inboundTraceparent + `","X-Request-ID":"` + inboundTraceID + `"}`),
+	}
+	require.True(t, r.publishRecord(ctx, db, amqp, rec))
+
+	require.NotNil(t, amqp.LastPublishCtx, "publish context must be captured")
+	tp, ok := gobrickstrace.ParentFromContext(amqp.LastPublishCtx)
+	assert.True(t, ok, "publish context must carry the persisted traceparent")
+	assert.Equal(t, inboundTraceparent, tp)
+	assert.Equal(t, inboundTraceID, gobrickstrace.EnsureTraceID(amqp.LastPublishCtx),
+		"publish context trace id must be the originating trace id, not a fresh one")
 }
 
 func TestMarkRecordFailedLogsButDoesNotPanicOnStoreError(t *testing.T) {

--- a/outbox/test_helpers_test.go
+++ b/outbox/test_helpers_test.go
@@ -137,6 +137,7 @@ type fakeAMQP struct {
 	LastPublishOpts messaging.PublishOptions
 	LastPublishData []byte
 	LastPublishHdrs map[string]any
+	LastPublishCtx  context.Context
 }
 
 func newFakeAMQP() *fakeAMQP {
@@ -147,13 +148,14 @@ func (f *fakeAMQP) IsReady() bool { return f.Ready }
 
 func (f *fakeAMQP) Publish(_ context.Context, _ string, _ []byte) error { return nil }
 
-func (f *fakeAMQP) PublishToExchange(_ context.Context, opts messaging.PublishOptions, data []byte) error {
+func (f *fakeAMQP) PublishToExchange(ctx context.Context, opts messaging.PublishOptions, data []byte) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.PublishCalls++
 	f.LastPublishOpts = opts
 	f.LastPublishData = data
 	f.LastPublishHdrs = opts.Headers
+	f.LastPublishCtx = ctx
 	key := opts.Exchange + ":" + opts.RoutingKey
 	if err, found := f.PublishErrFor[key]; found {
 		return err

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=gaborage_go-bricks
 sonar.organization=gaborage
 
 sonar.projectName=GoBricks
-sonar.sources=app,config,database,httpclient,internal,logger,messaging,migration,multitenant,observability,scheduler,server,testing,tools,trace
+sonar.sources=app,cache,config,database,httpclient,internal,jose,keystore,logger,messaging,migration,multitenant,observability,outbox,scheduler,server,testing,tools,trace
 sonar.exclusions=**/*_test.go,**/vendor/**,**/mocks/**,**/*.gen.go
 
 sonar.tests=.

--- a/wiki/outbox.md
+++ b/wiki/outbox.md
@@ -92,6 +92,29 @@ outbox:
 | `Exchange` | string | No | Target AMQP exchange (falls back to `default_exchange` config) |
 | `RoutingKey` | string | No | AMQP routing key (falls back to `EventType`) |
 
+## Trace Propagation
+
+Outbox publishes are **trace-equivalent to direct AMQP publishes**: the W3C trace
+context (`traceparent` / `X-Request-ID`) is propagated end-to-end so a single
+trace id spans the originating HTTP request, the persisted outbox row, and the
+downstream consumer's per-message log.
+
+This requires capture at two points, because the relay runs as a *detached*
+scheduled job whose context carries no inbound trace:
+
+1. **`Publish` captures** the trace context from the publish `ctx` into the row's
+   `headers` column — the only point where the originating request context is
+   still live. Untraced publishes (background jobs with no trace in context) are
+   left untouched and persist no synthetic trace headers.
+2. **The relay rehydrates** that trace context from the persisted headers into the
+   context it republishes with, so the AMQP `CorrelationId` (surfaced by the
+   consumer's failure-path log and the consume span) and the re-injected
+   `traceparent` all carry the originating trace id rather than a freshly
+   generated one.
+
+No application code is required — capture/rehydration is automatic. Custom
+`Headers` you set on the event are preserved alongside the trace keys.
+
 ## Outbox Defaults
 
 GoBricks applies production-safe outbox defaults when outbox is enabled:

--- a/wiki/outbox.md
+++ b/wiki/outbox.md
@@ -95,9 +95,10 @@ outbox:
 ## Trace Propagation
 
 Outbox publishes are **trace-equivalent to direct AMQP publishes**: the W3C trace
-context (`traceparent` / `X-Request-ID`) is propagated end-to-end so a single
-trace id spans the originating HTTP request, the persisted outbox row, and the
-downstream consumer's per-message log.
+context (`traceparent` / `X-Request-ID`, plus `tracestate` when the inbound
+request carries it) is propagated end-to-end so a single trace id spans the
+originating HTTP request, the persisted outbox row, and the downstream
+consumer's per-message log.
 
 This requires capture at two points, because the relay runs as a *detached*
 scheduled job whose context carries no inbound trace:


### PR DESCRIPTION
## Problem

End-to-end W3C trace propagation was broken across **HTTP → outbox → consumer**. An inbound `traceparent` reached the HTTP handler log, but:

- the outbox row persisted **no** correlation/trace data, and
- the consumer's per-message log showed a **freshly-generated random id**.

## Root cause

The trace context is only live in the *request* context at `outbox.Publish`. But `Publish` serialized only `event.Headers` into the row and ignored `ctx`'s trace context. The relay then runs as a **detached scheduled job** with no ambient trace, so `messaging.preparePublishing` fell through to `GenerateTraceParent()` on every republish — minting a new id unrelated to the originating request. The consumer faithfully logged that fresh id.

So the consumer logger was never broken — it was being **fed a regenerated id** because the original was never persisted.

## Fix (both in the `outbox` package)

1. **`publisher.go`** — capture the trace context (`traceparent` / `X-Request-ID` / `tracestate`) from the publish `ctx` into the persisted `headers` column, reusing the same `trace.InjectIntoHeaders` the direct AMQP path uses. Untraced background publishes are left untouched (no synthetic headers; early-return avoids an allocation on the hot path). The caller's `Headers` map is copied, never mutated.
2. **`relay.go`** — rehydrate that trace context from the persisted headers into the context it republishes with, so the AMQP `CorrelationId` (surfaced by the consumer's **failure-path** log and the consume span) also carries the originating trace id rather than a generated one.

Net effect: **outbox publishes become trace-equivalent to direct AMQP publishes.** No application code change required.

## Why two changes

`Publish` is the only place the request context is alive, so capture must happen there. The relay can only *replay* what was persisted — but it also needs to rehydrate the context (not just rely on header precedence) so the `CorrelationId`-derived sinks (error log, span `conversation_id`) stay consistent on the error path too.

## Tests

- `TestOutboxTracePropagationContinuityAcrossThreeSites` — the same trace id appears at all three sites (HTTP ctx → outbox row → consumer correlation id), even when the relay republishes from a detached background ctx. This test **fails before the fix** (consumer sees a random id).
- `TestPublisherPublishPersistsTraceContext` — row headers carry the inbound `traceparent` + force-aligned `X-Request-ID`.
- `TestPublisherPublishPreservesCallerHeadersWithTrace` — caller headers survive; caller map not mutated.
- `TestPublisherPublishNoTraceLeavesHeadersUnchanged` — untraced publishes persist no synthetic headers.
- `TestPublishRecordRehydratesTraceContextForPublish` — the relay publishes with a ctx carrying the originating trace id (real relay path, not hand-rolled).

## Verification

- `make check` — PASSED (fmt + lint + test)
- `go test ./outbox/... -race -count=1` — PASSED
- `/code-review` (high) + `/security-audit` run on the diff; gosec clean, no secrets/raw-SQL/injection. Failure-path correlation divergence surfaced by the review is addressed by change #2.

Docs: added a **Trace Propagation** section to `wiki/outbox.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outbox publishing now captures and persists W3C trace context and correlation IDs from the publisher's context, preserving custom event headers so trace continuity is maintained through relay and downstream publishes.

* **Documentation**
  * Added guidance describing trace propagation behavior for outbox-driven publishes.

* **Tests**
  * Added unit and end-to-end tests validating trace persistence, tracestate handling, header preservation, and trace continuity across relay/consumer scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->