### PR TITLE
feat(openapi): cross-package resolution, named-type underlying kind, collision qualification (PR9)

### DIFF
--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -1973,8 +1973,14 @@ func (a *ProjectAnalyzer) namedScalarKind(name string, astFile *ast.File, filePa
 	if !ok {
 		return ""
 	}
+	if k, known := knownUnderlyingKinds[underlying]; known {
+		return k // e.g. `type Timeout time.Duration` -> integer
+	}
 	if k := primitiveKind(underlying); k != "" {
 		return k // underlying is a builtin scalar
+	}
+	if strings.Contains(underlying, ".") {
+		return "" // unknown qualified underlying — not classified
 	}
 	return a.namedScalarKind(underlying, astFile, filePath, depth+1) // chained named type
 }
@@ -2028,10 +2034,15 @@ func namedTypeUnderlyingInFile(file *ast.File, name string) (string, bool) {
 			if !ok || ts.Name.Name != name {
 				continue
 			}
-			if ident, isIdent := ts.Type.(*ast.Ident); isIdent {
-				return ident.Name, true
+			switch u := ts.Type.(type) {
+			case *ast.Ident:
+				return u.Name, true // `type Cents int64` -> "int64"
+			case *ast.SelectorExpr:
+				if pkg, isIdent := u.X.(*ast.Ident); isIdent {
+					return pkg.Name + "." + u.Sel.Name, true // `type Timeout time.Duration`
+				}
 			}
-			return "", false // underlying is not a bare ident
+			return "", false // underlying is a struct/slice/map/etc.
 		}
 	}
 	return "", false

--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -7,6 +7,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -85,10 +86,14 @@ const (
 // ProjectAnalyzer analyzes Go-Bricks projects to extract module and route information
 type ProjectAnalyzer struct {
 	projectRoot  string
+	modulePath   string // go.mod module path; prefix for translating in-module imports to dirs
 	fileSet      *token.FileSet
-	constants    map[string]string           // Map of constant names to their values
-	warnings     []string                    // Non-fatal diagnostics collected during analysis
-	typeRegistry map[string]*models.TypeInfo // Named struct types reachable from routes (by schema name)
+	constants    map[string]string               // Map of constant names to their values
+	warnings     []string                        // Non-fatal diagnostics collected during analysis
+	typeRegistry map[string]*models.TypeInfo     // Named struct types reachable from routes (by final schema name)
+	pkgCache     map[string]map[string]*ast.File // dir -> (file path -> parsed AST), populated on demand
+	nameAssign   map[string]string               // "pkg\x00Type" -> final schema name (collision qualification)
+	usedNames    map[string]struct{}             // final schema names already taken
 }
 
 // New creates a new project analyzer
@@ -98,6 +103,9 @@ func New(projectRoot string) *ProjectAnalyzer {
 		fileSet:      token.NewFileSet(),
 		constants:    make(map[string]string),
 		typeRegistry: make(map[string]*models.TypeInfo),
+		pkgCache:     make(map[string]map[string]*ast.File),
+		nameAssign:   make(map[string]string),
+		usedNames:    make(map[string]struct{}),
 	}
 }
 
