### PR TITLE
config: split comma-separated env vars for []string fields (#539)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ func (m *Module) Init(deps *ModuleDeps) error {
 ```
 
 **Struct Tags:** `config:"key.path"` (required), `required:"true"`, `default:"value"`.
-**Supported Types:** string, int, int64, float64, bool, time.Duration.
+**Supported Types:** string, int, int64, float64, bool, time.Duration, `[]string` (comma-separated via env/`default`, native sequence via YAML).
 **Configuration Priority:** Environment variables > `config.<env>.yaml` > `config.yaml` > defaults.
 
 ### Enhanced Handler Pattern

--- a/config/config.go
+++ b/config/config.go
@@ -122,7 +122,8 @@ func stringToTrimmedSliceHookFunc(sep string) mapstructure.DecodeHookFunc {
 		if f.Kind() != reflect.String || t != reflect.TypeOf([]string(nil)) {
 			return data, nil
 		}
-		return splitAndTrimList(data.(string), sep), nil
+		// reflect.Value.String() (not data.(string)) so named string types don't panic.
+		return splitAndTrimList(reflect.ValueOf(data).String(), sep), nil
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/confmap"
 	envprovider "github.com/knadh/koanf/providers/env/v2"
@@ -54,7 +55,9 @@ func Load() (*Config, error) {
 
 	// Unmarshal into config struct
 	var cfg Config
-	if err := k.Unmarshal("", &cfg); err != nil {
+	if err := k.UnmarshalWithConf("", &cfg, koanf.UnmarshalConf{
+		DecoderConfig: buildDecoderConfig(),
+	}); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
@@ -92,6 +95,19 @@ func tryLoadYAMLFile(k *koanf.Koanf, baseName string) error {
 		}
 	}
 	return nil
+}
+
+// buildDecoderConfig replicates koanf's default Unmarshal decoder
+// (knadh/koanf/v2 koanf.go:265-272) so we control the DecodeHook chain.
+// koanf fills in Result and TagName at unmarshal time.
+func buildDecoderConfig() *mapstructure.DecoderConfig {
+	return &mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			mapstructure.StringToTimeDurationHookFunc(),
+			mapstructure.TextUnmarshallerHookFunc(),
+		),
+		WeaklyTypedInput: true,
+	}
 }
 
 func loadDefaults(k *koanf.Koanf) error {

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -103,10 +104,25 @@ func tryLoadYAMLFile(k *koanf.Koanf, baseName string) error {
 func buildDecoderConfig() *mapstructure.DecoderConfig {
 	return &mapstructure.DecoderConfig{
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			stringToTrimmedSliceHookFunc(","),
 			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.TextUnmarshallerHookFunc(),
 		),
 		WeaklyTypedInput: true,
+	}
+}
+
+// stringToTrimmedSliceHookFunc splits a scalar string into []string on sep,
+// trimming each element and dropping empties. Scoped to string -> []string only
+// (Type-level), so []byte, other slices, and YAML sequences are untouched. This
+// lets a single env var express a multi-element list, e.g.
+// SCHEDULER_SECURITY_CIDRALLOWLIST=10.0.0.0/8,192.168.0.0/16.
+func stringToTrimmedSliceHookFunc(sep string) mapstructure.DecodeHookFunc {
+	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
+		if f.Kind() != reflect.String || t != reflect.TypeOf([]string(nil)) {
+			return data, nil
+		}
+		return splitAndTrimList(data.(string), sep), nil
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -109,6 +109,30 @@ func TestLoadWithEnvironmentVariables(t *testing.T) {
 	assert.Equal(t, serverHost, cfg.Server.Host)
 }
 
+func TestLoadMultiElementStringSliceEnv(t *testing.T) {
+	clearEnvironmentVariables()
+	t.Setenv("SCHEDULER_SECURITY_CIDRALLOWLIST", "10.0.0.0/8,192.168.0.0/16")
+	// Spaces around the delimiter exercise per-element trimming.
+	t.Setenv("SCHEDULER_SECURITY_TRUSTEDPROXIES", "10.0.0.0/8, 172.16.0.0/12 ,, 169.254.0.0/16")
+	t.Setenv("DEBUG_ALLOWEDIPS", "127.0.0.1,::1")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"10.0.0.0/8", "192.168.0.0/16"}, cfg.Scheduler.Security.CIDRAllowlist)
+	// Trimmed, with the empty element between the doubled commas dropped.
+	assert.Equal(t, []string{"10.0.0.0/8", "172.16.0.0/12", "169.254.0.0/16"}, cfg.Scheduler.Security.TrustedProxies)
+	assert.Equal(t, []string{"127.0.0.1", "::1"}, cfg.Debug.AllowedIPs)
+}
+
+func TestLoadSingleElementStringSliceEnv(t *testing.T) {
+	clearEnvironmentVariables()
+	t.Setenv("SCHEDULER_SECURITY_CIDRALLOWLIST", "10.0.0.0/8")
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"10.0.0.0/8"}, cfg.Scheduler.Security.CIDRAllowlist)
+}
+
 func TestLoadInvalidEnvironmentVariables(t *testing.T) {
 	baseEnv := map[string]string{
 		testDatabaseDatabase: "testdb",

--- a/config/converters.go
+++ b/config/converters.go
@@ -26,6 +26,23 @@ var (
 	errEmptyString = errors.New("empty string")
 )
 
+// splitAndTrimList splits raw on sep, trims each element, and drops empties.
+// Single source of truth for env/default string -> []string semantics, shared by
+// the config Unmarshal decode hook and InjectInto.
+func splitAndTrimList(raw, sep string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return []string{}
+	}
+	parts := strings.Split(raw, sep)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 // toInt converts various types to int with overflow protection.
 func toInt(value any) (int, error) {
 	n, err := toInt64(value)

--- a/config/converters.go
+++ b/config/converters.go
@@ -43,6 +43,26 @@ func splitAndTrimList(raw, sep string) []string {
 	return out
 }
 
+// toStringSlice converts a resolved config value to []string. Reuses
+// splitAndTrimList for the string case so InjectInto matches the Unmarshal
+// decode-hook semantics (comma-separated env/default string, YAML sequence).
+func toStringSlice(value any) ([]string, error) {
+	switch v := value.(type) {
+	case []string:
+		return v, nil
+	case []any: // YAML sequence
+		out := make([]string, len(v))
+		for i, el := range v {
+			out[i] = fmt.Sprintf("%v", el)
+		}
+		return out, nil
+	case string:
+		return splitAndTrimList(v, ","), nil
+	default:
+		return nil, fmt.Errorf(errMsgUnsupportedType, value)
+	}
+}
+
 // toInt converts various types to int with overflow protection.
 func toInt(value any) (int, error) {
 	n, err := toInt64(value)

--- a/config/converters.go
+++ b/config/converters.go
@@ -49,7 +49,8 @@ func splitAndTrimList(raw, sep string) []string {
 func toStringSlice(value any) ([]string, error) {
 	switch v := value.(type) {
 	case []string:
-		return v, nil
+		// Defensive copy so the caller's field doesn't alias koanf's stored slice.
+		return append([]string(nil), v...), nil
 	case []any: // YAML sequence
 		out := make([]string, len(v))
 		for i, el := range v {

--- a/config/converters_test.go
+++ b/config/converters_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -490,4 +491,31 @@ func TestAdditionalEdgeCases(t *testing.T) {
 		// This tests the error path in toBool when toInt64 fails for uint types
 		assert.False(t, result) // Should return false on conversion error
 	})
+}
+
+func TestToStringSlice(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    []string
+		wantErr bool
+	}{
+		{name: "string_split_and_trim", input: "a, b ,c", want: []string{"a", "b", "c"}},
+		{name: "string_drops_empties", input: "a,,b,", want: []string{"a", "b"}},
+		{name: "empty_string", input: "", want: []string{}},
+		{name: "string_slice_passthrough", input: []string{"x", "y"}, want: []string{"x", "y"}},
+		{name: "any_slice_stringified", input: []any{"x", 2}, want: []string{"x", "2"}},
+		{name: "unsupported_type", input: 42, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toStringSlice(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/config/converters_test.go
+++ b/config/converters_test.go
@@ -519,3 +519,11 @@ func TestToStringSlice(t *testing.T) {
 		})
 	}
 }
+
+func TestToStringSliceCopiesInputSlice(t *testing.T) {
+	in := []string{"a", "b"}
+	out, err := toStringSlice(in)
+	require.NoError(t, err)
+	out[0] = "mutated"
+	assert.Equal(t, "a", in[0], "toStringSlice must not alias the input slice")
+}

--- a/config/injection.go
+++ b/config/injection.go
@@ -15,7 +15,8 @@ const tagValueTrue = "true"
 //   - `required:"true"` - marks the field as required (default: false)
 //   - `default:"value"` - provides a default value if the config key is missing
 //
-// Supported field types: string, int, int64, float64, bool, time.Duration
+// Supported field types: string, int, int64, float64, bool, time.Duration, []string
+// ([]string accepts a comma-separated string from env/default tags or a native YAML sequence)
 func (c *Config) InjectInto(target any) error {
 	if c == nil || c.k == nil {
 		return &ConfigError{
@@ -90,6 +91,12 @@ func (c *Config) setFieldValue(field reflect.Value, configKey string, required b
 		return nil
 	}
 
+	// []string is the one supported composite type; handle it before the kind
+	// switch so other slice element types still fall through to "unsupported".
+	if field.Type() == reflect.TypeOf([]string(nil)) {
+		return c.assignStringSliceField(field, configKey, required, value)
+	}
+
 	return c.assignFieldValue(field, configKey, required, value)
 }
 
@@ -131,7 +138,7 @@ func (c *Config) assignFieldValue(field reflect.Value, configKey string, require
 			Category: errCategoryInvalid,
 			Field:    configKey,
 			Message:  fmt.Sprintf("unsupported type %s", field.Type()),
-			Action:   "use string, int, int64, float64, bool, or time.Duration",
+			Action:   "use string, int, int64, float64, bool, time.Duration, or []string",
 		}
 	}
 }
@@ -181,6 +188,29 @@ func (c *Config) assignBoolField(field reflect.Value, configKey string, value an
 		return err
 	}
 	field.SetBool(boolVal)
+	return nil
+}
+
+func (c *Config) assignStringSliceField(field reflect.Value, configKey string, required bool, value any) error {
+	slice, err := toStringSlice(value)
+	if err != nil {
+		return &ConfigError{
+			Category: errCategoryInvalid,
+			Field:    configKey,
+			Message:  fmt.Sprintf("'%v' is not a valid string list", value),
+			Action:   "provide a comma-separated string or a YAML sequence",
+		}
+	}
+	if required && len(slice) == 0 {
+		envVar := strings.ToUpper(strings.ReplaceAll(configKey, ".", "_"))
+		return &ConfigError{
+			Category: errCategoryMissing,
+			Field:    configKey,
+			Message:  errMessageRequired,
+			Action:   fmt.Sprintf("set %s env var or add '%s' to config.yaml", envVar, configKey),
+		}
+	}
+	field.Set(reflect.ValueOf(slice))
 	return nil
 }
 

--- a/config/injection.go
+++ b/config/injection.go
@@ -9,6 +9,10 @@ import (
 
 const tagValueTrue = "true"
 
+// actionSetEnvOrYAML is the remediation hint for missing/empty injected fields.
+// Format args: env var name, then the config key path.
+const actionSetEnvOrYAML = "set %s env var or add '%s' to config.yaml"
+
 // InjectInto populates a struct with configuration values based on struct tags.
 // It supports the following struct tags:
 //   - `config:"key.path"` - specifies the configuration key to use
@@ -112,7 +116,7 @@ func (c *Config) resolveFieldValue(configKey string, required bool, defaultValue
 			Category: errCategoryMissing,
 			Field:    configKey,
 			Message:  errMessageRequired,
-			Action:   fmt.Sprintf("set %s env var or add '%s' to config.yaml", envVar, configKey),
+			Action:   fmt.Sprintf(actionSetEnvOrYAML, envVar, configKey),
 		}
 	}
 
@@ -207,7 +211,7 @@ func (c *Config) assignStringSliceField(field reflect.Value, configKey string, r
 			Category: errCategoryMissing,
 			Field:    configKey,
 			Message:  errMessageRequired,
-			Action:   fmt.Sprintf("set %s env var or add '%s' to config.yaml", envVar, configKey),
+			Action:   fmt.Sprintf(actionSetEnvOrYAML, envVar, configKey),
 		}
 	}
 	field.Set(reflect.ValueOf(slice))
@@ -226,7 +230,7 @@ func (c *Config) convertToString(value any, key string, required bool) (string, 
 				Category: errCategoryMissing,
 				Field:    key,
 				Message:  "cannot be empty",
-				Action:   fmt.Sprintf("set %s env var or add '%s' to config.yaml", envVar, key),
+				Action:   fmt.Sprintf(actionSetEnvOrYAML, envVar, key),
 			}
 		}
 		return trimmed, nil

--- a/config/injection_test.go
+++ b/config/injection_test.go
@@ -410,3 +410,34 @@ func BenchmarkConfigInjectionComplex(b *testing.B) {
 		}
 	}
 }
+
+type sliceInjectConfig struct {
+	Hosts    []string `config:"svc.hosts"`
+	Defaults []string `config:"svc.defaults" default:"a,b,c"`
+	Required []string `config:"svc.required" required:"true"`
+}
+
+func TestConfigInjectionStringSliceFromEnv(t *testing.T) {
+	clearEnvironmentVariables()
+	t.Setenv("SVC_HOSTS", "h1, h2 ,h3")
+	t.Setenv("SVC_REQUIRED", "r1")
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	var sc sliceInjectConfig
+	require.NoError(t, cfg.InjectInto(&sc))
+	assert.Equal(t, []string{"h1", "h2", "h3"}, sc.Hosts)
+	assert.Equal(t, []string{"a", "b", "c"}, sc.Defaults)
+	assert.Equal(t, []string{"r1"}, sc.Required)
+}
+
+func TestConfigInjectionStringSliceRequiredMissing(t *testing.T) {
+	clearEnvironmentVariables()
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	var sc sliceInjectConfig
+	err = cfg.InjectInto(&sc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "svc.required")
+}

--- a/config/validation.go
+++ b/config/validation.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"slices"
 	"strings"
 	"time"
@@ -455,7 +456,42 @@ func applyDatabaseTimezoneDefault(cfg *DatabaseConfig) error {
 func validateScheduler(cfg *SchedulerConfig) error {
 	normalized, err := normalizeIANATimezone("scheduler.timezone", cfg.Timezone)
 	cfg.Timezone = normalized
-	return err
+	if err != nil {
+		return err
+	}
+	if err := validateCIDRList("scheduler.security.cidrallowlist", cfg.Security.CIDRAllowlist); err != nil {
+		return err
+	}
+	return validateCIDRList("scheduler.security.trustedproxies", cfg.Security.TrustedProxies)
+}
+
+// validateCIDRList fails when a non-empty list contains zero parseable CIDRs.
+// Empty lists are valid (localhost-only / no-trusted-proxy defaults). Partial-invalid
+// lists pass here and keep the existing middleware-time WARN so a single typo does not
+// crash startup, while an all-invalid security control fails fast instead of silently
+// degrading to a more restrictive (or, for redaction, weaker) posture.
+func validateCIDRList(field string, list []string) error {
+	if len(list) == 0 {
+		return nil
+	}
+	var invalid []string
+	valid := 0
+	for _, entry := range list {
+		if _, _, err := net.ParseCIDR(strings.TrimSpace(entry)); err != nil {
+			invalid = append(invalid, entry)
+			continue
+		}
+		valid++
+	}
+	if valid == 0 {
+		return &ConfigError{
+			Category: errCategoryInvalid,
+			Field:    field,
+			Message:  fmt.Sprintf("no valid CIDR entries (all %d rejected: %v)", len(list), invalid),
+			Action:   "use CIDR notation, e.g. 10.0.0.0/8; comma-separate multiple values in one env var",
+		}
+	}
+	return nil
 }
 
 // validateNamedDatabases validates the named databases configuration.

--- a/config/validation.go
+++ b/config/validation.go
@@ -470,6 +470,9 @@ func validateScheduler(cfg *SchedulerConfig) error {
 // lists pass here and keep the existing middleware-time WARN so a single typo does not
 // crash startup, while an all-invalid security control fails fast instead of silently
 // degrading to a more restrictive (or, for redaction, weaker) posture.
+//
+// The parse loop intentionally mirrors scheduler/cidr_middleware.go's parser; config
+// cannot import scheduler (import cycle), so the few lines are duplicated rather than shared.
 func validateCIDRList(field string, list []string) error {
 	if len(list) == 0 {
 		return nil

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -3820,3 +3820,62 @@ func TestValidateSchedulerTimezoneWiredIntoValidate(t *testing.T) {
 	assert.ErrorContains(t, err, "scheduler config:")
 	assert.ErrorContains(t, err, "scheduler.timezone")
 }
+
+func TestValidateSchedulerCIDRListRejectsAllInvalid(t *testing.T) {
+	tests := []struct {
+		name      string
+		security  SchedulerSecurityConfig
+		wantField string
+	}{
+		{
+			name:      "allowlist_all_invalid",
+			security:  SchedulerSecurityConfig{CIDRAllowlist: []string{"not-a-cidr", "also-bad"}},
+			wantField: "scheduler.security.cidrallowlist",
+		},
+		{
+			name:      "trustedproxies_all_invalid",
+			security:  SchedulerSecurityConfig{TrustedProxies: []string{"garbage"}},
+			wantField: "scheduler.security.trustedproxies",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &SchedulerConfig{Security: tt.security}
+			err := validateScheduler(cfg)
+			assertValidationError(t, err, tt.wantField)
+		})
+	}
+}
+
+func TestValidateSchedulerCIDRListAcceptsValidCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		security SchedulerSecurityConfig
+	}{
+		{name: "empty_lists", security: SchedulerSecurityConfig{}},
+		{name: "single_valid", security: SchedulerSecurityConfig{CIDRAllowlist: []string{"10.0.0.0/8"}}},
+		{name: "valid_multi", security: SchedulerSecurityConfig{CIDRAllowlist: []string{"10.0.0.0/8", "192.168.0.0/16"}}},
+		{name: "partial_invalid_keeps_valid", security: SchedulerSecurityConfig{CIDRAllowlist: []string{"10.0.0.0/8", "bad"}}},
+		{name: "valid_trustedproxies", security: SchedulerSecurityConfig{TrustedProxies: []string{"172.16.0.0/12"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &SchedulerConfig{Security: tt.security}
+			require.NoError(t, validateScheduler(cfg))
+		})
+	}
+}
+
+// TestLoadFailsOnAllInvalidCIDRAllowlistEnv proves the env -> comma-split -> validate
+// chain: a multi-element env list of invalid CIDRs splits into several invalid entries,
+// which then fail startup instead of silently degrading to localhost-only.
+func TestLoadFailsOnAllInvalidCIDRAllowlistEnv(t *testing.T) {
+	clearEnvironmentVariables()
+	t.Setenv("SCHEDULER_SECURITY_CIDRALLOWLIST", "bad1,bad2")
+	cfg, err := Load()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "scheduler.security.cidrallowlist")
+}

--- a/docs/superpowers/plans/2026-06-04-config-env-string-slice.md
+++ b/docs/superpowers/plans/2026-06-04-config-env-string-slice.md
@@ -1,0 +1,564 @@
+# Comma-Separated Env `[]string` Config Fields — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a comma-separated env var populate a multi-element `[]string` config field across both config paths (koanf `Unmarshal` and `InjectInto`), and fail startup loudly when a non-empty security CIDR list has zero valid entries.
+
+**Architecture:** A Type-scoped `string → []string` decode hook is added to `config.Load()`'s decoder (isolated first by a behavior-preserving prefactor). A single shared `splitAndTrimList` helper backs both the decode hook and `InjectInto`'s new `[]string` converter so semantics can't drift. `validateScheduler` gains a zero-valid-CIDR gate.
+
+**Tech Stack:** Go 1.26, koanf v2.3.5, go-viper/mapstructure v2.5.0, testify.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-config-env-string-slice-design.md`
+
+---
+
+## File Structure
+
+- `config/config.go` — extract `buildDecoderConfig()`, add `stringToTrimmedSliceHookFunc`, route `Load()` through `UnmarshalWithConf`.
+- `config/converters.go` — add shared `splitAndTrimList()` + `toStringSlice()`.
+- `config/validation.go` — add `validateCIDRList()`, call from `validateScheduler`.
+- `config/injection.go` — add `reflect.Slice` arm + `assignStringSliceField()`; update doc comment.
+- `config/config_test.go`, `config/converters_test.go`, `config/validation_test.go`, `config/injection_test.go` — tests.
+- `CLAUDE.md`, `llms.txt` — doc updates for `InjectInto` supported types.
+
+---
+
+## Task 1: Prefactor — isolate the decoder config (behavior-preserving)
+
+**Files:**
+- Modify: `config/config.go` (imports; `Load()` unmarshal call; new `buildDecoderConfig`)
+
+- [ ] **Step 1: Add imports**
+
+In `config/config.go` import block add `reflect` and the mapstructure alias:
+
+```go
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/confmap"
+	envprovider "github.com/knadh/koanf/providers/env/v2"
+	"github.com/knadh/koanf/providers/file"
+	"github.com/knadh/koanf/v2"
+
+	"github.com/gaborage/go-bricks/logger"
+)
+```
+
+- [ ] **Step 2: Add `buildDecoderConfig` (exact replica of koanf default)**
+
+Add near the bottom of `config/config.go`:
+
+```go
+// buildDecoderConfig replicates koanf's default Unmarshal decoder
+// (knadh/koanf/v2 koanf.go:265-272) so we control the DecodeHook chain.
+// koanf fills in Result and TagName at unmarshal time.
+func buildDecoderConfig() *mapstructure.DecoderConfig {
+	return &mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			mapstructure.StringToTimeDurationHookFunc(),
+			mapstructure.TextUnmarshallerHookFunc(),
+		),
+		WeaklyTypedInput: true,
+	}
+}
+```
+
+- [ ] **Step 3: Route `Load()` through `UnmarshalWithConf`**
+
+Replace the unmarshal call in `Load()`:
+
+```go
+	// Unmarshal into config struct
+	var cfg Config
+	if err := k.UnmarshalWithConf("", &cfg, koanf.UnmarshalConf{
+		DecoderConfig: buildDecoderConfig(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+```
+
+- [ ] **Step 4: Verify the whole config suite still passes (no behavior change)**
+
+Run: `go test ./config/... -race`
+Expected: PASS (the prefactor must not change any behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add config/config.go
+git commit -m "refactor(config): extract buildDecoderConfig to control unmarshal decode hooks"
+```
+
+---
+
+## Task 2: The fix — comma-split-and-trim decode hook (Unmarshal path)
+
+**Files:**
+- Create helper: `config/converters.go` (`splitAndTrimList`)
+- Modify: `config/config.go` (`stringToTrimmedSliceHookFunc`, add to chain)
+- Test: `config/config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `config/config_test.go`:
+
+```go
+func TestLoadMultiElementStringSliceEnv(t *testing.T) {
+	clearEnvironmentVariables()
+	t.Setenv("SCHEDULER_SECURITY_CIDRALLOWLIST", "10.0.0.0/8,192.168.0.0/16")
+	t.Setenv("SCHEDULER_SECURITY_TRUSTEDPROXIES", "10.0.0.0/8, 172.16.0.0/12")
+	t.Setenv("DEBUG_ALLOWEDIPS", "127.0.0.1,::1")
+	t.Setenv("LOG_SENSITIVE_FIELDS", "pan, cvv2 , otp")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"10.0.0.0/8", "192.168.0.0/16"}, cfg.Scheduler.Security.CIDRAllowlist)
+	assert.Equal(t, []string{"10.0.0.0/8", "172.16.0.0/12"}, cfg.Scheduler.Security.TrustedProxies)
+	assert.Equal(t, []string{"127.0.0.1", "::1"}, cfg.Debug.AllowedIPs)
+	assert.Equal(t, []string{"pan", "cvv2", "otp"}, cfg.Log.SensitiveFields)
+}
+
+func TestLoadSingleElementStringSliceEnv(t *testing.T) {
+	clearEnvironmentVariables()
+	t.Setenv("SCHEDULER_SECURITY_CIDRALLOWLIST", "10.0.0.0/8")
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"10.0.0.0/8"}, cfg.Scheduler.Security.CIDRAllowlist)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./config/ -run TestLoadMultiElementStringSliceEnv -v`
+Expected: FAIL — `cfg.Scheduler.Security.CIDRAllowlist` is `["10.0.0.0/8,192.168.0.0/16"]` (len 1).
+
+- [ ] **Step 3: Add the shared split helper**
+
+Add to `config/converters.go` (package already imports `strings`):
+
+```go
+// splitAndTrimList splits raw on sep, trims each element, and drops empties.
+// Single source of truth for env/default string -> []string semantics, shared by
+// the config Unmarshal decode hook and InjectInto.
+func splitAndTrimList(raw, sep string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return []string{}
+	}
+	parts := strings.Split(raw, sep)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Add the decode hook and wire it into the chain**
+
+In `config/config.go`, add the hook:
+
+```go
+// stringToTrimmedSliceHookFunc splits a scalar string into []string on sep,
+// trimming each element and dropping empties. Scoped to string -> []string only
+// (Type-level), so []byte, other slices, and YAML sequences are untouched.
+func stringToTrimmedSliceHookFunc(sep string) mapstructure.DecodeHookFunc {
+	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
+		if f.Kind() != reflect.String || t != reflect.TypeOf([]string(nil)) {
+			return data, nil
+		}
+		return splitAndTrimList(data.(string), sep), nil
+	}
+}
+```
+
+And prepend it in `buildDecoderConfig`'s compose chain:
+
+```go
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			stringToTrimmedSliceHookFunc(","),
+			mapstructure.StringToTimeDurationHookFunc(),
+			mapstructure.TextUnmarshallerHookFunc(),
+		),
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./config/ -run 'TestLoadMultiElementStringSliceEnv|TestLoadSingleElementStringSliceEnv' -v`
+Expected: PASS.
+
+- [ ] **Step 6: Verify the YAML-sequence path still works (regression)**
+
+Run: `go test ./config/... -race`
+Expected: PASS — YAML sequences arrive as slices and skip the hook.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add config/config.go config/converters.go config/config_test.go
+git commit -m "fix(config): split comma-separated env vars into []string fields (#539)"
+```
+
+---
+
+## Task 3: Fail-fast on all-invalid security CIDR lists
+
+**Files:**
+- Modify: `config/validation.go` (`net` import; `validateCIDRList`; call sites in `validateScheduler`)
+- Test: `config/validation_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `config/validation_test.go`:
+
+```go
+func TestValidateSchedulerCIDRListFailsWhenAllInvalid(t *testing.T) {
+	clearEnvironmentVariables()
+	t.Setenv("SCHEDULER_SECURITY_CIDRALLOWLIST", "not-a-cidr,also-bad")
+	cfg, err := Load()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "scheduler.security.cidrallowlist")
+}
+
+func TestValidateSchedulerTrustedProxiesFailsWhenAllInvalid(t *testing.T) {
+	clearEnvironmentVariables()
+	t.Setenv("SCHEDULER_SECURITY_TRUSTEDPROXIES", "garbage")
+	cfg, err := Load()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "scheduler.security.trustedproxies")
+}
+
+func TestValidateSchedulerCIDRListPassesCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "valid_multi", value: "10.0.0.0/8,192.168.0.0/16"},
+		{name: "partial_invalid_keeps_valid", value: "10.0.0.0/8,bad"},
+		{name: "single_valid", value: "10.0.0.0/8"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearEnvironmentVariables()
+			t.Setenv("SCHEDULER_SECURITY_CIDRALLOWLIST", tt.value)
+			cfg, err := Load()
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./config/ -run TestValidateSchedulerCIDR -v` and `-run TestValidateSchedulerTrustedProxies`
+Expected: the all-invalid tests FAIL (today `Load()` succeeds and the middleware degrades to localhost-only).
+
+- [ ] **Step 3: Add `net` import**
+
+In `config/validation.go` import block add `"net"`:
+
+```go
+import (
+	"fmt"
+	"net"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/gaborage/go-bricks/logger"
+)
+```
+
+- [ ] **Step 4: Add `validateCIDRList` and call it from `validateScheduler`**
+
+```go
+func validateScheduler(cfg *SchedulerConfig) error {
+	normalized, err := normalizeIANATimezone("scheduler.timezone", cfg.Timezone)
+	cfg.Timezone = normalized
+	if err != nil {
+		return err
+	}
+	if err := validateCIDRList("scheduler.security.cidrallowlist", cfg.Security.CIDRAllowlist); err != nil {
+		return err
+	}
+	return validateCIDRList("scheduler.security.trustedproxies", cfg.Security.TrustedProxies)
+}
+
+// validateCIDRList fails when a non-empty list contains zero parseable CIDRs.
+// Empty lists are valid (localhost-only / no-trusted-proxy defaults). Partial-invalid
+// lists pass here and keep the existing middleware-time WARN.
+func validateCIDRList(field string, list []string) error {
+	if len(list) == 0 {
+		return nil
+	}
+	var invalid []string
+	valid := 0
+	for _, entry := range list {
+		if _, _, err := net.ParseCIDR(strings.TrimSpace(entry)); err != nil {
+			invalid = append(invalid, entry)
+			continue
+		}
+		valid++
+	}
+	if valid == 0 {
+		return &ConfigError{
+			Category: errCategoryInvalid,
+			Field:    field,
+			Message:  fmt.Sprintf("no valid CIDR entries (all %d rejected: %v)", len(list), invalid),
+			Action:   "use CIDR notation, e.g. 10.0.0.0/8; comma-separate multiple values in one env var",
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./config/ -run TestValidateScheduler -v`
+Expected: PASS (all-invalid → error; valid/partial/single → ok).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add config/validation.go config/validation_test.go
+git commit -m "feat(config): fail startup when scheduler CIDR list has zero valid entries (#539)"
+```
+
+---
+
+## Task 4: `InjectInto` `[]string` support
+
+**Files:**
+- Modify: `config/converters.go` (`toStringSlice`)
+- Modify: `config/injection.go` (`reflect.Slice` arm; `assignStringSliceField`; doc comment)
+- Test: `config/injection_test.go`, `config/converters_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a struct + tests to `config/injection_test.go`:
+
+```go
+type sliceInjectConfig struct {
+	Hosts    []string `config:"svc.hosts"`
+	Defaults []string `config:"svc.defaults" default:"a,b,c"`
+	Required []string `config:"svc.required" required:"true"`
+}
+
+func TestConfigInjectionStringSliceFromEnv(t *testing.T) {
+	clearEnvironmentVariables()
+	t.Setenv("SVC_HOSTS", "h1, h2 ,h3")
+	t.Setenv("SVC_REQUIRED", "r1")
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	var sc sliceInjectConfig
+	require.NoError(t, cfg.InjectInto(&sc))
+	assert.Equal(t, []string{"h1", "h2", "h3"}, sc.Hosts)
+	assert.Equal(t, []string{"a", "b", "c"}, sc.Defaults)
+	assert.Equal(t, []string{"r1"}, sc.Required)
+}
+
+func TestConfigInjectionStringSliceRequiredMissing(t *testing.T) {
+	clearEnvironmentVariables()
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	var sc sliceInjectConfig
+	err = cfg.InjectInto(&sc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "svc.required")
+}
+```
+
+Add to `config/converters_test.go`:
+
+```go
+func TestToStringSlice(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    []string
+		wantErr bool
+	}{
+		{name: "string_split", input: "a, b ,c", want: []string{"a", "b", "c"}},
+		{name: "string_slice", input: []string{"x", "y"}, want: []string{"x", "y"}},
+		{name: "any_slice", input: []any{"x", 2}, want: []string{"x", "2"}},
+		{name: "empty_string", input: "", want: []string{}},
+		{name: "unsupported", input: 42, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toStringSlice(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./config/ -run 'TestConfigInjectionStringSlice|TestToStringSlice' -v`
+Expected: FAIL — `toStringSlice` undefined; injection returns "unsupported type".
+
+- [ ] **Step 3: Add `toStringSlice` to `config/converters.go`**
+
+```go
+// toStringSlice converts a resolved config value to []string. Reuses
+// splitAndTrimList for the string case so InjectInto matches Unmarshal semantics.
+func toStringSlice(value any) ([]string, error) {
+	switch v := value.(type) {
+	case []string:
+		return v, nil
+	case []any: // YAML sequence
+		out := make([]string, len(v))
+		for i, el := range v {
+			out[i] = fmt.Sprintf("%v", el)
+		}
+		return out, nil
+	case string:
+		return splitAndTrimList(v, ","), nil
+	default:
+		return nil, fmt.Errorf(errMsgUnsupportedType, value)
+	}
+}
+```
+
+- [ ] **Step 4: Add the slice arm + assignment in `config/injection.go`**
+
+In `assignFieldValue`, add a case before `default`:
+
+```go
+	case reflect.Slice:
+		if field.Type().Elem().Kind() == reflect.String {
+			return c.assignStringSliceField(field, configKey, required, value)
+		}
+		return &ConfigError{
+			Category: errCategoryInvalid,
+			Field:    configKey,
+			Message:  fmt.Sprintf("unsupported type %s", field.Type()),
+			Action:   "use string, int, int64, float64, bool, time.Duration, or []string",
+		}
+```
+
+Add the method:
+
+```go
+func (c *Config) assignStringSliceField(field reflect.Value, configKey string, required bool, value any) error {
+	slice, err := toStringSlice(value)
+	if err != nil {
+		return &ConfigError{
+			Category: errCategoryInvalid,
+			Field:    configKey,
+			Message:  fmt.Sprintf("'%v' is not a valid string list", value),
+			Action:   "provide a comma-separated string or a YAML sequence",
+		}
+	}
+	if required && len(slice) == 0 {
+		envVar := strings.ToUpper(strings.ReplaceAll(configKey, ".", "_"))
+		return &ConfigError{
+			Category: errCategoryMissing,
+			Field:    configKey,
+			Message:  errMessageRequired,
+			Action:   fmt.Sprintf("set %s env var or add '%s' to config.yaml", envVar, configKey),
+		}
+	}
+	field.Set(reflect.ValueOf(slice))
+	return nil
+}
+```
+
+Update the `InjectInto` doc comment line:
+
+```go
+// Supported field types: string, int, int64, float64, bool, time.Duration, []string
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./config/ -run 'TestConfigInjectionStringSlice|TestToStringSlice' -v`
+Expected: PASS.
+
+- [ ] **Step 6: Confirm unsupported-type still errors**
+
+Run: `go test ./config/ -run TestConfigInjectionUnsupportedFieldType -v`
+Expected: PASS (`chan int` remains unsupported).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add config/converters.go config/injection.go config/injection_test.go config/converters_test.go
+git commit -m "feat(config): support []string fields in InjectInto (#539)"
+```
+
+---
+
+## Task 5: Documentation
+
+**Files:**
+- Modify: `CLAUDE.md` (Configuration Injection → Supported Types)
+- Modify: `llms.txt` (if it enumerates `InjectInto` supported types)
+
+- [ ] **Step 1: Update CLAUDE.md**
+
+Change the "Supported Types" line under Configuration Injection to:
+
+```
+**Supported Types:** string, int, int64, float64, bool, time.Duration, []string (comma-separated via env, native sequence via YAML).
+```
+
+- [ ] **Step 2: Update llms.txt if applicable**
+
+Run: `grep -n "time.Duration" llms.txt`
+If a supported-types list is present, add `[]string` to it; otherwise skip.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md llms.txt
+git commit -m "docs(config): document []string support for env vars and InjectInto (#539)"
+```
+
+---
+
+## Task 6: Full verification + mandated reviews
+
+- [ ] **Step 1: Run the full pre-commit gate**
+
+Run: `make check`
+Expected: fmt + lint + race tests all pass.
+
+- [ ] **Step 2: Run mandated reviews on the diff (per CLAUDE.md)**
+
+Run `/code-review` then `/security-audit` on the staged/branch diff; apply findings (code-review first), re-run `make check`.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin feature/config-env-string-slice
+```
+Open PR titled `config: split comma-separated env vars for []string fields (#539)`, body referencing the issue, the four changes, and the fail-fast behavior note.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Change 1 → Task 1; Change 2 → Task 2; Change 3 → Task 3; Change 4 → Task 4; docs → Task 5; verification/reviews → Task 6. All spec sections mapped.
+- **Placeholder scan:** none — every code step has concrete code.
+- **Type consistency:** `splitAndTrimList`, `stringToTrimmedSliceHookFunc`, `buildDecoderConfig`, `validateCIDRList`, `toStringSlice`, `assignStringSliceField` names are used identically across tasks; `errMsgUnsupportedType`, `errMessageRequired`, `errCategoryInvalid`, `errCategoryMissing` reuse existing constants.

--- a/docs/superpowers/plans/2026-06-04-config-env-string-slice.md
+++ b/docs/superpowers/plans/2026-06-04-config-env-string-slice.md
@@ -519,7 +519,7 @@ git commit -m "feat(config): support []string fields in InjectInto (#539)"
 
 Change the "Supported Types" line under Configuration Injection to:
 
-```
+```text
 **Supported Types:** string, int, int64, float64, bool, time.Duration, []string (comma-separated via env, native sequence via YAML).
 ```
 

--- a/docs/superpowers/specs/2026-06-04-config-env-string-slice-design.md
+++ b/docs/superpowers/specs/2026-06-04-config-env-string-slice-design.md
@@ -38,6 +38,17 @@ path affects **every** `[]string` field — all of which are security-relevant:
 | `debug.allowedips` | `DEBUG_ALLOWEDIPS` | debug-endpoint IP gate degraded |
 | `log.sensitive_fields` | `LOG_SENSITIVE_FIELDS` | one bogus field name matches nothing → **redaction silently weakened** (fail-open; PCI/PII leak) |
 
+> **Finding during implementation:** `log.sensitive_fields` has a *second, distinct* bug
+> that the comma-split fix cannot reach. The env `TransformFunc` rewrites every `_` to `.`,
+> so `LOG_SENSITIVE_FIELDS` becomes the koanf key `log.sensitive.fields`, which does **not**
+> match the field's key `log.sensitive_fields` (underscore *inside* a segment). The env var is
+> therefore dropped entirely — the value never reaches the field, split or not. This field is
+> documented as YAML-or-code only (never env), so this is an undocumented-path bug with a
+> separate root cause (env-key segment vs. nesting ambiguity) whose proper fix changes global
+> env-key resolution. **Tracked as a follow-up issue; out of scope here.** The comma-split fix
+> fully fixes the three env-mappable `[]string` fields (`cidrallowlist`, `trustedproxies`,
+> `allowedips`) plus the YAML and `InjectInto` paths for all `[]string` fields.
+
 There is a **second, independent path** with the same gap: `Config.InjectInto()`
 (service-specific config) reads `c.k.Get(key)` directly and **bypasses** koanf's `Unmarshal`,
 so any decode-hook fix does not reach it. It currently rejects `[]string` fields outright
@@ -293,6 +304,9 @@ All tests use camelCase function names; table cases use snake_case descriptions
 
 ## Out of scope
 
+- **`LOG_SENSITIVE_FIELDS` (and any underscore-in-segment key) env override** — the `_`→`.`
+  transform mismaps it to `log.sensitive.fields`. Separate root cause, global blast radius;
+  filed as a follow-up issue.
 - `debug.allowedips` fail-fast (mixed IP-or-CIDR rule; the comma-split fix covers its bug).
 - Deduping `scheduler/cidr_middleware.go` `parseCIDRAllowlist` / `parseTrustedProxies`.
 - Any `[]string` element that must itself contain a comma.

--- a/docs/superpowers/specs/2026-06-04-config-env-string-slice-design.md
+++ b/docs/superpowers/specs/2026-06-04-config-env-string-slice-design.md
@@ -1,0 +1,308 @@
+# Design: comma-separated env vars for `[]string` config fields
+
+**Status:** Approved (brainstorming) — pending implementation plan
+**Date:** 2026-06-04
+**Area:** `config` (root cause), `scheduler` (most visible symptom)
+**Issue:** [#539](https://github.com/gaborage/go-bricks/issues/539)
+**Kind:** bug / security
+
+## Problem
+
+A `[]string` config field cannot be set to a **multi-element** list via a single
+environment variable. `SCHEDULER_SECURITY_CIDRALLOWLIST=10.0.0.0/8,192.168.0.0/16`
+loads as a **one-element** slice `["10.0.0.0/8,192.168.0.0/16"]` — the comma is part of
+the string, not a delimiter.
+
+Root cause, verified against the source:
+
+1. **Env provider passes the value through unchanged.** `config/config.go:45-53` registers
+   an env `TransformFunc` that only re-cases the key (`return k, v`); koanf `env/v2` stores
+   the value verbatim.
+2. **Unmarshal has no string→slice hook.** `config/config.go:57` calls `k.Unmarshal("", &cfg)`,
+   which uses koanf v2.3.5's **default** `DecoderConfig` (`koanf.go:265-272`):
+   `WeaklyTypedInput: true` with `DecodeHook = StringToTimeDurationHookFunc + textUnmarshalerHookFunc`.
+   There is **no** `StringToSliceHookFunc`.
+3. **Weak typing lifts a scalar string into a 1-element slice.** `go-viper/mapstructure/v2@v2.5.0`
+   wraps the whole string in `[]any{data}` for a `string → []string` conversion.
+4. **Downstream rejection.** `scheduler/cidr_middleware.go:52` (`parseCIDRAllowlist`)
+   `net.ParseCIDR`s the single element, it fails, zero valid nets remain, and the middleware
+   silently falls back to **localhost-only** with only a middleware-time WARN.
+
+A **single**-element env override works; only multi-element lists are broken. The same code
+path affects **every** `[]string` field — all of which are security-relevant:
+
+| Config key | Env var | Failure mode (multi-value via env) |
+|---|---|---|
+| `scheduler.security.cidrallowlist` | `SCHEDULER_SECURITY_CIDRALLOWLIST` | 0 valid CIDRs → **localhost-only** (fail-closed, allowlist ignored) |
+| `scheduler.security.trustedproxies` | `SCHEDULER_SECURITY_TRUSTEDPROXIES` | 0 valid proxies → proxy headers untrusted, real client IPs lost |
+| `debug.allowedips` | `DEBUG_ALLOWEDIPS` | debug-endpoint IP gate degraded |
+| `log.sensitive_fields` | `LOG_SENSITIVE_FIELDS` | one bogus field name matches nothing → **redaction silently weakened** (fail-open; PCI/PII leak) |
+
+There is a **second, independent path** with the same gap: `Config.InjectInto()`
+(service-specific config) reads `c.k.Get(key)` directly and **bypasses** koanf's `Unmarshal`,
+so any decode-hook fix does not reach it. It currently rejects `[]string` fields outright
+with "unsupported type" (`config/injection.go:129-136`).
+
+## Decision
+
+Treat the comma as a delimiter for `string → []string` conversion, uniformly across **both**
+config paths, and fail loudly at startup when a non-empty security CIDR list resolves to zero
+valid entries.
+
+### Scope decisions (locked during brainstorming)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Fix approach | **Universal decode hook** (not per-key env registry, not docs-only) | One change fixes every `[]string` field, present and future. No hand-maintained key list to forget. Matches "Explicit > Implicit / no silent failures". |
+| Whitespace / empties | **Trim each element, drop empties** | `logger/filter.go:220` substring-matches sensitive-field names **without** trimming; the stock `mapstructure.StringToSliceHookFunc` would leave `" cvv2"` and silently fail to redact. |
+| All-invalid security CIDR list | **Fail-fast at startup** (`config.Validate`) | A fat-fingered security control must fail loudly, not silently lock to localhost. |
+| Fail-fast trigger | **Non-empty list, zero valid entries** | Matches the issue wording. Partial-invalid (≥1 valid) stays tolerated with the existing middleware WARN — minimal behavior change. |
+| `InjectInto` `[]string` | **In scope** (per user) | Closes the symmetry gap so service config behaves like framework config. Shares the split helper so semantics can't drift. |
+| `debug.allowedips` fail-fast | **Out of scope** | Mixed IP-or-CIDR parse rule; debug is disabled by default; the comma-split fix already resolves its core bug. |
+| Scheduler CIDR-parse dedupe | **Out of scope** | Fail-fast lives in `config` (cannot import `scheduler` — circular). The scheduler file is left essentially untouched; no churn warranted. |
+
+### Behavior contract (`string → []string`)
+
+| Input (env value or `default:` tag) | Result |
+|---|---|
+| `"10.0.0.0/8,192.168.0.0/16"` | `["10.0.0.0/8", "192.168.0.0/16"]` |
+| `"10.0.0.0/8"` | `["10.0.0.0/8"]` (unchanged from today) |
+| `"pan, cvv2 , otp"` | `["pan", "cvv2", "otp"]` (trimmed) |
+| `"a,,b,"` | `["a", "b"]` (empties dropped) |
+| `""` or `" , "` | `[]string{}` |
+| YAML sequence / `confmap` default `[]string` | passed through untouched (arrives as a slice, not a string) |
+
+**Caveat (accepted):** assumes no single list element legitimately contains a comma. True for
+CIDRs, IPs, and field names — the only `[]string` fields that exist.
+
+## Detailed Design
+
+### Change 1 — Prefactor: isolate the decoder config (behavior-preserving)
+
+> *Make the change easy.* This commit changes no behavior; the entire existing `config`
+> suite must stay green.
+
+In `config/config.go`, extract a helper that **exactly replicates** koanf's current default
+decoder, then route `Load()` through `UnmarshalWithConf`:
+
+```go
+// buildDecoderConfig replicates koanf's default Unmarshal decoder (koanf.go:265-272)
+// so we control the DecodeHook chain. koanf fills in Result and TagName.
+func buildDecoderConfig() *mapstructure.DecoderConfig {
+    return &mapstructure.DecoderConfig{
+        DecodeHook: mapstructure.ComposeDecodeHookFunc(
+            mapstructure.StringToTimeDurationHookFunc(),
+            mapstructure.TextUnmarshallerHookFunc(),
+        ),
+        WeaklyTypedInput: true,
+    }
+}
+```
+
+```go
+// was: if err := k.Unmarshal("", &cfg); err != nil {
+if err := k.UnmarshalWithConf("", &cfg, koanf.UnmarshalConf{
+    DecoderConfig: buildDecoderConfig(),
+}); err != nil {
+    return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+}
+```
+
+Notes:
+- koanf's default text hook (`textUnmarshalerHookFunc`) is unexported; we substitute the
+  public `mapstructure.TextUnmarshallerHookFunc()`. Safe: the `Config` struct has **no**
+  `[]byte`, custom string types, or `TextUnmarshaler` fields (verified), so the two behave
+  identically here. Including it preserves forward-compatibility.
+- `WeaklyTypedInput: true` is retained — the config relies on it (`"8080"`→int, `"true"`→bool).
+
+### Change 2 — The fix (Unmarshal path): comma-split-and-trim hook
+
+Add one hook to the chain in `buildDecoderConfig`, backed by a shared helper (see Change 4):
+
+```go
+// stringToTrimmedSliceHookFunc splits a scalar string into []string on sep,
+// trimming each element and dropping empties. Scoped to string -> []string only
+// (Type-level), so []byte and other slices/YAML sequences are untouched.
+func stringToTrimmedSliceHookFunc(sep string) mapstructure.DecodeHookFunc {
+    return func(f reflect.Type, t reflect.Type, data any) (any, error) {
+        if f.Kind() != reflect.String || t != reflect.TypeOf([]string(nil)) {
+            return data, nil
+        }
+        return splitAndTrimList(data.(string), sep), nil
+    }
+}
+```
+
+Added to the compose chain as the first hook: `stringToTrimmedSliceHookFunc(",")`.
+Order is immaterial — each hook fires on a disjoint target type.
+
+### Change 3 — Fail-fast on all-invalid security CIDR lists
+
+In `config/validation.go`, extend `validateScheduler` (the existing startup-fail hook):
+
+```go
+func validateScheduler(cfg *SchedulerConfig) error {
+    normalized, err := normalizeIANATimezone("scheduler.timezone", cfg.Timezone)
+    cfg.Timezone = normalized
+    if err != nil {
+        return err
+    }
+    if err := validateCIDRList("scheduler.security.cidrallowlist", cfg.Security.CIDRAllowlist); err != nil {
+        return err
+    }
+    return validateCIDRList("scheduler.security.trustedproxies", cfg.Security.TrustedProxies)
+}
+
+// validateCIDRList fails when a non-empty list contains zero parseable CIDRs.
+// Empty lists are valid (localhost-only / no-trusted-proxy defaults). Partial-invalid
+// lists pass here and keep the existing middleware-time WARN.
+func validateCIDRList(field string, list []string) error {
+    if len(list) == 0 {
+        return nil
+    }
+    var invalid []string
+    valid := 0
+    for _, entry := range list {
+        if _, _, err := net.ParseCIDR(strings.TrimSpace(entry)); err != nil {
+            invalid = append(invalid, entry)
+            continue
+        }
+        valid++
+    }
+    if valid == 0 {
+        return &ConfigError{
+            Category: errCategoryInvalid,
+            Field:    field,
+            Message:  fmt.Sprintf("no valid CIDR entries (all %d rejected: %v)", len(list), invalid),
+            Action:   "use CIDR notation, e.g. 10.0.0.0/8; comma-separate multiple in one env var",
+        }
+    }
+    return nil
+}
+```
+
+Adds a `net` import to `config/validation.go`. The middleware's defensive localhost-only
+fallback stays intact (it is exported and unit-tested directly); this is an additional,
+earlier gate, not a replacement.
+
+### Change 4 — `InjectInto` `[]string` support (shared split semantics)
+
+**Shared seam** in `config/converters.go` so both paths produce identical results:
+
+```go
+// splitAndTrimList splits raw on sep, trims each element, and drops empties.
+// Single source of truth for env/default string -> []string semantics, shared by
+// the Unmarshal decode hook (Change 2) and InjectInto (below).
+func splitAndTrimList(raw, sep string) []string {
+    if strings.TrimSpace(raw) == "" {
+        return []string{}
+    }
+    parts := strings.Split(raw, sep)
+    out := make([]string, 0, len(parts))
+    for _, p := range parts {
+        if p = strings.TrimSpace(p); p != "" {
+            out = append(out, p)
+        }
+    }
+    return out
+}
+
+// toStringSlice converts a resolved config value to []string.
+func toStringSlice(value any) ([]string, error) {
+    switch v := value.(type) {
+    case []string:
+        return v, nil
+    case []any: // YAML sequence
+        out := make([]string, len(v))
+        for i, el := range v {
+            out[i] = fmt.Sprintf("%v", el)
+        }
+        return out, nil
+    case string:
+        return splitAndTrimList(v, ","), nil
+    default:
+        return nil, fmt.Errorf(errMsgUnsupportedType, value)
+    }
+}
+```
+
+In `config/injection.go`, add a `reflect.Slice` arm to `assignFieldValue`:
+
+```go
+case reflect.Slice:
+    if field.Type().Elem().Kind() == reflect.String {
+        return c.assignStringSliceField(field, configKey, required, value)
+    }
+    return &ConfigError{ /* unsupported type, as today */ }
+```
+
+```go
+func (c *Config) assignStringSliceField(field reflect.Value, configKey string, required bool, value any) error {
+    slice, err := toStringSlice(value)
+    if err != nil {
+        return &ConfigError{Category: errCategoryInvalid, Field: configKey, /* ... */}
+    }
+    if required && len(slice) == 0 {
+        return &ConfigError{Category: errCategoryMissing, Field: configKey, /* ... */}
+    }
+    field.Set(reflect.ValueOf(slice))
+    return nil
+}
+```
+
+Semantics: env comma string → split; YAML sequence → as-is; `default:"a,b,c"` → split;
+`required:"true"` + empty → missing error (mirrors `assignStringField`). Non-string element
+kinds (e.g. `[]int`) keep today's "unsupported type" error — `[]string` is the documented
+addition, nothing more.
+
+### Documentation updates
+
+- `config/injection.go` — `InjectInto` doc comment: add `[]string` to supported types.
+- `CLAUDE.md` — "Configuration Injection → Supported Types": add `[]string`.
+- `llms.txt` / `wiki/` — update if they enumerate `InjectInto` supported types.
+- Note in config docs / `.env.example` (if present) that comma-separated env vars now
+  populate multi-element `[]string` fields.
+
+## Testing (TDD order)
+
+**Step A — Fix tests first (red before Change 2):**
+- `config.Load()` with `SCHEDULER_SECURITY_CIDRALLOWLIST=10.0.0.0/8,192.168.0.0/16` → len 2, exact values.
+- `LOG_SENSITIVE_FIELDS=pan, cvv2 , otp` → `["pan","cvv2","otp"]` (trim + drop empties).
+- Single-element env still works (regression).
+- `DEBUG_ALLOWEDIPS` / `SCHEDULER_SECURITY_TRUSTEDPROXIES` multi-element.
+- YAML-sequence path still yields the right slice (regression; temp `config.yaml` or existing fixtures).
+
+**Step B — Prefactor regression (Change 1):** full existing `config` suite green.
+
+**Step C — Fail-fast tests (Change 3):**
+- Non-empty all-invalid `cidrallowlist` via env → `Load()` errors naming `scheduler.security.cidrallowlist`.
+- Non-empty all-invalid `trustedproxies` → error naming the field.
+- Partial-invalid (≥1 valid) → no error.
+- Empty list → no error. Valid multi → no error.
+
+**Step D — `InjectInto` tests (Change 4):**
+- `[]string` field from env comma string → multi-element, trimmed.
+- From YAML sequence → multi-element.
+- From `default:"a,b,c"` tag → split.
+- `required:"true"` + missing/empty → error.
+- Single element. `toStringSlice` unit tests (string / `[]any` / `[]string` / unsupported).
+- `TestConfigInjectionUnsupportedFieldType` (`chan int`) still passes.
+
+All tests use camelCase function names; table cases use snake_case descriptions
+(per CLAUDE.md). `make check` green before commit.
+
+## Out of scope
+
+- `debug.allowedips` fail-fast (mixed IP-or-CIDR rule; the comma-split fix covers its bug).
+- Deduping `scheduler/cidr_middleware.go` `parseCIDRAllowlist` / `parseTrustedProxies`.
+- Any `[]string` element that must itself contain a comma.
+
+## Risk / blast radius
+
+- The decode hook is **additive** and Type-scoped to `string → []string`; `[]byte`,
+  durations, text-unmarshalers, and YAML/`confmap` slices are unaffected (verified).
+- Change 3 can newly fail `Load()` for an app that sets an **all-invalid** security CIDR env
+  var (previously: silent localhost-only). Empty defaults are unaffected, so apps not touching
+  these fields see no change. This is the intended, safer behavior.
+- Change 4 only widens `InjectInto` from "unsupported" to "supported" for `[]string`; no
+  existing supported type changes.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-co-op/gocron/v2 v2.21.2
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-playground/validator/v10 v10.30.3
+	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/knadh/koanf/parsers/yaml v1.1.0
@@ -79,7 +80,6 @@ require (
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect


### PR DESCRIPTION
## Summary

Fixes #539. A `[]string` config field could not be set to a **multi-element** list via a single environment variable: `SCHEDULER_SECURITY_CIDRALLOWLIST=10.0.0.0/8,192.168.0.0/16` loaded as the one-element slice `["10.0.0.0/8,192.168.0.0/16"]` (the comma was part of the string). For the scheduler CIDR allowlist this meant every entry was an invalid CIDR, all were rejected, and the middleware silently fell back to **localhost-only** — dropping the operator's intended allowlist with only a middleware-time WARN.

Root cause: koanf's default `Unmarshal` decoder has no `string → []string` split hook, so mapstructure's weak-typing lifts the whole scalar string into a one-element slice. The same path affects every `[]string` field.

## Changes

1. **Prefactor (behavior-preserving):** extract `buildDecoderConfig()` — an exact replica of koanf's default decoder — so the framework controls the `DecodeHook` chain. No behavior change; the full existing `config` suite stays green.
2. **Fix (Unmarshal path):** add a Type-scoped `string → []string` comma-split-and-trim decode hook. Splits on `,`, trims each element, drops empties. Scoped to `[]string` only, so `[]byte`, other slices, and YAML sequences are untouched.
3. **Fail-fast:** `validateScheduler` now rejects a **non-empty** `scheduler.security.cidrallowlist` / `trustedproxies` that resolves to **zero** valid CIDRs — a fat-fingered security control fails loudly at startup instead of silently locking to localhost. Partial-invalid lists still pass and keep the existing middleware WARN.
4. **`InjectInto` (service config):** `[]string` is now a supported field type, via a *shared* `splitAndTrimList` helper so the env/`default`-string semantics can't drift from the Unmarshal path. YAML sequences and comma-separated strings both work.

A defensive copy was added so `InjectInto` doesn't alias koanf's stored slice, and the decode hook uses `reflect.Value.String()` so named string types can't panic (code-review hardening).

## Behavior contract (`string → []string`)

| Input | Result |
|---|---|
| `10.0.0.0/8,192.168.0.0/16` | `["10.0.0.0/8", "192.168.0.0/16"]` |
| `pan, cvv2 , otp` | `["pan", "cvv2", "otp"]` (trimmed) |
| `a,,b,` | `["a", "b"]` (empties dropped) |
| `""` | `[]string{}` |
| YAML sequence | passed through untouched |

## Related finding (separate follow-up)

`log.sensitive_fields` cannot be set via `LOG_SENSITIVE_FIELDS` at all: the env `TransformFunc` rewrites `_`→`.`, so the var maps to `log.sensitive.fields`, not the field's key `log.sensitive_fields`. This is a **distinct** bug (env-key segment-vs-nesting ambiguity, global blast radius) and this field is documented as YAML-or-code only. It is **out of scope** here and will be filed as a follow-up. This PR fully fixes the three env-mappable `[]string` fields (`cidrallowlist`, `trustedproxies`, `allowedips`) plus the YAML and `InjectInto` paths.

## Testing

- New tests: multi/single-element env splitting, whitespace trimming + empty-element dropping, fail-fast on all-invalid lists (with partial/empty/valid passing), `InjectInto` `[]string` from env/default/required-missing, `toStringSlice` units incl. no-alias.
- `make check` green (fmt + lint + race). `/code-review` (high) and `/security-review` run on the diff; findings applied. Security review found the change to be a net security improvement.

Suggested labels (cannot self-apply): `area/config`, `area/scheduler`, `bug`.

Design/plan: `docs/superpowers/specs/2026-06-04-config-env-string-slice-design.md`, `docs/superpowers/plans/2026-06-04-config-env-string-slice.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support comma-separated environment variables to populate list-type configuration fields while preserving native YAML sequence handling; trims whitespace and drops empty elements.

* **Bug Fixes**
  * Startup now validates security CIDR lists and fails fast when a non-empty list contains no valid entries.

* **Documentation**
  * Updated configuration docs and design notes to describe comma-separated list support and expected behavior.

* **Tests**
  * Added tests for parsing, injection, copy-safety, and CIDR validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->