### PR TITLE
feat(openapi): CLI document-metadata flags + UX hardening (PR12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -532,7 +532,7 @@ For Windows-specific test patterns, CI workflow internals, and operational issue
 ```bash
 cd tools/openapi
 make install                    # Install CLI tool
-go-bricks-openapi generate -project . -output docs/openapi.yaml
+go-bricks-openapi generate --project . --output docs/openapi.yaml
 go-bricks-openapi doctor        # Check compatibility
 make demo                       # Test on example service
 ```

--- a/tools/openapi/README.md
+++ b/tools/openapi/README.md
@@ -9,10 +9,10 @@ Static analysis-based OpenAPI 3.0.1 specification generator for go-bricks servic
 go install ./tools/openapi/cmd/go-bricks-openapi
 
 # Generate OpenAPI spec
-go-bricks-openapi generate -project . -output docs/openapi.yaml
+go-bricks-openapi generate --project . --output docs/openapi.yaml
 
 # Check tool health and compatibility
-go-bricks-openapi doctor -project .
+go-bricks-openapi doctor --project .
 ```
 
 ## Commands

--- a/tools/openapi/cmd/go-bricks-openapi/main.go
+++ b/tools/openapi/cmd/go-bricks-openapi/main.go
@@ -20,6 +20,10 @@ func main() {
 This tool analyzes go-bricks services and generates OpenAPI specifications automatically
 from route registrations, type definitions, and validation tags.`,
 		Version: version,
+		// Errors and usage are reported once below (a single "Error:" line, no usage
+		// dump) rather than by cobra's default handler on a RunE error.
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 
 	// Add commands

--- a/tools/openapi/internal/commands/doctor.go
+++ b/tools/openapi/internal/commands/doctor.go
@@ -62,7 +62,7 @@ Checks include:
   go-bricks-openapi doctor
 
   # Check specific project
-  go-bricks-openapi doctor -project ./my-service`,
+  go-bricks-openapi doctor --project ./my-service`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDoctor(opts)
 		},
@@ -414,10 +414,15 @@ type routeClassification struct {
 	handlerID   string
 }
 
