### PR TITLE
ci: source Go toolchain from go.mod toolchain directive (self-healing)

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
 
@@ -175,7 +175,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
 
@@ -263,7 +263,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
 
@@ -430,7 +430,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
 
@@ -490,7 +490,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version-file: tools/migration/go.mod
           cache: true
           cache-dependency-path: tools/migration/go.sum
 
@@ -558,7 +558,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version-file: tools/migration/go.mod
           cache: true
           cache-dependency-path: tools/migration/go.sum
 
@@ -597,7 +597,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version-file: tools/migration/go.mod
           cache: true
           cache-dependency-path: tools/migration/go.sum
 
@@ -624,7 +624,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version-file: tools/migration/go.mod
           cache: true
           cache-dependency-path: tools/migration/go.sum
 
@@ -648,7 +648,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
 
@@ -671,7 +671,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
 
@@ -691,7 +691,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
       - name: Run govulncheck (framework)
@@ -713,7 +713,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version-file: tools/migration/go.mod
           cache: true
           cache-dependency-path: tools/migration/go.sum
       - name: Run govulncheck (migrate tool)
@@ -731,7 +731,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version-file: go.mod
           cache: true
           cache-dependency-path: |
             go.sum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
       - run: go mod download
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version-file: tools/migration/go.mod
           cache: true
           cache-dependency-path: tools/migration/go.sum
       - name: Build + validate CLI

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/gaborage/go-bricks
 
 go 1.26.0
 
+toolchain go1.26.4
+
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Masterminds/squirrel v1.5.4

--- a/tools/migration/go.mod
+++ b/tools/migration/go.mod
@@ -2,6 +2,8 @@ module github.com/gaborage/go-bricks/tools/migration
 
 go 1.26.0
 
+toolchain go1.26.4
+
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.10
 	github.com/aws/aws-sdk-go-v2/config v1.32.21


### PR DESCRIPTION
## Problem

govulncheck started failing CI's vuln gate (`vuln-migrate-tool`, `vuln-framework`, `vuln-weekly`) on two Go **standard-library** advisories — `GO-2026-5037` (crypto/x509) and `GO-2026-5039` (net/textproto) — both fixed in **go1.26.4**. The failure is unrelated to any code change: govulncheck's DB learns of a stdlib advisory the moment a Go security release ships, while CI was still building with the previous patch (1.26.3).

#528 applied an interim fix (exact pin `go-version: '1.26.4'`), but that literal must be hand-bumped on every future Go security release. (`check-latest: true` does **not** solve it: it resolves against the `actions/go-versions` manifest, which lags `go.dev/dl` by hours-to-days, so it still installed 1.26.3.)

## Change

Make **`go.mod` the single source of truth** for the Go toolchain:

- Add `toolchain go1.26.4` to both `go.mod` files.
- Replace the `go-version: '1.26.4'` literal with `go-version-file` in every `setup-go` block.

`setup-go` reads the `toolchain` directive (falling back to the `go` directive) and installs that exact version — fetching directly from `go.dev/dl` when it is newer than the Actions manifest (as 1.26.4 currently is). Because the *installed* toolchain is now 1.26.4, the `GOTOOLCHAIN=local` that setup-go sets is satisfied with no runtime toolchain switching.

### Why this is durable

**Renovate's native gomod manager bumps the `toolchain` directive** on future Go releases — so the vuln gate self-heals via a normal, reviewable dependency PR, with no workflow edits, and immune to the `actions/go-versions` manifest lag that defeats `check-latest`.

| Job class | `go-version-file` |
|---|---|
| framework | `go.mod` |
| migrate-tool | `tools/migration/go.mod` |
| vuln-weekly (both modules) | `go.mod` (root; both modules pin the same toolchain) |

## Verification

- `go mod tidy` verified idempotent — no `go.sum` churn, so release.yml's `git diff --exit-code go.mod go.sum` stays green.
- `make check` green; `actionlint` clean (exit 0).
- Final end-to-end confirmation is this PR's own CI: setup-go installing 1.26.4 from the directive and the three vuln jobs passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI and release workflows to use configuration-based Go version management instead of hardcoded values.
  * Added Go version specifications to module files for consistent toolchain usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->