### PR TITLE
build(migrate): make go-bricks-migrate go install-able (drop replace, go.work, build-info)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 !*.go
 !go.sum
 !go.mod
+!go.work
+!go.work.sum
 
 !README.md
 !LICENSE

--- a/go.work
+++ b/go.work
@@ -1,0 +1,6 @@
+go 1.26.3
+
+use (
+	.
+	./tools/migration
+)

--- a/tools/migration/Makefile
+++ b/tools/migration/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help build test lint fmt update clean install check test-coverage validate-cli dev-deps release-dry-run vuln sec
 
 BINARY_NAME := go-bricks-migrate
-VERSION := $(shell git describe --tags --match "tools/migration/v*" --always --dirty 2>/dev/null | sed "s\#^tools/migration/\#\#" || echo "dev")
+VERSION := $(shell git describe --tags --match "tools/migration/v*" --always --dirty 2>/dev/null | sed "s\#^tools/migration/\#\#" | grep . || echo "dev")
 # Keep in sync with the other module's Makefile.
 GOVULNCHECK_VERSION := v1.1.4
 # Keep in sync with the other module's Makefile.

--- a/tools/migration/Makefile
+++ b/tools/migration/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help build test lint fmt update clean install check test-coverage validate-cli dev-deps release-dry-run vuln sec
 
 BINARY_NAME := go-bricks-migrate
-VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+VERSION := $(shell git describe --tags --match "tools/migration/v*" --always --dirty 2>/dev/null | sed "s\#^tools/migration/\#\#" || echo "dev")
 # Keep in sync with the other module's Makefile.
 GOVULNCHECK_VERSION := v1.1.4
 # Keep in sync with the other module's Makefile.

--- a/tools/migration/Makefile
+++ b/tools/migration/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help build test lint fmt update clean install check test-coverage validate-cli dev-deps release-dry-run vuln sec
 
 BINARY_NAME := go-bricks-migrate
-VERSION := $(shell git describe --tags --match "tools/migration/v*" --always --dirty 2>/dev/null | sed "s\#^tools/migration/\#\#" | grep . || echo "dev")
+VERSION := $(shell git describe --tags --match "tools/migration/v*" --always --dirty 2>/dev/null | sed "s|^tools/migration/||" | grep . || echo "dev")
 # Keep in sync with the other module's Makefile.
 GOVULNCHECK_VERSION := v1.1.4
 # Keep in sync with the other module's Makefile.

--- a/tools/migration/README.md
+++ b/tools/migration/README.md
@@ -17,6 +17,8 @@ Deep dives:
 
 ## Install
 
+> CLI releases are tagged `tools/migration/vX.Y.Z` (published with each framework release). `@vX.Y.Z` resolves that tag; `@latest` resolves the newest one (and falls back to an unversioned pseudo-version until the first such tag exists).
+
 ```bash
 # Pin to a specific release (recommended):
 go install github.com/gaborage/go-bricks/tools/migration/cmd/go-bricks-migrate@v0.38.0
@@ -27,8 +29,6 @@ go install github.com/gaborage/go-bricks/tools/migration/cmd/go-bricks-migrate@l
 # From a clone (contributors):
 cd tools/migration && make build   # produces ./go-bricks-migrate
 ```
-
-> `@latest` resolves the latest `tools/migration/vX.Y.Z` tag. Until the first such tag is published it installs an unversioned default-branch pseudo-version, so prefer pinning `@vX.Y.Z`.
 
 ## Quick start
 

--- a/tools/migration/README.md
+++ b/tools/migration/README.md
@@ -17,18 +17,20 @@ Deep dives:
 
 ## Install
 
-> CLI releases are tagged `tools/migration/vX.Y.Z` (published with each framework release). `@vX.Y.Z` resolves that tag; `@latest` resolves the newest one (and falls back to an unversioned pseudo-version until the first such tag exists).
+CLI releases are tagged `tools/migration/vX.Y.Z` — the first, `tools/migration/v0.38.0`, is published with this release. Once a tag exists:
 
 ```bash
-# Pin to a specific release (recommended):
-go install github.com/gaborage/go-bricks/tools/migration/cmd/go-bricks-migrate@v0.38.0
-
-# Latest CLI release (after the first tools/migration/vX.Y.Z tag exists):
+# Latest CLI release:
 go install github.com/gaborage/go-bricks/tools/migration/cmd/go-bricks-migrate@latest
+
+# Pin to a specific release:
+go install github.com/gaborage/go-bricks/tools/migration/cmd/go-bricks-migrate@v0.38.0
 
 # From a clone (contributors):
 cd tools/migration && make build   # produces ./go-bricks-migrate
 ```
