### PR TITLE
feat(openapi): deepen validator-constraint coverage (PR11)

### DIFF
--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -1943,7 +1943,7 @@ func (a *ProjectAnalyzer) registerFieldRef(f *models.FieldInfo, pkg string, astF
 // scalar underlying type to their OpenAPI kind. (time.Time is a struct handled by
 // the generator's well-known map, so it is intentionally absent.)
 var knownUnderlyingKinds = map[string]string{
-	"time.Duration": "integer",
+	"time.Duration": kindInteger,
 }
 
 // resolveUnderlyingKind returns the OpenAPI 3-way kind ("integer"/"number"/
@@ -1994,7 +1994,7 @@ func (a *ProjectAnalyzer) namedScalarKind(name string, astFile *ast.File, filePa
 func primitiveKind(goType string) string {
 	switch {
 	case isIntegerType(goType):
-		return "integer"
+		return kindInteger
 	case isFloatType(goType):
 		return "number"
 	case isStringType(goType):
@@ -2336,10 +2336,10 @@ func (a *ProjectAnalyzer) parseFieldTags(fieldInfo *models.FieldInfo, tag *ast.B
 	fieldInfo.Example = tags.example
 	fieldInfo.RawValidation = tags.rawValidation
 
-	// Parse validation constraints
+	// Parse validation constraints (collection-scope) plus element-scope rules
+	// after a `dive`. Required is always collection-scope.
 	if tags.rawValidation != "" {
-		fieldInfo.Constraints = a.parseValidationTag(tags.rawValidation)
-		// Set Required flag based on constraints
+		fieldInfo.Constraints, fieldInfo.ElementConstraints = a.parseValidationTag(tags.rawValidation)
 		if fieldInfo.Constraints[constraintRequired] == boolTrueString {
 			fieldInfo.Required = true
 		}
@@ -2489,30 +2489,42 @@ func (a *ProjectAnalyzer) extractTag(tagStr, tagName string) string {
 
 // parseValidationTag parses a validation tag string into a constraints map
 // Example: "required,email,min=5,max=100" -> {"required": "true", "email": "true", "min": "5", "max": "100"}
-func (a *ProjectAnalyzer) parseValidationTag(validateTag string) map[string]string {
-	constraints := make(map[string]string)
+// parseValidationTag parses a validate tag into collection-scope constraints and
+// (when a `dive` token is present) element-scope constraints. Rules before `dive`
+// apply to the field/collection; rules after apply to each slice element. The
+// `dive` token itself is not stored. elementConstraints is nil when there is no
+// `dive`. A second (nested) `dive` is ignored — element scope is kept flat.
+func (a *ProjectAnalyzer) parseValidationTag(validateTag string) (constraints, elementConstraints map[string]string) {
+	constraints = make(map[string]string)
 	if validateTag == "" {
-		return constraints
+		return constraints, nil
 	}
 
-	// Split by comma
-	rules := strings.Split(validateTag, ",")
-	for _, rule := range rules {
+	inElement := false
+	for _, rule := range strings.Split(validateTag, ",") {
 		rule = strings.TrimSpace(rule)
 		if rule == "" {
 			continue
 		}
+		if rule == "dive" {
+			if !inElement {
+				inElement = true
+				elementConstraints = make(map[string]string)
+			}
+			continue
+		}
 
-		// Check if rule has a value (e.g., "min=5")
+		target := constraints
+		if inElement {
+			target = elementConstraints
+		}
+		// Check if rule has a value (e.g., "min=5"); else a boolean constraint.
 		if equalIdx := strings.IndexByte(rule, '='); equalIdx != -1 {
-			key := rule[:equalIdx]
-			value := rule[equalIdx+1:]
-			constraints[key] = value
+			target[rule[:equalIdx]] = rule[equalIdx+1:]
 		} else {
-			// Boolean constraint (e.g., "required", "email")
-			constraints[rule] = boolTrueString
+			target[rule] = boolTrueString
 		}
 	}
 
-	return constraints
+	return constraints, elementConstraints
 }

--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -2514,16 +2514,18 @@ func (a *ProjectAnalyzer) parseValidationTag(validateTag string) (constraints, e
 			continue
 		}
 
+		key, value := rule, boolTrueString
+		if equalIdx := strings.IndexByte(rule, '='); equalIdx != -1 {
+			key, value = rule[:equalIdx], rule[equalIdx+1:]
+		}
+		// `required` is always collection-scope (field presence), even after `dive`
+		// — OpenAPI has no per-element required, and Required must not be silently
+		// dropped onto the element map.
 		target := constraints
-		if inElement {
+		if inElement && key != constraintRequired {
 			target = elementConstraints
 		}
-		// Check if rule has a value (e.g., "min=5"); else a boolean constraint.
-		if equalIdx := strings.IndexByte(rule, '='); equalIdx != -1 {
-			target[rule[:equalIdx]] = rule[equalIdx+1:]
-		} else {
-			target[rule] = boolTrueString
-		}
+		target[key] = value
 	}
 
 	return constraints, elementConstraints

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -4113,6 +4113,11 @@ func TestParseValidationTagDive(t *testing.T) {
 	assert.Equal(t, map[string]string{"min": "1"}, c)
 	assert.Equal(t, map[string]string{"email": "true"}, e)
 
+	// `required` is always collection-scope, even after dive (must not be lost).
+	c, e = a.parseValidationTag("dive,required,email")
+	assert.Equal(t, "true", c["required"], "required after dive stays collection-scope")
+	assert.Equal(t, map[string]string{"email": "true"}, e, "other post-dive rules stay element-scope")
+
 	c, e = a.parseValidationTag("")
 	assert.Empty(t, c)
 	assert.Nil(t, e)

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -4091,3 +4091,29 @@ func TestLocalTypeUnderlyingSiblingFile(t *testing.T) {
 	_, ok = a.localTypeUnderlying("Missing", af, aPath)
 	assert.False(t, ok)
 }
+
+// TestParseValidationTagDive covers the collection/element scope split at `dive`.
+func TestParseValidationTagDive(t *testing.T) {
+	a := New(t.TempDir())
+
+	c, e := a.parseValidationTag("min=1,dive,email")
+	assert.Equal(t, map[string]string{"min": "1"}, c, "rules before dive are collection-scope")
+	assert.Equal(t, map[string]string{"email": "true"}, e, "rules after dive are element-scope")
+
+	c, e = a.parseValidationTag("dive,gte=0")
+	assert.Empty(t, c, "no collection rules")
+	assert.Equal(t, map[string]string{"gte": "0"}, e)
+
+	c, e = a.parseValidationTag("required,min=2")
+	assert.Equal(t, map[string]string{"required": "true", "min": "2"}, c)
+	assert.Nil(t, e, "no dive -> nil element constraints")
+
+	// Nested dive is ignored: element scope stays flat, no crash.
+	c, e = a.parseValidationTag("min=1,dive,dive,email")
+	assert.Equal(t, map[string]string{"min": "1"}, c)
+	assert.Equal(t, map[string]string{"email": "true"}, e)
+
+	c, e = a.parseValidationTag("")
+	assert.Empty(t, c)
+	assert.Nil(t, e)
+}

--- a/tools/openapi/internal/analyzer/constraints.go
+++ b/tools/openapi/internal/analyzer/constraints.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -13,20 +14,33 @@ type OpenAPIConstraint struct {
 
 const (
 	// OpenAPI constraint property names
-	constraintFormat    = "format"
-	constraintMinLength = "minLength"
-	constraintMaxLength = "maxLength"
-	constraintMinimum   = "minimum"
-	constraintMaximum   = "maximum"
-	constraintEnum      = "enum"
+	constraintFormat           = "format"
+	constraintMinLength        = "minLength"
+	constraintMaxLength        = "maxLength"
+	constraintMinimum          = "minimum"
+	constraintMaximum          = "maximum"
+	constraintMinItems         = "minItems"
+	constraintMaxItems         = "maxItems"
+	constraintEnum             = "enum"
+	constraintPattern          = "pattern"
+	constraintExclusiveMinimum = "exclusiveMinimum"
+	constraintExclusiveMaximum = "exclusiveMaximum"
 
 	// Validator tag values
-	validatorOneOf = "oneof"
+	validatorOneOf    = "oneof"
+	validatorDatetime = "datetime"
 
 	// OpenAPI format values
-	formatEmail = "email"
-	formatUUID  = "uuid"
-	formatDate  = "date"
+	formatEmail    = "email"
+	formatUUID     = "uuid"
+	formatDate     = "date"
+	formatDateTime = "date-time"
+	formatByte     = "byte"
+	formatIPv4     = "ipv4"
+
+	// OpenAPI 3-way kind values (also the values of FieldInfo.UnderlyingKind).
+	kindInteger = "integer"
+	kindNumber  = "number"
 
 	// Go primitive type names referenced for type discrimination
 	goTypeInt64   = "int64"
@@ -36,36 +50,55 @@ const (
 
 // MapConstraintToOpenAPI converts validation constraints to OpenAPI schema properties
 // Takes the field type and constraints map, returns OpenAPI-compatible constraints
-func MapConstraintToOpenAPI(fieldType string, constraints map[string]string) []OpenAPIConstraint {
+func MapConstraintToOpenAPI(fieldType, underlyingKind string, constraints map[string]string) []OpenAPIConstraint {
 	var result []OpenAPIConstraint
 
-	// Determine base type (strip pointer prefix if present)
 	baseType := strings.TrimPrefix(fieldType, "*")
+	// []byte/[]uint8 are well-known base64 string types, not arrays — treat them as
+	// scalars (the well-known mapper already types them string/binary), not slices.
+	// Their min/max are byte counts, which do NOT equal the base64-encoded character
+	// length, so we deliberately drop length bounds on them rather than emit a wrong
+	// minLength/maxLength. Maps likewise carry no cardinality here (effectiveKind is
+	// "" for a map type, so min/max are dropped); minProperties/maxProperties support
+	// is tracked as a follow-up.
+	isSlice := isSliceType(fieldType) && !isByteSlice(baseType)
+	effKind := effectiveKind(baseType, underlyingKind)
 
 	for key, value := range constraints {
-		// Skip required - handled at schema level
 		if key == constraintRequired {
+			continue // handled at schema level
+		}
+
+		// Slice fields: only cardinality (min/max/len -> minItems/maxItems) applies
+		// to the array itself; element rules arrive via ElementConstraints + dive.
+		if isSlice {
+			if h := handleSliceCardinality(key, value); h != nil {
+				result = append(result, h...)
+			}
 			continue
 		}
 
-		// Try each constraint handler in sequence
-		var handled []OpenAPIConstraint
-
-		handled = handleFormatConstraint(key)
+		handled := handleFormatConstraint(key, value)
 		if handled == nil {
-			handled = handleMinConstraint(key, value, baseType)
+			handled = handlePatternFormatConstraint(key, value)
 		}
 		if handled == nil {
-			handled = handleMaxConstraint(key, value, baseType)
+			handled = handleMinConstraint(key, value, effKind)
 		}
 		if handled == nil {
-			handled = handleLenConstraint(key, value, baseType)
+			handled = handleMaxConstraint(key, value, effKind)
 		}
 		if handled == nil {
-			handled = handleNumericComparison(key, value, baseType)
+			handled = handleLenConstraint(key, value, effKind)
 		}
 		if handled == nil {
-			handled = handleEnumConstraint(key, value, baseType)
+			handled = handleNumericComparison(key, value, effKind)
+		}
+		if handled == nil {
+			handled = handleEnumConstraint(key, value, effKind)
+		}
+		if handled == nil {
+			handled = handleEqConstraint(key, value, effKind)
 		}
 		if handled == nil {
 			handled = handlePatternConstraint(key, value)
@@ -77,154 +110,307 @@ func MapConstraintToOpenAPI(fieldType string, constraints map[string]string) []O
 	return result
 }
 
-// handleFormatConstraint maps format validation tags to OpenAPI format constraints
-func handleFormatConstraint(key string) []OpenAPIConstraint {
-	formatMap := map[string]string{
-		formatEmail: formatEmail,
-		"url":       "uri",
-		"uri":       "uri",
-		formatUUID:  formatUUID,
-		"uuid4":     formatUUID,
-		formatDate:  formatDate,
-		"datetime":  "date-time",
+// effectiveKind resolves the OpenAPI 3-way kind to drive string-vs-numeric
+// decisions: the analyzer-resolved UnderlyingKind (for named scalars like
+// `type Cents int64` / time.Duration) wins; otherwise it is derived from the
+// builtin base type. Empty when the type is neither string nor numeric.
+func effectiveKind(baseType, underlyingKind string) string {
+	if underlyingKind != "" {
+		return underlyingKind
 	}
+	switch {
+	case isStringType(baseType):
+		return goTypeString
+	case isIntegerType(baseType):
+		return kindInteger
+	case isFloatType(baseType):
+		return kindNumber
+	}
+	return ""
+}
 
-	if format, ok := formatMap[key]; ok {
+func isEffectiveString(k string) bool  { return k == goTypeString }
+func isEffectiveNumeric(k string) bool { return k == kindInteger || k == kindNumber }
+
+// isByteSlice reports whether t is []byte/[]uint8 (a base64 string, not an array).
+func isByteSlice(t string) bool { return t == "[]byte" || t == "[]uint8" }
+
+// isSliceType reports whether t denotes a slice (after an optional leading
+// pointer). Twin of generator.isSliceType — keep in sync.
+func isSliceType(t string) bool {
+	return strings.HasPrefix(strings.TrimPrefix(t, "*"), "[]")
+}
+
+// formatTagMap maps boolean validator format tags to their OpenAPI `format`.
+var formatTagMap = map[string]string{
+	formatEmail: formatEmail,
+	"url":       "uri",
+	"uri":       "uri",
+	formatUUID:  formatUUID,
+	"uuid4":     formatUUID,
+	formatDate:  formatDate,
+	formatIPv4:  formatIPv4,
+	"ipv6":      "ipv6",
+	"hostname":  "hostname",
+	"base64":    formatByte,
+}
+
+// handleFormatConstraint maps boolean format tags to OpenAPI `format`. datetime is
+// value-aware: a date-only layout maps to `date`, otherwise `date-time`.
+func handleFormatConstraint(key, value string) []OpenAPIConstraint {
+	if key == validatorDatetime {
+		if value == "" || value == boolTrueString {
+			return []OpenAPIConstraint{{Name: constraintFormat, Value: formatDateTime}}
+		}
+		return []OpenAPIConstraint{{Name: constraintFormat, Value: datetimeFormat(value)}}
+	}
+	if format, ok := formatTagMap[key]; ok {
 		return []OpenAPIConstraint{{Name: constraintFormat, Value: format}}
 	}
 	return nil
 }
 
-// handleMinConstraint maps 'min' constraint to minLength (strings) or minimum (numbers)
-func handleMinConstraint(key, value, baseType string) []OpenAPIConstraint {
+// stringContentPatterns maps boolean string-content tags to a canonical anchored
+// regex. JSON-Schema `pattern` is documentation-grade here (kin-openapi/redocly
+// accept arbitrary regex), so these mirror validator/v10 semantics closely.
+var stringContentPatterns = map[string]string{
+	"alpha":    `^[a-zA-Z]+$`,
+	"alphanum": `^[a-zA-Z0-9]+$`,
+	"numeric":  `^[-+]?[0-9]+(?:\.[0-9]+)?$`,
+	"hexcolor": `^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$`,
+	"e164":     `^\+[1-9]\d{1,14}$`,
+}
+
+// handlePatternFormatConstraint maps string-content tags to a `pattern`. Boolean
+// tags (alpha/alphanum/numeric/hexcolor/e164) use a fixed anchored regex;
+// value-bearing tags (contains/startswith/endswith) build an (un)anchored pattern
+// from the QuoteMeta-escaped literal. Bare `ip` is intentionally left
+// unconstrained: there is no single OpenAPI format for "IPv4 or IPv6" and a
+// correct combined regex is huge/error-prone, so we document the type as string
+// with no pattern rather than over- or mis-constrain it (covered by a test).
+func handlePatternFormatConstraint(key, value string) []OpenAPIConstraint {
+	if p, ok := stringContentPatterns[key]; ok {
+		return []OpenAPIConstraint{{Name: constraintPattern, Value: p}}
+	}
+	if value == "" {
+		return nil
+	}
+	switch key {
+	case "contains":
+		return []OpenAPIConstraint{{Name: constraintPattern, Value: regexp.QuoteMeta(value)}}
+	case "startswith":
+		return []OpenAPIConstraint{{Name: constraintPattern, Value: "^" + regexp.QuoteMeta(value)}}
+	case "endswith":
+		return []OpenAPIConstraint{{Name: constraintPattern, Value: regexp.QuoteMeta(value) + "$"}}
+	}
+	return nil
+}
+
+// handleMinConstraint maps 'min' to minLength (strings) or minimum (numbers).
+func handleMinConstraint(key, value, effKind string) []OpenAPIConstraint {
 	if key != "min" {
 		return nil
 	}
-
-	if isStringType(baseType) {
+	if isEffectiveString(effKind) {
 		if length, err := strconv.Atoi(value); err == nil {
 			return []OpenAPIConstraint{{Name: constraintMinLength, Value: length}}
 		}
-	} else if isNumericType(baseType) {
-		//nolint:S8148 // NOSONAR: Parse errors intentionally ignored - invalid validation tag values are silently skipped
+	} else if isEffectiveNumeric(effKind) {
+		//nolint:S8148 // NOSONAR: invalid validation tag values are silently skipped
 		if minVal, err := parseNumeric(value); err == nil {
 			return []OpenAPIConstraint{{Name: constraintMinimum, Value: minVal}}
 		}
 	}
-
 	return nil
 }
 
-// handleMaxConstraint maps 'max' constraint to maxLength (strings) or maximum (numbers)
-func handleMaxConstraint(key, value, baseType string) []OpenAPIConstraint {
+// handleMaxConstraint maps 'max' to maxLength (strings) or maximum (numbers).
+func handleMaxConstraint(key, value, effKind string) []OpenAPIConstraint {
 	if key != "max" {
 		return nil
 	}
-
-	if isStringType(baseType) {
+	if isEffectiveString(effKind) {
 		if length, err := strconv.Atoi(value); err == nil {
 			return []OpenAPIConstraint{{Name: constraintMaxLength, Value: length}}
 		}
-	} else if isNumericType(baseType) {
-		//nolint:S8148 // NOSONAR: Parse errors intentionally ignored - invalid validation tag values are silently skipped
+	} else if isEffectiveNumeric(effKind) {
+		//nolint:S8148 // NOSONAR: invalid validation tag values are silently skipped
 		if maxVal, err := parseNumeric(value); err == nil {
 			return []OpenAPIConstraint{{Name: constraintMaximum, Value: maxVal}}
 		}
 	}
-
 	return nil
 }
 
-// handleLenConstraint maps 'len' constraint to exact length (minLength + maxLength)
-func handleLenConstraint(key, value, baseType string) []OpenAPIConstraint {
-	if key != "len" || !isStringType(baseType) {
+// handleLenConstraint maps 'len' on a string to an exact length (minLength == maxLength).
+func handleLenConstraint(key, value, effKind string) []OpenAPIConstraint {
+	if key != "len" || !isEffectiveString(effKind) {
 		return nil
 	}
-
 	length, err := strconv.Atoi(value)
 	if err != nil {
 		return nil
 	}
-
 	return []OpenAPIConstraint{
 		{Name: constraintMinLength, Value: length},
 		{Name: constraintMaxLength, Value: length},
 	}
 }
 
-// handleNumericComparison maps gt/gte/lt/lte constraints to OpenAPI range constraints
-func handleNumericComparison(key, value, baseType string) []OpenAPIConstraint {
-	if !isNumericType(baseType) {
+// handleNumericComparison maps gt/gte/lt/lte: range constraints for numerics, and
+// minLength/maxLength for strings (a string comparison constrains its length).
+func handleNumericComparison(key, value, effKind string) []OpenAPIConstraint {
+	if isEffectiveString(effKind) {
+		return handleStringLengthComparison(key, value)
+	}
+	if !isEffectiveNumeric(effKind) {
 		return nil
 	}
-
 	numVal, err := parseNumeric(value)
 	if err != nil {
 		return nil
 	}
-
 	switch key {
 	case "gt":
-		// gt (greater than) becomes minimum with exclusiveMinimum
-		return []OpenAPIConstraint{
-			{Name: constraintMinimum, Value: numVal},
-			{Name: "exclusiveMinimum", Value: true},
-		}
+		return []OpenAPIConstraint{{Name: constraintMinimum, Value: numVal}, {Name: constraintExclusiveMinimum, Value: true}}
 	case "gte":
 		return []OpenAPIConstraint{{Name: constraintMinimum, Value: numVal}}
 	case "lt":
-		// lt (less than) becomes maximum with exclusiveMaximum
-		return []OpenAPIConstraint{
-			{Name: constraintMaximum, Value: numVal},
-			{Name: "exclusiveMaximum", Value: true},
-		}
+		return []OpenAPIConstraint{{Name: constraintMaximum, Value: numVal}, {Name: constraintExclusiveMaximum, Value: true}}
 	case "lte":
 		return []OpenAPIConstraint{{Name: constraintMaximum, Value: numVal}}
 	}
-
 	return nil
 }
 
-// handleEnumConstraint maps 'oneof' constraint to OpenAPI enum array
-// For numeric types, parses values as numbers; otherwise treats as strings
-func handleEnumConstraint(key, value, baseType string) []OpenAPIConstraint {
+// handleStringLengthComparison maps gt/gte/lt/lte on a string field to
+// minLength/maxLength (gt=N -> minLength N+1, lt=N -> maxLength N-1), clamped to
+// non-negative so the emitted bound stays valid OpenAPI.
+func handleStringLengthComparison(key, value string) []OpenAPIConstraint {
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return nil
+	}
+	switch key {
+	case "gt":
+		return []OpenAPIConstraint{{Name: constraintMinLength, Value: clampNonNeg(n + 1)}}
+	case "gte":
+		return []OpenAPIConstraint{{Name: constraintMinLength, Value: clampNonNeg(n)}}
+	case "lt":
+		return []OpenAPIConstraint{{Name: constraintMaxLength, Value: clampNonNeg(n - 1)}}
+	case "lte":
+		return []OpenAPIConstraint{{Name: constraintMaxLength, Value: clampNonNeg(n)}}
+	}
+	return nil
+}
+
+func clampNonNeg(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+// handleSliceCardinality maps min/max/len on a slice field to minItems/maxItems.
+func handleSliceCardinality(key, value string) []OpenAPIConstraint {
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return nil
+	}
+	switch key {
+	case "min":
+		return []OpenAPIConstraint{{Name: constraintMinItems, Value: n}}
+	case "max":
+		return []OpenAPIConstraint{{Name: constraintMaxItems, Value: n}}
+	case "len":
+		return []OpenAPIConstraint{{Name: constraintMinItems, Value: n}, {Name: constraintMaxItems, Value: n}}
+	}
+	return nil
+}
+
+// handleEnumConstraint maps 'oneof' to an enum array, numeric-coercing values for
+// numeric fields. Tokenization is quote-aware so single-quoted multi-word values
+// (oneof='New York' 'Los Angeles') stay intact.
+func handleEnumConstraint(key, value, effKind string) []OpenAPIConstraint {
 	if key != validatorOneOf {
 		return nil
 	}
-
-	// Parse space-separated values into enum array
-	enumValues := strings.Fields(value)
-	if len(enumValues) == 0 {
+	tokens := tokenizeOneOf(value)
+	if len(tokens) == 0 {
 		return nil
 	}
-
-	// Convert to []any; parse numerics when field is numeric
-	enumArray := make([]any, len(enumValues))
-	if isNumericType(baseType) {
-		for i, v := range enumValues {
-			//nolint:S8148 // NOSONAR: Parse errors intentionally fall back to string value
-			if num, err := parseNumeric(v); err == nil {
-				enumArray[i] = num
-			} else {
-				// Fallback to string if parsing fails
-				enumArray[i] = v
-			}
-		}
-	} else {
-		for i, v := range enumValues {
-			enumArray[i] = v
-		}
-	}
-
-	return []OpenAPIConstraint{{Name: constraintEnum, Value: enumArray}}
+	return []OpenAPIConstraint{{Name: constraintEnum, Value: coerceEnum(tokens, effKind)}}
 }
 
-// handlePatternConstraint maps 'regexp' constraint to OpenAPI pattern
+// handleEqConstraint maps 'eq=<v>' to a single-element enum (the cleanest OpenAPI
+// expression of equality). 'ne' has no clean scalar representation and is dropped.
+func handleEqConstraint(key, value, effKind string) []OpenAPIConstraint {
+	if key != "eq" {
+		return nil
+	}
+	return []OpenAPIConstraint{{Name: constraintEnum, Value: coerceEnum([]string{value}, effKind)}}
+}
+
+// coerceEnum converts enum tokens to []any, parsing numerics for numeric fields.
+func coerceEnum(tokens []string, effKind string) []any {
+	out := make([]any, len(tokens))
+	for i, v := range tokens {
+		if isEffectiveNumeric(effKind) {
+			//nolint:S8148 // NOSONAR: non-numeric tokens fall back to the string value
+			if num, err := parseNumeric(v); err == nil {
+				out[i] = num
+				continue
+			}
+		}
+		out[i] = v
+	}
+	return out
+}
+
+// tokenizeOneOf splits a oneof value on spaces outside single quotes, stripping the
+// quotes, so "'New York' 'Los Angeles'" -> ["New York", "Los Angeles"] and
+// "active pending" -> ["active", "pending"].
+func tokenizeOneOf(s string) []string {
+	var out []string
+	var b strings.Builder
+	inQuote := false
+	flush := func() {
+		if b.Len() > 0 {
+			out = append(out, b.String())
+			b.Reset()
+		}
+	}
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case c == '\'':
+			inQuote = !inQuote
+		case c == ' ' && !inQuote:
+			flush()
+		default:
+			b.WriteByte(c)
+		}
+	}
+	flush()
+	return out
+}
+
+// datetimeFormat inspects a Go time layout: a layout with no clock/time tokens is
+// date-only (-> "date"); anything with a clock/zone token is "date-time".
+func datetimeFormat(layout string) string {
+	for _, tok := range []string{"15", "03", "3:", "04", "05", ".000", "PM", "pm", "Z07", "-07", "-0700"} {
+		if strings.Contains(layout, tok) {
+			return formatDateTime
+		}
+	}
+	return formatDate
+}
+
+// handlePatternConstraint maps the 'regexp' tag to an OpenAPI pattern.
 func handlePatternConstraint(key, value string) []OpenAPIConstraint {
 	if key != "regexp" {
 		return nil
 	}
-	return []OpenAPIConstraint{{Name: "pattern", Value: value}}
+	return []OpenAPIConstraint{{Name: constraintPattern, Value: value}}
 }
 
 // isStringType checks if the type is a string type

--- a/tools/openapi/internal/analyzer/constraints.go
+++ b/tools/openapi/internal/analyzer/constraints.go
@@ -72,42 +72,36 @@ func MapConstraintToOpenAPI(fieldType, underlyingKind string, constraints map[st
 		// Slice fields: only cardinality (min/max/len -> minItems/maxItems) applies
 		// to the array itself; element rules arrive via ElementConstraints + dive.
 		if isSlice {
-			if h := handleSliceCardinality(key, value); h != nil {
-				result = append(result, h...)
-			}
+			result = append(result, handleSliceCardinality(key, value)...)
 			continue
 		}
-
-		handled := handleFormatConstraint(key, value)
-		if handled == nil {
-			handled = handlePatternFormatConstraint(key, value)
-		}
-		if handled == nil {
-			handled = handleMinConstraint(key, value, effKind)
-		}
-		if handled == nil {
-			handled = handleMaxConstraint(key, value, effKind)
-		}
-		if handled == nil {
-			handled = handleLenConstraint(key, value, effKind)
-		}
-		if handled == nil {
-			handled = handleNumericComparison(key, value, effKind)
-		}
-		if handled == nil {
-			handled = handleEnumConstraint(key, value, effKind)
-		}
-		if handled == nil {
-			handled = handleEqConstraint(key, value, effKind)
-		}
-		if handled == nil {
-			handled = handlePatternConstraint(key, value)
-		}
-
-		result = append(result, handled...)
+		result = append(result, dispatchScalarConstraint(key, value, effKind)...)
 	}
 
 	return result
+}
+
+// dispatchScalarConstraint routes a single (non-slice) constraint key to the first
+// matching handler. Order matters: format/pattern tags are tried before the
+// numeric/string handlers so a key is claimed by exactly one handler.
+func dispatchScalarConstraint(key, value, effKind string) []OpenAPIConstraint {
+	handlers := []func() []OpenAPIConstraint{
+		func() []OpenAPIConstraint { return handleFormatConstraint(key, value) },
+		func() []OpenAPIConstraint { return handlePatternFormatConstraint(key, value) },
+		func() []OpenAPIConstraint { return handleMinConstraint(key, value, effKind) },
+		func() []OpenAPIConstraint { return handleMaxConstraint(key, value, effKind) },
+		func() []OpenAPIConstraint { return handleLenConstraint(key, value, effKind) },
+		func() []OpenAPIConstraint { return handleNumericComparison(key, value, effKind) },
+		func() []OpenAPIConstraint { return handleEnumConstraint(key, value, effKind) },
+		func() []OpenAPIConstraint { return handleEqConstraint(key, value, effKind) },
+		func() []OpenAPIConstraint { return handlePatternConstraint(key, value) },
+	}
+	for _, h := range handlers {
+		if c := h(); c != nil {
+			return c
+		}
+	}
+	return nil
 }
 
 // effectiveKind resolves the OpenAPI 3-way kind to drive string-vs-numeric

--- a/tools/openapi/internal/analyzer/constraints_test.go
+++ b/tools/openapi/internal/analyzer/constraints_test.go
@@ -6,11 +6,12 @@ import (
 
 func TestMapConstraintToOpenAPI(t *testing.T) {
 	tests := []struct {
-		name        string
-		fieldType   string
-		constraints map[string]string
-		expected    []OpenAPIConstraint
-		description string
+		name           string
+		fieldType      string
+		underlyingKind string
+		constraints    map[string]string
+		expected       []OpenAPIConstraint
+		description    string
 	}{
 		{
 			name:        "email format",
@@ -43,7 +44,7 @@ func TestMapConstraintToOpenAPI(t *testing.T) {
 		{
 			name:        "datetime format",
 			fieldType:   "string",
-			constraints: map[string]string{"datetime": "true"},
+			constraints: map[string]string{validatorDatetime: "true"},
 			expected:    []OpenAPIConstraint{{Name: "format", Value: "date-time"}},
 			description: "should map datetime to date-time format",
 		},
@@ -112,7 +113,7 @@ func TestMapConstraintToOpenAPI(t *testing.T) {
 			constraints: map[string]string{"gt": "0"},
 			expected: []OpenAPIConstraint{
 				{Name: "minimum", Value: int64(0)},
-				{Name: "exclusiveMinimum", Value: true},
+				{Name: constraintExclusiveMinimum, Value: true},
 			},
 			description: "should map gt to exclusive minimum",
 		},
@@ -229,11 +230,183 @@ func TestMapConstraintToOpenAPI(t *testing.T) {
 			expected:    []OpenAPIConstraint{},
 			description: "should return empty array for no constraints",
 		},
+		// --- PR11: named-numeric via UnderlyingKind ---
+		{
+			name: "named integer min/max via UnderlyingKind", fieldType: "Cents", underlyingKind: kindInteger,
+			constraints: map[string]string{"min": "100", "max": "1000"},
+			expected:    []OpenAPIConstraint{{Name: "minimum", Value: int64(100)}, {Name: "maximum", Value: int64(1000)}},
+			description: "type Cents int64 must map numeric constraints (was dropped)",
+		},
+		{
+			name: "time.Duration gte via UnderlyingKind", fieldType: "time.Duration", underlyingKind: kindInteger,
+			constraints: map[string]string{"gte": "1"},
+			expected:    []OpenAPIConstraint{{Name: "minimum", Value: int64(1)}},
+			description: "time.Duration maps numeric constraints",
+		},
+		{
+			name: "named integer gt via UnderlyingKind", fieldType: "Cents", underlyingKind: kindInteger,
+			constraints: map[string]string{"gt": "0"},
+			expected:    []OpenAPIConstraint{{Name: "minimum", Value: int64(0)}, {Name: constraintExclusiveMinimum, Value: true}},
+			description: "gt on named numeric emits minimum + exclusiveMinimum",
+		},
+		{
+			name: "named integer oneof via UnderlyingKind", fieldType: "Status", underlyingKind: kindInteger,
+			constraints: map[string]string{"oneof": "1 2 3"},
+			expected:    []OpenAPIConstraint{{Name: "enum", Value: []any{int64(1), int64(2), int64(3)}}},
+			description: "oneof on named numeric yields numeric enum",
+		},
+		// --- PR11: string length comparisons ---
+		{
+			name: "string gt -> minLength+1", fieldType: "string",
+			constraints: map[string]string{"gt": "3"},
+			expected:    []OpenAPIConstraint{{Name: "minLength", Value: 4}},
+			description: "gt on string constrains length",
+		},
+		{
+			name: "string gt=0 non-empty idiom", fieldType: "string",
+			constraints: map[string]string{"gt": "0"},
+			expected:    []OpenAPIConstraint{{Name: "minLength", Value: 1}},
+			description: "gt=0 -> minLength 1",
+		},
+		{
+			name: "string lt -> maxLength-1", fieldType: "string",
+			constraints: map[string]string{"lt": "10"},
+			expected:    []OpenAPIConstraint{{Name: "maxLength", Value: 9}},
+			description: "lt on string constrains length",
+		},
+		{
+			name: "string gt negative clamps to 0", fieldType: "string",
+			constraints: map[string]string{"gt": "-5"},
+			expected:    []OpenAPIConstraint{{Name: "minLength", Value: 0}},
+			description: "negative length clamps to non-negative",
+		},
+		// --- PR11: slice cardinality ---
+		{
+			name: "slice min -> minItems", fieldType: "[]string",
+			constraints: map[string]string{"min": "1"},
+			expected:    []OpenAPIConstraint{{Name: "minItems", Value: 1}},
+			description: "min on []T maps to minItems",
+		},
+		{
+			name: "slice len -> minItems+maxItems", fieldType: "[]int",
+			constraints: map[string]string{"len": "3"},
+			expected:    []OpenAPIConstraint{{Name: "minItems", Value: 3}, {Name: "maxItems", Value: 3}},
+			description: "len on []T maps to minItems == maxItems",
+		},
+		{
+			name: "pointer slice min -> minItems", fieldType: "*[]string",
+			constraints: map[string]string{"min": "2"},
+			expected:    []OpenAPIConstraint{{Name: "minItems", Value: 2}},
+			description: "pointer-to-slice stripped, cardinality applies",
+		},
+		{
+			name: "byte slice is not an array", fieldType: "[]byte",
+			constraints: map[string]string{"min": "10"},
+			expected:    []OpenAPIConstraint{},
+			description: "[]byte is a base64 string, not a cardinality-bearing array",
+		},
+		// --- PR11: oneof quoting, eq, ne, datetime, formats, patterns ---
+		{
+			name: "oneof quoted multi-word", fieldType: "string",
+			constraints: map[string]string{"oneof": "'New York' 'Los Angeles'"},
+			expected:    []OpenAPIConstraint{{Name: "enum", Value: []any{"New York", "Los Angeles"}}},
+			description: "quote-aware oneof keeps spaces",
+		},
+		{
+			name: "oneof unquoted still splits", fieldType: "string",
+			constraints: map[string]string{"oneof": "active pending"},
+			expected:    []OpenAPIConstraint{{Name: "enum", Value: []any{"active", "pending"}}},
+			description: "unquoted oneof splits on spaces",
+		},
+		{
+			name: "eq -> single-element enum", fieldType: "string",
+			constraints: map[string]string{"eq": "GOLD"},
+			expected:    []OpenAPIConstraint{{Name: "enum", Value: []any{"GOLD"}}},
+			description: "eq maps to a single-value enum",
+		},
+		{
+			name: "ne -> nothing", fieldType: "string",
+			constraints: map[string]string{"ne": "X"},
+			expected:    []OpenAPIConstraint{},
+			description: "ne has no clean OpenAPI representation",
+		},
+		{
+			name: "datetime date-only layout -> date", fieldType: "string",
+			constraints: map[string]string{validatorDatetime: "2006-01-02"},
+			expected:    []OpenAPIConstraint{{Name: "format", Value: "date"}},
+			description: "date-only layout maps to format date",
+		},
+		{
+			name: "datetime with clock -> date-time", fieldType: "string",
+			constraints: map[string]string{validatorDatetime: "2006-01-02T15:04:05Z07:00"},
+			expected:    []OpenAPIConstraint{{Name: "format", Value: "date-time"}},
+			description: "layout with clock tokens maps to date-time",
+		},
+		{
+			name: "ipv4 format", fieldType: "string",
+			constraints: map[string]string{formatIPv4: "true"},
+			expected:    []OpenAPIConstraint{{Name: "format", Value: formatIPv4}},
+			description: "ipv4 maps to format ipv4",
+		},
+		{
+			name: "base64 -> byte format", fieldType: "string",
+			constraints: map[string]string{"base64": "true"},
+			expected:    []OpenAPIConstraint{{Name: "format", Value: "byte"}},
+			description: "base64 maps to OpenAPI byte format",
+		},
+		{
+			name: "alpha -> anchored pattern", fieldType: "string",
+			constraints: map[string]string{"alpha": "true"},
+			expected:    []OpenAPIConstraint{{Name: "pattern", Value: `^[a-zA-Z]+$`}},
+			description: "alpha maps to a letter-only pattern",
+		},
+		{
+			name: "startswith -> anchored escaped pattern", fieldType: "string",
+			constraints: map[string]string{"startswith": "a.b"},
+			expected:    []OpenAPIConstraint{{Name: "pattern", Value: `^a\.b`}},
+			description: "startswith escapes metacharacters and anchors at start",
+		},
+		{
+			name: "bare ip -> no format/pattern (documented)", fieldType: "string",
+			constraints: map[string]string{"ip": "true"},
+			expected:    []OpenAPIConstraint{},
+			description: "bare ip has no single clean OpenAPI format; left unconstrained by design",
+		},
+		{
+			name: "contains -> unanchored escaped pattern", fieldType: "string",
+			constraints: map[string]string{"contains": "a.b"},
+			expected:    []OpenAPIConstraint{{Name: "pattern", Value: `a\.b`}},
+			description: "contains escapes metacharacters, no anchors",
+		},
+		{
+			name: "endswith -> end-anchored escaped pattern", fieldType: "string",
+			constraints: map[string]string{"endswith": ".json"},
+			expected:    []OpenAPIConstraint{{Name: "pattern", Value: `\.json$`}},
+			description: "endswith escapes and anchors at end",
+		},
+		{
+			name: "string gte -> minLength", fieldType: "string",
+			constraints: map[string]string{"gte": "3"},
+			expected:    []OpenAPIConstraint{{Name: "minLength", Value: 3}},
+			description: "gte on string is a length floor",
+		},
+		{
+			name: "string lte -> maxLength", fieldType: "string",
+			constraints: map[string]string{"lte": "10"},
+			expected:    []OpenAPIConstraint{{Name: "maxLength", Value: 10}},
+			description: "lte on string is a length ceiling",
+		},
+		{
+			name: "slice max -> maxItems", fieldType: "[]string",
+			constraints: map[string]string{"max": "5"},
+			expected:    []OpenAPIConstraint{{Name: "maxItems", Value: 5}},
+			description: "max on []T maps to maxItems",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := MapConstraintToOpenAPI(tt.fieldType, tt.constraints)
+			result := MapConstraintToOpenAPI(tt.fieldType, tt.underlyingKind, tt.constraints)
 
 			if len(result) != len(tt.expected) {
 				t.Errorf("%s: expected %d constraints, got %d", tt.description, len(tt.expected), len(result))

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -123,6 +123,8 @@ type OpenAPIProperty struct {
 	Items                *OpenAPIProperty            `yaml:"items,omitempty"` // For arrays
 	MinLength            *int                        `yaml:"minLength,omitempty"`
 	MaxLength            *int                        `yaml:"maxLength,omitempty"`
+	MinItems             *int                        `yaml:"minItems,omitempty"` // For arrays (slice cardinality)
+	MaxItems             *int                        `yaml:"maxItems,omitempty"`
 	Minimum              *float64                    `yaml:"minimum,omitempty"`
 	Maximum              *float64                    `yaml:"maximum,omitempty"`
 	ExclusiveMinimum     *bool                       `yaml:"exclusiveMinimum,omitempty"`
@@ -1069,11 +1071,13 @@ func (g *OpenAPIGenerator) fieldInfoToProperty(field *models.FieldInfo) *OpenAPI
 		ref := &OpenAPIProperty{Ref: refPath(field.RefName)}
 		if isSliceType(field.Type) {
 			// The inner $ref must stand alone, but the array wrapper carries the
-			// field's documentation.
+			// field's documentation and cardinality (minItems/maxItems). Element-scope
+			// (dive) rules have nowhere valid to go on a $ref element, so they drop.
 			arr := &OpenAPIProperty{Type: typeArray, Items: ref, Description: field.Description}
 			if field.Example != "" {
 				arr.Example = field.Example
 			}
+			g.applyConstraints(arr, field)
 			return arr
 		}
 		return ref
@@ -1116,10 +1120,31 @@ func (g *OpenAPIGenerator) fieldInfoToProperty(field *models.FieldInfo) *OpenAPI
 	// Map Go type to OpenAPI type and format
 	g.setTypeAndFormat(prop, field.Type)
 
-	// Apply constraints from validation tags
+	// Apply collection/scalar constraints (incl. minItems/maxItems for slices),
+	// then element-scope (dive) constraints onto the array's items.
 	g.applyConstraints(prop, field)
+	g.applyElementConstraints(prop, field)
 
 	return prop
+}
+
+// applyElementConstraints maps a slice field's element-scope (post-`dive`) rules
+// onto prop.Items (e.g. `dive,email` -> items.format:email). No-op for non-slice
+// fields or when there are no element constraints.
+func (g *OpenAPIGenerator) applyElementConstraints(prop *OpenAPIProperty, field *models.FieldInfo) {
+	if len(field.ElementConstraints) == 0 || prop.Items == nil {
+		return
+	}
+	elemType := sliceElementType(field.Type)
+	for _, c := range analyzer.MapConstraintToOpenAPI(elemType, "", field.ElementConstraints) {
+		g.applyConstraint(prop.Items, c)
+	}
+}
+
+// sliceElementType strips a leading pointer and slice marker to expose the element
+// type ("[]string" -> "string", "*[]Address" -> "Address").
+func sliceElementType(goType string) string {
+	return strings.TrimPrefix(strings.TrimPrefix(goType, "*"), "[]")
 }
 
 // isSliceType reports whether a Go type string denotes a slice (after an
@@ -1252,8 +1277,9 @@ func (g *OpenAPIGenerator) applyConstraints(prop *OpenAPIProperty, field *models
 		return
 	}
 
-	// Use the constraint mapper from analyzer package
-	openAPIConstraints := analyzer.MapConstraintToOpenAPI(field.Type, field.Constraints)
+	// Use the constraint mapper from analyzer package; UnderlyingKind lets named
+	// scalars (type Cents int64, time.Duration) map numeric/string constraints.
+	openAPIConstraints := analyzer.MapConstraintToOpenAPI(field.Type, field.UnderlyingKind, field.Constraints)
 
 	// Apply each constraint using specialized applicators
 	for _, constraint := range openAPIConstraints {
@@ -1261,22 +1287,26 @@ func (g *OpenAPIGenerator) applyConstraints(prop *OpenAPIProperty, field *models
 	}
 }
 
-// applyConstraint routes a constraint to its specialized applicator
-func (g *OpenAPIGenerator) applyConstraint(prop *OpenAPIProperty, constraint analyzer.OpenAPIConstraint) {
-	// Map constraint names to applicator functions
-	applicators := map[string]func(*OpenAPIProperty, any){
-		"format":           applyFormatConstraint,
-		"minLength":        applyMinLengthConstraint,
-		"maxLength":        applyMaxLengthConstraint,
-		"minimum":          applyMinimumConstraint,
-		"maximum":          applyMaximumConstraint,
-		"exclusiveMinimum": applyExclusiveMinimumConstraint,
-		"exclusiveMaximum": applyExclusiveMaximumConstraint,
-		"pattern":          applyPatternConstraint,
-		"enum":             applyEnumConstraint,
-	}
+// constraintApplicators maps an OpenAPIConstraint name to the function that writes
+// it onto a property. Static — defined once rather than per applyConstraint call
+// (applyConstraint runs once per emitted constraint, incl. the per-element loop).
+var constraintApplicators = map[string]func(*OpenAPIProperty, any){
+	"format":           applyFormatConstraint,
+	"minLength":        applyMinLengthConstraint,
+	"maxLength":        applyMaxLengthConstraint,
+	"minItems":         applyMinItemsConstraint,
+	"maxItems":         applyMaxItemsConstraint,
+	"minimum":          applyMinimumConstraint,
+	"maximum":          applyMaximumConstraint,
+	"exclusiveMinimum": applyExclusiveMinimumConstraint,
+	"exclusiveMaximum": applyExclusiveMaximumConstraint,
+	"pattern":          applyPatternConstraint,
+	"enum":             applyEnumConstraint,
+}
 
-	if applicator, exists := applicators[constraint.Name]; exists {
+// applyConstraint routes a constraint to its specialized applicator.
+func (g *OpenAPIGenerator) applyConstraint(prop *OpenAPIProperty, constraint analyzer.OpenAPIConstraint) {
+	if applicator, exists := constraintApplicators[constraint.Name]; exists {
 		applicator(prop, constraint.Value)
 	}
 }
@@ -1299,6 +1329,20 @@ func applyMinLengthConstraint(prop *OpenAPIProperty, value any) {
 func applyMaxLengthConstraint(prop *OpenAPIProperty, value any) {
 	if val, ok := value.(int); ok {
 		prop.MaxLength = &val
+	}
+}
+
+// applyMinItemsConstraint sets the minItems field (array cardinality)
+func applyMinItemsConstraint(prop *OpenAPIProperty, value any) {
+	if val, ok := value.(int); ok {
+		prop.MinItems = &val
+	}
+}
+
+// applyMaxItemsConstraint sets the maxItems field (array cardinality)
+func applyMaxItemsConstraint(prop *OpenAPIProperty, value any) {
+	if val, ok := value.(int); ok {
+		prop.MaxItems = &val
 	}
 }
 

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -1110,8 +1110,17 @@ func (g *OpenAPIGenerator) fieldInfoToProperty(field *models.FieldInfo) *OpenAPI
 
 	// A named, non-struct scalar (e.g. `type Cents int64`) carries its resolved
 	// OpenAPI kind from the analyzer; emit that instead of the object fallback
-	// setTypeAndFormat would pick for an unrecognized type name.
+	// setTypeAndFormat would pick for an unrecognized type name. For a slice of a
+	// named scalar ([]Cents) the resolved kind is the ELEMENT's, so emit an array
+	// whose items carry that kind (and the dive element constraints).
 	if field.UnderlyingKind != "" {
+		if isSliceType(field.Type) {
+			prop.Type = typeArray
+			prop.Items = &OpenAPIProperty{Type: field.UnderlyingKind}
+			g.applyConstraints(prop, field)        // minItems/maxItems on the array
+			g.applyElementConstraints(prop, field) // dive rules on items
+			return prop
+		}
 		prop.Type = field.UnderlyingKind
 		g.applyConstraints(prop, field)
 		return prop
@@ -1135,8 +1144,12 @@ func (g *OpenAPIGenerator) applyElementConstraints(prop *OpenAPIProperty, field 
 	if len(field.ElementConstraints) == 0 || prop.Items == nil {
 		return
 	}
+	// field.UnderlyingKind is resolved from the slice's element type (the analyzer
+	// strips */[] before classifying), so it is the ELEMENT's kind for a
+	// slice-of-named-scalar (e.g. []Cents -> "integer"), letting element numeric
+	// constraints map. Empty for builtin elements, where the type string suffices.
 	elemType := sliceElementType(field.Type)
-	for _, c := range analyzer.MapConstraintToOpenAPI(elemType, "", field.ElementConstraints) {
+	for _, c := range analyzer.MapConstraintToOpenAPI(elemType, field.UnderlyingKind, field.ElementConstraints) {
 		g.applyConstraint(prop.Items, c)
 	}
 }

--- a/tools/openapi/internal/generator/openapi_test.go
+++ b/tools/openapi/internal/generator/openapi_test.go
@@ -2494,3 +2494,60 @@ func TestAssignOperationIDsDedup(t *testing.T) {
 	assert.Equal(t, "mList", ids["GET /a"], "first sorted key keeps the bare id")
 	assert.Equal(t, "mList2", ids["GET /b"], "later collision gets the numeric suffix")
 }
+
+// TestFieldInfoToPropertyConstraintsPR11 covers PR11's constraint additions:
+// numeric exclusive bounds, string length comparisons, named-numeric via
+// UnderlyingKind, slice cardinality, and dive element constraints.
+func TestFieldInfoToPropertyConstraintsPR11(t *testing.T) {
+	gen := New(defaultTitle, "1.0.0", defaultDescription)
+
+	t.Run("numeric lt -> maximum + exclusiveMaximum", func(t *testing.T) {
+		p := gen.fieldInfoToProperty(&models.FieldInfo{Type: "int", JSONName: "n", Constraints: map[string]string{"lt": "100"}})
+		require.NotNil(t, p.Maximum)
+		assert.Equal(t, 100.0, *p.Maximum)
+		require.NotNil(t, p.ExclusiveMaximum)
+		assert.True(t, *p.ExclusiveMaximum)
+	})
+
+	t.Run("string gt -> minLength, not minimum", func(t *testing.T) {
+		p := gen.fieldInfoToProperty(&models.FieldInfo{Type: "string", JSONName: "s", Constraints: map[string]string{"gt": "3"}})
+		require.NotNil(t, p.MinLength)
+		assert.Equal(t, 4, *p.MinLength)
+		assert.Nil(t, p.Minimum, "a string gt must not leak a numeric minimum")
+	})
+
+	t.Run("named numeric via UnderlyingKind -> minimum/maximum", func(t *testing.T) {
+		p := gen.fieldInfoToProperty(&models.FieldInfo{Type: "Cents", UnderlyingKind: "integer", JSONName: "amt", Constraints: map[string]string{"min": "1", "max": "100"}})
+		require.NotNil(t, p.Minimum)
+		assert.Equal(t, 1.0, *p.Minimum)
+		require.NotNil(t, p.Maximum)
+		assert.Equal(t, 100.0, *p.Maximum)
+	})
+
+	t.Run("slice cardinality + dive element format", func(t *testing.T) {
+		p := gen.fieldInfoToProperty(&models.FieldInfo{
+			Type: "[]string", JSONName: "tags",
+			Constraints:        map[string]string{"min": "1", "max": "10"},
+			ElementConstraints: map[string]string{"email": "true"},
+		})
+		assert.Equal(t, typeArray, p.Type)
+		require.NotNil(t, p.MinItems)
+		assert.Equal(t, 1, *p.MinItems)
+		require.NotNil(t, p.MaxItems)
+		assert.Equal(t, 10, *p.MaxItems)
+		require.NotNil(t, p.Items)
+		assert.Equal(t, "email", p.Items.Format, "dive,email puts format:email under items")
+	})
+
+	t.Run("ref-slice carries minItems on the array wrapper", func(t *testing.T) {
+		p := gen.fieldInfoToProperty(&models.FieldInfo{
+			Type: "[]Address", RefName: "Address", JSONName: "addrs",
+			Constraints: map[string]string{"min": "1"},
+		})
+		assert.Equal(t, typeArray, p.Type)
+		require.NotNil(t, p.Items)
+		assert.Equal(t, refPath("Address"), p.Items.Ref, "$ref element stands alone")
+		require.NotNil(t, p.MinItems)
+		assert.Equal(t, 1, *p.MinItems)
+	})
+}

--- a/tools/openapi/internal/generator/openapi_test.go
+++ b/tools/openapi/internal/generator/openapi_test.go
@@ -2539,6 +2539,19 @@ func TestFieldInfoToPropertyConstraintsPR11(t *testing.T) {
 		assert.Equal(t, "email", p.Items.Format, "dive,email puts format:email under items")
 	})
 
+	t.Run("named-scalar slice element keeps numeric kind (dive)", func(t *testing.T) {
+		// []Cents -> field.UnderlyingKind=="integer" (analyzer strips the slice), so
+		// dive,gte=0 maps to a numeric minimum on the items, not a dropped constraint.
+		p := gen.fieldInfoToProperty(&models.FieldInfo{
+			Type: "[]Cents", UnderlyingKind: "integer", JSONName: "amounts",
+			ElementConstraints: map[string]string{"gte": "0"},
+		})
+		assert.Equal(t, typeArray, p.Type)
+		require.NotNil(t, p.Items)
+		require.NotNil(t, p.Items.Minimum, "element gte must map to a numeric minimum on items")
+		assert.Equal(t, 0.0, *p.Items.Minimum)
+	})
+
 	t.Run("ref-slice carries minItems on the array wrapper", func(t *testing.T) {
 		p := gen.fieldInfoToProperty(&models.FieldInfo{
 			Type: "[]Address", RefName: "Address", JSONName: "addrs",

--- a/tools/openapi/internal/models/models.go
+++ b/tools/openapi/internal/models/models.go
@@ -81,6 +81,10 @@ type FieldInfo struct {
 	Example       string            // Parsed from `example:"..."` tag
 	RawValidation string            // Raw validation tag string (e.g., "required,email,min=5")
 	Constraints   map[string]string // Parsed validation constraints for OpenAPI mapping
+	// ElementConstraints holds validate rules that appear AFTER a `dive` token, so
+	// they apply to each ELEMENT of a slice/array (e.g. `min=1,dive,email` puts min=1
+	// on the array and email on each element). Nil when the field has no `dive`.
+	ElementConstraints map[string]string
 	// RefName is the schema name of the field's underlying named struct type when
 	// the field (or its slice/pointer element) resolves to one in the registry.
 	// Set, the property is emitted as a $ref (or items.$ref for a slice) rather

--- a/tools/openapi/internal/spectest/testdata/constraints/api.go
+++ b/tools/openapi/internal/spectest/testdata/constraints/api.go
@@ -1,0 +1,41 @@
+// Package shop exercises PR11 validator-constraint coverage end-to-end.
+package shop
+
+import (
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/server"
+)
+
+// Cents is a named integer scalar; its underlying kind (integer) drives numeric
+// constraints (min/max) instead of the object fallback.
+type Cents int64
+
+// CreateReq carries one field per PR11 constraint family.
+type CreateReq struct {
+	Amount Cents    `json:"amount" validate:"min=1,max=10000"`         // named numeric -> minimum/maximum
+	Name   string   `json:"name" validate:"gt=2,lt=50"`                  // string gt/lt -> minLength/maxLength
+	Tags   []string `json:"tags" validate:"min=1,max=5,dive,email"`      // slice cardinality + dive element format
+	Server string   `json:"server" validate:"ipv4"`                      // content format
+	Slug   string   `json:"slug" validate:"startswith=svc-"`             // value pattern
+	Region string   `json:"region" validate:"oneof='North East' 'South West'"` // quoted enum
+}
+
+// Ack is the create acknowledgement.
+type Ack struct {
+	ID int64 `json:"id"`
+}
+
+// Module wires the route.
+type Module struct{}
+
+func (m *Module) Name() string                    { return "shop" }
+func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error                 { return nil }
+
+func (m *Module) create(req CreateReq, ctx server.HandlerContext) (server.Result[Ack], server.IAPIError) {
+	return server.Created(Ack{}), nil
+}
+
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
+	server.POST(hr, r, "/items", m.create, server.WithTags("items"))
+}

--- a/tools/openapi/internal/spectest/testdata/constraints/expected.yaml
+++ b/tools/openapi/internal/spectest/testdata/constraints/expected.yaml
@@ -1,0 +1,114 @@
+openapi: 3.0.1
+info:
+  title: Constraintsdemo API
+  version: 1.0.0
+  description: Generated API specification
+servers:
+  - url: /
+    description: Relative to the deployment host
+paths:
+  /items:
+    post:
+      operationId: shopCreate
+      summary: POST /items
+      tags:
+        - items
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateReq'
+      responses:
+        "201":
+          description: Resource created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Ack'
+                  meta:
+                    type: object
+                    properties:
+                      timestamp:
+                        type: string
+                        format: date-time
+                        description: RFC3339 response timestamp
+                      traceId:
+                        type: string
+                        description: W3C trace identifier for the request
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "422":
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    Ack:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+    CreateReq:
+      type: object
+      properties:
+        amount:
+          type: integer
+          minimum: 1
+          maximum: 10000
+        name:
+          type: string
+          minLength: 3
+          maxLength: 49
+        region:
+          type: string
+          enum:
+            - North East
+            - South West
+        server:
+          type: string
+          format: ipv4
+        slug:
+          type: string
+          pattern: ^svc-
+        tags:
+          type: array
+          items:
+            type: string
+            format: email
+          minItems: 1
+          maxItems: 5
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: object
+          description: Error details with code and message
+        meta:
+          type: object
+          description: Response metadata
+      required:
+        - error
+  securitySchemes:
+    TenantID:
+      type: apiKey
+      in: header
+      name: X-Tenant-ID
+security:
+  - TenantID: []

--- a/tools/openapi/internal/spectest/testdata/constraints/go.mod
+++ b/tools/openapi/internal/spectest/testdata/constraints/go.mod
@@ -1,0 +1,5 @@
+module github.com/example/constraintsdemo
+
+go 1.25
+
+require github.com/gaborage/go-bricks v0.37.0


### PR DESCRIPTION
## PR11 — Deepen validator-constraint coverage

Eleventh PR in the OpenAPI-tool gap initiative. Designed via a validator/v10 fan-out and adversarially verified. Consumes PR9's `UnderlyingKind`.

### What changed
- **String content** → `format` (`ipv4`/`ipv6`/`hostname`; `base64`→`byte`) or anchored `pattern` (`alpha`/`alphanum`/`numeric`/`hexcolor`/`e164`); value-bearing `contains`/`startswith`/`endswith` → `QuoteMeta`-escaped (un)anchored pattern. Bare `ip` is left **unconstrained by design** (no single OpenAPI format; documented + tested).
- **Named/qualified numerics:** `MapConstraintToOpenAPI` now takes `UnderlyingKind`, so `type Cents int64` / `time.Duration` map `min`/`max`/`gt`/`oneof` via an `effectiveKind` (previously dropped). String `gt`/`gte`/`lt`/`lte` → `minLength`/`maxLength` (`gt=N`→N+1, `lt=N`→N-1, clamped ≥0).
- **Slice cardinality:** `min`/`max`/`len` on `[]T` → `minItems`/`maxItems`. `dive` splits the tag into collection- vs element-scope (`FieldInfo.ElementConstraints`); element rules apply to `items` (`dive,email` → `items.format:email`).
- **Quote-aware `oneof`** (`'New York' 'Los Angeles'` → enum); `eq=<v>` → single-element enum; `datetime=<layout>` → `date` (date-only) or `date-time`.
- Wires `applyExclusiveMaximumConstraint` (was **0%** coverage) via an `lt=N` path.

### Reviewed (workflow + agent)
- Adversarial 3-lens verify (mapping correctness, generator slice/dive wiring, regression): no blocker/major.
- Cleanup review: hoisted `formatTagMap` + `constraintApplicators` to package vars (were rebuilt per call).
- Documented gaps (no correctness risk): map fields don't yet emit `minProperties` (tracked in **#497**); `[]byte` length bounds intentionally dropped (byte count ≠ base64-char length).

### Validation
- `make check` green; tool coverage **91.8%** (`applyExclusiveMaximumConstraint` 0%→100%).
- New `constraints` fixture exercises every family end-to-end; validates through in-process **kin-openapi** + the pinned **redocly** gate. `constraints_test` extended with one case per rule.

Depends on gaborage/go-bricks#494 (PR9, merged). Part of the roadmap in `.claude/tasks/openapi-tool-gap-analysis.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced OpenAPI schema generation with richer constraint mapping (anchored/escaped string patterns, quote‑aware enums, exclusive bounds)
  * Added array cardinality constraints (minItems/maxItems) and proper propagation of per‑element validation into item schemas
  * New test fixtures exercising constraint mapping and sample API spec

* **Bug Fixes**
  * Corrected parsing of validation "dive" to separate collection vs element constraints
  * Improved numeric/datetime and byte‑slice handling so appropriate constraints are emitted

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->