### PR TITLE
feat(database): add repository.method attribute to operation duration metric

### DIFF
--- a/database/internal/tracking/metrics.go
+++ b/database/internal/tracking/metrics.go
@@ -43,6 +43,11 @@ const (
 	attrDBNamespace      = "db.namespace"
 	attrConnectionState  = "state" // Values: "idle", "used"
 
+	// attrRepositoryMethod is a custom (non-semconv) attribute carrying the
+	// business-operation method name that issued the query. It is supplied by the
+	// caller via WithRepositoryMethod and must be low-cardinality.
+	attrRepositoryMethod = "repository.method"
+
 	// Special values for table/collection name
 	unknownTable = "unknown"
 )
@@ -200,6 +205,7 @@ func getDBMeter() metric.Meter {
 // - db.operation.name: Operation type (select, insert, update, delete, etc.) - always included
 // - db.collection.name: Table/collection name - optional, included when available
 // - db.namespace: Vendor-specific namespace format - optional, included when available
+// - repository.method: Caller-supplied business-operation name - optional, set via WithRepositoryMethod
 //
 // Non-blocking Behavior:
 // If the global meter or histogram is not initialized, the function is a no-op and returns
@@ -232,6 +238,11 @@ func recordDBMetrics(ctx context.Context, tc *Context, query string, duration ti
 	}
 	if tc.Namespace != "" {
 		attrs = append(attrs, attribute.String(attrDBNamespace, tc.Namespace))
+	}
+	// Add the caller-supplied repository method when present (low-cardinality
+	// business-operation label set via WithRepositoryMethod).
+	if method, ok := RepositoryMethodFromContext(ctx); ok {
+		attrs = append(attrs, attribute.String(attrRepositoryMethod, method))
 	}
 
 	// Record histogram with duration in seconds (not milliseconds)

--- a/database/internal/tracking/metrics_test.go
+++ b/database/internal/tracking/metrics_test.go
@@ -434,6 +434,47 @@ func TestExtractTableName(t *testing.T) {
 	}
 }
 
