### PR TITLE
feat(openapi): render typed response envelope + constructor-derived status codes (PR6)

### DIFF
--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/gaborage/go-bricks/tools/openapi/internal/models"
@@ -26,6 +27,7 @@ const (
 	frameworkTypeError          = "error"
 	frameworkPkgServer          = "server"
 	frameworkPkgApp             = "app"
+	stdlibPkgHTTP               = "http"
 	frameworkTypeModuleDeps     = "ModuleDeps"
 
 	// Framework response wrappers. Result[R] / ResultWithMeta[R] are unwrapped to
@@ -587,7 +589,7 @@ func (w *routeWalker) routeFromCall(call *ast.CallExpr, prefixes map[string]stri
 		Tags:   []string{},
 		Path:   normalizePath(prefix + rawPath),
 	}
-	route.HandlerName, route.Request, route.Response = w.a.extractHandlerInfo(call, w.astFile, w.filePath, w.structName)
+	route.HandlerName, route.Request, route.Response, route.SuccessStatus = w.a.extractHandlerInfo(call, w.astFile, w.filePath, w.structName)
 	for i := 4; i < len(call.Args); i++ {
 		w.a.extractRouteMetadata(call.Args[i], route, w.serverAliases)
 	}
@@ -751,27 +753,27 @@ func (a *ProjectAnalyzer) extractHandlerInfo(
 	astFile *ast.File,
 	filePath string,
 	structName string,
-) (handlerName string, reqType, respType *models.TypeInfo) {
+) (handlerName string, reqType, respType *models.TypeInfo, successStatus int) {
 	if len(callExpr.Args) <= 3 {
-		return "", nil, nil
+		return "", nil, nil, 0
 	}
 
 	handlerName, receiverType, isPackageFunc, ok := a.resolveHandler(callExpr.Args[3], structName, astFile, filePath)
 	if !ok {
-		return "", nil, nil
+		return "", nil, nil, 0
 	}
 
 	// Extract handler signature if we have required context.
 	if astFile != nil && filePath != "" {
-		req, resp, err := a.extractHandlerSignature(astFile, filePath, receiverType, isPackageFunc, handlerName)
+		req, resp, status, err := a.extractHandlerSignature(astFile, filePath, receiverType, isPackageFunc, handlerName)
 		if err != nil {
 			// Don't fail — some routes use inline or external handlers.
-			return handlerName, nil, nil
+			return handlerName, nil, nil, 0
 		}
-		return handlerName, req, resp
+		return handlerName, req, resp, status
 	}
 
-	return handlerName, nil, nil
+	return handlerName, nil, nil, 0
 }
 
 // resolveHandler determines the handler name and where to find its signature from
@@ -875,6 +877,12 @@ func (a *ProjectAnalyzer) extractRouteMetadata(arg ast.Expr, route *models.Route
 		route.Summary = a.extractStringFromFirstArg(callExpr)
 	case "WithDescription":
 		route.Description = a.extractStringFromFirstArg(callExpr)
+	case "WithHandlerName":
+		if name := a.extractStringFromFirstArg(callExpr); name != "" {
+			route.HandlerName = name
+		}
+	case "WithRawResponse":
+		route.RawResponse = true
 	}
 }
 