+
+> `@latest` and `@vX.Y.Z` resolve `tools/migration/vX.Y.Z` tags. Before the first such tag exists, `@latest` installs an unversioned default-branch pseudo-version, so wait for the tag.
 
 ## Quick start
 

--- a/tools/migration/README.md
+++ b/tools/migration/README.md
@@ -18,11 +18,17 @@ Deep dives:
 ## Install
 
 ```bash
-cd tools/migration
-make build               # produces ./go-bricks-migrate
-# or
-make install             # go install via $GOBIN
+# Pin to a specific release (recommended):
+go install github.com/gaborage/go-bricks/tools/migration/cmd/go-bricks-migrate@v0.38.0
+
+# Latest CLI release (after the first tools/migration/vX.Y.Z tag exists):
+go install github.com/gaborage/go-bricks/tools/migration/cmd/go-bricks-migrate@latest
+
+# From a clone (contributors):
+cd tools/migration && make build   # produces ./go-bricks-migrate
 ```
+
+> `@latest` resolves the latest `tools/migration/vX.Y.Z` tag. Until the first such tag is published it installs an unversioned default-branch pseudo-version, so prefer pinning `@vX.Y.Z`.
 
 ## Quick start
 

--- a/tools/migration/cmd/go-bricks-migrate/main.go
+++ b/tools/migration/cmd/go-bricks-migrate/main.go
@@ -3,11 +3,29 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/gaborage/go-bricks/tools/migration/internal/commands"
 )
 
 var version = "dev" // Set via -ldflags at build time.
+
+// resolveVersion prefers the ldflags-injected version (set during `make build`),
+// then falls back to module build info (populated for `go install ...@vX.Y.Z`),
+// then to the literal default. debug.ReadBuildInfo is injected for testability.
+func resolveVersion(ldflags string, read func() (*debug.BuildInfo, bool)) string {
+	if ldflags != "" && ldflags != "dev" {
+		return ldflags
+	}
+	if bi, ok := read(); ok && bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+		return bi.Main.Version
+	}
+	return ldflags
+}
+
+func init() {
+	version = resolveVersion(version, debug.ReadBuildInfo)
+}
 
 func main() {
 	root := commands.NewRootCommand()

--- a/tools/migration/cmd/go-bricks-migrate/main.go
+++ b/tools/migration/cmd/go-bricks-migrate/main.go
@@ -26,11 +26,8 @@ func resolveVersion(ldflags string, read func() (*debug.BuildInfo, bool)) string
 	return "dev"
 }
 
