### PR TITLE
fix(openapi): strict doctor diagnostics + version-floor reconciliation (PR13)

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -670,8 +670,10 @@ jobs:
           # Validate CLI commands work (equivalent to make validate-cli)
           ./go-bricks-openapi.exe version
           ./go-bricks-openapi.exe --help
-          # Use absolute path to project root from tools/openapi working directory
-          $projectRoot = Resolve-Path "../../"
+          # doctor must run against a real go-bricks project (dependency + modules
+          # present); the framework root has neither, which the stricter doctor now
+          # fails. Mirror make validate-cli's SPEC_FIXTURE target.
+          $projectRoot = Resolve-Path "internal/spectest/testdata/nested_schema"
           ./go-bricks-openapi.exe doctor --project $projectRoot
           Write-Host "CLI validation passed"
 

--- a/tools/openapi/Makefile
+++ b/tools/openapi/Makefile
@@ -46,7 +46,7 @@ install: build ## Install the CLI tool locally
 	go install -ldflags "-X main.version=$(VERSION)" ./cmd/go-bricks-openapi
 
 demo: build ## Run demo generation on demo project (requires cloning demo repo)
-	./$(BINARY_NAME) doctor --project ../../
+	./$(BINARY_NAME) doctor --project $(SPEC_FIXTURE)
 	@echo "To run demo generation:"
 	@echo "1. Clone demo project: git clone https://github.com/gaborage/go-bricks-demo-project.git"
 	@echo "2. Generate spec: ./$(BINARY_NAME) generate --project ../go-bricks-demo-project/openapi-demo --output demo-spec.yaml"
@@ -54,7 +54,9 @@ demo: build ## Run demo generation on demo project (requires cloning demo repo)
 validate-cli: build ## Validate CLI commands work correctly
 	./$(BINARY_NAME) version
 	./$(BINARY_NAME) --help
-	./$(BINARY_NAME) doctor --project ../../
+	# doctor must run against a real go-bricks project (dep + modules present);
+	# the framework root has neither, which the stricter PR13 doctor now fails.
+	./$(BINARY_NAME) doctor --project $(SPEC_FIXTURE)
 	@echo "✓ CLI validation passed"
 
 validate-spec: build ## Generate a fixture spec and validate it with redocly (requires npx; CI/Unix)