@@ -146,6 +154,9 @@ func (a *ProjectAnalyzer) AnalyzeProject() (*models.Project, error) {
 	// accumulate stale warnings or type-registry entries.
 	a.warnings = nil
 	a.typeRegistry = make(map[string]*models.TypeInfo)
+	a.pkgCache = make(map[string]map[string]*ast.File)
+	a.nameAssign = make(map[string]string)
+	a.usedNames = make(map[string]struct{})
 
 	// Discover project metadata from go.mod
 	a.discoverProjectMetadata(project)
@@ -179,18 +190,20 @@ func (a *ProjectAnalyzer) discoverProjectMetadata(project *models.Project) {
 func (a *ProjectAnalyzer) parseGoModForProjectName(project *models.Project, content []byte) {
 	lines := strings.Split(string(content), "\n")
 	for _, line := range lines {
-		if strings.HasPrefix(line, "module ") {
-			moduleName := strings.TrimSpace(strings.TrimPrefix(line, "module"))
-			// Extract just the last part as the project name
-			parts := strings.Split(moduleName, "/")
-			if len(parts) > 0 {
-				name := parts[len(parts)-1]
-				if name != "" {
-					project.Name = strings.ToUpper(name[:1]) + name[1:] + " API"
-				}
-			}
-			break
+		if !strings.HasPrefix(line, "module ") {
+			continue
 		}
+		moduleName := strings.TrimSpace(strings.TrimPrefix(line, "module"))
+		a.modulePath = moduleName // full module path for in-module import resolution
+		// Extract just the last part as the project name
+		parts := strings.Split(moduleName, "/")
+		if len(parts) > 0 {
+			name := parts[len(parts)-1]
+			if name != "" {
+				project.Name = strings.ToUpper(name[:1]) + name[1:] + " API"
+			}
+		}
+		break
 	}
 }
 
@@ -1681,40 +1694,54 @@ func (a *ProjectAnalyzer) populateTypeFields(typeInfo *models.TypeInfo, astFile 
 		return
 	}
 	registered := a.registerType(typeInfo.Name, typeInfo.Package, astFile, filePath)
+	if registered == nil && typeInfo.Package != "" {
+		// A qualified request/response type (e.g. server.Result[types.Money]) arrives
+		// as Name="Money", Package="types" (the import alias). Resolve it
+		// cross-package using that alias against the handler file's imports.
+		registered = a.registerQualifiedType(typeInfo.Package+"."+typeInfo.Name, astFile)
+	}
 	if registered == nil {
 		return
 	}
 	// Mirror the registered fields onto the route's TypeInfo (request bodies and
-	// responses read Fields directly).
+	// responses read Fields directly). Adopt the final (collision-qualified) name
+	// too, so the response envelope's $ref points at the component actually emitted.
+	typeInfo.Name = registered.Name
 	typeInfo.Fields = registered.Fields
 	typeInfo.JOSE = registered.JOSE
 }
 
-// registerType resolves the struct named name in the package of astFile, adds it
-// to the type registry, and recurses into its struct-typed fields. It is
-// idempotent and registers a type BEFORE recursing so a self- or mutually-
-// referential type (e.g. Category{Parent *Category}) terminates. Returns nil when
-// name is not a resolvable local struct (a primitive, external, or unknown type).
+// registerType resolves the named type and registers it (and its struct-typed
+// fields) into the type registry, returning its TypeInfo (whose Name is the final,
+// possibly collision-qualified, schema name). A qualified name (pkg.Type) is
+// resolved cross-package when it points at an in-module package; stdlib and
+// third-party types return nil (left to the generator's well-known map / object
+// fallback). Returns nil when the name is not a resolvable struct.
 func (a *ProjectAnalyzer) registerType(name, pkg string, astFile *ast.File, filePath string) *models.TypeInfo {
-	if existing, ok := a.typeRegistry[name]; ok {
-		// Two packages contributing the same type name collide on one (name-keyed)
-		// component schema; surface it rather than silently first-winning.
-		// Package-qualified disambiguation is handled separately.
-		if pkg != "" && existing.Package != "" && existing.Package != pkg {
-			a.addWarningf("type name %q is defined in both %q and %q; they share one component schema", name, existing.Package, pkg)
-		}
-		return existing
+	if strings.Contains(name, ".") {
+		return a.registerQualifiedType(name, astFile)
 	}
 	structType, err := a.findStructDefinition(astFile, filePath, name)
 	if err != nil {
 		return nil
 	}
+	return a.registerStruct(name, pkg, structType, astFile, filePath)
+}
 
-	ti := &models.TypeInfo{Name: name, Package: pkg}
-	a.typeRegistry[name] = ti // register before recursing (cycle guard)
+// registerStruct registers a resolved struct under its collision-qualified schema
+// name and recurses into its fields. It registers BEFORE recursing so self- or
+// mutually-referential types (e.g. Category{Parent *Category}) terminate.
+func (a *ProjectAnalyzer) registerStruct(typeName, pkg string, structType *ast.StructType, astFile *ast.File, filePath string) *models.TypeInfo {
+	key := a.schemaKey(typeName, pkg)
+	if existing, ok := a.typeRegistry[key]; ok {
+		return existing
+	}
+
+	ti := &models.TypeInfo{Name: key, Package: pkg}
+	a.typeRegistry[key] = ti // register before recursing (cycle guard)
 	// Seed the embedded-promotion ancestor set with this type so a self-embed
 	// (e.g. type Node struct{ *Node }) is not promoted into itself.
-	ti.Fields = a.extractStructFields(structType, pkg, astFile, filePath, map[string]struct{}{name: {}})
+	ti.Fields = a.extractStructFields(structType, pkg, astFile, filePath, map[string]struct{}{typeName: {}})
 	ti.JOSE = hasJOSESentinelTag(structType)
 
 	for i := range ti.Fields {
@@ -1723,25 +1750,287 @@ func (a *ProjectAnalyzer) registerType(name, pkg string, astFile *ast.File, file
 	return ti
 }
 
+// schemaKey returns a stable, collision-free component name for (pkg, typeName).
+// It prefers the bare type name and falls back to <Pkg><TypeName> (then a numeric
+// suffix) when that bare name is already taken by a different package, so two
+// packages each defining e.g. Request get distinct components. Idempotent per
+// (pkg, typeName).
+//
+// On a collision the bare name goes to whichever (pkg, typeName) is registered
+// first; which one that is follows discovery order. Discovery walks the project
+// deterministically, so a given source tree yields a stable assignment, but the
+// emitted spec is always valid either way — every $ref resolves to the component
+// the field/response actually carries (RefName / TypeInfo.Name are the final
+// key). A future enhancement could make the choice order-independent (e.g. always
+// qualify by package), but that is a naming-policy change, not a correctness fix.
+func (a *ProjectAnalyzer) schemaKey(typeName, pkg string) string {
+	k := pkg + "\x00" + typeName
+	if name, ok := a.nameAssign[k]; ok {
+		return name
+	}
+	final := typeName
+	if _, taken := a.usedNames[final]; taken {
+		final = exportedPkgName(pkg) + typeName
+		for i := 2; ; i++ {
+			if _, dup := a.usedNames[final]; !dup {
+				break
+			}
+			final = exportedPkgName(pkg) + typeName + strconv.Itoa(i)
+		}
+	}
+	a.usedNames[final] = struct{}{}
+	a.nameAssign[k] = final
+	return final
+}
+
+// qualifiedStruct is a struct resolved from another in-module package, with the
+// context needed to recurse into it in its own package.
+type qualifiedStruct struct {
+	typeName string
+	pkg      string
+	st       *ast.StructType
+	file     *ast.File
+	filePath string
+}
+
+// resolveQualifiedStruct resolves a pkg.Type reference against astFile's imports.
+// It parses the in-module target package (with a per-dir cache) and finds the
+// named struct. Returns ok=false for stdlib/third-party imports, unknown aliases,
+// or names that are not a struct in the target package.
+func (a *ProjectAnalyzer) resolveQualifiedStruct(qualified string, astFile *ast.File) (qualifiedStruct, bool) {
+	dot := strings.LastIndex(qualified, ".")
+	if dot < 0 {
+		return qualifiedStruct{}, false
+	}
+	pkgAlias, typeName := qualified[:dot], qualified[dot+1:]
+	importPath, ok := a.fileImports(astFile)[pkgAlias]
+	if !ok {
+		return qualifiedStruct{}, false // unknown alias (e.g. dot/blank import)
+	}
+	dir, ok := a.inModuleDir(importPath)
+	if !ok {
+		return qualifiedStruct{}, false // stdlib/third-party — well-known map or object
+	}
+	files, err := a.parsePackageDir(dir)
+	if err != nil {
+		return qualifiedStruct{}, false
+	}
+	// Iterate files in a stable order so the resolved definition is deterministic
+	// even when several files in the dir could match (e.g. build-tagged variants).
+	for _, path := range slices.Sorted(maps.Keys(files)) {
+		file := files[path]
+		if st := a.findStructInFile(file, typeName); st != nil {
+			return qualifiedStruct{typeName: typeName, pkg: file.Name.Name, st: st, file: file, filePath: path}, true
+		}
+	}
+	return qualifiedStruct{}, false // not a struct in the target package (alias/interface)
+}
+
+// registerQualifiedType resolves and registers a cross-package struct as a
+// component, returning nil when it cannot be resolved in-module.
+func (a *ProjectAnalyzer) registerQualifiedType(qualified string, astFile *ast.File) *models.TypeInfo {
+	q, ok := a.resolveQualifiedStruct(qualified, astFile)
+	if !ok {
+		return nil
+	}
+	return a.registerStruct(q.typeName, q.pkg, q.st, q.file, q.filePath)
+}
+
+// inModuleDir translates an import path to a filesystem dir under projectRoot when
+// it is within this module, else reports false.
+func (a *ProjectAnalyzer) inModuleDir(importPath string) (string, bool) {
+	if a.modulePath == "" {
+		return "", false
+	}
+	if importPath == a.modulePath {
+		return a.projectRoot, true
+	}
+	prefix := a.modulePath + "/"
+	if !strings.HasPrefix(importPath, prefix) {
+		return "", false
+	}
+	rel := strings.TrimPrefix(importPath, prefix)
+	return filepath.Join(a.projectRoot, filepath.FromSlash(rel)), true
+}
+
+// fileImports maps each import's local alias to its import path. The default alias
+// is the path's last segment (an approximation of the package name, correct for
+// the common case where they match); explicit aliases override it. Blank (_) and
+// dot (.) imports are skipped.
+func (a *ProjectAnalyzer) fileImports(astFile *ast.File) map[string]string {
+	out := make(map[string]string, len(astFile.Imports))
+	for _, imp := range astFile.Imports {
+		path := strings.Trim(imp.Path.Value, `"`)
+		alias := filepath.Base(path)
+		if imp.Name != nil {
+			if imp.Name.Name == "_" || imp.Name.Name == "." {
+				continue
+			}
+			alias = imp.Name.Name
+		}
+		out[alias] = path
+	}
+	return out
+}
+
+// parsePackageDir parses all non-test Go files in a directory, caching the result
+// per directory so repeated cross-package lookups reuse one parse.
+func (a *ProjectAnalyzer) parsePackageDir(dir string) (map[string]*ast.File, error) {
+	if cached, ok := a.pkgCache[dir]; ok {
+		return cached, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	files := make(map[string]*ast.File)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, goFileExt) || strings.HasSuffix(name, testFileExt) {
+			continue
+		}
+		full := filepath.Join(dir, name)
+		f, perr := parser.ParseFile(a.fileSet, full, nil, parser.ParseComments)
+		if perr != nil {
+			continue
+		}
+		files[full] = f
+	}
+	a.pkgCache[dir] = files
+	return files, nil
+}
+
+// exportedPkgName upper-cases the first letter of a package name for use as a
+// component-name qualifier (orders -> Orders). Returns "" unchanged.
+func exportedPkgName(pkg string) string {
+	if pkg == "" {
+		return ""
+	}
+	return strings.ToUpper(pkg[:1]) + pkg[1:]
+}
+
 // registerFieldRef registers the named struct type(s) a field references and
-// stamps the matching ref name onto the field. A map field refs its value struct
-// via MapValueRefName (a map is never itself a $ref); any other field refs its
-// underlying struct (after pointer/slice unwrap) via RefName. Fields excluded
-// from JSON (json:"-") are skipped so a type reachable only through them is not
-// registered as an orphan component.
+// stamps the matching (final, collision-qualified) ref name onto the field. A map
+// field refs its value struct via MapValueRefName (a map is never itself a $ref);
+// any other field refs its underlying struct (after pointer/slice unwrap) via
+// RefName. Fields excluded from JSON (json:"-") are skipped so a type reachable
+// only through them is not registered as an orphan component.
 func (a *ProjectAnalyzer) registerFieldRef(f *models.FieldInfo, pkg string, astFile *ast.File, filePath string) {
 	if f.JSONName == jsonSkipValue && f.ParamType == "" {
 		return
 	}
 	if vName, isMap := mapValueStructName(f.Type); isMap {
-		if a.registerType(vName, pkg, astFile, filePath) != nil {
-			f.MapValueRefName = vName
+		if reg := a.registerType(vName, pkg, astFile, filePath); reg != nil {
+			f.MapValueRefName = reg.Name
 		}
 		return
 	}
-	if base := baseStructTypeName(f.Type); a.registerType(base, pkg, astFile, filePath) != nil {
-		f.RefName = base
+	if reg := a.registerType(baseStructTypeName(f.Type), pkg, astFile, filePath); reg != nil {
+		f.RefName = reg.Name
+		return // a struct ref carries no scalar underlying kind
 	}
+	// Not a struct: classify a named, non-struct scalar (Cents -> integer, etc.).
+	f.UnderlyingKind = a.resolveUnderlyingKind(f.Type, astFile, filePath)
+}
+
+// knownUnderlyingKinds maps qualified stdlib/library types with a non-struct
+// scalar underlying type to their OpenAPI kind. (time.Time is a struct handled by
+// the generator's well-known map, so it is intentionally absent.)
+var knownUnderlyingKinds = map[string]string{
+	"time.Duration": "integer",
+}
+
+// resolveUnderlyingKind returns the OpenAPI 3-way kind ("integer"/"number"/
+// "string") of a named, non-struct scalar type, or "" when the type is a builtin
+// primitive (handled directly), a struct, or unresolved. It strips pointer/slice
+// markers, recognizes a small set of qualified stdlib types, and resolves
+// local `type X <primitive>` declarations to their underlying kind.
+func (a *ProjectAnalyzer) resolveUnderlyingKind(typeStr string, astFile *ast.File, filePath string) string {
+	base := baseStructTypeName(typeStr)
+	if k, ok := knownUnderlyingKinds[base]; ok {
+		return k
+	}
+	if strings.Contains(base, ".") {
+		return "" // other qualified types: not classified here
+	}
+	if primitiveKind(base) != "" {
+		return "" // a builtin used directly is not a named wrapper
+	}
+	return a.namedScalarKind(base, astFile, filePath, 0)
+}
+
+// namedScalarKind resolves a LOCAL named type to its underlying primitive kind,
+// following alias chains (type Cents int64 -> integer; type A B; type B int -> A
+// resolves to integer). depth bounds pathological chains.
+func (a *ProjectAnalyzer) namedScalarKind(name string, astFile *ast.File, filePath string, depth int) string {
+	if depth > 8 {
+		return ""
+	}
+	underlying, ok := a.localTypeUnderlying(name, astFile, filePath)
+	if !ok {
+		return ""
+	}
+	if k := primitiveKind(underlying); k != "" {
+		return k // underlying is a builtin scalar
+	}
+	return a.namedScalarKind(underlying, astFile, filePath, depth+1) // chained named type
+}
+
+// primitiveKind maps a Go builtin scalar type name to its OpenAPI 3-way kind, or
+// "" if it is not one of them. It reuses the constraint mapper's type classifiers
+// so the integer/float/string sets live in one place.
+func primitiveKind(goType string) string {
+	switch {
+	case isIntegerType(goType):
+		return "integer"
+	case isFloatType(goType):
+		return "number"
+	case isStringType(goType):
+		return goTypeString
+	}
+	return ""
+}
+
+// localTypeUnderlying finds a local `type Name <ident>` declaration and returns
+// the underlying identifier (e.g. Cents -> "int64"). Returns ok=false when Name
+// is not a local non-struct named type.
+func (a *ProjectAnalyzer) localTypeUnderlying(name string, astFile *ast.File, filePath string) (string, bool) {
+	search := func(file *ast.File) (string, bool) {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok || ts.Name.Name != name {
+					continue
+				}
+				if ident, ok := ts.Type.(*ast.Ident); ok {
+					return ident.Name, true
+				}
+				return "", false // underlying is not a bare ident (struct/slice/etc.)
+			}
+		}
+		return "", false
+	}
+	if u, ok := search(astFile); ok {
+		return u, true
+	}
+	// Sibling files in the same package, via the cached per-dir parse.
+	files, err := a.parsePackageDir(filepath.Dir(filePath))
+	if err != nil {
+		return "", false
+	}
+	for _, file := range files {
+		if u, ok := search(file); ok {
+			return u, true
+		}
+	}
+	return "", false
 }
 
 // baseStructTypeName strips slice and pointer markers from a Go type string to
@@ -1958,11 +2247,12 @@ func mergeFieldsByPrecedence(shallow, promoted []models.FieldInfo) []models.Fiel
 //   - With json:"-" it is excluded.
 //   - Otherwise its exported fields are PROMOTED (flattened) into the parent.
 //
-// Embedded pointers (*Base) are unwrapped. An embedded type that cannot be
-// resolved to a local struct — a cross-package type (PR9's resolver) or a named
-// non-struct like `type Code string` (named-type underlying-kind is also PR9) —
-// is skipped without crashing. The visited ancestor set (add-before-recurse /
-// delete-after backtracking) terminates self- and mutually-embedded cycles.
+// Embedded pointers (*Base) are unwrapped. A cross-package (in-module) embedded
+// struct is resolved and promoted from its own package. An embedded type that
+// still cannot be resolved to a struct — a stdlib/third-party type or a named
+// non-struct like `type Code string` — is skipped without crashing. The visited
+// ancestor set (add-before-recurse / delete-after backtracking) terminates self-
+// and mutually-embedded cycles.
 func (a *ProjectAnalyzer) embeddedFields(field *ast.Field, pkg string, astFile *ast.File, filePath string, visited map[string]struct{}) (fields []models.FieldInfo, promoted bool) {
 	typeName := baseStructTypeName(a.typeToString(field.Type))
 
@@ -1982,14 +2272,22 @@ func (a *ProjectAnalyzer) embeddedFields(field *ast.Field, pkg string, astFile *
 	if _, seen := visited[typeName]; seen {
 		return nil, false // cycle / self-embed guard
 	}
-	embedded, err := a.findStructDefinition(astFile, filePath, typeName)
-	if err != nil {
-		return nil, false // unresolvable (cross-package or non-struct) — skip, never crash
+	// Local embed: promote the struct's fields from this package.
+	if embedded, err := a.findStructDefinition(astFile, filePath, typeName); err == nil {
+		visited[typeName] = struct{}{}
+		fields = a.extractStructFields(embedded, pkg, astFile, filePath, visited)
+		delete(visited, typeName) // backtrack: keep visited scoped to the current chain
+		return fields, true
 	}
-	visited[typeName] = struct{}{}
-	fields = a.extractStructFields(embedded, pkg, astFile, filePath, visited)
-	delete(visited, typeName) // backtrack: keep visited scoped to the current chain
-	return fields, true
+	// Cross-package (in-module) embed: resolve and promote from the target package
+	// so its fields are extracted in their own package context.
+	if q, ok := a.resolveQualifiedStruct(typeName, astFile); ok {
+		visited[typeName] = struct{}{}
+		fields = a.extractStructFields(q.st, q.pkg, q.file, q.filePath, visited)
+		delete(visited, typeName)
+		return fields, true
+	}
+	return nil, false // unresolvable (stdlib/third-party or non-struct) — skip, never crash
 }
 
 // buildFieldInfo creates a FieldInfo from a field name and AST field

--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -1996,38 +1996,42 @@ func primitiveKind(goType string) string {
 
 // localTypeUnderlying finds a local `type Name <ident>` declaration and returns
 // the underlying identifier (e.g. Cents -> "int64"). Returns ok=false when Name
-// is not a local non-struct named type.
+// is not a local non-struct named type. It searches the current file first, then
+// sibling files in the same package (via the cached per-dir parse).
 func (a *ProjectAnalyzer) localTypeUnderlying(name string, astFile *ast.File, filePath string) (string, bool) {
-	search := func(file *ast.File) (string, bool) {
-		for _, decl := range file.Decls {
-			gen, ok := decl.(*ast.GenDecl)
-			if !ok || gen.Tok != token.TYPE {
-				continue
-			}
-			for _, spec := range gen.Specs {
-				ts, ok := spec.(*ast.TypeSpec)
-				if !ok || ts.Name.Name != name {
-					continue
-				}
-				if ident, ok := ts.Type.(*ast.Ident); ok {
-					return ident.Name, true
-				}
-				return "", false // underlying is not a bare ident (struct/slice/etc.)
-			}
-		}
-		return "", false
-	}
-	if u, ok := search(astFile); ok {
+	if u, ok := namedTypeUnderlyingInFile(astFile, name); ok {
 		return u, true
 	}
-	// Sibling files in the same package, via the cached per-dir parse.
 	files, err := a.parsePackageDir(filepath.Dir(filePath))
 	if err != nil {
 		return "", false
 	}
 	for _, file := range files {
-		if u, ok := search(file); ok {
+		if u, ok := namedTypeUnderlyingInFile(file, name); ok {
 			return u, true
+		}
+	}
+	return "", false
+}
+
+// namedTypeUnderlyingInFile returns the underlying identifier of a `type Name
+// <ident>` declaration in file, or ok=false when name is absent or its underlying
+// type is not a bare identifier (a struct/slice/map/etc.).
+func namedTypeUnderlyingInFile(file *ast.File, name string) (string, bool) {
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok || ts.Name.Name != name {
+				continue
+			}
+			if ident, isIdent := ts.Type.(*ast.Ident); isIdent {
+				return ident.Name, true
+			}
+			return "", false // underlying is not a bare ident
 		}
 	}
 	return "", false

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -3948,10 +3948,16 @@ func (m *Module) Name() string { return "mod" }
 func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
 func (m *Module) Shutdown() error { return nil }
 type Cents int64
+type Alias Cents
+type Timeout time.Duration
+type Inner struct{ X int }
 type Money struct {
-	Amount Cents         ` + "`json:\"amount\"`" + `
-	TTL    time.Duration ` + "`json:\"ttl\"`" + `
-	Plain  int           ` + "`json:\"plain\"`" + `
+	Amount  Cents         ` + "`json:\"amount\"`" + `
+	Chained Alias         ` + "`json:\"chained\"`" + `
+	Wait    Timeout       ` + "`json:\"wait\"`" + `
+	TTL     time.Duration ` + "`json:\"ttl\"`" + `
+	Plain   int           ` + "`json:\"plain\"`" + `
+	Nested  Inner         ` + "`json:\"nested\"`" + `
 }
 func (m *Module) g(ctx server.HandlerContext) (server.Result[Money], server.IAPIError) { return server.Created(Money{}), nil }
 func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
@@ -3962,12 +3968,19 @@ func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegist
 	money := a.typeRegistry["Money"]
 	require.NotNil(t, money)
 	kind := map[string]string{}
+	ref := map[string]string{}
 	for i := range money.Fields {
 		kind[money.Fields[i].JSONName] = money.Fields[i].UnderlyingKind
+		ref[money.Fields[i].JSONName] = money.Fields[i].RefName
 	}
 	assert.Equal(t, "integer", kind["amount"], "type Cents int64 -> integer")
+	assert.Equal(t, "integer", kind["chained"], "type Alias Cents -> chain to int64 -> integer")
+	assert.Equal(t, "integer", kind["wait"], "type Timeout time.Duration -> integer (selector underlying)")
 	assert.Equal(t, "integer", kind["ttl"], "time.Duration -> integer")
 	assert.Equal(t, "", kind["plain"], "a builtin used directly is not a named wrapper")
+	// A named STRUCT is a $ref, not a scalar underlying kind.
+	assert.Equal(t, "", kind["nested"], "named struct has no scalar underlying kind")
+	assert.Equal(t, "Inner", ref["nested"], "named struct is a $ref")
 }
 
 // TestSchemaKeyCollision locks the collision-qualification rule: same (pkg,type)
@@ -4046,4 +4059,32 @@ var _ = other.X
 	assert.Nil(t, a.registerQualifiedType("time.Duration", f), "stdlib import is not in-module -> nil")
 	assert.Nil(t, a.registerQualifiedType("missingpkg.Foo", f), "unknown alias -> nil")
 	assert.Nil(t, a.registerQualifiedType("other.Missing", f), "in-module but dir/type absent -> nil")
+}
+
+// TestLocalTypeUnderlyingSiblingFile covers resolving a named type whose
+// declaration lives in a SIBLING file of the same package (the parsePackageDir
+// fallback), and the not-found / non-ident arms.
+func TestLocalTypeUnderlyingSiblingFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.go"),
+		[]byte("package p\ntype User struct{ Amount Cents }\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.go"),
+		[]byte("package p\ntype Cents int64\ntype Wrapped struct{ X int }\n"), 0600))
+	a := New(dir)
+	aPath := filepath.Join(dir, "a.go")
+	af, err := parser.ParseFile(a.fileSet, aPath, nil, parser.ParseComments)
+	require.NoError(t, err)
+
+	// Cents is declared in b.go (a sibling file) — found via the per-dir parse.
+	u, ok := a.localTypeUnderlying("Cents", af, aPath)
+	assert.True(t, ok, "named type in a sibling file resolves")
+	assert.Equal(t, "int64", u)
+
+	// A named struct has no bare-ident underlying -> ok=false.
+	_, ok = a.localTypeUnderlying("Wrapped", af, aPath)
+	assert.False(t, ok, "a named struct is not a scalar underlying")
+
+	// Absent type -> ok=false.
+	_, ok = a.localTypeUnderlying("Missing", af, aPath)
+	assert.False(t, ok)
 }

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -3920,3 +3920,130 @@ func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegist
 	omit := fieldJSONNames(t, a, "OmitOnly")
 	assert.True(t, omit["tag"] && omit["only"], "name-less (,omitempty) embed still promotes")
 }
+
+// TestPrimitiveKind covers the 3-way mapping. The full integer/float/string
+// membership sets are exhaustively covered by constraints_test.go; here we only
+// assert primitiveKind's delegation and the non-primitive zero value.
+func TestPrimitiveKind(t *testing.T) {
+	assert.Equal(t, "integer", primitiveKind(goTypeInt64))
+	assert.Equal(t, "number", primitiveKind(goTypeFloat64))
+	assert.Equal(t, goTypeString, primitiveKind(goTypeString))
+	assert.Equal(t, "", primitiveKind("bool"))
+	assert.Equal(t, "", primitiveKind("Widget"))
+}
+
+// TestResolveUnderlyingKind covers named-scalar classification end-to-end:
+// local `type Cents int64`, the qualified time.Duration, and a plain builtin
+// (which is NOT a named wrapper, so empty).
+func TestResolveUnderlyingKind(t *testing.T) {
+	src := `package mod
+import (
+	"time"
+
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+type Module struct{}
+func (m *Module) Name() string { return "mod" }
+func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
+type Cents int64
+type Money struct {
+	Amount Cents         ` + "`json:\"amount\"`" + `
+	TTL    time.Duration ` + "`json:\"ttl\"`" + `
+	Plain  int           ` + "`json:\"plain\"`" + `
+}
+func (m *Module) g(ctx server.HandlerContext) (server.Result[Money], server.IAPIError) { return server.Created(Money{}), nil }
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/m", m.g)
+}
+`
+	a, _ := analyzeSingleModule(t, src)
+	money := a.typeRegistry["Money"]
+	require.NotNil(t, money)
+	kind := map[string]string{}
+	for i := range money.Fields {
+		kind[money.Fields[i].JSONName] = money.Fields[i].UnderlyingKind
+	}
+	assert.Equal(t, "integer", kind["amount"], "type Cents int64 -> integer")
+	assert.Equal(t, "integer", kind["ttl"], "time.Duration -> integer")
+	assert.Equal(t, "", kind["plain"], "a builtin used directly is not a named wrapper")
+}
+
+// TestSchemaKeyCollision locks the collision-qualification rule: same (pkg,type)
+// is idempotent; a different package with the same type name is qualified.
+func TestSchemaKeyCollision(t *testing.T) {
+	a := New(t.TempDir())
+	assert.Equal(t, "Request", a.schemaKey("Request", "users"))
+	assert.Equal(t, "Request", a.schemaKey("Request", "users"), "idempotent for same (pkg,type)")
+	assert.Equal(t, "OrdersRequest", a.schemaKey("Request", "orders"), "collision qualified by package")
+	assert.Equal(t, "OrdersRequest", a.schemaKey("Request", "orders"), "qualified name is stable")
+	// A third package with the same name gets a further-qualified/distinct name.
+	got := a.schemaKey("Request", "billing")
+	assert.NotContains(t, []string{"Request", "OrdersRequest"}, got, "third collision is distinct")
+}
+
+// TestInModuleDir covers the import-path -> dir translation and the
+// stdlib/third-party fall-through.
+func TestInModuleDir(t *testing.T) {
+	root := t.TempDir()
+	a := New(root)
+	a.modulePath = "github.com/example/app"
+	dir, ok := a.inModuleDir("github.com/example/app/types")
+	assert.True(t, ok)
+	assert.Equal(t, filepath.Join(root, "types"), dir)
+	dir, ok = a.inModuleDir("github.com/example/app")
+	assert.True(t, ok)
+	assert.Equal(t, root, dir)
+	_, ok = a.inModuleDir("time")
+	assert.False(t, ok, "stdlib is not in-module")
+	_, ok = a.inModuleDir("github.com/google/uuid")
+	assert.False(t, ok, "third-party is not in-module")
+}
+
+// TestParsePackageDirCaches asserts the per-dir parse cache (miss then hit) and
+// graceful handling of a missing directory.
+func TestParsePackageDirCaches(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "x.go"), []byte("package x\ntype T struct{}\n"), 0600))
+	a := New(dir)
+
+	_, cachedBefore := a.pkgCache[dir]
+	assert.False(t, cachedBefore, "cache miss before first parse")
+	first, err := a.parsePackageDir(dir)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	cached, ok := a.pkgCache[dir]
+	assert.True(t, ok, "dir cached after first parse")
+	// Mutate the cached map; a cache HIT must return this same instance.
+	cached["sentinel-marker"] = nil
+	second, err := a.parsePackageDir(dir)
+	require.NoError(t, err)
+	_, sawSentinel := second["sentinel-marker"]
+	assert.True(t, sawSentinel, "second call is a cache hit (returns the stored map, not a re-parse)")
+
+	_, err = a.parsePackageDir(filepath.Join(dir, "does-not-exist"))
+	assert.Error(t, err, "missing dir returns an error, not a panic")
+}
+
+// TestRegisterQualifiedTypeFallThroughs covers the cross-package resolver's
+// non-resolving arms: no dot, stdlib import, unknown alias, and an in-module path
+// whose directory/type is absent.
+func TestRegisterQualifiedTypeFallThroughs(t *testing.T) {
+	a := New(t.TempDir())
+	a.modulePath = "example.com/app"
+	src := `package x
+import (
+	"time"
+	other "example.com/app/other"
+)
+var _ = time.Now
+var _ = other.X
+`
+	f, err := parser.ParseFile(token.NewFileSet(), "x.go", src, parser.ParseComments)
+	require.NoError(t, err)
+	assert.Nil(t, a.registerQualifiedType("NoDot", f), "no dot -> nil")
+	assert.Nil(t, a.registerQualifiedType("time.Duration", f), "stdlib import is not in-module -> nil")
+	assert.Nil(t, a.registerQualifiedType("missingpkg.Foo", f), "unknown alias -> nil")
+	assert.Nil(t, a.registerQualifiedType("other.Missing", f), "in-module but dir/type absent -> nil")
+}

--- a/tools/openapi/internal/analyzer/constraints.go
+++ b/tools/openapi/internal/analyzer/constraints.go
@@ -1,7 +1,6 @@
 package analyzer
 
 import (
-	"slices"
 	"strconv"
 	"strings"
 )
@@ -31,6 +30,7 @@ const (
 
 	// Go primitive type names referenced for type discrimination
 	goTypeInt64   = "int64"
+	goTypeFloat32 = "float32"
 	goTypeFloat64 = "float64"
 )
 
@@ -232,15 +232,24 @@ func isStringType(typeName string) bool {
 	return typeName == goTypeString
 }
 
-// isNumericType checks if the type is a numeric type
-func isNumericType(typeName string) bool {
-	numericTypes := []string{
-		"int", "int8", "int16", "int32", goTypeInt64,
-		"uint", "uint8", "uint16", "uint32", "uint64",
-		"float32", goTypeFloat64,
+// isIntegerType reports whether the Go type name is a signed/unsigned integer.
+func isIntegerType(typeName string) bool {
+	switch typeName {
+	case "int", "int8", "int16", "int32", goTypeInt64,
+		"uint", "uint8", "uint16", "uint32", "uint64":
+		return true
 	}
+	return false
+}
 
-	return slices.Contains(numericTypes, typeName)
+// isFloatType reports whether the Go type name is a floating-point type.
+func isFloatType(typeName string) bool {
+	return typeName == goTypeFloat32 || typeName == goTypeFloat64
+}
+
+// isNumericType checks if the type is a numeric type (integer or float).
+func isNumericType(typeName string) bool {
+	return isIntegerType(typeName) || isFloatType(typeName)
 }
 
 // parseNumeric converts a string to a numeric value (int or float)

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -873,6 +873,15 @@ func (g *OpenAPIGenerator) fieldInfoToProperty(field *models.FieldInfo) *OpenAPI
 		return prop
 	}
 
+	// A named, non-struct scalar (e.g. `type Cents int64`) carries its resolved
+	// OpenAPI kind from the analyzer; emit that instead of the object fallback
+	// setTypeAndFormat would pick for an unrecognized type name.
+	if field.UnderlyingKind != "" {
+		prop.Type = field.UnderlyingKind
+		g.applyConstraints(prop, field)
+		return prop
+	}
+
 	// Map Go type to OpenAPI type and format
 	g.setTypeAndFormat(prop, field.Type)
 

--- a/tools/openapi/internal/models/models.go
+++ b/tools/openapi/internal/models/models.go
@@ -87,4 +87,10 @@ type FieldInfo struct {
 	// property is an object whose additionalProperties is a $ref to that schema.
 	// Distinct from RefName: a map field is never itself a $ref.
 	MapValueRefName string
+	// UnderlyingKind is the OpenAPI 3-way kind ("integer", "number", or "string")
+	// a named, non-struct scalar type resolves to — e.g. `type Cents int64` ->
+	// "integer", time.Duration -> "integer". Empty for builtin primitives (handled
+	// directly), structs, and unresolved types. Consumed by the type/constraint
+	// mappers so a named numeric is documented as its underlying kind.
+	UnderlyingKind string
 }

--- a/tools/openapi/internal/spectest/testdata/collision/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/collision/expected.yaml
@@ -101,6 +101,7 @@ components:
         quantity:
           type: integer
           format: int32
+          minimum: 1
         sku:
           type: string
       required:

--- a/tools/openapi/internal/spectest/testdata/collision/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/collision/expected.yaml
@@ -1,41 +1,57 @@
 openapi: 3.0.1
 info:
-  title: Events API
+  title: Coll API
   version: 1.0.0
   description: Generated API specification
 paths:
-  /events/{id}:
-    get:
-      operationId: getEvent
-      summary: GET /events/{id}
+  /orders:
+    post:
+      operationId: createOrder
+      summary: POST /orders
       tags:
-        - events
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
+        - orders
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrdersRequest'
       responses:
-        "200":
-          description: Successful response
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  data:
-                    $ref: '#/components/schemas/Event'
-                  meta:
-                    type: object
-                    properties:
-                      timestamp:
-                        type: string
-                        format: date-time
-                        description: RFC3339 response timestamp
-                      traceId:
-                        type: string
-                        description: W3C trace identifier for the request
+                $ref: '#/components/schemas/ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /users:
+    post:
+      operationId: createUser
+      summary: POST /users
+      tags:
+        - users
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Request'
+      responses:
+        "204":
+          description: No Content
         "400":
           description: Bad Request
           content:
@@ -56,13 +72,6 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 components:
   schemas:
-    Address:
-      type: object
-      properties:
-        city:
-          type: string
-        street:
-          type: string
     ErrorResponse:
       type: object
       properties:
@@ -74,47 +83,6 @@ components:
           description: Response metadata
       required:
         - error
-    Event:
-      type: object
-      properties:
-        addrs:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/Address'
-        count:
-          type: integer
-          format: int64
-          minimum: 0
-        createdAt:
-          type: string
-          format: date-time
-        history:
-          type: object
-          additionalProperties:
-            type: array
-            items:
-              $ref: '#/components/schemas/Address'
-        id:
-          type: string
-          format: uuid
-        labels:
-          type: object
-          additionalProperties:
-            type: string
-        payload:
-          type: string
-          format: binary
-        raw:
-          type: object
-        ttl:
-          type: integer
-    GetEventReq:
-      type: object
-      properties:
-        iD:
-          type: string
-      required:
-        - iD
     JOSEErrorEnvelope:
       type: object
       properties:
@@ -127,6 +95,16 @@ components:
       required:
         - code
         - message
+    OrdersRequest:
+      type: object
+      properties:
+        quantity:
+          type: integer
+          format: int32
+        sku:
+          type: string
+      required:
+        - sku
     RawErrorResponse:
       type: object
       properties:
@@ -139,6 +117,14 @@ components:
       required:
         - code
         - message
+    Request:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+      required:
+        - email
     SuccessResponse:
       type: object
       properties:

--- a/tools/openapi/internal/spectest/testdata/collision/go.mod
+++ b/tools/openapi/internal/spectest/testdata/collision/go.mod
@@ -1,0 +1,5 @@
+module github.com/example/coll
+
+go 1.25
+
+require github.com/gaborage/go-bricks v0.37.0

--- a/tools/openapi/internal/spectest/testdata/collision/handler.go
+++ b/tools/openapi/internal/spectest/testdata/collision/handler.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"github.com/example/coll/orders"
+	"github.com/example/coll/users"
+	"github.com/gaborage/go-bricks/server"
+)
+
+// Handler holds the API handlers.
+type Handler struct{}
+
+func (h *Handler) createUser(req users.Request, ctx server.HandlerContext) (server.NoContentResult, server.IAPIError) {
+	return server.NoContent(), nil
+}
+func (h *Handler) createOrder(req orders.Request, ctx server.HandlerContext) (server.NoContentResult, server.IAPIError) {
+	return server.NoContent(), nil
+}

--- a/tools/openapi/internal/spectest/testdata/collision/module.go
+++ b/tools/openapi/internal/spectest/testdata/collision/module.go
@@ -1,0 +1,22 @@
+// Package api demonstrates component-name collision qualification: two distinct
+// in-module packages each define a Request type.
+package api
+
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+
+// Module wires the routes to a Handler.
+type Module struct {
+	h *Handler
+}
+
+func (m *Module) Name() string                    { return "api" }
+func (m *Module) Init(deps *app.ModuleDeps) error { m.h = &Handler{}; return nil }
+func (m *Module) Shutdown() error                 { return nil }
+
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.POST(hr, r, "/users", m.h.createUser, server.WithTags("users"))
+	server.POST(hr, r, "/orders", m.h.createOrder, server.WithTags("orders"))
+}

--- a/tools/openapi/internal/spectest/testdata/collision/orders/req.go
+++ b/tools/openapi/internal/spectest/testdata/collision/orders/req.go
@@ -4,5 +4,5 @@ package orders
 // Request is the order-creation request body (different shape, same name).
 type Request struct {
 	SKU      string `json:"sku" validate:"required"`
-	Quantity int    `json:"quantity"`
+	Quantity int    `json:"quantity" validate:"min=1"`
 }

--- a/tools/openapi/internal/spectest/testdata/collision/orders/req.go
+++ b/tools/openapi/internal/spectest/testdata/collision/orders/req.go
@@ -1,0 +1,8 @@
+// Package orders defines a Request type that collides by name with users.Request.
+package orders
+
+// Request is the order-creation request body (different shape, same name).
+type Request struct {
+	SKU      string `json:"sku" validate:"required"`
+	Quantity int    `json:"quantity"`
+}

--- a/tools/openapi/internal/spectest/testdata/collision/users/req.go
+++ b/tools/openapi/internal/spectest/testdata/collision/users/req.go
@@ -1,0 +1,7 @@
+// Package users defines a Request type that collides by name with orders.Request.
+package users
+
+// Request is the user-creation request body.
+type Request struct {
+	Email string `json:"email" validate:"required,email"`
+}

--- a/tools/openapi/internal/spectest/testdata/crosspkg/catalog.go
+++ b/tools/openapi/internal/spectest/testdata/crosspkg/catalog.go
@@ -1,0 +1,49 @@
+package shop
+
+import (
+	"net/http"
+
+	"github.com/example/cross/types"
+	"github.com/gaborage/go-bricks/server"
+)
+
+// Handler holds the shop's HTTP handlers.
+type Handler struct{}
+
+// Cents is a local named scalar; its underlying kind (integer) is emitted instead
+// of the object fallback.
+type Cents int64
+
+// Order has a field of an in-module sibling-package type (types.Money) -> $ref,
+// plus a named-scalar field (Discount) emitted as its underlying integer kind.
+type Order struct {
+	ID       int64       `json:"id"`
+	Total    types.Money `json:"total"`
+	Discount Cents       `json:"discount"`
+}
+
+// Receipt embeds a cross-package (in-module) struct -> its fields (amount,
+// currency) are promoted alongside note.
+type Receipt struct {
+	types.Money
+	Note string `json:"note"`
+}
+
+// IDReq identifies a resource by path parameter.
+type IDReq struct {
+	ID int64 `param:"id" validate:"required"`
+}
+
+func (h *Handler) getOrder(req IDReq, ctx server.HandlerContext) (server.Result[Order], server.IAPIError) {
+	return server.NewResult(http.StatusOK, Order{}), nil
+}
+
+// getPrice returns a sibling-package type directly as the top-level response.
+func (h *Handler) getPrice(req IDReq, ctx server.HandlerContext) (server.Result[types.Money], server.IAPIError) {
+	return server.NewResult(http.StatusOK, types.Money{}), nil
+}
+
+// getReceipt returns a struct that embeds a cross-package type (promotion).
+func (h *Handler) getReceipt(req IDReq, ctx server.HandlerContext) (server.Result[Receipt], server.IAPIError) {
+	return server.NewResult(http.StatusOK, Receipt{}), nil
+}

--- a/tools/openapi/internal/spectest/testdata/crosspkg/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/crosspkg/expected.yaml
@@ -1,0 +1,248 @@
+openapi: 3.0.1
+info:
+  title: Cross API
+  version: 1.0.0
+  description: Generated API specification
+paths:
+  /orders/{id}:
+    get:
+      operationId: getOrder
+      summary: GET /orders/{id}
+      tags:
+        - shop
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Order'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /prices/{id}:
+    get:
+      operationId: getPrice
+      summary: GET /prices/{id}
+      tags:
+        - shop
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Money'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /receipts/{id}:
+    get:
+      operationId: getReceipt
+      summary: GET /receipts/{id}
+      tags:
+        - shop
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Receipt'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: object
+          description: Error details with code and message
+        meta:
+          type: object
+          description: Response metadata
+      required:
+        - error
+    IDReq:
+      type: object
+      properties:
+        iD:
+          type: integer
+          format: int64
+      required:
+        - iD
+    JOSEErrorEnvelope:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
+        message:
+          type: string
+          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
+      required:
+        - code
+        - message
+    Money:
+      type: object
+      properties:
+        amount:
+          type: integer
+          format: int64
+        currency:
+          type: string
+    Order:
+      type: object
+      properties:
+        discount:
+          type: integer
+        id:
+          type: integer
+          format: int64
+        total:
+          $ref: '#/components/schemas/Money'
+    RawErrorResponse:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code
+        message:
+          type: string
+          description: Human-readable error message
+      required:
+        - code
+        - message
+    Receipt:
+      type: object
+      properties:
+        amount:
+          type: integer
+          format: int64
+        currency:
+          type: string
+        note:
+          type: string
+    SuccessResponse:
+      type: object
+      properties:
+        data:
+          type: object
+          description: Response data
+        meta:
+          type: object
+          properties:
+            timestamp:
+              type: string
+              format: date-time
+              description: RFC3339 response timestamp
+            traceId:
+              type: string
+              description: W3C trace identifier for the request

--- a/tools/openapi/internal/spectest/testdata/crosspkg/go.mod
+++ b/tools/openapi/internal/spectest/testdata/crosspkg/go.mod
@@ -1,0 +1,5 @@
+module github.com/example/cross
+
+go 1.25
+
+require github.com/gaborage/go-bricks v0.37.0

--- a/tools/openapi/internal/spectest/testdata/crosspkg/module.go
+++ b/tools/openapi/internal/spectest/testdata/crosspkg/module.go
@@ -1,0 +1,22 @@
+// Package shop demonstrates cross-package (in-module sibling) type resolution.
+package shop
+
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+
+// Module wires the routes to a Handler.
+type Module struct {
+	h *Handler
+}
+
+func (m *Module) Name() string                    { return "shop" }
+func (m *Module) Init(deps *app.ModuleDeps) error { m.h = &Handler{}; return nil }
+func (m *Module) Shutdown() error                 { return nil }
+
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.GET(hr, r, "/orders/:id", m.h.getOrder, server.WithTags("shop"))
+	server.GET(hr, r, "/prices/:id", m.h.getPrice, server.WithTags("shop"))
+	server.GET(hr, r, "/receipts/:id", m.h.getReceipt, server.WithTags("shop"))
+}

--- a/tools/openapi/internal/spectest/testdata/crosspkg/types/money.go
+++ b/tools/openapi/internal/spectest/testdata/crosspkg/types/money.go
@@ -1,0 +1,8 @@
+// Package types holds shared value types used across the API (a sibling package).
+package types
+
+// Money is defined in a sibling in-module package and referenced cross-package.
+type Money struct {
+	Amount   int64  `json:"amount"`
+	Currency string `json:"currency"`
+}


### PR DESCRIPTION
## PR9 — Cross-package resolution, named-type underlying kind, name-collision qualification

Ninth PR in the OpenAPI-tool gap initiative — three coupled registry/type-resolution extensions sharing one module-path resolver (`risk: high · effort: L`).

### 1. Cross-package resolution
A field/response of an **in-module sibling-package** struct now resolves to a component and `$ref`s it. File imports are mapped alias→path; an in-module path is translated to a directory under the go.mod module prefix and parsed with a **per-directory cache**; stdlib/third-party types fall through to the generator's well-known map / object. Cross-package **embedded** structs are also promoted — completing PR8's deferral.

### 2. Named-type underlying kind
A named, non-struct scalar (`type Cents int64`, `time.Duration`) resolves to its OpenAPI 3-way kind (`integer`/`number`/`string`), carried on `FieldInfo.UnderlyingKind` and **emitted by the generator** instead of the `object` fallback. Alias chains (`type A B; type B int`) are followed.

### 3. Component-name collision qualification
Two packages each defining e.g. `Request` now yield **two distinct components** — the registry is keyed by a collision-qualified name (bare preferred, `<Pkg><Name>` on conflict) and field/response `$ref`s adopt the final name.

`constraints.go`: `isNumericType` refactored into `isIntegerType`/`isFloatType` (DRY; `primitiveKind` reuses them).

### Surfaced by `/code-review` (fixed)
- `UnderlyingKind` was plumbed but unused (a `Cents` field still emitted `{object}`) → **wired into the generator** with golden coverage.
- Missing alias-chain resolution → bounded recursion.
- Sibling-file parse was uncached → now uses the per-dir cache.
- Nondeterministic file iteration in the resolver → **sorted**.
- Collision bare-name follows discovery order → documented (the spec is valid either way; every `$ref` resolves to the component the field actually carries).

### Validation
- `make check` green; tool coverage **90.7%**.
- New `crosspkg` (sibling type as field + top-level response + cross-pkg embed + named scalar) and `collision` (two `Request` types) fixtures validate through in-process **kin-openapi** + the pinned **redocly** gate.
- Unit tests: `schemaKey` collisions, underlying-kind (local + `time.Duration` + non-wrapper), `inModuleDir`, parse-cache hit/miss, resolver fall-throughs.

Part of the roadmap in `.claude/tasks/openapi-tool-gap-analysis.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cross-package type resolution with deterministic component naming and a per-directory parsing cache.
  * Schema generation now honors named scalar underlying kinds for accurate OpenAPI types.
  * Enhanced promotion of in-module embedded structs across packages.

* **Bug Fixes**
  * Fixed schema name collision handling and map field references to use resolved component names.
  * Safer handling of unresolvable embeds and qualified type fallbacks.

* **Tests**
  * Added unit tests and spec fixtures covering cross-package resolution, collisions, caching, and underlying-kind inference.

* **Chores**
  * Added spectest fixtures and test modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->