### PR TITLE
refactor(database): extract shared SQL table-name validator to internal/sqlid

### DIFF
--- a/docs/superpowers/plans/2026-06-04-outbox-inbox-db-primitives.md
+++ b/docs/superpowers/plans/2026-06-04-outbox-inbox-db-primitives.md
@@ -30,6 +30,7 @@
 ### Task 1.1: sqlid package (replicate outbox's exact rules)
 
 - [ ] **Step 1 — failing test** `internal/sqlid/sqlid_test.go`:
+
 ```go
 package sqlid
 
@@ -66,8 +67,10 @@ func TestValidateTableName(t *testing.T) {
 	}
 }
 ```
+
 - [ ] **Step 2 — run red:** `go test ./internal/sqlid/` → FAIL (package/func undefined).
 - [ ] **Step 3 — implement** `internal/sqlid/sqlid.go`:
+
 ```go
 // Package sqlid validates SQL identifiers (table names) before they are
 // interpolated into DDL/DML, guarding against SQL identifier injection.
@@ -109,12 +112,14 @@ func ValidateTableName(name string) error {
 	return nil
 }
 ```
+
 - [ ] **Step 4 — run green:** `go test ./internal/sqlid/ -v` → PASS.
 - [ ] **Step 5 — commit:** `git add internal/sqlid && git commit -m "refactor(database): add internal/sqlid table-name validator"`
 
 ### Task 1.2: outbox delegates to sqlid (behavior-preserving)
 
 - [ ] **Step 1** — Modify `outbox/store.go`: replace the `validIdentifierPattern` var and `validateTableName` body (lines 13-44) with a thin wrapper that delegates and keeps the `outbox:` prefix; drop now-unused `regexp`/`strings` imports if no longer referenced (verify with the compiler):
+
 ```go
 // validateTableName checks that name is a safe SQL identifier, wrapping the
 // shared sqlid validator with the outbox package error prefix.
@@ -125,12 +130,14 @@ func validateTableName(name string) error {
 	return nil
 }
 ```
+
 Add `"github.com/gaborage/go-bricks/internal/sqlid"` to the import block; remove `"regexp"` and (if unused elsewhere in the file) `"strings"`.
 - [ ] **Step 2 — verify existing outbox tests still pass** (behavior preserved): `go test ./outbox/` → PASS. The existing `outbox/store_test.go` cases (`outbox$events`, `outbox#events` valid; dangerous rejected) must still pass; the error strings now read `outbox: table name …` (was `outbox: table name …` — confirm test assertions match; if a test asserts an exact old substring, update it minimally).
 - [ ] **Step 3 — `make check`** → PASS.
 - [ ] **Step 4 — commit:** `git add outbox/store.go outbox/*_test.go && git commit -m "refactor(outbox): use internal/sqlid for table-name validation"`
 
 ### Task 1.3: open + babysit PR1
+
 - [ ] `/code-review` then `/security-review` on the diff; address findings.
 - [ ] `gh pr create --base main --title "refactor(database): extract shared SQL table-name validator to internal/sqlid" --body <see PR body template>`.
 - [ ] Babysit: CI green, CodeRabbit comments addressed, SonarCloud quality gate pass. Then merge (per merge policy confirmed with user).
@@ -150,6 +157,7 @@ Add `"github.com/gaborage/go-bricks/internal/sqlid"` to the import block; remove
 ### Task 2.1: classifier predicates (unit-tested with fabricated driver errors)
 
 - [ ] **Step 1 — failing test** `database/errors_test.go`:
+
 ```go
 package database
 
@@ -229,8 +237,10 @@ func TestConstraintName(t *testing.T) {
 	}
 }
 ```
+
 - [ ] **Step 2 — run red:** `go test ./database/ -run 'Unique|ForeignKey|NotFound|ConstraintName'` → FAIL.
 - [ ] **Step 3 — implement** `database/errors.go`:
+
 ```go
 package database
 
@@ -304,6 +314,7 @@ func ConstraintName(err error) (string, bool) {
 	return "", false
 }
 ```
+
 - [ ] **Step 4 — run green:** `go test ./database/ -run 'Unique|ForeignKey|NotFound|ConstraintName' -v` → PASS.
 - [ ] **Step 5 — `make check`** → PASS (gofmt may reorder the const block; let it).
 - [ ] **Step 6 — commit:** `git add database/errors.go database/errors_test.go && git commit -m "feat(database): add IsUniqueViolation/IsForeignKeyViolation/IsNotFound/ConstraintName"`
