### PR TITLE
feat(database): add WithTx/WithTxOptions transaction helpers

### DIFF
--- a/database/internal/tracking/otel_test.go
+++ b/database/internal/tracking/otel_test.go
@@ -133,6 +133,12 @@ func TestCreateDBSpanErrorRecording(t *testing.T) {
 			shouldRecordErr: false,
 		},
 		{
+			name:            "sql_err_tx_done",
+			err:             sql.ErrTxDone,
+			expectedStatus:  codes.Unset, // Benign: deferred rollback after commit
+			shouldRecordErr: false,
+		},
+		{
 			name:            "actual_error",
 			err:             errors.New(testutil.TestConnectionRefused),
 			expectedStatus:  codes.Error,

--- a/database/internal/tracking/utils.go
+++ b/database/internal/tracking/utils.go
@@ -112,10 +112,15 @@ func TrackDBOperation(ctx context.Context, tc *Context, query string, args []any
 	}
 
 	if err != nil {
-		// Treat sql.ErrNoRows specially - not an actual error, log as debug
-		if errors.Is(err, sql.ErrNoRows) {
+		// Treat sql.ErrNoRows and sql.ErrTxDone specially - not actual errors,
+		// log as debug. ErrTxDone is returned by the deferred Rollback of an
+		// already-committed transaction (e.g. the WithTx helper), which is benign.
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
 			logEvent.Debug().Msg("Database operation returned no rows")
-		} else {
+		case errors.Is(err, sql.ErrTxDone):
+			logEvent.Debug().Msg("Database transaction already finalized")
+		default:
 			logEvent.Error().Err(err).Msg("Database operation error")
 		}
 	} else if elapsed > tc.Settings.SlowQueryThreshold() {
@@ -245,8 +250,9 @@ func createDBSpan(ctx context.Context, tc *Context, query string, start time.Tim
 
 	// Record error status
 	if err != nil {
-		// sql.ErrNoRows is not an actual error - it's a normal empty result
-		if !errors.Is(err, sql.ErrNoRows) {
+		// sql.ErrNoRows (empty result) and sql.ErrTxDone (deferred rollback after
+		// commit) are not actual errors - do not mark the span as failed.
+		if !errors.Is(err, sql.ErrNoRows) && !errors.Is(err, sql.ErrTxDone) {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 		}

--- a/database/internal/tracking/utils_test.go
+++ b/database/internal/tracking/utils_test.go
@@ -303,6 +303,29 @@ func TestTrackDBOperationHandlesSqlErrNoRows(t *testing.T) {
 	}
 }
 
+func TestTrackDBOperationHandlesSqlErrTxDone(t *testing.T) {
+	ctx := logger.WithDBCounter(context.Background())
+	recLogger := newRecordingLogger()
+	settings := Settings{slowQueryThreshold: time.Second}
+
+	start := time.Now().Add(-10 * time.Millisecond)
+	// A deferred Rollback after a successful Commit returns sql.ErrTxDone; it must
+	// be treated as benign (debug), not logged at error level.
+	TrackDBOperation(ctx, &Context{Logger: recLogger, Vendor: "postgresql", Settings: settings}, "ROLLBACK", nil, start, 0, sql.ErrTxDone)
+
+	events := recLogger.events()
+	if len(events) != 1 {
+		t.Fatalf(singleEventExpected, len(events))
+	}
+	event := events[0]
+	if event.Level != levelDebug {
+		t.Fatalf("expected debug level for sql.ErrTxDone, got %s", event.Level)
+	}
+	if event.Msg != "Database transaction already finalized" {
+		t.Fatalf("unexpected message: %q", event.Msg)
+	}
+}
+
 func TestTrackDBOperationLogsErrors(t *testing.T) {
 	ctx := logger.WithDBCounter(context.Background())
 	recLogger := newRecordingLogger()

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -37,7 +37,12 @@ func WithTxOptions(ctx context.Context, db Interface, opts *sql.TxOptions, fn fu
 	committed := false
 	defer func() {
 		if p := recover(); p != nil {
-			_ = tx.Rollback(ctx)
+			// Roll back, but never let a panicking Rollback mask the original
+			// panic: swallow any rollback panic so panic(p) re-throws the real cause.
+			func() {
+				defer func() { _ = recover() }()
+				_ = tx.Rollback(ctx)
+			}()
 			panic(p)
 		}
 		// Roll back unless the transaction already committed. The rollback error

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -1,0 +1,59 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+)
+
+// WithTx runs fn inside a database transaction. It commits when fn returns nil,
+// rolls back and returns fn's original error when fn returns an error, and rolls
+// back then re-panics if fn panics. After a successful commit the deferred
+// rollback is skipped (a committed flag guards it), so there is no post-commit
+// rollback noise on the happy path.
+//
+// fn must use the provided tx for all database work; using the outer db handle
+// inside fn escapes the transaction.
+func WithTx(ctx context.Context, db Interface, fn func(ctx context.Context, tx Tx) error) error {
+	return WithTxOptions(ctx, db, nil, fn)
+}
+
+// WithTxOptions behaves like WithTx but begins the transaction with the given
+// options (isolation level, read-only mode) via BeginTx. A nil opts is
+// equivalent to WithTx.
+func WithTxOptions(ctx context.Context, db Interface, opts *sql.TxOptions, fn func(ctx context.Context, tx Tx) error) error {
+	var (
+		tx  Tx
+		err error
+	)
+	if opts != nil {
+		tx, err = db.BeginTx(ctx, opts)
+	} else {
+		tx, err = db.Begin(ctx)
+	}
+	if err != nil {
+		return err
+	}
+
+	committed := false
+	defer func() {
+		if p := recover(); p != nil {
+			_ = tx.Rollback(ctx)
+			panic(p)
+		}
+		// Roll back unless the transaction already committed. The rollback error
+		// is intentionally ignored: fn's (or Commit's) error is the one that
+		// matters, and the tracking layer still logs a genuine rollback failure.
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+
+	if ferr := fn(ctx, tx); ferr != nil {
+		return ferr
+	}
+	if cerr := tx.Commit(ctx); cerr != nil {
+		return cerr
+	}
+	committed = true
+	return nil
+}

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -1,0 +1,88 @@
+package database_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/gaborage/go-bricks/database"
+	dbtesting "github.com/gaborage/go-bricks/database/testing"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithTxCommitsOnSuccess(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction().ExpectExec(`INSERT INTO t`).WillReturnRowsAffected(1)
+
+	var captured dbtypes.Tx
+	err := database.WithTx(t.Context(), db, func(ctx context.Context, tx dbtypes.Tx) error {
+		captured = tx
+		_, e := tx.Exec(ctx, "INSERT INTO t VALUES (1)")
+		return e
+	})
+	require.NoError(t, err)
+
+	tt, ok := captured.(*dbtesting.TestTx)
+	require.True(t, ok)
+	assert.True(t, tt.IsCommitted(), "tx should be committed")
+	assert.False(t, tt.IsRolledBack(), "tx should not be rolled back after commit")
+}
+
+func TestWithTxRollsBackAndReturnsFnError(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction()
+
+	sentinel := errors.New("boom")
+	var captured dbtypes.Tx
+	err := database.WithTx(t.Context(), db, func(_ context.Context, tx dbtypes.Tx) error {
+		captured = tx
+		return sentinel
+	})
+	assert.ErrorIs(t, err, sentinel, "WithTx must return the original fn error")
+	assert.True(t, captured.(*dbtesting.TestTx).IsRolledBack(), "tx should be rolled back on fn error")
+}
+
+func TestWithTxRollsBackAndRepanics(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction()
+
+	var captured dbtypes.Tx
+	assert.PanicsWithValue(t, "kaboom", func() {
+		_ = database.WithTx(t.Context(), db, func(_ context.Context, tx dbtypes.Tx) error {
+			captured = tx
+			panic("kaboom")
+		})
+	})
+	assert.True(t, captured.(*dbtesting.TestTx).IsRolledBack(), "tx should be rolled back on panic")
+}
+
+func TestWithTxReturnsBeginError(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	// No ExpectTransaction queued -> Begin returns an error.
+
+	called := false
+	err := database.WithTx(t.Context(), db, func(_ context.Context, _ dbtypes.Tx) error {
+		called = true
+		return nil
+	})
+	require.Error(t, err)
+	assert.False(t, called, "fn must not run when Begin fails")
+}
+
+func TestWithTxOptionsCommitsOnSuccess(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction().ExpectExec(`INSERT INTO t`).WillReturnRowsAffected(1)
+
+	opts := &sql.TxOptions{Isolation: sql.LevelSerializable, ReadOnly: false}
+	var captured dbtypes.Tx
+	err := database.WithTxOptions(t.Context(), db, opts, func(ctx context.Context, tx dbtypes.Tx) error {
+		captured = tx
+		_, e := tx.Exec(ctx, "INSERT INTO t VALUES (1)")
+		return e
+	})
+	require.NoError(t, err)
+	assert.True(t, captured.(*dbtesting.TestTx).IsCommitted())
+}

--- a/database/transaction_test.go
+++ b/database/transaction_test.go
@@ -72,6 +72,40 @@ func TestWithTxReturnsBeginError(t *testing.T) {
 	assert.False(t, called, "fn must not run when Begin fails")
 }
 
+// panicRollbackTx wraps a Tx and panics on Rollback, to exercise the case where
+// a rollback during panic recovery itself panics.
+type panicRollbackTx struct {
+	dbtypes.Tx
+}
+
+func (panicRollbackTx) Rollback(context.Context) error { panic("rollback boom") }
+
+// panicRollbackDB wraps an Interface so Begin yields a panicRollbackTx.
+type panicRollbackDB struct {
+	dbtypes.Interface
+}
+
+func (d panicRollbackDB) Begin(ctx context.Context) (dbtypes.Tx, error) {
+	tx, err := d.Interface.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return panicRollbackTx{tx}, nil
+}
+
+func TestWithTxRepanicsOriginalEvenWhenRollbackPanics(t *testing.T) {
+	base := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	base.ExpectTransaction()
+	db := panicRollbackDB{Interface: base}
+
+	// The original panic must propagate, not the rollback's "rollback boom".
+	assert.PanicsWithValue(t, "original", func() {
+		_ = database.WithTx(t.Context(), db, func(_ context.Context, _ dbtypes.Tx) error {
+			panic("original")
+		})
+	})
+}
+
 func TestWithTxOptionsCommitsOnSuccess(t *testing.T) {
 	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
 	db.ExpectTransaction().ExpectExec(`INSERT INTO t`).WillReturnRowsAffected(1)


### PR DESCRIPTION
## Summary

**PR 3 of 5** for the #533–536 cluster. Delivers **#534** (a `WithTx` transaction-scope helper) plus the load-bearing prefactor that makes it noise-free.

## What changed

**`database/transaction.go` (#534)** — free functions (the public `database.Interface` is a type *alias* to an interface, so a method isn't viable):

```go
func WithTx(ctx, db Interface, fn func(ctx, tx Tx) error) error
func WithTxOptions(ctx, db Interface, opts *sql.TxOptions, fn func(ctx, tx Tx) error) error
```

Semantics: commit on `nil`; roll back and return **fn's original error** on failure; roll back and **re-panic** on panic (a panicking rollback can't mask the original panic); a `committed` flag suppresses the post-commit rollback so the happy path emits no noise. `WithTxOptions` threads `*sql.TxOptions` (isolation / read-only) through `BeginTx`.

**`database/internal/tracking/utils.go` (prefactor P0.2)** — a deferred `Rollback` after a successful `Commit` returns `sql.ErrTxDone`, which was logged at **ERROR** and recorded as a span error. Downgraded to debug / no-span, mirroring the existing `sql.ErrNoRows` handling. Without this, `WithTx`'s deferred rollback would otherwise produce noise; it also de-noises the documented `defer tx.Rollback()` pattern for downstream apps and tests.

## Tests
- `transaction_test.go`: commit-on-success, rollback-returns-fn-error, panic-re-panics, **panic-survives-a-panicking-rollback**, begin-error, options-variant.
- `utils_test.go` / `otel_test.go`: `ErrTxDone` → debug log **and** not recorded as a span error.
- `make check` green (incl. `-race`, golangci-lint).

## Scope
- Additive + an observability-only behavior change in the tracking layer (no public API change there). No production code currently hand-rolls the begin/commit/rollback pattern, so there's nothing to retrofit beyond docs/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transaction management helpers for executing database operations within SQL transactions with automatic commit/rollback handling.

* **Bug Fixes**
  * Improved error handling to prevent benign transaction finalization states from being logged as failures, reducing noise in error logs.

* **Tests**
  * Added comprehensive test coverage for transaction handling, including success, failure, and edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->