### PR TITLE
feat(openapi): promote embedded/anonymous struct fields (PR8)

### DIFF
--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -1712,7 +1712,9 @@ func (a *ProjectAnalyzer) registerType(name, pkg string, astFile *ast.File, file
 
 	ti := &models.TypeInfo{Name: name, Package: pkg}
 	a.typeRegistry[name] = ti // register before recursing (cycle guard)
-	ti.Fields = a.extractStructFields(structType, pkg)
+	// Seed the embedded-promotion ancestor set with this type so a self-embed
+	// (e.g. type Node struct{ *Node }) is not promoted into itself.
+	ti.Fields = a.extractStructFields(structType, pkg, astFile, filePath, map[string]struct{}{name: {}})
 	ti.JOSE = hasJOSESentinelTag(structType)
 
 	for i := range ti.Fields {
@@ -1879,40 +1881,115 @@ func (a *ProjectAnalyzer) findStructInFile(astFile *ast.File, typeName string) *
 	return nil
 }
 
-// extractStructFields extracts field information from a struct type including struct tags
-func (a *ProjectAnalyzer) extractStructFields(structType *ast.StructType, _ string) []models.FieldInfo {
-	var fields []models.FieldInfo
-
+// extractStructFields extracts field information from a struct type including
+// struct tags. astFile/filePath locate sibling files for resolving embedded
+// struct types; visited is the embedded-promotion ancestor set (cycle guard).
+//
+// Direct named fields and json-tagged embeds (which nest at the parent's level)
+// are "shallow"; fields flattened from an untagged embed are "promoted" (deeper).
+// On a JSON-name collision the shallow field wins, mirroring encoding/json's
+// shallower-depth-wins rule (so a parent field is never silently overridden by a
+// promoted one, regardless of declaration order).
+func (a *ProjectAnalyzer) extractStructFields(structType *ast.StructType, pkg string, astFile *ast.File, filePath string, visited map[string]struct{}) []models.FieldInfo {
 	if structType.Fields == nil {
-		return fields
-	}
-
-	for _, field := range structType.Fields.List {
-		fields = append(fields, a.processStructField(field)...)
-	}
-
-	return fields
-}
-
-// processStructField processes a single AST field and returns all associated FieldInfo entries
-func (a *ProjectAnalyzer) processStructField(field *ast.Field) []models.FieldInfo {
-	// Skip fields without names (embedded structs, for now)
-	if len(field.Names) == 0 {
 		return nil
 	}
 
-	fieldInfos := make([]models.FieldInfo, 0, len(field.Names))
+	var shallow, promoted []models.FieldInfo
+	for _, field := range structType.Fields.List {
+		if len(field.Names) == 0 {
+			fields, isPromotion := a.embeddedFields(field, pkg, astFile, filePath, visited)
+			if isPromotion {
+				promoted = append(promoted, fields...)
+			} else {
+				shallow = append(shallow, fields...)
+			}
+			continue
+		}
+		shallow = append(shallow, a.namedFields(field)...)
+	}
+
+	return mergeFieldsByPrecedence(shallow, promoted)
+}
+
+// namedFields builds FieldInfo entries for a single non-anonymous AST field
+// (one per exported name; unexported names are skipped).
+func (a *ProjectAnalyzer) namedFields(field *ast.Field) []models.FieldInfo {
+	out := make([]models.FieldInfo, 0, len(field.Names))
 	for _, fieldName := range field.Names {
-		// Skip unexported fields
 		if !fieldName.IsExported() {
 			continue
 		}
+		out = append(out, a.buildFieldInfo(fieldName.Name, field))
+	}
+	return out
+}
 
-		fieldInfo := a.buildFieldInfo(fieldName.Name, field)
-		fieldInfos = append(fieldInfos, fieldInfo)
+// mergeFieldsByPrecedence concatenates shallow then promoted fields, dropping any
+// promoted field whose JSON name already appears (so shallower wins). Among
+// promoted fields a colliding name keeps the first (equal-depth ambiguity is
+// rare; encoding/json would drop both, but documenting one is more useful).
+func mergeFieldsByPrecedence(shallow, promoted []models.FieldInfo) []models.FieldInfo {
+	seen := make(map[string]struct{}, len(shallow))
+	for i := range shallow {
+		if n := shallow[i].JSONName; n != "" {
+			seen[n] = struct{}{}
+		}
+	}
+	out := shallow
+	for i := range promoted {
+		if n := promoted[i].JSONName; n != "" {
+			if _, dup := seen[n]; dup {
+				continue
+			}
+			seen[n] = struct{}{}
+		}
+		out = append(out, promoted[i])
+	}
+	return out
+}
+
+// embeddedFields handles an anonymous (embedded) struct field, mirroring
+// encoding/json promotion rules. It returns the resulting fields and whether they
+// were PROMOTED (flattened from the embed, i.e. deeper) vs nested at the parent
+// level:
+//   - With an explicit json name (Base `json:"base"`) it NESTS as a single field
+//     of the embedded type (rendered as a $ref) — returned as shallow.
+//   - With json:"-" it is excluded.
+//   - Otherwise its exported fields are PROMOTED (flattened) into the parent.
+//
+// Embedded pointers (*Base) are unwrapped. An embedded type that cannot be
+// resolved to a local struct — a cross-package type (PR9's resolver) or a named
+// non-struct like `type Code string` (named-type underlying-kind is also PR9) —
+// is skipped without crashing. The visited ancestor set (add-before-recurse /
+// delete-after backtracking) terminates self- and mutually-embedded cycles.
+func (a *ProjectAnalyzer) embeddedFields(field *ast.Field, pkg string, astFile *ast.File, filePath string, visited map[string]struct{}) (fields []models.FieldInfo, promoted bool) {
+	typeName := baseStructTypeName(a.typeToString(field.Type))
+
+	// An explicit json name turns embedding into nesting (a parent-level field).
+	if field.Tag != nil {
+		jsonName := a.parseStructTags(strings.Trim(field.Tag.Value, "`")).jsonName
+		switch jsonName {
+		case jsonSkipValue:
+			return nil, false // json:"-" — excluded
+		case "":
+			// no explicit name — fall through to promotion
+		default:
+			return []models.FieldInfo{a.buildFieldInfo(typeName, field)}, false
+		}
 	}
 
-	return fieldInfos
+	if _, seen := visited[typeName]; seen {
+		return nil, false // cycle / self-embed guard
+	}
+	embedded, err := a.findStructDefinition(astFile, filePath, typeName)
+	if err != nil {
+		return nil, false // unresolvable (cross-package or non-struct) — skip, never crash
+	}
+	visited[typeName] = struct{}{}
+	fields = a.extractStructFields(embedded, pkg, astFile, filePath, visited)
+	delete(visited, typeName) // backtrack: keep visited scoped to the current chain
+	return fields, true
 }
 
 // buildFieldInfo creates a FieldInfo from a field name and AST field

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -3746,3 +3746,177 @@ func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegist
 	assert.Empty(t, byJSON["addrs"].RefName, "a map field is never a whole-field $ref")
 	assert.Empty(t, byJSON["tags"].MapValueRefName, "primitive-valued map has no value ref")
 }
+
+// fieldJSONNames returns the set of JSON names on a registered type's fields.
+func fieldJSONNames(t *testing.T, a *ProjectAnalyzer, typeName string) map[string]bool {
+	t.Helper()
+	ti := a.typeRegistry[typeName]
+	require.NotNil(t, ti, "type %q must be registered", typeName)
+	out := map[string]bool{}
+	for i := range ti.Fields {
+		out[ti.Fields[i].JSONName] = true
+	}
+	return out
+}
+
+// TestEmbeddedPromotion covers value/pointer promotion and json-tagged nesting.
+func TestEmbeddedPromotion(t *testing.T) {
+	src := `package mod
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+type Base struct { ID int64 ` + "`json:\"id\"`" + `; CreatedAt string ` + "`json:\"createdAt\"`" + ` }
+type User struct { Base; Name string ` + "`json:\"name\"`" + ` }
+type Account struct { *Base; Balance int64 ` + "`json:\"balance\"`" + ` }
+type Wrapper struct { Base ` + "`json:\"base\"`" + `; Label string ` + "`json:\"label\"`" + ` }
+func (m *Module) u(ctx server.HandlerContext) (server.Result[User], server.IAPIError) { return server.Created(User{}), nil }
+func (m *Module) a(ctx server.HandlerContext) (server.Result[Account], server.IAPIError) { return server.Created(Account{}), nil }
+func (m *Module) w(ctx server.HandlerContext) (server.Result[Wrapper], server.IAPIError) { return server.Created(Wrapper{}), nil }
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/u", m.u)
+	server.GET(hr, r, "/a", m.a)
+	server.GET(hr, r, "/w", m.w)
+}
+`
+	a, _ := analyzeSingleModule(t, src)
+
+	user := fieldJSONNames(t, a, "User")
+	assert.True(t, user["id"] && user["createdAt"], "value-embedded Base fields must be promoted")
+	assert.True(t, user["name"], "own field present")
+
+	acct := fieldJSONNames(t, a, "Account")
+	assert.True(t, acct["id"] && acct["createdAt"], "pointer-embedded *Base fields must be promoted")
+	assert.True(t, acct["balance"])
+
+	wrap := fieldJSONNames(t, a, "Wrapper")
+	assert.True(t, wrap["base"], "json-tagged embedding nests under the tag name, not promoted")
+	assert.False(t, wrap["id"], "json-tagged embedding must NOT promote the embedded fields")
+	assert.True(t, wrap["label"])
+	wf := a.typeRegistry["Wrapper"]
+	var baseField *models.FieldInfo
+	for i := range wf.Fields {
+		if wf.Fields[i].JSONName == "base" {
+			baseField = &wf.Fields[i]
+		}
+	}
+	require.NotNil(t, baseField)
+	assert.Equal(t, "Base", baseField.RefName, "nested embedding is a $ref to the embedded type")
+	_, ok := a.typeRegistry["Base"]
+	assert.True(t, ok, "nested-embedded Base is registered as a component")
+}
+
+// TestEmbeddedSelfReferenceTerminates ensures a self-embedded type does not loop.
+func TestEmbeddedSelfReferenceTerminates(t *testing.T) {
+	src := `package mod
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+type Node struct { *Node; Val int ` + "`json:\"val\"`" + ` }
+func (m *Module) n(ctx server.HandlerContext) (server.Result[Node], server.IAPIError) { return server.Created(Node{}), nil }
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/n", m.n)
+}
+`
+	a, _ := analyzeSingleModule(t, src)
+	node := fieldJSONNames(t, a, "Node")
+	assert.True(t, node["val"], "non-embedded field survives")
+	assert.Len(t, a.typeRegistry["Node"].Fields, 1, "self-embed is skipped (only Val remains), no infinite loop")
+}
+
+// TestEmbeddedCrossPackageDoesNotCrash ensures an unresolvable embedded type is
+// skipped gracefully (cross-package resolution is PR9).
+func TestEmbeddedCrossPackageDoesNotCrash(t *testing.T) {
+	src := `package mod
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+	"example.com/other"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+type Foo struct { other.Bar; X int ` + "`json:\"x\"`" + ` }
+func (m *Module) f(ctx server.HandlerContext) (server.Result[Foo], server.IAPIError) { return server.Created(Foo{}), nil }
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/f", m.f)
+}
+`
+	a, _ := analyzeSingleModule(t, src)
+	foo := fieldJSONNames(t, a, "Foo")
+	assert.True(t, foo["x"], "own field present despite unresolvable embedded type")
+	assert.Len(t, a.typeRegistry["Foo"].Fields, 1, "unresolvable embedded type is skipped, not crashed")
+}
+
+// TestEmbeddedFieldPrecedence locks encoding/json's shallower-wins rule: a
+// parent's own field beats a promoted (embedded) field of the same JSON name,
+// regardless of declaration order. Also covers json:"-" exclusion and a
+// name-less (",omitempty") embed still promoting.
+func TestEmbeddedFieldPrecedence(t *testing.T) {
+	src := `package mod
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+type Base struct { Tag string ` + "`json:\"tag\"`" + `; Only string ` + "`json:\"only\"`" + ` }
+// EmbedFirst declares the embed BEFORE its own colliding field.
+type EmbedFirst struct { Base; Tag int ` + "`json:\"tag\"`" + ` }
+// OwnFirst declares its own colliding field BEFORE the embed.
+type OwnFirst struct { Tag int ` + "`json:\"tag\"`" + `; Base }
+// Skipped embeds Base with json:"-" -> excluded entirely.
+type Skipped struct { Base ` + "`json:\"-\"`" + `; Keep string ` + "`json:\"keep\"`" + ` }
+// OmitOnly embeds Base with a name-less tag -> still promotes.
+type OmitOnly struct { Base ` + "`json:\",omitempty\"`" + ` }
+func (m *Module) a(ctx server.HandlerContext) (server.Result[EmbedFirst], server.IAPIError) { return server.Created(EmbedFirst{}), nil }
+func (m *Module) b(ctx server.HandlerContext) (server.Result[OwnFirst], server.IAPIError) { return server.Created(OwnFirst{}), nil }
+func (m *Module) c(ctx server.HandlerContext) (server.Result[Skipped], server.IAPIError) { return server.Created(Skipped{}), nil }
+func (m *Module) d(ctx server.HandlerContext) (server.Result[OmitOnly], server.IAPIError) { return server.Created(OmitOnly{}), nil }
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/a", m.a)
+	server.GET(hr, r, "/b", m.b)
+	server.GET(hr, r, "/c", m.c)
+	server.GET(hr, r, "/d", m.d)
+}
+`
+	a, _ := analyzeSingleModule(t, src)
+
+	// The parent's own "tag" (int) must win over Base's promoted "tag" (string),
+	// in BOTH declaration orders.
+	for _, typeName := range []string{"EmbedFirst", "OwnFirst"} {
+		ti := a.typeRegistry[typeName]
+		require.NotNil(t, ti, typeName)
+		var tagType string
+		count := 0
+		for _, f := range ti.Fields {
+			if f.JSONName == "tag" {
+				tagType = f.Type
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "%s: exactly one 'tag' field after precedence merge", typeName)
+		assert.Equal(t, "int", tagType, "%s: parent's own int tag wins over promoted string tag", typeName)
+		// The non-colliding promoted field is still present.
+		assert.True(t, fieldJSONNames(t, a, typeName)["only"], "%s: non-colliding promoted field survives", typeName)
+	}
+
+	skipped := fieldJSONNames(t, a, "Skipped")
+	assert.False(t, skipped["tag"] || skipped["only"], "json:\"-\" embed must be fully excluded")
+	assert.True(t, skipped["keep"], "own field survives")
+
+	omit := fieldJSONNames(t, a, "OmitOnly")
+	assert.True(t, omit["tag"] && omit["only"], "name-less (,omitempty) embed still promotes")
+}

--- a/tools/openapi/internal/spectest/testdata/embedded/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/embedded/expected.yaml
@@ -1,0 +1,259 @@
+openapi: 3.0.1
+info:
+  title: Embed API
+  version: 1.0.0
+  description: Generated API specification
+paths:
+  /accounts/{id}:
+    get:
+      operationId: getAccount
+      summary: GET /accounts/{id}
+      tags:
+        - embed
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Account'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /users/{id}:
+    get:
+      operationId: getUser
+      summary: GET /users/{id}
+      tags:
+        - embed
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/User'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /wrappers/{id}:
+    get:
+      operationId: getWrapper
+      summary: GET /wrappers/{id}
+      tags:
+        - embed
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Wrapper'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    Account:
+      type: object
+      properties:
+        balance:
+          type: integer
+          format: int64
+        createdAt:
+          type: string
+          format: date-time
+        id:
+          type: integer
+          format: int64
+    Base:
+      type: object
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+        id:
+          type: integer
+          format: int64
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: object
+          description: Error details with code and message
+        meta:
+          type: object
+          description: Response metadata
+      required:
+        - error
+    IDReq:
+      type: object
+      properties:
+        iD:
+          type: integer
+          format: int64
+      required:
+        - iD
+    JOSEErrorEnvelope:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
+        message:
+          type: string
+          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
+      required:
+        - code
+        - message
+    RawErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+        message:
+          type: string
+          description: Human-readable error message
+      required:
+        - code
+        - message
+    SuccessResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          description: Response data
+        meta:
+          type: object
+          properties:
+            timestamp:
+              type: string
+              format: date-time
+              description: RFC3339 response timestamp
+            traceId:
+              type: string
+              description: W3C trace identifier for the request
+    User:
+      type: object
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Wrapper:
+      type: object
+      properties:
+        base:
+          $ref: '#/components/schemas/Base'
+        label:
+          type: string

--- a/tools/openapi/internal/spectest/testdata/embedded/go.mod
+++ b/tools/openapi/internal/spectest/testdata/embedded/go.mod
@@ -1,0 +1,5 @@
+module github.com/example/embed
+
+go 1.25
+
+require github.com/gaborage/go-bricks v0.37.0

--- a/tools/openapi/internal/spectest/testdata/embedded/handler.go
+++ b/tools/openapi/internal/spectest/testdata/embedded/handler.go
@@ -1,0 +1,52 @@
+package embed
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gaborage/go-bricks/server"
+)
+
+// Handler holds the HTTP handlers.
+type Handler struct{}
+
+// Base is an embedded struct whose exported fields are promoted into the parent.
+type Base struct {
+	ID        int64     `json:"id"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+// User embeds Base by value (no json tag) -> id and createdAt are promoted
+// alongside name.
+type User struct {
+	Base
+	Name string `json:"name"`
+}
+
+// Account embeds *Base (pointer) -> promotes the same fields as value embedding.
+type Account struct {
+	*Base
+	Balance int64 `json:"balance"`
+}
+
+// Wrapper embeds Base WITH a json tag -> nests as a sub-object ("base") instead
+// of promoting (rendered as a $ref to Base).
+type Wrapper struct {
+	Base  `json:"base"`
+	Label string `json:"label"`
+}
+
+// IDReq identifies a resource by path parameter.
+type IDReq struct {
+	ID int64 `param:"id" validate:"required"`
+}
+
+func (h *Handler) getUser(req IDReq, ctx server.HandlerContext) (server.Result[User], server.IAPIError) {
+	return server.NewResult(http.StatusOK, User{}), nil
+}
+func (h *Handler) getAccount(req IDReq, ctx server.HandlerContext) (server.Result[Account], server.IAPIError) {
+	return server.NewResult(http.StatusOK, Account{}), nil
+}
+func (h *Handler) getWrapper(req IDReq, ctx server.HandlerContext) (server.Result[Wrapper], server.IAPIError) {
+	return server.NewResult(http.StatusOK, Wrapper{}), nil
+}

--- a/tools/openapi/internal/spectest/testdata/embedded/module.go
+++ b/tools/openapi/internal/spectest/testdata/embedded/module.go
@@ -1,0 +1,23 @@
+// Package embed demonstrates embedded/anonymous struct field promotion and
+// json-tagged named embedding (nesting).
+package embed
+
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+
+// Module wires the routes to a Handler.
+type Module struct {
+	h *Handler
+}
+
+func (m *Module) Name() string                    { return "embed" }
+func (m *Module) Init(deps *app.ModuleDeps) error { m.h = &Handler{}; return nil }
+func (m *Module) Shutdown() error                 { return nil }
+
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/users/:id", m.h.getUser, server.WithTags("embed"))
+	server.GET(hr, r, "/accounts/:id", m.h.getAccount, server.WithTags("embed"))
+	server.GET(hr, r, "/wrappers/:id", m.h.getWrapper, server.WithTags("embed"))
+}


### PR DESCRIPTION
## PR8 — Embedded/anonymous struct field promotion

Eighth PR in the OpenAPI-tool gap initiative. Anonymous (embedded) struct fields were previously **dropped entirely** from the generated schema; they now follow `encoding/json` semantics.

### What changed
| Embed form | Result |
|---|---|
| `Base` (untagged) | exported fields **promoted** (flattened) into the parent |
| `Base` `` `json:"base"` `` | **nests** as a single `$ref` field |
| `Base` `` `json:"-"` `` | excluded |
| `*Base` (pointer) | promoted same as value embedding |

- Promotion recurses through the embedded struct with a **backtracking `visited` ancestor set** (seeded with the type's own name), so `type Node struct{ *Node }` and mutual cycles terminate.
- An embedded type that can't be resolved to a local struct (cross-package, or a named non-struct like `type Code string`) is **skipped without crashing** — full cross-package / named-type resolution is PR9.
- Per `encoding/json`'s **shallower-depth-wins** rule, a parent's own field beats a promoted field of the same JSON name *regardless of declaration order*; promoted-vs-promoted collisions (diamonds) keep the first, avoiding duplicate properties / `required` entries.

### Surfaced by `/code-review` (fixed)
The first cut let a promoted (deeper) field silently override a parent field of the same JSON name depending on declaration order — emitting the wrong type. Fixed with the precedence merge; a regression test asserts the parent wins in **both** declaration orders.

### Validation
- `make check` green; tool coverage **91.9%**.
- New `embedded` fixture (value-promote, pointer-promote, json-tagged nest) validates through in-process **kin-openapi** + the pinned **redocly** gate.
- Unit tests: self-embed termination, cross-package skip, `json:"-"` / `,omitempty` embeds, shallower-wins precedence.

Part of the roadmap in `.claude/tasks/openapi-tool-gap-analysis.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of embedded struct fields in OpenAPI spec generation, including proper JSON promotion and nesting rules with cycle detection to prevent infinite recursion.

* **Tests**
  * Added comprehensive test coverage for embedded struct behavior, including promotion, self-reference handling, cross-package scenarios, and JSON field precedence rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->