--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -380,32 +380,35 @@ func (a *ProjectAnalyzer) extractModuleFromAST(astFile *ast.File, filePath strin
 // (valid Name+Init but an unrecognized RegisterRoutes signature) so the caller can
 // surface it.
 func (a *ProjectAnalyzer) findModuleStruct(astFile *ast.File, filePath string) (moduleStruct, nearMiss string) {
+	for _, name := range structTypeNames(astFile) {
+		isModule, isNearMiss := a.hasModuleMethods(astFile, name, filePath)
+		if isModule {
+			return name, ""
+		}
+		if isNearMiss && nearMiss == "" {
+			nearMiss = name
+		}
+	}
+	return "", nearMiss
+}
+
+// structTypeNames returns the names of all struct type declarations in the file.
+func structTypeNames(astFile *ast.File) []string {
+	var names []string
 	for _, decl := range astFile.Decls {
 		genDecl, ok := decl.(*ast.GenDecl)
 		if !ok || genDecl.Tok != token.TYPE {
 			continue
 		}
-
 		for _, spec := range genDecl.Specs {
-			typeSpec, ok := spec.(*ast.TypeSpec)
-			if !ok {
-				continue
-			}
-
-			if _, ok := typeSpec.Type.(*ast.StructType); !ok {
-				continue
-			}
-
-			isModule, isNearMiss := a.hasModuleMethods(astFile, typeSpec.Name.Name, filePath)
-			if isModule {
-				return typeSpec.Name.Name, ""
-			}
-			if isNearMiss && nearMiss == "" {
-				nearMiss = typeSpec.Name.Name
+			if typeSpec, ok := spec.(*ast.TypeSpec); ok {
+				if _, isStruct := typeSpec.Type.(*ast.StructType); isStruct {
+					names = append(names, typeSpec.Name.Name)
+				}
 			}
 		}
 	}
-	return "", nearMiss
+	return names
 }
 
 // hasModuleMethods reports whether a struct is a go-bricks module, and — when it
@@ -433,15 +436,19 @@ func (a *ProjectAnalyzer) hasModuleMethods(astFile *ast.File, structName, filePa
 		a.collectMethodFlagsFromFile(file, structName, requiredMethods, serverAliases, appAliases)
 	}
 
-	// A module needs the core methods with valid signatures.
-	if requiredMethods[moduleMethodName] && requiredMethods[moduleMethodInit] && requiredMethods[moduleMethodRegisterRoutes] {
+	// A real module satisfies the go-bricks Module interface (Name + Init +
+	// Shutdown) and registers routes. Requiring Shutdown avoids treating a
+	// non-compliant struct as a module (which would also wrongly suppress a
+	// near-miss diagnostic for its package).
+	isCore := requiredMethods[moduleMethodName] &&
+		requiredMethods[moduleMethodInit] &&
+		requiredMethods[moduleMethodShutdown]
+	if isCore && requiredMethods[moduleMethodRegisterRoutes] {
 		return true, false
 	}
-	// Near miss: valid Name+Init, and a RegisterRoutes declared (by name) but with
-	// an unrecognized signature.
-	nearMiss := requiredMethods[moduleMethodName] &&
-		requiredMethods[moduleMethodInit] &&
-		a.structDeclaresMethod(files, structName, moduleMethodRegisterRoutes)
+	// Near miss: a complete module shape (Name + Init + Shutdown) that declares a
+	// RegisterRoutes method (by name) but with an unrecognized signature.
+	nearMiss := isCore && a.structDeclaresMethod(files, structName, moduleMethodRegisterRoutes)
 	return false, nearMiss
 }
 

--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -234,7 +234,7 @@ func (a *ProjectAnalyzer) discoverModules() ([]models.Module, error) {
 	slices.Sort(dirs)
 	for _, dir := range dirs {
 		c := d.nearMiss[dir]
-		a.addWarningf("struct %q in %s has Name and Init but an unrecognized %s signature; "+
+		a.addWarningf("struct %q in %s has Name, Init, and Shutdown but an unrecognized %s signature; "+
 			"it is skipped and its routes are omitted (want func(*server.HandlerRegistry, server.RouteRegistrar))",
 			c.structName, c.relFile, moduleMethodRegisterRoutes)
 	}

--- a/tools/openapi/internal/analyzer/analyzer.go
+++ b/tools/openapi/internal/analyzer/analyzer.go
@@ -207,23 +207,56 @@ func (a *ProjectAnalyzer) parseGoModForProjectName(project *models.Project, cont
 	}
 }
 
-// discoverModules finds all go-bricks modules in the project
+// discoverModules finds all go-bricks modules in the project and, afterward,
+// surfaces near-miss diagnostics for packages that produced no real module.
 func (a *ProjectAnalyzer) discoverModules() ([]models.Module, error) {
 	d := &moduleDiscoverer{
-		analyzer: a,
-		modules:  []models.Module{},
-		seen:     make(map[string]bool),
+		analyzer:   a,
+		modules:    []models.Module{},
+		seen:       make(map[string]bool),
+		moduleDirs: make(map[string]bool),
+		nearMiss:   make(map[string]nearMissCandidate),
 	}
 
 	err := filepath.Walk(a.projectRoot, d.walk)
+
+	// Surface a near-miss only for a directory (Go package) that produced no real
+	// module — so a struct that looks like a module but has a wrong RegisterRoutes
+	// signature does not silently drop its routes, while a package that does have a
+	// valid module (anywhere in it) is never falsely flagged. Sorted for
+	// deterministic output across the unordered walk.
+	dirs := make([]string, 0, len(d.nearMiss))
+	for dir := range d.nearMiss {
+		if !d.moduleDirs[dir] {
+			dirs = append(dirs, dir)
+		}
+	}
+	slices.Sort(dirs)
+	for _, dir := range dirs {
+		c := d.nearMiss[dir]
+		a.addWarningf("struct %q in %s has Name and Init but an unrecognized %s signature; "+
+			"it is skipped and its routes are omitted (want func(*server.HandlerRegistry, server.RouteRegistrar))",
+			c.structName, c.relFile, moduleMethodRegisterRoutes)
+	}
+
 	return d.modules, err
+}
+
+// nearMissCandidate identifies a struct that looks like a module but has an
+// unrecognized RegisterRoutes signature, plus a project-relative file path so the
+// diagnostic can point the user at the right package.
+type nearMissCandidate struct {
+	structName string
+	relFile    string
 }
 
 // moduleDiscoverer holds the state for module discovery
 type moduleDiscoverer struct {
-	analyzer *ProjectAnalyzer
-	modules  []models.Module
-	seen     map[string]bool
+	analyzer   *ProjectAnalyzer
+	modules    []models.Module
+	seen       map[string]bool              // package names already added (dedup modules)
+	moduleDirs map[string]bool              // directories that produced a real module
+	nearMiss   map[string]nearMissCandidate // directory -> first near-miss struct
 }
 
 // walk is the callback function for filepath.Walk to discover modules
@@ -240,17 +273,30 @@ func (d *moduleDiscoverer) walk(path string, info os.FileInfo, err error) error 
 		return nil
 	}
 
-	module, err := d.analyzer.analyzeGoFile(path)
+	module, nearMiss, err := d.analyzer.analyzeGoFile(path)
 	if err != nil {
 		// Log error but continue processing other files
 		return nil
 	}
 
+	dir := filepath.Dir(path)
 	if module != nil {
+		d.moduleDirs[dir] = true
 		key := module.Package
 		if !d.seen[key] {
 			d.modules = append(d.modules, *module)
 			d.seen[key] = true
+		}
+		return nil
+	}
+
+	if nearMiss != "" {
+		if _, ok := d.nearMiss[dir]; !ok {
+			rel, relErr := filepath.Rel(d.analyzer.projectRoot, path)
+			if relErr != nil {
+				rel = path
+			}
+			d.nearMiss[dir] = nearMissCandidate{structName: nearMiss, relFile: rel}
 		}
 	}
 
@@ -262,31 +308,34 @@ func shouldSkipDir(name string) bool {
 	return name == vendorDir || name == gitDir || strings.HasPrefix(name, ".") || name == nodeModulesDir
 }
 
-// analyzeGoFile parses a Go file and extracts module information
-func (a *ProjectAnalyzer) analyzeGoFile(filePath string) (*models.Module, error) {
+// analyzeGoFile parses a Go file and extracts module information. The second
+// return value is the name of a near-miss module struct found in the file (empty
+// if none); discoverModules resolves it against the set of packages that produced
+// a real module before deciding whether to warn.
+func (a *ProjectAnalyzer) analyzeGoFile(filePath string) (module *models.Module, nearMiss string, err error) {
 	if err := a.validateGoFilePath(filePath); err != nil {
-		return nil, fmt.Errorf("invalid file path %s: %w", filePath, err)
+		return nil, "", fmt.Errorf("invalid file path %s: %w", filePath, err)
 	}
 
 	// #nosec G304 - filePath is validated to be a .go file within project root
 	src, err := os.ReadFile(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read file %s: %w", filePath, err)
+		return nil, "", fmt.Errorf("failed to read file %s: %w", filePath, err)
 	}
 
 	// Parse the Go file
 	astFile, err := parser.ParseFile(a.fileSet, filePath, src, parser.ParseComments)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse file %s: %w", filePath, err)
+		return nil, "", fmt.Errorf("failed to parse file %s: %w", filePath, err)
 	}
 
 	// Extract constants first (needed for route path resolution)
 	a.extractConstants(astFile)
 
 	// Check if this file contains a go-bricks module
-	module, structName := a.extractModuleFromAST(astFile, filePath)
+	module, structName, nearMiss := a.extractModuleFromAST(astFile, filePath)
 	if module == nil {
-		return nil, nil // Not a module file
+		return nil, nearMiss, nil // Not a module file (nearMiss may be set)
 	}
 
 	// Extract routes from the RegisterRoutes method, including other files in the package
@@ -299,14 +348,17 @@ func (a *ProjectAnalyzer) analyzeGoFile(filePath string) (*models.Module, error)
 		module.Routes[i].Package = module.Package
 	}
 
-	return module, nil
+	return module, "", nil
 }
 
-// extractModuleFromAST checks if the AST contains a go-bricks module
-func (a *ProjectAnalyzer) extractModuleFromAST(astFile *ast.File, filePath string) (module *models.Module, structName string) {
-	structName = a.findModuleStruct(astFile, filePath)
+// extractModuleFromAST checks if the AST contains a go-bricks module. It also
+// returns the name of a "near miss" struct (looks like a module but has an
+// unrecognized RegisterRoutes signature) found in this file, so discoverModules
+// can warn about it iff the package has no real module.
+func (a *ProjectAnalyzer) extractModuleFromAST(astFile *ast.File, filePath string) (module *models.Module, structName, nearMiss string) {
+	structName, nearMiss = a.findModuleStruct(astFile, filePath)
 	if structName == "" {
-		return nil, ""
+		return nil, "", nearMiss
 	}
 
 	// Use package name as module name and extract package-level description
@@ -319,11 +371,15 @@ func (a *ProjectAnalyzer) extractModuleFromAST(astFile *ast.File, filePath strin
 		Description: moduleDescription,
 		Routes:      []models.Route{},
 	}
-	return module, structName
+	return module, structName, ""
 }
 
-// findModuleStruct iterates through declarations to find a go-bricks module struct
-func (a *ProjectAnalyzer) findModuleStruct(astFile *ast.File, filePath string) string {
+// findModuleStruct iterates declarations to find a go-bricks module struct. It
+// returns the first valid module struct (and an empty nearMiss, since the package
+// then has a module); if no module is found it returns the first near-miss struct
+// (valid Name+Init but an unrecognized RegisterRoutes signature) so the caller can
+// surface it.
+func (a *ProjectAnalyzer) findModuleStruct(astFile *ast.File, filePath string) (moduleStruct, nearMiss string) {
 	for _, decl := range astFile.Decls {
 		genDecl, ok := decl.(*ast.GenDecl)
 		if !ok || genDecl.Tok != token.TYPE {
@@ -340,17 +396,26 @@ func (a *ProjectAnalyzer) findModuleStruct(astFile *ast.File, filePath string) s
 				continue
 			}
 
-			// Check if this struct has methods that indicate it's a Module
-			if a.hasModuleMethods(astFile, typeSpec.Name.Name, filePath) {
-				return typeSpec.Name.Name
+			isModule, isNearMiss := a.hasModuleMethods(astFile, typeSpec.Name.Name, filePath)
+			if isModule {
+				return typeSpec.Name.Name, ""
+			}
+			if isNearMiss && nearMiss == "" {
+				nearMiss = typeSpec.Name.Name
 			}
 		}
 	}
-	return ""
+	return "", nearMiss
 }
 
-// hasModuleMethods checks if the struct has methods indicating it's a go-bricks module
-func (a *ProjectAnalyzer) hasModuleMethods(astFile *ast.File, structName, filePath string) bool {
+// hasModuleMethods reports whether a struct is a go-bricks module, and — when it
+// is not — whether it is a "near miss": it has a valid Name and Init and declares
+// a RegisterRoutes method, but that method's signature is unrecognized. A near
+// miss is a struct the developer almost certainly intended as a module; the
+// caller decides whether to surface it (only when the package has no real module,
+// resolved in discoverModules) so a single signature typo doesn't drop a module's
+// routes with no feedback.
+func (a *ProjectAnalyzer) hasModuleMethods(astFile *ast.File, structName, filePath string) (isModule, isNearMiss bool) {
 	requiredMethods := map[string]bool{
 		moduleMethodName:           false,
 		moduleMethodInit:           false,
@@ -360,19 +425,41 @@ func (a *ProjectAnalyzer) hasModuleMethods(astFile *ast.File, structName, filePa
 
 	files, err := a.parsePackage(filePath, astFile.Name.Name)
 	if err != nil || files == nil {
-		serverAliases := a.extractImportAliases(astFile, serverImportPath)
-		appAliases := a.extractImportAliases(astFile, appImportPath)
-		a.collectMethodFlagsFromFile(astFile, structName, requiredMethods, serverAliases, appAliases)
-	} else {
-		for _, file := range files {
-			serverAliases := a.extractImportAliases(file, serverImportPath)
-			appAliases := a.extractImportAliases(file, appImportPath)
-			a.collectMethodFlagsFromFile(file, structName, requiredMethods, serverAliases, appAliases)
-		}
+		files = map[string]*ast.File{filePath: astFile}
+	}
+	for _, file := range files {
+		serverAliases := a.extractImportAliases(file, serverImportPath)
+		appAliases := a.extractImportAliases(file, appImportPath)
+		a.collectMethodFlagsFromFile(file, structName, requiredMethods, serverAliases, appAliases)
 	}
 
-	// Check if we have at least the core methods with valid signatures
-	return requiredMethods[moduleMethodName] && requiredMethods[moduleMethodInit] && requiredMethods[moduleMethodRegisterRoutes]
+	// A module needs the core methods with valid signatures.
+	if requiredMethods[moduleMethodName] && requiredMethods[moduleMethodInit] && requiredMethods[moduleMethodRegisterRoutes] {
+		return true, false
+	}
+	// Near miss: valid Name+Init, and a RegisterRoutes declared (by name) but with
+	// an unrecognized signature.
+	nearMiss := requiredMethods[moduleMethodName] &&
+		requiredMethods[moduleMethodInit] &&
+		a.structDeclaresMethod(files, structName, moduleMethodRegisterRoutes)
+	return false, nearMiss
+}
+
+// structDeclaresMethod reports whether any file declares a method named
+// methodName on structName, regardless of the method's signature.
+func (a *ProjectAnalyzer) structDeclaresMethod(files map[string]*ast.File, structName, methodName string) bool {
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			funcDecl, ok := decl.(*ast.FuncDecl)
+			if !ok || funcDecl.Name.Name != methodName {
+				continue
+			}
+			if a.isMethodOnStruct(funcDecl.Recv, structName) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // isMethodOnStruct checks if a function is a method on the specified struct

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -1,7 +1,6 @@
 package analyzer
 
 import (
-	"context"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -986,6 +985,7 @@ func TestUnrecognizedRegisterRoutesWarning(t *testing.T) {
 type Module struct{}
 func (m *Module) Name() string { return "widgets" }
 func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
 func (m *Module) RegisterRoutes() {}`) // missing (*server.HandlerRegistry, server.RouteRegistrar)
 
 	a := New(dir)
@@ -993,7 +993,7 @@ func (m *Module) RegisterRoutes() {}`) // missing (*server.HandlerRegistry, serv
 		t.Fatalf("AnalyzeProject: %v", err)
 	}
 
-	warnings := a.Warnings(context.Background())
+	warnings := a.Warnings(t.Context())
 	found := false
 	for _, w := range warnings {
 		if strings.Contains(w, "Module") && strings.Contains(w, moduleMethodRegisterRoutes) && strings.Contains(w, "module.go") {
@@ -1014,20 +1014,22 @@ func TestNearMissSuppressedWhenValidModuleExists(t *testing.T) {
 type Widget struct{}
 func (w *Widget) Name() string { return "widget" }
 func (w *Widget) Init(deps *app.ModuleDeps) error { return nil }
+func (w *Widget) Shutdown() error { return nil }
 func (w *Widget) RegisterRoutes() {}
 
 type Module struct{}
 func (m *Module) Name() string { return "shop" }
 func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
 func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {}`)
 
 	a := New(dir)
 	if _, err := a.AnalyzeProject(); err != nil {
 		t.Fatalf("AnalyzeProject: %v", err)
 	}
-	if hasRegisterRoutesWarning(a.Warnings(context.Background())) {
+	if hasRegisterRoutesWarning(a.Warnings(t.Context())) {
 		t.Errorf("no near-miss warning expected when the package has a valid module, got: %v",
-			a.Warnings(context.Background()))
+			a.Warnings(t.Context()))
 	}
 }
 
@@ -1038,15 +1040,16 @@ func TestNoWarningForNonModuleStruct(t *testing.T) {
 	dir := writeAnalyzerProject(t, "helper.go", `package helper
 type Module struct{}
 func (m *Module) Name() string { return "helper" }
-func (m *Module) Init(deps *app.ModuleDeps) error { return nil }`)
+func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }`)
 
 	a := New(dir)
 	if _, err := a.AnalyzeProject(); err != nil {
 		t.Fatalf("AnalyzeProject: %v", err)
 	}
-	if hasRegisterRoutesWarning(a.Warnings(context.Background())) {
+	if hasRegisterRoutesWarning(a.Warnings(t.Context())) {
 		t.Errorf("expected no near-miss diagnostic for a struct lacking RegisterRoutes, got: %v",
-			a.Warnings(context.Background()))
+			a.Warnings(t.Context()))
 	}
 }
 
@@ -1848,6 +1851,7 @@ type Module struct{}
 
 func (m *Module) Name() string { return "test" }
 func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
+func (m *Module) Shutdown() error { return nil }
 func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {}`,
 			expected: true,
 		},

--- a/tools/openapi/internal/analyzer/analyzer_test.go
+++ b/tools/openapi/internal/analyzer/analyzer_test.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"context"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -364,7 +365,7 @@ func TestAnalyzeGoFile(t *testing.T) {
 	moduleFile := createTestModuleFile(t, tempDir)
 
 	analyzer := New(tempDir)
-	module, err := analyzer.analyzeGoFile(moduleFile)
+	module, _, err := analyzer.analyzeGoFile(moduleFile)
 
 	if err != nil {
 		t.Fatalf("analyzeGoFile() failed: %v", err)
@@ -383,7 +384,7 @@ func TestAnalyzeNonModuleFile(t *testing.T) {
 
 	utilFile := filepath.Join(tempDir, "util.go")
 	analyzer := New(tempDir)
-	module, err := analyzer.analyzeGoFile(utilFile)
+	module, _, err := analyzer.analyzeGoFile(utilFile)
 
 	if err != nil {
 		t.Fatalf("analyzeGoFile() failed: %v", err)
@@ -945,12 +946,107 @@ func (m *Module) RegisterRoutes() {}`,
 				t.Fatalf(parseFailedFormat, err)
 			}
 
-			result, _ := analyzer.extractModuleFromAST(astFile, "test")
+			result, _, _ := analyzer.extractModuleFromAST(astFile, "test")
 			found := (result != nil)
 			if found != tt.expected {
 				t.Errorf("Expected module found=%v, got %v", tt.expected, found)
 			}
 		})
+	}
+}
+
+// hasRegisterRoutesWarning reports whether any analyzer warning is the near-miss
+// RegisterRoutes diagnostic.
+func hasRegisterRoutesWarning(warnings []string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, moduleMethodRegisterRoutes) && strings.Contains(w, "unrecognized") {
+			return true
+		}
+	}
+	return false
+}
+
+// writeAnalyzerProject writes one .go file into a fresh temp dir and returns the
+// dir, for driving AnalyzeProject end-to-end.
+func writeAnalyzerProject(t *testing.T, fileName, src string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, fileName), []byte(src), 0o644); err != nil {
+		t.Fatalf("write %s: %v", fileName, err)
+	}
+	return dir
+}
+
+// TestUnrecognizedRegisterRoutesWarning verifies that, in a package with no valid
+// module, a struct which looks like a module (valid Name + Init) but whose
+// RegisterRoutes signature is unrecognized is surfaced with a package-qualified
+// diagnostic rather than silently dropped (PR13 acceptance #4).
+func TestUnrecognizedRegisterRoutesWarning(t *testing.T) {
+	dir := writeAnalyzerProject(t, "module.go", `package widgets
+type Module struct{}
+func (m *Module) Name() string { return "widgets" }
+func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
+func (m *Module) RegisterRoutes() {}`) // missing (*server.HandlerRegistry, server.RouteRegistrar)
+
+	a := New(dir)
+	if _, err := a.AnalyzeProject(); err != nil {
+		t.Fatalf("AnalyzeProject: %v", err)
+	}
+
+	warnings := a.Warnings(context.Background())
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "Module") && strings.Contains(w, moduleMethodRegisterRoutes) && strings.Contains(w, "module.go") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a package-qualified RegisterRoutes near-miss diagnostic, got: %v", warnings)
+	}
+}
+
+// TestNearMissSuppressedWhenValidModuleExists verifies the near-miss diagnostic is
+// NOT emitted when the package already contains a valid module — even when the
+// near-miss struct is declared first (the review's order-dependence / false-
+// positive concern).
+func TestNearMissSuppressedWhenValidModuleExists(t *testing.T) {
+	dir := writeAnalyzerProject(t, "shop.go", `package shop
+type Widget struct{}
+func (w *Widget) Name() string { return "widget" }
+func (w *Widget) Init(deps *app.ModuleDeps) error { return nil }
+func (w *Widget) RegisterRoutes() {}
+
+type Module struct{}
+func (m *Module) Name() string { return "shop" }
+func (m *Module) Init(deps *app.ModuleDeps) error { return nil }
+func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {}`)
+
+	a := New(dir)
+	if _, err := a.AnalyzeProject(); err != nil {
+		t.Fatalf("AnalyzeProject: %v", err)
+	}
+	if hasRegisterRoutesWarning(a.Warnings(context.Background())) {
+		t.Errorf("no near-miss warning expected when the package has a valid module, got: %v",
+			a.Warnings(context.Background()))
+	}
+}
+
+// TestNoWarningForNonModuleStruct verifies the near-miss diagnostic is reserved
+// for genuine near-misses: a struct that simply has no RegisterRoutes method is
+// not a module and must not produce a warning.
+func TestNoWarningForNonModuleStruct(t *testing.T) {
+	dir := writeAnalyzerProject(t, "helper.go", `package helper
+type Module struct{}
+func (m *Module) Name() string { return "helper" }
+func (m *Module) Init(deps *app.ModuleDeps) error { return nil }`)
+
+	a := New(dir)
+	if _, err := a.AnalyzeProject(); err != nil {
+		t.Fatalf("AnalyzeProject: %v", err)
+	}
+	if hasRegisterRoutesWarning(a.Warnings(context.Background())) {
+		t.Errorf("expected no near-miss diagnostic for a struct lacking RegisterRoutes, got: %v",
+			a.Warnings(context.Background()))
 	}
 }
 
