### PR TITLE
fix(jose,keystore,outbox): resolve SonarCloud CRITICAL smells + cover nil-map branches

### DIFF
--- a/jose/policy.go
+++ b/jose/policy.go
@@ -59,6 +59,14 @@ func (p *Policy) Validate() error {
 		}
 	}
 
+	if err := p.validateAlgorithms(); err != nil {
+		return err
+	}
+	return p.validateDirection()
+}
+
+// validateAlgorithms checks SigAlg/KeyAlg/Enc against the allowlists, in that order.
+func (p *Policy) validateAlgorithms() error {
 	if !IsAllowedSigAlg(p.SigAlg) {
 		return &Error{
 			Sentinel: ErrAlgorithmDisallowed,
@@ -83,38 +91,16 @@ func (p *Policy) Validate() error {
 			Enc:      string(p.Enc),
 		}
 	}
+	return nil
+}
 
+// validateDirection dispatches to the per-direction kid checks.
+func (p *Policy) validateDirection() error {
 	switch p.Direction {
 	case DirectionInbound:
-		if p.DecryptKid == "" || p.VerifyKid == "" {
-			return &Error{
-				Sentinel: ErrPolicyMismatch,
-				Code:     codePolicyIncomplete,
-				Message:  "inbound policy requires both decrypt and verify kids",
-			}
-		}
-		if p.SignKid != "" || p.EncryptKid != "" {
-			return &Error{
-				Sentinel: ErrPolicyMismatch,
-				Code:     codePolicyDirectionMismatch,
-				Message:  "inbound policy must not declare sign/encrypt kids",
-			}
-		}
+		return p.validateInbound()
 	case DirectionOutbound:
-		if p.SignKid == "" || p.EncryptKid == "" {
-			return &Error{
-				Sentinel: ErrPolicyMismatch,
-				Code:     codePolicyIncomplete,
-				Message:  "outbound policy requires both sign and encrypt kids",
-			}
-		}
-		if p.DecryptKid != "" || p.VerifyKid != "" {
-			return &Error{
-				Sentinel: ErrPolicyMismatch,
-				Code:     codePolicyDirectionMismatch,
-				Message:  "outbound policy must not declare decrypt/verify kids",
-			}
-		}
+		return p.validateOutbound()
 	default:
 		return &Error{
 			Sentinel: ErrPolicyMismatch,
@@ -122,6 +108,42 @@ func (p *Policy) Validate() error {
 			Message:  "unknown direction",
 		}
 	}
+}
 
+// validateInbound requires decrypt+verify kids and forbids sign/encrypt kids.
+func (p *Policy) validateInbound() error {
+	if p.DecryptKid == "" || p.VerifyKid == "" {
+		return &Error{
+			Sentinel: ErrPolicyMismatch,
+			Code:     codePolicyIncomplete,
+			Message:  "inbound policy requires both decrypt and verify kids",
+		}
+	}
+	if p.SignKid != "" || p.EncryptKid != "" {
+		return &Error{
+			Sentinel: ErrPolicyMismatch,
+			Code:     codePolicyDirectionMismatch,
+			Message:  "inbound policy must not declare sign/encrypt kids",
+		}
+	}
+	return nil
+}
+
+// validateOutbound requires sign+encrypt kids and forbids decrypt/verify kids.
+func (p *Policy) validateOutbound() error {
+	if p.SignKid == "" || p.EncryptKid == "" {
+		return &Error{
+			Sentinel: ErrPolicyMismatch,
+			Code:     codePolicyIncomplete,
+			Message:  "outbound policy requires both sign and encrypt kids",
+		}
+	}
+	if p.DecryptKid != "" || p.VerifyKid != "" {
+		return &Error{
+			Sentinel: ErrPolicyMismatch,
+			Code:     codePolicyDirectionMismatch,
+			Message:  "outbound policy must not declare decrypt/verify kids",
+		}
+	}
 	return nil
 }

--- a/jose/testing/fixtures.go
+++ b/jose/testing/fixtures.go
@@ -9,6 +9,14 @@ import (
 	"github.com/gaborage/go-bricks/jose"
 )
 
+// Fixed kid strings for the bidirectional fixture. Production VTS-style
+// integrations use matching kid names on both ends, so header kids on a sealed
+// payload must equal the receiver's expected kid for ExpectedKid validation.
+const (
+	clientKid = "client-key"
+	peerKid   = "peer-key"
+)
+
 // GenerateTestKeyPair returns a freshly-minted 2048-bit RSA key pair suitable for
 // JOSE round-trip tests. The smaller key size is chosen for test speed — production
 // keystores should use 3072+ bits.
@@ -75,8 +83,8 @@ func NewBidirectionalFixture(t testing.TB) *BidirectionalFixture {
 	clientPriv, _ := GenerateTestKeyPair(t)
 	peerPriv, _ := GenerateTestKeyPair(t)
 	resolver := NewTestResolver(map[string]any{
-		"client-key": clientPriv,
-		"peer-key":   peerPriv,
+		clientKid: clientPriv,
+		peerKid:   peerPriv,
 	})
 	mkOut := func(signKid, encKid string) *jose.Policy {
 		return &jose.Policy{
@@ -98,10 +106,10 @@ func NewBidirectionalFixture(t testing.TB) *BidirectionalFixture {
 		ClientPrivate:  clientPriv,
 		PeerPrivate:    peerPriv,
 		Resolver:       resolver,
-		ClientOutbound: mkOut("client-key", "peer-key"),
-		ClientInbound:  mkIn("client-key", "peer-key"),
-		PeerOutbound:   mkOut("peer-key", "client-key"),
-		PeerInbound:    mkIn("peer-key", "client-key"),
+		ClientOutbound: mkOut(clientKid, peerKid),
+		ClientInbound:  mkIn(clientKid, peerKid),
+		PeerOutbound:   mkOut(peerKid, clientKid),
+		PeerInbound:    mkIn(peerKid, clientKid),
 	}
 }
 

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -62,6 +62,10 @@ import (
 	"github.com/gaborage/go-bricks/config"
 )
 
+// errKeyNotFoundFmt is the fmt.Errorf format used by every accessor when a
+// logical key name is absent from the store (%q = the requested name).
+const errKeyNotFoundFmt = "keystore: key %q not found"
+
 // keyEntry holds the parsed material for one logical name: either an RSA pair
 // (public set, private optional) or a symmetric secret. The two are mutually
 // exclusive — the config layer rejects mixed entries before newStore runs.
@@ -81,7 +85,7 @@ type store struct {
 func (s *store) PublicKey(name string) (*rsa.PublicKey, error) {
 	kp, ok := s.keys[name]
 	if !ok {
-		return nil, fmt.Errorf("keystore: key %q not found", name)
+		return nil, fmt.Errorf(errKeyNotFoundFmt, name)
 	}
 	if kp.public == nil {
 		return nil, fmt.Errorf("keystore: key %q has no public key configured", name)
@@ -93,7 +97,7 @@ func (s *store) PublicKey(name string) (*rsa.PublicKey, error) {
 func (s *store) PrivateKey(name string) (*rsa.PrivateKey, error) {
 	kp, ok := s.keys[name]
 	if !ok {
-		return nil, fmt.Errorf("keystore: key %q not found", name)
+		return nil, fmt.Errorf(errKeyNotFoundFmt, name)
 	}
 	if kp.private == nil {
 		return nil, fmt.Errorf("keystore: key %q has no private key configured", name)
@@ -106,7 +110,7 @@ func (s *store) PrivateKey(name string) (*rsa.PrivateKey, error) {
 func (s *store) Secret(name string) ([]byte, error) {
 	kp, ok := s.keys[name]
 	if !ok {
-		return nil, fmt.Errorf("keystore: key %q not found", name)
+		return nil, fmt.Errorf(errKeyNotFoundFmt, name)
 	}
 	if kp.secret == nil {
 		return nil, fmt.Errorf("keystore: key %q has no symmetric secret configured", name)

--- a/outbox/publisher_test.go
+++ b/outbox/publisher_test.go
@@ -413,6 +413,19 @@ func TestOutboxTracePropagationContinuityAcrossThreeSites(t *testing.T) {
 		"consumer correlation_id must equal the inbound traceparent trace-id, not a fresh random id")
 }
 
+// TestMapHeaderAccessorNilMap exercises the defensive nil-map branches of the
+// accessor's Get/Set (unreachable via marshalHeaders, which always passes a
+// non-nil map, but part of the type's contract and mirrored from the AMQP
+// accessor): Get returns nil, and Set lazily initializes the backing map.
+func TestMapHeaderAccessorNilMap(t *testing.T) {
+	a := &mapHeaderAccessor{} // nil backing map
+
+	assert.Nil(t, a.Get("missing"), "Get on a nil map must return nil, not panic")
+
+	a.Set("k", "v") // must lazily allocate the map
+	assert.Equal(t, "v", a.Get("k"), "Set must initialize the map and store the value")
+}
+
 func TestMarshalPayloadStruct(t *testing.T) {
 	type TestPayload struct {
 		Name string `json:"name"`


### PR DESCRIPTION
## What

Follow-up to PR #482 (outbox trace propagation), covering two things:

1. **Resolve 4 CRITICAL SonarCloud code smells** that became visible once #482 added `cache`/`jose`/`keystore`/`outbox` to `sonar.sources` (those packages were previously unanalyzed entirely):
   - `keystore/keystore.go` (S1192) — extract `errKeyNotFoundFmt` constant (message was duplicated across `PublicKey`/`PrivateKey`/`Secret`).
   - `jose/testing/fixtures.go` (S1192) — extract `clientKid`/`peerKid` constants (each kid literal duplicated 5×; the deliberate arg reversal in the peer policies is preserved).
   - `jose/policy.go` (S3776) — decompose `Policy.Validate` (cognitive complexity 17 → ~3) into `validateAlgorithms` / `validateDirection` / `validateInbound` / `validateOutbound`. Pure extract-method: check order, short-circuit semantics, and all 8 error returns are byte-identical.

2. **Cover `mapHeaderAccessor` nil-map branches** — a small test that narrowly missed #482's squash-merge, taking those 2 defensive lines to 100%.

## Why the JOSE/keystore refactor is safe

`Policy.Validate` is security-sensitive. The decomposition is a behavior-preserving extract-method, verified by: the jose test suite (95%+ coverage of the validation paths), an explicit equivalence review (all error Sentinel/Code/Message/Alg/Enc fields confirmed identical), and `gosec` (0 issues).

## Verification

- `make check` — PASSED
- `go test ./jose/... ./keystore/... ./outbox/...` — PASSED
- `/code-review` (high) + `/security-audit` — no findings; gosec clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit coverage for edge-case map accessor behavior to prevent panics and ensure lazy allocation.
  * Updated test fixtures for more consistent key identifiers in bidirectional scenarios.
* **Refactor**
  * Reworked policy validation flow for clearer, more maintainable direction and algorithm checks.
* **Chores**
  * Consolidated key-not-found error formatting for consistent error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->