+// TestRecordDBMetricsRepositoryMethodAttribute verifies that the caller-supplied
+// repository method (issue #510) is emitted as the repository.method attribute on
+// the db.client.operation.duration histogram.
+func TestRecordDBMetricsRepositoryMethodAttribute(t *testing.T) {
+	mp, cleanup := setupTestMeterProvider(t)
+	defer cleanup()
+
+	log := newDisabledTestLogger()
+	tc := &Context{Logger: log, Vendor: "postgresql", Settings: NewSettings(nil)}
+
+	ctx := WithRepositoryMethod(context.Background(), "GetCustomer")
+	recordDBMetrics(ctx, tc, TestQuerySelectUsers, 10*time.Millisecond, 0, nil)
+
+	rm := mp.Collect(t)
+	require.True(t, findMetricAttributeValue(rm, metricDBDuration, attrRepositoryMethod, "GetCustomer"),
+		"db.client.operation.duration should carry repository.method=GetCustomer")
+}
+
+// TestRecordDBMetricsWithoutRepositoryMethod verifies the repository.method
+// attribute is absent when the caller did not set it (no empty-string series).
+func TestRecordDBMetricsWithoutRepositoryMethod(t *testing.T) {
+	mp, cleanup := setupTestMeterProvider(t)
+	defer cleanup()
+
+	log := newDisabledTestLogger()
+	tc := &Context{Logger: log, Vendor: "postgresql", Settings: NewSettings(nil)}
+
+	recordDBMetrics(context.Background(), tc, TestQuerySelectUsers, 10*time.Millisecond, 0, nil)
+
+	rm := mp.Collect(t)
+	m := obtest.FindMetric(rm, metricDBDuration)
+	require.NotNil(t, m)
+	hist, ok := m.Data.(metricdata.Histogram[float64])
+	require.True(t, ok, "expected histogram data for %s", metricDBDuration)
+	require.NotEmpty(t, hist.DataPoints)
+	for _, attr := range hist.DataPoints[0].Attributes.ToSlice() {
+		assert.NotEqual(t, attrRepositoryMethod, string(attr.Key),
+			"repository.method must be absent when not set via WithRepositoryMethod")
+	}
+}
+
 func TestRecordDBMetricsWithTableAttribute(t *testing.T) {
 	mp, cleanup := setupTestMeterProvider(t)
 	defer cleanup()

--- a/database/internal/tracking/repository_method.go
+++ b/database/internal/tracking/repository_method.go
@@ -17,9 +17,11 @@ type repositoryMethodKey struct{}
 // The value MUST be a static, low-cardinality identifier such as a method or
 // function name. Because it becomes a metric attribute, interpolating
 // per-request data (IDs, emails, ...) would explode metric cardinality. An empty
-// method is ignored and ctx is returned unchanged.
+// method, or a nil ctx, is ignored and ctx is returned unchanged (the nil guard
+// mirrors RepositoryMethodFromContext and avoids context.WithValue's
+// "cannot create context from nil parent" panic).
 func WithRepositoryMethod(ctx context.Context, method string) context.Context {
-	if method == "" {
+	if ctx == nil || method == "" {
 		return ctx
 	}
 	return context.WithValue(ctx, repositoryMethodKey{}, method)

--- a/database/internal/tracking/repository_method.go
+++ b/database/internal/tracking/repository_method.go
@@ -1,0 +1,37 @@
+package tracking
+
+import "context"
+
+// repositoryMethodKey is the unexported context-key type under which the
+// caller-supplied repository method name is stored. A dedicated struct type
+// avoids collisions with context keys defined by other packages.
+type repositoryMethodKey struct{}
+
+// WithRepositoryMethod returns a copy of ctx that records the name of the
+// repository method responsible for the database operations executed with it.
+// The tracking layer reads this value and adds it as the `repository.method`
+// attribute on the db.client.operation.duration metric, so dashboards can
+// attribute query latency to the business operation that issued it (for example
+// "GetCustomer" vs "InsertTransaction") rather than only the SQL verb.
+//
+// The value MUST be a static, low-cardinality identifier such as a method or
+// function name. Because it becomes a metric attribute, interpolating
+// per-request data (IDs, emails, ...) would explode metric cardinality. An empty
+// method is ignored and ctx is returned unchanged.
+func WithRepositoryMethod(ctx context.Context, method string) context.Context {
+	if method == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, repositoryMethodKey{}, method)
+}
+
+// RepositoryMethodFromContext returns the repository method name previously
+// stored in ctx by WithRepositoryMethod. The boolean is false when no method is
+// set (including for a nil context).
+func RepositoryMethodFromContext(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	method, ok := ctx.Value(repositoryMethodKey{}).(string)
+	return method, ok
+}

--- a/database/internal/tracking/repository_method_test.go
+++ b/database/internal/tracking/repository_method_test.go
@@ -1,0 +1,51 @@
+package tracking
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithRepositoryMethodRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := WithRepositoryMethod(context.Background(), "GetCustomer")
+	method, ok := RepositoryMethodFromContext(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "GetCustomer", method)
+}
+
+func TestWithRepositoryMethodEmptyIsNoOp(t *testing.T) {
+	t.Parallel()
+	parent := context.Background()
+	ctx := WithRepositoryMethod(parent, "")
+
+	// An empty method must not allocate a new context value.
+	assert.Equal(t, parent, ctx)
+	_, ok := RepositoryMethodFromContext(ctx)
+	assert.False(t, ok)
+}
+
+func TestWithRepositoryMethodOverwrite(t *testing.T) {
+	t.Parallel()
+	ctx := WithRepositoryMethod(context.Background(), "First")
+	ctx = WithRepositoryMethod(ctx, "Second")
+	method, ok := RepositoryMethodFromContext(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "Second", method)
+}
+
+func TestRepositoryMethodFromContextAbsent(t *testing.T) {
+	t.Parallel()
+	method, ok := RepositoryMethodFromContext(context.Background())
+	assert.False(t, ok)
+	assert.Empty(t, method)
+}
+
+func TestRepositoryMethodFromContextNil(t *testing.T) {
+	t.Parallel()
+	var ctx context.Context // nil context — must be handled defensively
+	method, ok := RepositoryMethodFromContext(ctx)
+	assert.False(t, ok)
+	assert.Empty(t, method)
+}

--- a/database/internal/tracking/repository_method_test.go
+++ b/database/internal/tracking/repository_method_test.go
@@ -26,6 +26,14 @@ func TestWithRepositoryMethodEmptyIsNoOp(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestWithRepositoryMethodNilContext(t *testing.T) {
+	t.Parallel()
+	var ctx context.Context // nil context — must not panic
+	var out context.Context
+	assert.NotPanics(t, func() { out = WithRepositoryMethod(ctx, "GetCustomer") })
+	assert.Nil(t, out, "nil ctx is returned unchanged")
+}
+
 func TestWithRepositoryMethodOverwrite(t *testing.T) {
 	t.Parallel()
 	ctx := WithRepositoryMethod(context.Background(), "First")

--- a/database/tracking.go
+++ b/database/tracking.go
@@ -23,6 +23,20 @@ var (
 	TrackDBOperation              = tracking.TrackDBOperation
 	NewTrackingSettings           = tracking.NewSettings
 	RegisterConnectionPoolMetrics = tracking.RegisterConnectionPoolMetrics
+
+	// WithRepositoryMethod records the business-operation (repository) method name
+	// on ctx so the tracking layer emits it as the `repository.method` attribute on
+	// the db.client.operation.duration metric. Pass the resulting context to the
+	// database call:
+	//
+	//	ctx = database.WithRepositoryMethod(ctx, "GetCustomer")
+	//	rows, err := db.Query(ctx, query, args...)
+	//
+	// The method name must be a static, low-cardinality identifier.
+	WithRepositoryMethod = tracking.WithRepositoryMethod
+	// RepositoryMethodFromContext returns the repository method name stored on ctx
+	// by WithRepositoryMethod, and whether one was set.
+	RepositoryMethodFromContext = tracking.RepositoryMethodFromContext
 )
 
 // Re-export internal constants

--- a/database/tracking_test.go
+++ b/database/tracking_test.go
@@ -811,6 +811,22 @@ func TestTrackedStmtExec(t *testing.T) {
 	assertDBCounter(ctx, t, 2)
 }
 
+// TestWithRepositoryMethodReExport verifies the public database.WithRepositoryMethod
+// / database.RepositoryMethodFromContext re-exports are wired to the tracking
+// implementation and round-trip a method name (issue #510).
+func TestWithRepositoryMethodReExport(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithRepositoryMethod(context.Background(), "InsertTransaction")
+	method, ok := RepositoryMethodFromContext(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, "InsertTransaction", method)
+
+	// Absent by default.
+	_, ok = RepositoryMethodFromContext(context.Background())
+	assert.False(t, ok)
+}
+
 func TestTrackedConnectionClose(t *testing.T) {
 	t.Parallel()
 	db, mock, err := sqlmock.New()

--- a/llms.txt
+++ b/llms.txt
@@ -3969,7 +3969,7 @@ When `observability.enabled: true`, the framework auto-emits:
 | Family | Metric | Type | Attributes |
 |---|---|---|---|
 | HTTP server | `http.server.request.duration` | Histogram (s) | `http.method`, `http.route`, `http.status_code` |
-| Database | `db.client.operation.duration` | Histogram (s) | `db.system`, `db.operation`, `db.collection.name`, `db.namespace`, `repository.method` (opt-in via `database.WithRepositoryMethod`) |
+| Database | `db.client.operation.duration` | Histogram (s) | `db.system.name`, `db.operation.name`, `db.collection.name`, `db.namespace`, `repository.method` (opt-in via `database.WithRepositoryMethod`) |
 | Database pool | `db.client.connection.count` | UpDownCounter | `state` (`open`/`idle`) |
 | Database pool | `db.client.connection.max` / `.idle.max` / `.idle.min` | UpDownCounter | — |
 | Database pool | `db.client.connection.wait_count` / `.timeouts` | Counter | — |

--- a/llms.txt
+++ b/llms.txt
@@ -3969,7 +3969,7 @@ When `observability.enabled: true`, the framework auto-emits:
 | Family | Metric | Type | Attributes |
 |---|---|---|---|
 | HTTP server | `http.server.request.duration` | Histogram (s) | `http.method`, `http.route`, `http.status_code` |
-| Database | `db.client.operation.duration` | Histogram (s) | `db.system`, `db.operation`, `error.type` |
+| Database | `db.client.operation.duration` | Histogram (s) | `db.system`, `db.operation`, `db.collection.name`, `db.namespace`, `repository.method` (opt-in via `database.WithRepositoryMethod`) |
 | Database pool | `db.client.connection.count` | UpDownCounter | `state` (`open`/`idle`) |
 | Database pool | `db.client.connection.max` / `.idle.max` / `.idle.configured` | Gauge | — |
 | Database pool | `db.client.connection.wait_count` / `.timeouts` | Counter | — |

--- a/wiki/database.md
+++ b/wiki/database.md
@@ -258,6 +258,30 @@ database:
       interval: 30s
 ```
 
+## Repository Method Attribution
+
+The `db.client.operation.duration` metric carries `db.operation.name` (the SQL verb:
+`select`, `insert`, …) but not which application method issued the query. To attribute
+query latency to a business operation in dashboards (e.g. `GetCustomer` vs
+`InsertTransaction`), tag the context before the call with `database.WithRepositoryMethod`:
+
+```go
+func (r *CustomerRepo) GetCustomer(ctx context.Context, id int64) (*Customer, error) {
+    ctx = database.WithRepositoryMethod(ctx, "GetCustomer")
+    row := r.db.QueryRow(ctx, query, id)
+    // ...
+}
+```
+
+The tracking layer reads the value and adds it as the `repository.method` attribute on
+the duration histogram. The attribute is omitted entirely when unset (no empty-string
+series). `database.RepositoryMethodFromContext(ctx)` reads the value back for custom
+instrumentation.
+
+**Cardinality contract:** the method name MUST be a static, low-cardinality identifier
+(a method or function name). Because it becomes a metric attribute, interpolating
+per-request data such as IDs or emails would explode metric cardinality.
+
 ## Session Timezone (Breaking Change — ADR-016)
 
 | Setting | Default | Purpose |


### PR DESCRIPTION
## Summary

Closes #510. `db.client.operation.duration` carries `db.operation.name` (the SQL verb: `select`, `insert`, …) but not *which application method* issued the query. Dashboard widgets like **"Slowest Database Operations"** (which `FACET repository.method`) could therefore only show generic verbs without business context — `GetCustomer` vs `InsertTransaction` were indistinguishable.

## Design

Adds an **opt-in, per-call** context helper:

```go
func (r *CustomerRepo) GetCustomer(ctx context.Context, id int64) (*Customer, error) {
    ctx = database.WithRepositoryMethod(ctx, "GetCustomer")
    row := r.db.QueryRow(ctx, query, id)
    // ...
}
```

`recordDBMetrics` reads the value and adds it as the custom `repository.method` attribute on the duration histogram. The attribute is **omitted entirely when unset** (no empty-string series). `database.RepositoryMethodFromContext(ctx)` reads it back for custom instrumentation.

**Design choices** (answering the issue's open questions):
- **Attribute name `repository.method`** (custom) — matches the existing Terraform/NR dashboard widget; there is no OTEL semconv attribute for "which business method ran the query".
- **Opt-in per query via context** — explicit (`Explicit > Implicit`), zero overhead when unused, thread-safe (context is immutable), and naturally request-scoped (unlike the connection-scoped `tracking.Context`).
- **Cardinality contract** — documented in the godoc, the attribute-const comment, and `wiki/database.md`: the name MUST be a static, low-cardinality identifier. The framework can't enforce this (it's caller-supplied), so it's documented as a contract, consistent with how other metric attributes are handled.
- **Metric-only scope** — matches the issue title; the attribute is not added to the DB span.

## Implementation

- `database/internal/tracking/repository_method.go` — `WithRepositoryMethod` / `RepositoryMethodFromContext` (unexported `struct{}` context key, collision-proof; matches the `With*`/`*FromContext` convention used by `trace`, `multitenant`, `jose`).
- Re-exported from the public `database/tracking.go` (same var-alias pattern as the other tracking re-exports).
- `recordDBMetrics` appends `repository.method` only when present.

## Tests

- `repository_method_test.go` — round-trip, empty-is-no-op, overwrite, absent, nil-context (all `t.Parallel`).
- `metrics_test.go` — attribute is emitted on the histogram when set; absent when unset.
- `database/tracking_test.go` — public re-export round-trips.

## Docs

- `wiki/database.md` — new "Repository Method Attribution" section with usage + cardinality contract.
- `llms.txt` — corrected the `db.client.operation.duration` attribute list (added `repository.method`; also removed a stale `error.type` that the code never emits, and restored the omitted `db.collection.name` / `db.namespace`).

## Verification

`make check` green (fmt + lint incl. gosec + race tests). No new attack surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics can now include an opt-in, low-cardinality "repository.method" tag for database operations.
  * Public helpers let callers attach and read a repository method identifier on contexts for downstream metrics.

* **Documentation**
  * Metric attribute docs updated to include `repository.method`.
  * New guide describing how and when to tag contexts with repository method identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->