### PR TITLE
feat(openapi): conformance — servers, security, qualified operationIds, schema gating (PR10)

### DIFF
--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -891,8 +891,11 @@ func (a *ProjectAnalyzer) extractRouteMetadata(arg ast.Expr, route *models.Route
 	case "WithDescription":
 		route.Description = a.extractStringFromFirstArg(callExpr)
 	case "WithHandlerName":
+		// An explicit operationId override; kept distinct from the handler method
+		// name (HandlerName) so the generator module-qualifies the derived id but
+		// honors the explicit one verbatim.
 		if name := a.extractStringFromFirstArg(callExpr); name != "" {
-			route.HandlerName = name
+			route.OperationID = name
 		}
 	case "WithRawResponse":
 		route.RawResponse = true

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -3628,8 +3628,11 @@ func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegist
 	_, routes := analyzeSingleModule(t, src)
 	raw := routeForPath(t, routes, "GET /raw")
 	assert.True(t, raw.RawResponse, "WithRawResponse() must set RawResponse")
-	assert.Equal(t, "customOp", routeForPath(t, routes, "GET /named").HandlerName,
-		"WithHandlerName must override the operationId source")
+	named := routeForPath(t, routes, "GET /named")
+	assert.Equal(t, "customOp", named.OperationID,
+		"WithHandlerName sets the explicit OperationID (distinct from the handler method name)")
+	assert.Equal(t, "named", named.HandlerName,
+		"HandlerName stays the handler method name, so the generator can module-qualify the derived id")
 }
 
 // TestExtractSuccessStatusLastWins confirms that when a handler returns a server

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -73,6 +73,7 @@ const (
 	respDescSuccess = "Successful response"
 	respDescCreated = "Resource created successfully"
 	paramTypePath   = "path"
+	paramTypeHeader = "header"
 	propNameError   = "error"
 	propNameData    = "data"
 	propNameMeta    = "meta"
@@ -93,6 +94,10 @@ type OpenAPIGenerator struct {
 	title       string
 	version     string
 	description string
+	// operationIDs maps a route key ("METHOD /path") to its assigned, unique
+	// operationId. Populated once per Generate from a deterministic pass over all
+	// routes so ids are module-qualified and collision-free across modules.
+	operationIDs map[string]string
 }
 
 // OpenAPIInfo represents the info section of an OpenAPI specification
@@ -214,9 +219,20 @@ func (g *OpenAPIGenerator) Generate(project *models.Project) (string, error) {
 	}
 	sb.WriteString(infoYAML)
 
+	// Assign deterministic, collision-free operationIds before building paths.
+	allRoutes := g.getAllRoutes(project)
+	g.operationIDs = g.assignOperationIDs(allRoutes)
+
+	// Servers: a relative-root default so the document is self-describing and
+	// passes the no-empty-servers gate (the concrete URL is a PR11 flag).
+	serversYAML, err := g.marshalYAMLSection("servers", defaultServers())
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal servers section: %w", err)
+	}
+	sb.WriteString(serversYAML)
+
 	// Paths — built as a struct graph and emitted through the same yaml.Marshal
 	// path as info/components (an empty project marshals to "paths: {}").
-	allRoutes := g.getAllRoutes(project)
 	pathsYAML, err := g.marshalYAMLSection("paths", g.buildPaths(allRoutes))
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal paths section: %w", err)
@@ -230,8 +246,11 @@ func (g *OpenAPIGenerator) Generate(project *models.Project) (string, error) {
 	if types == nil {
 		types = routeTypeRegistry(project)
 	}
-	standardSchemas := g.createStandardSchemas()
-	generatedSchemas := g.generateSchemasFromTypes(types)
+	// Standard schemas are gated to those actually referenced (so no-unused-components
+	// holds): ErrorResponse always; SuccessResponse/JOSEErrorEnvelope only for JOSE
+	// routes; RawErrorResponse only for raw routes.
+	standardSchemas := g.createStandardSchemas(allRoutes)
+	generatedSchemas := g.generateSchemasFromTypes(types, referencedSchemaNames(allRoutes, types))
 
 	// Merge schemas (generated schemas override standard if there's a conflict)
 	schemas := make(map[string]*OpenAPISchema)
@@ -239,7 +258,8 @@ func (g *OpenAPIGenerator) Generate(project *models.Project) (string, error) {
 	maps.Copy(schemas, generatedSchemas)
 
 	components := map[string]any{
-		"schemas": schemas,
+		"schemas":         schemas,
+		"securitySchemes": securitySchemes(),
 	}
 
 	componentsYAML, err := g.marshalYAMLSection("components", components)
@@ -248,7 +268,53 @@ func (g *OpenAPIGenerator) Generate(project *models.Project) (string, error) {
 	}
 	sb.WriteString(componentsYAML)
 
+	// Root-level security: the framework resolves tenancy from the X-Tenant-ID
+	// header, modeled as an apiKey scheme. Emitted last so security-defined sees
+	// the scheme already declared.
+	securityYAML, err := g.marshalYAMLSection("security", rootSecurity())
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal security section: %w", err)
+	}
+	sb.WriteString(securityYAML)
+
 	return sb.String(), nil
+}
+
+// tenantSecurityScheme is the component name for the X-Tenant-ID apiKey scheme.
+const tenantSecurityScheme = "TenantID"
+
+// openAPIServer is a Server Object.
+type openAPIServer struct {
+	URL         string `yaml:"url"`
+	Description string `yaml:"description,omitempty"`
+}
+
+// securityScheme is a Security Scheme Object (apiKey form).
+type securityScheme struct {
+	Type string `yaml:"type"`
+	In   string `yaml:"in,omitempty"`
+	Name string `yaml:"name,omitempty"`
+}
+
+// defaultServers returns the default servers block: a single relative-root entry.
+// (A concrete --server URL is a PR11 flag.)
+func defaultServers() []openAPIServer {
+	return []openAPIServer{{URL: "/", Description: "Relative to the deployment host"}}
+}
+
+// securitySchemes returns the components.securitySchemes map. The framework
+// resolves the tenant from the X-Tenant-ID request header (apiKey-in-header);
+// bearer/oauth schemes can be added here later without restructuring.
+func securitySchemes() map[string]securityScheme {
+	return map[string]securityScheme{
+		tenantSecurityScheme: {Type: "apiKey", In: paramTypeHeader, Name: "X-Tenant-ID"},
+	}
+}
+
+// rootSecurity returns the document-level security requirement referencing the
+// tenant apiKey scheme.
+func rootSecurity() []map[string][]string {
+	return []map[string][]string{{tenantSecurityScheme: {}}}
 }
 
 // getTitle returns the project title or default
