### PR TITLE
ci: centralize govulncheck + gosec via Makefile; raise Go floor to 1.26

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -54,7 +54,7 @@ body:
     id: go-version
     attributes:
       label: Go version
-      placeholder: go1.25.1
+      placeholder: go1.26.0
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -686,6 +686,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -706,6 +708,8 @@ jobs:
         working-directory: tools/migration
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -722,6 +726,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -748,11 +748,18 @@ jobs:
         with:
           go-version: '1.26'
           cache: true
-          cache-dependency-path: go.sum
-      - name: Run govulncheck (framework)
-        run: make vuln
-      - name: Run govulncheck (migrate tool)
-        run: make -C tools/migration vuln
+          cache-dependency-path: |
+            go.sum
+            tools/migration/go.sum
+      - name: Run govulncheck (both modules)
+        run: |
+          set +e
+          make vuln; fw=$?
+          make -C tools/migration vuln; cli=$?
+          if [ "$fw" -ne 0 ] || [ "$cli" -ne 0 ]; then
+            echo "::error::govulncheck found vulnerabilities (framework exit=$fw, migrate-tool exit=$cli)"
+            exit 1
+          fi
 
   # ============================================================================
   # SonarCloud (framework + tool coverage)

--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '17 6 * * 1'   # Mondays 06:17 UTC — weekly vuln re-scan of main
 
 jobs:
   # ============================================================================
@@ -13,6 +15,7 @@ jobs:
   changes:
     permissions:
       contents: read
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
       # yamllint: valid GitHub Actions context expression
@@ -695,6 +698,61 @@ jobs:
             echo "No packages found to scan"
             exit 1
           fi
+
+  vuln-framework:
+    permissions:
+      contents: read
+    needs: changes
+    if: needs.changes.outputs.framework == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Run govulncheck (framework)
+        run: make vuln
+
+  vuln-migrate-tool:
+    permissions:
+      contents: read
+    needs: changes
+    if: needs.changes.outputs.migrate_tool == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/migration
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+          cache-dependency-path: tools/migration/go.sum
+      - name: Run govulncheck (migrate tool)
+        run: make vuln
+
+  vuln-weekly:
+    permissions:
+      contents: read
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Run govulncheck (framework)
+        run: make vuln
+      - name: Run govulncheck (migrate tool)
+        run: make -C tools/migration vuln
 
   # ============================================================================
   # SonarCloud (framework + tool coverage)

--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -628,18 +628,8 @@ jobs:
           cache: true
           cache-dependency-path: tools/migration/go.sum
 
-      - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
-
-      - name: Run Gosec Security Scanner (migrate tool)
-        run: |
-          set -euo pipefail
-          packages=$(go list ./cmd/... ./internal/...)
-          if [ -z "$packages" ]; then
-            echo "No packages found to scan"
-            exit 1
-          fi
-          gosec $packages
+      - name: Run gosec (migrate tool)
+        run: make sec
 
   # ============================================================================
   # Shared Jobs (run for framework OR tool OR both)
@@ -685,19 +675,8 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
-      - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
-
-      - name: Run Gosec Security Scanner (framework)
-        run: |
-          set -euo pipefail
-          packages=$(go list ./... | grep -vE '/tools(/|$)')
-          if [ -n "$packages" ]; then
-            gosec $packages
-          else
-            echo "No packages found to scan"
-            exit 1
-          fi
+      - name: Run gosec (framework)
+        run: make sec
 
   vuln-framework:
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 GoBricks is an enterprise-grade Go framework for building microservices with modular, reusable components. It provides a complete foundation for production-ready applications with HTTP servers, AMQP messaging, multi-database connectivity (PostgreSQL/Oracle), and clean architecture patterns.
 
 **Requirements:**
-- Go 1.25 required
+- Go 1.26 required
 - Docker Desktop or Docker Engine (integration tests only)
 
 ## Workflow Rules
@@ -127,7 +127,7 @@ make lint                       # Run golangci-lint
 ### Code Quality
 - Linting: `.golangci.yml` with staticcheck, gosec, gocritic.
 - SonarCloud: Project `gaborage_go-bricks`, 80% coverage target.
-- CI/CD: Multi-platform (Ubuntu, Windows) × Go 1.25.
+- CI/CD: Multi-platform (Ubuntu, Windows) × Go 1.26.
 - Race detection enabled on all platforms.
 
 ## Architecture