@@ -336,6 +347,7 @@ func ConstraintName(err error) (string, bool) {
 - [ ] **Step 2 — run red.**
 - [ ] **Step 3 — implement** in `database/internal/tracking/utils.go`:
   - TrackDBOperation error block (currently lines 114-122):
+
 ```go
 	if err != nil {
 		// Treat sql.ErrNoRows and post-commit/rollback sql.ErrTxDone specially -
@@ -354,7 +366,9 @@ func ConstraintName(err error) (string, bool) {
 		logEvent.Debug().Msg("Database operation executed")
 	}
 ```
+
   - createDBSpan record-error guard (currently lines 246-251):
+
 ```go
 	if err != nil {
 		// sql.ErrNoRows and sql.ErrTxDone are not real errors.
@@ -364,6 +378,7 @@ func ConstraintName(err error) (string, bool) {
 		}
 	}
 ```
+
   (No new imports — `errors` and `database/sql` already imported.)
 - [ ] **Step 4 — run green** + `make check`.
 - [ ] **Step 5 — commit:** `git commit -am "fix(database): treat post-commit sql.ErrTxDone as benign in tracking (no ERROR log/span)"`
@@ -371,6 +386,7 @@ func ConstraintName(err error) (string, bool) {
 ### Task 3.2: WithTx + WithTxOptions
 
 - [ ] **Step 1 — failing test** `database/transaction_test.go` (use `database/testing` TestDB; assert commit on success, rollback+original-error on fn error, rollback+re-panic on panic, and no ERROR log on happy path):
+
 ```go
 package database_test
 
@@ -416,9 +432,11 @@ func TestWithTxRollsBackAndRepanics(t *testing.T) {
 	})
 }
 ```
+
 (If `dbtesting` cannot satisfy a bare `ExpectTransaction()` with no exec on the rollback path, adjust to the TestDB's documented rollback expectation API — consult `database/testing/fake_tx.go` `IsRolledBack()`.)
 - [ ] **Step 2 — run red.**
 - [ ] **Step 3 — implement** `database/transaction.go`:
+
 ```go
 package database
 
@@ -472,10 +490,12 @@ func WithTxOptions(ctx context.Context, db Interface, opts *sql.TxOptions, fn fu
 	return nil
 }
 ```
+
 - [ ] **Step 4 — run green** + `make check`.
 - [ ] **Step 5 — commit:** `git add database/transaction.go database/transaction_test.go && git commit -m "feat(database): add WithTx and WithTxOptions transaction helpers"`
 
 ### Task 3.3: dogfood docs (update examples to use WithTx)
+
 - [ ] Update the doc-comment examples in `outbox/outbox.go` and `database/types/transactor.go` to show `database.WithTx`; update `llms.txt` and `wiki/outbox.md`. Keep one manual Begin/Commit example for callers needing the tx handle outside a closure. Commit: `docs: show WithTx in transaction examples`.
 
 ### Task 3.4: open + babysit PR3.
@@ -496,6 +516,7 @@ func WithTxOptions(ctx context.Context, db Interface, opts *sql.TxOptions, fn fu
 ### Task 4.1: headers.go
 
 - [ ] **Step 1 — failing test** `outbox/headers_test.go`:
+
 ```go
 package outbox
 
@@ -528,8 +549,10 @@ func TestEventIDFromHeaders(t *testing.T) {
 	assert.False(t, ok)
 }
 ```
+
 - [ ] **Step 2 — run red.**
 - [ ] **Step 3 — implement** `outbox/headers.go`:
+
 ```go
 package outbox
 
@@ -568,10 +591,12 @@ func EventIDFromHeaders(h amqp.Table) (string, bool) {
 	}
 }
 ```
+
 - [ ] **Step 4 — run green** + `make check`.
 - [ ] **Step 5 — commit.**
 
 ### Task 4.2: rewire literals to constants
+
 - [ ] `outbox/relay.go:84-85` → `headers[HeaderEventID] = record.ID` / `headers[HeaderEventType] = record.EventType`.
 - [ ] Update `outbox/relay_test.go:191,192,208`, `outbox/publisher_test.go:404` to reference `HeaderEventID`/`HeaderEventType`. Update `outbox/outbox.go:8` doc to mention `outbox.HeaderEventID` / `outbox.EventIDFromHeaders`.
 - [ ] `go test ./outbox/` → PASS; `make check` → PASS. Commit: `refactor(outbox): reference HeaderEventID/HeaderEventType constants at the relay`.
@@ -599,7 +624,9 @@ func EventIDFromHeaders(h amqp.Table) (string, bool) {
 - Modify: `config/types.go:480-482` + `config.example.yaml:112` (outbox `auto_create_table` doc → default **false**, behavior-preserving) and add an `inbox:` block to `config.example.yaml`.
 
 ### Task 5.1: app wiring (interfaces + deps field + registry branch)
+
 - [ ] In `app/module.go`, after the OutboxProvider block (line 112) add:
+
 ```go
 // InboxProcessor runs a handler exactly once per event id, recording the id in a
 // durable, tenant-aware ledger atomically with the handler's writes. Defined here
@@ -616,13 +643,17 @@ type InboxProvider interface {
 	InboxProcessor() InboxProcessor
 }
 ```
+
 - [ ] Add the `ModuleDeps` field after `Outbox OutboxPublisher` (line 190):
+
 ```go
 	// Inbox provides durable consumer-side idempotency (ProcessOnce).
 	// This field is nil if no inbox module is registered or inbox.enabled is false.
 	Inbox InboxProcessor
 ```
+
 - [ ] In `app/module_registry.go`, after the KeyStoreProvider branch (line 89), before line 91:
+
 ```go
 	// Special case: If this module is an InboxProvider (inbox module),
 	// make it available to other modules via deps.Inbox
@@ -633,10 +664,13 @@ type InboxProvider interface {
 			Msg("Inbox module registered - available to other modules via deps.Inbox")
 	}
 ```
+
 - [ ] `make check` (app compiles with nil Inbox everywhere — keyed ModuleDeps literals unaffected). Commit: `feat(app): add InboxProcessor/InboxProvider wiring and deps.Inbox`.
 
 ### Task 5.2: config (InboxConfig + outbox doc fix + example)
+
 - [ ] Add `InboxConfig` to `config/types.go` after OutboxConfig (mirror tag style; `AutoCreateTable` honest off-by-default; `RetentionPeriod time.Duration`):
+
 ```go
 // InboxConfig holds consumer-side idempotency (inbox) settings.
 // Production-safe defaults are applied when inbox is enabled:
@@ -650,12 +684,15 @@ type InboxConfig struct {
 	RetentionPeriod time.Duration `koanf:"retention_period" json:"retention_period" yaml:"retention_period" toml:"retention_period" mapstructure:"retention_period"`
 }
 ```
+
 - [ ] Add `Inbox InboxConfig` to the `Config` struct after the `Outbox` line (run gofmt to realign).
 - [ ] Fix outbox doc (`config/types.go:480-482`): change `AutoCreateTable` comment to "Default: false. Set true in development; keep false for managed migrations." and `config.example.yaml:112` `auto_create_table: false`. Add an `inbox:` block to `config.example.yaml` after the outbox block (`enabled: false`, `table_name: gobricks_inbox`, `auto_create_table: false`, `retention_period: 168h`).
 - [ ] `make check`. Commit: `feat(config): add InboxConfig; correct outbox auto_create_table default doc to false`.
 
 ### Task 5.3: inbox store (Record, Store iface, PG + Oracle, sqlid guard)
+
 - [ ] **Record + Store + validateTableName** `inbox/store.go` (mirror `outbox/store.go` shape; package `inbox`; reuse `sqlid`):
+
 ```go
 package inbox
 
@@ -693,7 +730,9 @@ func validateTableName(name string) error {
 	return nil
 }
 ```
+
 - [ ] **Postgres** `inbox/store_postgres.go` (`//nolint:dupl` line before `package inbox`; `$N`; **ON CONFLICT DO NOTHING + RowsAffected**):
+
 ```go
 //nolint:dupl // Intentional: PostgreSQL and Oracle stores share structure but differ in SQL dialect
 package inbox
@@ -769,7 +808,9 @@ func (s *postgresStore) CreateTable(ctx context.Context, db dbtypes.Interface) e
 
 var _ Store = (*postgresStore)(nil)
 ```
+
 - [ ] **Oracle** `inbox/store_oracle.go` (`:N`; **plain INSERT + catch `database.IsUniqueViolation`**; no `IF NOT EXISTS`; function index). NOTE: imports `github.com/gaborage/go-bricks/database` for `IsUniqueViolation`:
+
 ```go
 //nolint:dupl // Intentional: Oracle and PostgreSQL stores share structure but differ in SQL dialect
 package inbox
@@ -844,12 +885,15 @@ func (s *oracleStore) CreateTable(ctx context.Context, db dbtypes.Interface) err
 
 var _ Store = (*oracleStore)(nil)
 ```
+
 NOTE on Oracle PK name: `pk_%s` consumes tableName once; if the table name is schema-qualified, the constraint name would contain a dot — guard by deriving the constraint suffix from the last segment, or document that schema-qualified inbox names are unsupported in v1 (simplest: require an unqualified `table_name` for inbox; validate in config). Decide during implementation; default to requiring unqualified inbox table names and asserting it in `validateConfig`.
 - [ ] **Tests** `inbox/store_postgres_test.go` / `inbox/store_oracle_test.go` mirror outbox store tests: `MarkProcessed` inserted=true (RowsAffected 1), duplicate inserted=false (PG RowsAffected 0; Oracle `WillReturnError` with a fabricated `*network.OracleError{ErrCode:1}` → inserted=false), `DeleteProcessed`, `CreateTable`. Conformance guards already in the store files.
 - [ ] `make check`. Commit: `feat(inbox): vendor-split ledger store (PG ON CONFLICT / Oracle catch unique violation)`.
 
 ### Task 5.4: config defaults + validation
+
 - [ ] `inbox/config.go` (mirror `outbox/config.go`):
+
 ```go
 package inbox
 
@@ -889,10 +933,13 @@ func validateConfig(c *config.InboxConfig) error {
 	return nil
 }
 ```
+
 - [ ] `inbox/config_test.go`: defaults applied, negative retention rejected, dotted table rejected. `make check`. Commit: `feat(inbox): config defaults and validation`.
 
 ### Task 5.5: Inbox processor (ProcessOnce — composes WithTx + store) + cleanup + module
+
 - [ ] `inbox/inbox.go`:
+
 ```go
 package inbox
 
@@ -935,7 +982,9 @@ func (i *Inbox) ProcessOnce(ctx context.Context, eventID string, fn func(ctx con
 	})
 }
 ```
+
 - [ ] `inbox/cleanup.go` (mirror `outbox/cleanup.go`; `DeleteProcessed`):
+
 ```go
 package inbox
 
@@ -968,15 +1017,18 @@ func (c *Cleanup) Execute(ctx scheduler.JobContext) error {
 	return nil
 }
 ```
+
 - [ ] `inbox/module.go` (mirror `outbox/module.go`: Module struct with `logger/config/getDB/store/cfg/initMu/tableCreated/processor`, `NewModule`, `Name`="inbox", `Init` (capture deps.Logger/Config/DB, `m.cfg = m.config.Inbox`, applyDefaults, validateConfig, Enabled short-circuit, fail-fast `getDB==nil`, build `&Inbox{module:m}`), `ensureStoreInitialized` (verbatim shape — switch `db.DatabaseType()` → `NewPostgresStore`/`NewOracleStore`, `tableCreated` guard, CreateTable-as-warning), `InboxProcessor()` provider method returning the `*Inbox`, `RegisterJobs` (only the cleanup `DailyAt("inbox-cleanup", …)` when `RetentionPeriod > 0` — **no relay**, so implement `app.JobProvider` for cleanup only; use a `lazyStore` wrapper for the cleanup job mirroring outbox), `Shutdown`). Inbox has no `getMsg`/`publisher`/messaging fail-fast.
 - [ ] `inbox/inbox_test.go`: `ProcessOnce` runs fn once on first id (TestDB: ExpectTransaction → ExpectExec INSERT RowsAffected 1 → fn side-effect exec → commit), skips fn on duplicate (RowsAffected 0 → fn NOT called → commit), and propagates fn errors (rollback). Use a captured bool to assert fn invocation.
 - [ ] `make check`. Commit: `feat(inbox): ProcessOnce idempotency helper, cleanup job, and module wiring`.
 
 ### Task 5.6: inbox/testing mock + assertions
+
 - [ ] `inbox/testing/mock_inbox.go`: `MockInbox` implementing `app.InboxProcessor` — records each `ProcessOnce(eventID)`, configurable "already processed" set (skip fn) and error; runs `fn(ctx, nil)` when not a duplicate so handler logic is exercised; thread-safe (mutex). `inbox/testing/assertions.go`: `AssertProcessed`, `AssertNotProcessed`, `AssertProcessCount` mirroring outbox/testing.
 - [ ] `make check`. Commit: `feat(inbox): testing mock and assertions`.
 
 ### Task 5.7: integration tests (both vendors)
+
 - [ ] `inbox/*_integration_test.go` (`//go:build integration`): same event id processed twice against PG and Oracle containers → fn runs once, second call is a no-op; verify PG path not poisoned and Oracle path survives. `make test-integration`.
 - [ ] Commit: `test(inbox): integration coverage for exactly-once across both vendors`.
 
@@ -985,6 +1037,7 @@ func (c *Cleanup) Execute(ctx scheduler.JobContext) error {
 ---
 
 ## Self-review notes (run before executing)
+
 - **Spec coverage:** P0.1→PR1; #533→PR2; P0.2+#534→PR3; #535→PR4; #536+InboxConfig+outbox-doc-fix→PR5. All §-items mapped.
 - **Type consistency:** `Store.MarkProcessed(ctx, tx, Record) (bool, error)` used identically in PG/Oracle/Inbox/tests; `app.InboxProcessor.ProcessOnce(ctx, eventID, fn func(ctx, tx dbtypes.Tx) error) error` matches `inbox.Inbox.ProcessOnce`; `database.IsUniqueViolation(error) bool` consumed by `inbox/store_oracle.go`; `sqlid.ValidateTableName` consumed by outbox + inbox.
 - **Decision encodings:** PG ON CONFLICT vs Oracle catch (Task 5.3); auto-create OFF-by-default honest bool (Task 5.2/5.4); error-only WithTx (Task 3.2); retention 168h not 7d (Task 5.4).

--- a/docs/superpowers/plans/2026-06-04-outbox-inbox-db-primitives.md
+++ b/docs/superpowers/plans/2026-06-04-outbox-inbox-db-primitives.md
@@ -1,0 +1,991 @@
+# DB primitives + outbox header + consumer inbox (#533–536) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver four go-bricks issues as five sequential PRs: a shared SQL-identifier validator (prefactor), a vendor-aware DB error classifier (#533), a `WithTx` transaction helper + tracking-noise fix (#534), exported outbox header constants + getter (#535), and a new durable consumer-side `inbox` package (#536).
+
+**Architecture:** Each PR is additive and independently reviewable, branched off updated `main`, driven through CI + CodeRabbit + SonarCloud. `#536` composes the three primitives. Spec: `docs/superpowers/specs/2026-06-04-outbox-inbox-db-primitives-design.md`.
+
+**Tech Stack:** Go 1.26, pgx/v5 (`pgconn`), sijms/go-ora/v2 (`network`), rabbitmq/amqp091-go, testify, `database/testing` (TestDB fluent mock), koanf config, release-please.
+
+**Conventions (apply to every PR):**
+- TDD: failing test → run (red) → implement → run (green) → `make check` → commit.
+- Commit trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- Conventional-Commit PR title IS the changelog entry (release-please owns `CHANGELOG.md`; never hand-edit it). Titles: `feat(scope): …` / `refactor(scope): …` / `fix(scope): …`.
+- Tests: camelCase `TestXxx`, `t.Context()` (Go 1.26), `require`/`assert`, partial SQL-pattern matching, `var _ Iface = (*concrete)(nil)` conformance guards.
+- Run `make check` before every commit; `/code-review` + `/security-review` before opening each PR.
+
+---
+
+## PR1 — `internal/sqlid` shared table-name validator (prefactor, behavior-preserving)
+
+**Branch:** `feat/sqlid-validator` (off `main`)
+**PR title:** `refactor(database): extract shared SQL table-name validator to internal/sqlid`
+
+**Files:**
+- Create: `internal/sqlid/sqlid.go`
+- Create: `internal/sqlid/sqlid_test.go`
+- Modify: `outbox/store.go:13-44` (delegate `validateTableName` to `sqlid`, keep `outbox:` prefix)
+
+### Task 1.1: sqlid package (replicate outbox's exact rules)
+
+- [ ] **Step 1 — failing test** `internal/sqlid/sqlid_test.go`:
+```go
+package sqlid
+
+import "testing"
+
+func TestValidateTableName(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"simple", "gobricks_inbox", false},
+		{"schema_qualified", "myschema.gobricks_inbox", false},
+		{"dollar_hash", "outbox$events#1", false},
+		{"empty", "", true},
+		{"semicolon", "t; DROP TABLE x", true},
+		{"comment_dashes", "t--x", true},
+		{"block_comment_open", "t/*x", true},
+		{"block_comment_close", "t*/x", true},
+		{"three_parts", "a.b.c", true},
+		{"leading_digit", "1table", true},
+		{"space", "my table", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTableName(tc.input)
+			if tc.wantErr && err == nil {
+				t.Fatalf("ValidateTableName(%q) = nil, want error", tc.input)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("ValidateTableName(%q) = %v, want nil", tc.input, err)
+			}
+		})
+	}
+}
+```
+- [ ] **Step 2 — run red:** `go test ./internal/sqlid/` → FAIL (package/func undefined).
+- [ ] **Step 3 — implement** `internal/sqlid/sqlid.go`:
+```go
+// Package sqlid validates SQL identifiers (table names) before they are
+// interpolated into DDL/DML, guarding against SQL identifier injection.
+// The rules mirror the historical outbox validator and database/internal/columns/parser.go.
+package sqlid
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// validIdentifierPattern matches safe SQL identifiers (letters, digits, underscore, $, #).
+var validIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_$#]*$`)
+
+// ValidateTableName checks that name is a safe SQL identifier.
+// Supports optional schema-qualified names (e.g., "myschema.table").
+// Returns a descriptive error when name is empty, contains dangerous SQL
+// fragments, has more than two dot-separated parts, or any part is not a
+// valid identifier.
+func ValidateTableName(name string) error {
+	if name == "" {
+		return fmt.Errorf("table name must not be empty")
+	}
+	for _, dangerous := range []string{";", "--", "/*", "*/"} {
+		if strings.Contains(name, dangerous) {
+			return fmt.Errorf("table name %q contains dangerous SQL characters", name)
+		}
+	}
+	parts := strings.Split(name, ".")
+	if len(parts) > 2 {
+		return fmt.Errorf("table name %q has too many dot-separated parts (expected schema.table or table)", name)
+	}
+	for _, part := range parts {
+		if !validIdentifierPattern.MatchString(part) {
+			return fmt.Errorf("table name part %q contains invalid identifier characters", part)
+		}
+	}
+	return nil
+}
+```
+- [ ] **Step 4 — run green:** `go test ./internal/sqlid/ -v` → PASS.
+- [ ] **Step 5 — commit:** `git add internal/sqlid && git commit -m "refactor(database): add internal/sqlid table-name validator"`
+
+### Task 1.2: outbox delegates to sqlid (behavior-preserving)
+
+- [ ] **Step 1** — Modify `outbox/store.go`: replace the `validIdentifierPattern` var and `validateTableName` body (lines 13-44) with a thin wrapper that delegates and keeps the `outbox:` prefix; drop now-unused `regexp`/`strings` imports if no longer referenced (verify with the compiler):
+```go
+// validateTableName checks that name is a safe SQL identifier, wrapping the
+// shared sqlid validator with the outbox package error prefix.
+func validateTableName(name string) error {
+	if err := sqlid.ValidateTableName(name); err != nil {
+		return fmt.Errorf("outbox: %w", err)
+	}
+	return nil
+}
+```
+Add `"github.com/gaborage/go-bricks/internal/sqlid"` to the import block; remove `"regexp"` and (if unused elsewhere in the file) `"strings"`.
+- [ ] **Step 2 — verify existing outbox tests still pass** (behavior preserved): `go test ./outbox/` → PASS. The existing `outbox/store_test.go` cases (`outbox$events`, `outbox#events` valid; dangerous rejected) must still pass; the error strings now read `outbox: table name …` (was `outbox: table name …` — confirm test assertions match; if a test asserts an exact old substring, update it minimally).
+- [ ] **Step 3 — `make check`** → PASS.
+- [ ] **Step 4 — commit:** `git add outbox/store.go outbox/*_test.go && git commit -m "refactor(outbox): use internal/sqlid for table-name validation"`
+
+### Task 1.3: open + babysit PR1
+- [ ] `/code-review` then `/security-review` on the diff; address findings.
+- [ ] `gh pr create --base main --title "refactor(database): extract shared SQL table-name validator to internal/sqlid" --body <see PR body template>`.
+- [ ] Babysit: CI green, CodeRabbit comments addressed, SonarCloud quality gate pass. Then merge (per merge policy confirmed with user).
+
+---
+
+## PR2 — #533 `database` error classifier
+
+**Branch:** `feat/db-error-classifier` (off updated `main`)
+**PR title:** `feat(database): add vendor-aware unique/FK/not-found error classifiers`
+
+**Files:**
+- Create: `database/errors.go`
+- Create: `database/errors_test.go`
+- Create: `database/errors_integration_test.go` (`//go:build integration`)
+
+### Task 2.1: classifier predicates (unit-tested with fabricated driver errors)
+
+- [ ] **Step 1 — failing test** `database/errors_test.go`:
+```go
+package database
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	oranet "github.com/sijms/go-ora/v2/network"
+)
+
+func TestIsUniqueViolation(t *testing.T) {
+	pgUnique := &pgconn.PgError{Code: "23505", ConstraintName: "uq_email"}
+	oraUnique := &oranet.OracleError{ErrCode: 1}
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"pg_unique", pgUnique, true},
+		{"pg_unique_wrapped", fmt.Errorf("insert: %w", pgUnique), true},
+		{"pg_fk_not_unique", &pgconn.PgError{Code: "23503"}, false},
+		{"oracle_unique", oraUnique, true},
+		{"oracle_other", &oranet.OracleError{ErrCode: 942}, false},
+		{"plain", errors.New("boom"), false},
+		{"no_rows", sql.ErrNoRows, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsUniqueViolation(tc.err); got != tc.want {
+				t.Fatalf("IsUniqueViolation = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsForeignKeyViolation(t *testing.T) {
+	if !IsForeignKeyViolation(&pgconn.PgError{Code: "23503"}) {
+		t.Fatal("pg 23503 should be FK violation")
+	}
+	if !IsForeignKeyViolation(&oranet.OracleError{ErrCode: 2291}) {
+		t.Fatal("ORA-02291 should be FK violation")
+	}
+	if IsForeignKeyViolation(&pgconn.PgError{Code: "23505"}) {
+		t.Fatal("pg 23505 is not FK violation")
+	}
+	if IsForeignKeyViolation(nil) {
+		t.Fatal("nil is not FK violation")
+	}
+}
+
+func TestIsNotFound(t *testing.T) {
+	if !IsNotFound(sql.ErrNoRows) {
+		t.Fatal("sql.ErrNoRows should be not-found")
+	}
+	if !IsNotFound(fmt.Errorf("scan: %w", sql.ErrNoRows)) {
+		t.Fatal("wrapped sql.ErrNoRows should be not-found")
+	}
+	if IsNotFound(nil) || IsNotFound(errors.New("x")) {
+		t.Fatal("nil/plain are not not-found")
+	}
+}
+
+func TestConstraintName(t *testing.T) {
+	name, ok := ConstraintName(&pgconn.PgError{Code: "23505", ConstraintName: "uq_email"})
+	if !ok || name != "uq_email" {
+		t.Fatalf("ConstraintName = %q,%v want uq_email,true", name, ok)
+	}
+	if _, ok := ConstraintName(&oranet.OracleError{ErrCode: 1}); ok {
+		t.Fatal("Oracle exposes no constraint name; want ok=false")
+	}
+	if _, ok := ConstraintName(nil); ok {
+		t.Fatal("nil → ok=false")
+	}
+}
+```
+- [ ] **Step 2 — run red:** `go test ./database/ -run 'Unique|ForeignKey|NotFound|ConstraintName'` → FAIL.
+- [ ] **Step 3 — implement** `database/errors.go`:
+```go
+package database
+
+import (
+	"database/sql"
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	oranet "github.com/sijms/go-ora/v2/network"
+)
+
+// SQLSTATE / ORA codes for constraint classification.
+const (
+	pgUniqueViolation     = "23505"
+	pgForeignKeyViolation = "23503"
+	oraUniqueViolation    = 1    // ORA-00001
+	oraForeignKeyViolation = 2291 // ORA-02291
+)
+
+// IsUniqueViolation reports whether err is a unique/primary-key constraint
+// violation (PostgreSQL SQLSTATE 23505, Oracle ORA-00001), traversing the
+// framework wrap chain via errors.As.
+func IsUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == pgUniqueViolation
+	}
+	var oraErr *oranet.OracleError
+	if errors.As(err, &oraErr) {
+		return oraErr.ErrCode == oraUniqueViolation
+	}
+	return false
+}
+
+// IsForeignKeyViolation reports whether err is a foreign-key constraint
+// violation (PostgreSQL 23503, Oracle ORA-02291).
+func IsForeignKeyViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == pgForeignKeyViolation
+	}
+	var oraErr *oranet.OracleError
+	if errors.As(err, &oraErr) {
+		return oraErr.ErrCode == oraForeignKeyViolation
+	}
+	return false
+}
+
+// IsNotFound reports whether err is a no-rows result (sql.ErrNoRows).
+// This is a scan-path signal; it is not produced by Exec.
+func IsNotFound(err error) bool {
+	return err != nil && errors.Is(err, sql.ErrNoRows)
+}
+
+// ConstraintName returns the violated constraint name when the driver exposes
+// it. PostgreSQL populates this; Oracle does not, so ok is false on Oracle.
+func ConstraintName(err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.ConstraintName != "" {
+		return pgErr.ConstraintName, true
+	}
+	return "", false
+}
+```
+- [ ] **Step 4 — run green:** `go test ./database/ -run 'Unique|ForeignKey|NotFound|ConstraintName' -v` → PASS.
+- [ ] **Step 5 — `make check`** → PASS (gofmt may reorder the const block; let it).
+- [ ] **Step 6 — commit:** `git add database/errors.go database/errors_test.go && git commit -m "feat(database): add IsUniqueViolation/IsForeignKeyViolation/IsNotFound/ConstraintName"`
+
+### Task 2.2: integration test (both vendors, real driver error)
+
+- [ ] **Step 1** — `database/errors_integration_test.go` (first line `//go:build integration`): using the existing testcontainers helpers (mirror `database/postgresql/connection_integration_test.go` setup), insert a duplicate key against Postgres and Oracle, then assert `IsUniqueViolation(err)` is true and (Postgres) `ConstraintName` returns the constraint. Reference the existing integration harness for container bootstrap — do not hand-roll.
+- [ ] **Step 2 — run:** `make test-integration` (Docker required) → PASS. If the local environment lacks Docker, note it in the PR and rely on CI's integration job.
+- [ ] **Step 3 — commit:** `git add database/errors_integration_test.go && git commit -m "test(database): integration coverage for unique-violation classifier (both vendors)"`
+
+### Task 2.3: open + babysit PR2 (same babysit loop as PR1).
+
+---
+
+## PR3 — P0.2 tracking `ErrTxDone` downgrade + #534 `WithTx`
+
+**Branch:** `feat/withtx-helper` (off updated `main`)
+**PR title:** `feat(database): add WithTx/WithTxOptions transaction helpers`
+
+**Files:**
+- Modify: `database/internal/tracking/utils.go:114-125` (TrackDBOperation) and `:246-253` (createDBSpan)
+- Create: `database/internal/tracking/utils_test.go` additions (ErrTxDone downgrade test) — or extend existing
+- Create: `database/transaction.go`
+- Create: `database/transaction_test.go`
+- Modify (docs, dogfood): `outbox/outbox.go` doc example, `database/types/transactor.go` doc example, `llms.txt`, `wiki/outbox.md`
+
+### Task 3.1: downgrade post-commit `sql.ErrTxDone` in tracking (P0.2)
+
+- [ ] **Step 1 — failing test** (extend tracking tests): assert that a `sql.ErrTxDone` passed through `TrackDBOperation` logs at Debug (not Error) and that `createDBSpan` does not record it as a span error, while a generic rollback error still logs Error. Mirror the existing `sql.ErrNoRows` test in `database/internal/tracking/utils_test.go`.
+- [ ] **Step 2 — run red.**
+- [ ] **Step 3 — implement** in `database/internal/tracking/utils.go`:
+  - TrackDBOperation error block (currently lines 114-122):
+```go
+	if err != nil {
+		// Treat sql.ErrNoRows and post-commit/rollback sql.ErrTxDone specially -
+		// not actual errors, log as debug.
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			logEvent.Debug().Msg("Database operation returned no rows")
+		case errors.Is(err, sql.ErrTxDone):
+			logEvent.Debug().Msg("Database transaction already finalized")
+		default:
+			logEvent.Error().Err(err).Msg("Database operation error")
+		}
+	} else if elapsed > tc.Settings.SlowQueryThreshold() {
+		logEvent.Warn().Msgf("Slow database operation detected (%s)", elapsed)
+	} else {
+		logEvent.Debug().Msg("Database operation executed")
+	}
+```
+  - createDBSpan record-error guard (currently lines 246-251):
+```go
+	if err != nil {
+		// sql.ErrNoRows and sql.ErrTxDone are not real errors.
+		if !errors.Is(err, sql.ErrNoRows) && !errors.Is(err, sql.ErrTxDone) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+	}
+```
+  (No new imports — `errors` and `database/sql` already imported.)
+- [ ] **Step 4 — run green** + `make check`.
+- [ ] **Step 5 — commit:** `git commit -am "fix(database): treat post-commit sql.ErrTxDone as benign in tracking (no ERROR log/span)"`
+
+### Task 3.2: WithTx + WithTxOptions
+
+- [ ] **Step 1 — failing test** `database/transaction_test.go` (use `database/testing` TestDB; assert commit on success, rollback+original-error on fn error, rollback+re-panic on panic, and no ERROR log on happy path):
+```go
+package database_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gaborage/go-bricks/database"
+	dbtesting "github.com/gaborage/go-bricks/database/testing"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithTxCommitsOnSuccess(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction().ExpectExec(`INSERT INTO t`).WillReturnRowsAffected(1)
+	err := database.WithTx(t.Context(), db, func(ctx context.Context, tx dbtypes.Tx) error {
+		_, e := tx.Exec(ctx, "INSERT INTO t VALUES (1)")
+		return e
+	})
+	require.NoError(t, err)
+}
+
+func TestWithTxRollsBackAndReturnsFnError(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction()
+	sentinel := errors.New("boom")
+	err := database.WithTx(t.Context(), db, func(ctx context.Context, tx dbtypes.Tx) error {
+		return sentinel
+	})
+	assert.ErrorIs(t, err, sentinel)
+}
+
+func TestWithTxRollsBackAndRepanics(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction()
+	assert.PanicsWithValue(t, "kaboom", func() {
+		_ = database.WithTx(t.Context(), db, func(ctx context.Context, tx dbtypes.Tx) error {
+			panic("kaboom")
+		})
+	})
+}
+```
+(If `dbtesting` cannot satisfy a bare `ExpectTransaction()` with no exec on the rollback path, adjust to the TestDB's documented rollback expectation API — consult `database/testing/fake_tx.go` `IsRolledBack()`.)
+- [ ] **Step 2 — run red.**
+- [ ] **Step 3 — implement** `database/transaction.go`:
+```go
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+)
+
+// WithTx runs fn inside a database transaction. It commits when fn returns nil,
+// rolls back when fn returns an error (returning fn's original error), and rolls
+// back then re-panics if fn panics. After a successful commit the deferred
+// rollback is skipped, so there is no post-commit rollback noise.
+func WithTx(ctx context.Context, db Interface, fn func(ctx context.Context, tx Tx) error) (err error) {
+	return WithTxOptions(ctx, db, nil, fn)
+}
+
+// WithTxOptions is WithTx with an explicit isolation level / read-only mode.
+func WithTxOptions(ctx context.Context, db Interface, opts *sql.TxOptions, fn func(ctx context.Context, tx Tx) error) (err error) {
+	var tx Tx
+	if opts != nil {
+		tx, err = db.BeginTx(ctx, opts)
+	} else {
+		tx, err = db.Begin(ctx)
+	}
+	if err != nil {
+		return err
+	}
+
+	committed := false
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback(ctx)
+			panic(p)
+		}
+		if !committed {
+			if rbErr := tx.Rollback(ctx); rbErr != nil && !errors.Is(rbErr, sql.ErrTxDone) && err == nil {
+				err = rbErr
+			}
+		}
+	}()
+
+	if err = fn(ctx, tx); err != nil {
+		return err
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+```
+- [ ] **Step 4 — run green** + `make check`.
+- [ ] **Step 5 — commit:** `git add database/transaction.go database/transaction_test.go && git commit -m "feat(database): add WithTx and WithTxOptions transaction helpers"`
+
+### Task 3.3: dogfood docs (update examples to use WithTx)
+- [ ] Update the doc-comment examples in `outbox/outbox.go` and `database/types/transactor.go` to show `database.WithTx`; update `llms.txt` and `wiki/outbox.md`. Keep one manual Begin/Commit example for callers needing the tx handle outside a closure. Commit: `docs: show WithTx in transaction examples`.
+
+### Task 3.4: open + babysit PR3.
+
+---
+
+## PR4 — #535 outbox header constants + getter
+
+**Branch:** `feat/outbox-header-export` (off updated `main`)
+**PR title:** `feat(outbox): export x-outbox-event-id header name and EventIDFromHeaders getter`
+
+**Files:**
+- Create: `outbox/headers.go`
+- Create: `outbox/headers_test.go`
+- Modify: `outbox/relay.go:84-85` (reference the constants)
+- Modify tests/docs referencing the literals (see occurrence list in spec/anchor): `outbox/relay_test.go:191,192,208`, `outbox/publisher_test.go:404`, `outbox/outbox.go:8` doc.
+
+### Task 4.1: headers.go
+
+- [ ] **Step 1 — failing test** `outbox/headers_test.go`:
+```go
+package outbox
+
+import (
+	"testing"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventIDFromHeaders(t *testing.T) {
+	id, ok := EventIDFromHeaders(amqp.Table{HeaderEventID: "evt-1"})
+	assert.True(t, ok)
+	assert.Equal(t, "evt-1", id)
+
+	id, ok = EventIDFromHeaders(amqp.Table{HeaderEventID: []byte("evt-2")})
+	assert.True(t, ok)
+	assert.Equal(t, "evt-2", id)
+
+	_, ok = EventIDFromHeaders(amqp.Table{})
+	assert.False(t, ok)
+
+	_, ok = EventIDFromHeaders(nil)
+	assert.False(t, ok)
+
+	_, ok = EventIDFromHeaders(amqp.Table{HeaderEventID: 42})
+	assert.False(t, ok)
+
+	_, ok = EventIDFromHeaders(amqp.Table{HeaderEventID: ""})
+	assert.False(t, ok)
+}
+```
+- [ ] **Step 2 — run red.**
+- [ ] **Step 3 — implement** `outbox/headers.go`:
+```go
+package outbox
+
+import amqp "github.com/rabbitmq/amqp091-go"
+
+// AMQP delivery header names stamped by the relay for consumer idempotency.
+// These are the single source of truth; relay.go references them.
+const (
+	// HeaderEventID carries the unique outbox event id (UUID) for deduplication.
+	HeaderEventID = "x-outbox-event-id"
+	// HeaderEventType carries the event type.
+	HeaderEventType = "x-outbox-event-type"
+)
+
+// EventIDFromHeaders extracts the outbox event id from AMQP delivery headers,
+// returning ok=false when absent, empty, or not a string/[]byte. Header values
+// may arrive as string or []byte over the wire, so both are normalized.
+func EventIDFromHeaders(h amqp.Table) (string, bool) {
+	raw, present := h[HeaderEventID]
+	if !present {
+		return "", false
+	}
+	switch v := raw.(type) {
+	case string:
+		if v == "" {
+			return "", false
+		}
+		return v, true
+	case []byte:
+		if len(v) == 0 {
+			return "", false
+		}
+		return string(v), true
+	default:
+		return "", false
+	}
+}
+```
+- [ ] **Step 4 — run green** + `make check`.
+- [ ] **Step 5 — commit.**
+
+### Task 4.2: rewire literals to constants
+- [ ] `outbox/relay.go:84-85` → `headers[HeaderEventID] = record.ID` / `headers[HeaderEventType] = record.EventType`.
+- [ ] Update `outbox/relay_test.go:191,192,208`, `outbox/publisher_test.go:404` to reference `HeaderEventID`/`HeaderEventType`. Update `outbox/outbox.go:8` doc to mention `outbox.HeaderEventID` / `outbox.EventIDFromHeaders`.
+- [ ] `go test ./outbox/` → PASS; `make check` → PASS. Commit: `refactor(outbox): reference HeaderEventID/HeaderEventType constants at the relay`.
+
+### Task 4.3: open + babysit PR4.
+
+---
+
+## PR5 — #536 `inbox` package (integrates 1–4)
+
+**Branch:** `feat/inbox-idempotency` (off updated `main`)
+**PR title:** `feat(inbox): add durable consumer-side idempotency ledger (ProcessOnce)`
+
+**Files:**
+- Create: `inbox/store.go`, `inbox/store_postgres.go`, `inbox/store_oracle.go`
+- Create: `inbox/config.go`
+- Create: `inbox/cleanup.go`
+- Create: `inbox/module.go`
+- Create: `inbox/inbox.go` (the `Inbox` processor implementing `app.InboxProcessor`)
+- Create: `inbox/testing/mock_inbox.go`, `inbox/testing/assertions.go`
+- Create: tests: `inbox/store_postgres_test.go`, `inbox/store_oracle_test.go`, `inbox/inbox_test.go`, `inbox/config_test.go`, `inbox/*_integration_test.go`
+- Modify: `app/module.go` (add `InboxProcessor` + `InboxProvider` interfaces near the Outbox triad at 68-112; add `Inbox InboxProcessor` field after `Outbox` at line 190)
+- Modify: `app/module_registry.go` (insert `InboxProvider` branch after KeyStoreProvider, between lines 89 and 91)
+- Modify: `config/types.go` (add `InboxConfig` after OutboxConfig at line 505; add `Inbox InboxConfig` field after line 27)
+- Modify: `config/types.go:480-482` + `config.example.yaml:112` (outbox `auto_create_table` doc → default **false**, behavior-preserving) and add an `inbox:` block to `config.example.yaml`.
+
+### Task 5.1: app wiring (interfaces + deps field + registry branch)
+- [ ] In `app/module.go`, after the OutboxProvider block (line 112) add:
+```go
+// InboxProcessor runs a handler exactly once per event id, recording the id in a
+// durable, tenant-aware ledger atomically with the handler's writes. Defined here
+// to avoid an app<->inbox import cycle; the inbox package implements it.
+type InboxProcessor interface {
+	// ProcessOnce runs fn inside a transaction exactly once per eventID. A redelivery
+	// of an already-processed id short-circuits (fn is not run) and returns nil.
+	ProcessOnce(ctx context.Context, eventID string, fn func(ctx context.Context, tx dbtypes.Tx) error) error
+}
+
+// InboxProvider is an optional interface modules implement to provide an
+// InboxProcessor for DI. The ModuleRegistry wires it into ModuleDeps.Inbox.
+type InboxProvider interface {
+	InboxProcessor() InboxProcessor
+}
+```
+- [ ] Add the `ModuleDeps` field after `Outbox OutboxPublisher` (line 190):
+```go
+	// Inbox provides durable consumer-side idempotency (ProcessOnce).
+	// This field is nil if no inbox module is registered or inbox.enabled is false.
+	Inbox InboxProcessor
+```
+- [ ] In `app/module_registry.go`, after the KeyStoreProvider branch (line 89), before line 91:
+```go
+	// Special case: If this module is an InboxProvider (inbox module),
+	// make it available to other modules via deps.Inbox
+	if inboxProvider, ok := module.(InboxProvider); ok {
+		r.deps.Inbox = inboxProvider.InboxProcessor()
+		r.logger.Info().
+			Str("module", moduleName).
+			Msg("Inbox module registered - available to other modules via deps.Inbox")
+	}
+```
+- [ ] `make check` (app compiles with nil Inbox everywhere — keyed ModuleDeps literals unaffected). Commit: `feat(app): add InboxProcessor/InboxProvider wiring and deps.Inbox`.
+
+### Task 5.2: config (InboxConfig + outbox doc fix + example)
+- [ ] Add `InboxConfig` to `config/types.go` after OutboxConfig (mirror tag style; `AutoCreateTable` honest off-by-default; `RetentionPeriod time.Duration`):
+```go
+// InboxConfig holds consumer-side idempotency (inbox) settings.
+// Production-safe defaults are applied when inbox is enabled:
+//   - TableName: "gobricks_inbox"
+//   - AutoCreateTable: false (opt-in; set true in dev or set false with managed migrations)
+//   - RetentionPeriod: 168h (7d; must exceed the broker's max redelivery window)
+type InboxConfig struct {
+	Enabled         bool          `koanf:"enabled" json:"enabled" yaml:"enabled" toml:"enabled" mapstructure:"enabled"`
+	TableName       string        `koanf:"table_name" json:"table_name" yaml:"table_name" toml:"table_name" mapstructure:"table_name"`
+	AutoCreateTable bool          `koanf:"auto_create_table" json:"auto_create_table" yaml:"auto_create_table" toml:"auto_create_table" mapstructure:"auto_create_table"`
+	RetentionPeriod time.Duration `koanf:"retention_period" json:"retention_period" yaml:"retention_period" toml:"retention_period" mapstructure:"retention_period"`
+}
+```
+- [ ] Add `Inbox InboxConfig` to the `Config` struct after the `Outbox` line (run gofmt to realign).
+- [ ] Fix outbox doc (`config/types.go:480-482`): change `AutoCreateTable` comment to "Default: false. Set true in development; keep false for managed migrations." and `config.example.yaml:112` `auto_create_table: false`. Add an `inbox:` block to `config.example.yaml` after the outbox block (`enabled: false`, `table_name: gobricks_inbox`, `auto_create_table: false`, `retention_period: 168h`).
+- [ ] `make check`. Commit: `feat(config): add InboxConfig; correct outbox auto_create_table default doc to false`.
+
+### Task 5.3: inbox store (Record, Store iface, PG + Oracle, sqlid guard)
+- [ ] **Record + Store + validateTableName** `inbox/store.go` (mirror `outbox/store.go` shape; package `inbox`; reuse `sqlid`):
+```go
+package inbox
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/internal/sqlid"
+)
+
+// Record is one row in the inbox ledger.
+type Record struct {
+	TenantID    string
+	EventID     string
+	ProcessedAt time.Time
+}
+
+// Store abstracts inbox ledger operations for vendor-agnostic SQL.
+type Store interface {
+	// MarkProcessed records (tenant_id, event_id) within tx. Returns inserted=true
+	// the first time and inserted=false on a duplicate (already processed).
+	MarkProcessed(ctx context.Context, tx dbtypes.Tx, rec Record) (inserted bool, err error)
+	// DeleteProcessed removes ledger rows processed before the given time.
+	DeleteProcessed(ctx context.Context, db dbtypes.Interface, before time.Time) (int64, error)
+	// CreateTable creates the inbox table and index if they do not exist.
+	CreateTable(ctx context.Context, db dbtypes.Interface) error
+}
+
+func validateTableName(name string) error {
+	if err := sqlid.ValidateTableName(name); err != nil {
+		return fmt.Errorf("inbox: %w", err)
+	}
+	return nil
+}
+```
+- [ ] **Postgres** `inbox/store_postgres.go` (`//nolint:dupl` line before `package inbox`; `$N`; **ON CONFLICT DO NOTHING + RowsAffected**):
+```go
+//nolint:dupl // Intentional: PostgreSQL and Oracle stores share structure but differ in SQL dialect
+package inbox
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+)
+
+const postgresCreateTableSQL = `
+CREATE TABLE IF NOT EXISTS %s (
+    tenant_id     VARCHAR(255) NOT NULL DEFAULT '',
+    event_id      VARCHAR(255) NOT NULL,
+    processed_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, event_id)
+)`
+
+const postgresCreateProcessedIndexSQL = `
+CREATE INDEX IF NOT EXISTS idx_%s_processed ON %s (processed_at)`
+
+type postgresStore struct{ tableName string }
+
+// NewPostgresStore creates a PostgreSQL inbox store.
+func NewPostgresStore(tableName string) (Store, error) {
+	if err := validateTableName(tableName); err != nil {
+		return nil, err
+	}
+	return &postgresStore{tableName: tableName}, nil
+}
+
+func (s *postgresStore) MarkProcessed(ctx context.Context, tx dbtypes.Tx, rec Record) (bool, error) {
+	query := fmt.Sprintf(
+		`INSERT INTO %s (tenant_id, event_id, processed_at) VALUES ($1, $2, $3)
+		 ON CONFLICT (tenant_id, event_id) DO NOTHING`,
+		s.tableName,
+	)
+	res, err := tx.Exec(ctx, query, rec.TenantID, rec.EventID, rec.ProcessedAt)
+	if err != nil {
+		return false, fmt.Errorf("inbox postgres: mark processed failed: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("inbox postgres: rows affected failed: %w", err)
+	}
+	return n == 1, nil
+}
+
+func (s *postgresStore) DeleteProcessed(ctx context.Context, db dbtypes.Interface, before time.Time) (int64, error) {
+	query := fmt.Sprintf(`DELETE FROM %s WHERE processed_at < $1`, s.tableName)
+	res, err := db.Exec(ctx, query, before)
+	if err != nil {
+		return 0, fmt.Errorf("inbox postgres: delete processed failed: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("inbox postgres: rows affected failed: %w", err)
+	}
+	return n, nil
+}
+
+func (s *postgresStore) CreateTable(ctx context.Context, db dbtypes.Interface) error {
+	if _, err := db.Exec(ctx, fmt.Sprintf(postgresCreateTableSQL, s.tableName)); err != nil {
+		return fmt.Errorf("inbox postgres: create table failed: %w", err)
+	}
+	if _, err := db.Exec(ctx, fmt.Sprintf(postgresCreateProcessedIndexSQL, s.tableName, s.tableName)); err != nil {
+		return fmt.Errorf("inbox postgres: create index failed: %w", err)
+	}
+	return nil
+}
+
+var _ Store = (*postgresStore)(nil)
+```
+- [ ] **Oracle** `inbox/store_oracle.go` (`:N`; **plain INSERT + catch `database.IsUniqueViolation`**; no `IF NOT EXISTS`; function index). NOTE: imports `github.com/gaborage/go-bricks/database` for `IsUniqueViolation`:
+```go
+//nolint:dupl // Intentional: Oracle and PostgreSQL stores share structure but differ in SQL dialect
+package inbox
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gaborage/go-bricks/database"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+)
+
+const oracleCreateTableSQL = `
+CREATE TABLE %s (
+    tenant_id     VARCHAR2(255) DEFAULT '' NOT NULL,
+    event_id      VARCHAR2(255) NOT NULL,
+    processed_at  TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+    CONSTRAINT pk_%s PRIMARY KEY (tenant_id, event_id)
+)`
+
+const oracleCreateProcessedIndexSQL = `
+CREATE INDEX idx_%s_processed ON %s (processed_at)`
+
+type oracleStore struct{ tableName string }
+
+// NewOracleStore creates an Oracle inbox store.
+func NewOracleStore(tableName string) (Store, error) {
+	if err := validateTableName(tableName); err != nil {
+		return nil, err
+	}
+	return &oracleStore{tableName: tableName}, nil
+}
+
+func (s *oracleStore) MarkProcessed(ctx context.Context, tx dbtypes.Tx, rec Record) (bool, error) {
+	query := fmt.Sprintf(
+		`INSERT INTO %s (tenant_id, event_id, processed_at) VALUES (:1, :2, :3)`,
+		s.tableName,
+	)
+	_, err := tx.Exec(ctx, query, rec.TenantID, rec.EventID, rec.ProcessedAt)
+	if err != nil {
+		if database.IsUniqueViolation(err) {
+			return false, nil // already processed (Oracle statement-level rollback keeps tx usable)
+		}
+		return false, fmt.Errorf("inbox oracle: mark processed failed: %w", err)
+	}
+	return true, nil
+}
+
+func (s *oracleStore) DeleteProcessed(ctx context.Context, db dbtypes.Interface, before time.Time) (int64, error) {
+	query := fmt.Sprintf(`DELETE FROM %s WHERE processed_at < :1`, s.tableName)
+	res, err := db.Exec(ctx, query, before)
+	if err != nil {
+		return 0, fmt.Errorf("inbox oracle: delete processed failed: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("inbox oracle: rows affected failed: %w", err)
+	}
+	return n, nil
+}
+
+func (s *oracleStore) CreateTable(ctx context.Context, db dbtypes.Interface) error {
+	if _, err := db.Exec(ctx, fmt.Sprintf(oracleCreateTableSQL, s.tableName, s.tableName)); err != nil {
+		return fmt.Errorf("inbox oracle: create table failed: %w", err)
+	}
+	if _, err := db.Exec(ctx, fmt.Sprintf(oracleCreateProcessedIndexSQL, s.tableName, s.tableName)); err != nil {
+		return fmt.Errorf("inbox oracle: create index failed: %w", err)
+	}
+	return nil
+}
+
+var _ Store = (*oracleStore)(nil)
+```
+NOTE on Oracle PK name: `pk_%s` consumes tableName once; if the table name is schema-qualified, the constraint name would contain a dot — guard by deriving the constraint suffix from the last segment, or document that schema-qualified inbox names are unsupported in v1 (simplest: require an unqualified `table_name` for inbox; validate in config). Decide during implementation; default to requiring unqualified inbox table names and asserting it in `validateConfig`.
+- [ ] **Tests** `inbox/store_postgres_test.go` / `inbox/store_oracle_test.go` mirror outbox store tests: `MarkProcessed` inserted=true (RowsAffected 1), duplicate inserted=false (PG RowsAffected 0; Oracle `WillReturnError` with a fabricated `*network.OracleError{ErrCode:1}` → inserted=false), `DeleteProcessed`, `CreateTable`. Conformance guards already in the store files.
+- [ ] `make check`. Commit: `feat(inbox): vendor-split ledger store (PG ON CONFLICT / Oracle catch unique violation)`.
+
+### Task 5.4: config defaults + validation
+- [ ] `inbox/config.go` (mirror `outbox/config.go`):
+```go
+package inbox
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gaborage/go-bricks/config"
+)
+
+// DefaultTableName is the default inbox ledger table name.
+const DefaultTableName = "gobricks_inbox"
+
+// DefaultRetentionPeriod is the default processed-event retention (7 days).
+// Must exceed the broker's maximum redelivery window. Written as a duration
+// (168h); Go's time.ParseDuration does not accept "7d".
+const DefaultRetentionPeriod = 7 * 24 * time.Hour
+
+func applyDefaults(c *config.InboxConfig) {
+	if c.TableName == "" {
+		c.TableName = DefaultTableName
+	}
+	if c.RetentionPeriod == 0 {
+		c.RetentionPeriod = DefaultRetentionPeriod
+	}
+	// AutoCreateTable intentionally left at its zero value (false, opt-in).
+}
+
+func validateConfig(c *config.InboxConfig) error {
+	if c.RetentionPeriod < 0 {
+		return fmt.Errorf("inbox: retention_period must not be negative, got %s", c.RetentionPeriod)
+	}
+	if strings.Contains(c.TableName, ".") {
+		return fmt.Errorf("inbox: table_name %q must be unqualified (schema-qualified names unsupported)", c.TableName)
+	}
+	return nil
+}
+```
+- [ ] `inbox/config_test.go`: defaults applied, negative retention rejected, dotted table rejected. `make check`. Commit: `feat(inbox): config defaults and validation`.
+
+### Task 5.5: Inbox processor (ProcessOnce — composes WithTx + store) + cleanup + module
+- [ ] `inbox/inbox.go`:
+```go
+package inbox
+
+import (
+	"context"
+	"time"
+
+	"github.com/gaborage/go-bricks/database"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/multitenant"
+)
+
+// Inbox runs handlers exactly once per event id, backed by a durable ledger.
+type Inbox struct {
+	module *Module
+}
+
+// ProcessOnce records eventID in the ledger and runs fn exactly once per id,
+// atomically. A redelivery of an already-processed id short-circuits (fn not run)
+// and returns nil. Tenant is resolved from ctx.
+func (i *Inbox) ProcessOnce(ctx context.Context, eventID string, fn func(ctx context.Context, tx dbtypes.Tx) error) error {
+	if err := i.module.ensureStoreInitialized(ctx); err != nil {
+		return err
+	}
+	db, err := i.module.getDB(ctx)
+	if err != nil {
+		return err
+	}
+	tenantID, _ := multitenant.GetTenant(ctx) // "" in single-tenant mode
+	rec := Record{TenantID: tenantID, EventID: eventID, ProcessedAt: time.Now()}
+	return database.WithTx(ctx, db, func(ctx context.Context, tx dbtypes.Tx) error {
+		inserted, err := i.module.store.MarkProcessed(ctx, tx, rec)
+		if err != nil {
+			return err
+		}
+		if !inserted {
+			return nil // already processed → skip fn, commit no-op
+		}
+		return fn(ctx, tx)
+	})
+}
+```
+- [ ] `inbox/cleanup.go` (mirror `outbox/cleanup.go`; `DeleteProcessed`):
+```go
+package inbox
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gaborage/go-bricks/scheduler"
+)
+
+// Cleanup removes processed-event rows older than the retention period.
+type Cleanup struct {
+	store           Store
+	retentionPeriod time.Duration
+}
+
+func (c *Cleanup) Execute(ctx scheduler.JobContext) error {
+	db := ctx.DB()
+	if db == nil {
+		return fmt.Errorf("inbox cleanup: database not available")
+	}
+	cutoff := time.Now().Add(-c.retentionPeriod)
+	deleted, err := c.store.DeleteProcessed(ctx, db, cutoff)
+	if err != nil {
+		return fmt.Errorf("inbox cleanup: delete failed: %w", err)
+	}
+	if deleted > 0 {
+		ctx.Logger().Info().Int64("deleted", deleted).Str("cutoff", cutoff.Format(time.RFC3339)).Msg("Inbox cleanup completed")
+	}
+	return nil
+}
+```
+- [ ] `inbox/module.go` (mirror `outbox/module.go`: Module struct with `logger/config/getDB/store/cfg/initMu/tableCreated/processor`, `NewModule`, `Name`="inbox", `Init` (capture deps.Logger/Config/DB, `m.cfg = m.config.Inbox`, applyDefaults, validateConfig, Enabled short-circuit, fail-fast `getDB==nil`, build `&Inbox{module:m}`), `ensureStoreInitialized` (verbatim shape — switch `db.DatabaseType()` → `NewPostgresStore`/`NewOracleStore`, `tableCreated` guard, CreateTable-as-warning), `InboxProcessor()` provider method returning the `*Inbox`, `RegisterJobs` (only the cleanup `DailyAt("inbox-cleanup", …)` when `RetentionPeriod > 0` — **no relay**, so implement `app.JobProvider` for cleanup only; use a `lazyStore` wrapper for the cleanup job mirroring outbox), `Shutdown`). Inbox has no `getMsg`/`publisher`/messaging fail-fast.
+- [ ] `inbox/inbox_test.go`: `ProcessOnce` runs fn once on first id (TestDB: ExpectTransaction → ExpectExec INSERT RowsAffected 1 → fn side-effect exec → commit), skips fn on duplicate (RowsAffected 0 → fn NOT called → commit), and propagates fn errors (rollback). Use a captured bool to assert fn invocation.
+- [ ] `make check`. Commit: `feat(inbox): ProcessOnce idempotency helper, cleanup job, and module wiring`.
+
+### Task 5.6: inbox/testing mock + assertions
+- [ ] `inbox/testing/mock_inbox.go`: `MockInbox` implementing `app.InboxProcessor` — records each `ProcessOnce(eventID)`, configurable "already processed" set (skip fn) and error; runs `fn(ctx, nil)` when not a duplicate so handler logic is exercised; thread-safe (mutex). `inbox/testing/assertions.go`: `AssertProcessed`, `AssertNotProcessed`, `AssertProcessCount` mirroring outbox/testing.
+- [ ] `make check`. Commit: `feat(inbox): testing mock and assertions`.
+
+### Task 5.7: integration tests (both vendors)
+- [ ] `inbox/*_integration_test.go` (`//go:build integration`): same event id processed twice against PG and Oracle containers → fn runs once, second call is a no-op; verify PG path not poisoned and Oracle path survives. `make test-integration`.
+- [ ] Commit: `test(inbox): integration coverage for exactly-once across both vendors`.
+
+### Task 5.8: open + babysit PR5.
+
+---
+
+## Self-review notes (run before executing)
+- **Spec coverage:** P0.1→PR1; #533→PR2; P0.2+#534→PR3; #535→PR4; #536+InboxConfig+outbox-doc-fix→PR5. All §-items mapped.
+- **Type consistency:** `Store.MarkProcessed(ctx, tx, Record) (bool, error)` used identically in PG/Oracle/Inbox/tests; `app.InboxProcessor.ProcessOnce(ctx, eventID, fn func(ctx, tx dbtypes.Tx) error) error` matches `inbox.Inbox.ProcessOnce`; `database.IsUniqueViolation(error) bool` consumed by `inbox/store_oracle.go`; `sqlid.ValidateTableName` consumed by outbox + inbox.
+- **Decision encodings:** PG ON CONFLICT vs Oracle catch (Task 5.3); auto-create OFF-by-default honest bool (Task 5.2/5.4); error-only WithTx (Task 3.2); retention 168h not 7d (Task 5.4).
+- **Open impl decision:** Oracle PK constraint name with schema-qualified table → resolved by requiring unqualified inbox `table_name` (validateConfig).

--- a/docs/superpowers/specs/2026-06-04-outbox-inbox-db-primitives-design.md
+++ b/docs/superpowers/specs/2026-06-04-outbox-inbox-db-primitives-design.md
@@ -10,7 +10,7 @@ Four GitHub issues form one coherent **transactional-outbox → consumer-idempot
 Three are small, independent primitives; the fourth (#536) composes all three into a new
 durable consumer-side "inbox".
 
-```
+```text
 #533 database.IsUniqueViolation ─┐
 #534 database.WithTx ────────────┼──►  #536 inbox.ProcessOnce  (new package)
 #535 outbox.HeaderEventID ───────┘
@@ -68,6 +68,7 @@ tests, and `llms.txt` examples carry the begin/commit/rollback shape). The prefa
 behavior-preserving (or doc-only) changes that make the four issues mechanical.
 
 ### P0.1 — Extract `internal/sqlid.ValidateTableName` (do-first, behavior-preserving for outbox)
+
 - New package **`internal/sqlid`** at the **repo root** (NOT `database/internal/…` — sibling packages
   `outbox/` and `migration/` cannot import another tree's `internal/`).
 - `func ValidateTableName(name string) error` — replicate outbox's exact current rules: optional
@@ -81,6 +82,7 @@ behavior-preserving (or doc-only) changes that make the four issues mechanical.
   unquoted-DDL bug here (see §9 discovered issues).
 
 ### P0.2 — Downgrade post-commit `sql.ErrTxDone` in the tracking layer (recommended; observability-only)
+
 - `database/internal/tracking/transaction.go` `Rollback` + `database/internal/tracking/utils.go`
   `TrackDBOperation` / `createDBSpan`: add an `errors.Is(err, sql.ErrTxDone)` arm that mirrors the
   existing `sql.ErrNoRows` special-case — log at DEBUG and skip `span.RecordError` instead of ERROR.
@@ -94,6 +96,7 @@ behavior-preserving (or doc-only) changes that make the four issues mechanical.
   rollback error — add a test asserting a genuine rollback error still logs ERROR).
 
 ### P0.3 — Config plumbing (mostly mirror; one doc-only outbox fix)
+
 - Correct outbox's doc/example to state `auto_create_table` default = **false** (matches 4 releases of
   actual shipped behavior; `applyDefaults` never set it). `config/types.go:480-482` doc comment +
   `config.example.yaml:112`. **Behavior-preserving** (code already does false).
@@ -184,6 +187,7 @@ func EventIDFromHeaders(h amqp091.Table) (string, bool)
 ## 8. #536 — new `inbox` package
 
 ### 8.1 Public surface
+
 ```go
 // app package (mirrors the OutboxPublisher/OutboxProvider triad; avoids the app<->inbox cycle)
 type InboxProcessor interface {                       // role-named to avoid an Inbox/Inbox/Inbox() collision
@@ -206,6 +210,7 @@ const DefaultTableName = "gobricks_inbox"
 ```
 
 ### 8.2 `ProcessOnce` flow (D3 — inbox owns the tx)
+
 ```go
 db, err := m.getDB(ctx)                 // tenant-resolved from the handler's tenant-scoped ctx
 if err != nil { return err }
@@ -216,12 +221,14 @@ return database.WithTx(ctx, db, func(ctx context.Context, tx dbtypes.Tx) error {
     return fn(ctx, tx)                  // side effects atomic with the marker
 })
 ```
+
 - **Postgres `MarkProcessed`:** `INSERT … (tenant_id,event_id,processed_at) VALUES ($1,$2,$3)
   ON CONFLICT (tenant_id,event_id) DO NOTHING`; `inserted = res.RowsAffected()==1`.
 - **Oracle `MarkProcessed`:** plain `INSERT` (`:1,:2,:3`); on error `if database.IsUniqueViolation(err)
   { return inserted=false }` else return the error. (#533 is the backstop.)
 
 ### 8.3 Storage / scaffolding (MIRROR outbox, do not extract — §4 rule-of-three)
+
 - `inbox/store.go` (`InboxStore`, `Record`, `sqlid.ValidateTableName` guard), `store_postgres.go`,
   `store_oracle.go` with vendor DDL **consts** (exported, so managed-migration shops can run them):
   - PG: `CREATE TABLE IF NOT EXISTS %s (tenant_id VARCHAR(255) NOT NULL DEFAULT '', event_id VARCHAR(255)
@@ -242,6 +249,7 @@ return database.WithTx(ctx, db, func(ctx context.Context, tx dbtypes.Tx) error {
   `config/loadDefaults()` and NOT `config/validation.go`.
 
 ### 8.4 App + config wiring (pure mirror — additive, non-breaking)
+
 - `app/module.go`: add `InboxProcessor`, `InboxProvider`, and the `ModuleDeps.Inbox` field
   (`app` already imports `dbtypes` and uses `dbtypes.Tx` → zero new imports). All `ModuleDeps{…}`
   literals in the repo are keyed → the new field is non-breaking.
@@ -254,6 +262,7 @@ return database.WithTx(ctx, db, func(ctx context.Context, tx dbtypes.Tx) error {
 - `config.example.yaml`: add an `inbox:` block after the outbox block (`retention_period: 168h`, never `7d`).
 
 ## 9. Discovered issues (out of scope — propose as separate tickets)
+
 - **Outbox schema-qualified table names are mishandled:** a name like `myschema.outbox_events` passes
   validation but yields an invalid index name `idx_myschema.outbox_events_pending` and an unquoted
   `CREATE TABLE`. Fixing needs quoting + last-segment index derivation (with a PG case-folding caveat).
@@ -262,6 +271,7 @@ return database.WithTx(ctx, db, func(ctx context.Context, tx dbtypes.Tx) error {
   differ deliberately) — separate, behavior-changing PR.
 
 ## 10. Testing strategy
+
 - Unit: per-vendor mirror-image test files driving the concrete store against
   `dbtesting.NewTestDB(dbtypes.PostgreSQL|Oracle)` fluent expectations; `testify`;
   `var _ InboxStore = (*postgresStore)(nil)` compile-time guards.
@@ -272,6 +282,7 @@ return database.WithTx(ctx, db, func(ctx context.Context, tx dbtypes.Tx) error {
   `/code-review` and `/security-review` before pushing.
 
 ## 11. Sequencing (one connected effort)
+
 1. **P0.1** `internal/sqlid` + outbox delegation (behavior-preserving).
 2. **#533** `database.IsUniqueViolation` et al. (+ **P0.2** tracking `ErrTxDone` downgrade).
 3. **#534** `WithTx`/`WithTxOptions` (+ dogfood docs/tests).

--- a/docs/superpowers/specs/2026-06-04-outbox-inbox-db-primitives-design.md
+++ b/docs/superpowers/specs/2026-06-04-outbox-inbox-db-primitives-design.md
@@ -1,0 +1,282 @@
+# Design: DB error/tx primitives + outbox header export + consumer-side inbox (#533–536)
+
+Date: 2026-06-04
+Status: Approved design — pending spec review, then implementation plan
+Issues: gaborage/go-bricks #533, #534, #535, #536
+
+## 1. Overview
+
+Four GitHub issues form one coherent **transactional-outbox → consumer-idempotency** story.
+Three are small, independent primitives; the fourth (#536) composes all three into a new
+durable consumer-side "inbox".
+
+```
+#533 database.IsUniqueViolation ─┐
+#534 database.WithTx ────────────┼──►  #536 inbox.ProcessOnce  (new package)
+#535 outbox.HeaderEventID ───────┘
+```
+
+- **#533** — vendor-aware error classifier (`IsUniqueViolation`, `IsForeignKeyViolation`,
+  `IsNotFound`, `ConstraintName`) in package `database`.
+- **#534** — `WithTx` / `WithTxOptions` transaction-scope helpers (free functions).
+- **#535** — export the `x-outbox-event-id` header name + a typed getter from `outbox`.
+- **#536** — new `inbox` package: a durable, tenant-aware idempotency ledger whose
+  `ProcessOnce` runs a handler exactly once per event id, atomically with the ledger marker.
+
+All work is **additive** (new exported symbols) and **non-breaking**. The project is pre-1.0
+(v0.39.1); a correct `feat(scope):` PR title is the CHANGELOG entry (release-please owns
+`CHANGELOG.md`; do **not** hand-edit it).
+
+## 2. Locked decisions
+
+| # | Decision | Choice |
+|---|----------|--------|
+| D1 | Scope/sequencing | All four in one effort, primitives first, then inbox builds on them |
+| D2 | #535 header constant home | `outbox` package (relay is the single source of truth) |
+| D3 | #536 `ProcessOnce` tx model | Inbox **owns the tx** and passes `tx` to `fn` (atomic dedup + side effects) |
+| D4 | #536 packaging | New `inbox` package + module, mirroring `outbox` |
+| D5 | Auto-create-table default | **OFF by default (opt-in)**; honest zero-value bool; outbox fix is **doc/example-only** (behavior-preserving) |
+| D6 | #534 shape | **Error-only** `WithTx` + `WithTxOptions`; no generics (YAGNI) |
+
+Secondary defaults (locked, low-stakes): #533 = boolean predicates (no `errors.Is` sentinels),
+scope = unique + FK + not-found (hold check/not-null — Oracle mapping is fuzzier),
+`ConstraintName` is Postgres-only; #534 callback is `func(ctx, tx) error`; inbox ledger keyed on
+`(tenant_id, event_id)`, no payload/event_type columns in v1; `DefaultTableName = "gobricks_inbox"`;
+`RetentionPeriod` default `7*24*time.Hour` (written `168h` in YAML — Go rejects `7d`); `0` = keep forever.
+
+## 3. Critical invariants (must be encoded in code + comments + tests)
+
+1. **PG vs Oracle dedup asymmetry.** On **Postgres** a `23505` unique violation *poisons the
+   transaction* (subsequent statements fail with "current transaction is aborted"), so the PG
+   path MUST use `INSERT … ON CONFLICT (tenant_id,event_id) DO NOTHING` and detect a duplicate via
+   `RowsAffected()==0`. On **Oracle** a unique violation is statement-level (the tx survives), so the
+   Oracle path uses a plain `INSERT` and catches `database.IsUniqueViolation`. **Never** unify these
+   into one "insert-then-catch" path — it works in Oracle tests and silently corrupts the PG tx.
+2. **`errors.As` wrap-chain survival.** The hot path returns driver errors verbatim
+   (`wrapper`/`tracking` never `fmt.Errorf`-wrap exec/query errors), so `errors.As` reaches
+   `*pgconn.PgError` and `*network.OracleError`. Callers MUST wrap with `%w` (not `%v`) to preserve this.
+3. **Read `RowsAffected()` from the `tx.Exec` `sql.Result` directly** — not the tracking layer's
+   best-effort `extractRowsAffected` (it swallows errors to 0; using it for control flow would treat
+   every insert as a duplicate).
+4. **Ledger insert precedes `fn`.** On a duplicate, short-circuit before running `fn` (PG: 0 rows, no
+   error, tx intact; Oracle: caught unique violation, tx intact).
+
+## 4. Phase 0 — Prefactors ("make the change easy")
+
+The repo has **no production hand-rolled tx blocks to retrofit** (exhaustive grep: only doc-comments,
+tests, and `llms.txt` examples carry the begin/commit/rollback shape). The prefactors below are the
+behavior-preserving (or doc-only) changes that make the four issues mechanical.
+
+### P0.1 — Extract `internal/sqlid.ValidateTableName` (do-first, behavior-preserving for outbox)
+- New package **`internal/sqlid`** at the **repo root** (NOT `database/internal/…` — sibling packages
+  `outbox/` and `migration/` cannot import another tree's `internal/`).
+- `func ValidateTableName(name string) error` — replicate outbox's exact current rules: optional
+  `schema.table` split (≤2 parts), reject empty and dangerous fragments (`;`, `--`, `/*`, `*/`),
+  per-segment regex `^[A-Za-z_][A-Za-z0-9_$#]*$`. Returns a neutral sentinel each caller wraps with
+  its own package prefix.
+- Migrate `outbox/store.go`'s private `validateTableName` to delegate (behavior-preserving — keeps the
+  `outbox:`-prefixed wrapping). The new `inbox` package consumes `sqlid.ValidateTableName` from day one.
+- **Out of scope:** do NOT migrate `provisioning`/`quiesce`/`roles` (their charset/length/quoting rules
+  deliberately differ — a separate PR). Do NOT fix outbox's pre-existing schema-qualified index-name /
+  unquoted-DDL bug here (see §9 discovered issues).
+
+### P0.2 — Downgrade post-commit `sql.ErrTxDone` in the tracking layer (recommended; observability-only)
+- `database/internal/tracking/transaction.go` `Rollback` + `database/internal/tracking/utils.go`
+  `TrackDBOperation` / `createDBSpan`: add an `errors.Is(err, sql.ErrTxDone)` arm that mirrors the
+  existing `sql.ErrNoRows` special-case — log at DEBUG and skip `span.RecordError` instead of ERROR.
+  Keep returning the original error to callers.
+- **Why:** the idiomatic `defer tx.Rollback()` after a successful `Commit` returns `ErrTxDone`, which
+  today logs at **ERROR** + records an error span — spurious noise for tests, the documented pattern,
+  and downstream apps. This is the exact pain #534 cites.
+- **Separable:** `WithTx` is correct *without* this (its `committed` flag means it never calls Rollback
+  after Commit). This prefactor de-noises everyone else. It is the one behavior-touching item — drop it
+  if you want strictly-minimal blast radius; risk is low (only `ErrTxDone` downgraded, never a real
+  rollback error — add a test asserting a genuine rollback error still logs ERROR).
+
+### P0.3 — Config plumbing (mostly mirror; one doc-only outbox fix)
+- Correct outbox's doc/example to state `auto_create_table` default = **false** (matches 4 releases of
+  actual shipped behavior; `applyDefaults` never set it). `config/types.go:480-482` doc comment +
+  `config.example.yaml:112`. **Behavior-preserving** (code already does false).
+- This establishes the honest, opt-in, off-by-default convention the inbox inherits cleanly.
+
+## 5. #533 — `database` error classifier
+
+New file **`database/errors.go`** (package `database`; it already imports the vendor packages, so
+importing `pgconn` and `go-ora/v2/network` is cycle-free; do NOT place in `database/types`, which must
+stay driver-free).
+
+```go
+// IsUniqueViolation reports whether err is a unique/primary-key constraint violation
+// (PostgreSQL SQLSTATE 23505, Oracle ORA-00001), traversing the framework wrap chain.
+func IsUniqueViolation(err error) bool
+
+// IsForeignKeyViolation reports whether err is a foreign-key violation
+// (PostgreSQL 23503, Oracle ORA-02291).
+func IsForeignKeyViolation(err error) bool
+
+// IsNotFound reports whether err is a no-rows result (sql.ErrNoRows). Scan-path only.
+func IsNotFound(err error) bool
+
+// ConstraintName returns the violated constraint name when the driver exposes it.
+// PostgreSQL only; returns ("", false) on Oracle (the driver carries no constraint name).
+func ConstraintName(err error) (string, bool)
+```
+
+Implementation: nil-guard, then `errors.As` onto `*pgconn.PgError` (`.Code == "23505"/"23503"`,
+`.ConstraintName`) and `*network.OracleError` (`.ErrCode == 1/2291`). Match the existing predicate idiom
+(`config.IsNotConfigured`, `httpclient.IsHTTPStatusError`).
+
+Tests: fabricate driver errors (unit) for both pointer **and** value `OracleError` targets; negative
+cases; `//go:build integration` round-trips inserting a real duplicate against containerized PG + Oracle
+to confirm the real driver error survives the wrap chain.
+
+**Sequenced first** — the inbox's Oracle path depends on it.
+
+## 6. #534 — `database.WithTx`
+
+New file **`database/transaction.go`** (package `database`). Free functions (forced: `database.Interface`
+is a type *alias* to `types.Interface` — a method would break every implementer/mock).
+
+```go
+// WithTx runs fn inside a transaction: commits on nil, rolls back on error,
+// rolls back and re-panics on panic. No post-commit rollback (a committed flag
+// suppresses the deferred rollback so there is no error-log noise on the happy path).
+func WithTx(ctx context.Context, db Interface, fn func(ctx context.Context, tx Tx) error) (err error)
+
+// WithTxOptions is WithTx with an explicit isolation level / read-only mode via BeginTx.
+func WithTxOptions(ctx context.Context, db Interface, opts *sql.TxOptions, fn func(ctx context.Context, tx Tx) error) (err error)
+```
+
+Contract:
+- `Begin`/`BeginTx` → `defer` closure: `recover()` → rollback → **re-panic**; else if `committed` skip;
+  else rollback.
+- On `fn` error: rollback, return the **original `fn` error** (not the rollback error; join a rollback
+  error only if it is not `sql.ErrTxDone`).
+- On success: `Commit`, set `committed = true`. After commit the deferred rollback is skipped; if it ever
+  fires its `sql.ErrTxDone` is ignored (never surfaced as the return value).
+- `WithTx` delegates to `WithTxOptions(ctx, db, nil, fn)`.
+
+Dogfooding (the only places the hand-rolled shape lives): update doc examples `outbox/outbox.go:18-31`,
+`database/types/transactor.go:22-42`, `llms.txt`, `wiki/outbox.md` to show `WithTx`; keep one manual
+example for callers that need the tx handle outside a closure. Add `database` tests: commit-on-success,
+fn-error-rolls-back-and-returns-fn-error, panic-rolls-back-and-re-panics, and **no ERROR log/span on the
+happy path** (ties to P0.2).
+
+## 7. #535 — export the outbox header name + getter
+
+In the `outbox` package:
+
+```go
+const HeaderEventID   = "x-outbox-event-id"   // referenced by the relay (single source of truth)
+const HeaderEventType = "x-outbox-event-type"
+
+// EventIDFromHeaders extracts the outbox event id from AMQP delivery headers,
+// returning ok=false when absent or empty. Normalizes string and []byte values.
+func EventIDFromHeaders(h amqp091.Table) (string, bool)
+```
+
+- `outbox` imports `github.com/rabbitmq/amqp091-go` directly (cycle-free; it already imports `messaging`
+  which imports it). `amqp091.Table` is what a consumer's `*amqp.Delivery.Headers` is.
+- Normalize **both** `string` and `[]byte` (the wire can deliver either).
+- Rewire `relay.go:84-85` and all literal sites (`relay_test.go:191,208`, `publisher_test.go:404`) and the
+  doc in `outbox/outbox.go:8` to reference the constants; update `wiki`/`llms.txt`.
+
+## 8. #536 — new `inbox` package
+
+### 8.1 Public surface
+```go
+// app package (mirrors the OutboxPublisher/OutboxProvider triad; avoids the app<->inbox cycle)
+type InboxProcessor interface {                       // role-named to avoid an Inbox/Inbox/Inbox() collision
+    ProcessOnce(ctx context.Context, eventID string, fn func(ctx context.Context, tx dbtypes.Tx) error) error
+}
+type InboxProvider interface { InboxProcessor() InboxProcessor }
+// ModuleDeps gains: Inbox InboxProcessor   // nil if no inbox module / inbox.enabled=false
+
+// inbox package
+func NewModule() *Module                               // app.Module + app.JobProvider + app.InboxProvider
+type InboxStore interface {                            // pluggable, vendor-split
+    MarkProcessed(ctx context.Context, tx dbtypes.Tx, rec Record) (inserted bool, err error)
+    DeleteProcessed(ctx context.Context, db dbtypes.Interface, before time.Time) (int64, error)
+    CreateTable(ctx context.Context, db dbtypes.Interface) error
+}
+func NewPostgresStore(tableName string) (InboxStore, error)
+func NewOracleStore(tableName string) (InboxStore, error)
+const DefaultTableName = "gobricks_inbox"
+// inbox/testing: MockInbox + Assert* helpers (mirror outbox/testing)
+```
+
+### 8.2 `ProcessOnce` flow (D3 — inbox owns the tx)
+```go
+db, err := m.getDB(ctx)                 // tenant-resolved from the handler's tenant-scoped ctx
+if err != nil { return err }
+return database.WithTx(ctx, db, func(ctx context.Context, tx dbtypes.Tx) error {   // #534
+    inserted, err := store.MarkProcessed(ctx, tx, Record{TenantID: tid, EventID: eventID, ProcessedAt: now})
+    if err != nil { return err }
+    if !inserted { return nil }         // duplicate → skip fn, commit no-op
+    return fn(ctx, tx)                  // side effects atomic with the marker
+})
+```
+- **Postgres `MarkProcessed`:** `INSERT … (tenant_id,event_id,processed_at) VALUES ($1,$2,$3)
+  ON CONFLICT (tenant_id,event_id) DO NOTHING`; `inserted = res.RowsAffected()==1`.
+- **Oracle `MarkProcessed`:** plain `INSERT` (`:1,:2,:3`); on error `if database.IsUniqueViolation(err)
+  { return inserted=false }` else return the error. (#533 is the backstop.)
+
+### 8.3 Storage / scaffolding (MIRROR outbox, do not extract — §4 rule-of-three)
+- `inbox/store.go` (`InboxStore`, `Record`, `sqlid.ValidateTableName` guard), `store_postgres.go`,
+  `store_oracle.go` with vendor DDL **consts** (exported, so managed-migration shops can run them):
+  - PG: `CREATE TABLE IF NOT EXISTS %s (tenant_id VARCHAR(255) NOT NULL DEFAULT '', event_id VARCHAR(255)
+    NOT NULL, processed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(), PRIMARY KEY (tenant_id,event_id))`
+    + `CREATE INDEX IF NOT EXISTS idx_%s_processed ON %s (processed_at)`.
+  - Oracle: `VARCHAR2(255)`, `SYSTIMESTAMP`, no `IF NOT EXISTS` (tolerate ORA-00955 as warning),
+    function-based index; mirror outbox's reserved-word handling.
+- `inbox/module.go`: copy `ensureStoreInitialized` (double-checked mutex, `switch db.DatabaseType()`,
+  `tableCreated` guard, CreateTable-failure-as-warning) and the `lazyStore` wrapper **verbatim in shape**
+  from outbox; add a one-line "sibling pattern: see outbox" comment for future extraction.
+- `inbox/cleanup.go` + `RegisterJobs`: copy outbox's `DailyAt` cleanup executor (cutoff =
+  `now - RetentionPeriod`, `DeleteProcessed`); register only when `RetentionPeriod > 0`. Inbox implements
+  `app.JobProvider` **only for this cleanup job** (the dedup itself is synchronous — no relay). Same
+  "register scheduler before inbox" caveat applies to the cleanup job only.
+- `inbox/config.go`: `const DefaultTableName`, `const DefaultRetentionPeriod = 7*24*time.Hour`,
+  module-owned `applyDefaults` + `validateConfig` (called in `Init` as `applyDefaults → validateConfig →
+  Enabled short-circuit`, mirroring outbox). Opt-in module defaults live in the module, NOT
+  `config/loadDefaults()` and NOT `config/validation.go`.
+
+### 8.4 App + config wiring (pure mirror — additive, non-breaking)
+- `app/module.go`: add `InboxProcessor`, `InboxProvider`, and the `ModuleDeps.Inbox` field
+  (`app` already imports `dbtypes` and uses `dbtypes.Tx` → zero new imports). All `ModuleDeps{…}`
+  literals in the repo are keyed → the new field is non-breaking.
+- `app/module_registry.go`: add the duck-typed auto-wire branch after the outbox branch
+  (`if p, ok := module.(InboxProvider); ok { r.deps.Inbox = p.InboxProcessor(); log }`). No generic
+  `Provider[T]` (4 divergent branches — keep them explicit).
+- `config/types.go`: add `InboxConfig{Enabled, TableName, AutoCreateTable, RetentionPeriod}` (five-tag
+  style, snake_case keys) + the `Inbox InboxConfig` field on `Config`. `AutoCreateTable` is the honest
+  off-by-default bool (D5). `RetentionPeriod` is `time.Duration`.
+- `config.example.yaml`: add an `inbox:` block after the outbox block (`retention_period: 168h`, never `7d`).
+
+## 9. Discovered issues (out of scope — propose as separate tickets)
+- **Outbox schema-qualified table names are mishandled:** a name like `myschema.outbox_events` passes
+  validation but yields an invalid index name `idx_myschema.outbox_events_pending` and an unquoted
+  `CREATE TABLE`. Fixing needs quoting + last-segment index derivation (with a PG case-folding caveat).
+  Pre-existing; not triggered by this work. Recommend a separate issue.
+- Unifying `provisioning`/`quiesce`/`roles` identifier validators onto `internal/sqlid` (their rules
+  differ deliberately) — separate, behavior-changing PR.
+
+## 10. Testing strategy
+- Unit: per-vendor mirror-image test files driving the concrete store against
+  `dbtesting.NewTestDB(dbtypes.PostgreSQL|Oracle)` fluent expectations; `testify`;
+  `var _ InboxStore = (*postgresStore)(nil)` compile-time guards.
+- Integration (`//go:build integration`, testcontainers): #533 real duplicate-key round-trip on both
+  vendors; #536 same-event-id-twice (assert `fn` runs once, second is a no-op) on both vendors, including
+  the PG tx-not-poisoned and Oracle tx-survives paths.
+- `make check` (fmt + lint + `-race`, 80% coverage, SonarCloud S8179 getter naming) must pass; run
+  `/code-review` and `/security-review` before pushing.
+
+## 11. Sequencing (one connected effort)
+1. **P0.1** `internal/sqlid` + outbox delegation (behavior-preserving).
+2. **#533** `database.IsUniqueViolation` et al. (+ **P0.2** tracking `ErrTxDone` downgrade).
+3. **#534** `WithTx`/`WithTxOptions` (+ dogfood docs/tests).
+4. **#535** `outbox.HeaderEventID`/`EventIDFromHeaders` (+ rewire literals).
+5. **P0.3** config doc fix + `InboxConfig` + example.
+6. **#536** `inbox` package + app wiring (consumes 1–5).
+
+Each step is independently reviewable; #536 is the integrating step that exercises every primitive.

--- a/internal/sqlid/sqlid.go
+++ b/internal/sqlid/sqlid.go
@@ -1,0 +1,46 @@
+// Package sqlid validates SQL identifiers (table names) before they are
+// interpolated into DDL/DML, guarding against SQL identifier injection.
+// The rules mirror the historical outbox validator and
+// database/internal/columns/parser.go for consistency across the framework.
+package sqlid
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// validIdentifierPattern matches safe SQL identifiers (letters, digits,
+// underscore, $, #). A leading digit is rejected.
+var validIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_$#]*$`)
+
+// ValidateTableName checks that name is a safe SQL identifier.
+// Supports optional schema-qualified names (e.g., "myschema.table").
+// Returns a descriptive error when name is empty, contains dangerous SQL
+// fragments, has more than two dot-separated parts, or any part is not a
+// valid identifier. The error message has no package prefix; callers wrap it
+// with their own prefix (e.g. fmt.Errorf("outbox: %w", err)).
+func ValidateTableName(name string) error {
+	if name == "" {
+		return fmt.Errorf("table name must not be empty")
+	}
+
+	for _, dangerous := range []string{";", "--", "/*", "*/"} {
+		if strings.Contains(name, dangerous) {
+			return fmt.Errorf("table name %q contains dangerous SQL characters", name)
+		}
+	}
+
+	parts := strings.Split(name, ".")
+	if len(parts) > 2 {
+		return fmt.Errorf("table name %q has too many dot-separated parts (expected schema.table or table)", name)
+	}
+
+	for _, part := range parts {
+		if !validIdentifierPattern.MatchString(part) {
+			return fmt.Errorf("table name part %q contains invalid identifier characters", part)
+		}
+	}
+
+	return nil
+}

--- a/internal/sqlid/sqlid.go
+++ b/internal/sqlid/sqlid.go
@@ -5,6 +5,7 @@
 package sqlid
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -22,7 +23,7 @@ var validIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_$#]*$`)
 // with their own prefix (e.g. fmt.Errorf("outbox: %w", err)).
 func ValidateTableName(name string) error {
 	if name == "" {
-		return fmt.Errorf("table name must not be empty")
+		return errors.New("table name must not be empty")
 	}
 
 	for _, dangerous := range []string{";", "--", "/*", "*/"} {

--- a/internal/sqlid/sqlid_test.go
+++ b/internal/sqlid/sqlid_test.go
@@ -1,0 +1,34 @@
+package sqlid
+
+import "testing"
+
+func TestValidateTableName(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"simple", "gobricks_inbox", false},
+		{"schema_qualified", "myschema.gobricks_inbox", false},
+		{"dollar_hash", "outbox$events#1", false},
+		{"empty", "", true},
+		{"semicolon", "t; DROP TABLE x", true},
+		{"comment_dashes", "t--x", true},
+		{"block_comment_open", "t/*x", true},
+		{"block_comment_close", "t*/x", true},
+		{"three_parts", "a.b.c", true},
+		{"leading_digit", "1table", true},
+		{"space", "my table", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTableName(tc.input)
+			if tc.wantErr && err == nil {
+				t.Fatalf("ValidateTableName(%q) = nil, want error", tc.input)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("ValidateTableName(%q) = %v, want nil", tc.input, err)
+			}
+		})
+	}
+}

--- a/outbox/store.go
+++ b/outbox/store.go
@@ -3,43 +3,19 @@ package outbox
 import (
 	"context"
 	"fmt"
-	"regexp"
-	"strings"
 	"time"
 
 	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/internal/sqlid"
 )
 
-// validIdentifierPattern matches safe SQL identifiers (letters, digits, underscore, $, #).
-// Mirrors the pattern in database/internal/columns/parser.go for consistency.
-var validIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_$#]*$`)
-
-// validateTableName checks that name is a safe SQL identifier.
+// validateTableName checks that name is a safe SQL identifier, delegating to the
+// shared sqlid validator and wrapping its error with the outbox package prefix.
 // Supports optional schema-qualified names (e.g., "myschema.outbox_events").
 func validateTableName(name string) error {
-	if name == "" {
-		return fmt.Errorf("outbox: table name must not be empty")
+	if err := sqlid.ValidateTableName(name); err != nil {
+		return fmt.Errorf("outbox: %w", err)
 	}
-
-	// Check for dangerous SQL fragments
-	for _, dangerous := range []string{";", "--", "/*", "*/"} {
-		if strings.Contains(name, dangerous) {
-			return fmt.Errorf("outbox: table name %q contains dangerous SQL characters", name)
-		}
-	}
-
-	// Split on "." for optional schema.table format
-	parts := strings.Split(name, ".")
-	if len(parts) > 2 {
-		return fmt.Errorf("outbox: table name %q has too many dot-separated parts (expected schema.table or table)", name)
-	}
-
-	for _, part := range parts {
-		if !validIdentifierPattern.MatchString(part) {
-			return fmt.Errorf("outbox: table name part %q contains invalid identifier characters", part)
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Summary

**PR 1 of 5** delivering the #533–536 cluster (DB primitives + outbox header export + consumer-side inbox). This PR is the behavior-preserving **prefactor**: it extracts the SQL table-name validator into a shared `internal/sqlid` package so the upcoming `inbox` package (#536) and the existing `outbox` package use one audited validator instead of duplicating the regex.

It also lands the design **spec** and **implementation plan** for the whole 5-PR effort (supporting context for reviewers).

## What changed
- **New `internal/sqlid`** — `ValidateTableName(name string) error`: empty check, dangerous-fragment rejection (`;`, `--`, `/*`, `*/`), ≤2 dot-separated parts, per-segment regex `^[A-Za-z_][A-Za-z0-9_$#]*$`. Repo-root `internal/` so sibling packages (`outbox`, future `inbox`, `migration`) can import it.
- **`outbox/store.go`** — `validateTableName` now delegates to `sqlid.ValidateTableName`, wrapping with the `outbox:` prefix. **Behavior-preserving**: error strings are byte-identical; the duplicated regex/validation is removed.
- Docs: design spec + implementation plan for #533–536.

## Why
Surfaced while planning #536 (a new `inbox` ledger table) which needs the same identifier validation. Extracting one validator avoids a 5th copy and keeps the SQL-identifier-injection surface reviewed in one place (the migration package's stricter validators are intentionally left untouched — separate rules).

## Verification
- `make check` green (fmt + lint + test, `-race`).
- New table-driven tests for `sqlid` (11 cases); existing outbox validator/store tests pass unchanged (behavior preserved).
- `/code-review` (1 lint nit fixed: `errors.New` for the static error) and `/security-review` (no findings — identical validation semantics) run on the diff.

## Scope notes
- Not breaking; no public API change (`outbox.validateTableName` is package-private; `outbox.NewPostgresStore`/`NewOracleStore` signatures unchanged).
- Discovered (out of scope, will file separately): outbox mishandles schema-qualified table names in generated index names. Tracked in the spec §9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design and implementation plans for database transaction and event-processing primitives (outbox + inbox), with phased PR sequencing and test strategies.

* **Refactor**
  * Centralized and strengthened SQL table-name validation into a shared module used by outbox code.

* **Tests**
  * Added unit tests validating identifier rules and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->