### PR TITLE
feat(openapi): recursive schema registry with $ref emission (PR5)

### DIFF
--- a/tools/openapi/Makefile
+++ b/tools/openapi/Makefile
@@ -8,7 +8,9 @@ VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 # @latest) so an upstream release cannot silently change the gate or break CI.
 REDOCLY_VERSION := 2.31.5
 # Fixture project the spec gate generates from, plus a throwaway output path.
-SPEC_FIXTURE := internal/spectest/testdata/path_param
+# nested_schema is the richest fixture (recursive $refs, nested + sliced structs),
+# so redocly validates the hardest case the generator produces.
+SPEC_FIXTURE := internal/spectest/testdata/nested_schema
 SPEC_TMP := $(CURDIR)/.openapi-fixture-spec.yaml
 
 # Default target

--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -1627,10 +1627,16 @@ func (a *ProjectAnalyzer) registerType(name, pkg string, astFile *ast.File, file
 // types (pkg.T) and maps are returned as-is and will not resolve to a local
 // struct (cross-package and map value resolution are handled separately).
 func baseStructTypeName(t string) string {
-	t = strings.TrimPrefix(t, "*")
-	t = strings.TrimPrefix(t, "[]")
-	t = strings.TrimPrefix(t, "*")
-	return t
+	for {
+		switch {
+		case strings.HasPrefix(t, "*"):
+			t = t[1:]
+		case strings.HasPrefix(t, "[]"):
+			t = t[2:]
+		default:
+			return t
+		}
+	}
 }
 
 // hasJOSESentinelTag reports whether the struct uses the JOSE sentinel-field

--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -82,18 +82,20 @@ const (
 
 // ProjectAnalyzer analyzes Go-Bricks projects to extract module and route information
 type ProjectAnalyzer struct {
-	projectRoot string
-	fileSet     *token.FileSet
-	constants   map[string]string // Map of constant names to their values
-	warnings    []string          // Non-fatal diagnostics collected during analysis
+	projectRoot  string
+	fileSet      *token.FileSet
+	constants    map[string]string           // Map of constant names to their values
+	warnings     []string                    // Non-fatal diagnostics collected during analysis
+	typeRegistry map[string]*models.TypeInfo // Named struct types reachable from routes (by schema name)
 }
 
 // New creates a new project analyzer
 func New(projectRoot string) *ProjectAnalyzer {
 	return &ProjectAnalyzer{
-		projectRoot: projectRoot,
-		fileSet:     token.NewFileSet(),
-		constants:   make(map[string]string),
+		projectRoot:  projectRoot,
+		fileSet:      token.NewFileSet(),
+		constants:    make(map[string]string),
+		typeRegistry: make(map[string]*models.TypeInfo),
 	}
 }
 
@@ -138,9 +140,10 @@ func (a *ProjectAnalyzer) AnalyzeProject() (*models.Project, error) {
 		Modules:     []models.Module{},
 	}
 
-	// Reset per-run diagnostics so repeated analyses on the same analyzer don't
-	// accumulate stale warnings.
+	// Reset per-run state so repeated analyses on the same analyzer don't
+	// accumulate stale warnings or type-registry entries.
 	a.warnings = nil
+	a.typeRegistry = make(map[string]*models.TypeInfo)
 
 	// Discover project metadata from go.mod
 	a.discoverProjectMetadata(project)
@@ -152,6 +155,7 @@ func (a *ProjectAnalyzer) AnalyzeProject() (*models.Project, error) {
 	}
 
 	project.Modules = modules
+	project.Types = a.typeRegistry
 	return project, nil
 }
 
@@ -1560,25 +1564,73 @@ func (a *ProjectAnalyzer) extractHandlerSignature(
 	return nil, nil, fmt.Errorf("handler %s not found for receiver %q", handlerName, receiverType)
 }
 
-// populateTypeFields populates the Fields slice for a TypeInfo by finding its struct definition
+// populateTypeFields populates a request/response TypeInfo's fields and registers
+// every named struct type reachable from it (nested, sliced, pointed-to, or
+// recursive) into the analyzer's type registry, so the generator can emit a
+// component per type and $ref between them.
 func (a *ProjectAnalyzer) populateTypeFields(typeInfo *models.TypeInfo, astFile *ast.File, filePath string) {
 	if typeInfo == nil {
 		return
 	}
-
-	// Find struct definition
-	structType, err := a.findStructDefinition(astFile, filePath, typeInfo.Name)
-	if err != nil {
-		// Struct not found - might be a primitive type or external type
+	registered := a.registerType(typeInfo.Name, typeInfo.Package, astFile, filePath)
+	if registered == nil {
 		return
 	}
+	// Mirror the registered fields onto the route's TypeInfo (request bodies and
+	// responses read Fields directly).
+	typeInfo.Fields = registered.Fields
+	typeInfo.JOSE = registered.JOSE
+}
 
-	// Extract fields from struct
-	typeInfo.Fields = a.extractStructFields(structType, typeInfo.Package)
-	// Scan for the JOSE sentinel field — the standard `_ struct{} `jose:"..."` ` pattern
-	// is filtered out of Fields by the unexported-name check, so JOSE detection runs as
-	// a separate pre-pass over raw struct fields.
-	typeInfo.JOSE = hasJOSESentinelTag(structType)
+// registerType resolves the struct named name in the package of astFile, adds it
+// to the type registry, and recurses into its struct-typed fields. It is
+// idempotent and registers a type BEFORE recursing so a self- or mutually-
+// referential type (e.g. Category{Parent *Category}) terminates. Returns nil when
+// name is not a resolvable local struct (a primitive, external, or unknown type).
+func (a *ProjectAnalyzer) registerType(name, pkg string, astFile *ast.File, filePath string) *models.TypeInfo {
+	if existing, ok := a.typeRegistry[name]; ok {
+		// Two packages contributing the same type name collide on one (name-keyed)
+		// component schema; surface it rather than silently first-winning.
+		// Package-qualified disambiguation is handled separately.
+		if pkg != "" && existing.Package != "" && existing.Package != pkg {
+			a.addWarningf("type name %q is defined in both %q and %q; they share one component schema", name, existing.Package, pkg)
+		}
+		return existing
+	}
+	structType, err := a.findStructDefinition(astFile, filePath, name)
+	if err != nil {
+		return nil
+	}
+
+	ti := &models.TypeInfo{Name: name, Package: pkg}
+	a.typeRegistry[name] = ti // register before recursing (cycle guard)
+	ti.Fields = a.extractStructFields(structType, pkg)
+	ti.JOSE = hasJOSESentinelTag(structType)
+
+	for i := range ti.Fields {
+		f := &ti.Fields[i]
+		// Skip fields excluded from JSON (mirrors typeInfoToSchema) so a type only
+		// reachable through a json:"-" field is not registered as an orphan/leaked
+		// component.
+		if f.JSONName == jsonSkipValue && f.ParamType == "" {
+			continue
+		}
+		if base := baseStructTypeName(f.Type); a.registerType(base, pkg, astFile, filePath) != nil {
+			f.RefName = base
+		}
+	}
+	return ti
+}
+
+// baseStructTypeName strips slice and pointer markers from a Go type string to
+// expose the underlying named type (e.g. "[]*Address" -> "Address"). Qualified
+// types (pkg.T) and maps are returned as-is and will not resolve to a local
+// struct (cross-package and map value resolution are handled separately).
+func baseStructTypeName(t string) string {
+	t = strings.TrimPrefix(t, "*")
+	t = strings.TrimPrefix(t, "[]")
+	t = strings.TrimPrefix(t, "*")
+	return t
 }
 
 // hasJOSESentinelTag reports whether the struct uses the JOSE sentinel-field

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -3132,6 +3132,122 @@ func TestTypeInfoFromExprResultWrappers(t *testing.T) {
 	})
 }
 
