### PR TITLE
feat(openapi): registration-walk route discovery (PR4)

### DIFF
--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -39,6 +39,10 @@ const (
 	moduleMethodRegisterRoutes = "RegisterRoutes"
 	moduleMethodShutdown       = "Shutdown"
 
+	// RouteRegistrar.Group(prefix) — sub-router with a path prefix.
+	groupMethodName        = "Group"
+	routeRegistrarTypeName = "RouteRegistrar"
+
 	// Go primitive type names used in AST inspection
 	goTypeString = "string"
 
@@ -80,6 +84,7 @@ type ProjectAnalyzer struct {
 	projectRoot string
 	fileSet     *token.FileSet
 	constants   map[string]string // Map of constant names to their values
+	warnings    []string          // Non-fatal diagnostics collected during analysis
 }
 
 // New creates a new project analyzer
@@ -89,6 +94,17 @@ func New(projectRoot string) *ProjectAnalyzer {
 		fileSet:     token.NewFileSet(),
 		constants:   make(map[string]string),
 	}
+}
+
+// addWarningf records a non-fatal diagnostic (e.g. a route whose path could not
+// be resolved to a literal). Callers surface these to the user after analysis.
+func (a *ProjectAnalyzer) addWarningf(format string, args ...any) {
+	a.warnings = append(a.warnings, fmt.Sprintf(format, args...))
+}
+
+// Warnings returns the non-fatal diagnostics collected during the last analysis.
+func (a *ProjectAnalyzer) Warnings() []string {
+	return a.warnings
 }
 
 // isFrameworkType checks if a type should be filtered out as a framework type.
@@ -118,6 +134,10 @@ func (a *ProjectAnalyzer) AnalyzeProject() (*models.Project, error) {
 		Description: "Generated API specification",
 		Modules:     []models.Module{},
 	}
+
+	// Reset per-run diagnostics so repeated analyses on the same analyzer don't
+	// accumulate stale warnings.
+	a.warnings = nil
 
 	// Discover project metadata from go.mod
 	a.discoverProjectMetadata(project)
@@ -418,63 +438,297 @@ func (a *ProjectAnalyzer) collectRoutesFromFile(astFile *ast.File, filePath, str
 			continue
 		}
 
-		routes = append(routes, a.extractRoutesFromFuncBodyWithAliases(funcDecl.Body, astFile, filePath, structName, serverAliases)...)
+		recvVar := receiverVarName(funcDecl.Recv)
+		routes = append(routes, a.extractRoutesFromFuncBodyWithAliases(funcDecl.Body, astFile, filePath, structName, recvVar, serverAliases)...)
 	}
 
 	return routes
 }
 
-// extractRoutesFromFuncBody extracts route registrations from function statements
+// extractRoutesFromFuncBody extracts route registrations from a function body
+// using only the default "server" alias and no handler/helper context.
 func (a *ProjectAnalyzer) extractRoutesFromFuncBody(body *ast.BlockStmt) []models.Route {
-	return a.extractRoutesFromFuncBodyWithAliases(body, nil, "", "", map[string]struct{}{frameworkPkgServer: {}})
+	return a.extractRoutesFromFuncBodyWithAliases(body, nil, "", "", "", map[string]struct{}{frameworkPkgServer: {}})
 }
 
