### PR TITLE
feat(outbox): export x-outbox-event-id header name and EventIDFromHeaders getter

### DIFF
--- a/outbox/headers.go
+++ b/outbox/headers.go
@@ -1,0 +1,40 @@
+package outbox
+
+import amqp "github.com/rabbitmq/amqp091-go"
+
+// AMQP delivery header names stamped by the relay for consumer idempotency.
+// These constants are the single source of truth; the relay references them
+// when publishing, so consumers can dedupe without re-declaring the literals.
+const (
+	// HeaderEventID carries the unique outbox event id (a UUID) used for
+	// consumer-side deduplication.
+	HeaderEventID = "x-outbox-event-id"
+
+	// HeaderEventType carries the event type of the published outbox record.
+	HeaderEventType = "x-outbox-event-type"
+)
+
+// EventIDFromHeaders extracts the outbox event id from AMQP delivery headers,
+// returning ok=false when the header is absent, empty, or not a string/[]byte.
+// AMQP header values can arrive as either string or []byte depending on the
+// broker and client, so both are normalized.
+func EventIDFromHeaders(h amqp.Table) (string, bool) {
+	raw, present := h[HeaderEventID]
+	if !present {
+		return "", false
+	}
+	switch v := raw.(type) {
+	case string:
+		if v == "" {
+			return "", false
+		}
+		return v, true
+	case []byte:
+		if len(v) == 0 {
+			return "", false
+		}
+		return string(v), true
+	default:
+		return "", false
+	}
+}

--- a/outbox/headers_test.go
+++ b/outbox/headers_test.go
@@ -1,0 +1,39 @@
+package outbox
+
+import (
+	"testing"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventIDFromHeaders(t *testing.T) {
+	cases := []struct {
+		name    string
+		headers amqp.Table
+		wantID  string
+		wantOK  bool
+	}{
+		{"string", amqp.Table{HeaderEventID: "evt-1"}, "evt-1", true},
+		{"bytes", amqp.Table{HeaderEventID: []byte("evt-2")}, "evt-2", true},
+		{"absent", amqp.Table{}, "", false},
+		{"nil_table", nil, "", false},
+		{"empty_string", amqp.Table{HeaderEventID: ""}, "", false},
+		{"empty_bytes", amqp.Table{HeaderEventID: []byte{}}, "", false},
+		{"wrong_type", amqp.Table{HeaderEventID: 42}, "", false},
+		{"other_header_only", amqp.Table{HeaderEventType: "order.created"}, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, ok := EventIDFromHeaders(tc.headers)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantID, id)
+		})
+	}
+}
+
+func TestHeaderConstants(t *testing.T) {
+	// The relay is the single source of truth; these literals must not drift.
+	assert.Equal(t, "x-outbox-event-id", HeaderEventID)
+	assert.Equal(t, "x-outbox-event-type", HeaderEventType)
+}

--- a/outbox/outbox.go
+++ b/outbox/outbox.go
@@ -5,8 +5,8 @@
 // then reliably delivered to the message broker by a background relay.
 //
 // This guarantees at-least-once delivery: events are never lost even if the broker
-// is temporarily unavailable. Consumers MUST be idempotent — use the x-outbox-event-id
-// header for deduplication.
+// is temporarily unavailable. Consumers MUST be idempotent — use the outbox.HeaderEventID
+// ("x-outbox-event-id") header for deduplication, via outbox.EventIDFromHeaders.
 //
 // Usage:
 //

--- a/outbox/publisher_test.go
+++ b/outbox/publisher_test.go
@@ -401,7 +401,7 @@ func TestOutboxTracePropagationContinuityAcrossThreeSites(t *testing.T) {
 	}
 	wire := map[string]any{}
 	maps.Copy(wire, stored)
-	wire["x-outbox-event-id"] = record.ID
+	wire[HeaderEventID] = record.ID
 	gobrickstrace.InjectIntoHeaders(context.Background(), &mapHeaderAccessor{headers: wire})
 
 	// Site 3 — consumer: messaging.Registry.processMessage derives the