+func TestRegisterTypeBuildsRegistryWithRefsAndCycleGuard(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/app\n\ngo 1.25\n"), 0600))
+	sub := filepath.Join(dir, "mod")
+	require.NoError(t, os.MkdirAll(sub, 0750))
+	// Node is self-referential through both a pointer and a slice; the cycle guard
+	// must register it exactly once.
+	src := `package mod
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(d *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+type Address struct { Street string }
+type Node struct {
+	Addr     Address
+	Parent   *Node
+	Children []Node
+	Tags     []string
+}
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.POST(hr, r, "/n", m.create)
+}
+func (m *Module) create(req Node, ctx server.HandlerContext) (server.Result[int], server.IAPIError) { return server.OK(0), nil }
+`
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "module.go"), []byte(src), 0600))
+
+	project, err := New(dir).AnalyzeProject()
+	require.NoError(t, err)
+
+	// Registry holds the request type and its reachable nested types, each once.
+	require.Contains(t, project.Types, "Node")
+	require.Contains(t, project.Types, "Address")
+	assert.Len(t, project.Types, 2, "Node + Address; the recursive Node is registered once")
+
+	fields := map[string]models.FieldInfo{}
+	for _, f := range project.Types["Node"].Fields {
+		fields[f.Name] = f
+	}
+	assert.Equal(t, "Address", fields["Addr"].RefName, "nested struct field -> RefName")
+	assert.Equal(t, "Node", fields["Parent"].RefName, "pointer self-ref -> RefName")
+	assert.Equal(t, "Node", fields["Children"].RefName, "slice self-ref -> RefName")
+	assert.Empty(t, fields["Tags"].RefName, "[]string field must not get a RefName")
+}
+
+func TestBaseStructTypeName(t *testing.T) {
+	assert.Equal(t, "Address", baseStructTypeName("Address"))
+	assert.Equal(t, "Address", baseStructTypeName("*Address"))
+	assert.Equal(t, "Address", baseStructTypeName("[]Address"))
+	assert.Equal(t, "Address", baseStructTypeName("[]*Address"))
+	assert.Equal(t, "string", baseStructTypeName("[]string"))
+	assert.Equal(t, "map[string]Address", baseStructTypeName("map[string]Address"), "maps returned as-is")
+}
+
+// analyzeModuleProject writes src as a module file under a temp project and runs
+// AnalyzeProject, returning the project (for inspecting project.Types).
+func analyzeModuleProject(t *testing.T, src string) *models.Project {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/app\n\ngo 1.25\n"), 0600))
+	sub := filepath.Join(dir, "mod")
+	require.NoError(t, os.MkdirAll(sub, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "module.go"), []byte(src), 0600))
+	project, err := New(dir).AnalyzeProject()
+	require.NoError(t, err)
+	return project
+}
+
+func TestRegisterTypeHandlesMutualRecursion(t *testing.T) {
+	src := `package mod
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(d *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+type A struct { Link *B }
+type B struct { Back *A }
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.POST(hr, r, "/a", m.create)
+}
+func (m *Module) create(req A, ctx server.HandlerContext) (server.Result[int], server.IAPIError) { return server.OK(0), nil }
+`
+	project := analyzeModuleProject(t, src)
+	require.Contains(t, project.Types, "A")
+	require.Contains(t, project.Types, "B")
+	assert.Len(t, project.Types, 2, "mutual recursion A<->B registers each type once")
+	assert.Equal(t, "B", project.Types["A"].Fields[0].RefName)
+	assert.Equal(t, "A", project.Types["B"].Fields[0].RefName)
+}
+
+func TestRegisterTypeSkipsJSONExcludedFields(t *testing.T) {
+	// A type reachable ONLY through a json:"-" field must not be registered as an
+	// (unreferenced, internal) component. Built via concatenation because the raw
+	// source needs backtick struct tags.
+	src := "package mod\n" +
+		"import (\n\t\"github.com/gaborage/go-bricks/app\"\n\t\"github.com/gaborage/go-bricks/server\"\n)\n" +
+		"type Module struct{}\n" +
+		"func (m *Module) Name() string { return \"mod\" }\n" +
+		"func (m *Module) Init(d *app.ModuleDeps) error { return nil }\n" +
+		"func (m *Module) Shutdown() error { return nil }\n" +
+		"type Secret struct { Token string }\n" +
+		"type Req struct {\n\tName   string `json:\"name\"`\n\tHidden Secret `json:\"-\"`\n}\n" +
+		"func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {\n" +
+		"\tserver.POST(hr, r, \"/r\", m.create)\n}\n" +
+		"func (m *Module) create(req Req, ctx server.HandlerContext) (server.Result[int], server.IAPIError) { return server.OK(0), nil }\n"
+	project := analyzeModuleProject(t, src)
+	require.Contains(t, project.Types, "Req")
+	assert.NotContains(t, project.Types, "Secret", `a type reachable only via a json:"-" field must not be registered`)
+}
+
 func TestAnalyzeProjectStampsModuleIdentity(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/app\n\ngo 1.25\n"), 0600))

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -3185,6 +3185,7 @@ func TestBaseStructTypeName(t *testing.T) {
 	assert.Equal(t, "Address", baseStructTypeName("*Address"))
 	assert.Equal(t, "Address", baseStructTypeName("[]Address"))
 	assert.Equal(t, "Address", baseStructTypeName("[]*Address"))
+	assert.Equal(t, "Address", baseStructTypeName("**[]*Address"), "double pointer before slice")
 	assert.Equal(t, "string", baseStructTypeName("[]string"))
 	assert.Equal(t, "map[string]Address", baseStructTypeName("map[string]Address"), "maps returned as-is")
 }

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -673,7 +673,13 @@ func (g *OpenAPIGenerator) fieldInfoToProperty(field *models.FieldInfo) *OpenAPI
 	if field.RefName != "" {
 		ref := &OpenAPIProperty{Ref: refPath(field.RefName)}
 		if isSliceType(field.Type) {
-			return &OpenAPIProperty{Type: typeArray, Items: ref}
+			// The inner $ref must stand alone, but the array wrapper carries the
+			// field's documentation.
+			arr := &OpenAPIProperty{Type: typeArray, Items: ref, Description: field.Description}
+			if field.Example != "" {
+				arr.Example = field.Example
+			}
+			return arr
 		}
 		return ref
 	}

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -202,9 +202,15 @@ func (g *OpenAPIGenerator) Generate(project *models.Project) (string, error) {
 	}
 	sb.WriteString(pathsYAML)
 
-	// Components with proper YAML marshaling
+	// Components with proper YAML marshaling. Prefer the analyzer-built type
+	// registry (which includes nested/recursive types); fall back to a flat
+	// registry of route request/response types for projects assembled without it.
+	types := project.Types
+	if types == nil {
+		types = routeTypeRegistry(project)
+	}
 	standardSchemas := g.createStandardSchemas()
-	generatedSchemas := g.generateSchemasFromTypes(allRoutes)
+	generatedSchemas := g.generateSchemasFromTypes(types)
 
 	// Merge schemas (generated schemas override standard if there's a conflict)
 	schemas := make(map[string]*OpenAPISchema)
@@ -573,31 +579,49 @@ func (g *OpenAPIGenerator) createStandardSchemas() map[string]*OpenAPISchema {
 }
 
 // generateSchemasFromTypes creates OpenAPI schemas from discovered type information
-func (g *OpenAPIGenerator) generateSchemasFromTypes(routes []models.Route) map[string]*OpenAPISchema {
-	schemas := make(map[string]*OpenAPISchema)
-	seen := make(map[string]bool)
-
-	for i := range routes {
-		// Generate schema for request type
-		if routes[i].Request != nil && !seen[routes[i].Request.Name] {
-			schema := g.typeInfoToSchema(routes[i].Request)
-			if schema != nil {
-				schemas[routes[i].Request.Name] = schema
-				seen[routes[i].Request.Name] = true
-			}
-		}
-
-		// Generate schema for response type
-		if routes[i].Response != nil && !seen[routes[i].Response.Name] {
-			schema := g.typeInfoToSchema(routes[i].Response)
-			if schema != nil {
-				schemas[routes[i].Response.Name] = schema
-				seen[routes[i].Response.Name] = true
-			}
+// generateSchemasFromTypes emits one component schema per registered type. The
+// registry already contains every named struct reachable from a route's request
+// or response (including nested, sliced, and recursive types), so iterating it
+// produces a self-contained set of components with all $refs resolvable.
+func (g *OpenAPIGenerator) generateSchemasFromTypes(types map[string]*models.TypeInfo) map[string]*OpenAPISchema {
+	schemas := make(map[string]*OpenAPISchema, len(types))
+	for _, ti := range types {
+		if schema := g.typeInfoToSchema(ti); schema != nil {
+			schemas[schemaName(ti)] = schema
 		}
 	}
-
 	return schemas
+}
+
+// schemaName is the single source for a type's component-schema name (and the
+// $ref that points at it). Centralized so name disambiguation across packages
+// can be added in one place later.
+func schemaName(ti *models.TypeInfo) string {
+	return ti.Name
+}
+
+// routeTypeRegistry builds a flat type registry from the request/response types
+// of a project's routes. It is the fallback used when project.Types is unset
+// (e.g. a Project assembled directly rather than via the analyzer); it does not
+// resolve nested types, which the analyzer's registry already includes.
+func routeTypeRegistry(project *models.Project) map[string]*models.TypeInfo {
+	types := make(map[string]*models.TypeInfo)
+	add := func(ti *models.TypeInfo) {
+		if ti == nil || ti.Name == "" {
+			return
+		}
+		if _, ok := types[ti.Name]; !ok {
+			types[ti.Name] = ti
+		}
+	}
+	for mi := range project.Modules {
+		for ri := range project.Modules[mi].Routes {
+			route := &project.Modules[mi].Routes[ri]
+			add(route.Request)
+			add(route.Response)
+		}
+	}
+	return types
 }
 
 // typeInfoToSchema converts a TypeInfo to an OpenAPI schema
@@ -641,8 +665,19 @@ func (g *OpenAPIGenerator) typeInfoToSchema(typeInfo *models.TypeInfo) *OpenAPIS
 	return schema
 }
 
-// fieldInfoToProperty converts a FieldInfo to an OpenAPI property
+// fieldInfoToProperty converts a FieldInfo to an OpenAPI property.
 func (g *OpenAPIGenerator) fieldInfoToProperty(field *models.FieldInfo) *OpenAPIProperty {
+	// A field whose underlying type is a registered struct is a $ref (or an array
+	// of $ref). A $ref must stand alone — it carries no sibling type/format or
+	// constraint keywords — so return early.
+	if field.RefName != "" {
+		ref := &OpenAPIProperty{Ref: refPath(field.RefName)}
+		if isSliceType(field.Type) {
+			return &OpenAPIProperty{Type: typeArray, Items: ref}
+		}
+		return ref
+	}
+
 	prop := &OpenAPIProperty{
 		Description: field.Description,
 	}
@@ -659,6 +694,12 @@ func (g *OpenAPIGenerator) fieldInfoToProperty(field *models.FieldInfo) *OpenAPI
 	g.applyConstraints(prop, field)
 
 	return prop
+}
+
+// isSliceType reports whether a Go type string denotes a slice (after an
+// optional leading pointer), e.g. "[]Address" or "*[]Address".
+func isSliceType(goType string) bool {
+	return strings.HasPrefix(strings.TrimPrefix(goType, "*"), "[]")
 }
 
 // setTypeAndFormat maps Go types to OpenAPI type and format

--- a/tools/openapi/internal/generator/openapi_test.go
+++ b/tools/openapi/internal/generator/openapi_test.go
@@ -949,6 +949,18 @@ func TestFieldInfoToPropertyRef(t *testing.T) {
 		require.NotNil(t, prop.Items)
 		assert.Equal(t, refPath("User"), prop.Items.Ref)
 	})
+	t.Run("slice_of_ref_keeps_array_level_docs", func(t *testing.T) {
+		prop := gen.fieldInfoToProperty(&models.FieldInfo{
+			Name: "Addrs", Type: "[]Address", RefName: "Address",
+			Description: "the user's addresses", Example: "n/a",
+		})
+		assert.Equal(t, typeArray, prop.Type)
+		assert.Equal(t, "the user's addresses", prop.Description, "array wrapper keeps the field description")
+		assert.Equal(t, "n/a", prop.Example)
+		require.NotNil(t, prop.Items)
+		assert.Equal(t, refPath("Address"), prop.Items.Ref)
+		assert.Empty(t, prop.Items.Description, "the inner $ref must stand alone")
+	})
 	t.Run("non_ref_field_keeps_type_and_constraints", func(t *testing.T) {
 		prop := gen.fieldInfoToProperty(&models.FieldInfo{
 			Name: "Name", Type: "string",

--- a/tools/openapi/internal/generator/openapi_test.go
+++ b/tools/openapi/internal/generator/openapi_test.go
@@ -783,104 +783,50 @@ func validateErrorResponseSchema(t *testing.T, schemas map[string]*OpenAPISchema
 func TestGenerateSchemasFromTypes(t *testing.T) {
 	gen := New(defaultTitle, "1.0.0", defaultDescription)
 
+	createUserReq := &models.TypeInfo{
+		Name: "CreateUserReq", Package: "users",
+		Fields: []models.FieldInfo{{Name: "Name", Type: "string", JSONName: "name"}},
+	}
+	user := &models.TypeInfo{
+		Name: "User", Package: "users",
+		Fields: []models.FieldInfo{
+			{Name: "ID", Type: "int64", JSONName: "id"},
+			{Name: "Name", Type: "string", JSONName: "name"},
+		},
+	}
+
 	tests := []struct {
 		name            string
-		routes          []models.Route
+		types           map[string]*models.TypeInfo
 		expectedCount   int
 		expectedSchemas []string
 	}{
 		{
-			name:          "no routes",
-			routes:        []models.Route{},
+			name:          "no types",
+			types:         map[string]*models.TypeInfo{},
 			expectedCount: 0,
 		},
 		{
-			name: "single request type",
-			routes: []models.Route{
-				{
-					Method: "POST",
-					Path:   usersAPIPath,
-					Request: &models.TypeInfo{
-						Name:    "CreateUserReq",
-						Package: "users",
-						Fields: []models.FieldInfo{
-							{Name: "Name", Type: "string", JSONName: "name"},
-						},
-					},
-				},
-			},
+			name:            "single type",
+			types:           map[string]*models.TypeInfo{"CreateUserReq": createUserReq},
 			expectedCount:   1,
 			expectedSchemas: []string{"CreateUserReq"},
 		},
 		{
-			name: "request and response types",
-			routes: []models.Route{
-				{
-					Method: "POST",
-					Path:   usersAPIPath,
-					Request: &models.TypeInfo{
-						Name:    "CreateUserReq",
-						Package: "users",
-						Fields: []models.FieldInfo{
-							{Name: "Name", Type: "string", JSONName: "name"},
-						},
-					},
-					Response: &models.TypeInfo{
-						Name:    "User",
-						Package: "users",
-						Fields: []models.FieldInfo{
-							{Name: "ID", Type: "int64", JSONName: "id"},
-							{Name: "Name", Type: "string", JSONName: "name"},
-						},
-					},
-				},
-			},
+			name:            "request and response types",
+			types:           map[string]*models.TypeInfo{"CreateUserReq": createUserReq, "User": user},
 			expectedCount:   2,
 			expectedSchemas: []string{"CreateUserReq", "User"},
-		},
-		{
-			name: "duplicate types across routes",
-			routes: []models.Route{
-				{
-					Method: "POST",
-					Path:   usersAPIPath,
-					Request: &models.TypeInfo{
-						Name:    "CreateUserReq",
-						Package: "users",
-						Fields: []models.FieldInfo{
-							{Name: "Name", Type: "string", JSONName: "name"},
-						},
-					},
-				},
-				{
-					Method: "PUT",
-					Path:   usersIDAPIPath,
-					Request: &models.TypeInfo{
-						Name:    "CreateUserReq", // Same type as POST
-						Package: "users",
-						Fields: []models.FieldInfo{
-							{Name: "Name", Type: "string", JSONName: "name"},
-						},
-					},
-				},
-			},
-			expectedCount:   1, // Should deduplicate
-			expectedSchemas: []string{"CreateUserReq"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			schemas := gen.generateSchemasFromTypes(tt.routes)
-
-			if len(schemas) != tt.expectedCount {
-				t.Errorf("Expected %d schemas, got %d", tt.expectedCount, len(schemas))
-			}
-
+			schemas := gen.generateSchemasFromTypes(tt.types)
+			assert.Len(t, schemas, tt.expectedCount)
 			for _, name := range tt.expectedSchemas {
-				if _, exists := schemas[name]; !exists {
-					t.Errorf("Expected schema %q not found", name)
-				}
+				_, exists := schemas[name]
+				assert.True(t, exists, "expected schema %q", name)
 			}
 		})
 	}
@@ -979,6 +925,40 @@ func assertSchemaShape(t *testing.T, expectedType string, expectedProps int, exp
 			t.Errorf("Expected required[%d] = %q, got %q", i, req, schema.Required[i])
 		}
 	}
+}
+
+func TestFieldInfoToPropertyRef(t *testing.T) {
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+
+	t.Run("struct_field_is_ref", func(t *testing.T) {
+		prop := gen.fieldInfoToProperty(&models.FieldInfo{Name: "Addr", Type: "Address", RefName: "Address"})
+		assert.Equal(t, refPath("Address"), prop.Ref)
+		assert.Empty(t, prop.Type, "a $ref must not carry a sibling type")
+		assert.Nil(t, prop.Items)
+	})
+	t.Run("slice_of_struct_is_items_ref", func(t *testing.T) {
+		prop := gen.fieldInfoToProperty(&models.FieldInfo{Name: "Addrs", Type: "[]Address", RefName: "Address"})
+		assert.Equal(t, typeArray, prop.Type)
+		require.NotNil(t, prop.Items)
+		assert.Equal(t, refPath("Address"), prop.Items.Ref)
+		assert.Empty(t, prop.Ref)
+	})
+	t.Run("slice_of_pointer_struct_is_items_ref", func(t *testing.T) {
+		prop := gen.fieldInfoToProperty(&models.FieldInfo{Name: "Reports", Type: "[]*User", RefName: "User"})
+		assert.Equal(t, typeArray, prop.Type)
+		require.NotNil(t, prop.Items)
+		assert.Equal(t, refPath("User"), prop.Items.Ref)
+	})
+	t.Run("non_ref_field_keeps_type_and_constraints", func(t *testing.T) {
+		prop := gen.fieldInfoToProperty(&models.FieldInfo{
+			Name: "Name", Type: "string",
+			Constraints: map[string]string{"min": "2"},
+		})
+		assert.Equal(t, typeString, prop.Type)
+		assert.Empty(t, prop.Ref)
+		require.NotNil(t, prop.MinLength)
+		assert.Equal(t, 2, *prop.MinLength)
+	})
 }
 
 func TestFieldInfoToProperty(t *testing.T) {

--- a/tools/openapi/internal/models/models.go
+++ b/tools/openapi/internal/models/models.go
@@ -6,6 +6,10 @@ type Project struct {
 	Description string
 	Version     string
 	Modules     []Module
+	// Types is the registry of every named struct type reachable from a route's
+	// request or response (including nested and recursively-referenced types),
+	// keyed by schema name. The generator emits one component schema per entry.
+	Types map[string]*TypeInfo
 }
 
 // Module represents a go-bricks module
@@ -65,4 +69,9 @@ type FieldInfo struct {
 	Example       string            // Parsed from `example:"..."` tag
 	RawValidation string            // Raw validation tag string (e.g., "required,email,min=5")
 	Constraints   map[string]string // Parsed validation constraints for OpenAPI mapping
+	// RefName is the schema name of the field's underlying named struct type when
+	// the field (or its slice/pointer element) resolves to one in the registry.
+	// Set, the property is emitted as a $ref (or items.$ref for a slice) rather
+	// than an inline object.
+	RefName string
 }

--- a/tools/openapi/internal/spectest/testdata/nested_schema/catalog.go
+++ b/tools/openapi/internal/spectest/testdata/nested_schema/catalog.go
@@ -1,0 +1,57 @@
+// Package catalog exercises nested, sliced, and recursive schema types so the
+// generator emits $ref / items.$ref and a component per reachable struct.
+package catalog
+
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+
+// Module is the catalog module.
+type Module struct{}
+
+func (m *Module) Name() string                 { return "catalog" }
+func (m *Module) Init(d *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error              { return nil }
+
+// Address is a nested value struct.
+type Address struct {
+	Street string `json:"street" validate:"required"`
+	City   string `json:"city"`
+}
+
+// CreateUserReq nests a struct and a slice of structs.
+type CreateUserReq struct {
+	Name      string    `json:"name" validate:"required,min=2"`
+	Address   Address   `json:"address"`   // nested struct -> $ref
+	Addresses []Address `json:"addresses"` // slice of struct -> items.$ref
+}
+
+// User self-references via a pointer and a slice of pointers.
+type User struct {
+	ID      int64   `json:"id"`
+	Profile Address `json:"profile"` // nested struct -> $ref
+	Manager *User   `json:"manager"` // pointer self-ref -> $ref
+	Reports []*User `json:"reports"` // slice of pointers -> items.$ref
+}
+
+// Category is recursive through both a pointer and a slice.
+type Category struct {
+	Name     string     `json:"name"`
+	Parent   *Category  `json:"parent"`   // self-ref pointer -> $ref
+	Children []Category `json:"children"` // self-ref slice -> items.$ref
+}
+
+// RegisterRoutes registers the module's HTTP routes.
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.POST(hr, r, "/users", m.createUser, server.WithTags("users"))
+	server.GET(hr, r, "/categories", m.listCategories, server.WithTags("categories"))
+}
+
+func (m *Module) createUser(req CreateUserReq, ctx server.HandlerContext) (server.Result[User], server.IAPIError) {
+	return server.Created(User{}), nil
+}
+
+func (m *Module) listCategories(ctx server.HandlerContext) (server.Result[Category], server.IAPIError) {
+	return server.OK(Category{}), nil
+}

--- a/tools/openapi/internal/spectest/testdata/nested_schema/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/nested_schema/expected.yaml
@@ -1,0 +1,132 @@
+openapi: 3.0.1
+info:
+  title: Catalog API
+  version: 1.0.0
+  description: Generated API specification
+paths:
+  /categories:
+    get:
+      operationId: listCategories
+      summary: GET /categories
+      tags:
+        - categories
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /users:
+    post:
+      operationId: createUser
+      summary: POST /users
+      tags:
+        - users
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUserReq'
+      responses:
+        "200":
+          description: Resource created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    Address:
+      type: object
+      properties:
+        city:
+          type: string
+        street:
+          type: string
+      required:
+        - street
+    Category:
+      type: object
+      properties:
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/Category'
+        name:
+          type: string
+        parent:
+          $ref: '#/components/schemas/Category'
+    CreateUserReq:
+      type: object
+      properties:
+        address:
+          $ref: '#/components/schemas/Address'
+        addresses:
+          type: array
+          items:
+            $ref: '#/components/schemas/Address'
+        name:
+          type: string
+          minLength: 2
+      required:
+        - name
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: object
+          description: Error details with code and message
+        meta:
+          type: object
+          description: Response metadata
+      required:
+        - error
+    JOSEErrorEnvelope:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
+        message:
+          type: string
+          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
+      required:
+        - code
+        - message
+    SuccessResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          description: Response data
+        meta:
+          type: object
+          description: Response metadata
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        manager:
+          $ref: '#/components/schemas/User'
+        profile:
+          $ref: '#/components/schemas/Address'
+        reports:
+          type: array
+          items:
+            $ref: '#/components/schemas/User'

--- a/tools/openapi/internal/spectest/testdata/nested_schema/go.mod
+++ b/tools/openapi/internal/spectest/testdata/nested_schema/go.mod
@@ -1,0 +1,5 @@
+module github.com/example/catalog
+
+go 1.25
+
+require github.com/gaborage/go-bricks v0.37.0


### PR DESCRIPTION
## PR 5 of the OpenAPI-tool fidelity roadmap — recursive schema registry

Depends on #485, #489 (merged). Makes the generated schemas faithful for any structured DTO.

### Before
Nested struct fields (`Address Address`) and slices of structs (`[]Address`) collapsed to a bare `type: object`, and only top-level request/response types became `components`. Any DTO with structure lost its shape.

### Now
Every named struct **reachable** from a route's request or response — nested, sliced, pointed-to, or recursive — is registered and emitted as its own component, with fields `$ref`-ing between them.

- **analyzer** — `registerType` resolves a local struct, adds it to a type registry, and recurses into its struct-typed fields setting `FieldInfo.RefName`. It registers a type **before** recursing, so self- and mutually-recursive types terminate (`Category{Parent *Category}`, `A↔B`). `baseStructTypeName` strips `*`/`[]`. The registry flows to the generator via `Project.Types`.
- **generator** — a struct field emits `$ref` (or `items.$ref` for a slice); a `$ref` property stands alone (no sibling `type`/constraints). `generateSchemasFromTypes` emits one component per registry entry, so every `$ref` resolves. `schemaName` centralizes component naming; `routeTypeRegistry` is a flat fallback for projects built without the analyzer.

### Proof
New `nested_schema` fixture exercises nested `$ref`, slice `items.$ref`, pointer/slice self-reference, and recursion end-to-end — e.g. `Category.children → items.$ref Category`, `User.manager → $ref User`, `CreateUserReq.addresses → items.$ref Address`. The **redocly CI gate now validates this fixture** (the richest one) instead of the simpler `path_param`.

### Pre-push verification
- `make check` green; `make validate-spec` (redocly on the recursive fixture) — `valid 🎉`
- `/code-review` (2 finder agents) caught **two real issues**, both fixed + tested:
  1. **`json:"-"` leak** — recursion registered an internal type reachable only through an excluded field → orphan/leaked component. Now skipped (mirrors `typeInfoToSchema`).
  2. **Cross-package name collision** — name-keyed registry silently first-wins on two same-named types. Now **warns** (full package-qualified disambiguation is PR9). Pre-existing (the old code also keyed schemas by name).
  Added mutual-recursion (`A↔B`) and `json:"-"` tests.
- `/security-audit` — gosec 0, govulncheck clean, no secrets
- Coverage: tool total **90.7%**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved OpenAPI generation to emit component schemas for nested and recursive Go types, using a centralized type registry for accurate $ref and array item references.

* **Tests**
  * Added comprehensive tests for type registry building, mutual recursion, JSON-excluded fields, and schema property generation.
  * Updated spectest fixtures and expected OpenAPI output to validate complex nested-schema scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->