@@ -470,7 +536,6 @@ func jsonMediaRef(name string) map[string]*OpenAPIMediaType {
 // plaintext-minimal envelope by the runtime, so the OpenAPI spec must reflect that.
 func (g *OpenAPIGenerator) buildResponses(route *models.Route) map[string]*OpenAPIResponse {
 	joseResponse := route.Response != nil && route.Response.JOSE
-	joseRoute := joseResponse || (route.Request != nil && route.Request.JOSE)
 	noContent := route.Response != nil && route.Response.NoContent
 
 	successCode := successStatusCode(route, noContent)
@@ -491,14 +556,9 @@ func (g *OpenAPIGenerator) buildResponses(route *models.Route) map[string]*OpenA
 
 	// Pre-trust failures on JOSE routes are plaintext minimal envelopes per the
 	// security model: when decrypt/verify fails the peer is unauthenticated and
-	// the server leaks nothing beyond {code,message}.
-	errorSchema := schemaErrorResponse
-	switch {
-	case joseRoute:
-		errorSchema = schemaJOSEErrorEnvelope
-	case route.RawResponse:
-		errorSchema = schemaRawErrorResponse
-	}
+	// the server leaks nothing beyond {code,message}. errorSchemaName is shared with
+	// the standard-schema gating so the two can never disagree.
+	errorSchema := errorSchemaName(route)
 
 	responses := map[string]*OpenAPIResponse{
 		"400": {Description: "Bad Request", Content: jsonMediaRef(errorSchema)},
@@ -608,13 +668,92 @@ func routeHasValidation(request *models.TypeInfo) bool {
 
 // getOperationID generates an operation ID for a route
 func (g *OpenAPIGenerator) getOperationID(route *models.Route) string {
-	if route.HandlerName != "" {
-		return route.HandlerName
+	if id, ok := g.operationIDs[routeKey(route)]; ok {
+		return id
 	}
-	// Fallback: create from method and path
-	cleanPath := strings.ReplaceAll(route.Path, "/", "_")
-	cleanPath = strings.ReplaceAll(cleanPath, ":", "")
-	return fmt.Sprintf("%s%s", strings.ToLower(route.Method), cleanPath)
+	return g.baseOperationID(route) // defensive fallback (route not in the pre-pass)
+}
+
+// routeKey identifies a route by its emitted slot (method + path); unique because
+// assignOperation de-dups duplicate (method, path) pairs first-wins.
+func routeKey(route *models.Route) string {
+	return strings.ToUpper(route.Method) + " " + route.Path
+}
+
+// assignOperationIDs assigns a deterministic, collision-free operationId to every
+// route: an explicit WithHandlerName id verbatim, else a module-qualified handler
+// name (usersGetUser), with a numeric suffix on any remaining collision. Routes
+// are processed in sorted key order so the assignment is stable across runs.
+func (g *OpenAPIGenerator) assignOperationIDs(routes []models.Route) map[string]string {
+	keys := make([]string, 0, len(routes))
+	byKey := make(map[string]*models.Route, len(routes))
+	for i := range routes {
+		k := routeKey(&routes[i])
+		// First-wins, mirroring assignOperation: the FIRST route for a (method,
+		// path) is the one emitted, so its handler must drive the operationId.
+		if _, seen := byKey[k]; seen {
+			continue
+		}
+		byKey[k] = &routes[i]
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	used := make(map[string]struct{}, len(routes))
+	out := make(map[string]string, len(routes))
+	for _, k := range keys {
+		if _, done := out[k]; done {
+			continue // duplicate (method, path) — one operation emitted
+		}
+		base := g.baseOperationID(byKey[k])
+		id := base
+		for n := 2; ; n++ {
+			if _, taken := used[id]; !taken {
+				break
+			}
+			id = base + strconv.Itoa(n)
+		}
+		used[id] = struct{}{}
+		out[k] = id
+	}
+	return out
+}
+
+// baseOperationID derives a route's un-deduplicated operationId: an explicit
+// WithHandlerName id is used as-is; otherwise the handler method name is
+// module-qualified (module "users" + "getUser" -> "usersGetUser"), falling back
+// to method+path when no handler name was resolved. The caller may still append a
+// numeric suffix if two routes produce the same base — operationIds must be
+// unique, so even an explicit id is suffixed on the (rare) explicit collision.
+func (g *OpenAPIGenerator) baseOperationID(route *models.Route) string {
+	if route.OperationID != "" {
+		return route.OperationID
+	}
+	name := route.HandlerName
+	if name == "" {
+		cleanPath := strings.ReplaceAll(route.Path, "/", "_")
+		cleanPath = strings.ReplaceAll(cleanPath, ":", "")
+		return strings.ToLower(route.Method) + cleanPath
+	}
+	if route.Module != "" {
+		return lowerFirst(route.Module) + upperFirst(name)
+	}
+	return name
+}
+
+// lowerFirst / upperFirst adjust the first rune's case for camelCase joining.
+func lowerFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToLower(s[:1]) + s[1:]
+}
+
+func upperFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
 }
 
 // getSummary returns the route summary or generates one
@@ -671,74 +810,99 @@ func (g *OpenAPIGenerator) marshalYAMLSection(sectionName string, data any) (str
 	return buf.String(), nil
 }
 
-// createStandardSchemas creates common response schemas using proper structs
-func (g *OpenAPIGenerator) createStandardSchemas() map[string]*OpenAPISchema {
-	return map[string]*OpenAPISchema{
-		// SuccessResponse is the generic envelope used as the JOSE plaintext-schema
-		// fallback (a typed route emits an inline envelope instead). Its meta reuses
-		// metaEnvelopeSchema so the documented metadata shape never diverges from the
-		// inline envelopes.
-		schemaSuccessResponse: {
-			Type: typeObject,
-			Properties: map[string]*OpenAPIProperty{
-				propNameData: {
-					Type:        typeObject,
-					Description: "Response data",
-				},
-				propNameMeta: metaEnvelopeSchema(),
-			},
+// errorSchemaName returns the error-component name a route's 4xx/5xx responses
+// reference: JOSEErrorEnvelope for JOSE routes (request or response tagged),
+// RawErrorResponse for raw-response routes, else ErrorResponse. Shared by
+// buildResponses (emit) and createStandardSchemas (gate) so they cannot diverge.
+func errorSchemaName(route *models.Route) string {
+	joseRoute := (route.Response != nil && route.Response.JOSE) ||
+		(route.Request != nil && route.Request.JOSE)
+	switch {
+	case joseRoute:
+		return schemaJOSEErrorEnvelope
+	case route.RawResponse:
+		return schemaRawErrorResponse
+	default:
+		return schemaErrorResponse
+	}
+}
+
+// createStandardSchemas returns only the common schemas actually referenced by
+// the given routes, so the document carries no unused components. The error
+// schema per route is selected by errorSchemaName (shared with buildResponses);
+// SuccessResponse is added only when a JOSE route falls back to the generic
+// envelope (an untyped JOSE response, mirroring successPlaintextSchema).
+func (g *OpenAPIGenerator) createStandardSchemas(routes []models.Route) map[string]*OpenAPISchema {
+	builders := map[string]func() *OpenAPISchema{
+		schemaErrorResponse:     errorResponseSchema,
+		schemaJOSEErrorEnvelope: joseErrorEnvelopeSchema,
+		schemaRawErrorResponse:  rawErrorResponseSchema,
+		schemaSuccessResponse:   successResponseSchema,
+	}
+	used := make(map[string]bool, len(builders))
+	for i := range routes {
+		r := &routes[i]
+		used[errorSchemaName(r)] = true
+		if r.Response != nil && r.Response.JOSE && r.Response.Name == "" {
+			used[schemaSuccessResponse] = true
+		}
+	}
+
+	out := make(map[string]*OpenAPISchema, len(used))
+	for name := range used {
+		out[name] = builders[name]()
+	}
+	return out
+}
+
+// successResponseSchema is the generic data/meta envelope used as the JOSE
+// plaintext-schema fallback (a typed route emits an inline envelope instead). Its
+// meta reuses metaEnvelopeSchema so the documented shape never diverges.
+func successResponseSchema() *OpenAPISchema {
+	return &OpenAPISchema{
+		Type: typeObject,
+		Properties: map[string]*OpenAPIProperty{
+			propNameData: {Type: typeObject, Description: "Response data"},
+			propNameMeta: metaEnvelopeSchema(),
 		},
-		schemaErrorResponse: {
-			Type: typeObject,
-			Properties: map[string]*OpenAPIProperty{
-				propNameError: {
-					Type: typeObject,
-					// Note: nested properties would need recursive handling for full OpenAPI spec
-					Description: "Error details with code and message",
-				},
-				"meta": {
-					Type:        typeObject,
-					Description: "Response metadata",
-				},
-			},
-			Required: []string{propNameError},
+	}
+}
+
+func errorResponseSchema() *OpenAPISchema {
+	return &OpenAPISchema{
+		Type: typeObject,
+		Properties: map[string]*OpenAPIProperty{
+			propNameError: {Type: typeObject, Description: "Error details with code and message"},
+			propNameMeta:  {Type: typeObject, Description: "Response metadata"},
 		},
-		// JOSEErrorEnvelope is the minimal plaintext error envelope returned for
-		// pre-trust JOSE failures (decrypt failed, signature invalid, kid unknown,
-		// etc.). The framework intentionally omits traceId/timestamp/framework
-		// metadata here — peer is unauthenticated and the envelope must leak
-		// nothing beyond the canonical {code,message} pair.
-		schemaJOSEErrorEnvelope: {
-			Type: typeObject,
-			Properties: map[string]*OpenAPIProperty{
-				propNameCode: {
-					Type:        typeString,
-					Description: "Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)",
-				},
-				propNameMessage: {
-					Type:        typeString,
-					Description: "Constant-time generic message — never reveals which key was tried or which library detected the failure",
-				},
-			},
-			Required: []string{propNameCode, propNameMessage},
+		Required: []string{propNameError},
+	}
+}
+
+// joseErrorEnvelopeSchema is the minimal plaintext error envelope for pre-trust
+// JOSE failures — it intentionally omits traceId/timestamp/framework metadata (the
+// peer is unauthenticated and must learn nothing beyond {code,message}).
+func joseErrorEnvelopeSchema() *OpenAPISchema {
+	return &OpenAPISchema{
+		Type: typeObject,
+		Properties: map[string]*OpenAPIProperty{
+			propNameCode:    {Type: typeString, Description: "Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)"},
+			propNameMessage: {Type: typeString, Description: "Constant-time generic message — never reveals which key was tried or which library detected the failure"},
 		},
-		// RawErrorResponse is the bare {code,message} error payload returned by
-		// routes registered WithRawResponse(): no data/meta envelope, mirroring
-		// the framework's formatRawErrorResponse (details is dev-only, omitted).
-		schemaRawErrorResponse: {
-			Type: typeObject,
-			Properties: map[string]*OpenAPIProperty{
-				propNameCode: {
-					Type:        typeString,
-					Description: "Machine-readable error code",
-				},
-				propNameMessage: {
-					Type:        typeString,
-					Description: "Human-readable error message",
-				},
-			},
-			Required: []string{propNameCode, propNameMessage},
+		Required: []string{propNameCode, propNameMessage},
+	}
+}
+
+// rawErrorResponseSchema is the bare {code,message} payload for WithRawResponse()
+// routes (no data/meta envelope), mirroring the framework's formatRawErrorResponse.
+func rawErrorResponseSchema() *OpenAPISchema {
+	return &OpenAPISchema{
+		Type: typeObject,
+		Properties: map[string]*OpenAPIProperty{
+			propNameCode:    {Type: typeString, Description: "Machine-readable error code"},
+			propNameMessage: {Type: typeString, Description: "Human-readable error message"},
 		},
+		Required: []string{propNameCode, propNameMessage},
 	}
 }
 
@@ -747,14 +911,63 @@ func (g *OpenAPIGenerator) createStandardSchemas() map[string]*OpenAPISchema {
 // registry already contains every named struct reachable from a route's request
 // or response (including nested, sliced, and recursive types), so iterating it
 // produces a self-contained set of components with all $refs resolvable.
-func (g *OpenAPIGenerator) generateSchemasFromTypes(types map[string]*models.TypeInfo) map[string]*OpenAPISchema {
+func (g *OpenAPIGenerator) generateSchemasFromTypes(types map[string]*models.TypeInfo, referenced map[string]bool) map[string]*OpenAPISchema {
 	schemas := make(map[string]*OpenAPISchema, len(types))
 	for _, ti := range types {
+		// A params-only request type (every field a path/query/header param, no JSON
+		// body) is represented purely as OpenAPI parameters; it has no requestBody
+		// $ref, so emitting a component would leave an unused orphan — UNLESS it is
+		// also referenced elsewhere (e.g. reused as a response), in which case the
+		// $ref must resolve to an emitted component.
+		if isParamsOnlyType(ti) && !referenced[schemaName(ti)] {
+			continue
+		}
 		if schema := g.typeInfoToSchema(ti); schema != nil {
 			schemas[schemaName(ti)] = schema
 		}
 	}
 	return schemas
+}
+
+// referencedSchemaNames collects every component name reachable via a real $ref:
+// typed (non-JOSE) response payloads, and field/map-value refs across all types.
+// Used so a params-only type that is also referenced is not skipped (which would
+// leave a dangling $ref).
+func referencedSchemaNames(routes []models.Route, types map[string]*models.TypeInfo) map[string]bool {
+	out := make(map[string]bool)
+	for i := range routes {
+		r := &routes[i]
+		// Typed, non-JOSE responses are emitted as data.$ref (or a raw $ref).
+		if r.Response != nil && r.Response.Name != "" && !r.Response.JOSE {
+			out[schemaName(r.Response)] = true
+		}
+	}
+	for _, ti := range types {
+		for j := range ti.Fields {
+			if n := ti.Fields[j].RefName; n != "" {
+				out[n] = true
+			}
+			if n := ti.Fields[j].MapValueRefName; n != "" {
+				out[n] = true
+			}
+		}
+	}
+	return out
+}
+
+// isParamsOnlyType reports whether a type's every field is a path/query/header
+// param (no JSON body field) and it is not JOSE-tagged — i.e. it is referenced
+// only as parameters, never as a body schema.
+func isParamsOnlyType(ti *models.TypeInfo) bool {
+	if ti == nil || ti.JOSE || len(ti.Fields) == 0 {
+		return false
+	}
+	for i := range ti.Fields {
+		if ti.Fields[i].ParamType == "" {
+			return false // a body field — needs a component schema
+		}
+	}
+	return true
 }
 
 // schemaName is the single source for a type's component-schema name (and the

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -94,10 +94,6 @@ type OpenAPIGenerator struct {
 	title       string
 	version     string
 	description string
-	// operationIDs maps a route key ("METHOD /path") to its assigned, unique
-	// operationId. Populated once per Generate from a deterministic pass over all
-	// routes so ids are module-qualified and collision-free across modules.
-	operationIDs map[string]string
 }
 
 // OpenAPIInfo represents the info section of an OpenAPI specification
@@ -219,9 +215,13 @@ func (g *OpenAPIGenerator) Generate(project *models.Project) (string, error) {
 	}
 	sb.WriteString(infoYAML)
 
-	// Assign deterministic, collision-free operationIds before building paths.
+	// Reduce to the EMITTED route set (first-wins per method+path, matching
+	// assignOperation), then drive operationIds, schema gating, and path building
+	// from that one set so the gate, refs, and paths can never disagree. opIDs is
+	// request-scoped (threaded, not stored) so Generate is reentrant.
 	allRoutes := g.getAllRoutes(project)
-	g.operationIDs = g.assignOperationIDs(allRoutes)
+	emitted := emittedRoutes(allRoutes)
+	opIDs := g.assignOperationIDs(emitted)
 
 	// Servers: a relative-root default so the document is self-describing and
 	// passes the no-empty-servers gate (the concrete URL is a PR11 flag).
@@ -233,7 +233,7 @@ func (g *OpenAPIGenerator) Generate(project *models.Project) (string, error) {
 
 	// Paths — built as a struct graph and emitted through the same yaml.Marshal
 	// path as info/components (an empty project marshals to "paths: {}").
-	pathsYAML, err := g.marshalYAMLSection("paths", g.buildPaths(allRoutes))
+	pathsYAML, err := g.marshalYAMLSection("paths", g.buildPaths(emitted, opIDs))
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal paths section: %w", err)
 	}
@@ -249,8 +249,8 @@ func (g *OpenAPIGenerator) Generate(project *models.Project) (string, error) {
 	// Standard schemas are gated to those actually referenced (so no-unused-components
 	// holds): ErrorResponse always; SuccessResponse/JOSEErrorEnvelope only for JOSE
 	// routes; RawErrorResponse only for raw routes.
-	standardSchemas := g.createStandardSchemas(allRoutes)
-	generatedSchemas := g.generateSchemasFromTypes(types, referencedSchemaNames(allRoutes, types))
+	standardSchemas := g.createStandardSchemas(emitted)
+	generatedSchemas := g.generateSchemasFromTypes(types, referencedSchemaNames(emitted, types))
 
 	// Merge schemas (generated schemas override standard if there's a conflict)
 	schemas := make(map[string]*OpenAPISchema)
@@ -379,7 +379,7 @@ func (g *OpenAPIGenerator) groupRoutesByPath(routes []models.Route) map[string][
 // buildPaths builds the paths object as a struct graph keyed by path. yaml.Marshal
 // sorts map keys, giving the same deterministic path ordering the previous
 // hand-rolled writer produced via sort.Strings.
-func (g *OpenAPIGenerator) buildPaths(routes []models.Route) map[string]*OpenAPIPathItem {
+func (g *OpenAPIGenerator) buildPaths(routes []models.Route, opIDs map[string]string) map[string]*OpenAPIPathItem {
 	pathGroups := g.groupRoutesByPath(routes)
 	paths := make(map[string]*OpenAPIPathItem, len(pathGroups))
 	for path := range pathGroups {
@@ -392,23 +392,41 @@ func (g *OpenAPIGenerator) buildPaths(routes []models.Route) map[string]*OpenAPI
 		group := pathGroups[path]
 		item := &OpenAPIPathItem{}
 		for i := range group {
-			g.assignOperation(item, &group[i])
+			g.assignOperation(item, &group[i], opIDs)
 		}
 		paths[path] = item
 	}
 	return paths
 }
 
+// emittedRoutes reduces routes to the set actually emitted: the first route per
+// (method, path), in discovery order, mirroring assignOperation's first-wins
+// de-dup. Schema gating, ref collection, and operationId assignment all run over
+// this set so they agree with the emitted paths.
+func emittedRoutes(routes []models.Route) []models.Route {
+	seen := make(map[string]struct{}, len(routes))
+	out := make([]models.Route, 0, len(routes))
+	for i := range routes {
+		k := routeKey(&routes[i])
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, routes[i])
+	}
+	return out
+}
+
 // assignOperation builds the operation for a route and attaches it to the path
 // item under the matching HTTP method. The analyzer only emits the standard
 // methods (analyzer.isHTTPMethod), so an unrecognized method is a no-op. A
 // (method, path) already populated is left untouched (first-wins de-dup).
-func (g *OpenAPIGenerator) assignOperation(item *OpenAPIPathItem, route *models.Route) {
+func (g *OpenAPIGenerator) assignOperation(item *OpenAPIPathItem, route *models.Route, opIDs map[string]string) {
 	slot := item.methodSlot(strings.ToUpper(route.Method))
 	if slot == nil || *slot != nil {
 		return
 	}
-	*slot = g.buildOperation(route)
+	*slot = g.buildOperation(route, opIDs)
 }
 
 // methodSlot returns a pointer to the operation field for an HTTP method, or nil
@@ -448,9 +466,9 @@ type Parameter struct {
 // buildOperation builds the Operation Object for a route. Empty tags/parameters
 // and an absent request body are dropped by the struct's omitempty tags, matching
 // the previous conditional text emission.
-func (g *OpenAPIGenerator) buildOperation(route *models.Route) *OpenAPIOperation {
+func (g *OpenAPIGenerator) buildOperation(route *models.Route, opIDs map[string]string) *OpenAPIOperation {
 	op := &OpenAPIOperation{
-		OperationID: g.getOperationID(route),
+		OperationID: g.getOperationID(route, opIDs),
 		Summary:     g.getSummary(route),
 		Description: route.Description,
 		Tags:        route.Tags,
@@ -667,8 +685,8 @@ func routeHasValidation(request *models.TypeInfo) bool {
 }
 
 // getOperationID generates an operation ID for a route
-func (g *OpenAPIGenerator) getOperationID(route *models.Route) string {
-	if id, ok := g.operationIDs[routeKey(route)]; ok {
+func (g *OpenAPIGenerator) getOperationID(route *models.Route, opIDs map[string]string) string {
+	if id, ok := opIDs[routeKey(route)]; ok {
 		return id
 	}
 	return g.baseOperationID(route) // defensive fallback (route not in the pre-pass)

--- a/tools/openapi/internal/generator/openapi_test.go
+++ b/tools/openapi/internal/generator/openapi_test.go
@@ -253,7 +253,7 @@ func TestGetOperationID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := gen.getOperationID(tt.route)
+			result := gen.getOperationID(tt.route, nil)
 			if result != tt.expected {
 				t.Errorf(resultNotExpectedErrorMsg, tt.expected, result)
 			}
@@ -360,7 +360,7 @@ func TestBuildPathsDropsNonRootedPath(t *testing.T) {
 	paths := gen.buildPaths([]models.Route{
 		{Method: "GET", Path: "/ok"},
 		{Method: "GET", Path: "broken"}, // no leading slash
-	})
+	}, nil)
 	_, hasOK := paths["/ok"]
 	_, hasBroken := paths["broken"]
 	assert.True(t, hasOK)
@@ -372,7 +372,7 @@ func TestBuildPathsDedupesSameMethodAndPath(t *testing.T) {
 	paths := gen.buildPaths([]models.Route{
 		{Method: "GET", Path: "/x", HandlerName: "first"},
 		{Method: "GET", Path: "/x", HandlerName: "second"}, // same (method,path)
-	})
+	}, nil)
 	require.NotNil(t, paths["/x"])
 	require.NotNil(t, paths["/x"].Get)
 	assert.Equal(t, "first", paths["/x"].Get.OperationID, "first registration wins on a duplicate (method,path)")
@@ -2050,14 +2050,14 @@ func TestAssignOperationByMethod(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.method, func(t *testing.T) {
 			item := &OpenAPIPathItem{}
-			gen.assignOperation(item, &models.Route{Method: tc.method, Path: "/x", HandlerName: "h"})
+			gen.assignOperation(item, &models.Route{Method: tc.method, Path: "/x", HandlerName: "h"}, nil)
 			assert.NotNil(t, tc.op(item), "operation should be attached under %s", tc.method)
 		})
 	}
 
 	t.Run("unknown_method_noop", func(t *testing.T) {
 		item := &OpenAPIPathItem{}
-		gen.assignOperation(item, &models.Route{Method: "TRACE", Path: "/x", HandlerName: "h"})
+		gen.assignOperation(item, &models.Route{Method: "TRACE", Path: "/x", HandlerName: "h"}, nil)
 		assert.Nil(t, item.Get)
 		assert.Nil(t, item.Post)
 	})
@@ -2489,6 +2489,8 @@ func TestAssignOperationIDsDedup(t *testing.T) {
 		{Method: "GET", Path: "/b", Module: "m", HandlerName: "list"},
 	}
 	ids := gen.assignOperationIDs(routes)
-	got := []string{ids["GET /a"], ids["GET /b"]}
-	assert.ElementsMatch(t, []string{"mList", "mList2"}, got, "collision gets a deterministic suffix")
+	// Deterministic, sorted first-wins: "GET /a" sorts before "GET /b", so /a keeps
+	// the bare id and /b gets the suffix.
+	assert.Equal(t, "mList", ids["GET /a"], "first sorted key keeps the bare id")
+	assert.Equal(t, "mList2", ids["GET /b"], "later collision gets the numeric suffix")
 }

--- a/tools/openapi/internal/generator/openapi_test.go
+++ b/tools/openapi/internal/generator/openapi_test.go
@@ -178,9 +178,9 @@ func TestGenerateWithRoutes(t *testing.T) {
 		t.Error("Missing POST method")
 	}
 
-	// Check operation details
-	if !strings.Contains(spec, "operationId: getUser") {
-		t.Error("Missing operation ID")
+	// Check operation details: operationId is module-qualified (users + GetUser).
+	if !strings.Contains(spec, "operationId: usersGetUser") {
+		t.Error("Missing module-qualified operation ID")
 	}
 	if !strings.Contains(spec, "summary: Get user by ID") {
 		t.Error("Missing summary")
@@ -199,11 +199,20 @@ func TestGenerateWithRoutes(t *testing.T) {
 	if !strings.Contains(spec, `"400":`) {
 		t.Error("Missing 400 response")
 	}
-	if !strings.Contains(spec, "SuccessResponse") {
-		t.Error("Missing success response schema")
+	// Non-JOSE routes use the inline data/meta envelope (SuccessResponse is gated
+	// to JOSE-untyped fallbacks now), so assert the inline envelope + ErrorResponse.
+	if !strings.Contains(spec, "data:") {
+		t.Error("Missing inline data/meta success envelope")
 	}
 	if !strings.Contains(spec, "ErrorResponse") {
 		t.Error("Missing error response schema")
+	}
+	// Conformance additions: servers + tenant security.
+	if !strings.Contains(spec, "servers:") {
+		t.Error("Missing servers block")
+	}
+	if !strings.Contains(spec, "X-Tenant-ID") {
+		t.Error("Missing X-Tenant-ID security scheme")
 	}
 }
 
@@ -706,10 +715,16 @@ func TestGettersWithEmptyValues(t *testing.T) {
 
 func TestCreateStandardSchemas(t *testing.T) {
 	gen := New(defaultTitle, "1.0.0", defaultDescription)
-	schemas := gen.createStandardSchemas()
+	// Routes that, between them, reference all four standard schemas: a normal
+	// route (ErrorResponse), a JOSE route with an untyped response (SuccessResponse
+	// + JOSEErrorEnvelope), and a raw route (RawErrorResponse).
+	routes := []models.Route{
+		{Method: "GET", Path: "/a", Response: &models.TypeInfo{Name: "Thing"}},
+		{Method: "POST", Path: "/j", Response: &models.TypeInfo{JOSE: true}},
+		{Method: "GET", Path: "/r", RawResponse: true, Response: &models.TypeInfo{Name: "Legacy"}},
+	}
+	schemas := gen.createStandardSchemas(routes)
 
-	// Test that standard schemas are created correctly: SuccessResponse,
-	// ErrorResponse, JOSEErrorEnvelope, and RawErrorResponse (raw-mode routes).
 	if len(schemas) != 4 {
 		t.Errorf("Expected 4 schemas, got %d", len(schemas))
 	}
@@ -727,6 +742,22 @@ func TestCreateStandardSchemas(t *testing.T) {
 	})
 	t.Run("RawErrorResponse schema", func(t *testing.T) {
 		validateMinimalErrorEnvelope(t, schemas, schemaRawErrorResponse)
+	})
+}
+
+func TestCreateStandardSchemasGating(t *testing.T) {
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+
+	t.Run("normal routes only -> just ErrorResponse", func(t *testing.T) {
+		s := gen.createStandardSchemas([]models.Route{{Method: "GET", Path: "/a", Response: &models.TypeInfo{Name: "Thing"}}})
+		assert.Contains(t, s, schemaErrorResponse)
+		assert.NotContains(t, s, schemaJOSEErrorEnvelope, "no JOSE route -> no JOSEErrorEnvelope")
+		assert.NotContains(t, s, schemaRawErrorResponse, "no raw route -> no RawErrorResponse")
+		assert.NotContains(t, s, schemaSuccessResponse, "typed responses use inline envelopes")
+	})
+
+	t.Run("empty project -> no standard schemas", func(t *testing.T) {
+		assert.Empty(t, gen.createStandardSchemas(nil))
 	})
 }
 
@@ -834,7 +865,7 @@ func TestGenerateSchemasFromTypes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			schemas := gen.generateSchemasFromTypes(tt.types)
+			schemas := gen.generateSchemasFromTypes(tt.types, nil)
 			assert.Len(t, schemas, tt.expectedCount)
 			for _, name := range tt.expectedSchemas {
 				_, exists := schemas[name]
@@ -1472,12 +1503,17 @@ func TestGenerateWithTypedRequestResponse(t *testing.T) {
 		t.Fatal("Components/schemas should be a map")
 	}
 
-	// Check that generated schemas exist
-	schemaNames := []string{"CreateUserReq", "User", "SuccessResponse", "ErrorResponse"}
+	// Check that generated schemas exist. SuccessResponse is intentionally absent:
+	// typed routes use the inline data/meta envelope, and the generic SuccessResponse
+	// is gated to JOSE-untyped fallbacks (no-unused-components).
+	schemaNames := []string{"CreateUserReq", "User", "ErrorResponse"}
 	for _, name := range schemaNames {
 		if _, exists := components[name]; !exists {
 			t.Errorf("Missing schema: %s", name)
 		}
+	}
+	if _, exists := components["SuccessResponse"]; exists {
+		t.Error("SuccessResponse should be gated out for non-JOSE typed routes")
 	}
 
 	// Verify CreateUserReq schema has proper constraints
@@ -2417,4 +2453,42 @@ func TestBuildResponsesValidationAdds422(t *testing.T) {
 	})
 	require.Contains(t, resps, "422", "a validated request body must advertise 422")
 	assert.Equal(t, refPath(schemaErrorResponse), resps["422"].Content[mediaJSON].Schema.Ref)
+}
+
+// TestAssignOperationIDs covers module-qualification, explicit WithHandlerName
+// override, and deterministic de-duplication.
+func TestAssignOperationIDs(t *testing.T) {
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+	routes := []models.Route{
+		{Method: "GET", Path: "/users/:id", Module: "users", HandlerName: "get"},
+		{Method: "GET", Path: "/orders/:id", Module: "orders", HandlerName: "get"},
+		{Method: "POST", Path: "/jobs", Module: "jobs", HandlerName: "create", OperationID: "enqueueJob"},
+		{Method: "GET", Path: "/bare"}, // no module/handler -> method+path fallback
+	}
+	ids := gen.assignOperationIDs(routes)
+
+	assert.Equal(t, "usersGet", ids["GET /users/:id"], "module-qualified")
+	assert.Equal(t, "ordersGet", ids["GET /orders/:id"], "different module -> distinct, no collision")
+	assert.Equal(t, "enqueueJob", ids["POST /jobs"], "explicit WithHandlerName wins verbatim")
+	assert.Equal(t, "get_bare", ids["GET /bare"], "no handler -> method+path fallback")
+
+	// All ids are unique.
+	seen := map[string]bool{}
+	for _, id := range ids {
+		assert.False(t, seen[id], "duplicate operationId %q", id)
+		seen[id] = true
+	}
+}
+
+// TestAssignOperationIDsDedup verifies a deterministic numeric suffix when two
+// routes derive the same base id (same module + handler).
+func TestAssignOperationIDsDedup(t *testing.T) {
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+	routes := []models.Route{
+		{Method: "GET", Path: "/a", Module: "m", HandlerName: "list"},
+		{Method: "GET", Path: "/b", Module: "m", HandlerName: "list"},
+	}
+	ids := gen.assignOperationIDs(routes)
+	got := []string{ids["GET /a"], ids["GET /b"]}
+	assert.ElementsMatch(t, []string{"mList", "mList2"}, got, "collision gets a deterministic suffix")
 }

--- a/tools/openapi/internal/models/models.go
+++ b/tools/openapi/internal/models/models.go
@@ -25,6 +25,10 @@ type Route struct {
 	Method      string
 	Path        string
 	HandlerName string
+	// OperationID is an explicit operationId set via server.WithHandlerName(...).
+	// When set it is used verbatim (not module-qualified); otherwise the generator
+	// derives a module-qualified, de-duplicated id from Module + HandlerName.
+	OperationID string
 	Summary     string
 	Description string
 	Tags        []string

--- a/tools/openapi/internal/spectest/testdata/collision/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/collision/expected.yaml
@@ -3,10 +3,13 @@ info:
   title: Coll API
   version: 1.0.0
   description: Generated API specification
+servers:
+  - url: /
+    description: Relative to the deployment host
 paths:
   /orders:
     post:
-      operationId: createOrder
+      operationId: apiCreateOrder
       summary: POST /orders
       tags:
         - orders
@@ -39,7 +42,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /users:
     post:
-      operationId: createUser
+      operationId: apiCreateUser
       summary: POST /users
       tags:
         - users
@@ -83,18 +86,6 @@ components:
           description: Response metadata
       required:
         - error
-    JOSEErrorEnvelope:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
-        message:
-          type: string
-          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
-      required:
-        - code
-        - message
     OrdersRequest:
       type: object
       properties:
@@ -106,18 +97,6 @@ components:
           type: string
       required:
         - sku
-    RawErrorResponse:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable error code
-        message:
-          type: string
-          description: Human-readable error message
-      required:
-        - code
-        - message
     Request:
       type: object
       properties:
@@ -126,19 +105,10 @@ components:
           format: email
       required:
         - email
-    SuccessResponse:
-      type: object
-      properties:
-        data:
-          type: object
-          description: Response data
-        meta:
-          type: object
-          properties:
-            timestamp:
-              type: string
-              format: date-time
-              description: RFC3339 response timestamp
-            traceId:
-              type: string
-              description: W3C trace identifier for the request
+  securitySchemes:
+    TenantID:
+      type: apiKey
+      in: header
+      name: X-Tenant-ID
+security:
+  - TenantID: []

--- a/tools/openapi/internal/spectest/testdata/crosspkg/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/crosspkg/expected.yaml
@@ -3,10 +3,13 @@ info:
   title: Cross API
   version: 1.0.0
   description: Generated API specification
+servers:
+  - url: /
+    description: Relative to the deployment host
 paths:
   /orders/{id}:
     get:
-      operationId: getOrder
+      operationId: shopGetOrder
       summary: GET /orders/{id}
       tags:
         - shop
@@ -57,7 +60,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /prices/{id}:
     get:
-      operationId: getPrice
+      operationId: shopGetPrice
       summary: GET /prices/{id}
       tags:
         - shop
@@ -108,7 +111,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /receipts/{id}:
     get:
-      operationId: getReceipt
+      operationId: shopGetReceipt
       summary: GET /receipts/{id}
       tags:
         - shop
@@ -170,26 +173,6 @@ components:
           description: Response metadata
       required:
         - error
-    IDReq:
-      type: object
-      properties:
-        iD:
-          type: integer
-          format: int64
-      required:
-        - iD
-    JOSEErrorEnvelope:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
-        message:
-          type: string
-          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
-      required:
-        - code
-        - message
     Money:
       type: object
       properties:
@@ -208,18 +191,6 @@ components:
           format: int64
         total:
           $ref: '#/components/schemas/Money'
-    RawErrorResponse:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable error code
-        message:
-          type: string
-          description: Human-readable error message
-      required:
-        - code
-        - message
     Receipt:
       type: object
       properties:
@@ -230,19 +201,10 @@ components:
           type: string
         note:
           type: string
-    SuccessResponse:
-      type: object
-      properties:
-        data:
-          type: object
-          description: Response data
-        meta:
-          type: object
-          properties:
-            timestamp:
-              type: string
-              format: date-time
-              description: RFC3339 response timestamp
-            traceId:
-              type: string
-              description: W3C trace identifier for the request
+  securitySchemes:
+    TenantID:
+      type: apiKey
+      in: header
+      name: X-Tenant-ID
+security:
+  - TenantID: []

--- a/tools/openapi/internal/spectest/testdata/embedded/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/embedded/expected.yaml
@@ -3,10 +3,13 @@ info:
   title: Embed API
   version: 1.0.0
   description: Generated API specification
+servers:
+  - url: /
+    description: Relative to the deployment host
 paths:
   /accounts/{id}:
     get:
-      operationId: getAccount
+      operationId: embedGetAccount
       summary: GET /accounts/{id}
       tags:
         - embed
@@ -57,7 +60,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /users/{id}:
     get:
-      operationId: getUser
+      operationId: embedGetUser
       summary: GET /users/{id}
       tags:
         - embed
@@ -108,7 +111,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /wrappers/{id}:
     get:
-      operationId: getWrapper
+      operationId: embedGetWrapper
       summary: GET /wrappers/{id}
       tags:
         - embed
@@ -191,54 +194,6 @@ components:
           description: Response metadata
       required:
         - error
-    IDReq:
-      type: object
-      properties:
-        iD:
-          type: integer
-          format: int64
-      required:
-        - iD
-    JOSEErrorEnvelope:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
-        message:
-          type: string
-          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
-      required:
-        - code
-        - message
-    RawErrorResponse:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable error code
-        message:
-          type: string
-          description: Human-readable error message
-      required:
-        - code
-        - message
-    SuccessResponse:
-      type: object
-      properties:
-        data:
-          type: object
-          description: Response data
-        meta:
-          type: object
-          properties:
-            timestamp:
-              type: string
-              format: date-time
-              description: RFC3339 response timestamp
-            traceId:
-              type: string
-              description: W3C trace identifier for the request
     User:
       type: object
       properties:
@@ -257,3 +212,10 @@ components:
           $ref: '#/components/schemas/Base'
         label:
           type: string
+  securitySchemes:
+    TenantID:
+      type: apiKey
+      in: header
+      name: X-Tenant-ID
+security:
+  - TenantID: []

--- a/tools/openapi/internal/spectest/testdata/handler_struct/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/handler_struct/expected.yaml
@@ -3,10 +3,13 @@ info:
   title: Shop API
   version: 1.0.0
   description: Generated API specification
+servers:
+  - url: /
+    description: Relative to the deployment host
 paths:
   /users:
     post:
-      operationId: createUser
+      operationId: shopCreateUser
       summary: Create a user
       tags:
         - users
@@ -56,7 +59,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /users/{id}:
     get:
-      operationId: getUser
+      operationId: shopGetUser
       summary: GET /users/{id}
       tags:
         - users
@@ -106,7 +109,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
     delete:
-      operationId: deleteUser
+      operationId: shopDeleteUser
       summary: DELETE /users/{id}
       tags:
         - users
@@ -164,54 +167,6 @@ components:
           description: Response metadata
       required:
         - error
-    GetUserReq:
-      type: object
-      properties:
-        iD:
-          type: integer
-          format: int64
-      required:
-        - iD
-    JOSEErrorEnvelope:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
-        message:
-          type: string
-          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
-      required:
-        - code
-        - message
-    RawErrorResponse:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable error code
-        message:
-          type: string
-          description: Human-readable error message
-      required:
-        - code
-        - message
-    SuccessResponse:
-      type: object
-      properties:
-        data:
-          type: object
-          description: Response data
-        meta:
-          type: object
-          properties:
-            timestamp:
-              type: string
-              format: date-time
-              description: RFC3339 response timestamp
-            traceId:
-              type: string
-              description: W3C trace identifier for the request
     User:
       type: object
       properties:
@@ -222,3 +177,10 @@ components:
           format: int64
         name:
           type: string
+  securitySchemes:
+    TenantID:
+      type: apiKey
+      in: header
+      name: X-Tenant-ID
+security:
+  - TenantID: []

--- a/tools/openapi/internal/spectest/testdata/jose/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/jose/expected.yaml
@@ -3,10 +3,13 @@ info:
   title: Vts API
   version: 1.0.0
   description: Generated API specification
+servers:
+  - url: /
+    description: Relative to the deployment host
 paths:
   /v1/tokens:
     post:
-      operationId: createToken
+      operationId: vtsCreateToken
       summary: POST /v1/tokens
       tags:
         - vts
@@ -66,17 +69,6 @@ components:
       properties:
         token:
           type: string
-    ErrorResponse:
-      type: object
-      properties:
-        error:
-          type: object
-          description: Error details with code and message
-        meta:
-          type: object
-          description: Response metadata
-      required:
-        - error
     JOSEErrorEnvelope:
       type: object
       properties:
@@ -89,31 +81,10 @@ components:
       required:
         - code
         - message
-    RawErrorResponse:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable error code
-        message:
-          type: string
-          description: Human-readable error message
-      required:
-        - code
-        - message
-    SuccessResponse:
-      type: object
-      properties:
-        data:
-          type: object
-          description: Response data
-        meta:
-          type: object
-          properties:
-            timestamp:
-              type: string
-              format: date-time
-              description: RFC3339 response timestamp
-            traceId:
-              type: string
-              description: W3C trace identifier for the request
+  securitySchemes:
+    TenantID:
+      type: apiKey
+      in: header
+      name: X-Tenant-ID
+security:
+  - TenantID: []

--- a/tools/openapi/internal/spectest/testdata/multi_param/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/multi_param/expected.yaml
@@ -3,10 +3,13 @@ info:
   title: Org API
   version: 1.0.0
   description: Generated API specification
+servers:
+  - url: /
+    description: Relative to the deployment host
 paths:
   /orgs/{orgID}/projects/{projectID}:
     get:
-      operationId: getProject
+      operationId: orgGetProject
       summary: GET /orgs/{orgID}/projects/{projectID}
       tags:
         - org
@@ -72,28 +75,6 @@ components:
           description: Response metadata
       required:
         - error
-    GetProjectReq:
-      type: object
-      properties:
-        orgID:
-          type: string
-        projectID:
-          type: string
-      required:
-        - orgID
-        - projectID
-    JOSEErrorEnvelope:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
-        message:
-          type: string
-          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
-      required:
-        - code
-        - message
     Project:
       type: object
       properties:
@@ -101,31 +82,10 @@ components:
           type: string
         name:
           type: string
-    RawErrorResponse:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable error code
-        message:
-          type: string
-          description: Human-readable error message
-      required:
-        - code
-        - message
-    SuccessResponse:
-      type: object
-      properties:
-        data:
-          type: object
-          description: Response data
-        meta:
-          type: object
-          properties:
-            timestamp:
-              type: string
-              format: date-time
-              description: RFC3339 response timestamp
-            traceId:
-              type: string
-              description: W3C trace identifier for the request
+  securitySchemes:
+    TenantID:
+      type: apiKey
+      in: header
+      name: X-Tenant-ID
+security:
+  - TenantID: []

--- a/tools/openapi/internal/spectest/testdata/nested_schema/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/nested_schema/expected.yaml
@@ -3,10 +3,13 @@ info:
   title: Catalog API
   version: 1.0.0
   description: Generated API specification
+servers:
+  - url: /
+    description: Relative to the deployment host
 paths:
   /categories:
     get:
-      operationId: listCategories
+      operationId: catalogListCategories
       summary: GET /categories
       tags:
         - categories
@@ -44,7 +47,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /users:
     post:
-      operationId: createUser
+      operationId: catalogCreateUser
       summary: POST /users
       tags:
         - users
@@ -139,46 +142,6 @@ components:
           description: Response metadata
       required:
         - error
-    JOSEErrorEnvelope:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
-        message:
-          type: string
-          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
-      required:
-        - code
-        - message
-    RawErrorResponse:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable error code
-        message:
-          type: string
-          description: Human-readable error message
-      required:
-        - code
-        - message
-    SuccessResponse:
-      type: object
-      properties:
-        data:
-          type: object
-          description: Response data
-        meta:
-          type: object
-          properties:
-            timestamp:
-              type: string
-              format: date-time
-              description: RFC3339 response timestamp
-            traceId:
-              type: string
-              description: W3C trace identifier for the request
     User:
       type: object
       properties:
@@ -193,3 +156,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/User'
+  securitySchemes:
+    TenantID:
+      type: apiKey
+      in: header
+      name: X-Tenant-ID
+security:
+  - TenantID: []

--- a/tools/openapi/internal/spectest/testdata/package_func/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/package_func/expected.yaml
@@ -3,10 +3,13 @@ info:
   title: Health API
   version: 1.0.0
   description: Generated API specification
+servers:
+  - url: /
+    description: Relative to the deployment host
 paths:
   /ping:
     get:
-      operationId: ping
+      operationId: healthPing
       summary: GET /ping
       tags:
         - health
@@ -55,48 +58,15 @@ components:
           description: Response metadata
       required:
         - error
-    JOSEErrorEnvelope:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
-        message:
-          type: string
-          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
-      required:
-        - code
-        - message
     PingResponse:
       type: object
       properties:
         status:
           type: string
-    RawErrorResponse:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable error code
-        message:
-          type: string
-          description: Human-readable error message
-      required:
-        - code
-        - message
-    SuccessResponse:
-      type: object
-      properties:
-        data:
-          type: object
-          description: Response data
-        meta:
-          type: object
-          properties:
-            timestamp:
-              type: string
-              format: date-time
-              description: RFC3339 response timestamp
-            traceId:
-              type: string
-              description: W3C trace identifier for the request
+  securitySchemes:
+    TenantID:
+      type: apiKey
+      in: header
+      name: X-Tenant-ID
+security:
+  - TenantID: []

--- a/tools/openapi/internal/spectest/testdata/path_param/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/path_param/expected.yaml
@@ -3,10 +3,13 @@ info:
   title: Catalog API
   version: 1.0.0
   description: Generated API specification
+servers:
+  - url: /
+    description: Relative to the deployment host
 paths:
   /products/{id}:
     get:
-      operationId: getProduct
+      operationId: catalogGetProduct
       summary: GET /products/{id}
       tags:
         - catalog
@@ -74,29 +77,6 @@ components:
           description: Response metadata
       required:
         - error
-    GetProductReq:
-      type: object
-      properties:
-        iD:
-          type: integer
-          format: int64
-        page:
-          type: integer
-          format: int32
-      required:
-        - iD
-    JOSEErrorEnvelope:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
-        message:
-          type: string
-          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
-      required:
-        - code
-        - message
     Product:
       type: object
       properties:
@@ -105,31 +85,10 @@ components:
           format: int64
         name:
           type: string
-    RawErrorResponse:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable error code
-        message:
-          type: string
-          description: Human-readable error message
-      required:
-        - code
-        - message
-    SuccessResponse:
-      type: object
-      properties:
-        data:
-          type: object
-          description: Response data
-        meta:
-          type: object
-          properties:
-            timestamp:
-              type: string
-              format: date-time
-              description: RFC3339 response timestamp
-            traceId:
-              type: string
-              description: W3C trace identifier for the request
+  securitySchemes:
+    TenantID:
+      type: apiKey
+      in: header
+      name: X-Tenant-ID
+security:
+  - TenantID: []

--- a/tools/openapi/internal/spectest/testdata/raw_response/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/raw_response/expected.yaml
@@ -3,6 +3,9 @@ info:
   title: Legacy API
   version: 1.0.0
   description: Generated API specification
+servers:
+  - url: /
+    description: Relative to the deployment host
 paths:
   /jobs:
     post:
@@ -56,7 +59,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /legacy/users/{id}:
     get:
-      operationId: getLegacyUser
+      operationId: legacyGetLegacyUser
       summary: GET /legacy/users/{id}
       tags:
         - legacy
@@ -112,26 +115,6 @@ components:
           description: Response metadata
       required:
         - error
-    GetLegacyReq:
-      type: object
-      properties:
-        iD:
-          type: integer
-          format: int64
-      required:
-        - iD
-    JOSEErrorEnvelope:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
-        message:
-          type: string
-          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
-      required:
-        - code
-        - message
     JobAck:
       type: object
       properties:
@@ -157,19 +140,10 @@ components:
       required:
         - code
         - message
-    SuccessResponse:
-      type: object
-      properties:
-        data:
-          type: object
-          description: Response data
-        meta:
-          type: object
-          properties:
-            timestamp:
-              type: string
-              format: date-time
-              description: RFC3339 response timestamp
-            traceId:
-              type: string
-              description: W3C trace identifier for the request
+  securitySchemes:
+    TenantID:
+      type: apiKey
+      in: header
+      name: X-Tenant-ID
+security:
+  - TenantID: []

--- a/tools/openapi/internal/spectest/testdata/registration/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/registration/expected.yaml
@@ -3,10 +3,13 @@ info:
   title: Storefront API
   version: 1.0.0
   description: Generated API specification
+servers:
+  - url: /
+    description: Relative to the deployment host
 paths:
   /api/version:
     get:
-      operationId: version
+      operationId: storefrontVersion
       summary: GET /api/version
       tags:
         - ops
@@ -44,7 +47,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /health:
     get:
-      operationId: health
+      operationId: storefrontHealth
       summary: GET /health
       tags:
         - ops
@@ -82,7 +85,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /items:
     post:
-      operationId: createItem
+      operationId: storefrontCreateItem
       summary: POST /items
       tags:
         - items
@@ -126,7 +129,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /v1/admin/stats:
     get:
-      operationId: stats
+      operationId: storefrontStats
       summary: GET /v1/admin/stats
       tags:
         - admin
@@ -164,7 +167,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /v1/items:
     get:
-      operationId: listItems
+      operationId: storefrontListItems
       summary: GET /v1/items
       tags:
         - items
@@ -221,43 +224,10 @@ components:
           format: int64
         name:
           type: string
-    JOSEErrorEnvelope:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
-        message:
-          type: string
-          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
-      required:
-        - code
-        - message
-    RawErrorResponse:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable error code
-        message:
-          type: string
-          description: Human-readable error message
-      required:
-        - code
-        - message
-    SuccessResponse:
-      type: object
-      properties:
-        data:
-          type: object
-          description: Response data
-        meta:
-          type: object
-          properties:
-            timestamp:
-              type: string
-              format: date-time
-              description: RFC3339 response timestamp
-            traceId:
-              type: string
-              description: W3C trace identifier for the request
+  securitySchemes:
+    TenantID:
+      type: apiKey
+      in: header
+      name: X-Tenant-ID
+security:
+  - TenantID: []

--- a/tools/openapi/internal/spectest/testdata/simple/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/simple/expected.yaml
@@ -3,10 +3,13 @@ info:
   title: Simple API
   version: 1.0.0
   description: Generated API specification
+servers:
+  - url: /
+    description: Relative to the deployment host
 paths:
   /ping:
     get:
-      operationId: ping
+      operationId: apiPing
       summary: GET /ping
       tags:
         - health
@@ -44,7 +47,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /users:
     post:
-      operationId: createUser
+      operationId: apiCreateUser
       summary: Create a user
       tags:
         - users
@@ -124,46 +127,6 @@ components:
           description: Response metadata
       required:
         - error
-    JOSEErrorEnvelope:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
-        message:
-          type: string
-          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
-      required:
-        - code
-        - message
-    RawErrorResponse:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable error code
-        message:
-          type: string
-          description: Human-readable error message
-      required:
-        - code
-        - message
-    SuccessResponse:
-      type: object
-      properties:
-        data:
-          type: object
-          description: Response data
-        meta:
-          type: object
-          properties:
-            timestamp:
-              type: string
-              format: date-time
-              description: RFC3339 response timestamp
-            traceId:
-              type: string
-              description: W3C trace identifier for the request
     User:
       type: object
       properties:
@@ -174,3 +137,10 @@ components:
           format: int64
         name:
           type: string
+  securitySchemes:
+    TenantID:
+      type: apiKey
+      in: header
+      name: X-Tenant-ID
+security:
+  - TenantID: []

--- a/tools/openapi/internal/spectest/testdata/well_known/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/well_known/expected.yaml
@@ -3,10 +3,13 @@ info:
   title: Events API
   version: 1.0.0
   description: Generated API specification
+servers:
+  - url: /
+    description: Relative to the deployment host
 paths:
   /events/{id}:
     get:
-      operationId: getEvent
+      operationId: eventsGetEvent
       summary: GET /events/{id}
       tags:
         - events
@@ -108,50 +111,10 @@ components:
           type: object
         ttl:
           type: integer
-    GetEventReq:
-      type: object
-      properties:
-        iD:
-          type: string
-      required:
-        - iD
-    JOSEErrorEnvelope:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable JOSE error code (e.g., JOSE_DECRYPT_FAILED, JOSE_SIGNATURE_INVALID, JOSE_KID_UNKNOWN)
-        message:
-          type: string
-          description: Constant-time generic message — never reveals which key was tried or which library detected the failure
-      required:
-        - code
-        - message
-    RawErrorResponse:
-      type: object
-      properties:
-        code:
-          type: string
-          description: Machine-readable error code
-        message:
-          type: string
-          description: Human-readable error message
-      required:
-        - code
-        - message
-    SuccessResponse:
-      type: object
-      properties:
-        data:
-          type: object
-          description: Response data
-        meta:
-          type: object
-          properties:
-            timestamp:
-              type: string
-              format: date-time
-              description: RFC3339 response timestamp
-            traceId:
-              type: string
-              description: W3C trace identifier for the request
+  securitySchemes:
+    TenantID:
+      type: apiKey
+      in: header
+      name: X-Tenant-ID
+security:
+  - TenantID: []

--- a/tools/openapi/redocly.yaml
+++ b/tools/openapi/redocly.yaml
@@ -8,14 +8,18 @@
 # Rules covering spec features the generator does not emit YET are relaxed here
 # and re-enabled by the PR that implements the feature, so the gate tightens
 # over time without ever blocking an intermediate, self-contained PR:
-#   no-empty-servers    -> re-enable when a `servers:` block is emitted (PR10)
-#   security-defined     -> re-enable when security schemes are emitted (PR10)
-#   no-unused-components -> re-enable when JOSEErrorEnvelope is gated (PR10)
-#   info-license         -> re-enable when --license is supported (PR12)
+#   no-empty-servers / security-defined / no-unused-components -> re-enabled in
+#     PR10 (servers block, X-Tenant-ID security scheme, gated standard schemas +
+#     params-only component skip).
+#   info-license -> re-enable when --license is supported (PR12)
+#
+# Note on no-unused-components + JOSE: a JOSE route's plaintext request/response
+# component is referenced from the RequestBody/Response *description* (the wire is
+# an opaque application/jose token, so a real $ref would misrepresent the shape).
+# redocly counts $ref nodes only, so it emits a WARNING (not an error) for those
+# plaintext components on JOSE specs — by design; the component documents the
+# decrypted shape. The standard schemas and all non-JOSE specs are clean.
 extends:
   - recommended
 rules:
-  no-empty-servers: off
-  security-defined: off
-  no-unused-components: off
   info-license: off


### PR DESCRIPTION
## PR10 — Conformance: servers, X-Tenant-ID security, module-qualified operationIds, schema gating

Tenth PR in the OpenAPI-tool gap initiative. Closes the remaining redocly conformance gaps and **re-enables three gate rules** (`no-empty-servers`, `security-defined`, `no-unused-components`).

### What changed
- **servers:** a relative-root default block (concrete `--server` URL is a PR11 flag).
- **security:** an apiKey-in-header scheme for `X-Tenant-ID` + root-level security; structured so bearer/oauth slot in later.
- **operationIds:** module-qualified (`users` + `GetUser` → `usersGetUser`), deterministic numeric-suffix de-dup (sorted, first-wins per method+path), and an explicit `WithHandlerName` id used as-is. `WithHandlerName` now sets a distinct `Route.OperationID` (not the handler method name).
- **Standard-schema gating:** `SuccessResponse`/`JOSEErrorEnvelope`/`RawErrorResponse` emitted only when referenced; `ErrorResponse` only for non-JOSE/non-raw routes. The per-route error schema comes from a shared `errorSchemaName()` so the gate and `buildResponses` can't diverge.
- **Params-only request structs** (only `path`/`query`/`header` tags) are no longer emitted as components — unless referenced elsewhere (guards against a dangling `$ref`). *Closes the params-only finding that recurred since PR8.*

### Surfaced by `/code-review` (fixed)
- `byKey` last-wins vs `assignOperation` first-wins → operationId mislabel on duplicate method+path (now first-wins).
- A params-only type that is *also* referenced (e.g. reused as a response) → guarded with a referenced-set so the `$ref` resolves.
- Gate/`buildResponses` error-schema duplication → unified into `errorSchemaName`.

### Known caveat (documented in redocly.yaml)
`no-unused-components` is WARN-level and still warns on a JOSE route's *plaintext* request/response components — those are referenced in the RequestBody/Response **description prose**, not a `$ref`, because the wire is an opaque `application/jose` token (a real `$ref` would misrepresent the shape). By design; the standard schemas and all non-JOSE specs are clean.

### Validation
- `make check` green; tool coverage **91.1%**.
- All 13 fixtures validate through in-process **kin-openapi** + the pinned **redocly** gate with the three rules re-enabled.

Part of the roadmap in `.claude/tasks/openapi-tool-gap-analysis.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added X-Tenant-ID API key authentication requirement to all OpenAPI endpoints
  * Support for explicit operationID customization in route metadata

* **Bug Fixes**
  * Improved OpenAPI schema generation to exclude unused component schemas
  * Fixed operationID assignment to be deterministic and collision-free

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->