@@ -494,7 +494,7 @@ make check        # fmt, lint, test with race detection
 ### CI/CD Pipeline
 - **Unified CI (`ci-v2.yml`):** Single workflow with intelligent path-based job execution via `dorny/paths-filter`.
 - Framework jobs run on Go and build-file changes (the `framework` filter's `**/*.go` intentionally also matches `tools/**/*.go`, so tool changes re-run the framework matrix); the `tools/migration` CLI additionally has its own path-gated jobs.
-- **Test Matrix:** Ubuntu/Windows × Go 1.25.
+- **Test Matrix:** Ubuntu/Windows × Go 1.26.
 - **Coverage:** Merged unit + integration coverage → SonarCloud.
 
 ### Tool Selection

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thank you for your interest in contributing to GoBricks! This document provides 
 ## Development Workflow
 
 ### Prerequisites
-- Go 1.25 or later
+- Go 1.26 or later
 - golangci-lint for linting
 - Make for build automation
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # Package selection for testing (excludes tools directories)
 PKGS := $(shell go list ./... | grep -vE '/(tools)(/|$$)')
 INTEGRATION_PKGS :=
+# Keep in sync with the other module's Makefile.
 GOVULNCHECK_VERSION := v1.1.4
 # Default target
 help: ## Show this help message

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-.PHONY: all help build test test-integration test-all test-coverage test-coverage-integration test-coverage-combined coverage-report lint fmt update clean check docker-check
+.PHONY: all help build test test-integration test-all test-coverage test-coverage-integration test-coverage-combined coverage-report lint fmt update clean check docker-check vuln
 
 # Package selection for testing (excludes tools directories)
 PKGS := $(shell go list ./... | grep -vE '/(tools)(/|$$)')
 INTEGRATION_PKGS :=
+GOVULNCHECK_VERSION := v1.1.4
 # Default target
 help: ## Show this help message
 	@echo "Available targets:"
@@ -68,3 +69,6 @@ clean: ## Clean build cache and test artifacts
 	rm -f *.test
 
 check: fmt lint test ## Run fmt, lint, and test (pre-commit checks)
+
+vuln: ## Run govulncheck vulnerability scan (pinned; identical to CI)
+	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
-.PHONY: all help build test test-integration test-all test-coverage test-coverage-integration test-coverage-combined coverage-report lint fmt update clean check docker-check vuln
+.PHONY: all help build test test-integration test-all test-coverage test-coverage-integration test-coverage-combined coverage-report lint fmt update clean check docker-check vuln sec
 
 # Package selection for testing (excludes tools directories)
 PKGS := $(shell go list ./... | grep -vE '/(tools)(/|$$)')
 INTEGRATION_PKGS :=
 # Keep in sync with the other module's Makefile.
 GOVULNCHECK_VERSION := v1.1.4
+# Keep in sync with the other module's Makefile.
+GOSEC_VERSION := v2.26.1
 # Default target
 help: ## Show this help message
 	@echo "Available targets:"
@@ -73,3 +75,6 @@ check: fmt lint test ## Run fmt, lint, and test (pre-commit checks)
 
 vuln: ## Run govulncheck vulnerability scan (pinned; identical to CI)
 	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
+
+sec: ## Run gosec security scanner (pinned; identical to CI)
+	go run github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION) $(PKGS)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Modern building blocks for Go microservices. GoBricks brings together configurat
 - **Production-ready defaults** for the boring-but-essential pieces (server, logging, configuration, tracing).
 - **Composable module system** that keeps HTTP, database, and messaging concerns organized.
 - **Mission-critical integrations** (PostgreSQL, Oracle, RabbitMQ, Flyway) with unified ergonomics.
-- **Modern Go practices** with type safety, performance optimizations, and Go 1.25 features.
+- **Modern Go practices** with type safety, performance optimizations, and Go 1.26 features.
 - **Extensible design** that works with modern Go idioms and the wider ecosystem.
 
 ---
@@ -90,7 +90,7 @@ go test -run TestName   # Run specific test
 ## Quick Start
 
 ### Requirements
-- **Go 1.25** required
+- **Go 1.26** required
 - Modern Go toolchain with module support
 - Docker Desktop or Docker Engine (integration tests only)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gaborage/go-bricks
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # GoBricks Framework
 
-Enterprise Go microservice toolkit (Go 1.25+). Provides multi-database access, typed HTTP handlers, AMQP messaging, tenant isolation, and built-in OpenTelemetry.
+Enterprise Go microservice toolkit (Go 1.26+). Provides multi-database access, typed HTTP handlers, AMQP messaging, tenant isolation, and built-in OpenTelemetry.
 
 ## Quick Start
 - `go get github.com/gaborage/go-bricks`

--- a/tools/migration/Makefile
+++ b/tools/migration/Makefile
@@ -1,9 +1,11 @@
-.PHONY: help build test lint fmt update clean install check test-coverage validate-cli dev-deps release-dry-run vuln
+.PHONY: help build test lint fmt update clean install check test-coverage validate-cli dev-deps release-dry-run vuln sec
 
 BINARY_NAME := go-bricks-migrate
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 # Keep in sync with the other module's Makefile.
 GOVULNCHECK_VERSION := v1.1.4
+# Keep in sync with the other module's Makefile.
+GOSEC_VERSION := v2.26.1
 
 help: ## Show this help message
 	@echo "go-bricks-migrate tool commands:"
@@ -48,6 +50,9 @@ dev-deps: ## Install development dependencies
 
 vuln: ## Run govulncheck vulnerability scan (pinned; identical to CI)
 	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
+
+sec: ## Run gosec security scanner (pinned; identical to CI)
+	go run github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION) ./cmd/... ./internal/...
 
 release-dry-run: ## Test release build without publishing
 	@echo "Testing release build for version: $(VERSION)"

