### PR TITLE
feat(openapi): testable Run() seam lifts cmd/main.go off 0% coverage (PR14)

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -675,6 +675,18 @@ jobs:
           # fails. Mirror make validate-cli's SPEC_FIXTURE target.
           $projectRoot = Resolve-Path "internal/spectest/testdata/nested_schema"
           ./go-bricks-openapi.exe doctor --project $projectRoot
+          # Exercise generate end-to-end and sanity-check the output (mirrors make
+          # validate-cli; network-free).
+          $specTmp = Join-Path $env:TEMP "openapi-cli-spec.yaml"
+          ./go-bricks-openapi.exe generate --project $projectRoot --output $specTmp
+          # PowerShell 5.1 does not abort on a native command's non-zero exit, so
+          # surface generate failures explicitly (matches this workflow's pattern).
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $hasMarker = Select-String -Path $specTmp -Pattern "openapi: 3.0.1" -Quiet
+          Remove-Item -Force $specTmp
+          if (-not $hasMarker) {
+            Write-Error "generated spec missing the OpenAPI version marker"; exit 1
+          }
           Write-Host "CLI validation passed"
 
       - name: Verify go mod (Ubuntu only)

--- a/tools/openapi/Makefile
+++ b/tools/openapi/Makefile
@@ -57,6 +57,11 @@ validate-cli: build ## Validate CLI commands work correctly
 	# doctor must run against a real go-bricks project (dep + modules present);
 	# the framework root has neither, which the stricter PR13 doctor now fails.
 	./$(BINARY_NAME) doctor --project $(SPEC_FIXTURE)
+	# Exercise generate end-to-end and sanity-check the output (network-free;
+	# full redocly lint lives in validate-spec).
+	./$(BINARY_NAME) generate --project $(SPEC_FIXTURE) --output $(SPEC_TMP)
+	@grep -q "openapi: 3.0.1" $(SPEC_TMP); status=$$?; rm -f $(SPEC_TMP); \
+		test $$status -eq 0 || (echo "generated spec missing the OpenAPI version marker" && exit 1)
 	@echo "✓ CLI validation passed"
 
 validate-spec: build ## Generate a fixture spec and validate it with redocly (requires npx; CI/Unix)

--- a/tools/openapi/cmd/go-bricks-openapi/main.go
+++ b/tools/openapi/cmd/go-bricks-openapi/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -9,9 +10,12 @@ import (
 	"github.com/gaborage/go-bricks/tools/openapi/internal/commands"
 )
 
-var version = "dev" // Will be set during build
+var version = "dev" // Will be set during build via -ldflags "-X main.version=..."
 
