### PR TITLE
ci(release): open release-please PRs as draft

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
+  "draft-pull-request": true,
   "packages": {
     ".": {
       "release-type": "go",


### PR DESCRIPTION
## Open release-please PRs as drafts

Adds `"draft-pull-request": true` to `release-please-config.json` so release-please opens and maintains its standing `chore(main): release vX.Y.Z` PR as a **draft**.

**Why (two wins):**
1. **Saves CodeRabbit credits.** This repo has no `.coderabbit.yaml`, so CodeRabbit's default applies — it does **not** auto-review drafts. As work lands and release-please updates the Release PR, those updates won't each trigger a (paid) CodeRabbit review.
2. **Prevents the merge-without-tag deadlock.** GitHub won't let you merge a draft PR. That removes the foot-gun we just hit on v0.38.0 — merging the Release PR without running `make release` left it `autorelease: pending` with no tag and **deadlocked release-please** (release-please #1561). With drafts, you can only merge after deliberately un-drafting.

**Workflow unchanged otherwise:** when you're ready to release, mark the Release PR "Ready for review", merge it, then immediately `make release VERSION=vX.Y.Z` (cuts the signed tag → `release.yml` publishes + clears the label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release process configuration to generate release pull requests as drafts, enabling review before publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->