-// extractRoutesFromFuncBodyWithAliases extracts route registrations with explicit server aliases
-func (a *ProjectAnalyzer) extractRoutesFromFuncBodyWithAliases(body *ast.BlockStmt, astFile *ast.File, filePath, structName string, serverAliases map[string]struct{}) []models.Route {
-	var routes []models.Route
+// extractRoutesFromFuncBodyWithAliases walks a RegisterRoutes body (and the
+// same-receiver helper methods it calls) to collect every route registration,
+// including those nested inside if/for/range/blocks and those registered on a
+// r.Group(prefix) registrar.
+func (a *ProjectAnalyzer) extractRoutesFromFuncBodyWithAliases(
+	body *ast.BlockStmt, astFile *ast.File, filePath, structName, recvVar string, serverAliases map[string]struct{},
+) []models.Route {
+	w := &routeWalker{
+		a:             a,
+		astFile:       astFile,
+		filePath:      filePath,
+		structName:    structName,
+		recvVar:       recvVar,
+		serverAliases: serverAliases,
+		// Seed the recursion stack with the entry method so a helper that calls
+		// back into RegisterRoutes cannot re-walk it (cycle guard for the root).
+		stack: map[string]bool{moduleMethodRegisterRoutes: true},
+	}
+	w.walkBody(body, nil)
+	return w.routes
+}
 
-	for _, stmt := range body.List {
-		if route := a.extractRouteFromStatement(stmt, astFile, filePath, structName, serverAliases); route != nil {
-			routes = append(routes, *route)
+// routeWalker collects routes from a RegisterRoutes method body and the
+// same-receiver helper methods it transitively calls.
+type routeWalker struct {
+	a             *ProjectAnalyzer
+	astFile       *ast.File
+	filePath      string
+	structName    string // module struct, for handler resolution
+	recvVar       string // module receiver var name (for helper calls); "" if none
+	serverAliases map[string]struct{}
+	stack         map[string]bool // helper methods currently on the walk stack (cycle guard)
+	routes        []models.Route
+}
+
+// walkBody collects server.METHOD route registrations from a body (with
+// r.Group(prefix) prefixes applied) and recurses into same-receiver helpers.
+// seed carries registrar->prefix bindings inherited from a caller (so a helper
+// invoked with a grouped registrar inherits that group's prefix).
+func (w *routeWalker) walkBody(body *ast.BlockStmt, seed map[string]string) {
+	if body == nil {
+		return
+	}
+	prefixes := w.collectGroupPrefixes(body)
+	for reg, prefix := range seed {
+		if _, ok := prefixes[reg]; !ok {
+			prefixes[reg] = prefix
+		}
+	}
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if route := w.routeFromCall(call, prefixes); route != nil {
+			w.routes = append(w.routes, *route)
+			return true
+		}
+		w.maybeRecurseHelper(call, prefixes)
+		return true
+	})
+}
+
+// collectGroupPrefixes maps each registrar variable assigned from <reg>.Group(p)
+// to its accumulated path prefix. Nested groups resolve because Go requires the
+// parent registrar to be declared (and thus visited) before the child.
+//
+// Note: prefix context is per-body; a prefix established in a caller is not
+// threaded into a helper method invoked with the grouped registrar.
+func (w *routeWalker) collectGroupPrefixes(body *ast.BlockStmt) map[string]string {
+	prefixes := map[string]string{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+			return true
+		}
+		lhs, ok := assign.Lhs[0].(*ast.Ident)
+		if !ok {
+			return true
+		}
+		call, ok := assign.Rhs[0].(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != groupMethodName || len(call.Args) < 1 {
+			return true
+		}
+		parent, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if prefix, pok := w.a.extractPathFromArg(call.Args[0]); pok {
+			prefixes[lhs.Name] = prefixes[parent.Name] + prefix
+		}
+		return true
+	})
+	return prefixes
+}
+
+// routeFromCall builds a route from a server.METHOD(...) call, or nil if the call
+// is not a route registration. Unresolvable paths drop the route with a warning.
+func (w *routeWalker) routeFromCall(call *ast.CallExpr, prefixes map[string]string) *models.Route {
+	method, ok := w.a.validateServerCall(call, w.serverAliases)
+	if !ok {
+		return nil
+	}
+
+	rawPath, resolved := w.a.extractPathFromArg(call.Args[2])
+	if !resolved {
+		w.a.addWarningf("skipping a server.%s route: its path argument could not be resolved to a literal string", method)
+		return nil
+	}
+
+	// Prepend the group prefix bound to the registrar argument (Args[1]).
+	prefix := ""
+	if reg, ok := call.Args[1].(*ast.Ident); ok {
+		prefix = prefixes[reg.Name]
+	}
+
+	route := &models.Route{
+		Method: strings.ToUpper(method),
+		Tags:   []string{},
+		Path:   normalizePath(prefix + rawPath),
+	}
+	route.HandlerName, route.Request, route.Response = w.a.extractHandlerInfo(call, w.astFile, w.filePath, w.structName)
+	for i := 4; i < len(call.Args); i++ {
+		w.a.extractRouteMetadata(call.Args[i], route, w.serverAliases)
+	}
+	return route
+}
+
+// maybeRecurseHelper recurses into a same-receiver route-registration helper
+// (w.recvVar.method(...) where method takes a server.RouteRegistrar) so routes
+// registered in helpers are discovered. The RouteRegistrar requirement excludes
+// non-registration methods (e.g. predicates or handler factories) so their
+// internal server.* calls are not mistaken for routes. The stack guards against
+// infinite recursion on mutually-recursive helpers while still allowing a helper
+// to be invoked more than once. The prefix bound to the registrar argument is
+// threaded into the helper's registrar parameter.
+func (w *routeWalker) maybeRecurseHelper(call *ast.CallExpr, prefixes map[string]string) {
+	if w.recvVar == "" || w.astFile == nil {
+		return
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+	recv, ok := sel.X.(*ast.Ident)
+	if !ok || recv.Name != w.recvVar {
+		return
+	}
+	method := sel.Sel.Name
+	if w.stack[method] {
+		return
+	}
+	decl := w.a.findMethodDecl(w.astFile, w.filePath, w.structName, method)
+	idx, paramName := routeRegistrarParam(decl)
+	if idx < 0 {
+		return // not a route-registration helper
+	}
+
+	// Thread the prefix of the registrar argument into the helper's registrar
+	// parameter so routes inside the helper inherit the caller's group prefix.
+	seed := map[string]string{}
+	if paramName != "" && idx < len(call.Args) {
+		if argIdent, ok := call.Args[idx].(*ast.Ident); ok {
+			if prefix := prefixes[argIdent.Name]; prefix != "" {
+				seed[paramName] = prefix
+			}
 		}
 	}
 
-	return routes
+	w.stack[method] = true
+	w.walkBody(decl.Body, seed)
+	delete(w.stack, method)
 }
 
-// validateServerCall validates that a statement is a valid server.METHOD() call.
-// Returns the call expression, HTTP method name, and whether the validation succeeded.
-func (a *ProjectAnalyzer) validateServerCall(stmt ast.Stmt, serverAliases map[string]struct{}) (*ast.CallExpr, string, bool) {
-	exprStmt, ok := stmt.(*ast.ExprStmt)
-	if !ok {
-		return nil, "", false
+// routeRegistrarParam returns the positional index and name of a function's
+// server.RouteRegistrar parameter, or (-1, "") if it has none. The index is
+// counted over flattened parameter names so it lines up with call arguments.
+func routeRegistrarParam(decl *ast.FuncDecl) (idx int, name string) {
+	if decl == nil || decl.Type.Params == nil {
+		return -1, ""
 	}
-
-	callExpr, ok := exprStmt.X.(*ast.CallExpr)
-	if !ok {
-		return nil, "", false
+	pos := 0
+	for _, field := range decl.Type.Params.List {
+		isReg := isRouteRegistrarType(field.Type)
+		if len(field.Names) == 0 {
+			if isReg {
+				return pos, ""
+			}
+			pos++
+			continue
+		}
+		for _, n := range field.Names {
+			if isReg {
+				return pos, n.Name
+			}
+			pos++
+		}
 	}
+	return -1, ""
+}
 
+// isRouteRegistrarType reports whether expr is server.RouteRegistrar.
+func isRouteRegistrarType(expr ast.Expr) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	return ok && pkg.Name == frameworkPkgServer && sel.Sel.Name == routeRegistrarTypeName
+}
+
+// validateServerCall reports whether call is a server.METHOD(hr, r, path, ...)
+// route registration and returns the HTTP method name.
+func (a *ProjectAnalyzer) validateServerCall(callExpr *ast.CallExpr, serverAliases map[string]struct{}) (method string, ok bool) {
 	selExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
 	if !ok {
-		return nil, "", false
+		return "", false
 	}
 
 	pkgIdent, ok := selExpr.X.(*ast.Ident)
 	if !ok || !a.aliasContains(serverAliases, pkgIdent.Name, frameworkPkgServer) {
-		return nil, "", false
+		return "", false
 	}
 
-	method := selExpr.Sel.Name
+	method = selExpr.Sel.Name
 	if !a.isHTTPMethod(method) {
-		return nil, "", false
+		return "", false
 	}
 
 	if len(callExpr.Args) < 3 {
-		return nil, "", false
+		return "", false
 	}
 
-	return callExpr, method, true
+	return method, true
+}
+
+// findMethodDecl finds the declaration of method methodName on structName,
+// searching the current file then the rest of the package.
+func (a *ProjectAnalyzer) findMethodDecl(astFile *ast.File, filePath, structName, methodName string) *ast.FuncDecl {
+	if decl := a.findMethodInFile(astFile, structName, methodName); decl != nil {
+		return decl
+	}
+	files, err := a.parsePackage(filePath, astFile.Name.Name)
+	if err == nil {
+		for _, file := range files {
+			if decl := a.findMethodInFile(file, structName, methodName); decl != nil {
+				return decl
+			}
+		}
+	}
+	return nil
+}
+
+// findMethodInFile finds a method named methodName on structName within one file.
+func (a *ProjectAnalyzer) findMethodInFile(astFile *ast.File, structName, methodName string) *ast.FuncDecl {
+	for _, decl := range astFile.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != methodName || fn.Body == nil {
+			continue
+		}
+		if a.isMethodOnStruct(fn.Recv, structName) {
+			return fn
+		}
+	}
+	return nil
+}
+
+// receiverVarName returns the receiver variable name of a method, or "" if the
+// receiver is unnamed (e.g. func (*Module) ...).
+func receiverVarName(recv *ast.FieldList) string {
+	if recv == nil || len(recv.List) == 0 || len(recv.List[0].Names) == 0 {
+		return ""
+	}
+	return recv.List[0].Names[0].Name
 }
 
 // extractHandlerInfo extracts handler name and type information from a route call.
@@ -577,35 +831,6 @@ func baseTypeName(expr ast.Expr) string {
 	return ""
 }
 
-// extractRouteFromStatement extracts a route from a statement like server.GET(...)
-func (a *ProjectAnalyzer) extractRouteFromStatement(stmt ast.Stmt, astFile *ast.File, filePath, structName string, serverAliases map[string]struct{}) *models.Route {
-	// Validate this is a server.METHOD() call
-	callExpr, method, valid := a.validateServerCall(stmt, serverAliases)
-	if !valid {
-		return nil
-	}
-
-	route := &models.Route{
-		Method: strings.ToUpper(method),
-		Tags:   []string{},
-	}
-
-	// Extract route path, normalizing Echo-style params to OpenAPI templating.
-	route.Path = normalizePath(a.extractPathFromArg(callExpr.Args[2]))
-
-	// Extract handler information
-	route.HandlerName, route.Request, route.Response = a.extractHandlerInfo(
-		callExpr, astFile, filePath, structName,
-	)
-
-	// Extract metadata from remaining arguments
-	for i := 4; i < len(callExpr.Args); i++ {
-		a.extractRouteMetadata(callExpr.Args[i], route, serverAliases)
-	}
-
-	return route
-}
-
 // isHTTPMethod checks if the method name is a valid HTTP method
 func (a *ProjectAnalyzer) isHTTPMethod(method string) bool {
 	httpMethods := []string{"GET", httpMethodPost, "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"}
@@ -681,23 +906,34 @@ func (a *ProjectAnalyzer) extractCommentDescription(commentGroup *ast.CommentGro
 	return strings.Join(lines, " ")
 }
 
-// extractPathFromArg extracts path string from AST argument (handles literals and constants)
-func (a *ProjectAnalyzer) extractPathFromArg(arg ast.Expr) string {
+// extractPathFromArg resolves a route path argument to a literal string. It
+// handles string literals, same-package string constants, and "+" concatenation
+// of resolvable operands. The bool result is false when the path could not be
+// fully resolved (an unknown identifier, a non-string expression, fmt.Sprintf,
+// etc.); the caller then drops the route rather than emitting a garbage path key.
+func (a *ProjectAnalyzer) extractPathFromArg(arg ast.Expr) (string, bool) {
 	switch expr := arg.(type) {
 	case *ast.BasicLit:
-		// Direct string literal
+		// Direct string literal.
 		if expr.Kind == token.STRING {
-			return strings.Trim(expr.Value, `"`)
+			return strings.Trim(expr.Value, `"`), true
 		}
 	case *ast.Ident:
-		// Constant reference - look up in constants map
+		// Same-package string constant.
 		if value, exists := a.constants[expr.Name]; exists {
-			return value
+			return value, true
 		}
-		// If not found, return the identifier name as a fallback
-		return expr.Name
+	case *ast.BinaryExpr:
+		// String concatenation: fold only when both operands resolve.
+		if expr.Op == token.ADD {
+			left, lok := a.extractPathFromArg(expr.X)
+			right, rok := a.extractPathFromArg(expr.Y)
+			if lok && rok {
+				return left + right, true
+			}
+		}
 	}
-	return ""
+	return "", false
 }
 
 // normalizePath converts an Echo-style route path into OpenAPI 3.0 path

--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"go/ast"
@@ -102,9 +103,11 @@ func (a *ProjectAnalyzer) addWarningf(format string, args ...any) {
 	a.warnings = append(a.warnings, fmt.Sprintf(format, args...))
 }
 
-// Warnings returns the non-fatal diagnostics collected during the last analysis.
-func (a *ProjectAnalyzer) Warnings() []string {
-	return a.warnings
+// Warnings returns a copy of the non-fatal diagnostics collected during the last
+// analysis. ctx is accepted per the repo's context-first convention for exported
+// APIs; the returned slice is cloned so callers cannot mutate analyzer state.
+func (a *ProjectAnalyzer) Warnings(_ context.Context) []string {
+	return slices.Clone(a.warnings)
 }
 
 // isFrameworkType checks if a type should be filtered out as a framework type.
@@ -518,8 +521,12 @@ func (w *routeWalker) walkBody(body *ast.BlockStmt, seed map[string]string) {
 // to its accumulated path prefix. Nested groups resolve because Go requires the
 // parent registrar to be declared (and thus visited) before the child.
 //
-// Note: prefix context is per-body; a prefix established in a caller is not
-// threaded into a helper method invoked with the grouped registrar.
+// Limitation: the map is keyed by identifier name across the whole body, so it
+// is not scope-aware. A registrar var name shadowed in different branches with
+// DIFFERENT prefixes (e.g. an `if` and `else` both doing `api := r.Group(...)`
+// with distinct paths) collapses to the last assignment. The idiomatic pattern
+// declares each group once at body scope, which resolves correctly; a fully
+// scope-aware walk is deferred until a real case requires it.
 func (w *routeWalker) collectGroupPrefixes(body *ast.BlockStmt) map[string]string {
 	prefixes := map[string]string{}
 	ast.Inspect(body, func(n ast.Node) bool {
@@ -608,7 +615,7 @@ func (w *routeWalker) maybeRecurseHelper(call *ast.CallExpr, prefixes map[string
 		return
 	}
 	decl := w.a.findMethodDecl(w.astFile, w.filePath, w.structName, method)
-	idx, paramName := routeRegistrarParam(decl)
+	idx, paramName := w.a.routeRegistrarParam(decl, w.serverAliases)
 	if idx < 0 {
 		return // not a route-registration helper
 	}
@@ -632,13 +639,14 @@ func (w *routeWalker) maybeRecurseHelper(call *ast.CallExpr, prefixes map[string
 // routeRegistrarParam returns the positional index and name of a function's
 // server.RouteRegistrar parameter, or (-1, "") if it has none. The index is
 // counted over flattened parameter names so it lines up with call arguments.
-func routeRegistrarParam(decl *ast.FuncDecl) (idx int, name string) {
+// serverAliases lets it recognize an aliased server import.
+func (a *ProjectAnalyzer) routeRegistrarParam(decl *ast.FuncDecl, serverAliases map[string]struct{}) (idx int, name string) {
 	if decl == nil || decl.Type.Params == nil {
 		return -1, ""
 	}
 	pos := 0
 	for _, field := range decl.Type.Params.List {
-		isReg := isRouteRegistrarType(field.Type)
+		isReg := a.isRouteRegistrarType(field.Type, serverAliases)
 		if len(field.Names) == 0 {
 			if isReg {
 				return pos, ""
@@ -656,14 +664,15 @@ func routeRegistrarParam(decl *ast.FuncDecl) (idx int, name string) {
 	return -1, ""
 }
 
-// isRouteRegistrarType reports whether expr is server.RouteRegistrar.
-func isRouteRegistrarType(expr ast.Expr) bool {
+// isRouteRegistrarType reports whether expr is server.RouteRegistrar (honoring an
+// aliased server import).
+func (a *ProjectAnalyzer) isRouteRegistrarType(expr ast.Expr, serverAliases map[string]struct{}) bool {
 	sel, ok := expr.(*ast.SelectorExpr)
 	if !ok {
 		return false
 	}
 	pkg, ok := sel.X.(*ast.Ident)
-	return ok && pkg.Name == frameworkPkgServer && sel.Sel.Name == routeRegistrarTypeName
+	return ok && a.aliasContains(serverAliases, pkg.Name, frameworkPkgServer) && sel.Sel.Name == routeRegistrarTypeName
 }
 
 // validateServerCall reports whether call is a server.METHOD(hr, r, path, ...)

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -536,40 +536,66 @@ func TestExtractPathFromArg(t *testing.T) {
 		name     string
 		arg      ast.Expr
 		expected string
+		expectOK bool
 	}{
 		{
 			name:     "string literal",
 			arg:      &ast.BasicLit{Kind: token.STRING, Value: `"/direct/path"`},
 			expected: "/direct/path",
+			expectOK: true,
 		},
 		{
 			name:     "constant reference found",
 			arg:      &ast.Ident{Name: "testRoute"},
 			expected: "/api/test",
+			expectOK: true,
 		},
 		{
+			// Unresolved identifiers are no longer emitted as garbage path keys.
 			name:     "constant reference not found",
 			arg:      &ast.Ident{Name: "unknownRoute"},
-			expected: "unknownRoute",
+			expected: "",
+			expectOK: false,
 		},
 		{
 			name:     "non-string literal",
 			arg:      &ast.BasicLit{Kind: token.INT, Value: "123"},
 			expected: "",
+			expectOK: false,
 		},
 		{
 			name:     "unsupported expression",
 			arg:      &ast.BinaryExpr{Op: token.ADD},
 			expected: "",
+			expectOK: false,
+		},
+		{
+			name: "concatenation of constant and literal",
+			arg: &ast.BinaryExpr{
+				Op: token.ADD,
+				X:  &ast.Ident{Name: "testRoute"},
+				Y:  &ast.BasicLit{Kind: token.STRING, Value: `"/extra"`},
+			},
+			expected: "/api/test/extra",
+			expectOK: true,
+		},
+		{
+			name: "concatenation with an unresolved operand",
+			arg: &ast.BinaryExpr{
+				Op: token.ADD,
+				X:  &ast.Ident{Name: "unknownRoute"},
+				Y:  &ast.BasicLit{Kind: token.STRING, Value: `"/extra"`},
+			},
+			expected: "",
+			expectOK: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := analyzer.extractPathFromArg(tt.arg)
-			if result != tt.expected {
-				t.Errorf(expectedGotFormat, tt.expected, result)
-			}
+			result, ok := analyzer.extractPathFromArg(tt.arg)
+			assert.Equal(t, tt.expectOK, ok, "resolved")
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
@@ -928,8 +954,9 @@ func (m *Module) RegisterRoutes() {}`,
 	}
 }
 
-// TestExtractRouteFromStatementEdgeCases tests edge cases for extractRouteFromStatement
-func TestExtractRouteFromStatementEdgeCases(t *testing.T) {
+// TestExtractRoutesFromFuncBodyEdgeCases tests edge cases for route extraction
+// from a function body (invalid calls, wrong package, bad arg counts).
+func TestExtractRoutesFromFuncBodyEdgeCases(t *testing.T) {
 	analyzer := New("test")
 
 	tests := []struct {
@@ -959,7 +986,9 @@ func test() { server.GET() }`,
 			name: "server call with too many arguments",
 			content: `package test
 func test() { server.GET("/path", handler, extra1, extra2, extra3) }`,
-			expected: 1, // This actually creates a valid route since it has path and handler
+			// Args[2] (extra1) is an unresolved identifier, not a literal path, so
+			// the route is dropped rather than emitted with a garbage path key.
+			expected: 0,
 		},
 		{
 			name: "non-existent HTTP method",
@@ -3132,4 +3161,245 @@ func (m *Module) list(ctx server.HandlerContext) (server.Result[int], server.IAP
 		assert.Equal(t, "users", project.Modules[0].Routes[i].Module, "route %d Module", i)
 		assert.Equal(t, "users", project.Modules[0].Routes[i].Package, "route %d Package", i)
 	}
+}
+
+// analyzeSingleModule writes src as a module file under a temp project, runs
+// AnalyzeProject, and returns the analyzer (for Warnings) and the flattened routes.
+func analyzeSingleModule(t *testing.T, src string) (*ProjectAnalyzer, []models.Route) {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/app\n\ngo 1.25\n"), 0600))
+	sub := filepath.Join(dir, "mod")
+	require.NoError(t, os.MkdirAll(sub, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "module.go"), []byte(src), 0600))
+
+	a := New(dir)
+	project, err := a.AnalyzeProject()
+	require.NoError(t, err)
+	var routes []models.Route
+	for i := range project.Modules {
+		routes = append(routes, project.Modules[i].Routes...)
+	}
+	return a, routes
+}
+
+func routePathSet(routes []models.Route) map[string]bool {
+	set := map[string]bool{}
+	for i := range routes {
+		set[routes[i].Method+" "+routes[i].Path] = true
+	}
+	return set
+}
+
+func TestRegistrationWalkDiscoversAllPatterns(t *testing.T) {
+	src := `package mod
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+const apiBase = "/api"
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(d *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	v1 := r.Group("/v1")
+	server.GET(hr, v1, "/items", m.h)
+	admin := v1.Group("/admin")
+	server.GET(hr, admin, "/stats", m.h)
+	if true {
+		server.GET(hr, r, "/health", m.h)
+	}
+	for i := 0; i < 1; i++ {
+		server.GET(hr, r, "/loop", m.h)
+	}
+	server.GET(hr, r, apiBase+"/version", m.h)
+	m.helper(hr, r)
+}
+func (m *Module) helper(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.POST(hr, r, "/items", m.h)
+}
+func (m *Module) h(ctx server.HandlerContext) (server.Result[int], server.IAPIError) { return server.OK(0), nil }
+`
+	_, routes := analyzeSingleModule(t, src)
+	got := routePathSet(routes)
+	for _, want := range []string{
+		"GET /v1/items",       // group prefix
+		"GET /v1/admin/stats", // nested group
+		"GET /health",         // inside if-block
+		"GET /loop",           // inside for-block
+		"GET /api/version",    // concatenated const + literal
+		"POST /items",         // helper-registered
+	} {
+		assert.True(t, got[want], "expected route %q; got %v", want, got)
+	}
+}
+
+func TestRegistrationWalkCycleGuard(t *testing.T) {
+	// helperA -> helperB -> helperA: the visited guard must prevent infinite
+	// recursion (the test simply completing proves it) and walk each helper once.
+	src := `package mod
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(d *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/a", m.h)
+	m.helperA(hr, r)
+}
+func (m *Module) helperA(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/b", m.h)
+	m.helperB(hr, r)
+}
+func (m *Module) helperB(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/c", m.h)
+	m.helperA(hr, r)
+}
+func (m *Module) h(ctx server.HandlerContext) (server.Result[int], server.IAPIError) { return server.OK(0), nil }
+`
+	_, routes := analyzeSingleModule(t, src)
+	got := routePathSet(routes)
+	assert.True(t, got["GET /a"])
+	assert.True(t, got["GET /b"])
+	assert.True(t, got["GET /c"])
+	assert.Len(t, routes, 3, "each helper walked exactly once despite the cycle")
+}
+
+func TestRegistrationWalkDropsUnresolvedPath(t *testing.T) {
+	src := `package mod
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(d *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/ok", m.h)
+	server.GET(hr, r, buildPath(), m.h)
+}
+func (m *Module) h(ctx server.HandlerContext) (server.Result[int], server.IAPIError) { return server.OK(0), nil }
+`
+	a, routes := analyzeSingleModule(t, src)
+	require.Len(t, routes, 1, "the route with an unresolvable path must be dropped")
+	assert.Equal(t, "/ok", routes[0].Path)
+	assert.NotEmpty(t, a.Warnings(), "a warning should be recorded for the dropped route")
+}
+
+func TestReceiverVarName(t *testing.T) {
+	named := &ast.FieldList{List: []*ast.Field{{Names: []*ast.Ident{{Name: "m"}}, Type: &ast.Ident{Name: "Module"}}}}
+	assert.Equal(t, "m", receiverVarName(named))
+	assert.Empty(t, receiverVarName(nil), "nil receiver")
+	assert.Empty(t, receiverVarName(&ast.FieldList{}), "empty receiver list")
+	assert.Empty(t, receiverVarName(&ast.FieldList{List: []*ast.Field{{Type: &ast.Ident{Name: "Module"}}}}), "unnamed receiver")
+}
+
+func TestRegistrationWalkHelperInSiblingFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/app\n\ngo 1.25\n"), 0600))
+	sub := filepath.Join(dir, "mod")
+	require.NoError(t, os.MkdirAll(sub, 0750))
+	moduleSrc := `package mod
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(d *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/a", m.h)
+	m.helper(hr, r)
+}
+func (m *Module) h(ctx server.HandlerContext) (server.Result[int], server.IAPIError) { return server.OK(0), nil }
+`
+	// The helper method lives in a sibling file — exercises findMethodDecl's
+	// package-wide fallback search.
+	helperSrc := `package mod
+import "github.com/gaborage/go-bricks/server"
+func (m *Module) helper(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.POST(hr, r, "/b", m.h)
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "module.go"), []byte(moduleSrc), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "helper.go"), []byte(helperSrc), 0600))
+
+	project, err := New(dir).AnalyzeProject()
+	require.NoError(t, err)
+	var routes []models.Route
+	for i := range project.Modules {
+		routes = append(routes, project.Modules[i].Routes...)
+	}
+	got := routePathSet(routes)
+	assert.True(t, got["GET /a"])
+	assert.True(t, got["POST /b"], "helper method in a sibling file must be discovered")
+}
+
+func TestRegistrationWalkThreadsGroupPrefixIntoHelper(t *testing.T) {
+	// A single helper invoked once per version group must be walked each time and
+	// inherit that group's prefix (exercises the recursion-stack guard allowing
+	// re-invocation, plus prefix threading into the helper's registrar param).
+	src := `package mod
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(d *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	v1 := r.Group("/v1")
+	m.itemRoutes(hr, v1)
+	v2 := r.Group("/v2")
+	m.itemRoutes(hr, v2)
+}
+func (m *Module) itemRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/items", m.h)
+}
+func (m *Module) h(ctx server.HandlerContext) (server.Result[int], server.IAPIError) { return server.OK(0), nil }
+`
+	_, routes := analyzeSingleModule(t, src)
+	got := routePathSet(routes)
+	assert.True(t, got["GET /v1/items"], "helper invoked with the v1 group inherits /v1")
+	assert.True(t, got["GET /v2/items"], "same helper invoked with the v2 group inherits /v2")
+	assert.Len(t, routes, 2, "the shared helper is walked once per invocation")
+}
+
+func TestRegistrationWalkIgnoresNonRegistrationMethods(t *testing.T) {
+	// A same-receiver method that is NOT a route-registration helper (no
+	// server.RouteRegistrar param) must not be recursed into, so a server.* call
+	// in its body is not harvested as a phantom route.
+	src := `package mod
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(d *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/real", m.h)
+	if m.featureEnabled() {
+		server.GET(hr, r, "/gated", m.h)
+	}
+}
+func (m *Module) featureEnabled() bool {
+	server.GET(nil, nil, "/phantom", m.h)
+	return true
+}
+func (m *Module) h(ctx server.HandlerContext) (server.Result[int], server.IAPIError) { return server.OK(0), nil }
+`
+	_, routes := analyzeSingleModule(t, src)
+	got := routePathSet(routes)
+	assert.True(t, got["GET /real"])
+	assert.True(t, got["GET /gated"], "a route inside an if-block is still discovered")
+	assert.False(t, got["GET /phantom"], "a server call inside a non-registration method must not become a route")
 }

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -3288,7 +3288,7 @@ func (m *Module) h(ctx server.HandlerContext) (server.Result[int], server.IAPIEr
 	a, routes := analyzeSingleModule(t, src)
 	require.Len(t, routes, 1, "the route with an unresolvable path must be dropped")
 	assert.Equal(t, "/ok", routes[0].Path)
-	assert.NotEmpty(t, a.Warnings(), "a warning should be recorded for the dropped route")
+	assert.NotEmpty(t, a.Warnings(t.Context()), "a warning should be recorded for the dropped route")
 }
 
 func TestReceiverVarName(t *testing.T) {
@@ -3402,4 +3402,31 @@ func (m *Module) h(ctx server.HandlerContext) (server.Result[int], server.IAPIEr
 	assert.True(t, got["GET /real"])
 	assert.True(t, got["GET /gated"], "a route inside an if-block is still discovered")
 	assert.False(t, got["GET /phantom"], "a server call inside a non-registration method must not become a route")
+}
+
+func TestRegistrationWalkHandlesAliasedServerImport(t *testing.T) {
+	// The server package is imported under an alias; helper recursion must still
+	// recognize the aliased srv.RouteRegistrar parameter.
+	src := `package mod
+import (
+	"github.com/gaborage/go-bricks/app"
+	srv "github.com/gaborage/go-bricks/server"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(d *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+func (m *Module) RegisterRoutes(hr *srv.HandlerRegistry, r srv.RouteRegistrar) {
+	srv.GET(hr, r, "/a", m.h)
+	m.helper(hr, r)
+}
+func (m *Module) helper(hr *srv.HandlerRegistry, r srv.RouteRegistrar) {
+	srv.POST(hr, r, "/b", m.h)
+}
+func (m *Module) h(ctx srv.HandlerContext) (srv.Result[int], srv.IAPIError) { return srv.OK(0), nil }
+`
+	_, routes := analyzeSingleModule(t, src)
+	got := routePathSet(routes)
+	assert.True(t, got["GET /a"], "route registered via an aliased server import is discovered")
+	assert.True(t, got["POST /b"], "helper with an aliased RouteRegistrar param is recursed")
 }

--- a/tools/openapi/internal/commands/generate.go
+++ b/tools/openapi/internal/commands/generate.go
@@ -75,6 +75,12 @@ func runGenerate(opts *GenerateOptions) error {
 		}
 	}
 
+	// Surface non-fatal analysis diagnostics (e.g. routes dropped due to an
+	// unresolvable path) on stderr so they don't corrupt the generated spec.
+	for _, w := range projectAnalyzer.Warnings() {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
+	}
+
 	// Generate OpenAPI spec
 	gen := generator.New("Go-Bricks API", "1.0.0", "Generated API specification")
 	specContent, err := gen.Generate(project)

--- a/tools/openapi/internal/commands/generate.go
+++ b/tools/openapi/internal/commands/generate.go
@@ -40,8 +40,8 @@ and produces a comprehensive YAML API specification with validation constraints.
 
   # Generate spec for specific project
   go-bricks-openapi generate -project ./my-service -output docs/openapi.yaml`,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return runGenerate(opts)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runGenerate(cmd.Context(), opts)
 		},
 	}
 
@@ -53,7 +53,7 @@ and produces a comprehensive YAML API specification with validation constraints.
 	return cmd
 }
 
-func runGenerate(opts *GenerateOptions) error {
+func runGenerate(ctx context.Context, opts *GenerateOptions) error {
 	// Validate options
 	if err := validateGenerateOptions(opts); err != nil {
 		return err
@@ -78,7 +78,7 @@ func runGenerate(opts *GenerateOptions) error {
 
 	// Surface non-fatal analysis diagnostics (e.g. routes dropped due to an
 	// unresolvable path) on stderr so they don't corrupt the generated spec.
-	for _, w := range projectAnalyzer.Warnings(context.Background()) {
+	for _, w := range projectAnalyzer.Warnings(ctx) {
 		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
 	}
 

--- a/tools/openapi/internal/commands/generate.go
+++ b/tools/openapi/internal/commands/generate.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -77,7 +78,7 @@ func runGenerate(opts *GenerateOptions) error {
 
 	// Surface non-fatal analysis diagnostics (e.g. routes dropped due to an
 	// unresolvable path) on stderr so they don't corrupt the generated spec.
-	for _, w := range projectAnalyzer.Warnings() {
+	for _, w := range projectAnalyzer.Warnings(context.Background()) {
 		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
 	}
 

--- a/tools/openapi/internal/commands/generate_test.go
+++ b/tools/openapi/internal/commands/generate_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -157,7 +158,7 @@ func TestRunGenerate(t *testing.T) {
 		Verbose:     false,
 	}
 
-	err := runGenerate(opts)
+	err := runGenerate(context.Background(), opts)
 	if err != nil {
 		t.Fatalf(generateCmdFailedMsg, err)
 	}
@@ -202,7 +203,7 @@ func TestRunGenerateDirectoryCreation(t *testing.T) {
 		Verbose:     false,
 	}
 
-	err := runGenerate(opts)
+	err := runGenerate(context.Background(), opts)
 	if err != nil {
 		t.Fatalf(generateCmdFailedMsg, err)
 	}
@@ -229,7 +230,7 @@ func TestRunGenerateVerbose(t *testing.T) {
 	}
 
 	// This should work without panicking even in verbose mode
-	err := runGenerate(opts)
+	err := runGenerate(context.Background(), opts)
 	if err != nil {
 		t.Fatalf("runGenerate() failed in verbose mode: %v", err)
 	}
@@ -363,7 +364,7 @@ func TestRunGenerateErrorCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := tt.setup(t)
-			err := runGenerate(opts)
+			err := runGenerate(context.Background(), opts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("runGenerate() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -381,7 +382,7 @@ func TestRunGenerateYAMLFormat(t *testing.T) {
 		Verbose:     true,
 	}
 
-	err := runGenerate(opts)
+	err := runGenerate(context.Background(), opts)
 	if err != nil {
 		t.Fatalf("runGenerate() failed for YAML format: %v", err)
 	}
@@ -519,7 +520,7 @@ func (m *TestModule) Init(deps any) error { return nil }`
 			os.MkdirAll(testDir, 0755)
 
 			opts := tt.setup(testDir)
-			err := runGenerate(opts)
+			err := runGenerate(context.Background(), opts)
 			if err != nil {
 				t.Fatalf(generateCmdFailedMsg, err)
 			}
@@ -622,7 +623,7 @@ func TestRunGenerateWithWriteError(t *testing.T) {
 			Verbose:     false,
 		}
 
-		err := runGenerate(opts)
+		err := runGenerate(context.Background(), opts)
 		if err != nil {
 			t.Errorf("Expected successful generation, got error: %v", err)
 		}

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -290,6 +290,12 @@ func (g *OpenAPIGenerator) buildPaths(routes []models.Route) map[string]*OpenAPI
 	pathGroups := g.groupRoutesByPath(routes)
 	paths := make(map[string]*OpenAPIPathItem, len(pathGroups))
 	for path := range pathGroups {
+		// Defensive guard: a valid OpenAPI path template must start with "/".
+		// The analyzer already drops unresolvable paths; this rejects anything
+		// that still slipped through rather than emitting an invalid document.
+		if !strings.HasPrefix(path, "/") {
+			continue
+		}
 		group := pathGroups[path]
 		item := &OpenAPIPathItem{}
 		for i := range group {
@@ -302,25 +308,36 @@ func (g *OpenAPIGenerator) buildPaths(routes []models.Route) map[string]*OpenAPI
 
 // assignOperation builds the operation for a route and attaches it to the path
 // item under the matching HTTP method. The analyzer only emits the standard
-// methods (analyzer.isHTTPMethod), so an unrecognized method is a no-op.
+// methods (analyzer.isHTTPMethod), so an unrecognized method is a no-op. A
+// (method, path) already populated is left untouched (first-wins de-dup).
 func (g *OpenAPIGenerator) assignOperation(item *OpenAPIPathItem, route *models.Route) {
-	op := g.buildOperation(route)
-	switch strings.ToUpper(route.Method) {
-	case httpMethodGet:
-		item.Get = op
-	case httpMethodPut:
-		item.Put = op
-	case httpMethodPost:
-		item.Post = op
-	case httpMethodDelete:
-		item.Delete = op
-	case httpMethodPatch:
-		item.Patch = op
-	case httpMethodHead:
-		item.Head = op
-	case httpMethodOptions:
-		item.Options = op
+	slot := item.methodSlot(strings.ToUpper(route.Method))
+	if slot == nil || *slot != nil {
+		return
 	}
+	*slot = g.buildOperation(route)
+}
+
+// methodSlot returns a pointer to the operation field for an HTTP method, or nil
+// for an unrecognized method.
+func (item *OpenAPIPathItem) methodSlot(method string) **OpenAPIOperation {
+	switch method {
+	case httpMethodGet:
+		return &item.Get
+	case httpMethodPut:
+		return &item.Put
+	case httpMethodPost:
+		return &item.Post
+	case httpMethodDelete:
+		return &item.Delete
+	case httpMethodPatch:
+		return &item.Patch
+	case httpMethodHead:
+		return &item.Head
+	case httpMethodOptions:
+		return &item.Options
+	}
+	return nil
 }
 
 // Parameter represents an OpenAPI parameter (path, query, or header). Field

--- a/tools/openapi/internal/generator/openapi_test.go
+++ b/tools/openapi/internal/generator/openapi_test.go
@@ -343,6 +343,29 @@ func TestGetAllRoutesStampsModuleIdentity(t *testing.T) {
 	assert.Empty(t, project.Modules[0].Routes[0].Module, "original route must remain unstamped")
 }
 
+func TestBuildPathsDropsNonRootedPath(t *testing.T) {
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+	paths := gen.buildPaths([]models.Route{
+		{Method: "GET", Path: "/ok"},
+		{Method: "GET", Path: "broken"}, // no leading slash
+	})
+	_, hasOK := paths["/ok"]
+	_, hasBroken := paths["broken"]
+	assert.True(t, hasOK)
+	assert.False(t, hasBroken, "a path key without a leading slash must be dropped")
+}
+
+func TestBuildPathsDedupesSameMethodAndPath(t *testing.T) {
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+	paths := gen.buildPaths([]models.Route{
+		{Method: "GET", Path: "/x", HandlerName: "first"},
+		{Method: "GET", Path: "/x", HandlerName: "second"}, // same (method,path)
+	})
+	require.NotNil(t, paths["/x"])
+	require.NotNil(t, paths["/x"].Get)
+	assert.Equal(t, "first", paths["/x"].Get.OperationID, "first registration wins on a duplicate (method,path)")
+}
+
 func TestGetAllRoutes(t *testing.T) {
 	gen := New(defaultTitle, "1.0.0", defaultDescription)
 

--- a/tools/openapi/internal/spectest/testdata/registration/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/registration/expected.yaml
@@ -1,0 +1,149 @@
+openapi: 3.0.1
+info:
+  title: Storefront API
+  version: 1.0.0
+  description: Generated API specification
+paths:
+  /api/version:
+    get:
+      operationId: version
+      summary: GET /api/version
+      tags:
+        - ops
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /health:
+    get:
+      operationId: health
+      summary: GET /health
+      tags:
+        - ops
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /items:
+    post:
+      operationId: createItem
+      summary: POST /items
+      tags:
+        - items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Item'
+      responses:
+        "200":
+          description: Resource created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/admin/stats:
+    get:
+      operationId: stats
+      summary: GET /v1/admin/stats
+      tags:
+        - admin
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /v1/items:
+    get:
+      operationId: listItems
+      summary: GET /v1/items
+      tags:
+        - items
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: object
+          description: Error details with code and message
+        meta:
+          type: object
+          description: Response metadata
+      required:
+        - error
+    Item:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    JOSEErrorEnvelope:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
+        message:
+          type: string
+          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
+      required:
+        - code
+        - message
+    SuccessResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          description: Response data
+        meta:
+          type: object
+          description: Response metadata

--- a/tools/openapi/internal/spectest/testdata/registration/go.mod
+++ b/tools/openapi/internal/spectest/testdata/registration/go.mod
@@ -1,0 +1,5 @@
+module github.com/example/storefront
+
+go 1.25
+
+require github.com/gaborage/go-bricks v0.37.0

--- a/tools/openapi/internal/spectest/testdata/registration/storefront.go
+++ b/tools/openapi/internal/spectest/testdata/registration/storefront.go
@@ -1,0 +1,58 @@
+// Package storefront registers routes via groups, helper methods, control-flow
+// blocks, and concatenated paths — exercising the analyzer's registration walk.
+package storefront
+
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+
+const apiBase = "/api"
+
+// Module is the storefront module.
+type Module struct{}
+
+func (m *Module) Name() string                    { return "storefront" }
+func (m *Module) Init(d *app.ModuleDeps) error    { return nil }
+func (m *Module) Shutdown() error                 { return nil }
+
+// Item is the storefront item resource.
+type Item struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+// RegisterRoutes registers routes through several non-trivial patterns.
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	// Grouped routes: /v1/items
+	v1 := r.Group("/v1")
+	server.GET(hr, v1, "/items", m.listItems, server.WithTags("items"))
+
+	// Nested group: /v1/admin/stats
+	admin := v1.Group("/admin")
+	server.GET(hr, admin, "/stats", m.stats, server.WithTags("admin"))
+
+	// Route registered inside a conditional block.
+	if true {
+		server.GET(hr, r, "/health", m.health, server.WithTags("ops"))
+	}
+
+	// Concatenated path from a constant: /api/version
+	server.GET(hr, r, apiBase+"/version", m.version, server.WithTags("ops"))
+
+	// Routes registered by a helper method.
+	m.registerItemWrites(hr, r)
+}
+
+// registerItemWrites is a helper the walker must recurse into.
+func (m *Module) registerItemWrites(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.POST(hr, r, "/items", m.createItem, server.WithTags("items"))
+}
+
+func (m *Module) listItems(ctx server.HandlerContext) (server.Result[Item], server.IAPIError) { return server.OK(Item{}), nil }
+func (m *Module) stats(ctx server.HandlerContext) (server.Result[Item], server.IAPIError)     { return server.OK(Item{}), nil }
+func (m *Module) health(ctx server.HandlerContext) (server.Result[Item], server.IAPIError)    { return server.OK(Item{}), nil }
+func (m *Module) version(ctx server.HandlerContext) (server.Result[Item], server.IAPIError)   { return server.OK(Item{}), nil }
+func (m *Module) createItem(req Item, ctx server.HandlerContext) (server.Result[Item], server.IAPIError) {
+	return server.Created(Item{}), nil
+}


### PR DESCRIPTION
## PR 4 of the OpenAPI-tool fidelity roadmap — registration-walk discovery

Depends on #488 (merged). Makes route discovery find routes wherever they're actually registered, not just as top-level statements.

### Before
Discovery only processed top-level `server.METHOD(...)` statements directly in `RegisterRoutes`. Routes registered inside control flow, via helper methods, or on a `r.Group(prefix)` sub-router were **silently missed or emitted at the wrong path**.

### Now
- **Nested control flow** — an `ast.Inspect` walk finds routes inside `if`/`for`/`range`/blocks.
- **Helper methods** — same-receiver helpers that take a `server.RouteRegistrar` are recursed into (a recursion-*stack* guard prevents cycles while allowing a shared helper to be invoked more than once, e.g. once per version group).
- **Group prefixes** — `r.Group("/v1")` (including nested groups) prepends the prefix; the prefix is also threaded into a helper invoked with a grouped registrar.
- **Path resolution** — `extractPathFromArg` folds `"+"` concatenation and same-package constants, and returns a resolved bool: unresolvable paths (`fmt.Sprintf`, unknown idents) **drop the route with a warning** instead of emitting a garbage key.
- **Generator guards** — `buildPaths` rejects non-`/` path keys; `assignOperation` de-dupes `(method, path)` (first-wins). Analyzer warnings print to stderr from `generate`.

### Proof
New `registration` fixture discovers all five patterns end-to-end: `/v1/items` (group), `/v1/admin/stats` (nested group), `/health` (`if`-block), `/api/version` (concatenated const), `/items` (helper-registered).

### Pre-push verification
- `make check` (fmt + lint + race tests + validate-cli) — green; `make validate-spec` — clean
- `/code-review` (2 finder agents) **caught three real correctness bugs**, all fixed + tested:
  1. **Phantom routes** — recursing into non-route helpers (predicate/factory methods with stray `server.*` calls) → now only `RouteRegistrar`-taking helpers are recursed.
  2. **Dropped routes** — a permanent-by-name cycle guard blocked a shared helper called twice → now a recursion-stack guard.
  3. **Wrong paths** — group prefix not threaded into helpers → now threaded (versioned-helper pattern verified: `GET /v1/items` + `GET /v2/items`).
  Plus: warnings reset per analysis; added tests for the dedupe arm, the non-`/` guard, and the above. Deferred: surfacing warnings in `doctor` → the doctor PR.
- `/security-audit` — gosec 0, govulncheck clean, no secrets
- Coverage: new walker functions well covered; tool total **90.5%**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emits non-fatal warnings during analysis and exposes them so the generator prints them before output.
  * Adds a sample OpenAPI spec for the Storefront API in testdata.

* **Bug Fixes**
  * Unresolvable route paths are dropped (no identifier fallback).
  * Paths without a leading "/" are skipped in generation.
  * Duplicate method+path registrations are deduplicated (first wins).

* **Tests**
  * Expanded tests covering nested/grouped registrations, helper recursion, path concatenation, warnings, aliased imports, and generator behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->