--- a/tools/migration/Makefile
+++ b/tools/migration/Makefile
@@ -1,7 +1,8 @@
-.PHONY: help build test lint fmt update clean install check test-coverage validate-cli dev-deps release-dry-run
+.PHONY: help build test lint fmt update clean install check test-coverage validate-cli dev-deps release-dry-run vuln
 
 BINARY_NAME := go-bricks-migrate
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+GOVULNCHECK_VERSION := v1.1.4
 
 help: ## Show this help message
 	@echo "go-bricks-migrate tool commands:"
@@ -43,6 +44,9 @@ check: fmt lint test validate-cli ## Run fmt, lint, test, and CLI validation (pr
 
 dev-deps: ## Install development dependencies
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
+vuln: ## Run govulncheck vulnerability scan (pinned; identical to CI)
+	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
 
 release-dry-run: ## Test release build without publishing
 	@echo "Testing release build for version: $(VERSION)"

--- a/tools/migration/Makefile
+++ b/tools/migration/Makefile
@@ -2,6 +2,7 @@
 
 BINARY_NAME := go-bricks-migrate
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+# Keep in sync with the other module's Makefile.
 GOVULNCHECK_VERSION := v1.1.4
 
 help: ## Show this help message

--- a/tools/migration/go.mod
+++ b/tools/migration/go.mod
@@ -1,6 +1,6 @@
 module github.com/gaborage/go-bricks/tools/migration
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.9

--- a/wiki/adr_006_otlp_log_export.md
+++ b/wiki/adr_006_otlp_log_export.md
@@ -366,7 +366,7 @@ observability:
    - ✅ `make check` passes (fmt, lint, race detection)
    - ✅ Zero linting issues (golangci-lint)
    - ✅ All existing tests pass unchanged
-   - ✅ Multi-platform CI (Ubuntu, Windows × Go 1.25)
+   - ✅ Multi-platform CI (Ubuntu, Windows × Go 1.26)
 
 ### Code Quality Metrics
 

--- a/wiki/adr_007_struct_based_columns.md
+++ b/wiki/adr_007_struct_based_columns.md
@@ -188,7 +188,7 @@ database/
 
 **CI/CD:**
 - `make check-all` validates framework + tool compatibility
-- Multi-platform (Ubuntu/Windows) × Go 1.25
+- Multi-platform (Ubuntu/Windows) × Go 1.26
 - SonarCloud: 80% coverage target maintained
 
 ## Future Considerations

--- a/wiki/adr_011_redis_cache.md
+++ b/wiki/adr_011_redis_cache.md
@@ -284,7 +284,7 @@ defer cache.Delete(ctx, lockKey)
 - **PR #2-8**: 80%+ coverage per PR (SonarCloud enforced)
 - **Integration Tests**: Real Redis via testcontainers (PR #8)
 - **Race Detection**: All tests run with `-race` flag
-- **Multi-Platform CI**: Ubuntu/Windows × Go 1.25
+- **Multi-Platform CI**: Ubuntu/Windows × Go 1.26
 
 ### Success Metrics
 1. **Zero Regressions**: All existing tests pass unchanged


### PR DESCRIPTION
## Phase A — Release-mechanism hygiene

First PR of the release-mechanism initiative (design spec: `docs/superpowers/specs/2026-05-31-release-mechanism-design.md`). Two independent, individually-shippable changes.

### 1. Security scanning + Makefile centralization (closes the "no CVE gate" gap)
- Add **`govulncheck`** to CI: path-gated `vuln-framework` + `vuln-migrate-tool` jobs on PRs, plus a **weekly** scheduled scan of both modules.
- **Centralize both `govulncheck` and `gosec` through the Makefile** so local == CI: `make vuln` and `make sec` exist in both modules' Makefiles (`go run <tool>@<pinned-version>`), and CI calls those same targets instead of inlining `go install`. Versions pinned in one place per module.
- Guard the `changes` job with `if: github.event_name != 'schedule'` so the weekly run doesn't trip the `dorny/paths-filter` step.
- The weekly job scans **both** modules in one step and fails if **either** finds a vuln (so a framework finding can't hide a CLI finding).

### 2. Go 1.26 floor
- Bump both modules' `go` directive `1.25.0 → 1.26.0` (no `toolchain` directive) and reconcile every Go-version doc reference (`CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `llms.txt`, `bug.yml`, and three ADRs).
- **Compatibility note:** this raises the minimum Go version. With the default `GOTOOLCHAIN=auto`, consumers on 1.25 transparently auto-download 1.26; `GOTOOLCHAIN=local` / airgapped consumers must upgrade.

### Verification
`make check`, `make vuln`, and `make sec` all green on both modules; `govulncheck` and `gosec` report 0 issues.

> Follow-up (not in this PR): consider adding `vuln-framework` / `vuln-migrate-tool` to branch-protection **required checks** if you want a reachable CVE to block merges (they currently run in parallel, not as a merge gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated minimum Go version requirement to 1.26 across docs and project configuration.

* **Tests**
  * Added scheduled weekly vulnerability rescans and new vulnerability/security scan steps in CI to improve security coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->