@@ -1068,7 +1164,7 @@ func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, e *echo.Echo) {}
 	}
 
 	// This should successfully analyze the file
-	_, err := analyzer.analyzeGoFile(moduleFile)
+	_, _, err := analyzer.analyzeGoFile(moduleFile)
 	if err != nil {
 		t.Errorf("analyzeGoFile should succeed for valid module: %v", err)
 	}
@@ -1146,7 +1242,7 @@ func (m *Module) createUser() {}
 
 	// Analyze the module file
 	analyzer := New(tempDir)
-	module, err := analyzer.analyzeGoFile(moduleFile)
+	module, _, err := analyzer.analyzeGoFile(moduleFile)
 
 	if err != nil {
 		t.Fatalf("Failed to analyze split module: %v", err)
@@ -1385,7 +1481,7 @@ func (m *Module) testHandler() {}`
 			t.Fatalf(parseFailedFormat, err)
 		}
 
-		result, structName := analyzer.extractModuleFromAST(astFile, filepath.Join(tempDir, "testmodule.go"))
+		result, structName, _ := analyzer.extractModuleFromAST(astFile, filepath.Join(tempDir, "testmodule.go"))
 		if result == nil {
 			t.Error("Expected to find a valid module")
 		}
@@ -1410,7 +1506,7 @@ func (m *Module) Init(deps *config.Config) error { return nil }`
 		}
 
 		//nolint:S8148 // NOSONAR: Error intentionally ignored - test verifies module detection, not error conditions
