### PR TITLE
feat(inbox): add durable consumer-side idempotency ledger (ProcessOnce)

### DIFF
--- a/app/module.go
+++ b/app/module.go
@@ -111,6 +111,25 @@ type OutboxProvider interface {
 	OutboxPublisher() OutboxPublisher
 }
 
+// InboxProcessor runs a handler exactly once per event id, recording the id in a
+// durable, tenant-aware ledger atomically with the handler's writes. It is the
+// consumer-side complement to the transactional outbox. Defined here to avoid an
+// app<->inbox import cycle; the inbox package implements it.
+type InboxProcessor interface {
+	// ProcessOnce runs fn inside a transaction exactly once per eventID. A
+	// redelivery of an already-processed id short-circuits (fn is not run) and
+	// returns nil. The tenant is resolved from ctx.
+	ProcessOnce(ctx context.Context, eventID string, fn func(ctx context.Context, tx dbtypes.Tx) error) error
+}
+
+// InboxProvider is an optional interface that modules can implement to provide an
+// InboxProcessor for dependency injection into other modules.
+// When a module implements this interface, the ModuleRegistry automatically wires
+// its InboxProcessor into ModuleDeps.Inbox.
+type InboxProvider interface {
+	InboxProcessor() InboxProcessor
+}
+
 // KeyStore provides access to named RSA key pairs loaded at startup.
 // Keys are loaded from DER files or base64-encoded values during module initialization.
 // All methods are safe for concurrent use (the store is read-only after init).