--- a/outbox/relay.go
+++ b/outbox/relay.go
@@ -81,8 +81,8 @@ func (r *Relay) publishRecord(ctx scheduler.JobContext, db dbtypes.Interface, ms
 	if headers == nil {
 		headers = make(map[string]any)
 	}
-	headers["x-outbox-event-id"] = record.ID
-	headers["x-outbox-event-type"] = record.EventType
+	headers[HeaderEventID] = record.ID
+	headers[HeaderEventType] = record.EventType
 
 	// Rehydrate the originating trace context (persisted by Publish) into the
 	// publish context. The relay job runs detached with no ambient trace, so

--- a/outbox/relay_test.go
+++ b/outbox/relay_test.go
@@ -188,8 +188,8 @@ func TestPublishRecordInjectsOutboxMetadataHeaders(t *testing.T) {
 	require.True(t, ok)
 
 	require.NotNil(t, amqp.LastPublishHdrs)
-	assert.Equal(t, "evt-42", amqp.LastPublishHdrs["x-outbox-event-id"])
-	assert.Equal(t, "order.created", amqp.LastPublishHdrs["x-outbox-event-type"])
+	assert.Equal(t, "evt-42", amqp.LastPublishHdrs[HeaderEventID])
+	assert.Equal(t, "order.created", amqp.LastPublishHdrs[HeaderEventType])
 	assert.Equal(t, "abc", amqp.LastPublishHdrs["x-correlation-id"], "preserves caller-supplied headers")
 }
 
@@ -205,7 +205,7 @@ func TestPublishRecordInjectsHeadersWhenRecordHasNone(t *testing.T) {
 	rec := &Record{ID: "evt-7", EventType: "x.y", Exchange: "ex", RoutingKey: "rk"}
 	require.True(t, r.publishRecord(ctx, db, amqp, rec))
 	require.NotNil(t, amqp.LastPublishHdrs)
-	assert.Equal(t, "evt-7", amqp.LastPublishHdrs["x-outbox-event-id"])
+	assert.Equal(t, "evt-7", amqp.LastPublishHdrs[HeaderEventID])
 }
 
 func TestPublishRecordReturnsFalseWhenMarkPublishedFails(t *testing.T) {


### PR DESCRIPTION
## Summary

**PR 4 of 5** for the #533–536 cluster. Closes **#535**: exports the outbox delivery-header name and a typed getter so consumers stop re-declaring the `"x-outbox-event-id"` literal.

## API (new `outbox/headers.go`)

```go
const HeaderEventID   = "x-outbox-event-id"   // relay references this (single source of truth)
const HeaderEventType = "x-outbox-event-type"

func EventIDFromHeaders(h amqp091.Table) (string, bool) // normalizes string AND []byte; ok=false if absent/empty/wrong-type
```

- `relay.go` now writes the headers via the constants; if the name ever changes, it changes in one place.
- The getter handles the wire reality that AMQP header values arrive as `string` **or** `[]byte`.
- `outbox` imports `amqp091-go` directly for the first time in production (no import cycle — amqp091 imports nothing from go-bricks).

## Tests
- Table-driven `EventIDFromHeaders`: string, []byte, absent, nil table, empty string, empty bytes, wrong type, other-header-only.
- `TestHeaderConstants` pins the on-the-wire literal so it can't silently drift.
- Rewired `relay_test.go` / `publisher_test.go` to the constants. `make check` green.

## Scope
- Additive + a mechanical literal→constant rewire; no behavior change for existing consumers (the emitted header value is byte-identical).
- Unblocks #536, whose inbox reads the event id via this getter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized AMQP header constants and helper function for message header handling.

* **Refactor**
  * Refactored outbox header management to use named constants instead of hardcoded strings for consistency.

* **Tests**
  * Added comprehensive unit tests for header parsing logic and constant validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->