### PR TITLE
docs: eliminate documentation & code-comment drift (+ reusable doc-drift workflows)

### DIFF
--- a/.claude/workflows/doc-drift-fix.js
+++ b/.claude/workflows/doc-drift-fix.js
@@ -1,0 +1,94 @@
+export const meta = {
+  name: 'doc-drift-fix',
+  description: 'Apply confirmed documentation & comment drift fixes, one editor agent per file (disjoint files, conflict-free)',
+  phases: [
+    { title: 'Load', detail: 'load the list of files with confirmed findings' },
+    { title: 'Fix', detail: 'one editor agent per file applies + re-verifies fixes' },
+  ],
+}
+
+const FIX_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    file: { type: 'string' },
+    appliedCount: { type: 'integer', description: 'number of findings actually applied' },
+    skipped: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { detail: { type: 'string', description: 'which finding was skipped and why' } },
+        required: ['detail'],
+      },
+    },
+    notes: { type: 'string', description: 'anything notable, e.g. multi-occurrence edits or build risks' },
+  },
+  required: ['file', 'appliedCount', 'skipped', 'notes'],
+}
+
+const LOAD_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { files: { type: 'array', items: { type: 'string' } } },
+  required: ['files'],
+}
+
+function fixPrompt(file) {
+  return `You are fixing documentation / code-comment drift in ONE file: \`${file}\`.
+Edit ONLY this file. Do NOT run git, make, go build, or any tests.
+
+STEP 1 — Load the confirmed findings for this file:
+  jq -c --arg f '${file}' '.[] | select(.file==$f)' /tmp/doc_findings.json
+  jq -c --arg f '${file}' '.[] | select(.file==$f)' /tmp/comment_findings.json
+Each finding has: line, severity, kind, claim, reality, evidence, suggestedFix, confidence.
+
+STEP 2 — For EACH finding:
+  a. Read the cited region of \`${file}\` (line numbers may have shifted slightly; locate by content).
+  b. RE-VERIFY against the CURRENT code: read the source location named in "evidence" (use rg / grep / Read) and confirm the drift is real right now.
+  c. If confirmed, apply "suggestedFix" with the Edit tool — minimal, surgical, matching surrounding style.
+  d. If the finding is wrong, already fixed, or risky, SKIP it and record the reason.
+
+CONSERVATIVE COMMENT RULES (.go files): only remove or rewrite a comment when it is genuinely (1) stale/contradictory to the code, (2) commented-out code, or (3) pure narration that restates the adjacent line. NEVER remove — fix the text instead if stale, never delete:
+  - doc comments on EXPORTED identifiers (staticcheck/godoc require them),
+  - //go:build, build tags, //go:generate, //go:embed, //nolint..., //export, //line directives,
+  - "// SECURITY:" annotations,
+  - comments that explain WHY (rationale, trade-offs, gotchas, ADR/issue links).
+  When in doubt, SKIP. Do not change code logic — comments only (plus, for the rare doc-comment-as-example case, keep it compilable).
+
+DOC RULES (.md/.txt): apply the corrected text; keep all code examples COMPILABLE and consistent with the doc's existing style. For ADR files (wiki/adr-*.md) do NOT rewrite historical decisions — only apply the specific corrective the finding asks for (fix a wrong Status/cross-reference, or add a "Superseded by …" note).
+
+Make NO unrelated changes. Then return: file, appliedCount, skipped (one {detail} per skipped finding with the reason), notes.`
+}
+
+phase('Load')
+const loaded = await agent(
+  `Run \`jq -r '.[]' /tmp/fix_files.json\` and return the resulting list of file paths as "files".`,
+  { label: 'load-files', phase: 'Load', schema: LOAD_SCHEMA, agentType: 'general-purpose', model: 'sonnet' },
+)
+
+const files = (loaded && loaded.files) || []
+log(`Applying fixes across ${files.length} files (one editor agent each).`)
+
+phase('Fix')
+const results = await parallel(
+  files.map((f) => () =>
+    agent(fixPrompt(f), { label: `fix:${f}`, phase: 'Fix', schema: FIX_SCHEMA, agentType: 'general-purpose', model: 'sonnet' })),
+)
+
+const ok = results.filter(Boolean)
+const totalApplied = ok.reduce((n, r) => n + (r.appliedCount || 0), 0)
+const totalSkipped = ok.reduce((n, r) => n + ((r.skipped && r.skipped.length) || 0), 0)
+const skippedDetails = ok.flatMap((r) => (r.skipped || []).map((s) => `${r.file}: ${s.detail}`))
+const failedFiles = files.filter((_, i) => !results[i])
+
+log(`Applied ${totalApplied} fixes; skipped ${totalSkipped}; ${failedFiles.length} file-agents failed.`)
+
+return {
+  totalApplied,
+  totalSkipped,
+  filesProcessed: ok.length,
+  failedFiles,
+  skippedDetails,
+  perFile: ok.map((r) => ({ file: r.file, applied: r.appliedCount, skipped: (r.skipped || []).length, notes: r.notes })),
+}