-		result, _ := analyzer.extractModuleFromAST(astFile, filepath.Join(tempDir, testFileName))
+		result, _, _ := analyzer.extractModuleFromAST(astFile, filepath.Join(tempDir, testFileName))
 		if result != nil {
 			t.Error("Expected no module found for wrong init parameter type")
 		}
@@ -1790,7 +1886,7 @@ func (m *Module) Init(deps *app.ModuleDeps) string { return "" }`,
 			}
 
 			//nolint:S8148 // NOSONAR: Error intentionally ignored - test verifies module detection, not error conditions
-			result, _ := analyzer.extractModuleFromAST(astFile, filepath.Join("test", "file.go"))
+			result, _, _ := analyzer.extractModuleFromAST(astFile, filepath.Join("test", "file.go"))
 			found := (result != nil)
 			if found != tt.expected {
 				t.Errorf("Expected module found=%v, got %v", tt.expected, found)
@@ -1864,7 +1960,7 @@ func Helper() {
 			t.Fatalf("failed to write helper.go: %v", err)
 		}
 
-		module, err := analyzer.analyzeGoFile(nonModuleFile)
+		module, _, err := analyzer.analyzeGoFile(nonModuleFile)
 		if err != nil {
 			t.Errorf("analyzeGoFile should not error for non-module files: %v", err)
 		}
@@ -1896,7 +1992,7 @@ func (c *ComplexStruct) SomeMethod() string {
 			t.Fatalf("failed to write complex.go: %v", err)
 		}
 
-		module, err := analyzer.analyzeGoFile(complexFile)
+		module, _, err := analyzer.analyzeGoFile(complexFile)
 		if err != nil {
 			t.Errorf("analyzeGoFile should not error for complex structs: %v", err)
 		}

--- a/tools/openapi/internal/commands/doctor.go
+++ b/tools/openapi/internal/commands/doctor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gaborage/go-bricks/tools/openapi/internal/analyzer"
 	"github.com/gaborage/go-bricks/tools/openapi/internal/models"
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
 	"golang.org/x/mod/semver"
 )
@@ -22,8 +23,12 @@ import (
 var errGoBricksMissing = fmt.Errorf("%s dependency not found in go.mod", goBricksDep)
 
 const (
-	goModFile   = "go.mod"
-	goBricksDep = "go-bricks"
+	goModFile = "go.mod"
+	// goBricksDep is the short name used in user-facing messages; goBricksModulePath
+	// is the exact module path matched against go.mod (avoids matching lookalikes
+	// such as github.com/x/not-go-bricks-wrapper).
+	goBricksDep        = "go-bricks"
+	goBricksModulePath = "github.com/gaborage/go-bricks"
 
 	// Version floors, single-sourced to match go.mod (go 1.25) and the README.
 	// minGoVersion is the toolchain floor in Go's own version format (compared
@@ -261,7 +266,7 @@ func checkGoBricksCompatibility(goModPath string, verbose bool) error {
 	}
 
 	// Parse go-bricks version from go.mod
-	gbVer, isReplace, err := parseGoBricksVersion(string(content))
+	gbVer, isReplace, err := parseGoBricksVersion(cleanPath, content)
 	if err != nil {
 		fmt.Printf("❌ %v\n", err) // dependency not found
 		return err
@@ -299,72 +304,36 @@ func checkGoBricksCompatibility(goModPath string, verbose bool) error {
 	return nil
 }
 
-// parseGoBricksVersion extracts the go-bricks version from go.mod content
-// Returns (version, isReplaceDirective, error)
-//
-//nolint:gocritic // Named returns would reduce clarity for boolean flag parameter
-func parseGoBricksVersion(goModContent string) (string, bool, error) {
-	lines := strings.Split(goModContent, "\n")
-
-	// First check for replace directives (local development)
-	if replacePath := findReplaceDirective(lines); replacePath != "" {
-		return replacePath, true, nil
+// parseGoBricksVersion parses go.mod and returns the go-bricks version.
+// It matches the exact module path (so lookalikes like
+// github.com/x/not-go-bricks-wrapper are ignored) and uses the structured
+// modfile parser (so block `require (...)` / `replace (...)` forms are handled).
+// A replace directive (single or block) reports isReplace=true with the target,
+// so the caller skips the version floor for local/fork development.
+func parseGoBricksVersion(goModPath string, content []byte) (gbVer string, isReplace bool, err error) {
+	mf, err := modfile.Parse(goModPath, content, nil)
+	if err != nil {
+		return "", false, fmt.Errorf("parse go.mod: %w", err)
 	}
 
-	// Look for require directive with version
-	if ver := findRequireVersion(lines); ver != "" {
-		return ver, false, nil
+	// Replace wins (local/fork development).
+	for _, r := range mf.Replace {
+		if r.Old.Path == goBricksModulePath {
+			target := r.New.Path
+			if r.New.Version != "" {
+				target += "@" + r.New.Version
+			}
+			return target, true, nil
+		}
+	}
+
+	for _, req := range mf.Require {
+		if req.Mod.Path == goBricksModulePath {
+			return req.Mod.Version, false, nil
+		}
 	}
 
 	return "", false, errGoBricksMissing
-}
-
-// findReplaceDirective searches for a replace directive in go.mod lines
-func findReplaceDirective(lines []string) string {
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "replace") && strings.Contains(trimmed, goBricksDep) {
-			// Format: replace github.com/gaborage/go-bricks => ../local-path
-			parts := strings.Split(trimmed, "=>")
-			if len(parts) == 2 {
-				return strings.TrimSpace(parts[1])
-			}
-		}
-	}
-	return ""
-}
-
-// findRequireVersion searches for a require directive with version in go.mod lines
-func findRequireVersion(lines []string) string {
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if !strings.Contains(trimmed, goBricksDep) || strings.HasPrefix(trimmed, "//") {
-			continue
-		}
-
-		// Format: github.com/gaborage/go-bricks v0.5.0
-		// or:     github.com/gaborage/go-bricks v0.5.0 // indirect
-		fields := strings.Fields(trimmed)
-		if ver := extractVersionFromFields(fields); ver != "" {
-			return ver
-		}
-	}
-	return ""
-}
-
-// extractVersionFromFields extracts version from go.mod require line fields
-func extractVersionFromFields(fields []string) string {
-	for i, field := range fields {
-		if strings.Contains(field, goBricksDep) && i+1 < len(fields) {
-			ver := fields[i+1]
-			// Remove "// indirect" or other comments
-			if commentIdx := strings.Index(ver, "//"); commentIdx != -1 {
-				ver = strings.TrimSpace(ver[:commentIdx])
-			}
-			return ver
-		}
-	}
-	return ""
 }
 
 // checkVersionCompatibility validates go-bricks version meets minimum requirements

--- a/tools/openapi/internal/commands/doctor.go
+++ b/tools/openapi/internal/commands/doctor.go
@@ -77,8 +77,8 @@ Checks include:
 
   # Check specific project
   go-bricks-openapi doctor --project ./my-service`,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return runDoctor(opts)
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runDoctor(cmd.Context(), opts)
 		},
 	}
 
@@ -89,7 +89,7 @@ Checks include:
 	return cmd
 }
 