-func init() {
-	version = resolveVersion(version, debug.ReadBuildInfo)
-}
-
 func main() {
+	version = resolveVersion(version, debug.ReadBuildInfo)
 	root := commands.NewRootCommand()
 	root.Version = version
 	root.AddCommand(

--- a/tools/migration/cmd/go-bricks-migrate/main.go
+++ b/tools/migration/cmd/go-bricks-migrate/main.go
@@ -20,7 +20,10 @@ func resolveVersion(ldflags string, read func() (*debug.BuildInfo, bool)) string
 	if bi, ok := read(); ok && bi.Main.Version != "" && bi.Main.Version != "(devel)" {
 		return bi.Main.Version
 	}
-	return ldflags
+	if ldflags != "" {
+		return ldflags
+	}
+	return "dev"
 }
 
 func init() {

--- a/tools/migration/cmd/go-bricks-migrate/main_test.go
+++ b/tools/migration/cmd/go-bricks-migrate/main_test.go
@@ -23,6 +23,8 @@ func TestResolveVersion(t *testing.T) {
 		{name: "buildinfo_when_dev", ldflags: "dev", read: bi("v0.39.0"), want: "v0.39.0"},
 		{name: "ignore_devel_pseudo", ldflags: "dev", read: bi("(devel)"), want: "dev"},
 		{name: "no_buildinfo", ldflags: "dev", read: none, want: "dev"},
+		{name: "empty_ldflags_buildinfo", ldflags: "", read: bi("v0.39.0"), want: "v0.39.0"},
+		{name: "empty_ldflags_no_buildinfo", ldflags: "", read: none, want: "dev"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tools/migration/cmd/go-bricks-migrate/main_test.go
+++ b/tools/migration/cmd/go-bricks-migrate/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestResolveVersion(t *testing.T) {
+	bi := func(v string) func() (*debug.BuildInfo, bool) {
+		return func() (*debug.BuildInfo, bool) {
+			return &debug.BuildInfo{Main: debug.Module{Version: v}}, true
+		}
+	}
+	none := func() (*debug.BuildInfo, bool) { return nil, false }
+
+	tests := []struct {
+		name    string
+		ldflags string
+		read    func() (*debug.BuildInfo, bool)
+		want    string
+	}{
+		{name: "ldflags_wins", ldflags: "v0.38.0", read: bi("v0.39.0"), want: "v0.38.0"},
+		{name: "buildinfo_when_dev", ldflags: "dev", read: bi("v0.39.0"), want: "v0.39.0"},
+		{name: "ignore_devel_pseudo", ldflags: "dev", read: bi("(devel)"), want: "dev"},
+		{name: "no_buildinfo", ldflags: "dev", read: none, want: "dev"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveVersion(tc.ldflags, tc.read); got != tc.want {
+				t.Errorf("resolveVersion(%q) = %q, want %q", tc.ldflags, got, tc.want)
+			}
+		})
+	}
+}

--- a/tools/migration/go.mod
+++ b/tools/migration/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.9
 	github.com/aws/aws-sdk-go-v2/config v1.32.20
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.9
-	github.com/gaborage/go-bricks v0.37.0
+	github.com/gaborage/go-bricks v0.38.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/knadh/koanf/parsers/yaml v1.1.0
 	github.com/knadh/koanf/providers/file v1.2.1
@@ -109,6 +109,3 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// Local development - replaced with versioned import on release.
-replace github.com/gaborage/go-bricks => ../../

--- a/tools/migration/go.sum
+++ b/tools/migration/go.sum
@@ -72,6 +72,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
+github.com/gaborage/go-bricks v0.38.0 h1:hZT9ItjHdePdpM7Xudu+xEmIzd8QIb1Joki9URz5/yA=
+github.com/gaborage/go-bricks v0.38.0/go.mod h1:SY0/tjg1DzOtvwk+8kOd2NaUYAPsTDWI39huCnb8k7g=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
## Phase D — make the migrate CLI `go install`-able

Final phase of the release-mechanism work. Makes `go install github.com/gaborage/go-bricks/tools/migration/cmd/go-bricks-migrate@vX.Y.Z` work and report the right version. (Titled `build(migrate):` so it doesn't trigger a framework release — the CLI has its own `tools/migration/vX.Y.Z` tag stream.)

### Changes
- **Drop the `replace` directive** from `tools/migration/go.mod` and pin `require go-bricks v0.38.0` (a real published version). A `replace` directive makes a module impossible to `go install @version`; removing it is the unblock. Verified: `GOWORK=off go -C tools/migration build ./...` builds against the **published** framework, not `../../`.
- **Add a root `go.work`** (allowlisted in `.gitignore`) so local dev still resolves the framework from the working tree. `go.work` is **not** consulted by `go install pkg@version`, so committing it is safe.
- **`main.go` reports the real version on `go install`** via `runtime/debug.ReadBuildInfo()` — ldflags only fire during `make build` in a git tree, so a module-cache build otherwise reported `"dev"`. TDD'd (`resolveVersion`, 6 table cases).
- **Scope the CLI's `git describe`** to `--match 'tools/migration/v*'` (strip the prefix) so the CLI version reflects its own tag, not the framework's. Document `go install` in the README.

### Verification
`GOWORK=off` build (published framework) ✅ · workspace dev build ✅ · `TestResolveVersion` 6/6 ✅ · gofmt/vet clean · `replace` count 0 · `require` = v0.38.0.

### Follow-up (immediately after merge)
A `tools/migration/v0.38.0` submodule tag will be cut (the CLI's first release tag) so `@v0.38.0` / `@latest` resolve. The tag-protection ruleset covers `tools/migration/v*` (admin-bypass), same as framework tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation docs for the CLI with new release-tag behavior and `go install` examples.

* **Chores**
  * Bumped dependency to v0.38.0.
  * Improved CLI version resolution and build/version tagging logic.
  * Adjusted ignore rules to ensure workspace files (go.work, go.work.sum) are preserved.

* **Tests**
  * Added unit tests covering CLI version resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->