### PR TITLE
fix(database)!: rename connection pool metrics to OTEL semconv names

### DIFF
--- a/database/internal/tracking/metrics.go
+++ b/database/internal/tracking/metrics.go
@@ -26,15 +26,20 @@ const (
 
 	// Connection pool metrics per OTel spec
 	// Note: Changed from Gauge to UpDownCounter per OTEL semconv recommendation
-	metricDBConnectionCount          = "db.client.connection.count"           // UpDownCounter with state attribute
-	metricDBConnectionIdleMax        = "db.client.connection.idle.max"        // Max configured idle connections
-	metricDBConnectionIdleConfigured = "db.client.connection.idle.configured" // Configured idle connections target (Go's sql.DB does not enforce a minimum)
-	metricDBConnectionMax            = "db.client.connection.max"             // Max configured connections
+	metricDBConnectionCount   = "db.client.connection.count"    // UpDownCounter with state attribute
+	metricDBConnectionIdleMax = "db.client.connection.idle.max" // Max configured idle connections
+	// metricDBConnectionIdleMin maps to OTEL semconv "db.client.connection.idle.min".
+	// Go's database/sql exposes a single idle knob (SetMaxIdleConns), so this gauge
+	// shares its source value (Pool.Idle.Connections) with idle.max; it is emitted under
+	// the semconv idle.min name because the framework treats Pool.Idle.Connections as the
+	// configured warm-pool target. See config.PoolIdleConfig.
+	metricDBConnectionIdleMin = "db.client.connection.idle.min" // Configured idle-connection target (semconv idle.min)
+	metricDBConnectionMax     = "db.client.connection.max"      // Max configured connections
 
-	// New pool saturation metrics per OTEL semconv
-	metricDBConnectionWaitCount    = "db.client.connection.wait_count"    // Counter: cumulative wait count
-	metricDBConnectionTimeouts     = "db.client.connection.timeouts"      // Counter: timeout events
-	metricDBConnectionPendingCount = "db.client.connection.pending_count" // UpDownCounter: currently waiting
+	// Pool saturation metrics per OTEL semconv
+	metricDBConnectionWaitCount       = "db.client.connection.wait_count"       // Counter: cumulative wait count
+	metricDBConnectionTimeouts        = "db.client.connection.timeouts"         // Counter: timeout events
+	metricDBConnectionPendingRequests = "db.client.connection.pending_requests" // UpDownCounter: requests currently waiting for a connection
 
 	// Attribute keys per OTel semantic conventions
 	attrDBSystem         = "db.system.name"
@@ -405,7 +410,7 @@ type poolMetricsRegistration struct {
 	// Connection state metrics (UpDownCounter per OTEL spec)
 	connectionCountCounter metric.Int64ObservableUpDownCounter // Current connections with state attribute
 	idleMaxCounter         metric.Int64ObservableUpDownCounter // Max configured idle connections
-	idleConfiguredCounter  metric.Int64ObservableUpDownCounter // Configured idle connections target (not enforced as minimum)
+	idleMinCounter         metric.Int64ObservableUpDownCounter // Configured idle-connection target, emitted as semconv idle.min
 	maxCounter             metric.Int64ObservableUpDownCounter // Max configured connections
 
 	// Pool saturation metrics (Counters for cumulative values)
@@ -413,7 +418,7 @@ type poolMetricsRegistration struct {
 	timeoutsCounter  metric.Int64ObservableCounter // Cumulative timeout count
 
 	// Pool pressure metric
-	pendingCountCounter metric.Int64ObservableUpDownCounter // Current number of pending requests
+	pendingRequestsCounter metric.Int64ObservableUpDownCounter // Current number of pending requests
 
 	// Base attributes for all metrics
 	baseAttrs []attribute.KeyValue
@@ -448,8 +453,8 @@ func (r *poolMetricsRegistration) observePoolStats(_ context.Context, observer m
 	if r.idleMaxCounter != nil {
 		observer.ObserveInt64(r.idleMaxCounter, ps.MaxIdle, metric.WithAttributes(r.baseAttrs...))
 	}
-	if r.idleConfiguredCounter != nil {
-		observer.ObserveInt64(r.idleConfiguredCounter, ps.ConfiguredIdle, metric.WithAttributes(r.baseAttrs...))
+	if r.idleMinCounter != nil {
+		observer.ObserveInt64(r.idleMinCounter, ps.ConfiguredIdle, metric.WithAttributes(r.baseAttrs...))
 	}
 	if r.maxCounter != nil {
 		observer.ObserveInt64(r.maxCounter, ps.MaxOpen, metric.WithAttributes(r.baseAttrs...))
@@ -466,8 +471,8 @@ func (r *poolMetricsRegistration) observePoolStats(_ context.Context, observer m
 	}
 
 	// Record current pending request count
-	if r.pendingCountCounter != nil {
-		observer.ObserveInt64(r.pendingCountCounter, ps.PendingCount, metric.WithAttributes(r.baseAttrs...))
+	if r.pendingRequestsCounter != nil {
+		observer.ObserveInt64(r.pendingRequestsCounter, ps.PendingCount, metric.WithAttributes(r.baseAttrs...))
 	}
 
 	return nil
@@ -482,11 +487,11 @@ func (r *poolMetricsRegistration) observePoolStats(_ context.Context, observer m
 // - db.client.connection.count{state="used"}: Active connections in use
 // - db.client.connection.count{state="idle"}: Idle connections in pool
 // - db.client.connection.idle.max: Maximum configured idle connections
-// - db.client.connection.idle.configured: Configured idle connection target (not enforced as minimum)
+// - db.client.connection.idle.min: Configured idle-connection target (shares Pool.Idle.Connections with idle.max; Go's sql.DB has a single idle knob)
 // - db.client.connection.max: Maximum configured connections
 // - db.client.connection.wait_count: Cumulative count of waits for connections from pool
 // - db.client.connection.timeouts: Cumulative count of connection wait timeouts
-// - db.client.connection.pending_count: Number of pending connection requests
+// - db.client.connection.pending_requests: Number of connection requests currently waiting
 //
 // Server Metadata Attributes:
 // All metrics include server.address, server.port, and db.namespace (when available) in addition
@@ -531,8 +536,8 @@ func RegisterConnectionPoolMetrics(conn interface {
 		"Number of connections that are currently in state described by the state attribute")
 	reg.idleMaxCounter = createObservableUpDownCounter(meter, metricDBConnectionIdleMax,
 		"The maximum number of idle open connections allowed")
-	reg.idleConfiguredCounter = createObservableUpDownCounter(meter, metricDBConnectionIdleConfigured,
-		"The configured idle connections target (Go's sql.DB does not enforce a minimum)")
+	reg.idleMinCounter = createObservableUpDownCounter(meter, metricDBConnectionIdleMin,
+		"The configured idle-connection target; Go's database/sql applies it via SetMaxIdleConns and does not actively maintain a minimum")
 	reg.maxCounter = createObservableUpDownCounter(meter, metricDBConnectionMax,
 		"The maximum number of open connections allowed")
 
@@ -545,18 +550,18 @@ func RegisterConnectionPoolMetrics(conn interface {
 		"The total number of times a connection request timed out")
 
 	// Create up-down counter for current pending requests
-	reg.pendingCountCounter = createObservableUpDownCounter(meter, metricDBConnectionPendingCount,
+	reg.pendingRequestsCounter = createObservableUpDownCounter(meter, metricDBConnectionPendingRequests,
 		"The number of connection requests currently waiting for a connection")
 
 	// Collect non-nil instruments for callback registration
 	instruments := collectObservables(
 		reg.connectionCountCounter,
 		reg.idleMaxCounter,
-		reg.idleConfiguredCounter,
+		reg.idleMinCounter,
 		reg.maxCounter,
 		reg.waitCountCounter,
 		reg.timeoutsCounter,
-		reg.pendingCountCounter,
+		reg.pendingRequestsCounter,
 	)
 	if len(instruments) == 0 {
 		return noOpCleanup()

--- a/database/internal/tracking/metrics_test.go
+++ b/database/internal/tracking/metrics_test.go
@@ -857,3 +857,41 @@ func TestExtractTableNameBackwardCompatibility(t *testing.T) {
 		assert.Equal(t, tc.expected, result, "Legacy query should still extract table correctly: %s", tc.query)
 	}
 }
+
+// TestRegisterConnectionPoolMetricsSemconvNames is the regression guard for issues
+// #509 and #511: the pool gauges must be emitted under the OTEL semantic-convention
+// names db.client.connection.pending_requests and db.client.connection.idle.min
+// (previously the non-standard .pending_count and .idle.configured, which produced
+// no data in dashboards keyed on the semconv names).
+func TestRegisterConnectionPoolMetricsSemconvNames(t *testing.T) {
+	mp, cleanup := setupTestMeterProvider(t)
+	defer cleanup()
+
+	mockConn := &mockStatsConnection{stats: map[string]any{
+		"in_use":                      int(2),
+		"idle":                        int(3),
+		"max_idle_connections":        int(5),
+		"configured_idle_connections": int(5),
+		"max_open_connections":        int(25),
+		"pending_count":               int(7),
+	}}
+
+	connCleanup := RegisterConnectionPoolMetrics(mockConn, "postgresql", "localhost", 5432, "testdb.public")
+	defer connCleanup()
+
+	rm := mp.Collect(t)
+
+	// The gauges must be emitted under the exact OTEL semconv wire names with their
+	// source values. Hard-coding the literal names (rather than the package constants)
+	// pins the observable wire contract against an accidental constant change.
+	obtest.AssertMetricExists(t, rm, "db.client.connection.idle.min")
+	obtest.AssertMetricExists(t, rm, "db.client.connection.pending_requests")
+	obtest.AssertMetricValue(t, rm, "db.client.connection.idle.min", int64(5))
+	obtest.AssertMetricValue(t, rm, "db.client.connection.pending_requests", int64(7))
+
+	// The old non-standard names must no longer be emitted.
+	assert.Nil(t, obtest.FindMetric(rm, "db.client.connection.idle.configured"),
+		"legacy idle.configured metric must not be emitted")
+	assert.Nil(t, obtest.FindMetric(rm, "db.client.connection.pending_count"),
+		"legacy pending_count metric must not be emitted")
+}

--- a/database/internal/wrapper/connection.go
+++ b/database/internal/wrapper/connection.go
@@ -102,6 +102,10 @@ func (c *Connection) Stats() (map[string]any, error) {
 	}
 
 	if c.Config != nil {
+		// Go's database/sql exposes a single idle knob (SetMaxIdleConns). The tracking
+		// layer surfaces it under both OTEL semconv gauges -- idle.max (hard cap) and
+		// idle.min (configured warm-pool target) -- so both keys intentionally carry the
+		// same configured value. See database/internal/tracking/metrics.go.
 		result["max_idle_connections"] = int(c.Config.Pool.Idle.Connections)
 		result["configured_idle_connections"] = int(c.Config.Pool.Idle.Connections)
 	}

--- a/llms.txt
+++ b/llms.txt
@@ -3971,9 +3971,9 @@ When `observability.enabled: true`, the framework auto-emits:
 | HTTP server | `http.server.request.duration` | Histogram (s) | `http.method`, `http.route`, `http.status_code` |
 | Database | `db.client.operation.duration` | Histogram (s) | `db.system`, `db.operation`, `error.type` |
 | Database pool | `db.client.connection.count` | UpDownCounter | `state` (`open`/`idle`) |
-| Database pool | `db.client.connection.max` / `.idle.max` / `.idle.configured` | Gauge | — |
+| Database pool | `db.client.connection.max` / `.idle.max` / `.idle.min` | Gauge | — |
 | Database pool | `db.client.connection.wait_count` / `.timeouts` | Counter | — |
-| Database pool | `db.client.connection.pending_count` | UpDownCounter | — |
+| Database pool | `db.client.connection.pending_requests` | UpDownCounter | — |
 | Messaging | `messaging.client.operation.duration` | Histogram (s) | `messaging.system`, `messaging.operation.name`, `error.type` |
 | Messaging | `messaging.client.sent.messages` / `consumed.messages` | Counter | `messaging.destination.name` |
 | Messaging | `messaging.client.publish.retries` | Counter | `messaging.destination.name` |

--- a/llms.txt
+++ b/llms.txt
@@ -3971,7 +3971,7 @@ When `observability.enabled: true`, the framework auto-emits:
 | HTTP server | `http.server.request.duration` | Histogram (s) | `http.method`, `http.route`, `http.status_code` |
 | Database | `db.client.operation.duration` | Histogram (s) | `db.system`, `db.operation`, `error.type` |
 | Database pool | `db.client.connection.count` | UpDownCounter | `state` (`open`/`idle`) |
-| Database pool | `db.client.connection.max` / `.idle.max` / `.idle.min` | Gauge | — |
+| Database pool | `db.client.connection.max` / `.idle.max` / `.idle.min` | UpDownCounter | — |
 | Database pool | `db.client.connection.wait_count` / `.timeouts` | Counter | — |
 | Database pool | `db.client.connection.pending_requests` | UpDownCounter | — |
 | Messaging | `messaging.client.operation.duration` | Histogram (s) | `messaging.system`, `messaging.operation.name`, `error.type` |


### PR DESCRIPTION
## Summary

Fixes #509 and #511. Two database connection-pool gauges in `database/internal/tracking/metrics.go` were emitted under names that do **not** match OpenTelemetry semantic conventions, so dashboard widgets keyed on the semconv names received no data:

| Old name | New name (OTEL semconv) | Issue |
|---|---|---|
| `db.client.connection.pending_count` | `db.client.connection.pending_requests` | #509 |
| `db.client.connection.idle.configured` | `db.client.connection.idle.min` | #511 |

## ⚠️ Breaking change

These are observable metric-name changes. Dashboards/alerts referencing the old names will lose data until updated to the new semconv names. Flagged as `BREAKING CHANGE:` in the commit so it surfaces in the changelog.

## Notes for reviewers

- **`idle.min` and `idle.max` intentionally share a source value.** Go's `database/sql` exposes a single idle knob (`SetMaxIdleConns`), fed from `Pool.Idle.Connections`. The framework documents that value as the "minimum warm connections" target (`config/types.go`), so emitting it under the semconv `idle.min` name is the correct framework interpretation. Both the metric definition and `database/internal/wrapper/connection.go` now carry inline comments explaining why the two keys share a value.
- **Known limitation (pre-existing, out of scope):** `pending_requests` reads a `pending_count` pool stat that `*sql.DB` never populates — Go's `sql.DBStats` has no "currently-pending-requests" field (only the cumulative `WaitCount`, already mapped to `wait_count`). So this gauge currently emits **0** in production regardless of name. The rename is still required for semconv compliance and dashboard wiring; surfacing a real value needs a driver-level stats source. Happy to open a follow-up issue to track that.

## Tests

Adds `TestRegisterConnectionPoolMetricsSemconvNames` to `metrics_test.go`, which:
- asserts the gauges are emitted under the **literal** semconv wire names with their source values (hard-coded literals, not the package constants, so the wire contract is pinned independently of an accidental constant change);
- asserts the legacy names (`idle.configured`, `pending_count`) are no longer emitted.

## Verification

- `make check` green (fmt + lint incl. gosec + race tests).
- Identifier rename verified complete across the repo; the surviving `configured_idle_connections` / `pending_count` strings are **stats-map source keys**, not metric names, and are intentionally unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated database connection-pool metrics to follow OpenTelemetry semantic conventions; several metric names were renamed for consistency (e.g., idle and pending metrics).

* **Documentation**
  * Updated auto-emitted Database pool metrics docs to reflect the new metric names and semantics.

* **Tests**
  * Added a regression test ensuring connection-pool metrics emit the expected OpenTelemetry semantic-convention names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->