-func runDoctor(opts *DoctorOptions) error {
+func runDoctor(ctx context.Context, opts *DoctorOptions) error {
 	fmt.Println("🏥 Running go-bricks-openapi health check...")
 	fmt.Println()
 
@@ -104,7 +104,7 @@ func runDoctor(opts *DoctorOptions) error {
 	// only print caveat noise that the error banner overrides anyway.
 	var hasWarnings bool
 	if !hasErrors {
-		hasWarnings = performDiagnosticsCheck(opts)
+		hasWarnings = performDiagnosticsCheck(ctx, opts)
 	}
 
 	// Final summary. Errors fail the run; warnings (e.g. no modules discovered,
@@ -172,11 +172,11 @@ func performGoModCheck(opts *DoctorOptions, hasErrors bool) bool {
 // performDiagnosticsCheck runs module diagnostics and displays build environment.
 // It returns whether any non-fatal caveat (no modules, unrecognized module
 // method, or analysis failure) was surfaced.
-func performDiagnosticsCheck(opts *DoctorOptions) bool {
+func performDiagnosticsCheck(ctx context.Context, opts *DoctorOptions) bool {
 	// Module diagnostics (analyze project structure)
 	fmt.Println()
 	fmt.Println("📊 Project Diagnostics:")
-	hasWarnings := runModuleDiagnostics(opts.ProjectRoot, opts.Verbose)
+	hasWarnings := runModuleDiagnostics(ctx, opts.ProjectRoot, opts.Verbose)
 
 	// Check build environment
 	fmt.Println()
@@ -391,7 +391,7 @@ func checkVersionCompatibility(ver string) error {
 // It returns whether a caveat was surfaced: an analysis failure, zero modules
 // discovered, or any analyzer diagnostic (e.g. a struct that looks like a module
 // but whose RegisterRoutes signature is unrecognized).
-func runModuleDiagnostics(projectRoot string, verbose bool) bool {
+func runModuleDiagnostics(ctx context.Context, projectRoot string, verbose bool) bool {
 	a := analyzer.New(projectRoot)
 
 	project, err := a.AnalyzeProject()
@@ -416,7 +416,7 @@ func runModuleDiagnostics(projectRoot string, verbose bool) bool {
 
 	// Surface analyzer diagnostics collected during analysis (unrecognized module
 	// methods, unresolvable route paths, etc.).
-	for _, w := range a.Warnings(context.Background()) {
+	for _, w := range a.Warnings(ctx) {
 		fmt.Printf("⚠️  %s\n", w)
 		warned = true
 	}

--- a/tools/openapi/internal/commands/doctor.go
+++ b/tools/openapi/internal/commands/doctor.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"go/build"
+	"go/version"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,13 +13,25 @@ import (
 	"github.com/gaborage/go-bricks/tools/openapi/internal/analyzer"
 	"github.com/gaborage/go-bricks/tools/openapi/internal/models"
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/module"
 	"golang.org/x/mod/semver"
 )
 
+// errGoBricksMissing is the canonical error when go.mod has no go-bricks
+// dependency (a hard failure, distinct from a merely-outdated version).
+var errGoBricksMissing = fmt.Errorf("%s dependency not found in go.mod", goBricksDep)
+
 const (
-	goModFile      = "go.mod"
-	goBricksDep    = "go-bricks"
-	minGoBricksVer = "v0.5.0"
+	goModFile   = "go.mod"
+	goBricksDep = "go-bricks"
+
+	// Version floors, single-sourced to match go.mod (go 1.25) and the README.
+	// minGoVersion is the toolchain floor in Go's own version format (compared
+	// at language/minor granularity so 1.25.x patches and 1.25 RCs all qualify);
+	// minGoBricksVer is the semver floor for the go-bricks features the generator
+	// relies on.
+	minGoVersion   = "go1.25"
+	minGoBricksVer = "v0.13.0"
 
 	// File patterns
 	goFileExt   = ".go"
@@ -85,17 +99,29 @@ func runDoctor(opts *DoctorOptions) error {
 	hasErrors = performGoVersionCheck(opts, hasErrors)
 	hasErrors = performProjectStructureCheck(opts, hasErrors)
 	hasErrors = performGoModCheck(opts, hasErrors)
-	performDiagnosticsCheck(opts)
 
-	// Final summary
-	fmt.Println()
-	if hasErrors {
-		fmt.Println("❌ Health check failed - please fix the issues above")
-		return fmt.Errorf("health check failed")
+	// Skip the (full-tree) project analysis once a hard error is known: it would
+	// only print caveat noise that the error banner overrides anyway.
+	var hasWarnings bool
+	if !hasErrors {
+		hasWarnings = performDiagnosticsCheck(opts)
 	}
 
-	fmt.Println("✅ All checks passed - ready to generate OpenAPI specs!")
-	return nil
+	// Final summary. Errors fail the run; warnings (e.g. no modules discovered,
+	// or a module whose RegisterRoutes signature is unrecognized) still allow
+	// generation but flip the banner from unconditional green to a caveat.
+	fmt.Println()
+	switch {
+	case hasErrors:
+		fmt.Println("❌ Health check failed - please fix the issues above")
+		return fmt.Errorf("health check failed")
+	case hasWarnings:
+		fmt.Println("⚠️  Ready with caveats - review the warnings above before generating")
+		return nil
+	default:
+		fmt.Println("✅ All checks passed - ready to generate OpenAPI specs!")
+		return nil
+	}
 }
 
 // performGoVersionCheck validates Go version compatibility
@@ -106,7 +132,7 @@ func performGoVersionCheck(opts *DoctorOptions, hasErrors bool) bool {
 	}
 	fmt.Printf("📋 Go Version: %s\n", goVersion)
 	if !isGoVersionSupported(goVersion) {
-		fmt.Println("❌ Go version 1.21+ required")
+		fmt.Printf("❌ Go %s+ required\n", strings.TrimPrefix(minGoVersion, "go"))
 		return true
 	}
 	fmt.Println("✅ Go version compatible")
@@ -133,51 +159,41 @@ func performGoModCheck(opts *DoctorOptions, hasErrors bool) bool {
 	}
 	fmt.Println("✅ go.mod found")
 
-	// Basic go-bricks version check (expanded in Phase 1)
+	// A missing go-bricks dependency, a below-floor version, or an unreadable
+	// go.mod is fatal: without the framework at a supported version the generator
+	// can't produce a faithful spec. checkGoBricksCompatibility reports the
+	// specific reason (and only the version path mentions the floor).
 	if err := checkGoBricksCompatibility(goModPath, opts.Verbose); err != nil {
-		if opts.Verbose {
-			fmt.Printf("⚠️  go-bricks compatibility: %v\n", err)
-		}
-		// Non-fatal for now - just warn in verbose mode
+		return true
 	}
 	return hasErrors
 }
 
-// performDiagnosticsCheck runs module diagnostics and displays build environment
-func performDiagnosticsCheck(opts *DoctorOptions) {
+// performDiagnosticsCheck runs module diagnostics and displays build environment.
+// It returns whether any non-fatal caveat (no modules, unrecognized module
+// method, or analysis failure) was surfaced.
+func performDiagnosticsCheck(opts *DoctorOptions) bool {
 	// Module diagnostics (analyze project structure)
 	fmt.Println()
 	fmt.Println("📊 Project Diagnostics:")
-	if err := runModuleDiagnostics(opts.ProjectRoot, opts.Verbose); err != nil {
-		if opts.Verbose {
-			fmt.Printf("⚠️  Module diagnostics: %v\n", err)
-		}
-		// Non-fatal - just informational
-	}
+	hasWarnings := runModuleDiagnostics(opts.ProjectRoot, opts.Verbose)
 
 	// Check build environment
 	fmt.Println()
 	fmt.Printf("🔧 GOROOT: %s\n", build.Default.GOROOT)
 	fmt.Printf("🔧 GOPATH: %s\n", build.Default.GOPATH)
+	return hasWarnings
 }
 
-func isGoVersionSupported(version string) bool {
-	// Convert Go version (e.g., "go1.21.5") to semver format (e.g., "v1.21.5")
-	if !strings.HasPrefix(version, "go") {
+func isGoVersionSupported(goVer string) bool {
+	// Use Go's own version parser so real toolchain strings parse, including
+	// release candidates like "go1.25rc1" (which semver cannot represent).
+	if !version.IsValid(goVer) {
 		return false
 	}
-
-	// Remove "go" prefix and add "v" prefix for semver
-	semverVersion := "v" + strings.TrimPrefix(version, "go")
-
-	// Check if version is valid semver format
-	if !semver.IsValid(semverVersion) {
-		return false
-	}
-
-	// Compare with minimum required version (1.21.0)
-	minVersion := "v1.21.0"
-	return semver.Compare(semverVersion, minVersion) >= 0
+	// Compare at language (minor) granularity so any 1.25.x patch and the 1.25
+	// release candidates satisfy the floor, while 1.24.x and below do not.
+	return version.Compare(version.Lang(goVer), minGoVersion) >= 0
 }
 
 func checkProjectStructure(projectRoot string) error {
@@ -227,48 +243,59 @@ func checkProjectStructure(projectRoot string) error {
 	return nil
 }
 
-// checkGoBricksCompatibility performs compatibility check with go-bricks framework
+// checkGoBricksCompatibility reports go-bricks compatibility. It prints the
+// specific ❌ reason for each failure mode (so an I/O error never gets a
+// version-floor hint) and returns a non-nil error iff the run should fail.
 func checkGoBricksCompatibility(goModPath string, verbose bool) error {
 	// Validate and resolve path securely to prevent path traversal
 	cleanPath, err := validateAndResolvePath(goModPath)
 	if err != nil {
+		fmt.Printf("❌ cannot resolve go.mod path: %v\n", err)
 		return err
 	}
 
 	content, err := readFileFn(cleanPath)
 	if err != nil {
+		fmt.Printf("❌ failed to read go.mod: %v\n", err)
 		return fmt.Errorf("failed to read go.mod: %w", err)
 	}
 
-	goModContent := string(content)
-
 	// Parse go-bricks version from go.mod
-	version, isReplace, err := parseGoBricksVersion(goModContent)
+	gbVer, isReplace, err := parseGoBricksVersion(string(content))
 	if err != nil {
+		fmt.Printf("❌ %v\n", err) // dependency not found
 		return err
 	}
 
-	// Handle local replace directives
+	// Local development: dependency is present via a replace directive, so the
+	// local checkout governs behavior — skip the version floor (but still report
+	// the dependency unconditionally).
 	if isReplace {
+		fmt.Printf("ℹ️  %s: local replace directive detected (%s)\n", goBricksDep, gbVer)
 		if verbose {
-			fmt.Printf("ℹ️  go-bricks: local replace directive detected (%s)\n", version)
 			fmt.Println("   → Skipping version compatibility check (using local development version)")
 		}
 		return nil
 	}
 
-	// Display version
-	fmt.Printf("📦 go-bricks version: %s\n", version)
+	// Display version unconditionally so the dependency status is always visible.
+	fmt.Printf("📦 %s version: %s\n", goBricksDep, gbVer)
 
-	// Check version compatibility
-	if err := checkVersionCompatibility(version); err != nil {
-		fmt.Printf("⚠️  Version compatibility: %v\n", err)
-		fmt.Printf("   → OpenAPI metadata features require %s %s+\n", goBricksDep, minGoBricksVer)
-		// Non-fatal warning
-	} else {
-		fmt.Printf("✅ %s version compatible\n", goBricksDep)
+	// Pseudo-versions (e.g. from `go get @main` / untagged or fork builds) sort
+	// below any tagged floor by semver rules yet may track a commit ahead of it —
+	// treat them like a replace directive and skip the floor rather than failing
+	// with a misleading "below minimum" message.
+	if module.IsPseudoVersion(gbVer) {
+		fmt.Printf("ℹ️  %s is a pseudo-version (untagged build) — skipping the version floor\n", gbVer)
+		return nil
 	}
 
+	// A below-floor (or unparseable) version is fatal.
+	if err := checkVersionCompatibility(gbVer); err != nil {
+		fmt.Printf("❌ %v\n   → OpenAPI generation requires %s %s+\n", err, goBricksDep, minGoBricksVer)
+		return err
+	}
+	fmt.Printf("✅ %s version compatible\n", goBricksDep)
 	return nil
 }
 
@@ -285,11 +312,11 @@ func parseGoBricksVersion(goModContent string) (string, bool, error) {
 	}
 
 	// Look for require directive with version
-	if version := findRequireVersion(lines); version != "" {
-		return version, false, nil
+	if ver := findRequireVersion(lines); ver != "" {
+		return ver, false, nil
 	}
 
-	return "", false, fmt.Errorf("%s dependency not found in go.mod", goBricksDep)
+	return "", false, errGoBricksMissing
 }
 
 // findReplaceDirective searches for a replace directive in go.mod lines
@@ -318,8 +345,8 @@ func findRequireVersion(lines []string) string {
 		// Format: github.com/gaborage/go-bricks v0.5.0
 		// or:     github.com/gaborage/go-bricks v0.5.0 // indirect
 		fields := strings.Fields(trimmed)
-		if version := extractVersionFromFields(fields); version != "" {
-			return version
+		if ver := extractVersionFromFields(fields); ver != "" {
+			return ver
 		}
 	}
 	return ""
@@ -329,55 +356,72 @@ func findRequireVersion(lines []string) string {
 func extractVersionFromFields(fields []string) string {
 	for i, field := range fields {
 		if strings.Contains(field, goBricksDep) && i+1 < len(fields) {
-			version := fields[i+1]
+			ver := fields[i+1]
 			// Remove "// indirect" or other comments
-			if commentIdx := strings.Index(version, "//"); commentIdx != -1 {
-				version = strings.TrimSpace(version[:commentIdx])
+			if commentIdx := strings.Index(ver, "//"); commentIdx != -1 {
+				ver = strings.TrimSpace(ver[:commentIdx])
 			}
-			return version
+			return ver
 		}
 	}
 	return ""
 }
 
 // checkVersionCompatibility validates go-bricks version meets minimum requirements
-func checkVersionCompatibility(version string) error {
+func checkVersionCompatibility(ver string) error {
 	// Ensure version starts with 'v'
-	if !strings.HasPrefix(version, "v") {
-		version = "v" + version
+	if !strings.HasPrefix(ver, "v") {
+		ver = "v" + ver
 	}
 
 	// Validate semver format
-	if !semver.IsValid(version) {
-		return fmt.Errorf("invalid semantic version format: %s", version)
+	if !semver.IsValid(ver) {
+		return fmt.Errorf("invalid semantic version format: %s", ver)
 	}
 
 	// Check minimum version for OpenAPI metadata support
-	if semver.Compare(version, minGoBricksVer) < 0 {
-		return fmt.Errorf("version %s is below minimum %s", version, minGoBricksVer)
+	if semver.Compare(ver, minGoBricksVer) < 0 {
+		return fmt.Errorf("version %s is below minimum %s", ver, minGoBricksVer)
 	}
 
 	return nil
 }
 
-// runModuleDiagnostics analyzes the project and reports module/route statistics
-func runModuleDiagnostics(projectRoot string, verbose bool) error {
-	// Create analyzer
+// runModuleDiagnostics analyzes the project and reports module/route statistics.
+// It returns whether a caveat was surfaced: an analysis failure, zero modules
+// discovered, or any analyzer diagnostic (e.g. a struct that looks like a module
+// but whose RegisterRoutes signature is unrecognized).
+func runModuleDiagnostics(projectRoot string, verbose bool) bool {
 	a := analyzer.New(projectRoot)
 
-	// Analyze project
 	project, err := a.AnalyzeProject()
 	if err != nil {
-		return fmt.Errorf("failed to analyze project: %w", err)
+		fmt.Printf("⚠️  Module analysis failed: %v\n", err)
+		return true
 	}
 
-	// Calculate statistics
 	stats := calculateProjectStats(project)
-
-	// Display results
 	displayProjectStats(stats, verbose)
 
-	return nil
+	warned := false
+	if stats.ModuleCount == 0 {
+		fmt.Println("⚠️  No go-bricks modules discovered — the generated spec would have no operations")
+		warned = true
+	}
+	// displayProjectStats already printed a ⚠️ for untyped routes; fold it into the
+	// caveat flag so the banner stays consistent with what was printed.
+	if len(stats.UntypedRoutes) > 0 {
+		warned = true
+	}
+
+	// Surface analyzer diagnostics collected during analysis (unrecognized module
+	// methods, unresolvable route paths, etc.).
+	for _, w := range a.Warnings(context.Background()) {
+		fmt.Printf("⚠️  %s\n", w)
+		warned = true
+	}
+
+	return warned
 }
 
 // ProjectStats holds project analysis statistics

--- a/tools/openapi/internal/commands/doctor_test.go
+++ b/tools/openapi/internal/commands/doctor_test.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
+	"bytes"
 	"errors"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -11,6 +13,32 @@ import (
 	"github.com/gaborage/go-bricks/tools/openapi/internal/models"
 )
 
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what it
+// printed. The pipe is drained in a goroutine so a large (or fn-aborting) write
+// can't deadlock. NOTE: this mutates the global os.Stdout; do not call it from
+// parallel tests.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+	_ = w.Close()
+	return <-done
+}
+
 // Test constants to avoid string duplication
 const (
 	msgExpectedError   = "Expected error but got none"
@@ -18,8 +46,9 @@ const (
 	msgFailedToCreate  = "Failed to create test file: %v"
 	testMainGoFile     = "main.go"
 	packageMainContent = "package main"
-	goVersion          = "go1.21.0"
+	goVersion          = "go1.25.0" // the supported floor (matches minGoVersion)
 	msgUnexpectedError = "Unexpected error: %v"
+	msgBelowMinimum    = "below minimum"
 )
 
 // Helper function to assert error expectations
@@ -50,18 +79,8 @@ func TestIsGoVersionSupported(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "supported version - go1.21.0",
-			version:  goVersion,
-			expected: true,
-		},
-		{
-			name:     "supported version - go1.21.5",
-			version:  "go1.21.5",
-			expected: true,
-		},
-		{
-			name:     "supported version - go1.22.0",
-			version:  "go1.22.0",
+			name:     "supported version - exactly the floor",
+			version:  goVersion, // go1.25.0
 			expected: true,
 		},
 		{
@@ -70,28 +89,28 @@ func TestIsGoVersionSupported(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "supported version - go1.26.0",
+			version:  "go1.26.0",
+			expected: true,
+		},
+		{
+			name:     "unsupported version - go1.24.5 (just below floor)",
+			version:  "go1.24.5",
+			expected: false,
+		},
+		{
+			name:     "unsupported version - go1.22.0",
+			version:  "go1.22.0",
+			expected: false,
+		},
+		{
 			name:     "unsupported version - go1.20.0",
 			version:  "go1.20.0",
 			expected: false,
 		},
 		{
-			name:     "unsupported version - go1.19.5",
-			version:  "go1.19.5",
-			expected: false,
-		},
-		{
-			name:     "unsupported version - go1.18.10",
-			version:  "go1.18.10",
-			expected: false,
-		},
-		{
-			name:     "edge case - exactly minimum version",
-			version:  goVersion, // semver requires patch version
-			expected: true,
-		},
-		{
 			name:     "invalid format - missing go prefix",
-			version:  "1.21.0",
+			version:  "1.25.0",
 			expected: false,
 		},
 		{
@@ -101,18 +120,20 @@ func TestIsGoVersionSupported(t *testing.T) {
 		},
 		{
 			name:     "invalid format - malformed version",
-			version:  "go1.21.x",
+			version:  "go1.25.x",
 			expected: false,
 		},
 		{
-			name:     "pre-release version - go1.22.0-rc1",
-			version:  "go1.22.0-rc1",
+			// Real Go RC toolchain format (no dot, no patch). A 1.25 RC IS the
+			// 1.25 line, so it must satisfy the floor.
+			name:     "release candidate of the floor - go1.25rc1",
+			version:  "go1.25rc1",
 			expected: true,
 		},
 		{
-			name:     "beta version - go1.23.0-beta1",
-			version:  "go1.23.0-beta1",
-			expected: true,
+			name:     "release candidate below floor - go1.24rc1",
+			version:  "go1.24rc1",
+			expected: false,
 		},
 	}
 
@@ -159,6 +180,30 @@ go 1.21
 require (
 	github.com/spf13/cobra v1.8.0
 )
+`,
+			verbose:     false,
+			expectError: true,
+		},
+		{
+			// Pseudo-version (e.g. `go get @main`) must NOT be floor-failed: it can
+			// track a commit ahead of the floor.
+			name: "pseudo-version skips the floor",
+			goModContent: `module test-project
+
+go 1.25
+
+require github.com/gaborage/go-bricks v0.0.0-20240101000000-abcdef123456
+`,
+			verbose:     false,
+			expectError: false,
+		},
+		{
+			name: "below-floor version fails",
+			goModContent: `module test-project
+
+go 1.25
+
+require github.com/gaborage/go-bricks v0.12.0
 `,
 			verbose:     false,
 			expectError: true,
@@ -688,12 +733,12 @@ require go-bricks v1.0.0
 	assertError(t, err, true)
 }
 
-func TestRunDoctorWarnsAboutMissingGoBricks(t *testing.T) {
+func TestRunDoctorFailsOnMissingGoBricks(t *testing.T) {
 	tempDir := t.TempDir()
 	createTestGoFile(t, tempDir, testMainGoFile, packageMainContent)
 	err := os.WriteFile(filepath.Join(tempDir, goModFile), []byte(`module test
 
-go 1.21
+go 1.25
 
 require github.com/spf13/cobra v1.8.0
 `), 0644)
@@ -707,8 +752,65 @@ require github.com/spf13/cobra v1.8.0
 		Verbose:     true,
 	}
 
+	// A missing go-bricks dependency is now a hard failure (PR13).
 	err = runDoctor(opts)
-	assertError(t, err, false)
+	assertError(t, err, true)
+}
+
+// writeProject writes a go.mod and a single .go file into a fresh temp dir.
+func writeProject(t *testing.T, goMod, goSrc string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, goModFile), []byte(goMod), 0644); err != nil {
+		t.Fatalf(msgFailedToCreate, err)
+	}
+	createTestGoFile(t, dir, testMainGoFile, goSrc)
+	return dir
+}
+
+// TestRunDoctorZeroModulesIsCaveat verifies that a project with the dependency
+// present but no discovered modules emits a warning and the caveat banner —
+// not the unconditional green banner — yet does not fail the run (PR13 #2).
+func TestRunDoctorZeroModulesIsCaveat(t *testing.T) {
+	dir := writeProject(t,
+		"module test\n\ngo 1.25\n\nrequire github.com/gaborage/go-bricks v0.37.0\n",
+		packageMainContent) // package main, no go-bricks module
+
+	opts := &DoctorOptions{ProjectRoot: dir, GoVersion: goVersion}
+
+	var runErr error
+	out := captureStdout(t, func() { runErr = runDoctor(opts) })
+
+	if runErr != nil {
+		t.Errorf("zero modules should be a caveat, not a hard error: %v", runErr)
+	}
+	if !strings.Contains(out, "No go-bricks modules discovered") {
+		t.Errorf("expected a zero-modules warning, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Ready with caveats") {
+		t.Errorf("expected the caveat banner, got:\n%s", out)
+	}
+	if strings.Contains(out, "All checks passed") {
+		t.Errorf("unconditional green banner must not appear for a zero-module project:\n%s", out)
+	}
+}
+
+// TestRunDoctorFailsBelowGoBricksFloor verifies a below-floor go-bricks version
+// is a hard failure (PR13 #3).
+func TestRunDoctorFailsBelowGoBricksFloor(t *testing.T) {
+	dir := writeProject(t,
+		"module test\n\ngo 1.25\n\nrequire github.com/gaborage/go-bricks v0.12.0\n",
+		packageMainContent)
+
+	opts := &DoctorOptions{ProjectRoot: dir, GoVersion: goVersion}
+
+	var runErr error
+	out := captureStdout(t, func() { runErr = runDoctor(opts) })
+
+	assertError(t, runErr, true)
+	if !strings.Contains(out, msgBelowMinimum) {
+		t.Errorf("expected a below-minimum version message, got:\n%s", out)
+	}
 }
 
 func TestCheckProjectStructureWalkError(t *testing.T) {
@@ -880,25 +982,31 @@ func TestCheckVersionCompatibility(t *testing.T) {
 		errorMsg    string
 	}{
 		{
-			name:        "compatible version",
-			version:     "v0.5.0",
+			name:        "at the floor (v0.13.0)",
+			version:     "v0.13.0",
 			expectError: false,
 		},
 		{
-			name:        "newer version",
-			version:     "v1.0.0",
+			name:        "above the floor",
+			version:     "v0.37.0",
 			expectError: false,
 		},
 		{
-			name:        "version without v prefix",
-			version:     "0.5.0",
+			name:        "at the floor without v prefix",
+			version:     "0.13.0",
 			expectError: false,
 		},
 		{
-			name:        "below minimum",
+			name:        "just below the floor (v0.12.9)",
+			version:     "v0.12.9",
+			expectError: true,
+			errorMsg:    msgBelowMinimum,
+		},
+		{
+			name:        "well below the floor",
 			version:     "v0.4.0",
 			expectError: true,
-			errorMsg:    "below minimum",
+			errorMsg:    msgBelowMinimum,
 		},
 		{
 			name:        "invalid semver",

--- a/tools/openapi/internal/commands/doctor_test.go
+++ b/tools/openapi/internal/commands/doctor_test.go
@@ -163,7 +163,7 @@ func TestCheckGoBricksCompatibility(t *testing.T) {
 go 1.21
 
 require (
-	go-bricks v1.0.0
+	github.com/gaborage/go-bricks v1.0.0
 	github.com/spf13/cobra v1.8.0
 )
 `,
@@ -214,7 +214,7 @@ require github.com/gaborage/go-bricks v0.12.0
 go 1.21
 
 require (
-	go-bricks v2.0.0
+	github.com/gaborage/go-bricks v0.20.0
 )
 `,
 			verbose:     true,
@@ -292,7 +292,7 @@ func TestRunDoctor(t *testing.T) {
 
 go 1.21
 
-require go-bricks v1.0.0
+require github.com/gaborage/go-bricks v1.0.0
 `
 	err := os.WriteFile(filepath.Join(tempDir, goModFile), []byte(goModContent), 0644)
 	if err != nil {
@@ -491,7 +491,7 @@ func TestCheckGoBricksCompatibilityWithRelativePaths(t *testing.T) {
 
 go 1.21
 
-require go-bricks v1.0.0
+require github.com/gaborage/go-bricks v1.0.0
 `
 	goModPath := filepath.Join(tempDir, goModFile)
 	err := os.WriteFile(goModPath, []byte(goModContent), 0644)
@@ -717,7 +717,7 @@ func TestRunDoctorUnsupportedGoVersion(t *testing.T) {
 
 go 1.21
 
-require go-bricks v1.0.0
+require github.com/gaborage/go-bricks v1.0.0
 `), 0644)
 	if err != nil {
 		t.Fatalf(msgFailedToCreate, err)
@@ -949,11 +949,45 @@ require github.com/other/package v1.0.0
 			expectedReplace: false,
 			expectError:     true,
 		},
+		{
+			// A lookalike module path must NOT be matched as go-bricks.
+			name: "lookalike module is not matched",
+			goModContent: `module test
+require github.com/example/not-go-bricks-wrapper v1.2.3
+`,
+			expectedVersion: "",
+			expectedReplace: false,
+			expectError:     true,
+		},
+		{
+			name: "block require form",
+			goModContent: `module test
+require (
+	github.com/gaborage/go-bricks v0.20.0
+	github.com/spf13/cobra v1.8.0
+)
+`,
+			expectedVersion: "v0.20.0",
+			expectedReplace: false,
+			expectError:     false,
+		},
+		{
+			name: "block replace form",
+			goModContent: `module test
+require github.com/gaborage/go-bricks v0.0.0
+replace (
+	github.com/gaborage/go-bricks => ../local-go-bricks
+)
+`,
+			expectedVersion: "../local-go-bricks",
+			expectedReplace: true,
+			expectError:     false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			version, isReplace, err := parseGoBricksVersion(tt.goModContent)
+			version, isReplace, err := parseGoBricksVersion("go.mod", []byte(tt.goModContent))
 
 			if tt.expectError && err == nil {
 				t.Error(msgExpectedError)
@@ -1029,93 +1063,6 @@ func TestCheckVersionCompatibility(t *testing.T) {
 				}
 			} else if err != nil {
 				t.Errorf(msgUnexpectedError, err)
-			}
-		})
-	}
-}
-
-func TestFindReplaceDirective(t *testing.T) {
-	tests := []struct {
-		name     string
-		lines    []string
-		expected string
-	}{
-		{
-			name: "has replace",
-			lines: []string{
-				"module test",
-				"replace github.com/gaborage/go-bricks => ../local",
-			},
-			expected: "../local",
-		},
-		{
-			name: "no replace",
-			lines: []string{
-				"module test",
-				"require github.com/gaborage/go-bricks v0.5.0",
-			},
-			expected: "",
-		},
-		{
-			name: "replace with whitespace",
-			lines: []string{
-				"  replace  github.com/gaborage/go-bricks  =>  /absolute/path  ",
-			},
-			expected: "/absolute/path",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := findReplaceDirective(tt.lines)
-			if result != tt.expected {
-				t.Errorf("Expected %q, got %q", tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestFindRequireVersion(t *testing.T) {
-	tests := []struct {
-		name     string
-		lines    []string
-		expected string
-	}{
-		{
-			name: "simple require",
-			lines: []string{
-				"require github.com/gaborage/go-bricks v0.5.0",
-			},
-			expected: "v0.5.0",
-		},
-		{
-			name: "require with indirect",
-			lines: []string{
-				"require github.com/gaborage/go-bricks v0.6.0 // indirect",
-			},
-			expected: "v0.6.0",
-		},
-		{
-			name: "commented require",
-			lines: []string{
-				"// require github.com/gaborage/go-bricks v0.5.0",
-			},
-			expected: "",
-		},
-		{
-			name: "no go-bricks",
-			lines: []string{
-				"require github.com/other/package v1.0.0",
-			},
-			expected: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := findRequireVersion(tt.lines)
-			if result != tt.expected {
-				t.Errorf("Expected %q, got %q", tt.expected, result)
 			}
 		})
 	}

--- a/tools/openapi/internal/commands/doctor_test.go
+++ b/tools/openapi/internal/commands/doctor_test.go
@@ -46,7 +46,6 @@ const (
 	msgFailedToCreate  = "Failed to create test file: %v"
 	testMainGoFile     = "main.go"
 	packageMainContent = "package main"
-	goVersion          = "go1.25.0" // the supported floor (matches minGoVersion)
 	msgUnexpectedError = "Unexpected error: %v"
 	msgBelowMinimum    = "below minimum"
 )
@@ -80,7 +79,7 @@ func TestIsGoVersionSupported(t *testing.T) {
 	}{
 		{
 			name:     "supported version - exactly the floor",
-			version:  goVersion, // go1.25.0
+			version:  minGoVersion, // the production floor const ("go1.25")
 			expected: true,
 		},
 		{
@@ -339,7 +338,7 @@ require go-bricks v1.0.0
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := runDoctor(tt.opts)
+			err := runDoctor(t.Context(), tt.opts)
 			assertError(t, err, tt.expectError)
 		})
 	}
@@ -662,7 +661,7 @@ func TestRunDoctorMissingGoMod(t *testing.T) {
 		Verbose:     false,
 	}
 
-	err := runDoctor(opts)
+	err := runDoctor(t.Context(), opts)
 	if err == nil {
 		t.Error("Expected error for missing go.mod, but got none")
 	}
@@ -729,7 +728,7 @@ require go-bricks v1.0.0
 		GoVersion:   "go1.20.5",
 	}
 
-	err = runDoctor(opts)
+	err = runDoctor(t.Context(), opts)
 	assertError(t, err, true)
 }
 
@@ -748,12 +747,12 @@ require github.com/spf13/cobra v1.8.0
 
 	opts := &DoctorOptions{
 		ProjectRoot: tempDir,
-		GoVersion:   goVersion,
+		GoVersion:   minGoVersion,
 		Verbose:     true,
 	}
 
 	// A missing go-bricks dependency is now a hard failure (PR13).
-	err = runDoctor(opts)
+	err = runDoctor(t.Context(), opts)
 	assertError(t, err, true)
 }
 
@@ -776,10 +775,10 @@ func TestRunDoctorZeroModulesIsCaveat(t *testing.T) {
 		"module test\n\ngo 1.25\n\nrequire github.com/gaborage/go-bricks v0.37.0\n",
 		packageMainContent) // package main, no go-bricks module
 
-	opts := &DoctorOptions{ProjectRoot: dir, GoVersion: goVersion}
+	opts := &DoctorOptions{ProjectRoot: dir, GoVersion: minGoVersion}
 
 	var runErr error
-	out := captureStdout(t, func() { runErr = runDoctor(opts) })
+	out := captureStdout(t, func() { runErr = runDoctor(t.Context(), opts) })
 
 	if runErr != nil {
 		t.Errorf("zero modules should be a caveat, not a hard error: %v", runErr)
@@ -802,10 +801,10 @@ func TestRunDoctorFailsBelowGoBricksFloor(t *testing.T) {
 		"module test\n\ngo 1.25\n\nrequire github.com/gaborage/go-bricks v0.12.0\n",
 		packageMainContent)
 
-	opts := &DoctorOptions{ProjectRoot: dir, GoVersion: goVersion}
+	opts := &DoctorOptions{ProjectRoot: dir, GoVersion: minGoVersion}
 
 	var runErr error
-	out := captureStdout(t, func() { runErr = runDoctor(opts) })
+	out := captureStdout(t, func() { runErr = runDoctor(t.Context(), opts) })
 
 	assertError(t, runErr, true)
 	if !strings.Contains(out, msgBelowMinimum) {


### PR DESCRIPTION
## Summary

PR13 of the OpenAPI-tool gap-analysis roadmap. Turns `go-bricks-openapi doctor` into a real pre-flight gate instead of a report that prints green on a broken project.

### Behavior changes
- **Missing go-bricks dependency → hard failure** (was a verbose-only warning); dependency status reported unconditionally.
- **Version floors bumped + single-sourced** to match `go.mod`/README: **Go ≥ 1.25**, **go-bricks ≥ v0.13.0**. A below-floor go-bricks version now fails the run.
- **Zero modules (and untyped routes) → "Ready with caveats" banner** via a new warnings channel — surfaced, but non-fatal.
- **Near-miss module diagnostic**: a struct with valid `Name`+`Init` but an unrecognized `RegisterRoutes` signature is now reported (was silently dropped). Done as a **package-level resolution** — emitted only for a directory that produced no real module, with a **package-qualified** message — so it's order-independent, never collides on the conventional `Module` name, and never false-flags a package that has a valid module.
- **Makefile**: `validate-cli`/`demo` doctor repointed to the `nested_schema` fixture (the framework root has no go-bricks `require` + 0 modules, which the stricter doctor now fails).

### Hardening (from `/code-review` — 12 findings — and `/security-audit`)
| Finding | Fix |
|---|---|
| Near-miss dedup collided on `"Module"`; order-dependent; false-positive when a valid module exists; unqualified message | Redesigned as a package-level pass (dir-keyed, gated on "no module"), package-qualified message |
| Go RC toolchain `go1.25rc1` rejected as unparseable | Use stdlib `go/version` (language-level floor) |
| Pseudo-version (`go get @main`) hard-failed as "below minimum" | Skip the floor for pseudo-versions |
| I/O/path errors printed a spurious "requires v0.13.0+" hint | Per-failure-mode messages |
| Full-tree analysis ran (and printed caveat noise) under a hard-error banner | Skip analysis once a hard error is known |

## Testing
- `make check` green; full suite passes with `-race`.
- Coverage: analyzer **90.9%**, commands **87.7%**, generator 96.4%, spectest 81.2% (≥80% gate).
- Golden specs **unchanged**; `gosec` 0, `govulncheck` clean, lint 0.
- All behaviors verified end-to-end against the built binary (near-miss qualification, pseudo-version skip, caveat banner, boundary versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Doctor/health check now distinguishes fatal failures from non-fatal warnings, allowing "success with caveats" and clearer failure reporting.
  * Module discovery suppresses false "near-miss" warnings when a valid module exists.

* **Chores**
  * Minimum supported Go version raised to 1.25; compatibility messaging tightened and below-floor versions fail.
  * CLI demo/validation flows and CI now run against a real project fixture; doctor prints detected go-bricks version and fails when missing.

* **Tests**
  * Expanded tests covering doctor outcomes, go/go-bricks version checks, and near-miss diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->