@@ -188,6 +207,12 @@ type ModuleDeps struct {
 	// This field is nil if no outbox module is registered or outbox.enabled is false.
 	// Example: deps.Outbox.Publish(ctx, tx, &app.OutboxEvent{EventType: "order.created", ...})
 	Outbox OutboxPublisher
+
+	// Inbox provides durable consumer-side idempotency (exactly-once processing).
+	// ProcessOnce records the event id in a ledger atomically with the handler's writes.
+	// This field is nil if no inbox module is registered or inbox.enabled is false.
+	// Example: deps.Inbox.ProcessOnce(ctx, eventID, func(ctx, tx) error { ... })
+	Inbox InboxProcessor
 
 	// KeyStore provides access to named RSA key pairs for encryption/signing.
 	// Keys are loaded at startup from DER files or base64-encoded values.

--- a/app/module_registry.go
+++ b/app/module_registry.go
@@ -73,6 +73,15 @@ func (r *ModuleRegistry) Register(module Module) error {
 			Msg("Outbox module registered - available to other modules via deps.Outbox")
 	}
 
+	// Special case: If this module is an InboxProvider (inbox module),
+	// make it available to other modules via deps.Inbox
+	if inboxProvider, ok := module.(InboxProvider); ok {
+		r.deps.Inbox = inboxProvider.InboxProcessor()
+		r.logger.Info().
+			Str("module", moduleName).
+			Msg("Inbox module registered - available to other modules via deps.Inbox")
+	}
+
 	// Special case: If this module is a KeyStoreProvider (keystore module),
 	// make it available to other modules via deps.KeyStore
 	if ksProvider, ok := module.(KeyStoreProvider); ok {

--- a/app/module_test.go
+++ b/app/module_test.go
@@ -106,6 +106,18 @@ func TestModuleRegistryWiresInboxProvider(t *testing.T) {
 	assert.NotNil(t, deps.Inbox, "an InboxProvider module should wire deps.Inbox")
 }
 
+func TestModuleRegistryRegisterNonInboxModule(t *testing.T) {
+	deps := &ModuleDeps{Logger: logger.New("info", false)}
+	registry := NewModuleRegistry(deps)
+
+	module := &MockModule{name: testModule}
+	module.On("Init", deps).Return(nil)
+	require.NoError(t, registry.Register(module))
+
+	assert.Nil(t, deps.Inbox, "a non-InboxProvider module must not wire deps.Inbox")
+	module.AssertExpectations(t)
+}
+
 func TestModuleRegistryRegisterInitError(t *testing.T) {
 	log := logger.New("debug", true)
 	mockDB := &testmocks.MockDatabase{}

--- a/app/module_test.go
+++ b/app/module_test.go
@@ -75,6 +75,37 @@ func TestModuleRegistryRegisterSuccess(t *testing.T) {
 	module.AssertExpectations(t)
 }
 
+// MockInboxModule implements Module + InboxProvider for testing inbox wiring.
+type MockInboxModule struct {
+	name      string
+	processor InboxProcessor
+}
+
+func (m *MockInboxModule) Name() string                   { return m.name }
+func (m *MockInboxModule) Init(*ModuleDeps) error         { return nil }
+func (m *MockInboxModule) Shutdown() error                { return nil }
+func (m *MockInboxModule) InboxProcessor() InboxProcessor { return m.processor }
+
+var (
+	_ Module        = (*MockInboxModule)(nil)
+	_ InboxProvider = (*MockInboxModule)(nil)
+)
+
+// stubInboxProcessor is a minimal InboxProcessor for wiring tests.
+type stubInboxProcessor struct{}
+
+func (stubInboxProcessor) ProcessOnce(context.Context, string, func(context.Context, database.Tx) error) error {
+	return nil
+}
+
+func TestModuleRegistryWiresInboxProvider(t *testing.T) {
+	deps := &ModuleDeps{Logger: logger.New("info", false)}
+	registry := NewModuleRegistry(deps)
+
+	require.NoError(t, registry.Register(&MockInboxModule{name: "inbox", processor: stubInboxProcessor{}}))
+	assert.NotNil(t, deps.Inbox, "an InboxProvider module should wire deps.Inbox")
+}
+
 func TestModuleRegistryRegisterInitError(t *testing.T) {
 	log := logger.New("debug", true)
 	mockDB := &testmocks.MockDatabase{}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -121,7 +121,7 @@ inbox:
   enabled: false                     # Enable consumer-side idempotency (inbox) ledger
   table_name: gobricks_inbox         # Inbox ledger table name (unqualified)
   auto_create_table: false           # Create table on first use (opt-in; true in dev, false with managed migrations)
-  retention_period: 168h             # How long processed-event records are kept; must exceed broker max redelivery window (0 = keep forever)
+  retention_period: 168h             # How long processed-event records are kept; must exceed broker max redelivery window (0 = use default 168h)
 
 log:
   level: debug

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -110,12 +110,18 @@ keystore:
 outbox:
   enabled: false                     # Enable transactional outbox pattern
   table_name: gobricks_outbox        # Outbox table name in database
-  auto_create_table: true            # Create table on first use (set false for managed migrations)
+  auto_create_table: false           # Create table on first use (opt-in; true in dev, false with managed migrations)
   default_exchange: ""               # Fallback AMQP exchange when Event.Exchange is empty
   poll_interval: 5s                  # How often the relay checks for pending events
   batch_size: 100                    # Maximum events processed per relay cycle
   max_retries: 5                     # Max publish attempts before giving up
   retention_period: 72h              # How long published events are kept (0 = disable cleanup)
+
+inbox:
+  enabled: false                     # Enable consumer-side idempotency (inbox) ledger
+  table_name: gobricks_inbox         # Inbox ledger table name (unqualified)
+  auto_create_table: false           # Create table on first use (opt-in; true in dev, false with managed migrations)
+  retention_period: 168h             # How long processed-event records are kept; must exceed broker max redelivery window (0 = keep forever)
 
 log:
   level: debug

--- a/config/types.go
+++ b/config/types.go
@@ -529,8 +529,8 @@ type InboxConfig struct {
 
 	// RetentionPeriod is how long processed-event records are kept before cleanup.
 	// It MUST exceed the broker's maximum redelivery window, or a late redelivery
-	// could be reprocessed. Set to 0 to disable automatic cleanup (keep forever).
-	// Default: 168h (7 days).
+	// could be reprocessed. A zero value is treated as unset and replaced by the
+	// default; increase it to retain longer. Default: 168h (7 days).
 	RetentionPeriod time.Duration `koanf:"retention_period" json:"retention_period" yaml:"retention_period" toml:"retention_period" mapstructure:"retention_period"`
 }
 

--- a/config/types.go
+++ b/config/types.go
@@ -25,6 +25,7 @@ type Config struct {
 	Source      SourceConfig              `koanf:"source" json:"source" yaml:"source" toml:"source" mapstructure:"source"`
 	Scheduler   SchedulerConfig           `koanf:"scheduler" json:"scheduler" yaml:"scheduler" toml:"scheduler" mapstructure:"scheduler"`
 	Outbox      OutboxConfig              `koanf:"outbox" json:"outbox" yaml:"outbox" toml:"outbox" mapstructure:"outbox"`
+	Inbox       InboxConfig               `koanf:"inbox" json:"inbox" yaml:"inbox" toml:"inbox" mapstructure:"inbox"`
 	KeyStore    KeyStoreConfig            `koanf:"keystore" json:"keystore" yaml:"keystore" toml:"keystore" mapstructure:"keystore"`
 
 	// k holds the underlying Koanf instance for flexible access to custom configurations
@@ -463,7 +464,7 @@ type SourceConfig struct {
 // OutboxConfig holds transactional outbox settings.
 // Production-safe defaults are applied automatically when outbox is enabled:
 //   - TableName: "gobricks_outbox"
-//   - AutoCreateTable: true (create table on first use)
+//   - AutoCreateTable: false (opt-in; set true to create the table on first use)
 //   - PollInterval: 5s (relay poll frequency)
 //   - BatchSize: 100 (events per relay cycle)
 //   - MaxRetries: 5 (max publish attempts before giving up)
@@ -478,7 +479,8 @@ type OutboxConfig struct {
 	TableName string `koanf:"table_name" json:"table_name" yaml:"table_name" toml:"table_name" mapstructure:"table_name"`
 
 	// AutoCreateTable creates the outbox table on first use if it doesn't exist.
-	// Default: true. Set false for production environments with managed migrations.
+	// Default: false (opt-in). Set true to auto-create (e.g. in development); leave
+	// false in production with managed migrations.
 	AutoCreateTable bool `koanf:"auto_create_table" json:"auto_create_table" yaml:"auto_create_table" toml:"auto_create_table" mapstructure:"auto_create_table"`
 
 	// DefaultExchange is the fallback AMQP exchange when Event.Exchange is empty.
@@ -501,6 +503,34 @@ type OutboxConfig struct {
 	// RetentionPeriod is how long published events are kept before cleanup.
 	// Set to 0 to disable automatic cleanup.
 	// Default: 72h.
+	RetentionPeriod time.Duration `koanf:"retention_period" json:"retention_period" yaml:"retention_period" toml:"retention_period" mapstructure:"retention_period"`
+}
+
+// InboxConfig holds consumer-side idempotency (inbox) settings.
+// The inbox is the durable complement to the outbox: it records processed event
+// ids in a ledger so redeliveries are skipped. Production-safe defaults are
+// applied automatically when inbox is enabled:
+//   - TableName: "gobricks_inbox"
+//   - AutoCreateTable: false (opt-in; set true to create the table on first use)
+//   - RetentionPeriod: 168h / 7d (must exceed the broker's max redelivery window)
+type InboxConfig struct {
+	// Enabled activates the consumer-side inbox.
+	// When false, the inbox module is a no-op and deps.Inbox is nil.
+	Enabled bool `koanf:"enabled" json:"enabled" yaml:"enabled" toml:"enabled" mapstructure:"enabled"`
+
+	// TableName is the inbox ledger table name in the database.
+	// Default: "gobricks_inbox". Must be unqualified (no schema prefix).
+	TableName string `koanf:"table_name" json:"table_name" yaml:"table_name" toml:"table_name" mapstructure:"table_name"`
+
+	// AutoCreateTable creates the inbox table on first use if it doesn't exist.
+	// Default: false (opt-in). Set true to auto-create (e.g. in development); leave
+	// false in production with managed migrations.
+	AutoCreateTable bool `koanf:"auto_create_table" json:"auto_create_table" yaml:"auto_create_table" toml:"auto_create_table" mapstructure:"auto_create_table"`
+
+	// RetentionPeriod is how long processed-event records are kept before cleanup.
+	// It MUST exceed the broker's maximum redelivery window, or a late redelivery
+	// could be reprocessed. Set to 0 to disable automatic cleanup (keep forever).
+	// Default: 168h (7 days).
 	RetentionPeriod time.Duration `koanf:"retention_period" json:"retention_period" yaml:"retention_period" toml:"retention_period" mapstructure:"retention_period"`
 }
 

--- a/config/types.go
+++ b/config/types.go
@@ -462,7 +462,8 @@ type SourceConfig struct {
 }
 
 // OutboxConfig holds transactional outbox settings.
-// Production-safe defaults are applied automatically when outbox is enabled:
+// Default values when outbox is enabled (AutoCreateTable is opt-in: its default
+// false is the zero value, not actively applied):
 //   - TableName: "gobricks_outbox"
 //   - AutoCreateTable: false (opt-in; set true to create the table on first use)
 //   - PollInterval: 5s (relay poll frequency)
@@ -508,8 +509,9 @@ type OutboxConfig struct {
 
 // InboxConfig holds consumer-side idempotency (inbox) settings.
 // The inbox is the durable complement to the outbox: it records processed event
-// ids in a ledger so redeliveries are skipped. Production-safe defaults are
-// applied automatically when inbox is enabled:
+// ids in a ledger so redeliveries are skipped. Default values when inbox is
+// enabled (AutoCreateTable is opt-in: its default false is the zero value, not
+// actively applied):
 //   - TableName: "gobricks_inbox"
 //   - AutoCreateTable: false (opt-in; set true to create the table on first use)
 //   - RetentionPeriod: 168h / 7d (must exceed the broker's max redelivery window)
@@ -519,7 +521,8 @@ type InboxConfig struct {
 	Enabled bool `koanf:"enabled" json:"enabled" yaml:"enabled" toml:"enabled" mapstructure:"enabled"`
 
 	// TableName is the inbox ledger table name in the database.
-	// Default: "gobricks_inbox". Must be unqualified (no schema prefix).
+	// Default: "gobricks_inbox". Must be unqualified (no schema prefix) because the
+	// Oracle store derives a primary-key constraint name from it.
 	TableName string `koanf:"table_name" json:"table_name" yaml:"table_name" toml:"table_name" mapstructure:"table_name"`
 
 	// AutoCreateTable creates the inbox table on first use if it doesn't exist.

--- a/inbox/cleanup.go
+++ b/inbox/cleanup.go
@@ -1,0 +1,38 @@
+package inbox
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gaborage/go-bricks/scheduler"
+)
+
+// Cleanup is a scheduler.Executor that removes processed-event records older
+// than the configured retention period. Runs daily at 04:00 by default.
+type Cleanup struct {
+	store           Store
+	retentionPeriod time.Duration
+}
+
+func (c *Cleanup) Execute(ctx scheduler.JobContext) error {
+	db := ctx.DB()
+	if db == nil {
+		return fmt.Errorf("inbox cleanup: database not available")
+	}
+
+	cutoff := time.Now().Add(-c.retentionPeriod)
+
+	deleted, err := c.store.DeleteProcessed(ctx, db, cutoff)
+	if err != nil {
+		return fmt.Errorf("inbox cleanup: delete failed: %w", err)
+	}
+
+	if deleted > 0 {
+		ctx.Logger().Info().
+			Int64("deleted", deleted).
+			Str("cutoff", cutoff.Format(time.RFC3339)).
+			Msg("Inbox cleanup completed")
+	}
+
+	return nil
+}

--- a/inbox/config.go
+++ b/inbox/config.go
@@ -1,0 +1,39 @@
+package inbox
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gaborage/go-bricks/config"
+)
+
+// DefaultTableName is the default inbox ledger table name.
+const DefaultTableName = "gobricks_inbox"
+
+// DefaultRetentionPeriod is the default processed-event retention (7 days).
+// It must exceed the broker's maximum redelivery window. Written as a duration
+// (168h) because Go's time.ParseDuration does not accept a "7d" unit.
+const DefaultRetentionPeriod = 7 * 24 * time.Hour
+
+// applyDefaults fills zero-value fields with production-safe defaults.
+// AutoCreateTable is intentionally left at its zero value (false, opt-in).
+func applyDefaults(c *config.InboxConfig) {
+	if c.TableName == "" {
+		c.TableName = DefaultTableName
+	}
+	if c.RetentionPeriod == 0 {
+		c.RetentionPeriod = DefaultRetentionPeriod
+	}
+}
+
+// validateConfig checks that config values are within valid ranges.
+// Called after applyDefaults, so zero values have already been replaced.
+func validateConfig(c *config.InboxConfig) error {
+	if c.RetentionPeriod < 0 {
+		return fmt.Errorf("inbox: retention_period must not be negative, got %s", c.RetentionPeriod)
+	}
+	if err := validateTableName(c.TableName); err != nil {
+		return err
+	}
+	return nil
+}

--- a/inbox/config_test.go
+++ b/inbox/config_test.go
@@ -1,0 +1,37 @@
+package inbox
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gaborage/go-bricks/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyDefaults(t *testing.T) {
+	c := &config.InboxConfig{}
+	applyDefaults(c)
+	assert.Equal(t, DefaultTableName, c.TableName)
+	assert.Equal(t, DefaultRetentionPeriod, c.RetentionPeriod)
+	assert.False(t, c.AutoCreateTable, "AutoCreateTable stays opt-in (false)")
+}
+
+func TestApplyDefaultsPreservesExplicitValues(t *testing.T) {
+	c := &config.InboxConfig{TableName: "my_inbox", RetentionPeriod: 48 * time.Hour}
+	applyDefaults(c)
+	assert.Equal(t, "my_inbox", c.TableName)
+	assert.Equal(t, 48*time.Hour, c.RetentionPeriod)
+}
+
+func TestValidateConfig(t *testing.T) {
+	require.NoError(t, validateConfig(&config.InboxConfig{TableName: "gobricks_inbox", RetentionPeriod: time.Hour}))
+
+	err := validateConfig(&config.InboxConfig{TableName: "gobricks_inbox", RetentionPeriod: -time.Hour})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "retention_period must not be negative")
+
+	err = validateConfig(&config.InboxConfig{TableName: "schema.inbox", RetentionPeriod: time.Hour})
+	require.Error(t, err, "qualified table name rejected")
+	assert.Contains(t, err.Error(), "unqualified")
+}

--- a/inbox/coverage_test.go
+++ b/inbox/coverage_test.go
@@ -1,0 +1,105 @@
+package inbox
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gaborage/go-bricks/config"
+	dbtesting "github.com/gaborage/go-bricks/database/testing"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/messaging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeJobCtx is a minimal scheduler.JobContext backed by a test DB.
+type fakeJobCtx struct {
+	context.Context
+	db dbtypes.Interface
+}
+
+func (c fakeJobCtx) JobID() string               { return "inbox-cleanup" }
+func (c fakeJobCtx) TriggerType() string         { return "scheduled" }
+func (c fakeJobCtx) Logger() logger.Logger       { return logger.New("info", false) }
+func (c fakeJobCtx) DB() dbtypes.Interface       { return c.db }
+func (c fakeJobCtx) Messaging() messaging.Client { return nil }
+func (c fakeJobCtx) Config() *config.Config      { return nil }
+
+func newCoverageModule(db dbtypes.Interface, cfg config.InboxConfig) *Module {
+	return &Module{
+		logger: logger.New("info", false),
+		cfg:    cfg,
+		getDB:  func(context.Context) (dbtypes.Interface, error) { return db, nil },
+	}
+}
+
+func TestEnsureStoreInitializedOracleWithAutoCreate(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.Oracle)
+	db.ExpectExec(`CREATE TABLE gobricks_inbox`).WillReturnRowsAffected(0)
+	db.ExpectExec(`CREATE INDEX idx_gobricks_inbox_processed`).WillReturnRowsAffected(0)
+	m := newCoverageModule(db, config.InboxConfig{Enabled: true, TableName: "gobricks_inbox", AutoCreateTable: true})
+
+	require.NoError(t, m.ensureStoreInitialized(t.Context()))
+	assert.True(t, m.tableCreated)
+	assert.NotNil(t, m.store)
+}
+
+func TestLazyStoreDelegates(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction().ExpectExec(`INSERT INTO gobricks_inbox`).WillReturnRowsAffected(1)
+	db.ExpectExec(`CREATE TABLE`).WillReturnRowsAffected(0)
+	db.ExpectExec(`CREATE INDEX`).WillReturnRowsAffected(0)
+	m := newCoverageModule(db, config.InboxConfig{Enabled: true, TableName: "gobricks_inbox"})
+	ls := &lazyStore{module: m}
+
+	tx, err := db.Begin(t.Context())
+	require.NoError(t, err)
+	inserted, err := ls.MarkProcessed(t.Context(), tx, Record{EventID: "e", ProcessedAt: time.Now()})
+	require.NoError(t, err)
+	assert.True(t, inserted)
+
+	require.NoError(t, ls.CreateTable(t.Context(), db))
+}
+
+func TestCleanupExecute(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectExec(`DELETE FROM gobricks_inbox`).WillReturnRowsAffected(5)
+	m := newCoverageModule(db, config.InboxConfig{Enabled: true, TableName: "gobricks_inbox"})
+
+	c := &Cleanup{store: &lazyStore{module: m}, retentionPeriod: time.Hour}
+	ctx := fakeJobCtx{Context: context.Background(), db: db}
+	require.NoError(t, c.Execute(ctx))
+}
+
+func TestCleanupExecuteErrorsWithoutDB(t *testing.T) {
+	c := &Cleanup{store: &lazyStore{module: &Module{}}, retentionPeriod: time.Hour}
+	ctx := fakeJobCtx{Context: context.Background(), db: nil}
+	err := c.Execute(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database not available")
+}
+
+func TestModuleShutdown(t *testing.T) {
+	m := newCoverageModule(dbtesting.NewTestDB(dbtypes.PostgreSQL), config.InboxConfig{})
+	require.NoError(t, m.Shutdown())
+}
+
+func TestLazyStorePropagatesInitError(t *testing.T) {
+	m := &Module{
+		cfg:   config.InboxConfig{TableName: "gobricks_inbox"},
+		getDB: func(context.Context) (dbtypes.Interface, error) { return nil, errInitFailed },
+	}
+	ls := &lazyStore{module: m}
+
+	_, err := ls.MarkProcessed(context.Background(), nil, Record{})
+	require.ErrorIs(t, err, errInitFailed)
+	_, err = ls.DeleteProcessed(context.Background(), nil, time.Now())
+	require.ErrorIs(t, err, errInitFailed)
+	err = ls.CreateTable(context.Background(), nil)
+	require.ErrorIs(t, err, errInitFailed)
+}
+
+var errInitFailed = errors.New("db unavailable")

--- a/inbox/inbox.go
+++ b/inbox/inbox.go
@@ -1,0 +1,51 @@
+// Package inbox provides durable consumer-side idempotency: a ledger that records
+// processed event ids so redeliveries are skipped. It is the consumer-side
+// complement to the transactional outbox.
+//
+// Consumers extract the event id from the delivery (e.g. via
+// outbox.EventIDFromHeaders) and wrap their handler in deps.Inbox.ProcessOnce,
+// which records the id and runs the handler atomically, exactly once per id.
+package inbox
+
+import (
+	"context"
+	"time"
+
+	"github.com/gaborage/go-bricks/database"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/multitenant"
+)
+
+// Inbox implements app.InboxProcessor, backed by the module's lazily-initialized
+// vendor store.
+type Inbox struct {
+	module *Module
+}
+
+// ProcessOnce records eventID in the ledger and runs fn exactly once per id,
+// atomically within a single transaction. A redelivery of an already-processed
+// id short-circuits (fn is not run) and returns nil. The tenant is resolved from
+// ctx; in single-tenant mode the tenant id is empty.
+func (i *Inbox) ProcessOnce(ctx context.Context, eventID string, fn func(ctx context.Context, tx dbtypes.Tx) error) error {
+	if err := i.module.ensureStoreInitialized(ctx); err != nil {
+		return err
+	}
+	db, err := i.module.getDB(ctx)
+	if err != nil {
+		return err
+	}
+
+	tenantID, _ := multitenant.GetTenant(ctx)
+	rec := Record{TenantID: tenantID, EventID: eventID, ProcessedAt: time.Now()}
+
+	return database.WithTx(ctx, db, func(ctx context.Context, tx dbtypes.Tx) error {
+		inserted, err := i.module.store.MarkProcessed(ctx, tx, rec)
+		if err != nil {
+			return err
+		}
+		if !inserted {
+			return nil // already processed: skip fn, commit the no-op
+		}
+		return fn(ctx, tx)
+	})
+}

--- a/inbox/inbox_test.go
+++ b/inbox/inbox_test.go
@@ -1,0 +1,82 @@
+package inbox
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gaborage/go-bricks/config"
+	dbtesting "github.com/gaborage/go-bricks/database/testing"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestInbox builds an Inbox whose module resolves to the given test DB.
+// AutoCreateTable is false, so no logger is needed.
+func newTestInbox(db dbtypes.Interface) *Inbox {
+	m := &Module{
+		cfg:   config.InboxConfig{Enabled: true, TableName: "gobricks_inbox"},
+		getDB: func(context.Context) (dbtypes.Interface, error) { return db, nil },
+	}
+	return &Inbox{module: m}
+}
+
+func TestProcessOnceRunsFnOnFirstEvent(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction().
+		ExpectExec(`INSERT INTO gobricks_inbox`).
+		WillReturnRowsAffected(1)
+	in := newTestInbox(db)
+
+	ran := false
+	err := in.ProcessOnce(t.Context(), "evt-1", func(context.Context, dbtypes.Tx) error {
+		ran = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, ran, "fn runs on first occurrence of the event id")
+}
+
+func TestProcessOnceSkipsFnOnDuplicate(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	// ON CONFLICT DO NOTHING -> 0 rows affected -> already processed.
+	db.ExpectTransaction().
+		ExpectExec(`INSERT INTO gobricks_inbox`).
+		WillReturnRowsAffected(0)
+	in := newTestInbox(db)
+
+	ran := false
+	err := in.ProcessOnce(t.Context(), "evt-1", func(context.Context, dbtypes.Tx) error {
+		ran = true
+		return nil
+	})
+	require.NoError(t, err)
+	assert.False(t, ran, "fn is skipped when the event id was already processed")
+}
+
+func TestProcessOncePropagatesFnError(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction().
+		ExpectExec(`INSERT INTO gobricks_inbox`).
+		WillReturnRowsAffected(1)
+	in := newTestInbox(db)
+
+	sentinel := errors.New("handler failed")
+	err := in.ProcessOnce(t.Context(), "evt-1", func(context.Context, dbtypes.Tx) error {
+		return sentinel
+	})
+	assert.ErrorIs(t, err, sentinel, "a handler error rolls back and propagates")
+}
+
+func TestProcessOnceReturnsDBError(t *testing.T) {
+	m := &Module{
+		cfg:   config.InboxConfig{Enabled: true, TableName: "gobricks_inbox"},
+		getDB: func(context.Context) (dbtypes.Interface, error) { return nil, errors.New("db down") },
+	}
+	in := &Inbox{module: m}
+
+	err := in.ProcessOnce(t.Context(), "evt-1", func(context.Context, dbtypes.Tx) error { return nil })
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database unavailable")
+}

--- a/inbox/module.go
+++ b/inbox/module.go
@@ -1,0 +1,196 @@
+package inbox
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/config"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/logger"
+)
+
+// Module implements the GoBricks Module interface for the consumer-side inbox.
+// It provides durable, exactly-once event processing via deps.Inbox.ProcessOnce
+// and a daily cleanup job that prunes old processed-event records.
+//
+// Register it like any other module (the scheduler is optional but required for
+// the retention cleanup job):
+//
+//	fw.RegisterModules(
+//	    scheduler.NewModule(), // optional: enables inbox-cleanup
+//	    inbox.NewModule(),
+//	    &myapp.ConsumerModule{},
+//	)
+type Module struct {
+	logger logger.Logger
+	config *config.Config
+	getDB  func(context.Context) (dbtypes.Interface, error)
+
+	store     Store
+	processor app.InboxProcessor
+	cfg       config.InboxConfig
+
+	initMu       sync.Mutex // Protects lazy store initialization
+	tableCreated bool
+}
+
+// NewModule creates a new inbox Module instance.
+func NewModule() *Module {
+	return &Module{}
+}
+
+// Name implements app.Module.
+func (m *Module) Name() string {
+	return "inbox"
+}
+
+// Init implements app.Module.
+func (m *Module) Init(deps *app.ModuleDeps) error {
+	m.logger = deps.Logger
+	m.config = deps.Config
+	m.getDB = deps.DB
+
+	if m.config != nil {
+		m.cfg = m.config.Inbox
+	}
+	applyDefaults(&m.cfg)
+	if err := validateConfig(&m.cfg); err != nil {
+		return err
+	}
+
+	if !m.cfg.Enabled {
+		m.logger.Info().Msg("Inbox module disabled (inbox.enabled=false)")
+		return nil
+	}
+
+	// Fail fast: when the inbox is enabled, the DB resolver is required.
+	if m.getDB == nil {
+		return fmt.Errorf("inbox: database resolver (deps.DB) is required when inbox is enabled")
+	}
+
+	m.processor = &Inbox{module: m}
+
+	m.logger.Info().
+		Str("table", m.cfg.TableName).
+		Dur("retentionPeriod", m.cfg.RetentionPeriod).
+		Msg("Inbox module initialized")
+	return nil
+}
+
+// ensureStoreInitialized creates the vendor-specific store on first use.
+// Lazy because the database vendor type is only known once a connection exists.
+// Uses double-check locking (mutex, not sync.Once) so a failed init can retry.
+func (m *Module) ensureStoreInitialized(ctx context.Context) error {
+	m.initMu.Lock()
+	defer m.initMu.Unlock()
+
+	if m.store != nil {
+		return nil
+	}
+
+	db, err := m.getDB(ctx)
+	if err != nil {
+		return fmt.Errorf("inbox: database unavailable: %w", err)
+	}
+
+	var store Store
+	switch db.DatabaseType() {
+	case dbtypes.PostgreSQL:
+		store, err = NewPostgresStore(m.cfg.TableName)
+	case dbtypes.Oracle:
+		store, err = NewOracleStore(m.cfg.TableName)
+	default:
+		return fmt.Errorf("inbox: unsupported database vendor: %s", db.DatabaseType())
+	}
+	if err != nil {
+		return fmt.Errorf("inbox: failed to create store: %w", err)
+	}
+
+	// Auto-create the table if configured. Warning-only on failure: PostgreSQL
+	// uses IF NOT EXISTS (idempotent), Oracle may return ORA-00955 if it exists.
+	if m.cfg.AutoCreateTable && !m.tableCreated {
+		if createErr := store.CreateTable(ctx, db); createErr != nil {
+			m.logger.Warn().Err(createErr).
+				Str("table", m.cfg.TableName).
+				Msg("Inbox table creation failed (may already exist)")
+		}
+		m.tableCreated = true
+	}
+
+	m.store = store
+	return nil
+}
+
+// InboxProcessor implements app.InboxProvider — returns the processor for
+// ModuleDeps wiring. Returns nil when the inbox is disabled.
+func (m *Module) InboxProcessor() app.InboxProcessor {
+	return m.processor
+}
+
+// RegisterJobs implements app.JobProvider. The inbox has no relay; it registers
+// only the retention cleanup job, and only when retention is positive.
+func (m *Module) RegisterJobs(registrar app.JobRegistrar) error {
+	if !m.cfg.Enabled || m.cfg.RetentionPeriod <= 0 {
+		return nil
+	}
+
+	cleanup := &Cleanup{
+		store:           &lazyStore{module: m},
+		retentionPeriod: m.cfg.RetentionPeriod,
+	}
+
+	cleanupTime := time.Date(0, 1, 1, 4, 0, 0, 0, time.Local)
+	if err := registrar.DailyAt("inbox-cleanup", cleanup, cleanupTime); err != nil {
+		return fmt.Errorf("inbox: failed to register cleanup job: %w", err)
+	}
+
+	m.logger.Info().
+		Dur("retentionPeriod", m.cfg.RetentionPeriod).
+		Msg("Inbox cleanup job registered")
+	return nil
+}
+
+// Shutdown implements app.Module.
+func (m *Module) Shutdown() error {
+	m.logger.Info().Msg("Inbox module shut down")
+	return nil
+}
+
+// lazyStore wraps Store to lazily initialize via the module. Used by the cleanup
+// job, which starts after Init() (before the vendor is known).
+type lazyStore struct {
+	module *Module
+}
+
+func (s *lazyStore) MarkProcessed(ctx context.Context, tx dbtypes.Tx, rec Record) (bool, error) {
+	if err := s.module.ensureStoreInitialized(ctx); err != nil {
+		return false, err
+	}
+	return s.module.store.MarkProcessed(ctx, tx, rec)
+}
+
+func (s *lazyStore) DeleteProcessed(ctx context.Context, db dbtypes.Interface, before time.Time) (int64, error) {
+	if err := s.module.ensureStoreInitialized(ctx); err != nil {
+		return 0, err
+	}
+	return s.module.store.DeleteProcessed(ctx, db, before)
+}
+
+func (s *lazyStore) CreateTable(ctx context.Context, db dbtypes.Interface) error {
+	if err := s.module.ensureStoreInitialized(ctx); err != nil {
+		return err
+	}
+	return s.module.store.CreateTable(ctx, db)
+}
+
+// Compile-time guards.
+var (
+	_ app.Module         = (*Module)(nil)
+	_ app.InboxProvider  = (*Module)(nil)
+	_ app.JobProvider    = (*Module)(nil)
+	_ app.InboxProcessor = (*Inbox)(nil)
+	_ Store              = (*lazyStore)(nil)
+)

--- a/inbox/module.go
+++ b/inbox/module.go
@@ -142,9 +142,9 @@ func (m *Module) RegisterJobs(registrar app.JobRegistrar) error {
 		retentionPeriod: m.cfg.RetentionPeriod,
 	}
 
-	// DailyAt uses only the time-of-day (04:00 local); the date components are
-	// placeholders.
-	cleanupTime := time.Date(0, 1, 1, 4, 0, 0, 0, time.Local)
+	// DailyAt uses only the time-of-day (04:00) and applies the scheduler's
+	// configured timezone; the date and Location here are placeholders.
+	cleanupTime := time.Date(0, 1, 1, 4, 0, 0, 0, time.UTC)
 	if err := registrar.DailyAt("inbox-cleanup", cleanup, cleanupTime); err != nil {
 		return fmt.Errorf("inbox: failed to register cleanup job: %w", err)
 	}

--- a/inbox/module.go
+++ b/inbox/module.go
@@ -142,6 +142,8 @@ func (m *Module) RegisterJobs(registrar app.JobRegistrar) error {
 		retentionPeriod: m.cfg.RetentionPeriod,
 	}
 
+	// DailyAt uses only the time-of-day (04:00 local); the date components are
+	// placeholders.
 	cleanupTime := time.Date(0, 1, 1, 4, 0, 0, 0, time.Local)
 	if err := registrar.DailyAt("inbox-cleanup", cleanup, cleanupTime); err != nil {
 		return fmt.Errorf("inbox: failed to register cleanup job: %w", err)

--- a/inbox/module_test.go
+++ b/inbox/module_test.go
@@ -1,0 +1,106 @@
+package inbox
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gaborage/go-bricks/app"
+	"github.com/gaborage/go-bricks/config"
+	dbtesting "github.com/gaborage/go-bricks/database/testing"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRegistrar captures DailyAt registrations. Implements app.JobRegistrar.
+type fakeRegistrar struct {
+	dailyJobs map[string]any
+}
+
+func (r *fakeRegistrar) FixedRate(string, any, time.Duration) error { return nil }
+func (r *fakeRegistrar) DailyAt(jobID string, job any, _ time.Time) error {
+	if r.dailyJobs == nil {
+		r.dailyJobs = map[string]any{}
+	}
+	r.dailyJobs[jobID] = job
+	return nil
+}
+func (r *fakeRegistrar) WeeklyAt(string, any, time.Weekday, time.Time) error { return nil }
+func (r *fakeRegistrar) HourlyAt(string, any, int) error                     { return nil }
+func (r *fakeRegistrar) MonthlyAt(string, any, int, time.Time) error         { return nil }
+
+func testDeps() *app.ModuleDeps {
+	return &app.ModuleDeps{
+		Logger: logger.New("info", false),
+		DB: func(context.Context) (dbtypes.Interface, error) {
+			return dbtesting.NewTestDB(dbtypes.PostgreSQL), nil
+		},
+	}
+}
+
+func TestModuleNameIsInbox(t *testing.T) {
+	assert.Equal(t, "inbox", NewModule().Name())
+}
+
+func TestModuleInitDisabledExposesNilProcessor(t *testing.T) {
+	m := NewModule()
+	deps := testDeps()
+	deps.Config = &config.Config{Inbox: config.InboxConfig{Enabled: false}}
+
+	require.NoError(t, m.Init(deps))
+	assert.Nil(t, m.InboxProcessor(), "a disabled inbox must expose a nil InboxProcessor (no typed-nil interface)")
+}
+
+func TestModuleInitEnabledExposesProcessor(t *testing.T) {
+	m := NewModule()
+	deps := testDeps()
+	deps.Config = &config.Config{Inbox: config.InboxConfig{Enabled: true}}
+
+	require.NoError(t, m.Init(deps))
+	require.NotNil(t, m.InboxProcessor())
+}
+
+func TestModuleInitEnabledRequiresDB(t *testing.T) {
+	m := NewModule()
+	deps := testDeps()
+	deps.DB = nil
+	deps.Config = &config.Config{Inbox: config.InboxConfig{Enabled: true}}
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database resolver")
+}
+
+func TestModuleInitRejectsBadTableName(t *testing.T) {
+	m := NewModule()
+	deps := testDeps()
+	deps.Config = &config.Config{Inbox: config.InboxConfig{Enabled: true, TableName: "schema.inbox"}}
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unqualified")
+}
+
+func TestRegisterJobsRegistersCleanup(t *testing.T) {
+	m := NewModule()
+	deps := testDeps()
+	deps.Config = &config.Config{Inbox: config.InboxConfig{Enabled: true, RetentionPeriod: time.Hour}}
+	require.NoError(t, m.Init(deps))
+
+	reg := &fakeRegistrar{}
+	require.NoError(t, m.RegisterJobs(reg))
+	assert.Contains(t, reg.dailyJobs, "inbox-cleanup")
+}
+
+func TestRegisterJobsSkipsWhenDisabled(t *testing.T) {
+	m := NewModule()
+	deps := testDeps()
+	deps.Config = &config.Config{Inbox: config.InboxConfig{Enabled: false}}
+	require.NoError(t, m.Init(deps))
+
+	reg := &fakeRegistrar{}
+	require.NoError(t, m.RegisterJobs(reg))
+	assert.Empty(t, reg.dailyJobs)
+}

--- a/inbox/store.go
+++ b/inbox/store.go
@@ -37,15 +37,24 @@ type Store interface {
 	CreateTable(ctx context.Context, db dbtypes.Interface) error
 }
 
+// maxTableNameLen bounds the inbox table name so the longest derived Oracle
+// identifier — the index "idx_<name>_processed" (14 extra chars) — stays within
+// Oracle's 128-character identifier limit.
+const maxTableNameLen = 128 - len("idx__processed")
+
 // validateTableName checks that name is a safe, unqualified SQL identifier.
 // The inbox requires an unqualified name (no schema prefix) because the Oracle
-// store derives a primary-key constraint name from it.
+// store derives a primary-key constraint name from it, and bounds its length so
+// the derived constraint/index identifiers fit Oracle's limit.
 func validateTableName(name string) error {
 	if err := sqlid.ValidateTableName(name); err != nil {
 		return fmt.Errorf("inbox: %w", err)
 	}
 	if strings.Contains(name, ".") {
 		return fmt.Errorf("inbox: table name %q must be unqualified (no schema prefix)", name)
+	}
+	if len(name) > maxTableNameLen {
+		return fmt.Errorf("inbox: table name %q is too long (max %d; derived Oracle identifiers must fit 128 chars)", name, maxTableNameLen)
 	}
 	return nil
 }

--- a/inbox/store.go
+++ b/inbox/store.go
@@ -1,0 +1,51 @@
+package inbox
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/internal/sqlid"
+)
+
+// Record is a single row in the inbox ledger: a processed event id scoped to a
+// tenant, with the time it was processed.
+type Record struct {
+	TenantID    string
+	EventID     string
+	ProcessedAt time.Time
+}
+
+// Store abstracts inbox ledger operations for vendor-agnostic SQL.
+// Implementations exist for PostgreSQL and Oracle with vendor-specific
+// placeholder styles, DDL, and duplicate-detection (PostgreSQL ON CONFLICT vs
+// Oracle unique-violation catch).
+type Store interface {
+	// MarkProcessed records (tenant_id, event_id) within the given transaction.
+	// It returns inserted=true the first time an id is seen and inserted=false on
+	// a duplicate (the id was already processed).
+	MarkProcessed(ctx context.Context, tx dbtypes.Tx, rec Record) (inserted bool, err error)
+
+	// DeleteProcessed removes ledger rows processed before the given time.
+	// Returns the number of rows deleted.
+	DeleteProcessed(ctx context.Context, db dbtypes.Interface, before time.Time) (int64, error)
+
+	// CreateTable creates the inbox table and its index if they do not exist.
+	// Used for auto-migration when inbox.auto_create_table is true.
+	CreateTable(ctx context.Context, db dbtypes.Interface) error
+}
+
+// validateTableName checks that name is a safe, unqualified SQL identifier.
+// The inbox requires an unqualified name (no schema prefix) because the Oracle
+// store derives a primary-key constraint name from it.
+func validateTableName(name string) error {
+	if err := sqlid.ValidateTableName(name); err != nil {
+		return fmt.Errorf("inbox: %w", err)
+	}
+	if strings.Contains(name, ".") {
+		return fmt.Errorf("inbox: table name %q must be unqualified (no schema prefix)", name)
+	}
+	return nil
+}

--- a/inbox/store_integration_test.go
+++ b/inbox/store_integration_test.go
@@ -1,0 +1,217 @@
+//go:build integration
+
+package inbox
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gaborage/go-bricks/config"
+	"github.com/gaborage/go-bricks/database"
+	"github.com/gaborage/go-bricks/logger"
+	testconsts "github.com/gaborage/go-bricks/testing"
+	"github.com/gaborage/go-bricks/testing/containers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests prove the inbox ledger Store works end to end against REAL
+// PostgreSQL and Oracle containers. The connection is built through the
+// database-package factory (NewConnection -> database.Interface), so CreateTable
+// DDL, MarkProcessed (insert + duplicate detection), and DeleteProcessed travel
+// the full framework wrap chain on each vendor.
+//
+// The load-bearing case is the duplicate MarkProcessed: PostgreSQL relies on
+// INSERT ... ON CONFLICT DO NOTHING returning zero rows (no error, tx survives),
+// while Oracle catches ORA-00001 via database.IsUniqueViolation (statement-level,
+// tx survives). Both vendors must leave the transaction usable after a duplicate,
+// which the test proves by committing — and on Oracle by performing a subsequent
+// successful insert within the SAME transaction.
+
+const (
+	inboxTableName       = "inbox_it"
+	inboxTenantID        = "t1"
+	inboxShouldCreateMsg = "Should create inbox table"
+	inboxShouldBeginMsg  = "Should begin transaction"
+	inboxShouldCommitMsg = "Should commit transaction"
+)
+
+// newDisabledTestLogger mirrors database/internal/dbtestlog.NewDisabledTestLogger
+// (which is internal to the database/ subtree and not importable here): a
+// disabled logger reduces noise in integration tests that verify functionality
+// without needing logs.
+func newDisabledTestLogger() logger.Logger {
+	return logger.New(testconsts.TestLoggerLevelDisabled, true)
+}
+
+// inboxPoolConfig mirrors the pool sizing used by the existing integration
+// harnesses (database/errors_integration_test.go defaultPoolConfig).
+func inboxPoolConfig() config.PoolConfig {
+	return config.PoolConfig{
+		Max: config.PoolMaxConfig{
+			Connections: 25,
+		},
+		Idle: config.PoolIdleConfig{
+			Connections: 10,
+			Time:        30 * time.Minute,
+		},
+		Lifetime: config.LifetimeConfig{
+			Max: time.Hour,
+		},
+	}
+}
+
+// TestInboxStorePostgresIntegration exercises the PostgreSQL inbox store against
+// a real container: CreateTable DDL, first-insert, duplicate (ON CONFLICT DO
+// NOTHING returns inserted=false with the tx still usable), a second distinct
+// event, and retention DeleteProcessed.
+func TestInboxStorePostgresIntegration(t *testing.T) {
+	// Context with timeout to prevent indefinite hangs, mirroring the
+	// database/postgresql setupTestContainer harness.
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	t.Cleanup(cancel)
+
+	// MustStartPostgreSQLContainer auto-skips (t.Skip) when Docker is unavailable.
+	pgContainer := containers.MustStartPostgreSQLContainer(ctx, t, nil).WithCleanup(t)
+	log := newDisabledTestLogger()
+
+	// Build a database.Interface via the database-package factory (NewConnection).
+	// Type must be set so the factory dispatches to the PostgreSQL driver.
+	cfg := &config.DatabaseConfig{
+		Type:             database.PostgreSQL,
+		ConnectionString: pgContainer.ConnectionString(),
+		Pool:             inboxPoolConfig(),
+	}
+
+	conn, err := database.NewConnection(cfg, log)
+	require.NoError(t, err, "Failed to create PostgreSQL connection")
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	require.NoError(t, conn.Health(ctx), "Failed to ping PostgreSQL")
+
+	store, err := NewPostgresStore(inboxTableName)
+	require.NoError(t, err, "Failed to build PostgreSQL inbox store")
+
+	// CreateTable proves the DDL (PK + processed_at index) is valid on real PG.
+	require.NoError(t, store.CreateTable(ctx, conn), inboxShouldCreateMsg)
+	t.Cleanup(func() {
+		// Best-effort drop so reruns against a reused volume stay clean.
+		_, _ = conn.Exec(context.Background(), "DROP TABLE IF EXISTS "+inboxTableName)
+	})
+
+	now := time.Now()
+
+	// First insert: inserted=true.
+	tx, err := conn.Begin(ctx)
+	require.NoError(t, err, inboxShouldBeginMsg)
+	inserted, err := store.MarkProcessed(ctx, tx, Record{TenantID: inboxTenantID, EventID: "evt-1", ProcessedAt: now})
+	require.NoError(t, err, "First MarkProcessed should not error")
+	assert.True(t, inserted, "First (tenant_id, event_id) must be inserted")
+	require.NoError(t, tx.Commit(ctx), inboxShouldCommitMsg)
+
+	// Duplicate insert in a NEW transaction: inserted=false, no error, and the
+	// transaction must remain usable afterward. PG: ON CONFLICT returns 0 rows.
+	dupTx, err := conn.Begin(ctx)
+	require.NoError(t, err, inboxShouldBeginMsg)
+	inserted, err = store.MarkProcessed(ctx, dupTx, Record{TenantID: inboxTenantID, EventID: "evt-1", ProcessedAt: now})
+	require.NoError(t, err, "Duplicate MarkProcessed must NOT error on PostgreSQL")
+	assert.False(t, inserted, "Duplicate (tenant_id, event_id) must report inserted=false")
+	// The tx survives the duplicate: a distinct event inserts within the SAME tx.
+	inserted, err = store.MarkProcessed(ctx, dupTx, Record{TenantID: inboxTenantID, EventID: "evt-2", ProcessedAt: now})
+	require.NoError(t, err, "Distinct MarkProcessed after duplicate must not error")
+	assert.True(t, inserted, "Distinct event after a duplicate must be inserted in the same tx")
+	require.NoError(t, dupTx.Commit(ctx), inboxShouldCommitMsg)
+
+	// DeleteProcessed removes both rows processed before now+1h.
+	deleted, err := store.DeleteProcessed(ctx, conn, now.Add(time.Hour))
+	require.NoError(t, err, "DeleteProcessed should not error")
+	assert.GreaterOrEqual(t, deleted, int64(2), "DeleteProcessed must remove at least the two inserted rows")
+}
+
+// TestInboxStoreOracleIntegration exercises the Oracle inbox store against a real
+// container. The load-bearing assertion is the duplicate path: Oracle has no ON
+// CONFLICT, so MarkProcessed catches ORA-00001 via database.IsUniqueViolation;
+// because the violation is statement-level the SAME transaction must still be
+// usable, which the test proves with a subsequent successful insert + commit.
+func TestInboxStoreOracleIntegration(t *testing.T) {
+	// Context with timeout sized for Oracle's slower startup, mirroring the
+	// database/oracle harness.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	t.Cleanup(cancel)
+
+	// StartOracleContainer calls t.Skip internally when Docker is unavailable,
+	// so this test is skipped gracefully off a Docker host.
+	oraContainer, err := containers.StartOracleContainer(ctx, t, nil)
+	require.NoError(t, err, "Failed to start Oracle container")
+	oraContainer.WithCleanup(t)
+	log := newDisabledTestLogger()
+
+	// Build a database.Interface via the database-package factory (NewConnection)
+	// from the container's connection details. Type must be set so the factory
+	// dispatches to the Oracle driver; the service name carries the PDB.
+	cfg := &config.DatabaseConfig{
+		Type:     database.Oracle,
+		Host:     oraContainer.Host(),
+		Port:     oraContainer.Port(),
+		Username: oraContainer.Username(),
+		Password: oraContainer.Password(),
+		Oracle: config.OracleConfig{
+			Service: config.ServiceConfig{
+				Name: oraContainer.Database(),
+			},
+		},
+		Pool: inboxPoolConfig(),
+	}
+
+	conn, err := database.NewConnection(cfg, log)
+	require.NoError(t, err, "Failed to create Oracle connection")
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	require.NoError(t, conn.Health(ctx), "Failed to ping Oracle")
+
+	store, err := NewOracleStore(inboxTableName)
+	require.NoError(t, err, "Failed to build Oracle inbox store")
+
+	// CreateTable proves the Oracle DDL (named PK constraint + function-free
+	// index) is valid on the real vendor.
+	require.NoError(t, store.CreateTable(ctx, conn), inboxShouldCreateMsg)
+	t.Cleanup(func() {
+		// Best-effort drop; Oracle has no DROP TABLE IF EXISTS, so ignore the
+		// ORA-00942 that occurs if the table was never created.
+		_, _ = conn.Exec(context.Background(), "DROP TABLE "+inboxTableName)
+	})
+
+	now := time.Now()
+
+	// First insert: inserted=true.
+	tx, err := conn.Begin(ctx)
+	require.NoError(t, err, inboxShouldBeginMsg)
+	inserted, err := store.MarkProcessed(ctx, tx, Record{TenantID: inboxTenantID, EventID: "evt-1", ProcessedAt: now})
+	require.NoError(t, err, "First MarkProcessed should not error")
+	assert.True(t, inserted, "First (tenant_id, event_id) must be inserted")
+	require.NoError(t, tx.Commit(ctx), inboxShouldCommitMsg)
+
+	// Duplicate insert in a NEW transaction: ORA-00001 is caught and returned as
+	// inserted=false with no error. The CRITICAL property is that the SAME tx
+	// remains usable, proven by inserting a distinct event afterward + commit.
+	dupTx, err := conn.Begin(ctx)
+	require.NoError(t, err, inboxShouldBeginMsg)
+	inserted, err = store.MarkProcessed(ctx, dupTx, Record{TenantID: inboxTenantID, EventID: "evt-1", ProcessedAt: now})
+	require.NoError(t, err, "Duplicate MarkProcessed must catch ORA-00001 and NOT error on Oracle")
+	assert.False(t, inserted, "Duplicate (tenant_id, event_id) must report inserted=false")
+	// The tx survives ORA-00001: a distinct event inserts within the SAME tx.
+	inserted, err = store.MarkProcessed(ctx, dupTx, Record{TenantID: inboxTenantID, EventID: "evt-2", ProcessedAt: now})
+	require.NoError(t, err, "Distinct MarkProcessed after ORA-00001 must not error (tx must survive)")
+	assert.True(t, inserted, "Distinct event after a duplicate must be inserted in the same tx")
+	require.NoError(t, dupTx.Commit(ctx), inboxShouldCommitMsg)
+
+	// DeleteProcessed removes both rows processed before now+1h.
+	deleted, err := store.DeleteProcessed(ctx, conn, now.Add(time.Hour))
+	require.NoError(t, err, "DeleteProcessed should not error")
+	assert.GreaterOrEqual(t, deleted, int64(2), "DeleteProcessed must remove at least the two inserted rows")
+}

--- a/inbox/store_oracle.go
+++ b/inbox/store_oracle.go
@@ -1,0 +1,90 @@
+//nolint:dupl // Intentional: Oracle and PostgreSQL stores share structure but differ in SQL dialect
+package inbox
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gaborage/go-bricks/database"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+)
+
+// Oracle DDL for the inbox ledger table.
+// Uses VARCHAR2 instead of VARCHAR, SYSTIMESTAMP instead of NOW(), a named
+// primary-key constraint, and no IF NOT EXISTS (ORA-00955 if it already exists
+// is tolerated by the caller, which treats CreateTable errors as warnings).
+const oracleCreateTableSQL = `
+CREATE TABLE %s (
+    tenant_id     VARCHAR2(255) DEFAULT '' NOT NULL,
+    event_id      VARCHAR2(255) NOT NULL,
+    processed_at  TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+    CONSTRAINT pk_%s PRIMARY KEY (tenant_id, event_id)
+)`
+
+// Oracle index DDL for retention cleanup by processed_at.
+const oracleCreateProcessedIndexSQL = `
+CREATE INDEX idx_%s_processed ON %s (processed_at)`
+
+// oracleStore implements Store for Oracle using :1-style placeholders.
+type oracleStore struct {
+	tableName string
+}
+
+// NewOracleStore creates a new Oracle inbox store.
+// Returns an error if the table name is not a safe, unqualified identifier.
+func NewOracleStore(tableName string) (Store, error) {
+	if err := validateTableName(tableName); err != nil {
+		return nil, err
+	}
+	return &oracleStore{tableName: tableName}, nil
+}
+
+// MarkProcessed inserts the ledger row. Oracle has no ON CONFLICT, but a
+// unique-violation (ORA-00001) is statement-level and leaves the transaction
+// usable, so a duplicate is detected by catching it via database.IsUniqueViolation.
+func (s *oracleStore) MarkProcessed(ctx context.Context, tx dbtypes.Tx, rec Record) (bool, error) {
+	query := fmt.Sprintf(
+		`INSERT INTO %s (tenant_id, event_id, processed_at) VALUES (:1, :2, :3)`,
+		s.tableName,
+	)
+	_, err := tx.Exec(ctx, query, rec.TenantID, rec.EventID, rec.ProcessedAt)
+	if err != nil {
+		if database.IsUniqueViolation(err) {
+			return false, nil // already processed
+		}
+		return false, fmt.Errorf("inbox oracle: mark processed failed: %w", err)
+	}
+	return true, nil
+}
+
+func (s *oracleStore) DeleteProcessed(ctx context.Context, db dbtypes.Interface, before time.Time) (int64, error) {
+	query := fmt.Sprintf(`DELETE FROM %s WHERE processed_at < :1`, s.tableName)
+
+	res, err := db.Exec(ctx, query, before)
+	if err != nil {
+		return 0, fmt.Errorf("inbox oracle: delete processed failed: %w", err)
+	}
+	count, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("inbox oracle: rows affected failed: %w", err)
+	}
+	return count, nil
+}
+
+// CreateTable creates the inbox table and index in Oracle.
+// Unlike PostgreSQL (which uses IF NOT EXISTS), Oracle DDL returns ORA-00955 if
+// the object already exists; the caller (ensureStoreInitialized) treats all
+// CreateTable errors as warnings, so existing objects are handled gracefully.
+func (s *oracleStore) CreateTable(ctx context.Context, db dbtypes.Interface) error {
+	if _, err := db.Exec(ctx, fmt.Sprintf(oracleCreateTableSQL, s.tableName, s.tableName)); err != nil {
+		return fmt.Errorf("inbox oracle: create table failed: %w", err)
+	}
+	if _, err := db.Exec(ctx, fmt.Sprintf(oracleCreateProcessedIndexSQL, s.tableName, s.tableName)); err != nil {
+		return fmt.Errorf("inbox oracle: create index failed: %w", err)
+	}
+	return nil
+}
+
+// Compile-time guard: ensure oracleStore satisfies the Store interface.
+var _ Store = (*oracleStore)(nil)

--- a/inbox/store_oracle.go
+++ b/inbox/store_oracle.go
@@ -1,4 +1,3 @@
-//nolint:dupl // Intentional: Oracle and PostgreSQL stores share structure but differ in SQL dialect
 package inbox
 
 import (

--- a/inbox/store_oracle_test.go
+++ b/inbox/store_oracle_test.go
@@ -1,0 +1,90 @@
+package inbox
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	dbtesting "github.com/gaborage/go-bricks/database/testing"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	oranet "github.com/sijms/go-ora/v2/network"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const oracleTestTable = "gobricks_inbox"
+
+func newOracleTestStore(t *testing.T) *oracleStore {
+	t.Helper()
+	store, err := NewOracleStore(oracleTestTable)
+	require.NoError(t, err)
+	return store.(*oracleStore)
+}
+
+func TestOracleStoreMarkProcessedInserted(t *testing.T) {
+	store := newOracleTestStore(t)
+	db := dbtesting.NewTestDB(dbtypes.Oracle)
+	db.ExpectTransaction().
+		ExpectExec(`INSERT INTO gobricks_inbox`).
+		WillReturnRowsAffected(1)
+
+	tx, err := db.Begin(t.Context())
+	require.NoError(t, err)
+
+	inserted, err := store.MarkProcessed(t.Context(), tx, sampleRecord())
+	require.NoError(t, err)
+	assert.True(t, inserted)
+}
+
+func TestOracleStoreMarkProcessedDuplicate(t *testing.T) {
+	store := newOracleTestStore(t)
+	// ORA-00001 unique violation -> caught as a duplicate, not an error.
+	oraDup := &oranet.OracleError{ErrCode: 1}
+	db := dbtesting.NewTestDB(dbtypes.Oracle)
+	db.ExpectTransaction().
+		ExpectExec(`INSERT INTO gobricks_inbox`).
+		WillReturnError(oraDup)
+
+	tx, err := db.Begin(t.Context())
+	require.NoError(t, err)
+
+	inserted, err := store.MarkProcessed(t.Context(), tx, sampleRecord())
+	require.NoError(t, err, "ORA-00001 must be caught, not surfaced")
+	assert.False(t, inserted, "duplicate reports inserted=false")
+}
+
+func TestOracleStoreMarkProcessedNonUniqueError(t *testing.T) {
+	store := newOracleTestStore(t)
+	wantErr := errors.New("ORA-12541 no listener")
+	db := dbtesting.NewTestDB(dbtypes.Oracle)
+	db.ExpectTransaction().
+		ExpectExec(`INSERT INTO gobricks_inbox`).
+		WillReturnError(wantErr)
+
+	tx, err := db.Begin(t.Context())
+	require.NoError(t, err)
+
+	_, err = store.MarkProcessed(t.Context(), tx, sampleRecord())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Contains(t, err.Error(), "mark processed failed")
+}
+
+func TestOracleStoreDeleteProcessed(t *testing.T) {
+	store := newOracleTestStore(t)
+	db := dbtesting.NewTestDB(dbtypes.Oracle)
+	db.ExpectExec(`DELETE FROM gobricks_inbox`).WillReturnRowsAffected(2)
+
+	n, err := store.DeleteProcessed(t.Context(), db, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n)
+}
+
+func TestOracleStoreCreateTable(t *testing.T) {
+	store := newOracleTestStore(t)
+	db := dbtesting.NewTestDB(dbtypes.Oracle)
+	db.ExpectExec(`CREATE TABLE gobricks_inbox`).WillReturnRowsAffected(0)
+	db.ExpectExec(`CREATE INDEX idx_gobricks_inbox_processed`).WillReturnRowsAffected(0)
+
+	require.NoError(t, store.CreateTable(t.Context(), db))
+}

--- a/inbox/store_postgres.go
+++ b/inbox/store_postgres.go
@@ -1,0 +1,84 @@
+//nolint:dupl // Intentional: PostgreSQL and Oracle stores share structure but differ in SQL dialect
+package inbox
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+)
+
+// PostgreSQL DDL for the inbox ledger table.
+const postgresCreateTableSQL = `
+CREATE TABLE IF NOT EXISTS %s (
+    tenant_id     VARCHAR(255) NOT NULL DEFAULT '',
+    event_id      VARCHAR(255) NOT NULL,
+    processed_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (tenant_id, event_id)
+)`
+
+// PostgreSQL index DDL for retention cleanup by processed_at.
+const postgresCreateProcessedIndexSQL = `
+CREATE INDEX IF NOT EXISTS idx_%s_processed ON %s (processed_at)`
+
+// postgresStore implements Store for PostgreSQL using $1-style placeholders.
+type postgresStore struct {
+	tableName string
+}
+
+// NewPostgresStore creates a new PostgreSQL inbox store.
+// Returns an error if the table name is not a safe, unqualified identifier.
+func NewPostgresStore(tableName string) (Store, error) {
+	if err := validateTableName(tableName); err != nil {
+		return nil, err
+	}
+	return &postgresStore{tableName: tableName}, nil
+}
+
+// MarkProcessed inserts the ledger row, using ON CONFLICT DO NOTHING so a
+// duplicate is detected via RowsAffected without raising an error (a 23505 would
+// otherwise poison the transaction on PostgreSQL).
+func (s *postgresStore) MarkProcessed(ctx context.Context, tx dbtypes.Tx, rec Record) (bool, error) {
+	query := fmt.Sprintf(
+		`INSERT INTO %s (tenant_id, event_id, processed_at) VALUES ($1, $2, $3)
+		 ON CONFLICT (tenant_id, event_id) DO NOTHING`,
+		s.tableName,
+	)
+	res, err := tx.Exec(ctx, query, rec.TenantID, rec.EventID, rec.ProcessedAt)
+	if err != nil {
+		return false, fmt.Errorf("inbox postgres: mark processed failed: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("inbox postgres: rows affected failed: %w", err)
+	}
+	return n == 1, nil
+}
+
+func (s *postgresStore) DeleteProcessed(ctx context.Context, db dbtypes.Interface, before time.Time) (int64, error) {
+	query := fmt.Sprintf(`DELETE FROM %s WHERE processed_at < $1`, s.tableName)
+
+	res, err := db.Exec(ctx, query, before)
+	if err != nil {
+		return 0, fmt.Errorf("inbox postgres: delete processed failed: %w", err)
+	}
+	count, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("inbox postgres: rows affected failed: %w", err)
+	}
+	return count, nil
+}
+
+func (s *postgresStore) CreateTable(ctx context.Context, db dbtypes.Interface) error {
+	if _, err := db.Exec(ctx, fmt.Sprintf(postgresCreateTableSQL, s.tableName)); err != nil {
+		return fmt.Errorf("inbox postgres: create table failed: %w", err)
+	}
+	if _, err := db.Exec(ctx, fmt.Sprintf(postgresCreateProcessedIndexSQL, s.tableName, s.tableName)); err != nil {
+		return fmt.Errorf("inbox postgres: create index failed: %w", err)
+	}
+	return nil
+}
+
+// Compile-time guard: ensure postgresStore satisfies the Store interface.
+var _ Store = (*postgresStore)(nil)

--- a/inbox/store_postgres.go
+++ b/inbox/store_postgres.go
@@ -1,4 +1,3 @@
-//nolint:dupl // Intentional: PostgreSQL and Oracle stores share structure but differ in SQL dialect
 package inbox
 
 import (

--- a/inbox/store_postgres_test.go
+++ b/inbox/store_postgres_test.go
@@ -2,6 +2,7 @@ package inbox
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,6 +34,13 @@ func TestNewPostgresStoreRejectsBadTableName(t *testing.T) {
 	require.Error(t, err)
 	_, err = NewPostgresStore("myschema.gobricks_inbox")
 	require.Error(t, err, "qualified names must be rejected")
+
+	_, err = NewPostgresStore(strings.Repeat("a", maxTableNameLen+1))
+	require.Error(t, err, "over-length names must be rejected")
+	assert.Contains(t, err.Error(), "too long")
+
+	_, err = NewPostgresStore(strings.Repeat("a", maxTableNameLen))
+	require.NoError(t, err, "a name at the max length is accepted")
 }
 
 func TestPostgresStoreMarkProcessedInserted(t *testing.T) {

--- a/inbox/store_postgres_test.go
+++ b/inbox/store_postgres_test.go
@@ -1,0 +1,103 @@
+package inbox
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	dbtesting "github.com/gaborage/go-bricks/database/testing"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const pgTestTable = "gobricks_inbox"
+
+func newPostgresTestStore(t *testing.T) *postgresStore {
+	t.Helper()
+	store, err := NewPostgresStore(pgTestTable)
+	require.NoError(t, err)
+	return store.(*postgresStore)
+}
+
+func sampleRecord() Record {
+	return Record{
+		TenantID:    "tenant-a",
+		EventID:     "evt-1",
+		ProcessedAt: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestNewPostgresStoreRejectsBadTableName(t *testing.T) {
+	_, err := NewPostgresStore("bad; DROP")
+	require.Error(t, err)
+	_, err = NewPostgresStore("myschema.gobricks_inbox")
+	require.Error(t, err, "qualified names must be rejected")
+}
+
+func TestPostgresStoreMarkProcessedInserted(t *testing.T) {
+	store := newPostgresTestStore(t)
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction().
+		ExpectExec(`INSERT INTO gobricks_inbox`).
+		WillReturnRowsAffected(1)
+
+	tx, err := db.Begin(t.Context())
+	require.NoError(t, err)
+
+	inserted, err := store.MarkProcessed(t.Context(), tx, sampleRecord())
+	require.NoError(t, err)
+	assert.True(t, inserted, "first insert reports inserted=true")
+}
+
+func TestPostgresStoreMarkProcessedDuplicate(t *testing.T) {
+	store := newPostgresTestStore(t)
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	// ON CONFLICT DO NOTHING affects 0 rows on a duplicate (no error).
+	db.ExpectTransaction().
+		ExpectExec(`INSERT INTO gobricks_inbox`).
+		WillReturnRowsAffected(0)
+
+	tx, err := db.Begin(t.Context())
+	require.NoError(t, err)
+
+	inserted, err := store.MarkProcessed(t.Context(), tx, sampleRecord())
+	require.NoError(t, err)
+	assert.False(t, inserted, "duplicate reports inserted=false")
+}
+
+func TestPostgresStoreMarkProcessedError(t *testing.T) {
+	store := newPostgresTestStore(t)
+	wantErr := errors.New("connection reset")
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction().
+		ExpectExec(`INSERT INTO gobricks_inbox`).
+		WillReturnError(wantErr)
+
+	tx, err := db.Begin(t.Context())
+	require.NoError(t, err)
+
+	_, err = store.MarkProcessed(t.Context(), tx, sampleRecord())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Contains(t, err.Error(), "mark processed failed")
+}
+
+func TestPostgresStoreDeleteProcessed(t *testing.T) {
+	store := newPostgresTestStore(t)
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectExec(`DELETE FROM gobricks_inbox`).WillReturnRowsAffected(3)
+
+	n, err := store.DeleteProcessed(t.Context(), db, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), n)
+}
+
+func TestPostgresStoreCreateTable(t *testing.T) {
+	store := newPostgresTestStore(t)
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectExec(`CREATE TABLE IF NOT EXISTS gobricks_inbox`).WillReturnRowsAffected(0)
+	db.ExpectExec(`CREATE INDEX IF NOT EXISTS idx_gobricks_inbox_processed`).WillReturnRowsAffected(0)
+
+	require.NoError(t, store.CreateTable(t.Context(), db))
+}

--- a/inbox/testing/assertions.go
+++ b/inbox/testing/assertions.go
@@ -1,0 +1,37 @@
+package testing
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// AssertProcessed asserts that ProcessOnce was called for the given event id.
+func AssertProcessed(t *testing.T, mock *MockInbox, eventID string) {
+	t.Helper()
+	assert.Contains(t, mock.ProcessedIDs(), eventID,
+		"expected event id %q to be processed, but it was not", eventID)
+}
+
+// AssertNotProcessed asserts that ProcessOnce was never called for the given event id.
+func AssertNotProcessed(t *testing.T, mock *MockInbox, eventID string) {
+	t.Helper()
+	assert.NotContains(t, mock.ProcessedIDs(), eventID,
+		"expected event id %q to NOT be processed, but it was", eventID)
+}
+
+// AssertProcessCount asserts the total number of ProcessOnce calls.
+func AssertProcessCount(t *testing.T, mock *MockInbox, expected int) {
+	t.Helper()
+	assert.Len(t, mock.ProcessedIDs(), expected,
+		"expected %d ProcessOnce calls", expected)
+}
+
+// AssertHandlerRan asserts that the handler (fn) actually executed for the given
+// event id (i.e. it was a first-time, non-error processing).
+func AssertHandlerRan(t *testing.T, mock *MockInbox, eventID string) {
+	t.Helper()
+	assert.True(t, slices.Contains(mock.RanIDs(), eventID),
+		"expected handler to run for event id %q, but it did not", eventID)
+}

--- a/inbox/testing/mock_inbox.go
+++ b/inbox/testing/mock_inbox.go
@@ -1,0 +1,115 @@
+// Package testing provides test utilities for the consumer-side inbox.
+//
+// MockInbox implements app.InboxProcessor for unit testing, letting application
+// developers verify exactly-once handler logic without a real database.
+//
+// Usage:
+//
+//	mockInbox := inboxtest.NewMockInbox()
+//	handler := NewHandler(mockInbox)
+//	handler.Handle(ctx, delivery)
+//	inboxtest.AssertProcessed(t, mockInbox, "evt-1")
+package testing
+
+import (
+	"context"
+	"sync"
+
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+)
+
+// MockInbox implements app.InboxProcessor for unit testing.
+// It records every ProcessOnce call, auto-deduplicates repeated event ids (the
+// second call with the same id skips fn, like the real inbox), and supports a
+// configurable error and pre-marked already-processed ids.
+//
+// Thread-safe: all operations use sync.Mutex for concurrent test scenarios.
+type MockInbox struct {
+	mu         sync.Mutex
+	processed  []string        // every eventID passed to ProcessOnce
+	ranFor     []string        // eventIDs whose fn was actually executed
+	seen       map[string]bool // ids already processed (fn skipped on repeat)
+	processErr error
+}
+
+// NewMockInbox creates a new MockInbox with no configured failures.
+func NewMockInbox() *MockInbox {
+	return &MockInbox{seen: map[string]bool{}}
+}
+
+// WithError configures the mock to return err from every ProcessOnce call
+// (without running fn). Useful for testing handler error paths.
+func (m *MockInbox) WithError(err error) *MockInbox {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.processErr = err
+	return m
+}
+
+// MarkAlreadyProcessed pre-marks eventID as processed, so the next ProcessOnce
+// for that id treats it as a duplicate and skips fn.
+func (m *MockInbox) MarkAlreadyProcessed(eventID string) *MockInbox {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.seen[eventID] = true
+	return m
+}
+
+// ProcessOnce implements app.InboxProcessor. It records the call and runs fn
+// (with a nil tx) exactly once per eventID, unless an error is configured or the
+// id was already processed.
+func (m *MockInbox) ProcessOnce(ctx context.Context, eventID string, fn func(ctx context.Context, tx dbtypes.Tx) error) error {
+	m.mu.Lock()
+	if m.processErr != nil {
+		err := m.processErr
+		m.mu.Unlock()
+		return err
+	}
+	m.processed = append(m.processed, eventID)
+	dup := m.seen[eventID]
+	m.seen[eventID] = true
+	m.mu.Unlock()
+
+	if dup {
+		return nil
+	}
+	if fn == nil {
+		return nil
+	}
+	if err := fn(ctx, nil); err != nil {
+		return err
+	}
+	m.mu.Lock()
+	m.ranFor = append(m.ranFor, eventID)
+	m.mu.Unlock()
+	return nil
+}
+
+// ProcessedIDs returns a copy of every eventID passed to ProcessOnce.
+func (m *MockInbox) ProcessedIDs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.processed))
+	copy(out, m.processed)
+	return out
+}
+
+// RanIDs returns a copy of the eventIDs whose fn was actually executed
+// (excludes duplicates and error short-circuits).
+func (m *MockInbox) RanIDs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.ranFor))
+	copy(out, m.ranFor)
+	return out
+}
+
+// Reset clears all recorded state.
+func (m *MockInbox) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.processed = nil
+	m.ranFor = nil
+	m.seen = map[string]bool{}
+	m.processErr = nil
+}

--- a/inbox/testing/mock_inbox_test.go
+++ b/inbox/testing/mock_inbox_test.go
@@ -1,0 +1,61 @@
+package testing_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gaborage/go-bricks/app"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	inboxtest "github.com/gaborage/go-bricks/inbox/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time guard: MockInbox satisfies the production interface.
+var _ app.InboxProcessor = (*inboxtest.MockInbox)(nil)
+
+func noopFn(context.Context, dbtypes.Tx) error { return nil }
+
+func TestMockInboxRunsFnOncePerID(t *testing.T) {
+	m := inboxtest.NewMockInbox()
+
+	ran := 0
+	fn := func(context.Context, dbtypes.Tx) error { ran++; return nil }
+
+	require.NoError(t, m.ProcessOnce(context.Background(), "evt-1", fn))
+	require.NoError(t, m.ProcessOnce(context.Background(), "evt-1", fn)) // duplicate
+
+	assert.Equal(t, 1, ran, "fn runs once across duplicate event ids")
+	inboxtest.AssertProcessCount(t, m, 2)
+	inboxtest.AssertProcessed(t, m, "evt-1")
+	inboxtest.AssertHandlerRan(t, m, "evt-1")
+	inboxtest.AssertNotProcessed(t, m, "evt-2")
+}
+
+func TestMockInboxWithError(t *testing.T) {
+	wantErr := errors.New("inbox down")
+	m := inboxtest.NewMockInbox().WithError(wantErr)
+
+	err := m.ProcessOnce(context.Background(), "evt-1", noopFn)
+	assert.ErrorIs(t, err, wantErr)
+	inboxtest.AssertProcessCount(t, m, 0) // errored calls are not recorded as processed
+}
+
+func TestMockInboxMarkAlreadyProcessed(t *testing.T) {
+	m := inboxtest.NewMockInbox().MarkAlreadyProcessed("evt-1")
+
+	ran := false
+	require.NoError(t, m.ProcessOnce(context.Background(), "evt-1", func(context.Context, dbtypes.Tx) error {
+		ran = true
+		return nil
+	}))
+	assert.False(t, ran, "pre-marked id skips fn")
+}
+
+func TestMockInboxReset(t *testing.T) {
+	m := inboxtest.NewMockInbox()
+	require.NoError(t, m.ProcessOnce(context.Background(), "evt-1", noopFn))
+	m.Reset()
+	inboxtest.AssertProcessCount(t, m, 0)
+}

--- a/inbox/testing/mock_inbox_test.go
+++ b/inbox/testing/mock_inbox_test.go
@@ -42,6 +42,18 @@ func TestMockInboxWithError(t *testing.T) {
 	inboxtest.AssertProcessCount(t, m, 0) // errored calls are not recorded as processed
 }
 
+func TestMockInboxPropagatesHandlerError(t *testing.T) {
+	m := inboxtest.NewMockInbox()
+	wantErr := errors.New("handler boom")
+
+	err := m.ProcessOnce(context.Background(), "evt-1", func(context.Context, dbtypes.Tx) error {
+		return wantErr
+	})
+	assert.ErrorIs(t, err, wantErr)
+	inboxtest.AssertProcessed(t, m, "evt-1") // the call is recorded
+	inboxtest.AssertProcessCount(t, m, 1)
+}
+
 func TestMockInboxMarkAlreadyProcessed(t *testing.T) {
 	m := inboxtest.NewMockInbox().MarkAlreadyProcessed("evt-1")
 

--- a/outbox/config.go
+++ b/outbox/config.go
@@ -29,6 +29,8 @@ func validateConfig(c *config.OutboxConfig) error {
 }
 
 // applyDefaults fills in zero-value fields with production-safe defaults.
+// AutoCreateTable is intentionally not set here: its default (false, opt-in) is
+// the zero value, so auto-creation must be explicitly enabled.
 func applyDefaults(c *config.OutboxConfig) {
 	if c.TableName == "" {
 		c.TableName = DefaultTableName

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=gaborage_go-bricks
 sonar.organization=gaborage
 
 sonar.projectName=GoBricks
-sonar.sources=app,cache,config,database,httpclient,internal,jose,keystore,logger,messaging,migration,multitenant,observability,outbox,scheduler,server,testing,tools,trace
+sonar.sources=app,cache,config,database,httpclient,inbox,internal,jose,keystore,logger,messaging,migration,multitenant,observability,outbox,scheduler,server,testing,tools,trace
 # **/testdata/** — fixture projects are inputs to tests, not production source.
 # Their minimal go.mod files have no go.sum, which otherwise trips S8566.
 sonar.exclusions=**/*_test.go,**/vendor/**,**/mocks/**,**/*.gen.go,**/testdata/**


### PR DESCRIPTION
## Summary

**PR 5 of 5** — the integrating feature. Closes **#536**: a durable, tenant-aware consumer-side **inbox** that complements the transactional outbox, providing exactly-once processing via `deps.Inbox.ProcessOnce`. It composes the three primitives merged in PRs 1–4 (sqlid validator, `IsUniqueViolation`, `WithTx`, `HeaderEventID`).

## API

```go
// In a consumer handler:
eventID, ok := outbox.EventIDFromHeaders(delivery.Headers) // #535
if !ok { /* ... */ }
err := deps.Inbox.ProcessOnce(ctx, eventID, func(ctx context.Context, tx database.Tx) error {
    // business writes — committed atomically with the "processed" ledger marker
    return doWork(ctx, tx)
})
```

`ProcessOnce` records the event id in a ledger and runs `fn` exactly once per id within a single transaction; a redelivery of an already-processed id short-circuits (fn not run).

## Design highlights
- **Critical vendor invariant:** PostgreSQL uses `INSERT … ON CONFLICT (tenant_id,event_id) DO NOTHING` + `RowsAffected` (a 23505 would poison the tx); Oracle uses a plain `INSERT` and catches ORA-00001 via `database.IsUniqueViolation` (statement-level rollback keeps the tx usable). The two paths are split by vendor and **must not** be unified.
- **Atomicity:** the ledger insert and `fn` share one `WithTx` transaction — no dual-write window.
- **Tenant-aware:** keyed on `(tenant_id, event_id)`; tenant resolved from ctx.
- **Mirrors the outbox:** new `inbox` package with vendor-split store, lazy `CreateTable`, opt-in `AutoCreateTable` (default false), a `DailyAt` retention-cleanup job, and an `inbox/testing` MockInbox. Wired via `app.InboxProvider` → `deps.Inbox` (nil when disabled — interface-typed field avoids the typed-nil gotcha).
- **Config:** new `InboxConfig` (table `gobricks_inbox`, retention 168h/7d which must exceed the broker's max redelivery window). Also corrects the outbox `auto_create_table` doc to its actual default (`false`) — behavior-preserving.

## Tests
- Unit (~88% coverage): store PG/Oracle (incl. Oracle duplicate via a fabricated `*network.OracleError`), ProcessOnce (runs once / skips duplicate / propagates fn error), config, module wiring (disabled→nil processor, RegisterJobs), cleanup, MockInbox.
- Integration (`//go:build integration`): real PostgreSQL + Oracle containers — DDL validity, first-insert vs duplicate, tx-survival after a duplicate, DeleteProcessed. **Verified locally against PostgreSQL**; Oracle runs in CI.

## Scope
- New `inbox` package + minimal additive `app`/`config` wiring. `make check` green. No breaking changes.

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a consumer-side inbox for exactly-once/idempotent event processing with a processor and daily retention cleanup job; Postgres and Oracle stores supported.

* **Configuration**
  * New inbox config section (enabled, table name, auto_create_table is opt-in, retention period); example updated to show auto_create_table=false by default.

* **Tests**
  * Extensive unit, integration, and test utilities including a thread-safe mock and assertion helpers.

* **Chores**
  * Project scan config updated to include inbox sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->