--- a/.claude/workflows/doc-drift.js
+++ b/.claude/workflows/doc-drift.js
@@ -1,0 +1,310 @@
+export const meta = {
+  name: 'doc-drift',
+  description: 'Detect documentation drift (docs vs current code) and code-comment drift across the repo; emit a ranked markdown drift report',
+  whenToUse: 'Run before a release, after large refactors, or periodically to find docs/comments that no longer match the code. Read-only: produces a report, never edits.',
+  phases: [
+    { title: 'Discover', detail: 'enumerate tracked docs + non-test Go files via git' },
+    { title: 'Docs: review', detail: 'extract + verify concrete claims per doc cluster' },
+    { title: 'Docs: verify', detail: 'adversarially confirm candidate doc findings' },
+    { title: 'Comments: review', detail: 'flag stale / redundant comments per code cluster' },
+    { title: 'Comments: verify', detail: 'adversarially confirm candidate comment findings' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+// A single drift finding. Shared by review and verify stages so the verifier
+// can return the same shape (minus the rejected items).
+const FINDING_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          file: { type: 'string', description: 'doc or source file path the finding is about' },
+          line: { type: 'integer', description: 'line number in `file`; 0 if not applicable' },
+          severity: { type: 'string', enum: ['high', 'medium', 'low'] },
+          kind: { type: 'string', description: 'short tag, e.g. stale-api, wrong-default, removed-feature, broken-example, superseded-adr, stale-comment, commented-out-code, redundant-narration' },
+          claim: { type: 'string', description: 'what the doc/comment asserts' },
+          reality: { type: 'string', description: 'what the current code actually does' },
+          evidence: { type: 'string', description: 'the source location(s) (file:line) proving `reality`' },
+          suggestedFix: { type: 'string', description: 'concrete fix: the corrected text, or "delete"' },
+          confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+        },
+        required: ['file', 'line', 'severity', 'kind', 'claim', 'reality', 'evidence', 'suggestedFix', 'confidence'],
+      },
+    },
+  },
+  required: ['findings'],
+}
+
+const DISCOVERY_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    docs: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          path: { type: 'string' },
+          lines: { type: 'integer' },
+          lens: { type: 'string', enum: ['living', 'adr', 'index'] },
+        },
+        required: ['path', 'lines', 'lens'],
+      },
+    },
+    codeFiles: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'tracked non-test .go file paths',
+    },
+  },
+  required: ['docs', 'codeFiles'],
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function chunk(arr, n) {
+  const out = []
+  for (let i = 0; i < arr.length; i += n) out.push(arr.slice(i, i + n))
+  return out
+}
+
+function mkLiving(docs) {
+  return { type: 'doc', lens: 'living', label: docs.map((d) => d.path).join(', '), files: docs.map((d) => d.path) }
+}
+
+// Build doc clusters with per-lens batching. llms.txt is huge and example-heavy
+// so it is chunked by line range; big living docs get their own agent; small
+// ones are batched; ADRs are batched 3-per-agent under the superseded lens.
+function buildDocClusters(docs) {
+  const clusters = []
+  const llms = docs.find((d) => d.path === 'llms.txt')
+  const living = docs.filter((d) => d.lens === 'living' && d.path !== 'llms.txt')
+  const adrs = docs.filter((d) => d.lens === 'adr')
+  const index = docs.filter((d) => d.lens === 'index')
+
+  if (llms) {
+    const size = 1300
+    const n = Math.max(1, Math.ceil(llms.lines / size))
+    for (let i = 0; i < n; i++) {
+      clusters.push({
+        type: 'doc', lens: 'living', label: `llms.txt#${i + 1}/${n}`, files: [llms.path],
+        range: [i * size + 1, Math.min((i + 1) * size, llms.lines)],
+      })
+    }
+  }
+
+  const small = []
+  for (const d of living.slice().sort((a, b) => b.lines - a.lines)) {
+    if (d.lines >= 250) clusters.push({ type: 'doc', lens: 'living', label: d.path, files: [d.path] })
+    else small.push(d)
+  }
+  let cur = [], curLines = 0
+  for (const d of small) {
+    if (cur.length >= 3 || curLines + d.lines > 400) {
+      if (cur.length) { clusters.push(mkLiving(cur)); cur = []; curLines = 0 }
+    }
+    cur.push(d); curLines += d.lines
+  }
+  if (cur.length) clusters.push(mkLiving(cur))
+
+  for (const d of index) clusters.push({ type: 'doc', lens: 'index', label: d.path, files: [d.path] })
+  chunk(adrs.map((d) => d.path), 3).forEach((files, i) => clusters.push({ type: 'doc', lens: 'adr', label: `adrs#${i + 1}`, files }))
+
+  return clusters
+}
+
+const SEV_RANK = { high: 0, medium: 1, low: 2 }
+
+function renderReport(docFindings, commentFindings) {
+  const all = [...docFindings, ...commentFindings]
+  const bySev = (arr) => ({
+    high: arr.filter((f) => f.severity === 'high').length,
+    medium: arr.filter((f) => f.severity === 'medium').length,
+    low: arr.filter((f) => f.severity === 'low').length,
+  })
+  const d = bySev(docFindings)
+  const c = bySev(commentFindings)
+
+  const lines = []
+  lines.push('# Documentation & Comment Drift Report')
+  lines.push('')
+  lines.push('> Generated by the `doc-drift` workflow. Each finding cites the source location that contradicts the doc/comment. Verify before applying.')
+  lines.push('')
+  lines.push('## Summary')
+  lines.push('')
+  lines.push('| Category | High | Medium | Low | Total |')
+  lines.push('|---|---:|---:|---:|---:|')
+  lines.push(`| Documentation drift | ${d.high} | ${d.medium} | ${d.low} | ${docFindings.length} |`)
+  lines.push(`| Code-comment drift | ${c.high} | ${c.medium} | ${c.low} | ${commentFindings.length} |`)
+  lines.push(`| **All** | **${d.high + c.high}** | **${d.medium + c.medium}** | **${d.low + c.low}** | **${all.length}** |`)
+  lines.push('')
+
+  const section = (title, findings) => {
+    lines.push(`## ${title}`)
+    lines.push('')
+    if (!findings.length) { lines.push('_No findings._'); lines.push(''); return }
+    const sorted = findings.slice().sort((a, b) =>
+      (SEV_RANK[a.severity] - SEV_RANK[b.severity]) || a.file.localeCompare(b.file) || (a.line - b.line))
+    let curFile = null
+    for (const f of sorted) {
+      if (f.file !== curFile) { curFile = f.file; lines.push(`### \`${f.file}\``); lines.push('') }
+      const loc = f.line ? `:${f.line}` : ''
+      lines.push(`- **[${f.severity.toUpperCase()}] ${f.kind}** (\`${f.file}${loc}\`, confidence: ${f.confidence})`)
+      lines.push(`  - **Claims:** ${f.claim}`)
+      lines.push(`  - **Reality:** ${f.reality}`)
+      lines.push(`  - **Evidence:** ${f.evidence}`)
+      lines.push(`  - **Fix:** ${f.suggestedFix}`)
+    }
+    lines.push('')
+  }
+
+  section('Documentation drift', docFindings)
+  section('Code-comment drift', commentFindings)
+  return lines.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Prompt builders
+// ---------------------------------------------------------------------------
+
+const FINDING_FIELDS_NOTE = `For each finding provide: file, line (0 if N/A), severity (high = actively misleading / will break a reader who follows it; medium = incorrect but recoverable; low = cosmetic/minor staleness), a short kind tag, the claim, the reality, evidence as a source file:line, a concrete suggestedFix (the corrected text or "delete"), and your confidence. Every finding MUST cite a specific code location in evidence — if you cannot point at code, do not report it.`
+
+function reviewDocPrompt(cluster) {
+  const fileList = cluster.files.join(', ')
+  const rangeNote = cluster.range ? `\n\nIMPORTANT: Only analyze lines ${cluster.range[0]}-${cluster.range[1]} of ${cluster.files[0]} (read that range with the Read tool's offset/limit).` : ''
+
+  if (cluster.lens === 'adr') {
+    return `You are auditing Architecture Decision Records for drift: ${fileList}.
+
+ADRs are POINT-IN-TIME records. Describing an old/superseded approach is CORRECT, not drift — do NOT flag an ADR merely for documenting the old way.
+
+Report a finding ONLY when:
+(a) the decision recorded here has been silently REVERSED or SUPERSEDED by later code or a later ADR, yet this ADR is NOT marked superseded/amended; or
+(b) the ADR's Status line, ADR number, or cross-references are factually wrong (e.g. links to the wrong ADR, claims "Accepted" for something never implemented); or
+(c) the ADR is written as living present-tense guidance and that guidance is now false against current code.
+
+Use rg/grep and read the relevant source to confirm. ${FINDING_FIELDS_NOTE}`
+  }
+
+  if (cluster.lens === 'index') {
+    return `You are auditing the ADR index file: ${fileList}, against the actual ADR files in wiki/.
+
+Run \`ls wiki/adr-*.md\` and read the index. Report findings where: an ADR file exists but is missing from the index; the index lists an ADR that does not exist; a title or number in the index disagrees with the ADR file's own heading; or the index has numbering gaps/duplicates. (This index has fallen out of sync before, so be thorough.) ${FINDING_FIELDS_NOTE}`
+  }
+
+  // living
+  return `You are auditing project documentation for DRIFT against the current code implementation: ${fileList}.${rangeNote}
+
+Read the doc, then for every CONCRETE, VERIFIABLE claim — function/method/type signatures, struct field names & tags, config keys and their default values, CLI flags, environment variables, file/package paths, version numbers (e.g. Go version in go.mod), documented defaults/behavior, and especially CODE EXAMPLES — verify it against the ACTUAL current code with rg/grep and by reading the source.
+
+Report a finding ONLY when the doc contradicts the code: stale or wrong signature, renamed/removed symbol, wrong default value, moved path, a code example that would not compile or uses a removed/renamed API, an outdated version number, or a documented feature that no longer exists.
+
+Do NOT report: prose/style preferences, intentionally simplified examples that are still conceptually correct, clearly-labeled roadmap/future notes, or anything you cannot tie to a specific code location. Be skeptical and precise. ${FINDING_FIELDS_NOTE}`
+}
+
+function reviewCommentPrompt(cluster) {
+  const fileList = cluster.files.join(', ')
+  return `You are auditing CODE COMMENTS in these Go source files for drift and for violations of the project's bare-minimum-comment philosophy:
+${fileList}
+
+Read each file. Flag a comment when it is:
+1. STALE / CONTRADICTORY — describes behavior, parameters, return values, or logic that the adjacent code no longer matches (renamed symbols, changed defaults, removed branches, wrong parameter names, references to deleted types/functions/packages such as MongoDB, GetX() getters, or ToSql()).
+2. COMMENTED-OUT CODE — blocks of real code left as comments.
+3. REDUNDANT WHAT-NARRATION — a comment that merely restates what the immediately adjacent line obviously does (e.g. "// increment counter" above counter++, "// return nil" above return nil, or a doc comment that just re-says the signature in words).
+
+You MUST PRESERVE — never flag these for removal (only flag them if STALE/CONTRADICTORY):
+- Doc comments on EXPORTED identifiers (Go convention + staticcheck require them).
+- Build/tool directives: //go:build, build tags, //go:generate, //go:embed, //nolint..., //export, //line, //go:noinline, etc.
+- "// SECURITY:" annotations (mandated by project policy on f.Raw()/jf.Raw() call sites).
+- Comments that explain WHY — rationale, trade-offs, non-obvious gotchas, links to ADRs/issues/specs.
+
+Be CONSERVATIVE: when unsure whether a comment earns its place, do NOT flag it. kind should be one of: stale-comment, commented-out-code, redundant-narration. suggestedFix is usually "delete" or the rewritten comment text. ${FINDING_FIELDS_NOTE}`
+}
+
+function verifyPrompt(findings, kind) {
+  return `You are an ADVERSARIAL verifier. Below are CANDIDATE ${kind} drift findings from another agent. Independently re-check EACH one by reading the cited locations in the actual repo.
+
+REJECT (drop) any finding that is: a false positive; an illustrative-but-still-correct example; a required exported godoc mis-flagged as "redundant"; a build/tool directive; a SECURITY annotation; a why-rationale comment; an ADR correctly describing history; or anything whose stated "reality" you cannot confirm in the current code.
+
+For findings you CONFIRM, keep them — correcting severity, line, evidence, or suggestedFix if the candidate got them wrong. Return ONLY the confirmed findings (same schema). Default to REJECTION when uncertain: a trustworthy, low-noise report matters more than catching every last item.
+
+CANDIDATES (JSON):
+${JSON.stringify(findings, null, 2)}`
+}
+
+// ---------------------------------------------------------------------------
+// Stages
+// ---------------------------------------------------------------------------
+
+const reviewDocStage = (cluster) =>
+  agent(reviewDocPrompt(cluster), { label: `doc:${cluster.label}`, phase: 'Docs: review', schema: FINDING_SCHEMA, model: 'sonnet' })
+
+const reviewCommentStage = (cluster) =>
+  agent(reviewCommentPrompt(cluster), { label: `code:${cluster.label}`, phase: 'Comments: review', schema: FINDING_SCHEMA, model: 'sonnet' })
+
+function makeVerifyStage(kind, phaseName) {
+  return (review, cluster) => {
+    const findings = (review && review.findings) || []
+    if (!findings.length) return { findings: [] }
+    return agent(verifyPrompt(findings, kind), { label: `verify:${cluster.label}`, phase: phaseName, schema: FINDING_SCHEMA, model: 'sonnet' })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+phase('Discover')
+const inv = await agent(
+  `Enumerate this repository's tracked documentation and Go source for a drift analysis. Use git, wc, and ls. Return structured data.
+
+DOCS: list tracked doc files with \`git ls-files | grep -E '\\.(md|txt)$'\`. EXCLUDE anything under \`.claude/\` or \`docs/superpowers/\` (those are tooling/spec artifacts, not project docs) and EXCLUDE \`WARP.md\` (it is a symlink to CLAUDE.md). For each remaining file: get its line count with \`wc -l\`, and classify lens — "adr" if the path matches wiki/adr-*.md, "index" if the path is exactly wiki/architecture_decisions.md, otherwise "living".
+
+CODE: list tracked non-test Go files with \`git ls-files '*.go' | grep -v '_test\\.go$'\`. Return them all in codeFiles.
+
+Return docs (path, lines, lens) and codeFiles.`,
+  { label: 'discover', phase: 'Discover', schema: DISCOVERY_SCHEMA, model: 'sonnet' },
+)
+
+const docClusters = buildDocClusters(inv.docs)
+const codeClusters = chunk(inv.codeFiles.slice().sort(), 6).map((files, i) => ({ type: 'comment', label: `comments#${i + 1}`, files }))
+
+log(`Discovered ${inv.docs.length} docs -> ${docClusters.length} doc clusters; ${inv.codeFiles.length} Go files -> ${codeClusters.length} comment clusters.`)
+
+const [docResults, codeResults] = await Promise.all([
+  pipeline(docClusters, reviewDocStage, makeVerifyStage('documentation', 'Docs: verify')),
+  pipeline(codeClusters, reviewCommentStage, makeVerifyStage('code-comment', 'Comments: verify')),
+])
+
+const docFindings = docResults.filter(Boolean).flatMap((r) => (r && r.findings) || [])
+const commentFindings = codeResults.filter(Boolean).flatMap((r) => (r && r.findings) || [])
+
+log(`Confirmed ${docFindings.length} documentation findings and ${commentFindings.length} comment findings.`)
+
+const markdown = renderReport(docFindings, commentFindings)
+
+return {
+  markdown,
+  docFindings,
+  commentFindings,
+  stats: {
+    docs: inv.docs.length,
+    codeFiles: inv.codeFiles.length,
+    docClusters: docClusters.length,
+    codeClusters: codeClusters.length,
+    docFindings: docFindings.length,
+    commentFindings: commentFindings.length,
+  },
+}

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@
 !.claude/hooks/*
 !.claude/agents/*
 !.claude/skills/**
+!.claude/workflows/*
 
 # Test fixtures (JSON / SQL / golden files) live under testdata/ alongside the
 # source they exercise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,7 +324,7 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 }
 ```
 
-**Schedule Types:** `Every(duration)`, `Cron(expression)`, `DailyAt(time)`, `WeeklyAt(weekday, time)`. See [wiki/scheduler.md](wiki/scheduler.md).
+**Schedule Methods:** `FixedRate(duration)`, `DailyAt(time)`, `WeeklyAt(weekday, time)`, `HourlyAt(minute)`, `MonthlyAt(day, time)`. See [wiki/scheduler.md](wiki/scheduler.md).
 
 ### Messaging Architecture
 
@@ -587,7 +587,7 @@ type KeyStore interface {
 
 ## Dependencies
 
-- **Echo v4** — HTTP framework
+- **Echo v5** — HTTP framework
 - **zerolog** — Structured logging
 - **pgx/v5** — PostgreSQL driver
 - **go-ora/v2** — Oracle driver

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,7 +324,7 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 }
 ```
 
-**Schedule Methods:** `FixedRate(duration)`, `DailyAt(time)`, `WeeklyAt(weekday, time)`, `HourlyAt(minute)`, `MonthlyAt(day, time)`. See [wiki/scheduler.md](wiki/scheduler.md).
+**Schedule Methods:** `FixedRate(duration)`, `DailyAt(time)`, `WeeklyAt(weekday, time)`, `HourlyAt(minute)`, `MonthlyAt(dayOfMonth, time)`. See [wiki/scheduler.md](wiki/scheduler.md).
 
 ### Messaging Architecture
 

--- a/MULTI_TENANT.md
+++ b/MULTI_TENANT.md
@@ -20,7 +20,7 @@ Configure multi-tenancy in your `config.yaml`:
 multitenant:
   enabled: true
   resolver:
-    type: "header"           # or "subdomain", "composite"
+    type: "header"           # or "subdomain", "path", "composite"
     header: "X-Tenant-ID"   # header name for tenant resolution
     domain: "api.example.com" # root domain for subdomain resolution
     proxies: true           # trust X-Forwarded-Host headers
@@ -51,10 +51,11 @@ multitenant:
 
 ## Custom Tenant Store Implementation
 
-Implement the `app.TenantStore` interface to integrate with external systems like AWS Secrets Manager, HashiCorp Vault, or custom databases. The interface requires implementing three methods:
+Implement the `app.TenantStore` interface to integrate with external systems like AWS Secrets Manager, HashiCorp Vault, or custom databases. The interface is composed of `database.DBConfigProvider`, `messaging.BrokerURLProvider`, and `cache.ConfigProvider` plus `IsDynamic()`, so it requires implementing four methods:
 
 - `DBConfig(ctx context.Context, key string) (*config.DatabaseConfig, error)` - Returns database configuration for a specific tenant
 - `BrokerURL(ctx context.Context, key string) (string, error)` - Returns the tenant's messaging broker connection URL
+- `CacheConfig(ctx context.Context, key string) (*config.CacheConfig, error)` - Returns the tenant's cache configuration (nil when no cache is configured)
 - `IsDynamic() bool` - Returns true if tenant configuration can change at runtime (dynamic) or false if static
 
 The `IsDynamic()` flag controls framework behavior for caching and configuration refresh. Dynamic stores (external sources like AWS Secrets Manager) return `true`, while static stores (YAML-based) return `false`. The framework handles connection pooling, caching, and lifecycle management automatically once the store implementation returns the configuration.
@@ -65,6 +66,7 @@ The framework provides multiple built-in tenant resolution strategies:
 
 - **HeaderResolver**: Extracts tenant ID from HTTP headers (e.g., `X-Tenant-ID`)
 - **SubdomainResolver**: Derives tenant ID from request host subdomains with proxy support
+- **PathResolver**: Extracts tenant ID from a 1-indexed URL path segment, with an optional prefix gate (e.g. `/itsp/{tenantID}/...`)
 - **CompositeResolver**: Tries multiple resolvers sequentially until one succeeds, with optional regex validation
 - **ValidatingResolver**: Wraps any resolver with tenant ID format validation using regex patterns
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ func main() {
         log.Fatal(err)
     }
 
-    framework, err := app.NewWithConfig(cfg, nil)
+    framework, _, err := app.NewWithConfig(cfg, nil)
     if err != nil {
         log.Fatal(err)
     }
@@ -624,7 +624,7 @@ func (j *CleanupJob) Execute(ctx scheduler.JobContext) error {
 }
 ```
 
-**Schedule types:** `Every(duration)`, `Cron(expression)`, `DailyAt(time)`, `WeeklyAt(weekday, time)`.
+**Schedule types:** `FixedRate(duration)`, `Cron(expression)`, `DailyAt(time)`, `WeeklyAt(weekday, time)`.
 
 ### Transactional Outbox
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ func register(framework *app.App) error {
 
 ## HTTP Server
 
-Echo v4-based server with typed handlers, standardized response envelopes, and comprehensive middleware (logging, recovery, rate limiting, CORS).
+Echo v5-based server with typed handlers, standardized response envelopes, and comprehensive middleware (logging, recovery, rate limiting, CORS).
 
 ### Typed Handlers
 ```go
@@ -624,7 +624,7 @@ func (j *CleanupJob) Execute(ctx scheduler.JobContext) error {
 }
 ```
 
-**Schedule types:** `FixedRate(duration)`, `Cron(expression)`, `DailyAt(time)`, `WeeklyAt(weekday, time)`.
+**Schedule types:** `FixedRate(duration)`, `DailyAt(time)`, `WeeklyAt(weekday, time)`, `HourlyAt(minute)`, `MonthlyAt(dayOfMonth, time)`.
 
 ### Transactional Outbox
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -287,6 +287,7 @@ func TestUserModule_Integration(t *testing.T) {
     // Test route registration. NewHandlerRegistry needs a *config.Config, and
     // RegisterRoutes takes a server.RouteRegistrar (from srv.ModuleGroup()), not
     // a raw *echo.Echo.
+    srv := server.New(mockConfig, mockLogger)
     hr := server.NewHandlerRegistry(mockConfig)
     module.RegisterRoutes(hr, srv.ModuleGroup())
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -267,13 +267,14 @@ func TestUserModule_Integration(t *testing.T) {
     mockDB := fixtures.NewHealthyDatabase()
     mockMessaging := fixtures.NewWorkingMessagingClient()
     mockRegistry := fixtures.NewWorkingRegistry()
-    mockLogger := &mocks.MockLogger{} // Assuming you have a logger mock
-    mockConfig := &config.Config{}   // Use real config or mock
+    mockLogger := logger.New("info", true) // Use a real logger (no framework logger mock exists)
+    mockConfig := &config.Config{}         // Use real config or mock
 
-    // Create module dependencies
+    // Create module dependencies. DB and Messaging are accessor functions
+    // (tenant-aware), so wrap the mocks in closures rather than assigning directly.
     deps := &app.ModuleDeps{
-        DB:        mockDB,
-        Messaging: mockMessaging,
+        DB:        func(context.Context) (database.Interface, error) { return mockDB, nil },
+        Messaging: func(context.Context) (messaging.AMQPClient, error) { return mockMessaging, nil },
         Logger:    mockLogger,
         Config:    mockConfig,
     }
@@ -283,10 +284,11 @@ func TestUserModule_Integration(t *testing.T) {
     err := module.Init(deps)
     assert.NoError(t, err)
 
-    // Test route registration
-    echo := echo.New()
-    hr := server.NewHandlerRegistry()
-    module.RegisterRoutes(hr, echo)
+    // Test route registration. NewHandlerRegistry needs a *config.Config, and
+    // RegisterRoutes takes a server.RouteRegistrar (from srv.ModuleGroup()), not
+    // a raw *echo.Echo.
+    hr := server.NewHandlerRegistry(mockConfig)
+    module.RegisterRoutes(hr, srv.ModuleGroup())
 
     // Test messaging registration
     module.DeclareMessaging(mockDeclarations)
@@ -401,15 +403,22 @@ func TestExample(t *testing.T) {
 
 ### 5. Test Configuration Injection
 
+`config.Config` has no runtime `Set` method — supply test values through a
+source the loader reads (an env var or a test YAML) before calling `config.Load`:
+
 ```go
 func TestService_ConfigInjection(t *testing.T) {
-    cfg := &config.Config{}
-    cfg.Set("custom.service.timeout", "30s")
+    // Provide the value via an env var the loader reads (CUSTOM_SERVICE_TIMEOUT
+    // maps to the config key "custom.service.timeout").
+    t.Setenv("CUSTOM_SERVICE_TIMEOUT", "30s")
+
+    cfg, err := config.Load()
+    require.NoError(t, err)
 
     deps := &app.ModuleDeps{Config: cfg}
 
     service := &MyService{}
-    err := service.Init(deps) // This should inject config
+    err = service.Init(deps) // This should inject config
     assert.NoError(t, err)
 
     assert.Equal(t, 30*time.Second, service.config.Timeout)

--- a/app/bootstrap.go
+++ b/app/bootstrap.go
@@ -29,7 +29,7 @@ func (b *appBootstrap) coreComponents() (SignalHandler, TimeoutProvider, ServerR
 }
 
 // dependencies creates and configures all resource managers and dependencies.
-// Returns a bundle containing the database manager, messaging manager, resource provider, and observability.
+// Returns a bundle containing the database manager, messaging manager, cache manager, resource provider, and observability.
 func (b *appBootstrap) dependencies() *dependencyBundle {
 	// Create factory resolver and configuration builder
 	resolver := NewFactoryResolver(b.opts)

--- a/app/debug_health.go
+++ b/app/debug_health.go
@@ -88,7 +88,7 @@ func (d *DebugHandlers) handleHealthDebug(c *echo.Context) error {
 	// Add manager-specific health information if available
 	d.addManagerHealth(healthInfo)
 
-	// Calculate summary (incluyendo componentes añadidos)
+	// Summary is computed after addManagerHealth so manager components are included.
 	healthInfo.Summary = d.calculateHealthSummary(healthInfo.Components)
 	resp := d.newDebugResponse(start, healthInfo, nil)
 	return c.JSON(http.StatusOK, resp)

--- a/app/factory_resolver.go
+++ b/app/factory_resolver.go
@@ -43,7 +43,6 @@ func (f *FactoryResolver) MessagingClientFactory() messaging.ClientFactory {
 		}
 	}
 
-	// Default factory function that creates AMQPClient instances
 	return func(url string, log logger.Logger) messaging.AMQPClient {
 		return messaging.NewAMQPClient(url, log)
 	}
@@ -57,7 +56,6 @@ func (f *FactoryResolver) CacheConnector(resourceSource TenantStore, log logger.
 		return f.opts.CacheConnector
 	}
 
-	// Default connector creates Redis cache instances from config
 	return newRedisConnector(resourceSource, log)
 }
 

--- a/app/messaging_setup.go
+++ b/app/messaging_setup.go
@@ -39,9 +39,8 @@ func (m *MessagingInitializer) CollectDeclarations(registry *ModuleRegistry) (*m
 	return declarations, nil
 }
 
-// SetupLazyConsumerInit modifies the resource provider's GetMessaging function
-// to include lazy consumer initialization. This ensures consumers are started
-// on-demand when messaging is first accessed.
+// SetupLazyConsumerInit wires the collected declarations into the resource
+// provider so consumers are started on-demand when messaging is first accessed.
 func (m *MessagingInitializer) SetupLazyConsumerInit(
 	provider ResourceProvider,
 	declarations *messaging.Declarations,

--- a/cache/errors.go
+++ b/cache/errors.go
@@ -12,9 +12,10 @@ var (
 	// This is not considered a fatal error - callers should handle cache misses gracefully.
 	ErrNotFound = errors.New("cache: key not found")
 
-	// ErrCASFailed is returned when a CompareAndSet operation fails because
-	// the current value doesn't match the expected value.
-	// This indicates a concurrent modification or lock contention.
+	// ErrCASFailed is reserved for callers that wish to surface a failed
+	// compare-and-set as an error. The Redis client and mock report a failed
+	// comparison via the boolean return value of CompareAndSet (not this error);
+	// a false result indicates the current value didn't match the expected value.
 	ErrCASFailed = errors.New("cache: compare-and-set failed")
 
 	// ErrClosed is returned when attempting to use a closed cache connection.

--- a/cache/internal/tracking/metrics.go
+++ b/cache/internal/tracking/metrics.go
@@ -134,7 +134,7 @@ func ensureCacheMeterInitialized() {
 //   - ctx: context for metric recording
 //   - operation: operation name (get, set, delete, cas, etc.)
 //   - duration: operation duration
-//   - hit: whether this was a cache hit (for Get operations)
+//   - hit: whether this was a cache hit (for lookup operations: get and getorset)
 //   - err: error if operation failed
 //   - namespace: optional tenant identifier
 func RecordCacheOperation(ctx context.Context, operation string, duration time.Duration, hit bool, err error, namespace string) {

--- a/cache/testing/assertions.go
+++ b/cache/testing/assertions.go
@@ -304,11 +304,11 @@ func AssertGetValue(t *testing.T, c cache.Cache, key string) []byte {
 //
 // Example:
 //
-//	mock := NewMockCache().WithGetFailure(cache.ErrConnectionError)
+//	mock := NewMockCache().WithGetFailure(cache.ErrClosed)
 //	AssertError(t, func() error {
 //	    _, err := mock.Get(context.Background(), "key")
 //	    return err
-//	}, cache.ErrConnectionError)
+//	}, cache.ErrClosed)
 func AssertError(t *testing.T, operation func() error, expected error) {
 	t.Helper()
 

--- a/cache/testing/doc.go
+++ b/cache/testing/doc.go
@@ -42,7 +42,7 @@
 //	}
 //
 //	deps := &app.ModuleDeps{
-//	    GetCache: func(ctx context.Context) (cache.Cache, error) {
+//	    Cache: func(ctx context.Context) (cache.Cache, error) {
 //	        tenantID := multitenant.GetTenant(ctx)
 //	        return tenantCaches[tenantID], nil
 //	    },

--- a/cache/testing/doc.go
+++ b/cache/testing/doc.go
@@ -19,7 +19,7 @@
 // Chain configuration methods to simulate failures or delays:
 //
 //	mock := testing.NewMockCache().
-//	    WithGetFailure(cache.ErrConnectionError).
+//	    WithGetFailure(cache.ErrClosed).
 //	    WithDelay(100 * time.Millisecond)
 //
 // # Operation Tracking

--- a/cache/testing/doc.go
+++ b/cache/testing/doc.go
@@ -43,7 +43,7 @@
 //
 //	deps := &app.ModuleDeps{
 //	    Cache: func(ctx context.Context) (cache.Cache, error) {
-//	        tenantID := multitenant.GetTenant(ctx)
+//	        tenantID, _ := multitenant.GetTenant(ctx)
 //	        return tenantCaches[tenantID], nil
 //	    },
 //	}

--- a/config/env.go
+++ b/config/env.go
@@ -6,7 +6,7 @@ import (
 )
 
 // envFormat catches structural typos in app.env; semantic branching is via
-// IsDevelopment / IsProduction. See ADR-021 for the policy rationale.
+// IsDevelopment / IsProduction. See ADR-022 for the policy rationale.
 var envFormat = regexp.MustCompile(`^[a-z][a-z0-9-]{0,31}$`)
 
 const (

--- a/config/types.go
+++ b/config/types.go
@@ -9,8 +9,9 @@ import (
 // Config represents the overall application configuration structure.
 // It includes sections for application settings, server parameters,
 // database connection details, logging preferences, and messaging options.
-// The embedded koanf.Koanf instance allows for flexible access to
-// additional custom configurations not explicitly defined in the struct.
+// The underlying koanf.Koanf instance (the unexported k field) allows for
+// flexible access to additional custom configurations not explicitly defined
+// in the struct.
 type Config struct {
 	App         AppConfig                 `koanf:"app" json:"app" yaml:"app" toml:"app" mapstructure:"app"`
 	Server      ServerConfig              `koanf:"server" json:"server" yaml:"server" toml:"server" mapstructure:"server"`

--- a/config/validation.go
+++ b/config/validation.go
@@ -264,7 +264,7 @@ func validateDatabase(cfg *DatabaseConfig) error {
 // an invalid optional Port, and negative values for Pool/Query fields.
 // Pool.Max.Connections defaults to 25 when 0; Query.Log.MaxLength and Query.Slow.Threshold
 // default to the respective constants when 0. Negative values are rejected.
-// respectively. The cfg argument is mutated for those default assignments.
+// The cfg argument is mutated for those default assignments.
 func validateDatabaseWithConnectionString(cfg *DatabaseConfig) error {
 	if cfg.Type != "" {
 		if err := validateDatabaseType(cfg.Type); err != nil {

--- a/database/factory.go
+++ b/database/factory.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gaborage/go-bricks/logger"
 )
 
-// NewConnection creates a tracked database connection for the provided configuration.
 // NewConnection creates a tracked database connection based on the provided configuration.
 //
 // It initializes a concrete driver connection for the configured database type, wraps it with

--- a/database/internal/builder/oracle.go
+++ b/database/internal/builder/oracle.go
@@ -9,10 +9,6 @@ import (
 	dbtypes "github.com/gaborage/go-bricks/database/types"
 )
 
-// quoteOracleColumn handles Oracle-specific column name quoting.
-// It identifies Oracle reserved words and applies appropriate quoting.
-// Reserved words are managed in the sqllex package to prevent duplication.
-
 func oracleNeedsQuoting(identifier string) bool {
 	if identifier == "" {
 		return false
@@ -341,8 +337,6 @@ func (qb *QueryBuilder) quoteOracleColumnsForDML(columns ...string) []string {
 	return quoted
 }
 
-// buildOraclePaginationClause builds an Oracle-compatible pagination suffix.
-// Oracle 12c+ supports OFFSET ... ROWS FETCH NEXT ... ROWS ONLY syntax.
 // buildOraclePaginationClause constructs an Oracle-compatible pagination clause using OFFSET and FETCH NEXT syntax.
 // The returned string contains "OFFSET {offset} ROWS" and/or "FETCH NEXT {limit} ROWS ONLY" as applicable; it is empty if both limit and offset are less than or equal to zero.
 func buildOraclePaginationClause(limit, offset int) string {

--- a/database/internal/builder/query_builder.go
+++ b/database/internal/builder/query_builder.go
@@ -160,7 +160,7 @@ func (qb *QueryBuilder) MustExpr(sql string, alias ...string) dbtypes.RawExpress
 //   - structPtr: Pointer to a struct with `db:"column_name"` tags
 //
 // Returns:
-//   - dbtypes.ColumnMetadata: Interface providing Get(), Fields(), and All() methods
+//   - dbtypes.Columns: Interface providing Col(), Cols(), and All() methods
 //
 // Panics if:
 //   - structPtr is not a pointer to a struct

--- a/database/internal/columns/registry.go
+++ b/database/internal/columns/registry.go
@@ -53,8 +53,8 @@ var globalColumnRegistry = &ColumnRegistry{
 //	}
 //
 //	cols := RegisterColumns(dbtypes.Oracle, &User{})
-//	cols.Get("ID")    // Returns: `"ID"` (Oracle, quoted)
-//	cols.Get("Level") // Returns: `"LEVEL"` (Oracle reserved word, quoted)
+//	cols.Col("ID")    // Returns: `"ID"` (Oracle, quoted)
+//	cols.Col("Level") // Returns: `"LEVEL"` (Oracle reserved word, quoted)
 func RegisterColumns(vendor string, structPtr any) *ColumnMetadata {
 	return globalColumnRegistry.Get(vendor, structPtr)
 }

--- a/database/internal/tracking/connection.go
+++ b/database/internal/tracking/connection.go
@@ -21,13 +21,9 @@ type DB struct {
 	settings Settings
 }
 
-// NewDB creates a DB wrapper that tracks performance for the provided *sql.DB.
-// It records query and execution metrics (durations, truncated queries, optional parameter logging).
-// Uses log for emitting structured logs, vendor to identify the database type, and
 // NewDB returns a DB wrapper around the provided *sql.DB that records per-request
-// performance metrics, slow queries, and errors using the provided logger.
-// The wrapper is configured for the given vendor and derives per-connection
-// tracking settings from cfg when provided.
+// performance metrics, slow queries, and errors using log. The wrapper is configured
+// for the given vendor and derives per-connection tracking settings from cfg.
 func NewDB(db *sql.DB, log logger.Logger, vendor string, cfg *config.DatabaseConfig) *DB {
 	return &DB{
 		DB:       db,
@@ -111,13 +107,10 @@ type Connection struct {
 	namespace     string
 }
 
-// NewConnection returns a database.Interface that wraps conn and records query/operation
-// metrics and logs. The wrapper delegates all calls to the provided conn, uses conn.DatabaseType()
 // NewConnection returns a types.Interface that wraps conn and records per-operation
-// performance metrics, slow queries, and errors using the provided logger.
-//
-// The wrapper uses conn.DatabaseType() as the vendor identifier and derives
-// per-connection tracking settings from cfg via NewSettings.
+// performance metrics, slow queries, and errors using log. The wrapper uses
+// conn.DatabaseType() as the vendor identifier and derives per-connection tracking
+// settings from cfg via NewSettings.
 func NewConnection(conn types.Interface, log logger.Logger, cfg *config.DatabaseConfig) types.Interface {
 	return &Connection{
 		conn:     conn,

--- a/database/internal/tracking/metrics.go
+++ b/database/internal/tracking/metrics.go
@@ -150,8 +150,6 @@ func asInt64(v any) (int64, bool) {
 	}
 }
 
-// initDBMeter initializes the OpenTelemetry meter and metric instruments.
-// This function is called lazily and only once using sync.Once to ensure
 // initDBMeter initializes the package-level OpenTelemetry meter and the database
 // operation duration histogram.
 //

--- a/database/internal/tracking/settings.go
+++ b/database/internal/tracking/settings.go
@@ -40,9 +40,6 @@ type Context struct {
 	Namespace     string // db.namespace attribute (vendor-specific format)
 }
 
-// NewSettings creates Settings populated from the provided database configuration.
-// If cfg is nil or a numeric field is non-positive, sensible defaults are used:
-// DefaultSlowQueryThreshold for slowQueryThreshold and DefaultMaxQueryLength for maxQueryLength.
 // NewSettings creates a Settings configured from the provided DatabaseConfig.
 //
 // It initializes defaults from DefaultSlowQueryThreshold, DefaultMaxQueryLength,

--- a/database/internal/tracking/statement.go
+++ b/database/internal/tracking/statement.go
@@ -48,7 +48,6 @@ type Statement struct {
 	settings Settings
 }
 
-// NewStatement creates a Statement wrapper that tracks performance for prepared statements.
 // NewStatement wraps the provided statement with a tracking implementation that records execution
 // metrics for Query, QueryRow, and Exec.
 //

--- a/database/internal/tracking/transaction.go
+++ b/database/internal/tracking/transaction.go
@@ -21,7 +21,6 @@ type Transaction struct {
 	tc       *Context // cached context for tracking
 }
 
-// NewTransaction creates a Transaction wrapper that tracks performance for database transactions.
 // NewTransaction creates a Transaction wrapper around the provided tx that records execution
 // metrics for all transaction operations. The wrapper delegates calls to the given tx while
 // capturing timing and error information, stores the provided logger, vendor, and settings,

--- a/database/internal/tracking/utils.go
+++ b/database/internal/tracking/utils.go
@@ -56,9 +56,6 @@ const (
 	maxDBQueryAttrLen = 2000                 // Maximum length for db.query.text attribute
 )
 
-// TrackDBOperation logs database operation performance metrics and errors.
-// It provides centralized tracking for all database operations including queries,
-// statements, and transactions. The function handles slow query detection,
 // TrackDBOperation records metrics and emits a log event for a completed database operation.
 //
 // TrackDBOperation is a no-op if tc or its Logger is nil. It records the operation's duration to
@@ -144,10 +141,6 @@ func extractRowsAffected(result sql.Result, err error) int64 {
 	return affected
 }
 
-// TruncateString returns value truncated to at most maxLen characters.
-// If maxLen <= 0 or value is already shorter than or equal to maxLen, the
-// original string is returned. When maxLen <= 3 the function returns the
-// first maxLen characters (no ellipsis); otherwise it returns the first
 // TruncateString truncates value to at most maxLen runes, adding "..." when space allows to indicate truncation.
 //
 // If maxLen <= 0 the original value is returned unchanged. If the string's rune count is less than or equal to
@@ -194,8 +187,6 @@ func SanitizeArgs(args []any, maxLen int) []any {
 	return sanitized
 }
 
-// createDBSpan creates an OpenTelemetry span for a database operation.
-// It adds standard database semantic attributes per OTel spec v1.32.0 and records errors.
 // createDBSpan starts an OpenTelemetry span for a database operation using the provided start time.
 // It sets standard DB and network attributes (including `db.system.name`, `db.query.text`, `db.operation.name`,
 // `db.collection.name`, `db.namespace`, `server.address`, and `server.port`) when available, records errors
@@ -265,7 +256,6 @@ func createDBSpan(ctx context.Context, tc *Context, query string, start time.Tim
 	span.End()
 }
 
-// extractDBOperation extracts the operation type from a SQL query.
 // extractDBOperation determines the database operation name from the given SQL query.
 // It returns a lowercase operation such as "select", "insert", "update", "delete",
 // "create", "drop", "alter", or "truncate". If the query is empty or the first token
@@ -322,10 +312,6 @@ func extractDBOperation(query string) string {
 	}
 }
 
-// normalizeDBVendor normalizes the database vendor name to match OTel semantic conventions.
-// Returns vendor-specific db.system.name values per OTel spec:
-// - "postgresql" for PostgreSQL
-// - "oracle.db" for Oracle (note the .db suffix required by spec)
 // normalizeDBVendor maps common database vendor identifiers to the OpenTelemetry
 // `db.system.name` values.
 // It lowercases the input and maps known aliases (for example: "postgres" or

--- a/database/postgresql/connection.go
+++ b/database/postgresql/connection.go
@@ -69,9 +69,6 @@ func makeKeepAliveDialer(keepAliveCfg config.PoolKeepAliveConfig, log logger.Log
 	}
 }
 
-// quoteDSN quotes a DSN value according to libpq rules:
-// - Returns double single quotes for empty strings (empty value)
-// - Escapes backslashes and single quotes
 // quoteDSN returns a DSN-safe representation of value, wrapping it in single quotes
 // and escaping backslashes and single quotes when value contains characters other
 // than letters, digits, dot (.), underscore (_) or hyphen (-). If value is empty

--- a/database/types/querier.go
+++ b/database/types/querier.go
@@ -26,9 +26,9 @@ import (
 //	    execFunc     func(ctx context.Context, query string, args ...any) (sql.Result, error)
 //	}
 //
-//	// Inject via ModuleDeps.GetDB
+//	// Inject via ModuleDeps.DB
 //	deps := &app.ModuleDeps{
-//	    GetDB: func(ctx context.Context) (database.Interface, error) {
+//	    DB: func(ctx context.Context) (database.Interface, error) {
 //	        return mockQuerier, nil
 //	    },
 //	}

--- a/database/types/transactor.go
+++ b/database/types/transactor.go
@@ -20,7 +20,7 @@ import (
 // Usage in services:
 //
 //	func (s *OrderService) CreateWithPayment(ctx context.Context, order Order, payment Payment) error {
-//	    db, err := s.deps.GetDB(ctx)
+//	    db, err := s.deps.DB(ctx)
 //	    if err != nil {
 //	        return err
 //	    }

--- a/httpclient/interface.go
+++ b/httpclient/interface.go
@@ -125,8 +125,6 @@ func TraceStateFromContext(ctx context.Context) (string, bool) {
 // Format: version(2)-trace-id(32)-span-id(16)-flags(2), e.g., "00-<32>-<16>-01"
 func GenerateTraceParent() string { return gobrickstrace.GenerateTraceParent() }
 
-// allZero moved to trace; kept no-op here to avoid unused removal
-
 // NewTraceIDInterceptor creates a request interceptor that adds trace ID headers
 // This provides an alternative approach for users who want explicit control
 func NewTraceIDInterceptor() RequestInterceptor {

--- a/internal/testutil/constants.go
+++ b/internal/testutil/constants.go
@@ -23,7 +23,6 @@ const (
 
 const (
 	// TestHost is the standard localhost hostname for test environments.
-	// Used extensively across configuration, database, and integration tests (130+ occurrences).
 	TestHost = "localhost"
 
 	// TestHostWithPort is localhost with a common test port.

--- a/jose/context.go
+++ b/jose/context.go
@@ -39,14 +39,16 @@ func ClaimsFromContext(ctx context.Context) *Claims {
 	return c
 }
 
-// WithPolicy attaches the active outbound Policy for this request so the response
-// formatter can find it after the handler returns. Set by the inbound middleware
-// branch (or by the route-registration scaffolding for outbound-only routes).
+// WithPolicy attaches the given outbound Policy to the context for later retrieval
+// via PolicyFromContext. The current server wiring threads the outbound policy as an
+// explicit parameter and stores it on the route descriptor rather than on the context,
+// so this helper has no callers today; it remains as a context-key accessor pair.
 func WithPolicy(ctx context.Context, p *Policy) context.Context {
 	return context.WithValue(ctx, keyPolicy, p)
 }
 
-// PolicyFromContext returns the outbound Policy attached for this request, or nil.
+// PolicyFromContext returns the outbound Policy attached via WithPolicy, or nil if
+// none was attached (the default in the current wiring).
 func PolicyFromContext(ctx context.Context) *Policy {
 	p, _ := ctx.Value(keyPolicy).(*Policy)
 	return p

--- a/jose/testing/doc.go
+++ b/jose/testing/doc.go
@@ -10,8 +10,8 @@
 //
 //	priv, pub := jositest.GenerateTestKeyPair(t)
 //	resolver := jositest.NewTestResolver(map[string]any{
-//	    "our-key":  priv, // played as both the decrypt key (us) and sign key (peer in test)
-//	    "peer-key": pub,  // verify key
+//	    "our-key":  priv, // decrypt key (us, inbound) and encrypt target (outbound)
+//	    "peer-key": pub,  // verify key (inbound) and sign key (peer, outbound)
 //	})
 //
 //	inboundPolicy := &jose.Policy{

--- a/keystore/module.go
+++ b/keystore/module.go
@@ -5,8 +5,9 @@ import (
 	"github.com/gaborage/go-bricks/logger"
 )
 
-// Module implements the GoBricks app.Module interface for RSA key pair management.
-// It loads named RSA key pairs at startup and provides them to other modules via deps.KeyStore.
+// Module implements the GoBricks app.Module interface for named key-material management.
+// It loads named RSA key pairs and raw symmetric secrets at startup and provides them to
+// other modules via deps.KeyStore.
 //
 // Register before modules that need keys:
 //
@@ -30,7 +31,7 @@ func (m *Module) Name() string {
 }
 
 // Init implements app.Module.
-// Loads all configured key pairs and validates them. Fails fast on any error.
+// Loads all configured key material (RSA pairs and symmetric secrets) and validates it. Fails fast on any error.
 func (m *Module) Init(deps *app.ModuleDeps) error {
 	m.logger = deps.Logger
 

--- a/llms.txt
+++ b/llms.txt
@@ -27,11 +27,10 @@ func main() {
 	// - Metrics (HTTP, database, messaging)
 	// - Structured logging with trace correlation
 	// - HTTP request auto-instrumentation
-	fw, err := app.NewWithConfig(cfg, nil)
+	fw, _, err := app.NewWithConfig(cfg, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
-
 	fw.RegisterModules(/* modules */)
 
 	// Graceful shutdown: flushes pending spans/metrics before exit
@@ -44,12 +43,12 @@ func main() {
 ```yaml
 app:
   name: my-service
-  environment: development
+  env: development
 server:
   enabled: true
   port: 8080
 database:
-  type: postgres    # postgres | oracle
+  type: postgresql    # postgresql | oracle
   host: localhost
   port: 5432
   database: myapp_db
@@ -167,9 +166,9 @@ func (h *Handler) Create(req CreateUserReq, ctx server.HandlerContext) (server.R
 	user, err := h.svc.Create(ctx.Echo.Request().Context(), req.Name, req.Email)
 	switch {
 	case errors.Is(err, ErrUserExists):
-		return server.Result[User]{}, server.Conflict(err)
+		return server.Result[User]{}, server.NewConflictError(err.Error())
 	case err != nil:
-		return server.Result[User]{}, server.InternalServerError(err)
+		return server.Result[User]{}, server.NewInternalServerError(err.Error())
 	}
 	return server.Created(user), nil
 }
@@ -222,7 +221,7 @@ func main() {
 	cfg, err := config.Load()
 	if err != nil { log.Fatal(err) }
 
-	fw, err := app.NewWithConfig(cfg, nil)
+	fw, _, err := app.NewWithConfig(cfg, nil)
 	if err != nil { log.Fatal(err) }
 
 	usersMod  := &users.Module{}
@@ -308,7 +307,7 @@ Standard form — explicit fields (preferred for readability and pool tuning):
 
 ```yaml
 database:
-  type: postgres                          # postgres | oracle
+  type: postgresql                          # postgresql | oracle
   host: localhost
   port: 5432
   database: myapp_db
@@ -332,7 +331,7 @@ Alternative — pre-built connection string (useful when a secret manager inject
 
 ```yaml
 database:
-  type: postgres
+  type: postgresql
   connection_string: ${DATABASE_URL}      # e.g. postgres://user:pass@host:5432/dbname?sslmode=require
 ```
 
@@ -450,7 +449,7 @@ func (m *UserModule) FindActiveUsersBuilder(ctx context.Context) ([]User, error)
 | `Exec(ctx, sql, args...)` | `(sql.Result, error)` | INSERT / UPDATE / DELETE / DDL |
 | `Begin(ctx)` | `(types.Tx, error)` | Start a transaction — `defer tx.Rollback(ctx)`, then `tx.Commit(ctx)` |
 | `Health(ctx)` | `error` | Liveness check — auto-wired into `/health` endpoint |
-| `DatabaseType()` | `string` | `"postgres"` or `"oracle"` — feed into `database.NewQueryBuilder(...)` |
+| `DatabaseType()` | `string` | `"postgresql"` or `"oracle"` — feed into `database.NewQueryBuilder(...)` |
 
 Every method takes `context.Context` as the first argument so deadlines, cancellation, tenant ID, and W3C trace IDs propagate automatically into spans, logs, and metrics.
 
@@ -517,7 +516,7 @@ func (h *Handler) Create(req CreateUserReq, ctx server.HandlerContext) (server.R
 	reqCtx := ctx.Echo.Request().Context()
 	user, err := h.svc.Create(reqCtx, req)
 	if err != nil {
-		return server.Result[User]{}, server.InternalServerError(err)
+		return server.Result[User]{}, server.NewInternalServerError(err.Error())
 	}
 	return server.Created(user), nil
 }
@@ -539,7 +538,7 @@ type GetUserReq struct {
 func (h *Handler) GetUser(req GetUserReq, ctx server.HandlerContext) (server.Result[User], server.IAPIError) {
 	user, err := h.svc.FindByID(ctx.Echo.Request().Context(), req.ID)
 	if err != nil {
-		return server.Result[User]{}, server.NotFound(errors.New("user not found"))
+		return server.Result[User]{}, server.NewNotFoundError("user")
 	}
 	return server.OK(user), nil
 }
@@ -560,7 +559,7 @@ func (h *Handler) ListUsers(req ListUsersReq, ctx server.HandlerContext) (server
 	}
 	users, err := h.svc.List(ctx.Echo.Request().Context(), req.Status, limit)
 	if err != nil {
-		return server.Result[[]User]{}, server.InternalServerError(err)
+		return server.Result[[]User]{}, server.NewInternalServerError(err.Error())
 	}
 	return server.OK(users), nil
 }
@@ -591,7 +590,7 @@ func (h *Handler) ListUsersPaginated(req ListUsersReq, hctx server.HandlerContex
 	ctx := hctx.Echo.Request().Context()
 	users, total, err := h.svc.ListPaged(ctx, req.Limit, req.Offset)
 	if err != nil {
-		return server.ResultWithMeta[ListUsersResp]{}, server.InternalServerError(err)
+		return server.ResultWithMeta[ListUsersResp]{}, server.NewInternalServerError(err.Error())
 	}
 	return server.ResultWithMeta[ListUsersResp]{
 		Data:   ListUsersResp{Items: users},
@@ -625,7 +624,7 @@ func (h *Handler) UploadFile(req *FileUploadRequest, ctx server.HandlerContext) 
 	reqCtx := ctx.Echo.Request().Context()
 	fileID, err := h.storageService.Store(reqCtx, req.Data, req.Filename, req.MimeType)
 	if err != nil {
-		return server.Result[UploadResponse]{}, server.InternalServerError(err)
+		return server.Result[UploadResponse]{}, server.NewInternalServerError(err.Error())
 	}
 	return server.Created(UploadResponse{FileID: fileID, Size: len(req.Data)}), nil
 }
@@ -641,7 +640,7 @@ func (h *Handler) ExportRecords(req ExportRequest, ctx server.HandlerContext) (*
 	reqCtx := ctx.Echo.Request().Context()
 	records, err := h.recordService.GetAll(reqCtx, req.Filter)
 	if err != nil {
-		return nil, server.InternalServerError(err)
+		return nil, server.NewInternalServerError(err.Error())
 	}
 	return &BulkExportResponse{
 		Records: records,
@@ -666,7 +665,7 @@ func (h *Handler) BulkImport(req *BulkImportRequest, ctx server.HandlerContext) 
 	reqCtx := ctx.Echo.Request().Context()
 	result, err := h.importService.ProcessBulk(reqCtx, req.Records, req.DryRun)
 	if err != nil {
-		return nil, server.InternalServerError(err)
+		return nil, server.NewInternalServerError(err.Error())
 	}
 	return &BulkImportResponse{
 		Imported: result.Imported,
@@ -867,7 +866,7 @@ func (h *Handler) acceptJob(req JobReq, ctx server.HandlerContext) (server.Resul
 import (
 	"context"
 
-	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v5"
 	"github.com/gaborage/go-bricks/server"
 	"github.com/gaborage/go-bricks/multitenant"
 )
@@ -968,7 +967,7 @@ func TenantMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 
 // Access tenant in handler
 func (h *Handler) GetUser(req GetUserReq, ctx server.HandlerContext) (server.Result[User], server.IAPIError) {
-	tenantID := multitenant.GetTenant(ctx.Echo.Request().Context())
+	tenantID, _ := multitenant.GetTenant(ctx.Echo.Request().Context())
 	// tenantID is now available for tenant-specific logic
 	user, err := h.svc.GetUserForTenant(ctx.Echo.Request().Context(), tenantID, req.ID)
 	// ...
@@ -1860,7 +1859,7 @@ func TestMultiTenantCacheIsolation(t *testing.T) {
 
     deps := &app.ModuleDeps{
         Cache: func(ctx context.Context) (cache.Cache, error) {
-            tenantID := multitenant.GetTenant(ctx)
+            tenantID, _ := multitenant.GetTenant(ctx)
             switch tenantID {
             case "acme":
                 return acmeCache, nil
@@ -2090,7 +2089,7 @@ Example: 8 CPUs, 500 concurrent requests → PoolSize = 80
 
 **Cache Testing Utilities:**
 
-**Note:** GoBricks does not yet provide a `cache/testing` package (similar to `database/testing`). Use interface mocking for now.
+**Note:** GoBricks provides a `cache/testing` package (similar to `database/testing`) — see "Cache Testing Utilities" below.
 
 ```go
 import (
@@ -2229,7 +2228,7 @@ func TestUserService(t *testing.T) {
 ```go
 // Simulate cache failures
 mockCache := cachetest.NewMockCache().
-    WithGetFailure(cache.ErrConnectionError).
+    WithGetFailure(cache.ErrClosed).
     WithDelay(100 * time.Millisecond)
 
 // Service should gracefully degrade
@@ -2292,7 +2291,7 @@ func TestMultiTenantCacheIsolation(t *testing.T) {
 
     deps := &app.ModuleDeps{
         Cache: func(ctx context.Context) (cache.Cache, error) {
-            tenantID := multitenant.GetTenant(ctx)
+            tenantID, _ := multitenant.GetTenant(ctx)
             return tenantCaches[tenantID], nil
         },
     }
@@ -2321,7 +2320,7 @@ mock := cachetest.NewMockCacheWithID("test-cache-1")
 
 // Failure injection for specific operations
 mock := cachetest.NewMockCache().
-    WithGetFailure(cache.ErrConnectionError).
+    WithGetFailure(cache.ErrClosed).
     WithSetFailure(cache.ErrClosed).
     WithDeleteFailure(errors.New("custom error"))
 
@@ -2674,7 +2673,7 @@ func main() {
 	cfg, err := config.Load()
 	if err != nil { log.Fatal(err) }
 
-	fw, err := app.NewWithConfig(cfg, nil)
+	fw, _, err := app.NewWithConfig(cfg, nil)
 	if err != nil { log.Fatal(err) }
 
 	if err := fw.RegisterModules(&orders.Module{}); err != nil {
@@ -3458,9 +3457,9 @@ func (h *Handler) GetUser(req GetUserReq, ctx server.HandlerContext) (server.Res
     if err != nil {
         // Map domain errors to HTTP responses
         if errors.Is(err, app.ErrNoTenantInContext) {
-            return server.Result[User]{}, server.BadRequest(errors.New("X-Tenant-ID header required"))
+            return server.Result[User]{}, server.NewBadRequestError("X-Tenant-ID header required")
         }
-        return server.Result[User]{}, server.InternalServerError(err)
+        return server.Result[User]{}, server.NewInternalServerError(err.Error())
     }
 
     return server.OK(user), nil
@@ -3529,7 +3528,7 @@ import (
     "errors"
 
     "github.com/gaborage/go-bricks/database"
-    "github.com/gaborage/go-bricks/database/internal/builder"
+    dbtypes "github.com/gaborage/go-bricks/database/types"
     "github.com/gaborage/go-bricks/multitenant"
 )
 
@@ -3661,7 +3660,7 @@ multitenant:
 ```go
 // WithTenantFilter adds tenant isolation to any query
 // Returns a safe no-match condition if tenant context is missing (prevents data leaks)
-func WithTenantFilter(ctx context.Context, f *builder.Filter, cols dbtypes.ColumnMetadata) builder.Condition {
+func WithTenantFilter(ctx context.Context, f dbtypes.FilterFactory, cols dbtypes.Columns) dbtypes.Filter {
     tenantID, ok := multitenant.GetTenant(ctx)
     if !ok || tenantID == "" {
         // Return always-false condition to prevent returning any data
@@ -4226,7 +4225,7 @@ func (h *Handler) CreateUser(req CreateUserReq, ctx server.HandlerContext) (serv
 			Err(err).
 			Str("email", req.Email).
 			Msg("User creation failed")
-		return server.Result[User]{}, server.InternalServerError(err)
+		return server.Result[User]{}, server.NewInternalServerError(err.Error())
 	}
 
 	log.Info().
@@ -4364,7 +4363,7 @@ Action logs derive severity automatically:
 
 ```go
 import (
-    "github.com/labstack/echo/v4"
+    "github.com/labstack/echo/v5"
     "github.com/rs/zerolog"
 
     "github.com/gaborage/go-bricks/server"
@@ -4430,7 +4429,7 @@ func main() {
     // 2. Sets it as the global OTel provider (otel.SetTracerProvider)
     // 3. Registers otelecho.Middleware → creates spans for every incoming HTTP request
     // 4. Registers W3C propagator → inbound traceparent headers create linked spans
-    fw, err := app.NewWithConfig(cfg, nil)
+    fw, _, err := app.NewWithConfig(cfg, nil)
     if err != nil {
         log.Fatal(err)
     }
@@ -4934,7 +4933,7 @@ type IAPIError interface {
 | `NewInternalServerError(msg)` | 500 | `INTERNAL_ERROR` | Unexpected server errors |
 | `NewServiceUnavailableError(msg)` | 503 | `SERVICE_UNAVAILABLE` | Dependency down, maintenance |
 
-All types embed `*BaseAPIError` which provides `WithDetails(key, value)` for adding metadata (chainable). In development mode (`app.environment: development`), details are included in responses for all HTTP status codes. In production, details are hidden for 5xx errors to avoid leaking internals.
+All types embed `*BaseAPIError` which provides `WithDetails(key, value)` for adding metadata (chainable). In development mode (`app.env: development`), details are included in responses for all HTTP status codes. In production, details are hidden for 5xx errors to avoid leaking internals.
 
 ### Step 1: Define Domain Errors
 
@@ -5023,7 +5022,7 @@ type CreateOrderReq struct {
     "message": "insufficient stock for requested quantity",
     "details": { "suggestion": "reduce quantity or wait for restock" }
   },
-  "meta": { "api_version": "1.0" }
+  "meta": { "timestamp": "2026-01-01T00:00:00Z", "traceId": "abc123" }
 }
 ```
 
@@ -5060,15 +5059,15 @@ func (h *OrderConsumer) Handle(ctx context.Context, delivery *amqp.Delivery) err
     if err != nil {
         // Business-rule violations: log and ACK (skip, don't retry)
         if errors.Is(err, ErrInsufficientStock) {
-            h.logger.Warn("Order skipped: insufficient stock",
-                "product_id", req.ProductID, "quantity", req.Quantity)
+            h.logger.Warn().Int64("product_id", req.ProductID).Int("quantity", req.Quantity).
+                Msg("Order skipped: insufficient stock")
             return nil // ACK — retrying won't change stock levels
         }
 
         var dupErr *DuplicateOrderError
         if errors.As(err, &dupErr) {
-            h.logger.Warn("Duplicate order ignored",
-                "order_id", dupErr.OrderID, "existing_id", dupErr.ExistingID)
+            h.logger.Warn().Str("order_id", dupErr.OrderID).Str("existing_id", dupErr.ExistingID).
+                Msg("Duplicate order ignored")
             return nil // ACK — idempotent, already processed
         }
 

--- a/llms.txt
+++ b/llms.txt
@@ -3243,7 +3243,7 @@ func (m *Module) exchange(req ExchangeRequest, ctx server.HandlerContext) (Excha
 | Wrong Content-Type (not `application/jose`) | 415 | `JOSE_PLAINTEXT_REJECTED` | pre-trust | `application/json` |
 | Compact JWE parse failure | 400 | `JOSE_MALFORMED` | pre-trust | `application/json` |
 | `enc`/`alg` not in allowlist | 400 | `JOSE_ALGORITHM_DISALLOWED` | pre-trust | `application/json` |
-| `alg=none` (downgrade) | 401 | `JOSE_NONE_ALG_REJECTED` | pre-trust | `application/json` |
+| `alg=none` (downgrade) | 400 | `JOSE_ALGORITHM_DISALLOWED` | pre-trust | `application/json` |
 | Header missing `kid` | 401 | `JOSE_KID_MISSING` | pre-trust | `application/json` |
 | Unknown `kid` in header | 401 | `JOSE_KID_UNKNOWN` | pre-trust | `application/json` |
 | Decryption failed | 401 | `JOSE_DECRYPT_FAILED` | pre-trust | `application/json` |

--- a/logger/constants.go
+++ b/logger/constants.go
@@ -1,6 +1,6 @@
 package logger
 
-// DefaultMaskValue es el valor utilizado para enmascarar datos sensibles
+// DefaultMaskValue is the value used to mask sensitive data.
 const DefaultMaskValue = "***"
 
 // Log level string constants matching zerolog level names.

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -186,7 +186,8 @@ func (l *ZeroLogger) WithOTelProvider(provider OTelProvider) *ZeroLogger {
 	// Create OTel bridge to convert zerolog JSON to OTel log records
 	bridge := NewOTelBridge(provider.LoggerProvider())
 	if bridge == nil {
-		// Bridge creation failed gracefully (e.g., nil provider)
+		// Defensive: NewOTelBridge returns nil only for a nil provider, which is already
+		// guaranteed non-nil above; kept as a belt-and-suspenders guard.
 		return l
 	}
 

--- a/messaging/declarations.go
+++ b/messaging/declarations.go
@@ -260,7 +260,7 @@ func (d *Declarations) ReplayToRegistry(reg RegistryInterface) error {
 	return nil
 }
 
-// Stats returns statistics about the declarations.
+// DeclarationStats holds counts of each declaration type.
 type DeclarationStats struct {
 	Exchanges  int
 	Queues     int

--- a/messaging/manager.go
+++ b/messaging/manager.go
@@ -69,7 +69,7 @@ type consumerEntry struct {
 	key      string
 }
 
-// ManagerOptions configures the MessagingManager
+// ManagerOptions configures the Manager
 type ManagerOptions struct {
 	MaxPublishers int           // Maximum number of publisher clients to keep cached
 	IdleTTL       time.Duration // Time after which idle publishers are evicted

--- a/messaging/registry.go
+++ b/messaging/registry.go
@@ -801,7 +801,7 @@ func (r *Registry) handlePanicRecovery(
 		Bytes("stack", stack).
 		Msg("Panic recovered in message handler - discarding without requeue")
 
-	// Record failed message metrics (inline recordFailedMessage)
+	// Record failed message metrics
 	panicErr := fmt.Errorf("panic in message handler: %v", recovered)
 	tracking.RecordAMQPConsumeMetrics(msgCtx, delivery, consumer.Queue, processingTime, panicErr)
 

--- a/observability/README.md
+++ b/observability/README.md
@@ -37,13 +37,19 @@ package main
 
 import (
     "context"
+    "log"
+    "time"
+
     "github.com/gaborage/go-bricks/config"
     "github.com/gaborage/go-bricks/observability"
 )
 
 func main() {
     // Load configuration
-    cfg := config.New()
+    cfg, err := config.Load()
+    if err != nil {
+        log.Fatalf("Failed to load config: %v", err)
+    }
     var obsCfg observability.Config
     if err := cfg.InjectInto(&obsCfg); err != nil {
         panic(err)
@@ -54,7 +60,7 @@ func main() {
     if err != nil {
         panic(err)
     }
-    defer observability.Shutdown(provider, 5)
+    defer observability.Shutdown(provider, 5*time.Second)
 
     // Create tracer
     tracer := provider.TracerProvider().Tracer("my-service")
@@ -225,38 +231,55 @@ observability:
 ### Custom Provider Configuration
 
 ```go
-import "github.com/gaborage/go-bricks/observability"
+import (
+    "time"
+
+    "github.com/gaborage/go-bricks/observability"
+)
 
 // Create custom configuration
 cfg := &observability.Config{
     Enabled:     true,
-    ServiceName: "my-service",
-    ServiceVersion: "1.0.0",
+    Service: observability.ServiceConfig{
+        Name:    "my-service",
+        Version: "1.0.0",
+    },
     Environment: "production",
     Trace: observability.TraceConfig{
-        Enabled:  true,
+        Enabled:  observability.BoolPtr(true),
         Endpoint: "localhost:4318",
         Protocol: "http",
         Insecure: true,
         Headers: map[string]string{
             "Authorization": "Bearer token",
         },
-        SampleRate:    0.1,
-        BatchTimeout:  5 * time.Second,
-        ExportTimeout: 30 * time.Second,
-        MaxQueueSize:  2048,
-        MaxBatchSize:  512,
+        Sample: observability.SampleConfig{
+            Rate: observability.Float64Ptr(0.1),
+        },
+        Batch: observability.BatchConfig{
+            Timeout: 5 * time.Second,
+            Size:    512,
+        },
+        Export: observability.ExportConfig{
+            Timeout: 30 * time.Second,
+        },
+        Max: observability.MaxConfig{
+            Queue: observability.QueueConfig{Size: 2048},
+            Batch: observability.MaxBatchConfig{Size: 512},
+        },
     },
     Metrics: observability.MetricsConfig{
-        Enabled:  true,
+        Enabled:  observability.BoolPtr(true),
         Endpoint: "https://api.datadoghq.com",
         Protocol: "http",
         Insecure: observability.BoolPtr(false),
         Headers: map[string]string{
             "DD-API-KEY": "your-api-key",
         },
-        Interval:      15 * time.Second,
-        ExportTimeout: 45 * time.Second,
+        Interval: 15 * time.Second,
+        Export: observability.MetricsExportConfig{
+            Timeout: 45 * time.Second,
+        },
     },
 }
 
@@ -265,7 +288,7 @@ provider, err := observability.NewProvider(cfg)
 if err != nil {
     panic(err)
 }
-defer observability.Shutdown(provider, 5)
+defer observability.Shutdown(provider, 5*time.Second)
 ```
 
 ### Graceful Shutdown
@@ -273,11 +296,11 @@ defer observability.Shutdown(provider, 5)
 ```go
 import "github.com/gaborage/go-bricks/observability"
 
-// Shutdown with custom timeout (in seconds)
-observability.Shutdown(provider, 10)
+// Shutdown with custom timeout
+observability.Shutdown(provider, 10*time.Second)
 
 // Or panic on shutdown failure
-observability.MustShutdown(provider, 10)
+observability.MustShutdown(provider, 10*time.Second)
 
 // Manual shutdown with context
 ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/observability/config.go
+++ b/observability/config.go
@@ -140,9 +140,9 @@ func (c *Config) applyTraceDefaults() {
 
 	// Trace.Insecure intentionally left at its zero value (false) when unset.
 	// The stdout trace exporter never opens a network connection and ignores
-	// the flag. Logs.Insecure defaults independently (see applyLogsDefaults);
-	// the prior coupling was removed in this PR to avoid silently downgrading
-	// an unrelated remote OTLP logs endpoint when traces target stdout.
+	// the flag. Logs.Insecure defaults independently (see applyLogsDefaults)
+	// so targeting stdout traces does not silently downgrade an unrelated
+	// remote OTLP logs endpoint.
 
 	// Compression default - gzip for bandwidth reduction (New Relic recommendation)
 	if c.Trace.Compression == "" {

--- a/observability/metrics.go
+++ b/observability/metrics.go
@@ -104,7 +104,6 @@ func (p *provider) createMetricExporter() (sdkmetric.Exporter, error) {
 	}
 
 	// Create OTLP exporter based on protocol
-	// Metrics use the same protocol configuration as traces
 	protocol, useInsecure, headers := p.metricsTransportSettings()
 	debugLogger.Printf("Metrics transport settings: protocol=%s, insecure=%v, headers_count=%d",
 		protocol, useInsecure, len(headers))

--- a/outbox/publisher.go
+++ b/outbox/publisher.go
@@ -45,7 +45,6 @@ func (p *outboxPublisher) Publish(ctx context.Context, tx dbtypes.Tx, event *app
 		return "", fmt.Errorf("outbox: aggregate ID must not be empty")
 	}
 
-	// Marshal payload
 	payload, err := marshalPayload(event.Payload)
 	if err != nil {
 		return "", fmt.Errorf("outbox: failed to marshal payload: %w", err)
@@ -67,19 +66,16 @@ func (p *outboxPublisher) Publish(ctx context.Context, tx dbtypes.Tx, event *app
 		return "", fmt.Errorf("outbox: failed to marshal headers: %w", err)
 	}
 
-	// Resolve exchange
 	exchange := event.Exchange
 	if exchange == "" {
 		exchange = p.defaultExchange
 	}
 
-	// Resolve routing key
 	routingKey := event.RoutingKey
 	if routingKey == "" {
 		routingKey = event.EventType
 	}
 
-	// Generate event ID
 	eventID := uuid.New().String()
 
 	record := &Record{

--- a/outbox/store_oracle.go
+++ b/outbox/store_oracle.go
@@ -173,12 +173,10 @@ func (s *oracleStore) CreateTable(ctx context.Context, db dbtypes.Interface) err
 		return fmt.Errorf("outbox oracle: create table failed: %w", err)
 	}
 
-	// Create pending index
 	if _, err := db.Exec(ctx, fmt.Sprintf(oracleCreatePendingIndexSQL, s.tableName, s.tableName)); err != nil {
 		return fmt.Errorf("outbox oracle: create pending index failed: %w", err)
 	}
 
-	// Create published index
 	if _, err := db.Exec(ctx, fmt.Sprintf(oracleCreatePublishedIndexSQL, s.tableName, s.tableName)); err != nil {
 		return fmt.Errorf("outbox oracle: create published index failed: %w", err)
 	}

--- a/outbox/store_postgres.go
+++ b/outbox/store_postgres.go
@@ -158,17 +158,14 @@ func (s *postgresStore) DeletePublished(ctx context.Context, db dbtypes.Interfac
 }
 
 func (s *postgresStore) CreateTable(ctx context.Context, db dbtypes.Interface) error {
-	// Create table
 	if _, err := db.Exec(ctx, fmt.Sprintf(postgresCreateTableSQL, s.tableName)); err != nil {
 		return fmt.Errorf("outbox postgres: create table failed: %w", err)
 	}
 
-	// Create pending index
 	if _, err := db.Exec(ctx, fmt.Sprintf(postgresCreatePendingIndexSQL, s.tableName, s.tableName)); err != nil {
 		return fmt.Errorf("outbox postgres: create pending index failed: %w", err)
 	}
 
-	// Create published index
 	if _, err := db.Exec(ctx, fmt.Sprintf(postgresCreatePublishedIndexSQL, s.tableName, s.tableName)); err != nil {
 		return fmt.Errorf("outbox postgres: create published index failed: %w", err)
 	}

--- a/scheduler/constants.go
+++ b/scheduler/constants.go
@@ -2,8 +2,7 @@ package scheduler
 
 import "time"
 
-// Lifecycle and observability defaults. Previously inline literals scattered
-// across module.go.
+// Lifecycle and observability defaults.
 const (
 	// defaultShutdownTimeout is the wall-clock budget for in-flight jobs to
 	// complete during graceful shutdown when cfg.Scheduler.Timeout.Shutdown

--- a/scheduler/helpers.go
+++ b/scheduler/helpers.go
@@ -14,8 +14,8 @@ import (
 //
 // Example:
 //
-//	scheduler.DailyAt("cleanup-job", &CleanupJob{}, scheduler.ParseTime("03:00"))  // 3:00 AM
-//	scheduler.WeeklyAt("report-job", &ReportJob{}, time.Monday, scheduler.ParseTime("09:30"))  // Monday at 9:30 AM
+//	deps.Scheduler.DailyAt("cleanup-job", &CleanupJob{}, scheduler.ParseTime("03:00"))  // 3:00 AM
+//	deps.Scheduler.WeeklyAt("report-job", &ReportJob{}, time.Monday, scheduler.ParseTime("09:30"))  // Monday at 9:30 AM
 //
 // Format: "HH:MM" where HH is 00-23 and MM is 00-59
 //

--- a/server/constants.go
+++ b/server/constants.go
@@ -50,7 +50,6 @@ var reservedMetaKeys = map[string]struct{}{
 const (
 	// DefaultReadTimeout is the maximum duration for reading the entire request.
 	// This includes reading the request body and headers.
-	// Used in server.go and server_test.go (28+ occurrences).
 	DefaultReadTimeout = 15 * time.Second
 
 	// DefaultWriteTimeout is the maximum duration before timing out writes of the response.

--- a/server/handler.go
+++ b/server/handler.go
@@ -104,13 +104,11 @@ func newRequestAllocator[T any]() *requestAllocator[T] {
 func (ra *requestAllocator[T]) allocate() (request T, requestPtr any) {
 	if ra.isPointer {
 		// T is a pointer type (e.g., *Request)
-		// Allocate the underlying type and get pointer
 		elem := reflect.New(ra.elemType.Elem())
 		requestPtr = elem.Interface()
 		request = elem.Interface().(T)
 	} else {
 		// T is a value type (e.g., Request)
-		// Use zero value and take address
 		requestPtr = &request
 	}
 	return request, requestPtr
@@ -979,7 +977,6 @@ func getTraceID(c *echo.Context) string {
 			return requestID
 		}
 	}
-	// Generate a new UUID if none provided
 	newID := uuid.New().String()
 	// Set it so downstream might pick it up (only if response is still valid)
 	if resp := c.Response(); resp != nil {
@@ -1053,7 +1050,6 @@ func RegisterHandler[T any, R any](
 	handler HandlerFunc[T, R],
 	opts ...RouteOption,
 ) {
-	// Extract type information
 	var reqType T
 	var respType R
 

--- a/server/ip_preguard.go
+++ b/server/ip_preguard.go
@@ -18,7 +18,6 @@ const (
 // It uses a higher threshold than the main rate limiter and only protects against IP-based attacks.
 // If threshold is 0 or negative, IP pre-guard is disabled.
 func IPPreGuard(threshold int) echo.MiddlewareFunc {
-	// Disable IP pre-guard if threshold is 0 or negative
 	if threshold <= 0 {
 		return func(next echo.HandlerFunc) echo.HandlerFunc {
 			return next

--- a/server/jose.go
+++ b/server/jose.go
@@ -306,9 +306,9 @@ func joseDecodeRequestInner(c *echo.Context, p *jose.Policy, r jose.KeyResolver)
 
 // joseHandleResponseWithObs wraps joseHandleResponse with an OTEL span and records
 // failures via obs. The wrapped form is the only call site exercised at runtime —
-// joseHandleResponse remains exported (without the trailing Obs suffix on the actual
-// implementation) for testability and so the rh.handleResponse-style signature is
-// preserved for any future direct callers.
+// joseHandleResponse remains a separate package-private method (without the trailing
+// Obs suffix on the actual implementation) for testability and so the
+// rh.handleResponse-style signature is preserved for any future direct callers.
 func (rh *responseHandler) joseHandleResponseWithObs(c *echo.Context, response any, apiErr IAPIError, p *jose.Policy, r jose.KeyResolver, obs *joseObservability) error {
 	_, span := obs.tracerOrNoop().Start(c.Request().Context(), "jose.encode_response",
 		trace.WithSpanKind(trace.SpanKindServer),

--- a/server/ratelimit.go
+++ b/server/ratelimit.go
@@ -19,7 +19,6 @@ const (
 // It limits the number of requests from each IP address to prevent abuse.
 // If requestsPerSecond is 0 or negative, rate limiting is disabled.
 func RateLimit(requestsPerSecond int) echo.MiddlewareFunc {
-	// Disable rate limiting if requestsPerSecond is 0 or negative
 	if requestsPerSecond <= 0 {
 		return func(next echo.HandlerFunc) echo.HandlerFunc {
 			return next

--- a/testing/containers/oracle.go
+++ b/testing/containers/oracle.go
@@ -24,7 +24,7 @@ type OracleContainerConfig struct {
 	ImageTag string
 	// Password for SYSTEM, SYS, and APP users (default: "testpass")
 	Password string
-	// Database name (default: "FREE" for Oracle Free)
+	// Database name (default: "FREEPDB1", the Oracle Free default PDB)
 	Database string
 	// AppUser is the application user to create (default: "testuser")
 	AppUser string

--- a/testing/mocks/messaging.go
+++ b/testing/mocks/messaging.go
@@ -48,7 +48,6 @@ func (m *MockMessagingClient) Publish(ctx context.Context, destination string, d
 func (m *MockMessagingClient) Consume(ctx context.Context, destination string) (<-chan amqp.Delivery, error) {
 	arguments := m.MethodCalled("Consume", ctx, destination)
 
-	// Create a channel for this destination if it doesn't exist
 	m.mu.Lock()
 	if _, exists := m.messageChannels[destination]; !exists {
 		m.messageChannels[destination] = make(chan amqp.Delivery, 100)
@@ -66,7 +65,6 @@ func (m *MockMessagingClient) Consume(ctx context.Context, destination string) (
 func (m *MockMessagingClient) Close() error {
 	m.mu.Lock()
 	m.closed = true
-	// Close all message channels
 	for _, ch := range m.messageChannels {
 		close(ch)
 	}
@@ -83,7 +81,6 @@ func (m *MockMessagingClient) IsReady() bool {
 	closed := m.closed
 	m.mu.RUnlock()
 
-	// If closed, not ready
 	if closed {
 		return false
 	}
@@ -123,7 +120,6 @@ func (m *MockMessagingClient) SimulateMessageWithHeaders(destination string, bod
 		// Send the message in a non-blocking way
 		select {
 		case ch <- delivery:
-			// Message sent successfully
 		default:
 			// Channel is full, ignore
 		}

--- a/testing/mocks/registry.go
+++ b/testing/mocks/registry.go
@@ -108,12 +108,10 @@ func (m *MockRegistry) StopConsumers() {
 
 // Exchanges implements messaging.RegistryInterface
 func (m *MockRegistry) Exchanges() map[string]*messaging.ExchangeDeclaration {
-	// Check if expectation exists for this method
 	if m.hasExpectation("Exchanges") {
 		arguments := m.Called()
 		return arguments.Get(0).(map[string]*messaging.ExchangeDeclaration)
 	}
-	// Return copy of internal storage
 	result := make(map[string]*messaging.ExchangeDeclaration, len(m.exchanges))
 	maps.Copy(result, m.exchanges)
 	return result
@@ -121,12 +119,10 @@ func (m *MockRegistry) Exchanges() map[string]*messaging.ExchangeDeclaration {
 
 // Queues implements messaging.RegistryInterface
 func (m *MockRegistry) Queues() map[string]*messaging.QueueDeclaration {
-	// Check if expectation exists for this method
 	if m.hasExpectation("Queues") {
 		arguments := m.Called()
 		return arguments.Get(0).(map[string]*messaging.QueueDeclaration)
 	}
-	// Return copy of internal storage
 	result := make(map[string]*messaging.QueueDeclaration, len(m.queues))
 	maps.Copy(result, m.queues)
 	return result
@@ -134,12 +130,10 @@ func (m *MockRegistry) Queues() map[string]*messaging.QueueDeclaration {
 
 // Bindings implements messaging.RegistryInterface
 func (m *MockRegistry) Bindings() []*messaging.BindingDeclaration {
-	// Check if expectation exists for this method
 	if m.hasExpectation("Bindings") {
 		arguments := m.Called()
 		return arguments.Get(0).([]*messaging.BindingDeclaration)
 	}
-	// Return copy of internal storage
 	result := make([]*messaging.BindingDeclaration, len(m.bindings))
 	copy(result, m.bindings)
 	return result
@@ -147,12 +141,10 @@ func (m *MockRegistry) Bindings() []*messaging.BindingDeclaration {
 
 // Publishers implements messaging.RegistryInterface
 func (m *MockRegistry) Publishers() []*messaging.PublisherDeclaration {
-	// Check if expectation exists for this method
 	if m.hasExpectation("Publishers") {
 		arguments := m.Called()
 		return arguments.Get(0).([]*messaging.PublisherDeclaration)
 	}
-	// Return copy of internal storage
 	result := make([]*messaging.PublisherDeclaration, len(m.publishers))
 	copy(result, m.publishers)
 	return result
@@ -160,12 +152,10 @@ func (m *MockRegistry) Publishers() []*messaging.PublisherDeclaration {
 
 // Consumers implements messaging.RegistryInterface
 func (m *MockRegistry) Consumers() []*messaging.ConsumerDeclaration {
-	// Check if expectation exists for this method
 	if m.hasExpectation("Consumers") {
 		arguments := m.Called()
 		return arguments.Get(0).([]*messaging.ConsumerDeclaration)
 	}
-	// Return copy of internal storage
 	result := make([]*messaging.ConsumerDeclaration, len(m.consumers))
 	copy(result, m.consumers)
 	return result

--- a/tools/migration/README.md
+++ b/tools/migration/README.md
@@ -109,7 +109,6 @@ object. Both are newline-delimited; pipe through `jq -c .` to consume.
   "duration": "152ms",
   "status": "ok",
   "applied_versions": ["1", "2"],
-  "starting_version": "",
   "ending_version": "2",
   "duration_millis": 142,
   "flyway_version": "10.22.0"

--- a/tools/migration/internal/commands/common.go
+++ b/tools/migration/internal/commands/common.go
@@ -34,7 +34,7 @@ const (
 	jsonKeyTenants = "tenants"
 )
 
-// resolveFlags applies env-var fallbacks and returns a validated copy of flags.
+// resolveFlags applies env-var fallbacks and validates flags in place.
 // cmd is consulted via Flags().Changed so an explicit --secrets-prefix on the
 // command line wins over the env override even when both equal the default.
 func resolveFlags(cmd *cobra.Command, flags *CommonFlags) error {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -33,7 +33,7 @@ func WithTraceID(ctx context.Context, traceID string) context.Context {
 	return context.WithValue(ctx, traceIDKey, traceID)
 }
 
-// TraceIDFromContext returns a trace ID from context if present
+// IDFromContext returns a trace ID from context if present
 func IDFromContext(ctx context.Context) (string, bool) {
 	if traceID, ok := ctx.Value(traceIDKey).(string); ok && traceID != "" {
 		return traceID, true
@@ -54,7 +54,7 @@ func WithTraceParent(ctx context.Context, traceParent string) context.Context {
 	return context.WithValue(ctx, traceParentKey, traceParent)
 }
 
-// TraceParentFromContext returns a traceparent from context if present
+// ParentFromContext returns a traceparent from context if present
 func ParentFromContext(ctx context.Context) (string, bool) {
 	if tp, ok := ctx.Value(traceParentKey).(string); ok && tp != "" {
 		return tp, true
@@ -67,7 +67,7 @@ func WithTraceState(ctx context.Context, traceState string) context.Context {
 	return context.WithValue(ctx, traceStateKey, traceState)
 }
 
-// TraceStateFromContext returns a tracestate from context if present
+// StateFromContext returns a tracestate from context if present
 func StateFromContext(ctx context.Context) (string, bool) {
 	if ts, ok := ctx.Value(traceStateKey).(string); ok && ts != "" {
 		return ts, true

--- a/wiki/adr-001-enhanced-handler-system.md
+++ b/wiki/adr-001-enhanced-handler-system.md
@@ -116,6 +116,7 @@ Implement an enhanced handler system with the following characteristics (updated
   - Enables gradual migration strategy
 - **Alternative Considered:** Replace Echo entirely in interface
 - **Trade-offs:** Breaking change, but maintains flexibility
+- **Superseded in part by [ADR-002](adr-002-base-path-and-health-routes.md):** the second parameter is no longer the raw `*echo.Echo`; the current signature is `RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar)`.
 
 ### 8. **Context Access Design**
 - **Decision:** Provide optional HandlerContext for advanced scenarios

--- a/wiki/adr-002-base-path-and-health-routes.md
+++ b/wiki/adr-002-base-path-and-health-routes.md
@@ -56,6 +56,7 @@ type PathConfig struct {
 ```
 
 ### RouteRegistrar Interface
+
 ```go
 type RouteRegistrar interface {
     Add(method, path string, handler echo.HandlerFunc, middleware ...echo.MiddlewareFunc) echo.RouteInfo
@@ -92,6 +93,7 @@ server:
 ```
 
 ### Environment-Specific Configuration
+
 ```bash
 # Development
 SERVER_PATH_BASE="/dev/api"
@@ -104,6 +106,7 @@ SERVER_PATH_READY="/readiness"
 ```
 
 ### Route Resolution Examples
+
 With `server.path.base: "/api/v1"`:
 - Module route `/users` → `/api/v1/users`
 - Health endpoint → `/api/v1/health` (or custom path)

--- a/wiki/adr-002-base-path-and-health-routes.md
+++ b/wiki/adr-002-base-path-and-health-routes.md
@@ -4,6 +4,13 @@
 **Status**: Accepted
 **Decision Makers**: GoBricks Core Team
 
+> **Amended**: The configuration keys were restructured from a flat layout
+> (`server.base_path` / `server.health_route` / `server.ready_route`) into a
+> nested `server.path` sub-struct (`server.path.base` / `server.path.health` /
+> `server.path.ready`). The decision below is unchanged; only the key names and
+> struct shape differ. Examples in this document reflect the current nested
+> layout.
+
 ## Context
 
 GoBricks applications often need to be deployed behind proxies, load balancers, or in containerized environments where:
@@ -16,10 +23,10 @@ GoBricks applications often need to be deployed behind proxies, load balancers, 
 
 We will implement configurable base paths and health routes through:
 
-1. **Server Configuration Fields**:
-   - `base_path`: Global prefix applied to ALL routes including health endpoints
-   - `health_route`: Custom health endpoint path (default: `/health`)
-   - `ready_route`: Custom readiness endpoint path (default: `/ready`)
+1. **Server Configuration Fields** (under `server.path`):
+   - `base`: Global prefix applied to ALL routes including health endpoints
+   - `health`: Custom health endpoint path (default: `/health`)
+   - `ready`: Custom readiness endpoint path (default: `/ready`)
 
 2. **RouteRegistrar Abstraction**:
    - Create a `RouteRegistrar` interface to abstract Echo's routing capabilities
@@ -38,16 +45,20 @@ We will implement configurable base paths and health routes through:
 ```go
 type ServerConfig struct {
     // ... existing fields ...
-    BasePath    string `koanf:"base_path"`
-    HealthRoute string `koanf:"health_route"`
-    ReadyRoute  string `koanf:"ready_route"`
+    Path PathConfig `koanf:"path"`
+}
+
+type PathConfig struct {
+    Base   string `koanf:"base"`
+    Health string `koanf:"health"`
+    Ready  string `koanf:"ready"`
 }
 ```
 
 ### RouteRegistrar Interface
 ```go
 type RouteRegistrar interface {
-    Add(method, path string, handler echo.HandlerFunc, middleware ...echo.MiddlewareFunc) *echo.Route
+    Add(method, path string, handler echo.HandlerFunc, middleware ...echo.MiddlewareFunc) echo.RouteInfo
     Group(prefix string, middleware ...echo.MiddlewareFunc) RouteRegistrar
     Use(middleware ...echo.MiddlewareFunc)
     FullPath(path string) string
@@ -74,25 +85,26 @@ The `routeGroup` implementation includes:
 ### Basic Configuration
 ```yaml
 server:
-  base_path: "/api/v1"
-  health_route: "/health"
-  ready_route: "/ready"
+  path:
+    base: "/api/v1"
+    health: "/health"
+    ready: "/ready"
 ```
 
 ### Environment-Specific Configuration
 ```bash
 # Development
-SERVER_BASE_PATH="/dev/api"
-SERVER_HEALTH_ROUTE="/health"
+SERVER_PATH_BASE="/dev/api"
+SERVER_PATH_HEALTH="/health"
 
 # Production
-SERVER_BASE_PATH="/api/v1"
-SERVER_HEALTH_ROUTE="/status"
-SERVER_READY_ROUTE="/readiness"
+SERVER_PATH_BASE="/api/v1"
+SERVER_PATH_HEALTH="/status"
+SERVER_PATH_READY="/readiness"
 ```
 
 ### Route Resolution Examples
-With `base_path: "/api/v1"`:
+With `server.path.base: "/api/v1"`:
 - Module route `/users` → `/api/v1/users`
 - Health endpoint → `/api/v1/health` (or custom path)
 - Ready endpoint → `/api/v1/ready` (or custom path)

--- a/wiki/adr-003-database-by-intent.md
+++ b/wiki/adr-003-database-by-intent.md
@@ -23,7 +23,7 @@ Implement "database by intent" configuration with the following principles:
 
 ### Configuration Changes
 - **Removed**: All database defaults from `loadDefaults()` in `config/config.go`
-- **Added**: `IsDatabaseConfigured()` function in `config/validation.go`
+- **Added**: `IsDatabaseConfigured(cfg *DatabaseConfig) bool` function in `config/validation.go`
 - **Logic**: Database enabled when `ConnectionString != ""` OR `Host != ""` OR `Type != ""`
 
 ### Validation Changes
@@ -32,7 +32,7 @@ Implement "database by intent" configuration with the following principles:
 - **Consistency**: Shared logic between validation and runtime via `IsDatabaseConfigured()`
 
 ### Runtime Integration
-- **Updated**: `app.isDatabaseEnabled()` to use shared `config.IsDatabaseConfigured()`
+- **Updated**: The app builder checks `config.IsDatabaseConfigured(&cfg.Database)` directly (`app/app_builder.go`)
 - **Behavior**: Module dependency injection skips database when not configured
 
 ## Consequences

--- a/wiki/adr-006-otlp-log-export.md
+++ b/wiki/adr-006-otlp-log-export.md
@@ -155,6 +155,7 @@ func (b *appBootstrap) dependencies() *dependencyBundle {
 ```
 
 **6. Deterministic Sampling** (`observability/dual_processor.go`)
+
 ```go
 // shouldSample determines if an INFO/DEBUG log should be sampled based on trace ID.
 // All logs in the same trace are sampled together (deterministic per-trace decision).
@@ -185,6 +186,7 @@ func (p *DualModeLogProcessor) shouldSample(rec *sdklog.Record) bool {
     return hash%100 < uint64(p.samplingRate*100)
 }
 ```
+
 *(WARN and above are always exported before sampling is consulted; see `OnEmit` in `observability/dual_processor.go`.)*
 
 ## Implementation Details

--- a/wiki/adr-006-otlp-log-export.md
+++ b/wiki/adr-006-otlp-log-export.md
@@ -154,20 +154,38 @@ func (b *appBootstrap) dependencies() *dependencyBundle {
 }
 ```
 
-**6. Deterministic Sampling** (`observability/logs.go`)
+**6. Deterministic Sampling** (`observability/dual_processor.go`)
 ```go
-func (e *severityFilterExporter) shouldExport(rec *sdklog.Record) bool {
-    // Always export high-severity (WARN/ERROR/FATAL)
-    if e.alwaysSampleHigh && severity >= 13 {
+// shouldSample determines if an INFO/DEBUG log should be sampled based on trace ID.
+// All logs in the same trace are sampled together (deterministic per-trace decision).
+func (p *DualModeLogProcessor) shouldSample(rec *sdklog.Record) bool {
+    // Fast path: rate 0 drops all, rate 1 keeps all
+    if p.samplingRate <= 0 {
+        return false
+    }
+    if p.samplingRate >= 1.0 {
         return true
     }
 
-    // Deterministic hash-based sampling for INFO/DEBUG
-    hash := rec.Timestamp().UnixNano() % 100
-    threshold := int64(e.sampleRate * 100)
-    return hash < threshold
+    // Deterministic sampling on the first 8 bytes of the trace ID
+    traceID := rec.TraceID()
+    if !traceID.IsValid() {
+        // No trace ID: fall back to record timestamp
+        ts := rec.Timestamp().UnixNano()
+        if ts < 0 {
+            ts = 0
+        }
+        return uint64(ts)%100 < uint64(p.samplingRate*100)
+    }
+
+    traceBytes := traceID[:]
+    hash := uint64(traceBytes[0]) | uint64(traceBytes[1])<<8 | uint64(traceBytes[2])<<16 | uint64(traceBytes[3])<<24 |
+        uint64(traceBytes[4])<<32 | uint64(traceBytes[5])<<40 | uint64(traceBytes[6])<<48 | uint64(traceBytes[7])<<56
+
+    return hash%100 < uint64(p.samplingRate*100)
 }
 ```
+*(WARN and above are always exported before sampling is consulted; see `OnEmit` in `observability/dual_processor.go`.)*
 
 ## Implementation Details
 
@@ -188,8 +206,7 @@ func (e *severityFilterExporter) shouldExport(rec *sdklog.Record) bool {
 │  1. Load observability config (YAML + env)     │
 │  2. initLogProvider() [if logs.enabled=true]   │
 │     ├─ createLogExporter() [HTTP/gRPC/stdout]  │
-│     ├─ wrapWithSeverityFilter()                │
-│     └─ createLogProcessor() [batching]         │
+│     └─ createDualModeProcessor() [route+batch] │
 │  3. enhanceLoggerWithOTel(provider)            │
 │     ├─ Fail-fast: panic if pretty=true         │
 │     ├─ NewOTelBridge(loggerProvider)           │

--- a/wiki/adr-007-struct-based-columns.md
+++ b/wiki/adr-007-struct-based-columns.md
@@ -111,6 +111,7 @@ col := cols.Col("NonExistent")
 ```
 
 ### 5. **Backward Compatible Integration**
+
 - **Decision:** Additive API - existing string-based queries unchanged
 - **Method Signature:**
   - `Col(fieldName string) string` - Single field

--- a/wiki/adr-007-struct-based-columns.md
+++ b/wiki/adr-007-struct-based-columns.md
@@ -4,6 +4,8 @@
 **Status:** Accepted
 **Context:** Query builder ergonomics and column management
 
+> **Amended (v2.4):** The column accessor API was renamed — `Get()` → `Col()`, `Fields()` → `Cols()` (now returns `[]string`), and `All()` now returns `[]string` (was `[]any`); added `As()`/`Alias()`/`FieldMap()`/`AllFields()`. The examples and signature table below reflect the current API. See `database/types/interfaces.go`.
+
 ## Problem Statement
 
 The query builder required developers to manually repeat column names across struct definitions and query operations:
@@ -84,11 +86,11 @@ BenchmarkColumnMetadata_Get-12          5.518 ns/op  (field lookup)
 ```go
 // Oracle
 cols := qb.Columns(&User{})
-cols.Get("Level")  // Returns: `"LEVEL"` (quoted for Oracle)
+cols.Col("Level")  // Returns: `"LEVEL"` (quoted for Oracle)
 
 // PostgreSQL
 cols := qb.Columns(&User{})
-cols.Get("Level")  // Returns: "level" (no quoting needed)
+cols.Col("Level")  // Returns: "level" (no quoting needed)
 ```
 
 ### 4. **Explicit API Over Implicit Magic**
@@ -103,7 +105,7 @@ cols.Get("Level")  // Returns: "level" (no quoting needed)
 **Error Handling:**
 ```go
 cols := qb.Columns(&User{})
-col := cols.Get("NonExistent")
+col := cols.Col("NonExistent")
 // panic: column field "NonExistent" not found in type User
 //        (available fields: ID, Name, Email, Level)
 ```
@@ -111,9 +113,9 @@ col := cols.Get("NonExistent")
 ### 5. **Backward Compatible Integration**
 - **Decision:** Additive API - existing string-based queries unchanged
 - **Method Signature:**
-  - `Get(fieldName string) string` - Single field
-  - `Fields(...string) []any` - Bulk helper (compatible with Select variadic)
-  - `All() []any` - All columns in declaration order
+  - `Col(fieldName string) string` - Single field
+  - `Cols(...string) []string` - Bulk helper (compatible with Select variadic)
+  - `All() []string` - All columns in declaration order
 - **Rationale:**
   - Zero breaking changes for existing code
   - Opt-in adoption per service/module

--- a/wiki/adr-019-migration-audit-delivery.md
+++ b/wiki/adr-019-migration-audit-delivery.md
@@ -38,7 +38,7 @@ Require every consumer to provide an `AuditRecorder` implementation. Ship one or
 
 ### Option 3: Hybrid — OTel default, opt-in `AuditRecorder` override (Chosen)
 
-Always emit to the OpenTelemetry seam: a span per audit event (with the full attribute set) plus a structured log record via the `LoggerProvider`. Additionally, expose a `migration.AuditRecorder` interface; when configured on `migration.Runner` (or via `ModuleDeps`), every emitted event is dispatched to the sink **after** the OTel emission, in a non-blocking fan-out (separate goroutine with a bounded send queue) so the sink cannot stall the migration. Sink failures log a warning but do not abort the migration.
+Always emit to the OpenTelemetry seam: a span per audit event (with the full attribute set) plus a structured log record via the `LoggerProvider`. Additionally, expose a `migration.AuditRecorder` interface; when configured on `migration.FlywayMigrator` via `WithAuditRecorder`, every emitted event is dispatched to the sink **after** the OTel emission, in a non-blocking fan-out (separate goroutine with a bounded send queue) so the sink cannot stall the migration. Sink failures log a warning but do not abort the migration.
 
 **Chosen because:**
 
@@ -96,14 +96,14 @@ Conditional fields:
 package migration
 
 type AuditRecorder interface {
-    Record(ctx context.Context, event AuditEvent) error
+    Record(ctx context.Context, event *AuditEvent) error
 }
 ```
 
-Wired on the `Runner` (or via `ModuleDeps.AuditRecorder`). When set:
+Wired on the `FlywayMigrator` via `WithAuditRecorder(sink)`. When set:
 
 - Every event fires to the sink **after** the OTel emission, in a non-blocking fan-out (separate goroutine with a bounded send queue).
-- A sink-side error logs a warning and increments an internal `audit_sink_failures_total` metric, but **does not** abort the migration. Audit must not block business work; that's a deliberate trade-off — the sink owner is responsible for backing it with a durable buffer (Kafka commit-log, S3 staging, etc.) if zero-loss is required.
+- A sink-side error logs a warning and increments an internal `migration.audit.sink_failures` metric, but **does not** abort the migration. Audit must not block business work; that's a deliberate trade-off — the sink owner is responsible for backing it with a durable buffer (Kafka commit-log, S3 staging, etc.) if zero-loss is required.
 - The sink is invoked with the same `AuditEvent` struct that OTel sees — schemas can't drift.
 
 ### Stable error-class taxonomy
@@ -136,7 +136,7 @@ This list is part of the public API (additive changes only) so downstream alerti
 
 ## Migration
 
-No breaking changes. The interface is new in [#382](https://github.com/gaborage/go-bricks/issues/382)'s implementation PR. Existing `FlywayMigrator` callers see no behavioural change — audit emission is wired into the new `Runner` contract from [#376](https://github.com/gaborage/go-bricks/issues/376), not retrofitted onto `FlywayMigrator`.
+No breaking changes. The interface is new in [#382](https://github.com/gaborage/go-bricks/issues/382)'s implementation PR. Existing `FlywayMigrator` callers see no behavioural change — the always-on OTel audit emission and the optional `AuditRecorder` sink are wired onto `FlywayMigrator` via `WithAuditRecorder`, an opt-in builder method.
 
 ## Stakeholder check
 

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -84,8 +84,8 @@ Interface segregation for database testing utilities, enabling 73% less boilerpl
 
 ---
 
-### [ADR-009: Consumer Worker Pool Concurrency](adr-009-consumer-worker-pool-concurrency.md)
-**Date:** 2025-02-01 | **Status:** Accepted
+### [ADR-009: Consumer Worker Pool Concurrency with NumCPU × 4 Default](adr-009-consumer-worker-pool-concurrency.md)
+**Date:** 2025-01-13 | **Status:** Accepted
 
 Auto-scaling consumer worker pools with `NumCPU * 4` default, replacing single-threaded message processing for 20-30x throughput improvement.
 
@@ -93,12 +93,12 @@ Auto-scaling consumer worker pools with `NumCPU * 4` default, replacing single-t
 
 ---
 
-### [ADR-010: Panic-to-Error Conversion in Message Handlers](adr-010-panic-to-error-conversion.md)
-**Date:** 2025-02-15 | **Status:** Accepted
+### [ADR-010: Convert Panic-Based Validation to Error Returns](adr-010-panic-to-error-conversion.md)
+**Date:** 2025-11-29 | **Status:** Accepted
 
-Automatic panic recovery in AMQP message handlers with stack trace logging, consistent nack-without-requeue behavior, and service continuity.
+Converts panic-based fail-fast validation to idiomatic error returns for SonarCloud reliability compliance (S8148), improving the reliability rating from C to A.
 
-**Key Benefits:** Service resilience, consistent error semantics, observability integration
+**Key Benefits:** S8148 compliance, idiomatic error handling, improved reliability rating
 
 ---
 
@@ -121,7 +121,7 @@ Complete removal of MongoDB support to focus exclusively on PostgreSQL and Oracl
 ---
 
 ### [ADR-013: Interface Naming Conventions (S8196)](adr-013-interface-naming-conventions.md)
-**Date:** 2026-02-19 | **Status:** Accepted
+**Date:** 2026-03-11 | **Status:** Accepted
 
 Renames interfaces to follow Go's idiomatic naming per SonarCloud rule S8196. Interfaces renamed for clarity across scheduler, app, database, messaging, server, and cache packages.
 
@@ -219,7 +219,7 @@ Resolves issue #435. Replaces the strict `{development, staging, production}` al
 
 ### Numbering Policy
 
-ADR numbers (ADR-001 through ADR-011) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr-011-redis-cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
+ADR numbers (ADR-001 through ADR-022) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr-011-redis-cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
 
 ## Writing New ADRs
 

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -85,6 +85,7 @@ Interface segregation for database testing utilities, enabling 73% less boilerpl
 ---
 
 ### [ADR-009: Consumer Worker Pool Concurrency with NumCPU × 4 Default](adr-009-consumer-worker-pool-concurrency.md)
+
 **Date:** 2025-01-13 | **Status:** Accepted
 
 Auto-scaling consumer worker pools with `NumCPU * 4` default, replacing single-threaded message processing for 20-30x throughput improvement.
@@ -94,6 +95,7 @@ Auto-scaling consumer worker pools with `NumCPU * 4` default, replacing single-t
 ---
 
 ### [ADR-010: Convert Panic-Based Validation to Error Returns](adr-010-panic-to-error-conversion.md)
+
 **Date:** 2025-11-29 | **Status:** Accepted
 
 Converts panic-based fail-fast validation to idiomatic error returns for SonarCloud reliability compliance (S8148), improving the reliability rating from C to A.

--- a/wiki/cache.md
+++ b/wiki/cache.md
@@ -21,7 +21,7 @@ GoBricks provides Redis-based caching with type-safe serialization, multi-tenant
 - **Latency**: <1ms for Get/Set (localhost), ~2ms for atomic operations (Lua scripts)
 - **Throughput**: 100k reads/sec, 80k writes/sec (single Redis instance)
 - **CBOR Serialization**: ~83ns/op marshal, ~167ns/op unmarshal (simple structs)
-- **Connection Pool**: Default 10, configurable via `cache.redis.poolsize`
+- **Connection Pool**: Default 10, configurable via `cache.redis.pool_size`
 - **Network Impact**: +0.5-1ms (same datacenter), +50-200ms (cross-region, not recommended)
 
 **Benchmark Results** (Apple M4 Pro, localhost Redis):

--- a/wiki/cache.md
+++ b/wiki/cache.md
@@ -7,7 +7,7 @@ GoBricks provides Redis-based caching with type-safe serialization, multi-tenant
 **Core Components:**
 - **Redis Client**: Atomic operations (Get/Set/GetOrSet/CompareAndSet), connection pooling, health monitoring
 - **CacheManager**: Per-tenant cache lifecycle with lazy initialization, LRU eviction, idle cleanup, singleflight
-- **CBOR Serialization**: Type-safe encoding with security limits (max 10k array/map elements)
+- **CBOR Serialization**: Type-safe encoding with security limits (max 10k array/map elements, max nesting depth 16)
 - **Multi-tenant integration**: Automatic tenant resolution from context via `deps.Cache(ctx)`
 
 **Lifecycle Management (CacheManager):**
@@ -21,7 +21,7 @@ GoBricks provides Redis-based caching with type-safe serialization, multi-tenant
 - **Latency**: <1ms for Get/Set (localhost), ~2ms for atomic operations (Lua scripts)
 - **Throughput**: 100k reads/sec, 80k writes/sec (single Redis instance)
 - **CBOR Serialization**: ~83ns/op marshal, ~167ns/op unmarshal (simple structs)
-- **Connection Pool**: Default `NumCPU * 2`, configurable via `cache.redis.pool_size`
+- **Connection Pool**: Default 10, configurable via `cache.redis.poolsize`
 - **Network Impact**: +0.5-1ms (same datacenter), +50-200ms (cross-region, not recommended)
 
 **Benchmark Results** (Apple M4 Pro, localhost Redis):
@@ -64,13 +64,13 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 }
 
 func (s *Service) GetUser(ctx context.Context, id int64) (*User, error) {
-    cache, err := s.getCache(ctx)  // Resolves tenant from context
+    c, err := s.getCache(ctx)  // Resolves tenant from context
     if err != nil {
         return nil, err
     }
 
     // Try cache first
-    data, err := cache.Get(ctx, fmt.Sprintf("user:%d", id))
+    data, err := c.Get(ctx, fmt.Sprintf("user:%d", id))
     if err == nil {
         return cache.Unmarshal[User](data)
     }
@@ -80,7 +80,7 @@ func (s *Service) GetUser(ctx context.Context, id int64) (*User, error) {
 
     // Store in cache with TTL
     data, _ = cache.Marshal(user)
-    cache.Set(ctx, fmt.Sprintf("user:%d", id), data, 5*time.Minute)
+    c.Set(ctx, fmt.Sprintf("user:%d", id), data, 5*time.Minute)
 
     return user, nil
 }
@@ -92,7 +92,7 @@ func (s *Service) GetUser(ctx context.Context, id int64) (*User, error) {
 | Basic read | `Get(ctx, key)` | Query result caching | Single-key |
 | Basic write | `Set(ctx, key, value, ttl)` | Store computed result | Single-key |
 | Deduplication | `GetOrSet(ctx, key, value, ttl)` | Idempotency keys | Atomic SET NX |
-| Distributed lock | `CompareAndSet(ctx, key, expected, new, ttl)` | Job coordination | Lua script CAS |
+| Distributed lock | `CompareAndSet(ctx, key, expectedValue, newValue, ttl)` | Job coordination | Lua script CAS |
 | Type-safe store | `Marshal(v)` + `Set()` | Struct serialization | CBOR encoding |
 
 **Multi-Tenant Isolation:**

--- a/wiki/database.md
+++ b/wiki/database.md
@@ -89,7 +89,8 @@ type User struct {
 cols := qb.Columns(&User{})  // Cached per vendor
 
 query := qb.Select(cols.All()...).From("users")
-query := qb.Select(cols.Cols("ID", "Name")...).From("users")
+// or select specific fields:
+query = qb.Select(cols.Cols("ID", "Name")...).From("users")
 
 query := qb.Select(cols.All()...).
     From("users").
@@ -218,10 +219,12 @@ query := qb.Select(
 ```
 
 **SECURITY WARNING:** Raw SQL expressions are NOT escaped. Never interpolate user input:
+
 ```go
 qb.MustExpr("COUNT(*)", "total")                  // SAFE
 qb.MustExpr(fmt.Sprintf("UPPER(%s)", userInput))  // SQL INJECTION
 ```
+
 Use WHERE with placeholders for dynamic values: `qb.Select("*").From("users").Where(f.Eq(userColumn, userValue))`.
 
 ## Connection Pool Defaults

--- a/wiki/database.md
+++ b/wiki/database.md
@@ -19,7 +19,7 @@ GoBricks supports accessing multiple databases in single-tenant mode, useful for
 **Configuration:**
 ```yaml
 database:                # Default database (unchanged - backward compatible)
-  type: postgres
+  type: postgresql
   host: primary.db.example.com
   port: 5432
   database: main_db
@@ -33,7 +33,7 @@ databases:               # Named databases — supports mixed vendors
     username: legacy_user
     password: ${LEGACY_DATABASE_PASSWORD}
   analytics:
-    type: postgres
+    type: postgresql
     host: analytics.db.example.com
     port: 5432
     database: analytics_db

--- a/wiki/database.md
+++ b/wiki/database.md
@@ -89,7 +89,7 @@ type User struct {
 cols := qb.Columns(&User{})  // Cached per vendor
 
 query := qb.Select(cols.All()...).From("users")
-query := qb.Select(cols.Fields("ID", "Name")...).From("users")
+query := qb.Select(cols.Cols("ID", "Name")...).From("users")
 
 query := qb.Select(cols.All()...).
     From("users").
@@ -105,7 +105,7 @@ qb.Update("users").
 ```go
 type ProductService struct {
     qb   *builder.QueryBuilder
-    cols dbtypes.ColumnMetadata
+    cols dbtypes.Columns
 }
 
 func NewProductService(db database.Interface) *ProductService {
@@ -148,8 +148,8 @@ u := userCols.As("u")
 p := profileCols.As("p")
 
 query := qb.Select(u.Col("ID"), u.Col("Name"), p.Col("Bio")).
-    From(dbtypes.Table("users").As("u")).
-    LeftJoinOn(dbtypes.Table("profiles").As("p"),
+    From(dbtypes.MustTable("users").MustAs("u")).
+    LeftJoinOn(dbtypes.MustTable("profiles").MustAs("p"),
         jf.EqColumn(u.Col("ID"), p.Col("UserID"))).
     Where(f.Eq(u.Col("Status"), "active"))
 // Oracle: SELECT u."ID", u."NAME", p."BIO" FROM users u LEFT JOIN profiles p ON u."ID" = p."USER_ID" WHERE u."STATUS" = :1
@@ -162,15 +162,15 @@ jf := qb.JoinFilter()
 f := qb.Filter()
 
 query := qb.Select("*").
-    From(dbtypes.Table("orders").As("o")).
-    JoinOn(dbtypes.Table("customers").As("c"), jf.And(
+    From(dbtypes.MustTable("orders").MustAs("o")).
+    JoinOn(dbtypes.MustTable("customers").MustAs("c"), jf.And(
         jf.EqColumn("c.id", "o.customer_id"),         // Column-to-column
         jf.Eq("c.status", "active"),                  // Column-to-value
         jf.In("c.tier", []string{"gold", "platinum"}),
     )).
-    JoinOn(dbtypes.Table("products").As("p"), jf.And(
+    JoinOn(dbtypes.MustTable("products").MustAs("p"), jf.And(
         jf.EqColumn("p.id", "o.product_id"),
-        jf.Eq("p.price", qb.Expr("TO_NUMBER(o.max_price)")),
+        jf.Eq("p.price", qb.MustExpr("TO_NUMBER(o.max_price)")),
     )).
     Where(f.Eq("o.status", "pending"))
 ```
@@ -201,7 +201,7 @@ subquery := qb.Select("1").From("reviews").
     ))
 
 query := qb.Select(p.Col("Name")).
-    From(dbtypes.Table("products").As("p")).
+    From(dbtypes.MustTable("products").MustAs("p")).
     Where(f.Exists(subquery))
 ```
 
@@ -212,15 +212,15 @@ query := qb.Select(p.Col("Name")).
 ```go
 query := qb.Select(
     cols.Col("Category"),
-    qb.Expr("COUNT(*)", "product_count"),
-    qb.Expr("AVG(price)", "avg_price"),
+    qb.MustExpr("COUNT(*)", "product_count"),
+    qb.MustExpr("AVG(price)", "avg_price"),
 ).From("products").GroupBy(cols.Col("Category"))
 ```
 
 **SECURITY WARNING:** Raw SQL expressions are NOT escaped. Never interpolate user input:
 ```go
-qb.Expr("COUNT(*)", "total")                  // SAFE
-qb.Expr(fmt.Sprintf("UPPER(%s)", userInput))  // SQL INJECTION
+qb.MustExpr("COUNT(*)", "total")                  // SAFE
+qb.MustExpr(fmt.Sprintf("UPPER(%s)", userInput))  // SQL INJECTION
 ```
 Use WHERE with placeholders for dynamic values: `qb.Select("*").From("users").Where(f.Eq(userColumn, userValue))`.
 

--- a/wiki/handler-patterns.md
+++ b/wiki/handler-patterns.md
@@ -142,7 +142,7 @@ func (h *Handler) listUsers(req ListUsersReq, hctx server.HandlerContext) (serve
     ctx := hctx.Echo.Request().Context()
     users, total, err := h.svc.List(ctx, req.Limit, req.Offset)
     if err != nil {
-        return server.ResultWithMeta[ListUsersResp]{}, server.NewInternalServerError(err.Error())
+        return server.ResultWithMeta[ListUsersResp]{}, server.NewInternalServerError("failed to list users")
     }
     return server.ResultWithMeta[ListUsersResp]{
         Data:   ListUsersResp{Items: users},

--- a/wiki/handler-patterns.md
+++ b/wiki/handler-patterns.md
@@ -30,7 +30,7 @@ type LoginRequest struct {
 
 func (h *Handler) login(req LoginRequest, ctx server.HandlerContext) (Result[Token], server.IAPIError) {
     token := h.authService.Authenticate(req)
-    return server.OK(token), nil
+    return server.NewResult(http.StatusOK, token), nil
 }
 
 // Large request - use pointer type for performance
@@ -142,7 +142,7 @@ func (h *Handler) listUsers(req ListUsersReq, hctx server.HandlerContext) (serve
     ctx := hctx.Echo.Request().Context()
     users, total, err := h.svc.List(ctx, req.Limit, req.Offset)
     if err != nil {
-        return server.ResultWithMeta[ListUsersResp]{}, server.InternalServerError(err)
+        return server.ResultWithMeta[ListUsersResp]{}, server.NewInternalServerError(err.Error())
     }
     return server.ResultWithMeta[ListUsersResp]{
         Data:   ListUsersResp{Items: users},

--- a/wiki/jose.md
+++ b/wiki/jose.md
@@ -63,7 +63,7 @@ fw.RegisterModules(
 | Wrong Content-Type (not `application/jose`) | 415 | `JOSE_PLAINTEXT_REJECTED` |
 | Compact JWE parse failure | 400 | `JOSE_MALFORMED` |
 | `enc`/`alg` not allowed | 400 | `JOSE_ALGORITHM_DISALLOWED` |
-| `alg=none` (downgrade attempt) | 401 | `JOSE_NONE_ALG_REJECTED` (rejected by allowlist parse) |
+| `alg=none` (downgrade attempt) | 400 | `JOSE_ALGORITHM_DISALLOWED` (rejected by allowlist parse) |
 | Header missing `kid` | 401 | `JOSE_KID_MISSING` |
 | Unknown `kid` in header | 401 | `JOSE_KID_UNKNOWN` |
 | Decryption failed | 401 | `JOSE_DECRYPT_FAILED` |

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -26,7 +26,7 @@ decls.DeclarePublisher(&messaging.PublisherOptions{
 
 decls.DeclareConsumer(&messaging.ConsumerOptions{
     Queue: queue.Name, EventType: "CreateBatchIssuanceRequest",
-    Handler: amqp.NewHandler(m.logger),
+    Handler: m.handler, // a value implementing messaging.MessageHandler (Handle + EventType)
 }, nil)
 ```
 

--- a/wiki/migration-audit.md
+++ b/wiki/migration-audit.md
@@ -57,7 +57,7 @@ type AuditEvent struct {
     CompletedAt        time.Time
     Outcome            AuditOutcome   // "success" / "failed" / "skipped"
 
-    Version            string         // conditional: migration.applied (currently empty — see "Known gaps")
+    Version            string         // conditional: migration.applied (parsed Flyway ending version)
     FromState, ToState string         // conditional: state.transitioned
     ErrorClass         ErrorClass     // conditional: Outcome == failed
     GitCommitSHA       string         // optional
@@ -144,7 +144,6 @@ Both counters fire alongside Warn-level log records — useful for grep-based de
 
 ## Known gaps
 
-- **`Version` is currently empty** on `migration.applied` events. Populating it requires parsing Flyway's JSON output; that work is part of the structured-`Result` retrofit tracked in [#376](https://github.com/gaborage/go-bricks/issues/376). The other AuditEvent fields are sufficient for compliance correlation today.
 - **State-machine and quiesce events** (`state.transitioned`, `quiesce.set`, `quiesce.cleared`) are not yet emitted. Their emission lands when [#379](https://github.com/gaborage/go-bricks/issues/379) and [#380](https://github.com/gaborage/go-bricks/issues/380) ship.
 - **CLI flag plumbing** for `--applied-by` / `--git-sha` / `--pipeline-run-id` in `go-bricks-migrate` is a separate follow-up — for now, callers using the library API can populate `migration.Config.Audit` directly.
 

--- a/wiki/scheduler.md
+++ b/wiki/scheduler.md
@@ -39,4 +39,4 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 }
 ```
 
-**Schedule Types:** `Every(duration)`, `Cron(expression)`, `DailyAt(time)`, `WeeklyAt(weekday, time)`
+**Schedule Types:** `FixedRate(duration)`, `DailyAt(time)`, `WeeklyAt(weekday, time)`, `HourlyAt(minute)`, `MonthlyAt(dayOfMonth, time)`

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -104,7 +104,7 @@ tenants.ForTenant("acme").ExpectQuery("SELECT").WillReturnRows(...)
 tenants.ForTenant("globex").ExpectQuery("SELECT").WillReturnRows(...)
 
 deps := &app.ModuleDeps{
-    DB: tenants.AsDBFunc(),  // Resolves tenant from context
+    DB: tenants.AsGetDBFunc(),  // Resolves tenant from context
 }
 
 ctx := multitenant.SetTenant(context.Background(), "acme")
@@ -148,7 +148,7 @@ func TestUserServiceCaching(t *testing.T) {
 **Configurable Failures:**
 ```go
 mockCache := cachetest.NewMockCache().
-    WithGetFailure(cache.ErrConnectionError)
+    WithGetFailure(cache.ErrClosed)
 
 // Service should gracefully degrade
 user, err := svc.GetUser(ctx, 123)  // Falls back to database
@@ -167,7 +167,7 @@ tenantCaches := map[string]*cachetest.MockCache{
 
 deps := &app.ModuleDeps{
     Cache: func(ctx context.Context) (cache.Cache, error) {
-        tenantID := multitenant.GetTenant(ctx)
+        tenantID, _ := multitenant.GetTenant(ctx)
         return tenantCaches[tenantID], nil
     },
 }
@@ -200,7 +200,8 @@ func TestOrderServiceCreateOrder(t *testing.T) {
 
     mockOutbox := outboxtest.NewMockOutbox()
 
-    svc := NewOrderService(db.AsDBFunc(), mockOutbox)
+    getDB := func(ctx context.Context) (database.Interface, error) { return db, nil }
+    svc := NewOrderService(getDB, mockOutbox)
     err := svc.CreateOrder(ctx, order)
 
     assert.NoError(t, err)

--- a/wiki/troubleshooting.md
+++ b/wiki/troubleshooting.md
@@ -108,7 +108,7 @@ database:
 # Cache timeout errors
 # → Increase operation timeout: ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 # → Check network latency if Redis on different host
-# → Verify pool size adequate: cache.redis.poolsize >= NumCPU * 2
+# → Verify pool size adequate: cache.redis.pool_size >= NumCPU * 2
 
 # CacheManager eviction issues
 # → Increase max_size if seeing unexpected evictions: cache.manager.max_size

--- a/wiki/troubleshooting.md
+++ b/wiki/troubleshooting.md
@@ -108,7 +108,7 @@ database:
 # Cache timeout errors
 # → Increase operation timeout: ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 # → Check network latency if Redis on different host
-# → Verify pool size adequate: cache.redis.pool_size >= NumCPU * 2
+# → Verify pool size adequate: cache.redis.poolsize >= NumCPU * 2
 
 # CacheManager eviction issues
 # → Increase max_size if seeing unexpected evictions: cache.manager.max_size
@@ -222,7 +222,7 @@ observability:
 
 **Diagnostic commands:**
 ```bash
-grep "Starting AMQP consumers" logs/app.log
+grep "Starting message consumers" logs/app.log
 grep "Multiple consumers registered for same queue" logs/app.log
 grep "Panic recovered in message handler" logs/app.log
 ```


### PR DESCRIPTION
## What

Eliminates documentation drift (docs vs. current code) and stale/redundant code comments across the repository, and adds the reusable workflows that found and fixed them.

This was produced by a detect → fix → review pipeline:

1. **Detect** — a new `doc-drift` workflow swept all 54 tracked docs (README, llms.txt, CONTRIBUTING/CLAUDE, the full `wiki/`, ADRs) and 232 non-test `.go` files, adversarially verifying every candidate. It surfaced **147 confirmed findings** (73 documentation + 74 code-comment).
2. **Fix** — a `doc-drift-fix` workflow applied the confirmed fixes (one editor agent per file), conservatively: stale/contradictory comments rewritten, commented-out code and pure restate-the-code narration removed, **preserving** all exported godoc, `//go:`/`//nolint` directives, `// SECURITY:` annotations, and why-rationale.
3. **Review** — a recall-mode `/code-review` caught **13 "sibling-miss" bugs** (a symbol fixed in one doc but missed in a sibling, plus one uncompilable example); all were fixed. `/security-audit` (diff-scoped) confirmed no `// SECURITY:` annotation or build directive was removed and no secret was introduced.

## Highlights of the drift fixed

- **`CLAUDE.md` / `README.md` / `wiki/scheduler.md`** — scheduler advertised `Every()` / `Cron()` methods that don't exist; corrected to the real set (`FixedRate`, `DailyAt`, `WeeklyAt`, `HourlyAt`, `MonthlyAt`).
- **`CLAUDE.md` / `README.md`** — "Echo v4" → **Echo v5** (matches `go.mod`).
- **`llms.txt`** (the biggest offender, ~180 KB of examples) — `app.NewWithConfig` two-value → three-value returns; `type: postgres` → `postgresql` (config rejects `postgres`); nonexistent `server.Conflict/InternalServerError/NotFound` → `NewConflictError`/`NewInternalServerError`/`NewNotFoundError`; `multitenant.GetTenant` single → two-value; logger fluent `.Msg()` form; `alg=none` JOSE row `401/JOSE_NONE_ALG_REJECTED` → `400/JOSE_ALGORITHM_DISALLOWED`.
- **`MULTI_TENANT.md`** — `app.TenantStore` documented as four methods incl. `CacheConfig`.
- **`TESTING.md`** — route-registration example now constructs the `server.New(...)` instance it references.
- **`wiki/`, `observability/README.md`, `tools/migration/README.md`** — stale signatures, broken examples, wrong defaults, ADR index/status/cross-reference corrections.
- **Code comments** — stale/contradictory comments rewritten and redundant narration removed across ~50 packages (e.g. `database/internal/tracking/connection.go` had two concatenated, contradictory doc-comment blocks).

## Commits

1. `chore` — add the reusable `doc-drift` + `doc-drift-fix` workflows under `.claude/workflows/` (+ `.gitignore` allowlist).
2. `docs` — documentation drift fixes.
3. `refactor` — code-comment cleanup.
4. `fix` — resolve the `/code-review` findings.

## Verification

- `make check` (fmt + lint + race) passes.
- `/code-review` (recall mode) and diff-scoped `/security-audit` both run; findings addressed.

## Notes

- The full ranked drift report lives locally at `docs/doc-drift-report.md` (deliberately **not** committed — it goes stale once these fixes land).
- ADR historical YAML (e.g. `adr-016`'s `type: postgres`) was left intact per the "ADRs are point-in-time records" lens; only superseded-status / cross-reference errors were corrected in ADRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated documentation-drift detection and fix workflows.
  * Added helpers to build OpenTelemetry database namespace attributes.

* **Bug Fixes**
  * Outbox publish now validates event identifiers to prevent publishing with empty IDs.

* **Documentation**
  * Broad updates to guides, ADRs, scheduler types, and examples for caching, DB, messaging, multi-tenancy, and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->