-// classifyRoute determines the type information for a route
+// classifyRoute determines the type information for a route. A route counts as
+// "typed" when the analyzer resolved a *named* request or response type — the
+// same gate the generator uses to emit a component $ref (see
+// responsePayloadSchema). Keying off the name rather than the field count means
+// a named-but-fieldless type (e.g. `type Ack struct{}`) is correctly reported as
+// typed instead of triggering a false "no resolved type" / --strict failure.
 func classifyRoute(route *models.Route) routeClassification {
-	hasRequest := route.Request != nil && len(route.Request.Fields) > 0
-	hasResponse := route.Response != nil && len(route.Response.Fields) > 0
+	hasRequest := route.Request != nil && route.Request.Name != ""
+	hasResponse := route.Response != nil && route.Response.Name != ""
 
 	handlerID := route.HandlerName
 	if handlerID == "" {

--- a/tools/openapi/internal/commands/generate.go
+++ b/tools/openapi/internal/commands/generate.go
@@ -1,20 +1,29 @@
 package commands
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
 	"github.com/gaborage/go-bricks/tools/openapi/internal/analyzer"
 	"github.com/gaborage/go-bricks/tools/openapi/internal/generator"
+	"github.com/gaborage/go-bricks/tools/openapi/internal/models"
 )
 
 const (
 	cmdNameGenerate = "generate"
 	extYAML         = ".yaml"
+	extYML          = ".yml"
+	extJSON         = ".json"
+	formatYAML      = "yaml"
+	formatJSON      = "json"
 )
 
 // GenerateOptions holds options for the generate command
@@ -22,6 +31,18 @@ type GenerateOptions struct {
 	ProjectRoot string
 	OutputFile  string
 	Verbose     bool
+
+	// Document metadata (override the analyzer defaults).
+	Title       string
+	APIVersion  string
+	Description string
+	Servers     []string
+	License     string
+	LicenseURL  string
+
+	Format            string // "yaml" (default) or "json"
+	DisableTenantAuth bool   // omit the X-Tenant-ID security scheme (single-tenant)
+	Strict            bool   // treat warnings (empty/untyped) as a non-zero exit
 }
 
 // NewGenerateCommand creates the generate command
@@ -34,35 +55,49 @@ func NewGenerateCommand() *cobra.Command {
 		Long: `Analyzes a go-bricks service and generates an OpenAPI 3.0.1 specification.
 
 The tool discovers modules, analyzes route registrations and type definitions,
-and produces a comprehensive YAML API specification with validation constraints.`,
+and produces a comprehensive API specification with validation constraints.`,
 		Example: `  # Generate spec for current directory
   go-bricks-openapi generate
 
-  # Generate spec for specific project
-  go-bricks-openapi generate -project ./my-service -output docs/openapi.yaml`,
+  # Generate spec for a specific project, with metadata
+  go-bricks-openapi generate --project ./my-service --output docs/openapi.yaml \
+    --title "My Service" --api-version 2.1.0 --server https://api.example.com
+
+  # Emit JSON
+  go-bricks-openapi generate --project ./my-service --output docs/openapi.json --format json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runGenerate(cmd.Context(), opts)
 		},
 	}
 
-	// Flags
 	cmd.Flags().StringVarP(&opts.ProjectRoot, "project", "p", ".", "Project root directory")
 	cmd.Flags().StringVarP(&opts.OutputFile, "output", "o", "openapi.yaml", "Output file path")
 	cmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Verbose output")
+	cmd.Flags().StringVar(&opts.Title, "title", "", "info.title (overrides the project name)")
+	cmd.Flags().StringVar(&opts.APIVersion, "api-version", "", "info.version (overrides 1.0.0)")
+	cmd.Flags().StringVar(&opts.Description, "description", "", "info.description")
+	cmd.Flags().StringArrayVar(&opts.Servers, "server", nil, "Server URL (repeatable)")
+	cmd.Flags().StringVar(&opts.License, "license", "", "info.license.name")
+	cmd.Flags().StringVar(&opts.LicenseURL, "license-url", "", "info.license.url")
+	cmd.Flags().StringVar(&opts.Format, "format", "", "Output format: yaml (default) or json")
+	cmd.Flags().BoolVar(&opts.DisableTenantAuth, "no-tenant-security", false, "Omit the X-Tenant-ID security scheme (single-tenant)")
+	cmd.Flags().BoolVar(&opts.Strict, "strict", false, "Exit non-zero if the spec has warnings (no modules/routes, untyped routes)")
 
 	return cmd
 }
 
 func runGenerate(ctx context.Context, opts *GenerateOptions) error {
-	// Validate options
 	if err := validateGenerateOptions(opts); err != nil {
+		return err
+	}
+	format, err := resolveFormat(opts)
+	if err != nil {
 		return err
 	}
 
 	fmt.Printf("Generating OpenAPI spec for project: %s\n", opts.ProjectRoot)
 	fmt.Printf("Output file: %s\n", opts.OutputFile)
 
-	// Analyze the project to discover modules and routes
 	projectAnalyzer := analyzer.New(opts.ProjectRoot)
 	project, err := projectAnalyzer.AnalyzeProject()
 	if err != nil {
@@ -76,24 +111,33 @@ func runGenerate(ctx context.Context, opts *GenerateOptions) error {
 		}
 	}
 
-	// Surface non-fatal analysis diagnostics (e.g. routes dropped due to an
-	// unresolvable path) on stderr so they don't corrupt the generated spec.
+	// Surface non-fatal analysis diagnostics on stderr so they don't corrupt the spec.
 	for _, w := range projectAnalyzer.Warnings(ctx) {
 		fmt.Fprintf(os.Stderr, "warning: %s\n", w)
 	}
 
-	// Generate OpenAPI spec
-	gen := generator.New("Go-Bricks API", "1.0.0", "Generated API specification")
+	gen := generator.NewWithConfig(buildGeneratorConfig(opts))
 	specContent, err := gen.Generate(project)
 	if err != nil {
 		return fmt.Errorf("failed to generate spec: %w", err)
 	}
+	if format == formatJSON {
+		specContent, err = toJSON(specContent)
+		if err != nil {
+			return fmt.Errorf("failed to render JSON: %w", err)
+		}
+	}
 
-	// Write to file
+	// Content warnings (empty/untyped) on stderr. With --strict they are fatal
+	// BEFORE we persist, so a failed strict run never prints a success line or
+	// leaves a stale artifact on disk for a downstream step to consume.
+	if emitContentWarnings(project) && opts.Strict {
+		return fmt.Errorf("spec generated with warnings and --strict is set")
+	}
+
 	if err := os.MkdirAll(filepath.Dir(opts.OutputFile), 0750); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
-
 	if err := os.WriteFile(opts.OutputFile, []byte(specContent), 0600); err != nil {
 		return fmt.Errorf("failed to write output file: %w", err)
 	}
@@ -102,17 +146,197 @@ func runGenerate(ctx context.Context, opts *GenerateOptions) error {
 	return nil
 }
 
+// buildGeneratorConfig maps CLI options to a generator.Config.
+func buildGeneratorConfig(opts *GenerateOptions) *generator.Config {
+	cfg := &generator.Config{
+		Title:                 opts.Title,
+		Version:               opts.APIVersion,
+		Description:           opts.Description,
+		Servers:               opts.Servers,
+		DisableTenantSecurity: opts.DisableTenantAuth,
+	}
+	if opts.License != "" {
+		cfg.License = &generator.License{Name: opts.License, URL: opts.LicenseURL}
+	}
+	return cfg
+}
+
+// formatForExt maps a recognized output-file extension to its format. It returns
+// ok=false for any unrecognized or absent extension.
+func formatForExt(path string) (format string, ok bool) {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case extJSON:
+		return formatJSON, true
+	case extYAML, extYML:
+		return formatYAML, true
+	default:
+		return "", false
+	}
+}
+
+// resolveFormat resolves the effective output format. An explicit --format wins,
+// but it must not contradict a recognized output extension — writing JSON into a
+// .yaml file (or vice versa) produces a file whose extension lies about its
+// contents, so a mismatch is a hard error rather than a silent override. With no
+// --format the format is inferred from the extension (.json -> json, .yaml/.yml
+// -> yaml), defaulting to yaml. An unrecognized --format is an error.
+func resolveFormat(opts *GenerateOptions) (string, error) {
+	explicit := strings.ToLower(opts.Format)
+	extFormat, extKnown := formatForExt(opts.OutputFile)
+	if explicit != "" {
+		if explicit != formatYAML && explicit != formatJSON {
+			return "", fmt.Errorf("invalid --format %q (want yaml or json)", opts.Format)
+		}
+		if extKnown && extFormat != explicit {
+			return "", fmt.Errorf("--format %s conflicts with output extension %q "+
+				"(the file would lie about its contents)", explicit, filepath.Ext(opts.OutputFile))
+		}
+		return explicit, nil
+	}
+	if extKnown {
+		return extFormat, nil
+	}
+	return formatYAML, nil
+}
+
+// validateGenerateOptions validates the project root, rejects a --license-url
+// without a --license name (OpenAPI's License Object requires name before url),
+// and appends the resolved format's extension when the output filename has none.
 func validateGenerateOptions(opts *GenerateOptions) error {
-	// Check project root exists
 	if _, err := os.Stat(opts.ProjectRoot); os.IsNotExist(err) {
 		return fmt.Errorf("project root does not exist: %s", opts.ProjectRoot)
 	}
-
-	// Ensure output file has .yaml extension
-	ext := filepath.Ext(opts.OutputFile)
-	if ext == "" {
-		opts.OutputFile += extYAML
+	if opts.LicenseURL != "" && opts.License == "" {
+		return fmt.Errorf("--license-url requires --license (OpenAPI license.url requires license.name)")
 	}
-
+	format, err := resolveFormat(opts)
+	if err != nil {
+		return err
+	}
+	if filepath.Ext(opts.OutputFile) == "" {
+		if format == formatJSON {
+			opts.OutputFile += extJSON
+		} else {
+			opts.OutputFile += extYAML
+		}
+	}
 	return nil
+}
+
+// toJSON re-parses the generated YAML document and re-emits it as indented JSON,
+// preserving the canonical OpenAPI section order (openapi, info, servers, paths,
+// components, security). A plain map[string]any round-trip would let
+// encoding/json sort keys alphabetically and scramble that order, so we walk the
+// ordered yaml.Node tree and render mappings through orderedMap.
+func toJSON(yamlSpec string) (string, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlSpec), &root); err != nil {
+		return "", err
+	}
+	doc, err := yamlNodeToJSONValue(&root)
+	if err != nil {
+		return "", err
+	}
+	b, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b) + "\n", nil
+}
+
+// yamlNodeToJSONValue converts an ordered yaml.Node tree into a json-marshalable
+// value: mappings become *orderedMap (key order preserved), sequences []any, and
+// scalars their yaml-decoded Go type (string/int/float/bool/nil).
+func yamlNodeToJSONValue(node *yaml.Node) (any, error) {
+	switch node.Kind {
+	case yaml.DocumentNode:
+		if len(node.Content) == 0 {
+			return nil, nil
+		}
+		return yamlNodeToJSONValue(node.Content[0])
+	case yaml.MappingNode:
+		m := &orderedMap{
+			keys: make([]string, 0, len(node.Content)/2),
+			vals: make([]any, 0, len(node.Content)/2),
+		}
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			val, err := yamlNodeToJSONValue(node.Content[i+1])
+			if err != nil {
+				return nil, err
+			}
+			m.keys = append(m.keys, node.Content[i].Value)
+			m.vals = append(m.vals, val)
+		}
+		return m, nil
+	case yaml.SequenceNode:
+		arr := make([]any, 0, len(node.Content))
+		for _, item := range node.Content {
+			v, err := yamlNodeToJSONValue(item)
+			if err != nil {
+				return nil, err
+			}
+			arr = append(arr, v)
+		}
+		return arr, nil
+	case yaml.ScalarNode:
+		var v any
+		if err := node.Decode(&v); err != nil {
+			return nil, err
+		}
+		return v, nil
+	default:
+		return nil, fmt.Errorf("unsupported yaml node kind %d", node.Kind)
+	}
+}
+
+// orderedMap marshals to a JSON object preserving insertion order, unlike
+// map[string]any (which encoding/json sorts alphabetically). MarshalIndent
+// re-indents the compact output this produces, so nested maps stay ordered too.
+type orderedMap struct {
+	keys []string
+	vals []any
+}
+
+func (m *orderedMap) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, k := range m.keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		kb, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(kb)
+		buf.WriteByte(':')
+		vb, err := json.Marshal(m.vals[i])
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(vb)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// emitContentWarnings prints stderr warnings for a content-free or partially-typed
+// spec and reports whether any were emitted (so --strict can fail the run).
+func emitContentWarnings(project *models.Project) bool {
+	stats := calculateProjectStats(project)
+	warned := false
+	switch {
+	case stats.ModuleCount == 0:
+		fmt.Fprintln(os.Stderr, "warning: no go-bricks modules discovered — the spec has no operations")
+		warned = true
+	case stats.RouteCount == 0:
+		fmt.Fprintln(os.Stderr, "warning: modules discovered but no routes — the spec has no operations")
+		warned = true
+	}
+	if n := len(stats.UntypedRoutes); n > 0 {
+		fmt.Fprintf(os.Stderr, "warning: %d route(s) have no resolved request/response type: %s\n",
+			n, strings.Join(stats.UntypedRoutes, ", "))
+		warned = true
+	}
+	return warned
 }

--- a/tools/openapi/internal/commands/generate.go
+++ b/tools/openapi/internal/commands/generate.go
@@ -129,10 +129,10 @@ func runGenerate(ctx context.Context, opts *GenerateOptions) error {
 	}
 
 	// Content warnings (empty/untyped) on stderr. With --strict they are fatal
-	// BEFORE we persist, so a failed strict run never prints a success line or
-	// leaves a stale artifact on disk for a downstream step to consume.
+	// BEFORE we persist, so a failed strict run never prints a success line and
+	// leaves no consumable artifact (see failStrict).
 	if emitContentWarnings(project) && opts.Strict {
-		return fmt.Errorf("spec generated with warnings and --strict is set")
+		return failStrict(opts)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(opts.OutputFile), 0750); err != nil {
@@ -144,6 +144,16 @@ func runGenerate(ctx context.Context, opts *GenerateOptions) error {
 
 	fmt.Printf("✓ OpenAPI specification generated: %s\n", opts.OutputFile)
 	return nil
+}
+
+// failStrict removes any pre-existing output so a stale spec from an earlier run
+// can't be consumed by a downstream step that keys off file existence, then
+// returns the strict-mode failure error.
+func failStrict(opts *GenerateOptions) error {
+	if err := os.Remove(opts.OutputFile); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove stale output %s: %w", opts.OutputFile, err)
+	}
+	return fmt.Errorf("spec generated with warnings and --strict is set")
 }
 
 // buildGeneratorConfig maps CLI options to a generator.Config.
@@ -206,6 +216,10 @@ func validateGenerateOptions(opts *GenerateOptions) error {
 	if _, err := os.Stat(opts.ProjectRoot); os.IsNotExist(err) {
 		return fmt.Errorf("project root does not exist: %s", opts.ProjectRoot)
 	}
+	// Normalize so a whitespace-only --license is treated as missing and never
+	// emitted as a blank info.license.name.
+	opts.License = strings.TrimSpace(opts.License)
+	opts.LicenseURL = strings.TrimSpace(opts.LicenseURL)
 	if opts.LicenseURL != "" && opts.License == "" {
 		return fmt.Errorf("--license-url requires --license (OpenAPI license.url requires license.name)")
 	}

--- a/tools/openapi/internal/commands/generate_test.go
+++ b/tools/openapi/internal/commands/generate_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,6 +10,8 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/gaborage/go-bricks/tools/openapi/internal/models"
 )
 
 const (
@@ -733,5 +736,208 @@ func TestGenerateCommandFlagValidation(t *testing.T) {
 				t.Errorf("Flag '%s' should have a default value", flagName)
 			}
 		})
+	}
+}
+
+// TestResolveFormat covers explicit, inferred, and invalid format resolution.
+func TestResolveFormatPR12(t *testing.T) {
+	cases := []struct {
+		name, format, output, want string
+		wantErr                    bool
+	}{
+		{name: "default_yaml", output: "openapi.yaml", want: "yaml"},
+		{name: "default_yaml_no_ext", output: "openapi", want: "yaml"},
+		{name: "inferred_json_from_ext", output: "openapi.json", want: "json"},
+		{name: "inferred_yaml_from_yml_ext", output: "openapi.yml", want: "yaml"},
+		{name: "explicit_json_agrees_with_ext", format: "json", output: "openapi.json", want: "json"},
+		{name: "explicit_json_no_ext", format: "json", output: "openapi", want: "json"},
+		{name: "explicit_yaml_agrees_with_ext", format: "yaml", output: "openapi.yaml", want: "yaml"},
+		// Explicit --format must not contradict a recognized extension: the file
+		// would otherwise lie about its contents (JSON bytes in a .yaml file).
+		{name: "explicit_json_conflicts_yaml_ext", format: "json", output: "openapi.yaml", wantErr: true},
+		{name: "explicit_yaml_conflicts_json_ext", format: "yaml", output: "x.json", wantErr: true},
+		// An unrecognized extension carries no format claim, so explicit wins.
+		{name: "explicit_json_unknown_ext_ok", format: "json", output: "x.txt", want: "json"},
+		{name: "invalid_format", format: "xml", output: "x.yaml", wantErr: true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := resolveFormat(&GenerateOptions{Format: c.format, OutputFile: c.output})
+			if c.wantErr {
+				if err == nil {
+					t.Fatal("expected error for invalid format")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("resolveFormat = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestBuildGeneratorConfig maps CLI flags to a generator.Config.
+func TestBuildGeneratorConfig(t *testing.T) {
+	cfg := buildGeneratorConfig(&GenerateOptions{
+		Title: "My API", APIVersion: "2.0.0", Description: "d",
+		Servers: []string{"https://a", "https://b"},
+		License: "MIT", LicenseURL: "https://mit",
+		DisableTenantAuth: true,
+	})
+	if cfg.Title != "My API" || cfg.Version != "2.0.0" || cfg.Description != "d" {
+		t.Errorf("metadata not threaded: %+v", cfg)
+	}
+	if len(cfg.Servers) != 2 || cfg.Servers[0] != "https://a" {
+		t.Errorf("servers not threaded: %v", cfg.Servers)
+	}
+	if cfg.License == nil || cfg.License.Name != "MIT" || cfg.License.URL != "https://mit" {
+		t.Errorf("license not threaded: %+v", cfg.License)
+	}
+	if !cfg.DisableTenantSecurity {
+		t.Error("tenant-security opt-out not threaded")
+	}
+	// No --license -> nil license.
+	if got := buildGeneratorConfig(&GenerateOptions{}); got.License != nil {
+		t.Errorf("expected nil license when --license unset, got %+v", got.License)
+	}
+}
+
+// TestToJSON confirms the YAML spec re-renders as parseable JSON.
+func TestToJSON(t *testing.T) {
+	yamlSpec := "openapi: 3.0.1\ninfo:\n  title: T\n  version: 1.0.0\npaths: {}\n"
+	out, err := toJSON(yamlSpec)
+	if err != nil {
+		t.Fatalf("toJSON: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if doc["openapi"] != "3.0.1" {
+		t.Errorf("openapi field not preserved: %v", doc["openapi"])
+	}
+	info, ok := doc["info"].(map[string]any)
+	if !ok || info["title"] != "T" {
+		t.Errorf("info.title not preserved: %v", doc["info"])
+	}
+}
+
+// TestEmitContentWarnings covers the empty/untyped warning detection.
+func TestEmitContentWarnings(t *testing.T) {
+	if !emitContentWarnings(&models.Project{}) {
+		t.Error("empty project (no modules) should warn")
+	}
+	withRoutes := &models.Project{Modules: []models.Module{{Name: "m"}}}
+	if !emitContentWarnings(withRoutes) {
+		t.Error("module with no routes should warn")
+	}
+	typed := &models.Project{Modules: []models.Module{{Name: "m", Routes: []models.Route{
+		{Method: "GET", Path: "/x", HandlerName: "h", Response: &models.TypeInfo{Name: "R", Fields: []models.FieldInfo{{Name: "ID", JSONName: "id"}}}},
+	}}}}
+	if emitContentWarnings(typed) {
+		t.Error("a typed route should not warn")
+	}
+
+	// A named-but-fieldless response (e.g. `type Ack struct{}`) still resolves to
+	// a component $ref, so it must not be reported as untyped (would false-fail
+	// --strict).
+	namedEmpty := &models.Project{Modules: []models.Module{{Name: "m", Routes: []models.Route{
+		{Method: "POST", Path: "/ack", HandlerName: "ack", Response: &models.TypeInfo{Name: "Ack"}},
+	}}}}
+	if emitContentWarnings(namedEmpty) {
+		t.Error("a named-but-fieldless response is resolved (gets a $ref) and should not warn")
+	}
+}
+
+// TestExampleUsesDoubleDashFlags guards against the single-dash trap regression:
+// cobra long flags need `--project`/`--output`, not `-project`/`-output`.
+func TestExampleUsesDoubleDashFlags(t *testing.T) {
+	for _, cmd := range []string{NewGenerateCommand().Example, NewDoctorCommand().Example} {
+		if strings.Contains(cmd, " -project ") || strings.Contains(cmd, " -output ") {
+			t.Errorf("Example uses a single-dash long flag (parses as -p -r -o ...): %s", cmd)
+		}
+	}
+}
+
+// TestToJSONPreservesKeyOrder pins that JSON output keeps the canonical OpenAPI
+// section order rather than the alphabetical order encoding/json imposes on a
+// map[string]any round-trip.
+func TestToJSONPreservesKeyOrder(t *testing.T) {
+	// Canonical order is openapi, info, servers, paths — none of which is
+	// alphabetical, so a map round-trip would visibly reorder them.
+	yamlSpec := "openapi: 3.0.1\n" +
+		"info:\n  title: T\n  version: 1.0.0\n" +
+		"servers:\n  - url: /\n" +
+		"paths: {}\n"
+	out, err := toJSON(yamlSpec)
+	if err != nil {
+		t.Fatalf("toJSON: %v", err)
+	}
+	order := []string{`"openapi"`, `"info"`, `"servers"`, `"paths"`}
+	prev := -1
+	for _, key := range order {
+		idx := strings.Index(out, key)
+		if idx < 0 {
+			t.Fatalf("key %s missing from JSON output:\n%s", key, out)
+		}
+		if idx <= prev {
+			t.Errorf("key %s out of canonical order (alphabetized?):\n%s", key, out)
+		}
+		prev = idx
+	}
+	// title before version within info (insertion order, not alphabetical).
+	if strings.Index(out, `"title"`) > strings.Index(out, `"version"`) {
+		t.Errorf("nested info keys reordered:\n%s", out)
+	}
+}
+
+// TestValidateGenerateOptionsLicenseURLRequiresName covers the fail-fast guard:
+// --license-url without --license is rejected rather than silently dropped.
+func TestValidateGenerateOptionsLicenseURLRequiresName(t *testing.T) {
+	err := validateGenerateOptions(&GenerateOptions{
+		ProjectRoot: ".",
+		OutputFile:  "openapi.yaml",
+		LicenseURL:  "https://opensource.org/licenses/MIT",
+	})
+	if err == nil {
+		t.Fatal("expected --license-url without --license to error")
+	}
+	if !strings.Contains(err.Error(), "--license-url requires --license") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Both supplied together is fine.
+	if err := validateGenerateOptions(&GenerateOptions{
+		ProjectRoot: ".",
+		OutputFile:  "openapi.yaml",
+		License:     "MIT",
+		LicenseURL:  "https://opensource.org/licenses/MIT",
+	}); err != nil {
+		t.Errorf("name+url should validate, got: %v", err)
+	}
+}
+
+// TestRunGenerateStrictNoArtifact pins that a failed --strict run neither writes
+// the output file nor prints the success line — the gate runs before persisting.
+func TestRunGenerateStrictNoArtifact(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "openapi.yaml")
+	// An empty project root yields no modules -> a content warning -> --strict fails.
+	err := runGenerate(context.Background(), &GenerateOptions{
+		ProjectRoot: dir,
+		OutputFile:  out,
+		Strict:      true,
+	})
+	if err == nil {
+		t.Fatal("expected --strict to fail on a module-less project")
+	}
+	if !strings.Contains(err.Error(), "--strict is set") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf("strict failure must not leave an artifact, but %s exists (stat err: %v)", out, statErr)
 	}
 }

--- a/tools/openapi/internal/commands/generate_test.go
+++ b/tools/openapi/internal/commands/generate_test.go
@@ -909,35 +909,69 @@ func TestValidateGenerateOptionsLicenseURLRequiresName(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	// Both supplied together is fine.
+	// A whitespace-only --license is treated as missing (would otherwise emit a
+	// blank info.license.name).
 	if err := validateGenerateOptions(&GenerateOptions{
 		ProjectRoot: ".",
 		OutputFile:  "openapi.yaml",
-		License:     "MIT",
+		License:     "   ",
 		LicenseURL:  "https://opensource.org/licenses/MIT",
-	}); err != nil {
+	}); err == nil {
+		t.Error("expected whitespace-only --license to be rejected when --license-url is set")
+	}
+
+	// Both supplied together is fine, and surrounding whitespace is trimmed.
+	opts := &GenerateOptions{
+		ProjectRoot: ".",
+		OutputFile:  "openapi.yaml",
+		License:     "  MIT  ",
+		LicenseURL:  "  https://opensource.org/licenses/MIT  ",
+	}
+	if err := validateGenerateOptions(opts); err != nil {
 		t.Errorf("name+url should validate, got: %v", err)
+	}
+	if opts.License != "MIT" || opts.LicenseURL != "https://opensource.org/licenses/MIT" {
+		t.Errorf("license fields not trimmed: name=%q url=%q", opts.License, opts.LicenseURL)
 	}
 }
 
 // TestRunGenerateStrictNoArtifact pins that a failed --strict run neither writes
-// the output file nor prints the success line — the gate runs before persisting.
+// the output file nor prints the success line, AND that any stale artifact from
+// an earlier run is removed (so a downstream step can't consume it). The gate
+// runs before persisting.
 func TestRunGenerateStrictNoArtifact(t *testing.T) {
-	dir := t.TempDir()
-	out := filepath.Join(dir, "openapi.yaml")
-	// An empty project root yields no modules -> a content warning -> --strict fails.
-	err := runGenerate(context.Background(), &GenerateOptions{
-		ProjectRoot: dir,
-		OutputFile:  out,
-		Strict:      true,
+	strictFailErr := func(t *testing.T, out string) {
+		t.Helper()
+		// An empty project root yields no modules -> a content warning -> --strict fails.
+		err := runGenerate(context.Background(), &GenerateOptions{
+			ProjectRoot: filepath.Dir(out),
+			OutputFile:  out,
+			Strict:      true,
+		})
+		if err == nil {
+			t.Fatal("expected --strict to fail on a module-less project")
+		}
+		if !strings.Contains(err.Error(), "--strict is set") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+
+	t.Run("no pre-existing file is created", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "openapi.yaml")
+		strictFailErr(t, out)
+		if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+			t.Errorf("strict failure must not create an artifact, but %s exists (stat err: %v)", out, statErr)
+		}
 	})
-	if err == nil {
-		t.Fatal("expected --strict to fail on a module-less project")
-	}
-	if !strings.Contains(err.Error(), "--strict is set") {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
-		t.Errorf("strict failure must not leave an artifact, but %s exists (stat err: %v)", out, statErr)
-	}
+
+	t.Run("stale pre-existing file is removed", func(t *testing.T) {
+		out := filepath.Join(t.TempDir(), "openapi.yaml")
+		if err := os.WriteFile(out, []byte("openapi: 3.0.1\n# stale\n"), 0600); err != nil {
+			t.Fatalf("seed stale file: %v", err)
+		}
+		strictFailErr(t, out)
+		if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+			t.Errorf("strict failure must remove the stale artifact, but %s still exists", out)
+		}
+	})
 }

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -89,18 +89,48 @@ const (
 	mediaJOSE = "application/jose"
 )
 
+// License is the optional info.license block.
+type License struct {
+	Name string
+	URL  string
+}
+
+// Config configures a generator's document-level metadata. Zero values fall back
+// to sensible defaults (title/version from the analyzer or the built-in default,
+// a relative-root server, tenant security on).
+type Config struct {
+	Title       string
+	Version     string
+	Description string
+	Servers     []string // server URLs; empty -> a single relative-root "/"
+	License     *License
+	// DisableTenantSecurity omits the X-Tenant-ID security scheme + root security
+	// (for single-tenant services).
+	DisableTenantSecurity bool
+}
+
 // OpenAPIGenerator creates OpenAPI specifications from project models
 type OpenAPIGenerator struct {
 	title       string
 	version     string
 	description string
+	servers     []string
+	license     *License
+	tenantAuth  bool
+}
+
+// openAPILicense is the emitted info.license object.
+type openAPILicense struct {
+	Name string `yaml:"name"`
+	URL  string `yaml:"url,omitempty"`
 }
 
 // OpenAPIInfo represents the info section of an OpenAPI specification
 type OpenAPIInfo struct {
-	Title       string `yaml:"title"`
-	Version     string `yaml:"version"`
-	Description string `yaml:"description"`
+	Title       string          `yaml:"title"`
+	Version     string          `yaml:"version"`
+	Description string          `yaml:"description"`
+	License     *openAPILicense `yaml:"license,omitempty"`
 }
 
 // OpenAPISchema represents a schema definition
@@ -184,12 +214,25 @@ type OpenAPIMediaType struct {
 	Schema *OpenAPIProperty `yaml:"schema"`
 }
 
-// New creates a new OpenAPI generator
+// New creates a new OpenAPI generator with default servers/security (tenant auth
+// on). Retained for callers that only need title/version/description.
 func New(title, version, description string) *OpenAPIGenerator {
+	return NewWithConfig(&Config{Title: title, Version: version, Description: description})
+}
+
+// NewWithConfig creates a generator from a full Config (CLI-driven metadata). A
+// nil cfg is treated as the zero Config.
+func NewWithConfig(cfg *Config) *OpenAPIGenerator {
+	if cfg == nil {
+		cfg = &Config{}
+	}
 	return &OpenAPIGenerator{
-		title:       title,
-		version:     version,
-		description: description,
+		title:       cfg.Title,
+		version:     cfg.Version,
+		description: cfg.Description,
+		servers:     cfg.Servers,
+		license:     cfg.License,
+		tenantAuth:  !cfg.DisableTenantSecurity,
 	}
 }
 
@@ -210,6 +253,9 @@ func (g *OpenAPIGenerator) Generate(project *models.Project) (string, error) {
 		Version:     g.getVersion(project),
 		Description: g.getDescription(project),
 	}
+	if g.license != nil && g.license.Name != "" {
+		info.License = &openAPILicense{Name: g.license.Name, URL: g.license.URL}
+	}
 
 	infoYAML, err := g.marshalYAMLSection("info", info)
 	if err != nil {
@@ -225,9 +271,9 @@ func (g *OpenAPIGenerator) Generate(project *models.Project) (string, error) {
 	emitted := emittedRoutes(allRoutes)
 	opIDs := g.assignOperationIDs(emitted)
 
-	// Servers: a relative-root default so the document is self-describing and
-	// passes the no-empty-servers gate (the concrete URL is a PR11 flag).
-	serversYAML, err := g.marshalYAMLSection("servers", defaultServers())
+	// Servers: configured --server URLs, or a relative-root default so the document
+	// is self-describing and passes the no-empty-servers gate.
+	serversYAML, err := g.marshalYAMLSection("servers", g.configuredServers())
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal servers section: %w", err)
 	}
@@ -260,8 +306,12 @@ func (g *OpenAPIGenerator) Generate(project *models.Project) (string, error) {
 	maps.Copy(schemas, generatedSchemas)
 
 	components := map[string]any{
-		"schemas":         schemas,
-		"securitySchemes": securitySchemes(),
+		"schemas": schemas,
+	}
+	// Tenant security is opt-out (single-tenant services). When on, the scheme must
+	// be declared (security-defined) and referenced at the root.
+	if g.tenantAuth {
+		components["securitySchemes"] = securitySchemes()
 	}
 
 	componentsYAML, err := g.marshalYAMLSection("components", components)
@@ -273,13 +323,33 @@ func (g *OpenAPIGenerator) Generate(project *models.Project) (string, error) {
 	// Root-level security: the framework resolves tenancy from the X-Tenant-ID
 	// header, modeled as an apiKey scheme. Emitted last so security-defined sees
 	// the scheme already declared.
-	securityYAML, err := g.marshalYAMLSection("security", rootSecurity())
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal security section: %w", err)
+	if g.tenantAuth {
+		securityYAML, err := g.marshalYAMLSection("security", rootSecurity())
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal security section: %w", err)
+		}
+		sb.WriteString(securityYAML)
 	}
-	sb.WriteString(securityYAML)
 
 	return sb.String(), nil
+}
+
+// configuredServers returns the configured server URLs as Server Objects,
+// skipping blank or whitespace-only entries, and falling back to the
+// relative-root default when none remain. Filtering on content (not just slice
+// length) keeps a stray `--server ""` from emitting an invalid empty-URL Server
+// Object and bypassing the no-empty-servers default.
+func (g *OpenAPIGenerator) configuredServers() []openAPIServer {
+	out := make([]openAPIServer, 0, len(g.servers))
+	for _, url := range g.servers {
+		if trimmed := strings.TrimSpace(url); trimmed != "" {
+			out = append(out, openAPIServer{URL: trimmed})
+		}
+	}
+	if len(out) == 0 {
+		return defaultServers()
+	}
+	return out
 }
 
 // tenantSecurityScheme is the component name for the X-Tenant-ID apiKey scheme.
@@ -320,27 +390,46 @@ func rootSecurity() []map[string][]string {
 }
 
 // getTitle returns the project title or default
+// Built-in document defaults, the lowest-precedence fallback (used only when both
+// the explicit config value and the analyzer-derived project value are empty).
+const (
+	defaultDocTitle       = "Go-Bricks API"
+	defaultDocVersion     = "1.0.0"
+	defaultDocDescription = "Generated API specification"
+)
+
+// getTitle resolves info.title with precedence: explicit config (CLI --title) >
+// analyzer-derived project name (go.mod) > built-in default.
 func (g *OpenAPIGenerator) getTitle(project *models.Project) string {
+	if g.title != "" {
+		return g.title
+	}
 	if project.Name != "" {
 		return project.Name
 	}
-	return g.title
+	return defaultDocTitle
 }
 
 // getVersion returns the project version or default
 func (g *OpenAPIGenerator) getVersion(project *models.Project) string {
+	if g.version != "" {
+		return g.version
+	}
 	if project.Version != "" {
 		return project.Version
 	}
-	return g.version
+	return defaultDocVersion
 }
 
 // getDescription returns the project description or default
 func (g *OpenAPIGenerator) getDescription(project *models.Project) string {
+	if g.description != "" {
+		return g.description
+	}
 	if project.Description != "" {
 		return project.Description
 	}
-	return g.description
+	return defaultDocDescription
 }
 
 // getAllRoutes flattens routes from all modules, preserving each route's owning

--- a/tools/openapi/internal/generator/openapi.go
+++ b/tools/openapi/internal/generator/openapi.go
@@ -221,17 +221,29 @@ func New(title, version, description string) *OpenAPIGenerator {
 }
 
 // NewWithConfig creates a generator from a full Config (CLI-driven metadata). A
-// nil cfg is treated as the zero Config.
+// nil cfg is treated as the zero Config. Reference-typed fields (Servers,
+// License) are copied so the generator is immutable after construction: a caller
+// mutating its Config later cannot alter output or race with a concurrent
+// Generate.
 func NewWithConfig(cfg *Config) *OpenAPIGenerator {
 	if cfg == nil {
 		cfg = &Config{}
+	}
+	var servers []string
+	if len(cfg.Servers) > 0 {
+		servers = append([]string(nil), cfg.Servers...)
+	}
+	var license *License
+	if cfg.License != nil {
+		copied := *cfg.License
+		license = &copied
 	}
 	return &OpenAPIGenerator{
 		title:       cfg.Title,
 		version:     cfg.Version,
 		description: cfg.Description,
-		servers:     cfg.Servers,
-		license:     cfg.License,
+		servers:     servers,
+		license:     license,
 		tenantAuth:  !cfg.DisableTenantSecurity,
 	}
 }

--- a/tools/openapi/internal/generator/openapi_test.go
+++ b/tools/openapi/internal/generator/openapi_test.go
@@ -2639,4 +2639,24 @@ func TestNewWithConfig(t *testing.T) {
 		assert.Contains(t, spec, "url: /", "default server restored when none valid")
 		assert.NotContains(t, spec, `url: ""`)
 	})
+
+	t.Run("generator is immutable after construction", func(t *testing.T) {
+		// Mutating the caller's Config (or the slice/license it shared) after
+		// construction must not change the generator's output.
+		cfg := &Config{
+			Title: "T", Version: "1.0.0",
+			Servers: []string{"https://orig.example.com"},
+			License: &License{Name: "MIT", URL: "https://mit"},
+		}
+		gen := NewWithConfig(cfg)
+		cfg.Servers[0] = "https://mutated.example.com"
+		cfg.License.Name = "MUTATED"
+
+		spec, err := gen.Generate(&models.Project{})
+		require.NoError(t, err)
+		assert.Contains(t, spec, "url: https://orig.example.com", "server slice must be copied")
+		assert.NotContains(t, spec, "mutated.example.com")
+		assert.Contains(t, spec, "name: MIT", "license must be copied")
+		assert.NotContains(t, spec, "MUTATED")
+	})
 }

--- a/tools/openapi/internal/generator/openapi_test.go
+++ b/tools/openapi/internal/generator/openapi_test.go
@@ -110,7 +110,9 @@ func TestGenerateEmptyProject(t *testing.T) {
 }
 
 func TestGenerateWithProjectMetadata(t *testing.T) {
-	gen := New("Default API", "0.1.0", "Default description")
+	// No explicit document overrides, so analyzer-derived project metadata wins
+	// (precedence: explicit override > project metadata > built-in default).
+	gen := New("", "", "")
 	project := &models.Project{
 		Name:        "Custom API",
 		Version:     "2.0.0",
@@ -520,12 +522,10 @@ func TestGenerateWithMultipleMethodsPerPath(t *testing.T) {
 
 // TestGenerateWithProblematicValues verifies proper YAML escaping for special characters
 func TestGenerateWithProblematicValues(t *testing.T) {
-	// Test with values that could break manual YAML concatenation
-	gen := New(
-		"API: Special Characters Test", // Contains colon
-		"1.0.0-beta: yes",              // Contains colon and YAML boolean
-		"Multi-line description\nWith: colons and\n\"quotes\" and #comments",
-	)
+	// Test with values that could break manual YAML concatenation. No explicit
+	// overrides, so the problematic project-derived metadata flows through the
+	// escape path under test.
+	gen := New("", "", "")
 
 	project := &models.Project{
 		Name:        "Project: With Colons & Special \"Characters\"", // Problematic title
@@ -669,19 +669,19 @@ func TestGettersWithEmptyValues(t *testing.T) {
 			name:     "empty title with empty project",
 			project:  &models.Project{},
 			testFunc: func(p *models.Project) string { return gen.getTitle(p) },
-			expected: "", // Empty title from generator should be preserved
+			expected: defaultDocTitle, // no override, no project name -> built-in default
 		},
 		{
 			name:     "empty version with empty project",
 			project:  &models.Project{},
 			testFunc: func(p *models.Project) string { return gen.getVersion(p) },
-			expected: "", // Empty version from generator should be preserved
+			expected: defaultDocVersion, // no override, no project version -> built-in default
 		},
 		{
 			name:     "empty description with empty project",
 			project:  &models.Project{},
 			testFunc: func(p *models.Project) string { return gen.getDescription(p) },
-			expected: "", // Empty description from generator should be preserved
+			expected: defaultDocDescription, // no override, no project description -> built-in default
 		},
 		{
 			name:     "project overrides empty generator title",
@@ -710,6 +710,28 @@ func TestGettersWithEmptyValues(t *testing.T) {
 				t.Errorf("Expected %q, got %q", tt.expected, result)
 			}
 		})
+	}
+}
+
+// TestGetterPrecedenceExplicitOverride pins the top of the precedence chain:
+// an explicit document override (from --title/--api-version/--description)
+// wins over analyzer-derived project metadata.
+func TestGetterPrecedenceExplicitOverride(t *testing.T) {
+	gen := New("Override Title", "9.9.9", "Override description")
+	project := &models.Project{
+		Name:        "Project Title",
+		Version:     "2.0.0",
+		Description: "Project description",
+	}
+
+	if got := gen.getTitle(project); got != "Override Title" {
+		t.Errorf("title: explicit override should win, got %q", got)
+	}
+	if got := gen.getVersion(project); got != "9.9.9" {
+		t.Errorf("version: explicit override should win, got %q", got)
+	}
+	if got := gen.getDescription(project); got != "Override description" {
+		t.Errorf("description: explicit override should win, got %q", got)
 	}
 }
 
@@ -2562,5 +2584,59 @@ func TestFieldInfoToPropertyConstraintsPR11(t *testing.T) {
 		assert.Equal(t, refPath("Address"), p.Items.Ref, "$ref element stands alone")
 		require.NotNil(t, p.MinItems)
 		assert.Equal(t, 1, *p.MinItems)
+	})
+}
+
+// TestNewWithConfig covers the CLI-driven document metadata: custom servers,
+// license, and the tenant-security opt-out.
+func TestNewWithConfig(t *testing.T) {
+	t.Run("custom servers + license", func(t *testing.T) {
+		gen := NewWithConfig(&Config{
+			Title: "My API", Version: "2.1.0", Description: "d",
+			Servers: []string{"https://api.example.com", "https://staging.example.com"},
+			License: &License{Name: "MIT", URL: "https://opensource.org/licenses/MIT"},
+		})
+		spec, err := gen.Generate(&models.Project{})
+		require.NoError(t, err)
+		assert.Contains(t, spec, "title: My API")
+		assert.Contains(t, spec, "url: https://api.example.com")
+		assert.Contains(t, spec, "url: https://staging.example.com")
+		assert.Contains(t, spec, "name: MIT")
+		assert.Contains(t, spec, "url: https://opensource.org/licenses/MIT")
+		assert.Contains(t, spec, "X-Tenant-ID", "tenant security on by default")
+	})
+
+	t.Run("tenant security opt-out", func(t *testing.T) {
+		gen := NewWithConfig(&Config{Title: "T", Version: "1.0.0", DisableTenantSecurity: true})
+		spec, err := gen.Generate(&models.Project{})
+		require.NoError(t, err)
+		assert.NotContains(t, spec, "X-Tenant-ID", "opt-out omits the tenant scheme")
+		assert.NotContains(t, spec, "securitySchemes", "no schemes when security disabled")
+		// Default relative-root server still present.
+		assert.Contains(t, spec, "url: /")
+	})
+
+	t.Run("blank server is dropped, not emitted as empty url", func(t *testing.T) {
+		// A stray `--server ""` (e.g. an unset shell var) must not produce an
+		// invalid `url: ""` Server Object; the valid entry survives.
+		gen := NewWithConfig(&Config{
+			Title: "T", Version: "1.0.0",
+			Servers: []string{"  ", "https://api.example.com", ""},
+		})
+		spec, err := gen.Generate(&models.Project{})
+		require.NoError(t, err)
+		assert.Contains(t, spec, "url: https://api.example.com")
+		assert.NotContains(t, spec, `url: ""`, "blank server must not be emitted")
+	})
+
+	t.Run("all-blank servers fall back to relative-root default", func(t *testing.T) {
+		gen := NewWithConfig(&Config{
+			Title: "T", Version: "1.0.0",
+			Servers: []string{"", "   "},
+		})
+		spec, err := gen.Generate(&models.Project{})
+		require.NoError(t, err)
+		assert.Contains(t, spec, "url: /", "default server restored when none valid")
+		assert.NotContains(t, spec, `url: ""`)
 	})
 }

--- a/tools/openapi/internal/spectest/spectest.go
+++ b/tools/openapi/internal/spectest/spectest.go
@@ -24,18 +24,6 @@ import (
 	"github.com/gaborage/go-bricks/tools/openapi/internal/generator"
 )
 
-// Document metadata passed to the generator. NOTE: the generator currently
-// derives the emitted spec title from project metadata (the go.mod module name,
-// or a built-in default for a module-less project), so harnessTitle is
-// overridden in practice — it is supplied only to satisfy the generator.New
-// signature and becomes meaningful once a title override lands. harnessVersion
-// and harnessDescription fill the corresponding info fields.
-const (
-	harnessTitle       = "Fixture API"
-	harnessVersion     = "1.0.0"
-	harnessDescription = "Generated API specification"
-)
-
 // Generate runs the analyzer and generator over the project rooted at dir and
 // returns the emitted OpenAPI document as a string. ctx is the first parameter
 // per the repo's context-first convention; it is honoured for early
@@ -51,7 +39,10 @@ func Generate(ctx context.Context, dir string) (string, error) {
 		return "", fmt.Errorf("analyze %s: %w", dir, err)
 	}
 
-	spec, err := generator.New(harnessTitle, harnessVersion, harnessDescription).Generate(project)
+	// Empty metadata so the generator falls back to the analyzer-derived
+	// project name/version (from each fixture's go.mod) — the harness exercises the
+	// default path, not a CLI override.
+	spec, err := generator.New("", "", "").Generate(project)
 	if err != nil {
 		return "", fmt.Errorf("generate %s: %w", dir, err)
 	}


### PR DESCRIPTION
## Summary

PR12 of the OpenAPI-tool gap-analysis roadmap. Adds `generate` flags to override OpenAPI document metadata and emit JSON, fixes the document-metadata **precedence** bug, and applies the hardening surfaced by a pre-push `/code-review` + `/security-audit` on the diff.

### Flags (`generate`)
`--title`, `--api-version`, `--description`, `--server` (repeatable), `--license`, `--license-url`, `--format {yaml|json}`, `--no-tenant-security`, `--strict`.

Document metadata now follows an explicit precedence chain — **explicit CLI override > analyzer-derived project metadata (go.mod) > built-in default constant** — fixing `--title`/`--api-version`/`--description` being silently ignored. `New()` delegates to `NewWithConfig(*Config)`; `Generate` emits `info.license`, configured servers, and the tenant `securityScheme` only when enabled.

### Hardening (review + audit findings)
| # | Issue | Fix |
|---|-------|-----|
| 1 | `--format json --output x.yaml` silently wrote JSON into a `.yaml` file | `resolveFormat` now errors on a format/extension conflict; also recognizes `.yml` |
| 2 | `--strict` wrote the file **and** printed `✓ generated` before failing | strict gate runs **before** persisting — no success line, no stale artifact |
| 3 | `--license-url` without `--license` silently dropped | rejected at validation (OpenAPI requires `license.name`) |
| 4 | blank `--server ""` emitted an invalid `url: ""` Server Object | blank/whitespace entries skipped; falls back to relative-root default |
| 5 | `--format json` scrambled section order (alphabetical) | `toJSON` walks the ordered `yaml.Node` tree (`orderedMap`) to preserve canonical order |
| 6 | named-but-fieldless response (`type Ack struct{}`) mis-flagged untyped → false `--strict` failure | `classifyRoute` keys off resolved **name**, matching the generator's `$ref` gate |

Docs: corrected the single-dash CLI examples (`-project`/`-output`) to double-dash long flags in `CLAUDE.md` + `README`, with a regression test.

## Testing
- `make check` (tool) green; full suite passes with `-race`.
- Coverage: generator **96.3%**, commands **87.9%**, spectest **81.2%** (≥80% gate).
- Golden specs **unchanged** (spectest passes without `-update`).
- Security: `gosec` 0 issues, `govulncheck` no vulnerabilities, no hardcoded secrets, no raw-SQL hatches.
- All 6 fixes verified end-to-end against the built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add OpenAPI document metadata options (title, version, description, servers, license)
  * Support explicit JSON output and format inference; add strict validation mode
  * Allow opting out of tenant authentication in generated specs

* **Bug Fixes**
  * Cleaner CLI error output and improved format/validation error reporting

* **Documentation**
  * Update command examples to use long-form (--flag) syntax

* **Tests**
  * Expanded unit tests covering generation, format resolution, strict mode, and metadata handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gaborage/go-bricks/pull/500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->