@@ -1495,7 +1503,7 @@ func (a *ProjectAnalyzer) findHandlerInFile(
 	receiverType string,
 	isPackageFunc bool,
 	handlerName string,
-) (requestType, responseType *models.TypeInfo) {
+) (requestType, responseType *models.TypeInfo, successStatus int) {
 	for _, decl := range astFile.Decls {
 		funcDecl, ok := decl.(*ast.FuncDecl)
 		if !ok || funcDecl.Name.Name != handlerName {
@@ -1510,11 +1518,111 @@ func (a *ProjectAnalyzer) findHandlerInFile(
 		// Extract types using helpers
 		requestType := a.extractRequestType(funcDecl.Type.Params, astFile.Name.Name)
 		responseType := a.extractResponseType(funcDecl.Type.Results, astFile.Name.Name)
+		status := extractSuccessStatus(funcDecl)
 
-		return requestType, responseType
+		return requestType, responseType, status
 	}
 
-	return nil, nil
+	return nil, nil, 0
+}
+
+// extractSuccessStatus inspects a handler body for the result constructor used in
+// its return statements and maps it to an HTTP success status: server.Created ->
+// 201, Accepted -> 202, NoContent -> 204, NewResult(s, ...)/
+// NewResultWithMeta(s, ...) -> s (when s is an integer literal or an http.StatusXxx
+// constant). Returns 0 ("use the default" -> 200) when no recognizable server
+// constructor is returned.
+//
+// The LAST recognized return wins: idiomatic handlers put the happy-path return
+// last and any earlier server-constructor returns are typically guard branches
+// (e.g. a cache-hit early return), so the terminal status is the documented one.
+// The "server" qualifier is matched literally, consistent with the rest of the
+// type-resolution path (isResultWrapper, NoContentResult).
+func extractSuccessStatus(funcDecl *ast.FuncDecl) int {
+	if funcDecl.Body == nil {
+		return 0
+	}
+	status := 0
+	ast.Inspect(funcDecl.Body, func(n ast.Node) bool {
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok || len(ret.Results) == 0 {
+			return true
+		}
+		call, ok := ret.Results[0].(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok || pkg.Name != frameworkPkgServer {
+			return true
+		}
+		if s := statusForConstructor(sel.Sel.Name, call.Args); s != 0 {
+			status = s // last-wins: keep scanning, terminal return is authoritative
+		}
+		return true
+	})
+	return status
+}
+
+// statusForConstructor maps a server result-constructor name to its HTTP status.
+// For NewResult/NewResultWithMeta the status is the first argument resolved via
+// statusFromArg (an integer literal or an http.StatusXxx constant). Returns 0 for
+// anything unrecognized.
+func statusForConstructor(name string, args []ast.Expr) int {
+	switch name {
+	case "Created":
+		return 201
+	case "Accepted":
+		return 202
+	case "NoContent":
+		return 204
+	case "NewResult", "NewResultWithMeta":
+		if len(args) > 0 {
+			return statusFromArg(args[0])
+		}
+	}
+	return 0
+}
+
+// statusFromArg resolves the status argument of NewResult/NewResultWithMeta. It
+// accepts a bare integer literal (NewResult(201, ...)) and the idiomatic
+// net/http status constant (NewResult(http.StatusCreated, ...)), which is the
+// dominant real-world form. Returns 0 when the argument is anything else (a
+// variable, a non-http constant), letting the caller fall back to the default.
+func statusFromArg(arg ast.Expr) int {
+	switch a := arg.(type) {
+	case *ast.BasicLit:
+		if a.Kind == token.INT {
+			if v, err := strconv.Atoi(a.Value); err == nil {
+				return v
+			}
+		}
+	case *ast.SelectorExpr:
+		if pkg, ok := a.X.(*ast.Ident); ok && pkg.Name == stdlibPkgHTTP {
+			return httpStatusConstants[a.Sel.Name]
+		}
+	}
+	return 0
+}
+
+// httpStatusConstants maps the net/http 2xx status-constant names to their codes.
+// Only success codes are needed: a handler returning a 4xx/5xx as a non-error
+// Result is a misuse the generator does not try to model as a success response.
+var httpStatusConstants = map[string]int{
+	"StatusOK":                   200,
+	"StatusCreated":              201,
+	"StatusAccepted":             202,
+	"StatusNonAuthoritativeInfo": 203,
+	"StatusNoContent":            204,
+	"StatusResetContent":         205,
+	"StatusPartialContent":       206,
+	"StatusMultiStatus":          207,
+	"StatusAlreadyReported":      208,
+	"StatusIMUsed":               226,
 }
 
 // handlerReceiverMatches reports whether a function declaration's receiver matches
@@ -1539,29 +1647,29 @@ func (a *ProjectAnalyzer) extractHandlerSignature(
 	receiverType string,
 	isPackageFunc bool,
 	handlerName string,
-) (reqType, respType *models.TypeInfo, err error) {
+) (reqType, respType *models.TypeInfo, successStatus int, err error) {
 	// Try current file first
-	if reqType, respType := a.findHandlerInFile(astFile, receiverType, isPackageFunc, handlerName); reqType != nil || respType != nil {
+	if reqType, respType, status := a.findHandlerInFile(astFile, receiverType, isPackageFunc, handlerName); reqType != nil || respType != nil {
 		a.populateTypeFields(reqType, astFile, filePath)
 		a.populateTypeFields(respType, astFile, filePath)
-		return reqType, respType, nil
+		return reqType, respType, status, nil
 	}
 
 	// Try other files in the package
 	files, err := a.parsePackage(filePath, astFile.Name.Name)
 	if err == nil && files != nil {
 		for _, file := range files {
-			if reqType, respType := a.findHandlerInFile(file, receiverType, isPackageFunc, handlerName); reqType != nil || respType != nil {
+			if reqType, respType, status := a.findHandlerInFile(file, receiverType, isPackageFunc, handlerName); reqType != nil || respType != nil {
 				a.populateTypeFields(reqType, file, filePath)
 				a.populateTypeFields(respType, file, filePath)
-				return reqType, respType, nil
+				return reqType, respType, status, nil
 			}
 		}
 	}
 
 	// Handler not found - this is not necessarily an error
 	// Some routes might use inline handlers or external handlers
-	return nil, nil, fmt.Errorf("handler %s not found for receiver %q", handlerName, receiverType)
+	return nil, nil, 0, fmt.Errorf("handler %s not found for receiver %q", handlerName, receiverType)
 }
 
 // populateTypeFields populates a request/response TypeInfo's fields and registers

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -2387,7 +2387,7 @@ func (h *Handler) actualHandler() {}`,
 			require.NoError(t, err, "Failed to parse file")
 
 			analyzer := New(tempDir)
-			reqType, respType, err := analyzer.extractHandlerSignature(astFile, testFilePath, tt.structName, false, tt.handlerName)
+			reqType, respType, _, err := analyzer.extractHandlerSignature(astFile, testFilePath, tt.structName, false, tt.handlerName)
 
 			if tt.shouldFindHandler {
 				require.NoError(t, err, tt.description)
@@ -3546,4 +3546,143 @@ func (m *Module) h(ctx srv.HandlerContext) (srv.Result[int], srv.IAPIError) { re
 	got := routePathSet(routes)
 	assert.True(t, got["GET /a"], "route registered via an aliased server import is discovered")
 	assert.True(t, got["POST /b"], "helper with an aliased RouteRegistrar param is recursed")
+}
+
+// routeForPath returns the first route matching "METHOD /path", or fails.
+func routeForPath(t *testing.T, routes []models.Route, key string) models.Route {
+	t.Helper()
+	for i := range routes {
+		if routes[i].Method+" "+routes[i].Path == key {
+			return routes[i]
+		}
+	}
+	t.Fatalf("route %q not found", key)
+	return models.Route{}
+}
+
+// TestExtractSuccessStatusFromConstructors verifies the handler-body inspection
+// maps each result constructor to the right HTTP status, stamped on the route.
+func TestExtractSuccessStatusFromConstructors(t *testing.T) {
+	src := `package mod
+import (
+	"net/http"
+
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+type Thing struct{ ID int64 ` + "`json:\"id\"`" + ` }
+func (m *Module) created(ctx server.HandlerContext) (server.Result[Thing], server.IAPIError) { return server.Created(Thing{}), nil }
+func (m *Module) accepted(ctx server.HandlerContext) (server.Result[Thing], server.IAPIError) { return server.Accepted(Thing{}), nil }
+func (m *Module) okConst(ctx server.HandlerContext) (server.Result[Thing], server.IAPIError) { return server.NewResult(http.StatusOK, Thing{}), nil }
+func (m *Module) acceptedConst(ctx server.HandlerContext) (server.Result[Thing], server.IAPIError) { return server.NewResult(http.StatusAccepted, Thing{}), nil }
+func (m *Module) custom(ctx server.HandlerContext) (server.Result[Thing], server.IAPIError) { return server.NewResult(207, Thing{}), nil }
+func (m *Module) noContent(ctx server.HandlerContext) (server.NoContentResult, server.IAPIError) { return server.NoContent(), nil }
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.POST(hr, r, "/created", m.created)
+	server.POST(hr, r, "/accepted", m.accepted)
+	server.GET(hr, r, "/ok", m.okConst)
+	server.POST(hr, r, "/accepted-const", m.acceptedConst)
+	server.PUT(hr, r, "/custom", m.custom)
+	server.DELETE(hr, r, "/no-content", m.noContent)
+}
+`
+	_, routes := analyzeSingleModule(t, src)
+	assert.Equal(t, 201, routeForPath(t, routes, "POST /created").SuccessStatus)
+	assert.Equal(t, 202, routeForPath(t, routes, "POST /accepted").SuccessStatus)
+	// http.StatusXxx constants (the idiomatic real-world form) must resolve, not
+	// just bare integer literals.
+	assert.Equal(t, 200, routeForPath(t, routes, "GET /ok").SuccessStatus)
+	assert.Equal(t, 202, routeForPath(t, routes, "POST /accepted-const").SuccessStatus)
+	assert.Equal(t, 207, routeForPath(t, routes, "PUT /custom").SuccessStatus)
+	// NoContentResult is detected via the response type (signature), not the body;
+	// SuccessStatus stays 0 and the generator derives 204 from NoContent.
+	noContent := routeForPath(t, routes, "DELETE /no-content")
+	require.NotNil(t, noContent.Response)
+	assert.True(t, noContent.Response.NoContent, "NoContentResult response must carry NoContent=true")
+}
+
+// TestRawResponseAndHandlerNameMetadata verifies WithRawResponse and
+// WithHandlerName route options are parsed onto the route.
+func TestRawResponseAndHandlerNameMetadata(t *testing.T) {
+	src := `package mod
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+type Thing struct{ ID int64 ` + "`json:\"id\"`" + ` }
+func (m *Module) raw(ctx server.HandlerContext) (server.Result[Thing], server.IAPIError) { return server.Created(Thing{}), nil }
+func (m *Module) named(ctx server.HandlerContext) (server.Result[Thing], server.IAPIError) { return server.Created(Thing{}), nil }
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/raw", m.raw, server.WithRawResponse())
+	server.GET(hr, r, "/named", m.named, server.WithHandlerName("customOp"))
+}
+`
+	_, routes := analyzeSingleModule(t, src)
+	raw := routeForPath(t, routes, "GET /raw")
+	assert.True(t, raw.RawResponse, "WithRawResponse() must set RawResponse")
+	assert.Equal(t, "customOp", routeForPath(t, routes, "GET /named").HandlerName,
+		"WithHandlerName must override the operationId source")
+}
+
+// TestExtractSuccessStatusLastWins confirms that when a handler returns a server
+// constructor from an early guard branch and a different one from the terminal
+// happy path, the terminal (last) return is the documented status.
+func TestExtractSuccessStatusLastWins(t *testing.T) {
+	src := `package mod
+import (
+	"net/http"
+
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+type Thing struct{ ID int64 ` + "`json:\"id\"`" + ` }
+func (m *Module) upsert(ctx server.HandlerContext) (server.Result[Thing], server.IAPIError) {
+	if false {
+		return server.NewResult(http.StatusOK, Thing{}), nil
+	}
+	return server.Created(Thing{}), nil
+}
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.POST(hr, r, "/upsert", m.upsert)
+}
+`
+	_, routes := analyzeSingleModule(t, src)
+	assert.Equal(t, 201, routeForPath(t, routes, "POST /upsert").SuccessStatus,
+		"terminal happy-path return (Created/201) wins over the earlier guard return")
+}
+
+// TestStatusForConstructorEdgeCases locks the non-route-driven branches of the
+// constructor->status mapping: unrecognized constructors and NewResult with a
+// non-resolvable status argument both fall through to 0 ("use the default").
+func TestStatusForConstructorEdgeCases(t *testing.T) {
+	intLit := &ast.BasicLit{Kind: token.INT, Value: "418"}
+	identArg := &ast.Ident{Name: "code"}
+	// http.StatusAccepted -> SelectorExpr{X: http, Sel: StatusAccepted}
+	httpConst := &ast.SelectorExpr{X: &ast.Ident{Name: "http"}, Sel: &ast.Ident{Name: "StatusAccepted"}}
+	// fmt.Sprint -> a non-http selector must NOT be mistaken for a status constant.
+	otherConst := &ast.SelectorExpr{X: &ast.Ident{Name: "fmt"}, Sel: &ast.Ident{Name: "Sprint"}}
+	// http.StatusTeapot is not in the 2xx success map -> 0.
+	unknownHTTP := &ast.SelectorExpr{X: &ast.Ident{Name: "http"}, Sel: &ast.Ident{Name: "StatusTeapot"}}
+
+	assert.Equal(t, 0, statusForConstructor("Unknown", nil), "unrecognized constructor -> 0")
+	assert.Equal(t, 0, statusForConstructor("OK", nil), "server.OK does not exist -> 0")
+	assert.Equal(t, 0, statusForConstructor("NewResult", nil), "NewResult with no args -> 0")
+	assert.Equal(t, 0, statusForConstructor("NewResult", []ast.Expr{identArg}), "NewResult with a variable status -> 0")
+	assert.Equal(t, 0, statusForConstructor("NewResult", []ast.Expr{otherConst}), "non-http selector -> 0")
+	assert.Equal(t, 0, statusForConstructor("NewResult", []ast.Expr{unknownHTTP}), "non-2xx http constant -> 0")
+	assert.Equal(t, 418, statusForConstructor("NewResult", []ast.Expr{intLit}), "NewResult with int literal -> that status")
+	assert.Equal(t, 202, statusForConstructor("NewResultWithMeta", []ast.Expr{httpConst}), "NewResultWithMeta with http.StatusAccepted -> 202")
+	assert.Equal(t, 204, statusForConstructor("NoContent", nil))
 }

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -29,7 +29,10 @@ const (
 
 // Schema component names referenced in multiple emitter sites.
 const (
-	schemaErrorResponse = "ErrorResponse"
+	schemaErrorResponse     = "ErrorResponse"
+	schemaJOSEErrorEnvelope = "JOSEErrorEnvelope"
+	schemaRawErrorResponse  = "RawErrorResponse"
+	schemaSuccessResponse   = "SuccessResponse"
 )
 
 // HTTP method names used in switch discriminants and operation generation.
@@ -57,8 +60,13 @@ const (
 // Response/parameter description text reused across operations.
 const (
 	respDescSuccess = "Successful response"
+	respDescCreated = "Resource created successfully"
 	paramTypePath   = "path"
 	propNameError   = "error"
+	propNameData    = "data"
+	propNameMeta    = "meta"
+	propNameCode    = "code"
+	propNameMessage = "message"
 )
 
 // Media type constants for the OpenAPI content map. Centralized so a future rename
@@ -93,20 +101,21 @@ type OpenAPISchema struct {
 
 // OpenAPIProperty represents a schema property
 type OpenAPIProperty struct {
-	Type             string           `yaml:"type,omitempty"`
-	Format           string           `yaml:"format,omitempty"`
-	Description      string           `yaml:"description,omitempty"`
-	Example          any              `yaml:"example,omitempty"`
-	Ref              string           `yaml:"$ref,omitempty"`
-	Items            *OpenAPIProperty `yaml:"items,omitempty"` // For arrays
-	MinLength        *int             `yaml:"minLength,omitempty"`
-	MaxLength        *int             `yaml:"maxLength,omitempty"`
-	Minimum          *float64         `yaml:"minimum,omitempty"`
-	Maximum          *float64         `yaml:"maximum,omitempty"`
-	ExclusiveMinimum *bool            `yaml:"exclusiveMinimum,omitempty"`
-	ExclusiveMaximum *bool            `yaml:"exclusiveMaximum,omitempty"`
-	Pattern          string           `yaml:"pattern,omitempty"`
-	Enum             []any            `yaml:"enum,omitempty"`
+	Type             string                      `yaml:"type,omitempty"`
+	Properties       map[string]*OpenAPIProperty `yaml:"properties,omitempty"` // For inline objects (e.g. the data/meta envelope)
+	Format           string                      `yaml:"format,omitempty"`
+	Description      string                      `yaml:"description,omitempty"`
+	Example          any                         `yaml:"example,omitempty"`
+	Ref              string                      `yaml:"$ref,omitempty"`
+	Items            *OpenAPIProperty            `yaml:"items,omitempty"` // For arrays
+	MinLength        *int                        `yaml:"minLength,omitempty"`
+	MaxLength        *int                        `yaml:"maxLength,omitempty"`
+	Minimum          *float64                    `yaml:"minimum,omitempty"`
+	Maximum          *float64                    `yaml:"maximum,omitempty"`
+	ExclusiveMinimum *bool                       `yaml:"exclusiveMinimum,omitempty"`
+	ExclusiveMaximum *bool                       `yaml:"exclusiveMaximum,omitempty"`
+	Pattern          string                      `yaml:"pattern,omitempty"`
+	Enum             []any                       `yaml:"enum,omitempty"`
 }
 
 // The types below model the paths/operations half of an OpenAPI document as a
@@ -421,45 +430,168 @@ func jsonMediaRef(name string) map[string]*OpenAPIMediaType {
 	return map[string]*OpenAPIMediaType{mediaJSON: {Schema: &OpenAPIProperty{Ref: refPath(name)}}}
 }
 
-// buildResponses builds the responses object for a route. When the route's
-// response carries a jose: tag the 200 success response uses Content-Type
-// application/jose; the 4xx pre-trust failure path always uses application/json
-// (peer is unauthenticated, so the framework returns a plaintext minimal
-// envelope, never JOSE-wrapped — see the hybrid envelope contract in CLAUDE.md
-// JOSE Middleware).
+// buildResponses builds the responses object for a route.
 //
-// 4xx schema selection is driven by EITHER side carrying jose tags. The runtime
-// enforces bidirectional symmetry at registration, but the analyzer runs
+// Success response: the status code is the one the handler's result constructor
+// implies (server.Created -> 201, Accepted -> 202, NewResult(n) -> n,
+// NoContentResult -> 204), defaulting to 200. The body shape depends on the
+// route flavour:
+//   - NoContent       -> no body (204).
+//   - JOSE response    -> a single application/jose string token; the Response
+//     description names the plaintext component the decrypted payload conforms to.
+//   - RawResponse      -> the bare payload schema ($ref to the response component),
+//     bypassing the data/meta envelope (Strangler-Fig migration).
+//   - default          -> the standard envelope {data: <$ref to response>, meta},
+//     which is what finally references the response component the analyzer
+//     discovered (closing the "orphan component" window).
+//
+// Error responses: 400 and 500 are always present; 422 is added when the request
+// type carries validation tags (the framework returns 422 on validation
+// failure). The error schema is JOSEErrorEnvelope for JOSE routes (pre-trust
+// failures leak nothing beyond {code,message}), RawErrorResponse for raw routes,
+// and ErrorResponse otherwise.
+//
+// JOSE 4xx schema selection is driven by EITHER side carrying jose tags. The
+// runtime enforces bidirectional symmetry at registration, but the analyzer runs
 // statically against source so we can encounter asymmetric setups; in any such
 // case the pre-trust failure path is still routed through the JOSE
 // plaintext-minimal envelope by the runtime, so the OpenAPI spec must reflect that.
 func (g *OpenAPIGenerator) buildResponses(route *models.Route) map[string]*OpenAPIResponse {
 	joseResponse := route.Response != nil && route.Response.JOSE
 	joseRoute := joseResponse || (route.Request != nil && route.Request.JOSE)
+	noContent := route.Response != nil && route.Response.NoContent
 
-	resp200 := &OpenAPIResponse{}
-	if joseResponse {
+	successCode := successStatusCode(route, noContent)
+	success := &OpenAPIResponse{Description: g.successDescription(route, successCode, noContent)}
+	switch {
+	case noContent:
+		// 204: no response body.
+	case joseResponse:
 		// Description on the Response Object names the plaintext schema; the Media
 		// Type schema describes the wire shape (a string token).
-		resp200.Description = joseDescription("SuccessResponse")
-		resp200.Content = map[string]*OpenAPIMediaType{mediaJOSE: {Schema: joseTokenSchema()}}
-	} else {
-		resp200.Description = g.getResponseDescription(route.Method)
-		resp200.Content = jsonMediaRef("SuccessResponse")
+		success.Description = joseDescription(g.successPlaintextSchema(route))
+		success.Content = map[string]*OpenAPIMediaType{mediaJOSE: {Schema: joseTokenSchema()}}
+	case route.RawResponse:
+		success.Content = map[string]*OpenAPIMediaType{mediaJSON: {Schema: responsePayloadSchema(route.Response)}}
+	default:
+		success.Content = map[string]*OpenAPIMediaType{mediaJSON: {Schema: successEnvelopeSchema(route.Response)}}
 	}
 
 	// Pre-trust failures on JOSE routes are plaintext minimal envelopes per the
 	// security model: when decrypt/verify fails the peer is unauthenticated and
 	// the server leaks nothing beyond {code,message}.
 	errorSchema := schemaErrorResponse
-	if joseRoute {
-		errorSchema = "JOSEErrorEnvelope"
+	switch {
+	case joseRoute:
+		errorSchema = schemaJOSEErrorEnvelope
+	case route.RawResponse:
+		errorSchema = schemaRawErrorResponse
 	}
 
-	return map[string]*OpenAPIResponse{
-		"200": resp200,
+	responses := map[string]*OpenAPIResponse{
 		"400": {Description: "Bad Request", Content: jsonMediaRef(errorSchema)},
+		"500": {Description: "Internal Server Error", Content: jsonMediaRef(errorSchema)},
 	}
+	if routeHasValidation(route.Request) {
+		responses["422"] = &OpenAPIResponse{Description: "Unprocessable Entity", Content: jsonMediaRef(errorSchema)}
+	}
+	// Assign the success entry LAST so a success status that overlaps an error code
+	// (e.g. a handler that returns NewResult(400, ...) as a non-error Result) keeps
+	// the documented success response rather than being clobbered by the 400 entry.
+	responses[successCode] = success
+	return responses
+}
+
+// successStatusCode resolves the success response code as a string key. A 204
+// (NoContent) wins outright; otherwise the constructor-derived SuccessStatus is
+// used when set, defaulting to 200.
+func successStatusCode(route *models.Route, noContent bool) string {
+	if noContent {
+		return "204"
+	}
+	if route.SuccessStatus != 0 {
+		return strconv.Itoa(route.SuccessStatus)
+	}
+	return "200"
+}
+
+// successDescription returns a human description for the success response,
+// preferring a status-specific phrase over the method-derived default.
+func (g *OpenAPIGenerator) successDescription(route *models.Route, code string, noContent bool) string {
+	switch {
+	case noContent:
+		return "No Content"
+	case code == "201":
+		return respDescCreated
+	case code == "202":
+		return "Request accepted for processing"
+	default:
+		return g.getResponseDescription(route.Method)
+	}
+}
+
+// successPlaintextSchema names the plaintext component a JOSE response decrypts
+// to, falling back to the generic SuccessResponse envelope when the handler
+// declares no typed response.
+func (g *OpenAPIGenerator) successPlaintextSchema(route *models.Route) string {
+	if route.Response != nil && route.Response.Name != "" {
+		return schemaName(route.Response)
+	}
+	return schemaSuccessResponse
+}
+
+// successEnvelopeSchema builds the inline {data, meta} success envelope. When the
+// route has a typed response, data is a $ref to its component schema; otherwise
+// data is a generic object (the handler returned an untyped/empty payload).
+func successEnvelopeSchema(response *models.TypeInfo) *OpenAPIProperty {
+	data := responsePayloadSchema(response)
+	if data.Ref == "" {
+		// Untyped fallback (generic object) — annotate it for readers.
+		data.Description = "Response data"
+	}
+	return &OpenAPIProperty{
+		Type: typeObject,
+		Properties: map[string]*OpenAPIProperty{
+			propNameData: data,
+			propNameMeta: metaEnvelopeSchema(),
+		},
+	}
+}
+
+// metaEnvelopeSchema is the framework-authoritative envelope metadata block.
+// timestamp and traceId are always populated by the response writer.
+func metaEnvelopeSchema() *OpenAPIProperty {
+	return &OpenAPIProperty{
+		Type: typeObject,
+		Properties: map[string]*OpenAPIProperty{
+			"timestamp": {Type: typeString, Format: "date-time", Description: "RFC3339 response timestamp"},
+			"traceId":   {Type: typeString, Description: "W3C trace identifier for the request"},
+		},
+	}
+}
+
+// responsePayloadSchema returns the bare schema for a response component: a $ref
+// to the named type, or a generic object when the type is unnamed.
+func responsePayloadSchema(response *models.TypeInfo) *OpenAPIProperty {
+	if response == nil || response.Name == "" {
+		return &OpenAPIProperty{Type: typeObject}
+	}
+	return &OpenAPIProperty{Ref: refPath(schemaName(response))}
+}
+
+// routeHasValidation reports whether the request type carries any validation
+// constraints, which is what makes a 422 (Unprocessable Entity) reachable.
+func routeHasValidation(request *models.TypeInfo) bool {
+	if request == nil {
+		return false
+	}
+	for i := range request.Fields {
+		f := &request.Fields[i]
+		if f.Required || f.RawValidation != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // getOperationID generates an operation ID for a route
@@ -481,16 +613,18 @@ func (g *OpenAPIGenerator) getSummary(route *models.Route) string {
 	return fmt.Sprintf("%s %s", route.Method, route.Path)
 }
 
-// getResponseDescription returns a description based on HTTP method. The method
-// is normalized to upper-case (consistent with assignOperation) so a
-// lowercase/mixed-case input still maps to the right description rather than
-// silently falling through to the generic default.
+// getResponseDescription returns a description based on HTTP method, used for the
+// 200 success case. The method is normalized to upper-case (consistent with
+// assignOperation) so a lowercase/mixed-case input still maps to the right
+// description rather than silently falling through to the generic default.
+//
+// POST maps to the generic "Successful response", NOT "Resource created": a 201
+// is described as created by successDescription's status branch, so a POST that
+// returns 200 (e.g. a query-by-POST endpoint) is not mislabeled as a creation.
 func (g *OpenAPIGenerator) getResponseDescription(method string) string {
 	switch strings.ToUpper(method) {
-	case httpMethodGet:
+	case httpMethodGet, httpMethodPost:
 		return respDescSuccess
-	case httpMethodPost:
-		return "Resource created successfully"
 	case httpMethodPut:
 		return "Resource updated successfully"
 	case httpMethodDelete:
@@ -528,17 +662,18 @@ func (g *OpenAPIGenerator) marshalYAMLSection(sectionName string, data any) (str
 // createStandardSchemas creates common response schemas using proper structs
 func (g *OpenAPIGenerator) createStandardSchemas() map[string]*OpenAPISchema {
 	return map[string]*OpenAPISchema{
-		"SuccessResponse": {
+		// SuccessResponse is the generic envelope used as the JOSE plaintext-schema
+		// fallback (a typed route emits an inline envelope instead). Its meta reuses
+		// metaEnvelopeSchema so the documented metadata shape never diverges from the
+		// inline envelopes.
+		schemaSuccessResponse: {
 			Type: typeObject,
 			Properties: map[string]*OpenAPIProperty{
-				"data": {
+				propNameData: {
 					Type:        typeObject,
 					Description: "Response data",
 				},
-				"meta": {
-					Type:        typeObject,
-					Description: "Response metadata",
-				},
+				propNameMeta: metaEnvelopeSchema(),
 			},
 		},
 		schemaErrorResponse: {
@@ -561,19 +696,36 @@ func (g *OpenAPIGenerator) createStandardSchemas() map[string]*OpenAPISchema {
 		// etc.). The framework intentionally omits traceId/timestamp/framework
 		// metadata here — peer is unauthenticated and the envelope must leak
 		// nothing beyond the canonical {code,message} pair.
-		"JOSEErrorEnvelope": {
+		schemaJOSEErrorEnvelope: {
 			Type: typeObject,
 			Properties: map[string]*OpenAPIProperty{
-				"code": {
+				propNameCode: {
 					Type:        typeString,
 					Description: "Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)",
 				},
-				"message": {
+				propNameMessage: {
 					Type:        typeString,
 					Description: "Constant-time generic message — never reveals which key was tried or which library detected the failure",
 				},
 			},
-			Required: []string{"code", "message"},
+			Required: []string{propNameCode, propNameMessage},
+		},
+		// RawErrorResponse is the bare {code,message} error payload returned by
+		// routes registered WithRawResponse(): no data/meta envelope, mirroring
+		// the framework's formatRawErrorResponse (details is dev-only, omitted).
+		schemaRawErrorResponse: {
+			Type: typeObject,
+			Properties: map[string]*OpenAPIProperty{
+				propNameCode: {
+					Type:        typeString,
+					Description: "Machine-readable error code",
+				},
+				propNameMessage: {
+					Type:        typeString,
+					Description: "Human-readable error message",
+				},
+			},
+			Required: []string{propNameCode, propNameMessage},
 		},
 	}
 }

--- a/tools/openapi/internal/generator/openapi_test.go
+++ b/tools/openapi/internal/generator/openapi_test.go
@@ -297,7 +297,10 @@ func TestGetResponseDescription(t *testing.T) {
 		expected string
 	}{
 		{"GET", "Successful response"},
-		{"POST", "Resource created successfully"},
+		// POST maps to the generic phrase, NOT "created": a 201 is described as
+		// created by successDescription's status branch, so a POST returning 200 is
+		// not mislabeled as a creation.
+		{"POST", "Successful response"},
 		{"PUT", "Resource updated successfully"},
 		{"DELETE", "Resource deleted successfully"},
 		{"PATCH", "Resource partially updated"},
@@ -705,10 +708,26 @@ func TestCreateStandardSchemas(t *testing.T) {
 	gen := New(defaultTitle, "1.0.0", defaultDescription)
 	schemas := gen.createStandardSchemas()
 
-	// Test that standard schemas are created correctly
-	if len(schemas) != 3 {
-		t.Errorf("Expected 3 schemas, got %d", len(schemas))
+	// Test that standard schemas are created correctly: SuccessResponse,
+	// ErrorResponse, JOSEErrorEnvelope, and RawErrorResponse (raw-mode routes).
+	if len(schemas) != 4 {
+		t.Errorf("Expected 4 schemas, got %d", len(schemas))
 	}
+
+	t.Run("RawErrorResponse schema", func(t *testing.T) {
+		schema, ok := schemas[schemaRawErrorResponse]
+		if !ok {
+			t.Fatal("RawErrorResponse schema missing — raw-response routes need a bare {code,message} error envelope")
+		}
+		if _, hasMeta := schema.Properties[propNameMeta]; hasMeta {
+			t.Error("RawErrorResponse must NOT carry meta — raw mode bypasses the envelope entirely")
+		}
+		for _, p := range []string{"code", "message"} {
+			if _, ok := schema.Properties[p]; !ok {
+				t.Errorf("RawErrorResponse must include %q property", p)
+			}
+		}
+	})
 
 	t.Run("SuccessResponse schema", func(t *testing.T) {
 		validateSuccessResponseSchema(t, schemas)
@@ -2194,11 +2213,117 @@ func TestBuildResponsesNonJOSE(t *testing.T) {
 		Response: &models.TypeInfo{Name: "User", JOSE: false},
 	})
 
-	// Non-JOSE 200 uses application/json (the standard SuccessResponse envelope).
+	// Non-JOSE success uses application/json and the inline {data,meta} envelope
+	// whose data is a $ref to the response component (closes the orphan-component
+	// window: the discovered User schema is finally referenced).
+	require.Contains(t, resps, "200")
 	assert.NotContains(t, resps["200"].Content, mediaJOSE, "non-JOSE response must NOT use application/jose")
 	require.Contains(t, resps["200"].Content, mediaJSON)
-	assert.Equal(t, refPath("SuccessResponse"), resps["200"].Content[mediaJSON].Schema.Ref)
+	envelope := resps["200"].Content[mediaJSON].Schema
+	require.NotNil(t, envelope)
+	assert.Equal(t, typeObject, envelope.Type)
+	require.Contains(t, envelope.Properties, propNameData)
+	assert.Equal(t, refPath("User"), envelope.Properties[propNameData].Ref, "data must $ref the response component")
+	require.Contains(t, envelope.Properties, propNameMeta)
+	require.Contains(t, envelope.Properties[propNameMeta].Properties, "timestamp")
+	require.Contains(t, envelope.Properties[propNameMeta].Properties, "traceId")
+
+	// Standard error set: 400 and 500 always present; both reference ErrorResponse.
 	require.Contains(t, resps["400"].Content, mediaJSON)
 	assert.Equal(t, refPath(schemaErrorResponse), resps["400"].Content[mediaJSON].Schema.Ref,
 		"non-JOSE 4xx must reference standard ErrorResponse")
+	require.Contains(t, resps, "500")
+	assert.Equal(t, refPath(schemaErrorResponse), resps["500"].Content[mediaJSON].Schema.Ref)
+
+	// No request validation -> no 422.
+	assert.NotContains(t, resps, "422", "route without a validated request must not advertise 422")
+}
+
+func TestBuildResponsesStatusCodes(t *testing.T) {
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+
+	t.Run("created_201", func(t *testing.T) {
+		resps := gen.buildResponses(&models.Route{
+			Method:        "POST",
+			Response:      &models.TypeInfo{Name: "User"},
+			SuccessStatus: 201,
+		})
+		require.Contains(t, resps, "201")
+		assert.NotContains(t, resps, "200")
+		assert.Equal(t, "Resource created successfully", resps["201"].Description)
+	})
+
+	t.Run("accepted_202", func(t *testing.T) {
+		resps := gen.buildResponses(&models.Route{Method: "POST", SuccessStatus: 202})
+		require.Contains(t, resps, "202")
+		assert.Equal(t, "Request accepted for processing", resps["202"].Description)
+	})
+
+	t.Run("no_content_204_has_no_body", func(t *testing.T) {
+		resps := gen.buildResponses(&models.Route{
+			Method:   "DELETE",
+			Response: &models.TypeInfo{NoContent: true},
+		})
+		require.Contains(t, resps, "204")
+		assert.Nil(t, resps["204"].Content, "204 must not carry a response body")
+		assert.Equal(t, "No Content", resps["204"].Description)
+	})
+
+	t.Run("custom_status_from_NewResult", func(t *testing.T) {
+		resps := gen.buildResponses(&models.Route{Method: "GET", SuccessStatus: 207})
+		require.Contains(t, resps, "207")
+	})
+}
+
+func TestBuildResponsesRawMode(t *testing.T) {
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+	resps := gen.buildResponses(&models.Route{
+		Method:      "GET",
+		Response:    &models.TypeInfo{Name: "LegacyUser"},
+		RawResponse: true,
+	})
+
+	// Raw mode emits the bare payload schema ($ref), NOT the data/meta envelope.
+	schema := resps["200"].Content[mediaJSON].Schema
+	require.NotNil(t, schema)
+	assert.Equal(t, refPath("LegacyUser"), schema.Ref, "raw response must $ref the payload directly")
+	assert.NotContains(t, schema.Properties, propNameData, "raw response must NOT wrap in a data/meta envelope")
+
+	// Raw routes use the minimal RawErrorResponse for errors.
+	assert.Equal(t, refPath(schemaRawErrorResponse), resps["400"].Content[mediaJSON].Schema.Ref)
+	assert.Equal(t, refPath(schemaRawErrorResponse), resps["500"].Content[mediaJSON].Schema.Ref)
+}
+
+func TestResponsePayloadSchemaFallbacks(t *testing.T) {
+	// nil and unnamed responses fall back to a generic object (no $ref).
+	for _, ti := range []*models.TypeInfo{nil, {Name: ""}} {
+		schema := responsePayloadSchema(ti)
+		assert.Equal(t, typeObject, schema.Type)
+		assert.Empty(t, schema.Ref)
+	}
+	// Named responses become a $ref.
+	assert.Equal(t, refPath("Widget"), responsePayloadSchema(&models.TypeInfo{Name: "Widget"}).Ref)
+}
+
+func TestSuccessPlaintextSchemaFallsBackToSuccessResponse(t *testing.T) {
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+	// A JOSE response with no named type falls back to the generic envelope name.
+	got := gen.successPlaintextSchema(&models.Route{Response: &models.TypeInfo{JOSE: true}})
+	assert.Equal(t, schemaSuccessResponse, got)
+	// A named response is used verbatim.
+	got = gen.successPlaintextSchema(&models.Route{Response: &models.TypeInfo{Name: "TokenResponse"}})
+	assert.Equal(t, "TokenResponse", got)
+}
+
+func TestBuildResponsesValidationAdds422(t *testing.T) {
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+	resps := gen.buildResponses(&models.Route{
+		Method: "POST",
+		Request: &models.TypeInfo{Name: "CreateReq", Fields: []models.FieldInfo{
+			{Name: "Email", Required: true},
+		}},
+		Response: &models.TypeInfo{Name: "User"},
+	})
+	require.Contains(t, resps, "422", "a validated request body must advertise 422")
+	assert.Equal(t, refPath(schemaErrorResponse), resps["422"].Content[mediaJSON].Schema.Ref)
 }

--- a/tools/openapi/internal/generator/openapi_test.go
+++ b/tools/openapi/internal/generator/openapi_test.go
@@ -714,46 +714,39 @@ func TestCreateStandardSchemas(t *testing.T) {
 		t.Errorf("Expected 4 schemas, got %d", len(schemas))
 	}
 
-	t.Run("RawErrorResponse schema", func(t *testing.T) {
-		schema, ok := schemas[schemaRawErrorResponse]
-		if !ok {
-			t.Fatal("RawErrorResponse schema missing — raw-response routes need a bare {code,message} error envelope")
-		}
-		if _, hasMeta := schema.Properties[propNameMeta]; hasMeta {
-			t.Error("RawErrorResponse must NOT carry meta — raw mode bypasses the envelope entirely")
-		}
-		for _, p := range []string{"code", "message"} {
-			if _, ok := schema.Properties[p]; !ok {
-				t.Errorf("RawErrorResponse must include %q property", p)
-			}
-		}
-	})
-
 	t.Run("SuccessResponse schema", func(t *testing.T) {
 		validateSuccessResponseSchema(t, schemas)
 	})
-
-	t.Run("JOSEErrorEnvelope schema", func(t *testing.T) {
-		schema, ok := schemas["JOSEErrorEnvelope"]
-		if !ok {
-			t.Fatal("JOSEErrorEnvelope schema missing — pre-trust JOSE failures need a documented envelope distinct from ErrorResponse")
-		}
-		// The envelope MUST NOT include framework metadata fields (meta, traceId)
-		// — that's the whole security argument for having it as a separate schema.
-		if _, hasMeta := schema.Properties["meta"]; hasMeta {
-			t.Error("JOSEErrorEnvelope must NOT carry meta — peer is unauthenticated, leak nothing")
-		}
-		if _, hasCode := schema.Properties["code"]; !hasCode {
-			t.Error("JOSEErrorEnvelope must include 'code' property")
-		}
-		if _, hasMsg := schema.Properties["message"]; !hasMsg {
-			t.Error("JOSEErrorEnvelope must include 'message' property")
-		}
-	})
-
 	t.Run("ErrorResponse schema", func(t *testing.T) {
 		validateErrorResponseSchema(t, schemas)
 	})
+	// JOSEErrorEnvelope (pre-trust JOSE failures) and RawErrorResponse (raw-mode
+	// routes) are both minimal {code,message} envelopes that MUST NOT leak meta.
+	t.Run("JOSEErrorEnvelope schema", func(t *testing.T) {
+		validateMinimalErrorEnvelope(t, schemas, schemaJOSEErrorEnvelope)
+	})
+	t.Run("RawErrorResponse schema", func(t *testing.T) {
+		validateMinimalErrorEnvelope(t, schemas, schemaRawErrorResponse)
+	})
+}
+
+// validateMinimalErrorEnvelope asserts a {code,message}-only error schema: the
+// named component exists, carries no meta (leaking nothing beyond code/message),
+// and includes both required properties.
+func validateMinimalErrorEnvelope(t *testing.T, schemas map[string]*OpenAPISchema, name string) {
+	t.Helper()
+	schema, ok := schemas[name]
+	if !ok {
+		t.Fatalf("%s schema missing — a minimal {code,message} error envelope is required", name)
+	}
+	if _, hasMeta := schema.Properties[propNameMeta]; hasMeta {
+		t.Errorf("%s must NOT carry meta — the minimal envelope leaks nothing beyond code/message", name)
+	}
+	for _, p := range []string{propNameCode, propNameMessage} {
+		if _, ok := schema.Properties[p]; !ok {
+			t.Errorf("%s must include %q property", name, p)
+		}
+	}
 }
 
 func validateSuccessResponseSchema(t *testing.T, schemas map[string]*OpenAPISchema) {

--- a/tools/openapi/internal/models/models.go
+++ b/tools/openapi/internal/models/models.go
@@ -36,6 +36,14 @@ type Route struct {
 	// component names across modules.
 	Module  string
 	Package string
+	// SuccessStatus is the HTTP status of the success response, derived from the
+	// handler's result constructor (server.Created -> 201, Accepted -> 202,
+	// NewResult(n) -> n). Zero means "use the default" (200).
+	SuccessStatus int
+	// RawResponse is true when the route is registered WithRawResponse(): the
+	// handler bypasses the standard data/meta envelope and returns its payload
+	// directly (Strangler-Fig migration).
+	RawResponse bool
 }
 
 // TypeInfo represents type metadata for requests and responses

--- a/tools/openapi/internal/spectest/testdata/handler_struct/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/handler_struct/expected.yaml
@@ -17,14 +17,39 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateUserReq'
       responses:
-        "200":
+        "201":
           description: Resource created successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/User'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
         "400":
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -48,9 +73,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/User'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
         "400":
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -68,14 +118,22 @@ paths:
             type: integer
             format: int64
       responses:
-        "200":
-          description: Resource deleted successfully
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
-        "400":
-          description: Bad Request
+                $ref: '#/components/schemas/ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -126,6 +184,18 @@ components:
       required:
         - code
         - message
+    RawErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+        message:
+          type: string
+          description: Human-readable error message
+      required:
+        - code
+        - message
     SuccessResponse:
       type: object
       properties:
@@ -134,7 +204,14 @@ components:
           description: Response data
         meta:
           type: object
-          description: Response metadata
+          properties:
+            timestamp:
+              type: string
+              format: date-time
+              description: RFC3339 response timestamp
+            traceId:
+              type: string
+              description: W3C trace identifier for the request
     User:
       type: object
       properties:

--- a/tools/openapi/internal/spectest/testdata/handler_struct/handler.go
+++ b/tools/openapi/internal/spectest/testdata/handler_struct/handler.go
@@ -1,6 +1,10 @@
 package shop
 
-import "github.com/gaborage/go-bricks/server"
+import (
+	"net/http"
+
+	"github.com/gaborage/go-bricks/server"
+)
 
 // Handler holds the shop's HTTP handlers (separate from the Module struct).
 type Handler struct{}
@@ -28,14 +32,12 @@ func (h *Handler) createUser(req CreateUserReq, ctx server.HandlerContext) (serv
 }
 
 func (h *Handler) getUser(req GetUserReq, ctx server.HandlerContext) (server.Result[User], server.IAPIError) {
-	return server.OK(User{}), nil
+	return server.NewResult(http.StatusOK, User{}), nil
 }
 
 // deleteUser returns NoContentResult — a bodyless 204 response. The analyzer
-// marks the response TypeInfo with NoContent=true (no component is generated),
-// but rendering it as a 204 (instead of the current 200 with a SuccessResponse
-// body) is deferred to the response-envelope/status work; the golden therefore
-// still shows a 200 for this route today.
+// marks the response TypeInfo with NoContent=true (no component is generated)
+// and the generator renders it as a 204 with no response body.
 func (h *Handler) deleteUser(req GetUserReq, ctx server.HandlerContext) (server.NoContentResult, server.IAPIError) {
 	return server.NoContent(), nil
 }

--- a/tools/openapi/internal/spectest/testdata/jose/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/jose/expected.yaml
@@ -27,8 +27,8 @@ paths:
           description: |
             JOSE compact serialization (signed-then-encrypted). The wire payload
             is a base64url-encoded JWE compact form whose plaintext, after
-            decrypt+verify, conforms to the SuccessResponse schema —
-            see #/components/schemas/SuccessResponse.
+            decrypt+verify, conforms to the CreateTokenResponse schema —
+            see #/components/schemas/CreateTokenResponse.
           content:
             application/jose:
               schema:
@@ -36,6 +36,18 @@ paths:
                 format: jose
         "400":
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JOSEErrorEnvelope'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JOSEErrorEnvelope'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -77,6 +89,18 @@ components:
       required:
         - code
         - message
+    RawErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+        message:
+          type: string
+          description: Human-readable error message
+      required:
+        - code
+        - message
     SuccessResponse:
       type: object
       properties:
@@ -85,4 +109,11 @@ components:
           description: Response data
         meta:
           type: object
-          description: Response metadata
+          properties:
+            timestamp:
+              type: string
+              format: date-time
+              description: RFC3339 response timestamp
+            traceId:
+              type: string
+              description: W3C trace identifier for the request

--- a/tools/openapi/internal/spectest/testdata/jose/vts.go
+++ b/tools/openapi/internal/spectest/testdata/jose/vts.go
@@ -2,6 +2,8 @@
 package vts
 
 import (
+	"net/http"
+
 	"github.com/gaborage/go-bricks/app"
 	"github.com/gaborage/go-bricks/server"
 )
@@ -41,5 +43,5 @@ func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegist
 // will flip to application/jose and this fixture will exercise the full
 // JOSE-response round-trip end-to-end.
 func (m *Module) createToken(req CreateTokenRequest, ctx server.HandlerContext) (server.Result[CreateTokenResponse], server.IAPIError) {
-	return server.OK(CreateTokenResponse{}), nil
+	return server.NewResult(http.StatusOK, CreateTokenResponse{}), nil
 }

--- a/tools/openapi/internal/spectest/testdata/multi_param/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/multi_param/expected.yaml
@@ -27,9 +27,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Project'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
         "400":
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -76,6 +101,18 @@ components:
           type: string
         name:
           type: string
+    RawErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+        message:
+          type: string
+          description: Human-readable error message
+      required:
+        - code
+        - message
     SuccessResponse:
       type: object
       properties:
@@ -84,4 +121,11 @@ components:
           description: Response data
         meta:
           type: object
-          description: Response metadata
+          properties:
+            timestamp:
+              type: string
+              format: date-time
+              description: RFC3339 response timestamp
+            traceId:
+              type: string
+              description: W3C trace identifier for the request

--- a/tools/openapi/internal/spectest/testdata/multi_param/org.go
+++ b/tools/openapi/internal/spectest/testdata/multi_param/org.go
@@ -2,6 +2,8 @@
 package org
 
 import (
+	"net/http"
+
 	"github.com/gaborage/go-bricks/app"
 	"github.com/gaborage/go-bricks/server"
 )
@@ -32,5 +34,5 @@ func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegist
 }
 
 func (m *Module) getProject(req GetProjectReq, ctx server.HandlerContext) (server.Result[Project], server.IAPIError) {
-	return server.OK(Project{}), nil
+	return server.NewResult(http.StatusOK, Project{}), nil
 }

--- a/tools/openapi/internal/spectest/testdata/nested_schema/catalog.go
+++ b/tools/openapi/internal/spectest/testdata/nested_schema/catalog.go
@@ -3,6 +3,8 @@
 package catalog
 
 import (
+	"net/http"
+
 	"github.com/gaborage/go-bricks/app"
 	"github.com/gaborage/go-bricks/server"
 )
@@ -53,5 +55,5 @@ func (m *Module) createUser(req CreateUserReq, ctx server.HandlerContext) (serve
 }
 
 func (m *Module) listCategories(ctx server.HandlerContext) (server.Result[Category], server.IAPIError) {
-	return server.OK(Category{}), nil
+	return server.NewResult(http.StatusOK, Category{}), nil
 }

--- a/tools/openapi/internal/spectest/testdata/nested_schema/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/nested_schema/expected.yaml
@@ -16,9 +16,28 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Category'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
         "400":
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -36,14 +55,39 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateUserReq'
       responses:
-        "200":
+        "201":
           description: Resource created successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/User'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
         "400":
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -107,6 +151,18 @@ components:
       required:
         - code
         - message
+    RawErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+        message:
+          type: string
+          description: Human-readable error message
+      required:
+        - code
+        - message
     SuccessResponse:
       type: object
       properties:
@@ -115,7 +171,14 @@ components:
           description: Response data
         meta:
           type: object
-          description: Response metadata
+          properties:
+            timestamp:
+              type: string
+              format: date-time
+              description: RFC3339 response timestamp
+            traceId:
+              type: string
+              description: W3C trace identifier for the request
     User:
       type: object
       properties:

--- a/tools/openapi/internal/spectest/testdata/package_func/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/package_func/expected.yaml
@@ -16,9 +16,28 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/PingResponse'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
         "400":
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -53,6 +72,18 @@ components:
       properties:
         status:
           type: string
+    RawErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+        message:
+          type: string
+          description: Human-readable error message
+      required:
+        - code
+        - message
     SuccessResponse:
       type: object
       properties:
@@ -61,4 +92,11 @@ components:
           description: Response data
         meta:
           type: object
-          description: Response metadata
+          properties:
+            timestamp:
+              type: string
+              format: date-time
+              description: RFC3339 response timestamp
+            traceId:
+              type: string
+              description: W3C trace identifier for the request

--- a/tools/openapi/internal/spectest/testdata/package_func/health.go
+++ b/tools/openapi/internal/spectest/testdata/package_func/health.go
@@ -2,6 +2,8 @@
 package health
 
 import (
+	"net/http"
+
 	"github.com/gaborage/go-bricks/app"
 	"github.com/gaborage/go-bricks/server"
 )
@@ -24,5 +26,5 @@ func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegist
 }
 
 func ping(ctx server.HandlerContext) (server.Result[PingResponse], server.IAPIError) {
-	return server.OK(PingResponse{}), nil
+	return server.NewResult(http.StatusOK, PingResponse{}), nil
 }

--- a/tools/openapi/internal/spectest/testdata/path_param/catalog.go
+++ b/tools/openapi/internal/spectest/testdata/path_param/catalog.go
@@ -2,6 +2,8 @@
 package catalog
 
 import (
+	"net/http"
+
 	"github.com/gaborage/go-bricks/app"
 	"github.com/gaborage/go-bricks/server"
 )
@@ -32,5 +34,5 @@ func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegist
 }
 
 func (m *Module) getProduct(req GetProductReq, ctx server.HandlerContext) (server.Result[Product], server.IAPIError) {
-	return server.OK(Product{}), nil
+	return server.NewResult(http.StatusOK, Product{}), nil
 }

--- a/tools/openapi/internal/spectest/testdata/raw_response/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/raw_response/expected.yaml
@@ -1,38 +1,31 @@
 openapi: 3.0.1
 info:
-  title: Catalog API
+  title: Legacy API
   version: 1.0.0
   description: Generated API specification
 paths:
-  /products/{id}:
-    get:
-      operationId: getProduct
-      summary: GET /products/{id}
+  /jobs:
+    post:
+      operationId: enqueueLegacyJob
+      summary: POST /jobs
       tags:
-        - catalog
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int64
-        - name: page
-          in: query
-          required: false
-          schema:
-            type: integer
-            format: int32
+        - jobs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnqueueReq'
       responses:
-        "200":
-          description: Successful response
+        "202":
+          description: Request accepted for processing
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   data:
-                    $ref: '#/components/schemas/Product'
+                    $ref: '#/components/schemas/JobAck'
                   meta:
                     type: object
                     properties:
@@ -61,8 +54,53 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /legacy/users/{id}:
+    get:
+      operationId: getLegacyUser
+      summary: GET /legacy/users/{id}
+      tags:
+        - legacy
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LegacyUser'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RawErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RawErrorResponse'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RawErrorResponse'
 components:
   schemas:
+    EnqueueReq:
+      type: object
+      properties:
+        jobType:
+          type: string
+      required:
+        - jobType
     ErrorResponse:
       type: object
       properties:
@@ -74,15 +112,12 @@ components:
           description: Response metadata
       required:
         - error
-    GetProductReq:
+    GetLegacyReq:
       type: object
       properties:
         iD:
           type: integer
           format: int64
-        page:
-          type: integer
-          format: int32
       required:
         - iD
     JOSEErrorEnvelope:
@@ -97,7 +132,12 @@ components:
       required:
         - code
         - message
-    Product:
+    JobAck:
+      type: object
+      properties:
+        jobId:
+          type: string
+    LegacyUser:
       type: object
       properties:
         id:

--- a/tools/openapi/internal/spectest/testdata/raw_response/go.mod
+++ b/tools/openapi/internal/spectest/testdata/raw_response/go.mod
@@ -1,0 +1,5 @@
+module github.com/example/legacy
+
+go 1.25
+
+require github.com/gaborage/go-bricks v0.37.0

--- a/tools/openapi/internal/spectest/testdata/raw_response/handler.go
+++ b/tools/openapi/internal/spectest/testdata/raw_response/handler.go
@@ -1,0 +1,47 @@
+package legacy
+
+import (
+	"net/http"
+
+	"github.com/gaborage/go-bricks/server"
+)
+
+// Handler holds the legacy storefront's HTTP handlers.
+type Handler struct{}
+
+// LegacyUser is the raw response payload. Routes registered WithRawResponse emit
+// this schema directly (no data/meta envelope) for Strangler-Fig compatibility
+// with a pre-existing JSON shape.
+type LegacyUser struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+// GetLegacyReq identifies a legacy user by path parameter.
+type GetLegacyReq struct {
+	ID int64 `param:"id" validate:"required"`
+}
+
+// EnqueueReq is a validated request body for the async job endpoint.
+type EnqueueReq struct {
+	JobType string `json:"jobType" validate:"required"`
+}
+
+// JobAck is the acknowledgement returned when a job is accepted for async work.
+type JobAck struct {
+	JobID string `json:"jobId"`
+}
+
+// getLegacyUser returns the bare legacy shape (no envelope). Registered
+// WithRawResponse, so the generator emits a 200 whose schema is a direct $ref to
+// LegacyUser and whose error responses use the minimal RawErrorResponse.
+func (h *Handler) getLegacyUser(req GetLegacyReq, ctx server.HandlerContext) (server.Result[LegacyUser], server.IAPIError) {
+	return server.NewResult(http.StatusOK, LegacyUser{}), nil
+}
+
+// enqueueJob accepts a job for asynchronous processing. It returns
+// server.Accepted (202) and is registered WithHandlerName to override the
+// generated operationId.
+func (h *Handler) enqueueJob(req EnqueueReq, ctx server.HandlerContext) (server.Result[JobAck], server.IAPIError) {
+	return server.Accepted(JobAck{}), nil
+}

--- a/tools/openapi/internal/spectest/testdata/raw_response/module.go
+++ b/tools/openapi/internal/spectest/testdata/raw_response/module.go
@@ -1,0 +1,26 @@
+// Package legacy demonstrates raw-response mode (Strangler-Fig migration) and the
+// WithHandlerName operationId override. getLegacyUser bypasses the data/meta
+// envelope; enqueueJob returns 202 Accepted with an overridden operationId.
+package legacy
+
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+
+// Module wires the legacy routes to a Handler.
+type Module struct {
+	h *Handler
+}
+
+func (m *Module) Name() string                    { return "legacy" }
+func (m *Module) Init(deps *app.ModuleDeps) error { m.h = &Handler{}; return nil }
+func (m *Module) Shutdown() error                 { return nil }
+
+// RegisterRoutes registers a raw-response GET and an async POST.
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/legacy/users/:id", m.h.getLegacyUser,
+		server.WithTags("legacy"), server.WithRawResponse())
+	server.POST(hr, r, "/jobs", m.h.enqueueJob,
+		server.WithTags("jobs"), server.WithHandlerName("enqueueLegacyJob"))
+}

--- a/tools/openapi/internal/spectest/testdata/registration/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/registration/expected.yaml
@@ -16,9 +16,28 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Item'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
         "400":
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -35,9 +54,28 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Item'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
         "400":
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -55,14 +93,33 @@ paths:
             schema:
               $ref: '#/components/schemas/Item'
       responses:
-        "200":
+        "201":
           description: Resource created successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Item'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
         "400":
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -79,9 +136,28 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Item'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
         "400":
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -98,9 +174,28 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Item'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
         "400":
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -138,6 +233,18 @@ components:
       required:
         - code
         - message
+    RawErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+        message:
+          type: string
+          description: Human-readable error message
+      required:
+        - code
+        - message
     SuccessResponse:
       type: object
       properties:
@@ -146,4 +253,11 @@ components:
           description: Response data
         meta:
           type: object
-          description: Response metadata
+          properties:
+            timestamp:
+              type: string
+              format: date-time
+              description: RFC3339 response timestamp
+            traceId:
+              type: string
+              description: W3C trace identifier for the request

--- a/tools/openapi/internal/spectest/testdata/registration/storefront.go
+++ b/tools/openapi/internal/spectest/testdata/registration/storefront.go
@@ -3,6 +3,8 @@
 package storefront
 
 import (
+	"net/http"
+
 	"github.com/gaborage/go-bricks/app"
 	"github.com/gaborage/go-bricks/server"
 )
@@ -12,9 +14,9 @@ const apiBase = "/api"
 // Module is the storefront module.
 type Module struct{}
 
-func (m *Module) Name() string                    { return "storefront" }
-func (m *Module) Init(d *app.ModuleDeps) error    { return nil }
-func (m *Module) Shutdown() error                 { return nil }
+func (m *Module) Name() string                 { return "storefront" }
+func (m *Module) Init(d *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error              { return nil }
 
 // Item is the storefront item resource.
 type Item struct {
@@ -49,10 +51,18 @@ func (m *Module) registerItemWrites(hr *server.HandlerRegistry, r server.RouteRe
 	server.POST(hr, r, "/items", m.createItem, server.WithTags("items"))
 }
 
-func (m *Module) listItems(ctx server.HandlerContext) (server.Result[Item], server.IAPIError) { return server.OK(Item{}), nil }
-func (m *Module) stats(ctx server.HandlerContext) (server.Result[Item], server.IAPIError)     { return server.OK(Item{}), nil }
-func (m *Module) health(ctx server.HandlerContext) (server.Result[Item], server.IAPIError)    { return server.OK(Item{}), nil }
-func (m *Module) version(ctx server.HandlerContext) (server.Result[Item], server.IAPIError)   { return server.OK(Item{}), nil }
+func (m *Module) listItems(ctx server.HandlerContext) (server.Result[Item], server.IAPIError) {
+	return server.NewResult(http.StatusOK, Item{}), nil
+}
+func (m *Module) stats(ctx server.HandlerContext) (server.Result[Item], server.IAPIError) {
+	return server.NewResult(http.StatusOK, Item{}), nil
+}
+func (m *Module) health(ctx server.HandlerContext) (server.Result[Item], server.IAPIError) {
+	return server.NewResult(http.StatusOK, Item{}), nil
+}
+func (m *Module) version(ctx server.HandlerContext) (server.Result[Item], server.IAPIError) {
+	return server.NewResult(http.StatusOK, Item{}), nil
+}
 func (m *Module) createItem(req Item, ctx server.HandlerContext) (server.Result[Item], server.IAPIError) {
 	return server.Created(Item{}), nil
 }

--- a/tools/openapi/internal/spectest/testdata/simple/api.go
+++ b/tools/openapi/internal/spectest/testdata/simple/api.go
@@ -2,6 +2,8 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/gaborage/go-bricks/app"
 	"github.com/gaborage/go-bricks/server"
 )
@@ -38,5 +40,5 @@ func (m *Module) createUser(req CreateUserReq, ctx server.HandlerContext) (serve
 }
 
 func (m *Module) ping(ctx server.HandlerContext) (server.Result[User], server.IAPIError) {
-	return server.OK(User{}), nil
+	return server.NewResult(http.StatusOK, User{}), nil
 }

--- a/tools/openapi/internal/spectest/testdata/simple/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/simple/expected.yaml
@@ -16,9 +16,28 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/User'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
         "400":
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -36,14 +55,39 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateUserReq'
       responses:
-        "200":
+        "201":
           description: Resource created successfully
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/User'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
         "400":
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -92,6 +136,18 @@ components:
       required:
         - code
         - message
+    RawErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+        message:
+          type: string
+          description: Human-readable error message
+      required:
+        - code
+        - message
     SuccessResponse:
       type: object
       properties:
@@ -100,7 +156,14 @@ components:
           description: Response data
         meta:
           type: object
-          description: Response metadata
+          properties:
+            timestamp:
+              type: string
+              format: date-time
+              description: RFC3339 response timestamp
+            traceId:
+              type: string
+              description: W3C trace identifier for the request
     User:
       type: object
       properties:


### PR DESCRIPTION
## PR6 — Render typed response envelope + constructor-derived status codes

Sixth PR in the OpenAPI-tool gap initiative. Wires the response component schemas that PR3/PR5 discover into the actual response object — **closing the orphan-component window** the roadmap opened at PR3.

### What changed
- **Response envelope (`data.$ref`):** `responses[<code>]` now emits the inline `{data: $ref <Response>, meta}` envelope (with `timestamp`/`traceId`), so the discovered response component is finally referenced — no more generic `SuccessResponse` placeholder for typed routes.
- **Status codes from the result constructor:**
  - `server.Created` → **201**, `server.Accepted` → **202**, `server.NoContent` → **204** (no body), `server.NewResult(s, …)` → **s** where `s` is an integer literal **or** an `http.StatusXxx` constant (the idiomatic real-world form). Default 200. Last recognized return wins (terminal happy path beats an earlier guard).
- **Standard error set:** `400` + `500` always; `422` when the request type carries validation tags. Error schema is `JOSEErrorEnvelope` (JOSE routes), `RawErrorResponse` (raw routes), or `ErrorResponse`.
- **Raw-response mode (`WithRawResponse`):** bare payload `$ref`, no envelope, minimal `{code,message}` error (Strangler-Fig migration).
- **`WithHandlerName`** parsed as an operationId override.

### Fidelity fix surfaced by `/code-review`
Every fixture previously called **`server.OK(...)` — a function that does not exist in go-bricks**. Real 200 handlers write `server.NewResult(http.StatusOK, …)`. The first cut of the status feature parsed only integer literals, so it was **inert against idiomatic code**. Fixed: `http.StatusXxx` selectors resolve, all fixtures converted to the real API (so they model compilable code and exercise the selector path in goldens), plus a map-key-collision guard (a success status overlapping an error code keeps the success entry) and a POST-returning-200 no longer mislabeled "Resource created".

### Validation
- `make check` green (fmt + lint + test + CLI validation).
- All 9 goldens re-validate through in-process **kin-openapi** and the pinned **redocly** gate.
- New `raw_response` fixture covers raw mode, `WithHandlerName`, and `Accepted`→202.
- Tool coverage **91.4%** (≥80% bar); new status/envelope functions at 90–100%.

Depends on #490 (merged). Part of the roadmap in `.claude/tasks/openapi-tool-gap-analysis.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection of per-route success HTTP status (including 201 and 204)
  * Raw response mode to emit bare payloads without the standard envelope
  * Ability to set/override handler operation names for OpenAPI

* **Improvements**
  * OpenAPI responses now include explicit 400/422/500 error entries and a new simple error schema
  * Success responses use a standardized envelope with timestamp and traceId
  * Improved response-generation (JOSE/plaintext/raw variants) for more accurate docs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->