-func main() {
+// buildRootCmd constructs the go-bricks-openapi root command with all subcommands.
+// The version (injected at build time) is surfaced by the --version flag and the
+// version subcommand.
+func buildRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "go-bricks-openapi",
 		Short: "Generate OpenAPI specs for go-bricks services",
@@ -20,22 +24,38 @@ func main() {
 This tool analyzes go-bricks services and generates OpenAPI specifications automatically
 from route registrations, type definitions, and validation tags.`,
 		Version: version,
-		// Errors and usage are reported once below (a single "Error:" line, no usage
-		// dump) rather than by cobra's default handler on a RunE error.
+		// Errors and usage are reported once by run() (a single "Error:" line, no
+		// usage dump) rather than by cobra's default handler on a RunE error.
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 
-	// Add commands
 	rootCmd.AddCommand(
 		commands.NewGenerateCommand(),
 		commands.NewDoctorCommand(),
 		commands.NewVersionCommand(version),
 	)
 
-	// Execute
+	return rootCmd
+}
+
+// run is the testable seam behind main(): it builds the CLI, executes it against
+// args (typically os.Args[1:]) writing to stdout/stderr, and returns the process
+// exit code. A non-nil command error prints a single "Error:" line to stderr and
+// returns 1.
+func run(args []string, stdout, stderr io.Writer) int {
+	rootCmd := buildRootCmd()
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
+
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+		return 1
 	}
+	return 0
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
 }

--- a/tools/openapi/cmd/go-bricks-openapi/main_test.go
+++ b/tools/openapi/cmd/go-bricks-openapi/main_test.go
@@ -2,47 +2,15 @@ package main
 
 import (
 	"bytes"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/gaborage/go-bricks/tools/openapi/internal/testutil"
 )
-
-// captureStdout runs fn with os.Stdout redirected to a pipe and returns what was
-// printed there. The subcommands write progress via fmt.Printf (os.Stdout), which
-// cobra's SetOut does not intercept. The pipe is drained in a goroutine so a large
-// write can't deadlock; the write end is closed even if fn panics (so the drain
-// goroutine terminates), and the read end is closed once drained (no fd leak).
-// NOTE: mutates the global os.Stdout; do not call from parallel tests.
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-	orig := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	os.Stdout = w
-	defer func() { os.Stdout = orig }()
-
-	done := make(chan string, 1)
-	go func() {
-		var buf bytes.Buffer
-		_, _ = io.Copy(&buf, r)
-		_ = r.Close()
-		done <- buf.String()
-	}()
-
-	// Close the write end even if fn panics, so the drain goroutine reaches EOF
-	// and terminates instead of blocking forever.
-	func() {
-		defer func() { _ = w.Close() }()
-		fn()
-	}()
-	return <-done
-}
 
 // withVersion temporarily sets the build-injected version global for a test.
 // NOTE: mutates the package-level version; do not call from parallel tests.
@@ -91,12 +59,12 @@ func TestRunHelpListsSubcommands(t *testing.T) {
 }
 
 // TestRunVersionSubcommand verifies the version subcommand prints the injected
-// version (it writes via fmt.Printf to os.Stdout, hence captureStdout).
+// version (it writes via fmt.Printf to os.Stdout, hence testutil.CaptureStdout).
 func TestRunVersionSubcommand(t *testing.T) {
 	withVersion(t, "sub-1.2.3")
 	var out, errBuf bytes.Buffer
 	var code int
-	got := captureStdout(t, func() { code = run([]string{"version"}, &out, &errBuf) })
+	got := testutil.CaptureStdout(t, func() { code = run([]string{"version"}, &out, &errBuf) })
 	if code != 0 {
 		t.Fatalf("exit code = %d, want 0", code)
 	}
@@ -112,7 +80,7 @@ func TestRunGenerateHappyPath(t *testing.T) {
 	out := filepath.Join(dir, "spec.yaml")
 	var outBuf, errBuf bytes.Buffer
 	var code int
-	_ = captureStdout(t, func() {
+	_ = testutil.CaptureStdout(t, func() {
 		code = run([]string{"generate", "--project", dir, "--output", out}, &outBuf, &errBuf)
 	})
 	if code != 0 {

--- a/tools/openapi/cmd/go-bricks-openapi/main_test.go
+++ b/tools/openapi/cmd/go-bricks-openapi/main_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what was
+// printed there. The subcommands write progress via fmt.Printf (os.Stdout), which
+// cobra's SetOut does not intercept. The pipe is drained in a goroutine so a large
+// write can't deadlock; the write end is closed even if fn panics (so the drain
+// goroutine terminates), and the read end is closed once drained (no fd leak).
+// NOTE: mutates the global os.Stdout; do not call from parallel tests.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		_ = r.Close()
+		done <- buf.String()
+	}()
+
+	// Close the write end even if fn panics, so the drain goroutine reaches EOF
+	// and terminates instead of blocking forever.
+	func() {
+		defer func() { _ = w.Close() }()
+		fn()
+	}()
+	return <-done
+}
+
+// withVersion temporarily sets the build-injected version global for a test.
+// NOTE: mutates the package-level version; do not call from parallel tests.
+func withVersion(t *testing.T, v string) {
+	t.Helper()
+	orig := version
+	version = v
+	t.Cleanup(func() { version = orig })
+}
+
+// TestRunVersionFlag verifies --version surfaces the injected version (cobra's
+// builtin writes to the command's configured output, captured via SetOut).
+func TestRunVersionFlag(t *testing.T) {
+	withVersion(t, "test-9.9.9")
+	var out, errBuf bytes.Buffer
+	code := run([]string{"--version"}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errBuf.String())
+	}
+	if !strings.Contains(out.String(), "test-9.9.9") {
+		t.Errorf("--version output missing injected version: %q", out.String())
+	}
+}
+
+// TestRunHelpListsSubcommands verifies all three subcommands are registered. It
+// asserts each subcommand's distinctive Short description (which appears under
+// "Available Commands:" only when the subcommand is registered) rather than the
+// bare name — the name "version" also occurs in the --version flag line, so a
+// name check would pass even if the version subcommand were dropped.
+func TestRunHelpListsSubcommands(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := run([]string{"--help"}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	// Distinctive Short strings, one per subcommand.
+	for _, short := range []string{
+		"Generate OpenAPI specification from go-bricks service",
+		"Check environment and project compatibility",
+		"Show version information",
+	} {
+		if !strings.Contains(out.String(), short) {
+			t.Errorf("subcommand description %q not listed in --help:\n%s", short, out.String())
+		}
+	}
+}
+
+// TestRunVersionSubcommand verifies the version subcommand prints the injected
+// version (it writes via fmt.Printf to os.Stdout, hence captureStdout).
+func TestRunVersionSubcommand(t *testing.T) {
+	withVersion(t, "sub-1.2.3")
+	var out, errBuf bytes.Buffer
+	var code int
+	got := captureStdout(t, func() { code = run([]string{"version"}, &out, &errBuf) })
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(got, "sub-1.2.3") {
+		t.Errorf("version subcommand output missing injected version: %q", got)
+	}
+}
+
+// TestRunGenerateHappyPath verifies a successful generate exits 0 and writes a
+// parseable OpenAPI spec (not merely that the path exists).
+func TestRunGenerateHappyPath(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "spec.yaml")
+	var outBuf, errBuf bytes.Buffer
+	var code int
+	_ = captureStdout(t, func() {
+		code = run([]string{"generate", "--project", dir, "--output", out}, &outBuf, &errBuf)
+	})
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (stderr: %s)", code, errBuf.String())
+	}
+
+	content, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("expected spec at %s: %v", out, err)
+	}
+	if !strings.Contains(string(content), "openapi: 3.0.1") {
+		t.Errorf("generated spec missing the OpenAPI version marker:\n%s", content)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(content, &doc); err != nil {
+		t.Fatalf("generated spec is not valid YAML: %v", err)
+	}
+	if _, ok := doc["openapi"]; !ok {
+		t.Errorf("generated spec has no top-level openapi key: %v", doc)
+	}
+}
+
+// TestRunErrorPathSingleErrorNoUsage verifies the error path prints exactly one
+// "Error:" line and no usage block (the SilenceErrors/SilenceUsage contract).
+func TestRunErrorPathSingleErrorNoUsage(t *testing.T) {
+	var outBuf, errBuf bytes.Buffer
+	code := run([]string{"generate", "--project", filepath.Join(t.TempDir(), "does-not-exist"),
+		"--output", filepath.Join(t.TempDir(), "x.yaml")}, &outBuf, &errBuf)
+
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	stderr := errBuf.String()
+	if n := strings.Count(stderr, "Error:"); n != 1 {
+		t.Errorf("expected exactly one Error: line, got %d:\n%s", n, stderr)
+	}
+	if strings.Contains(stderr, "Usage:") {
+		t.Errorf("error path must not print a Usage: block:\n%s", stderr)
+	}
+}
+
+// TestRunSingleDashLongFlagFails guards the single-dash trap deterministically: a
+// single-dash long flag is NOT equivalent to its double-dash form. pflag parses
+// -<long> as a cluster of shorthand flags, so for a long flag with no shorthand
+// (--api-version) the first letter ('a') is an unknown shorthand and the run is
+// rejected — proving single-dash long flags are not silently honored.
+func TestRunSingleDashLongFlagFails(t *testing.T) {
+	var outBuf, errBuf bytes.Buffer
+	code := run([]string{"generate", "-api-version", "9.9.9"}, &outBuf, &errBuf)
+	if code != 1 {
+		t.Fatalf("expected exit 1 for a single-dash long flag, got %d (stderr: %s)", code, errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "unknown shorthand flag") {
+		t.Errorf("expected an 'unknown shorthand flag' parse error, got: %s", errBuf.String())
+	}
+}

--- a/tools/openapi/internal/commands/doctor_test.go
+++ b/tools/openapi/internal/commands/doctor_test.go
@@ -14,9 +14,10 @@ import (
 )
 
 // captureStdout runs fn with os.Stdout redirected to a pipe and returns what it
-// printed. The pipe is drained in a goroutine so a large (or fn-aborting) write
-// can't deadlock. NOTE: this mutates the global os.Stdout; do not call it from
-// parallel tests.
+// printed. The pipe is drained in a goroutine so a large write can't deadlock; the
+// write end is closed even if fn panics (so the drain goroutine terminates instead
+// of leaking), and the read end is closed once drained (no fd leak).
+// NOTE: mutates the global os.Stdout; do not call from parallel tests.
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 	orig := os.Stdout
@@ -31,11 +32,14 @@ func captureStdout(t *testing.T, fn func()) string {
 	go func() {
 		var buf bytes.Buffer
 		_, _ = io.Copy(&buf, r)
+		_ = r.Close()
 		done <- buf.String()
 	}()
 
-	fn()
-	_ = w.Close()
+	func() {
+		defer func() { _ = w.Close() }()
+		fn()
+	}()
 	return <-done
 }
 

--- a/tools/openapi/internal/commands/doctor_test.go
+++ b/tools/openapi/internal/commands/doctor_test.go
@@ -1,9 +1,7 @@
 package commands
 
 import (
-	"bytes"
 	"errors"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -11,37 +9,8 @@ import (
 	"testing"
 
 	"github.com/gaborage/go-bricks/tools/openapi/internal/models"
+	"github.com/gaborage/go-bricks/tools/openapi/internal/testutil"
 )
-
-// captureStdout runs fn with os.Stdout redirected to a pipe and returns what it
-// printed. The pipe is drained in a goroutine so a large write can't deadlock; the
-// write end is closed even if fn panics (so the drain goroutine terminates instead
-// of leaking), and the read end is closed once drained (no fd leak).
-// NOTE: mutates the global os.Stdout; do not call from parallel tests.
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-	orig := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
-	}
-	os.Stdout = w
-	defer func() { os.Stdout = orig }()
-
-	done := make(chan string, 1)
-	go func() {
-		var buf bytes.Buffer
-		_, _ = io.Copy(&buf, r)
-		_ = r.Close()
-		done <- buf.String()
-	}()
-
-	func() {
-		defer func() { _ = w.Close() }()
-		fn()
-	}()
-	return <-done
-}
 
 // Test constants to avoid string duplication
 const (
@@ -782,7 +751,7 @@ func TestRunDoctorZeroModulesIsCaveat(t *testing.T) {
 	opts := &DoctorOptions{ProjectRoot: dir, GoVersion: minGoVersion}
 
 	var runErr error
-	out := captureStdout(t, func() { runErr = runDoctor(t.Context(), opts) })
+	out := testutil.CaptureStdout(t, func() { runErr = runDoctor(t.Context(), opts) })
 
 	if runErr != nil {
 		t.Errorf("zero modules should be a caveat, not a hard error: %v", runErr)
@@ -808,7 +777,7 @@ func TestRunDoctorFailsBelowGoBricksFloor(t *testing.T) {
 	opts := &DoctorOptions{ProjectRoot: dir, GoVersion: minGoVersion}
 
 	var runErr error
-	out := captureStdout(t, func() { runErr = runDoctor(t.Context(), opts) })
+	out := testutil.CaptureStdout(t, func() { runErr = runDoctor(t.Context(), opts) })
 
 	assertError(t, runErr, true)
 	if !strings.Contains(out, msgBelowMinimum) {

--- a/tools/openapi/internal/testutil/capture.go
+++ b/tools/openapi/internal/testutil/capture.go
@@ -1,0 +1,47 @@
+// Package testutil provides shared test helpers for the go-bricks-openapi tool.
+package testutil
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+// CaptureStdout runs fn with os.Stdout redirected to a pipe and returns what was
+// printed there. Several subcommands write progress via fmt.Printf (os.Stdout),
+// which cobra's SetOut does not intercept, so capturing the real os.Stdout is the
+// only way to observe that output in tests.
+//
+// The pipe is drained in a goroutine so a large write can't deadlock; the write
+// end is closed even if fn panics (so the drain goroutine reaches EOF and
+// terminates instead of leaking), and the read end is closed once drained (no fd
+// leak).
+//
+// NOTE: mutates the global os.Stdout; do not call from parallel tests.
+func CaptureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		_ = r.Close()
+		done <- buf.String()
+	}()
+
+	// Close the write end even if fn panics, so the drain goroutine reaches EOF
+	// and terminates instead of blocking forever.
+	func() {
+		defer func() { _ = w.Close() }()
+		fn()
+	}()
+	return <-done
+}

--- a/tools/openapi/internal/testutil/capture_test.go
+++ b/tools/openapi/internal/testutil/capture_test.go
@@ -1,0 +1,41 @@
+package testutil
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestCaptureStdout(t *testing.T) {
+	got := CaptureStdout(t, func() {
+		fmt.Print("hello ")
+		fmt.Println("world")
+	})
+	if got != "hello world\n" {
+		t.Errorf("CaptureStdout = %q, want %q", got, "hello world\n")
+	}
+}
+
+func TestCaptureStdoutEmpty(t *testing.T) {
+	if got := CaptureStdout(t, func() {}); got != "" {
+		t.Errorf("CaptureStdout for no output = %q, want empty", got)
+	}
+}
+
+// TestCaptureStdoutPanicDoesNotDeadlock verifies that a panicking fn still closes
+// the pipe (so the drain goroutine terminates) and the panic propagates.
+func TestCaptureStdoutPanicDoesNotDeadlock(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected the panic to propagate out of CaptureStdout")
+		}
+		if !strings.Contains(fmt.Sprint(r), "boom") {
+			t.Errorf("unexpected panic value: %v", r)
+		}
+	}()
+	_ = CaptureStdout(t, func() {
+		fmt.Print("before panic")
+		panic("boom")
+	})
+}


### PR DESCRIPTION
## Summary

**Final PR** of the OpenAPI-tool gap-analysis roadmap (PR1–PR14). Closes the `cmd/go-bricks-openapi/main.go` 0%-coverage gap by extracting a testable `run()` seam.

- `main()` is now a thin `os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))`; `buildRootCmd()` + `run(args, stdout, stderr) int` are unit-testable via arg vectors + captured buffers.
- **cmd package coverage: 0% → 91.7%** (only the `os.Exit` line uncovered).
- `main_test.go` covers `--version` (injected version), `--help` (all three subcommands), the `version` subcommand, a generate happy path (reads back + parses the spec), the error path (one `Error:` line, no `Usage:`), and the single-dash trap.
- `validate-cli` (Makefile + the Windows CI inline step) now also runs `generate` and sanity-checks the output marker (network-free).

## Review hardening (`/code-review` 11 findings + `/security-audit` + conventions)

The recall-biased review caught that several first-draft tests *passed for the wrong reasons* — fixed so each fails when the thing it names breaks:
| Finding | Fix |
|---|---|
| single-dash test passed incidentally (pflag mangles `-project`→`-p`) | deterministic "unknown shorthand flag" via a no-shorthand flag |
| `--help` "version" check matched the `--version` flag line, not the subcommand | assert distinctive Short descriptions |
| happy-path test only `os.Stat`'d the file | read back + `yaml.Unmarshal` + `openapi: 3.0.1` |
| `captureStdout` leaked a goroutine on panic + never closed the read end | panic-safe `w.Close` + `r.Close` (both copies) |
| Makefile/Windows left the temp spec on a grep failure | clean up regardless |
| Windows generate step lacked a `$LASTEXITCODE` check | added (matches workflow convention) |

## Testing
- `make check` green; full suite passes with `-race`.
- Coverage: cmd **91.7%**, commands 87.2%, all packages ≥80%.
- Goldens unchanged; `gosec` 0, `govulncheck` clean, lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced OpenAPI tool validation on Windows to run end-to-end generation, assert generated spec contents, and clean up temporary output
  * Improved CLI execution flow and error reporting for clearer, deterministic exit behavior

* **Refactor**
  * Separated CLI construction and execution to improve testability

* **Tests**
  * Added comprehensive CLI tests and utilities, plus tests for stdout capture and panic-safe behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->