### PR TITLE
fix(config): rename underscored config keys to flat-smushed convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ GoBricks is a **production-grade framework for building MVPs fast**. It provides
 - Input validation is **mandatory** at all boundaries (HTTP, messaging, database).
 - Raw-SQL escape hatches (`f.Raw()` and `jf.Raw()`) require an inline `// SECURITY: Manual SQL review completed - <what was verified>` annotation at every call site. The annotation is a forcing function for review and makes call sites grep-discoverable (`git grep -E 'f\.Raw\(|jf\.Raw\('`). The rationale should name the specific property checked: identifier quoting for vendor reserved words, parameterization of value sides, absence of user-input concatenation, etc.
 - Secrets from environment variables or secret managers (AWS Secrets Manager, HashiCorp Vault).
-- No hardcoded credentials, no secrets in logs or error messages. The framework's logger applies a `SensitiveDataFilter` to every log line; for PCI/PII workloads (PAN, CVV2, OTP) extend the default list via `log.sensitive_fields` in YAML or `app.Options.LoggerFilterConfig` in code — see [wiki/observability.md#sensitive-data-filtering](wiki/observability.md#sensitive-data-filtering) for the field list, two-seam injection, matching semantics, and defense-in-depth guidance.
+- No hardcoded credentials, no secrets in logs or error messages. The framework's logger applies a `SensitiveDataFilter` to every log line; for PCI/PII workloads (PAN, CVV2, OTP) extend the default list via `log.sensitivefields` in YAML or `app.Options.LoggerFilterConfig` in code — see [wiki/observability.md#sensitive-data-filtering](wiki/observability.md#sensitive-data-filtering) for the field list, two-seam injection, matching semantics, and defense-in-depth guidance.
 - Audit logging for sensitive operations (access control, data modifications).
 
 ### Practices & Patterns
@@ -440,7 +440,7 @@ For dual-mode log routing, runtime metrics, custom-metric patterns, vendor authe
 | HTTP server read / write / idle / shutdown | `server.timeout.{read,write,idle,shutdown}` | 15s / 30s / 60s / 10s |
 | Outbound HTTP client | `httpclient.NewBuilder(...).WithTimeout(d)` | 30s |
 | Cache (Redis) dial / read / write | `cache.redis.{dialtimeout,readtimeout,writetimeout}` | 5s / 3s / 3s |
-| AMQP connection establishment | `messaging.reconnect.connection_timeout` | 30s |
+| AMQP connection establishment | `messaging.reconnect.connectiontimeout` | 30s |
 | Scheduler slow-job WARN / shutdown | `scheduler.timeout.{slowjob,shutdown}` | 25s / 30s |
 | Observability export | `observability.trace.export.timeout` | 10s (dev) / 60s (prod) |
 

--- a/README.md
+++ b/README.md
@@ -544,9 +544,9 @@ cache:
   enabled: true
   type: redis
   manager:
-    max_size: 100              # Max tenant cache instances (LRU-evicted)
-    idle_ttl: 15m              # Close caches idle longer than this
-    cleanup_interval: 5m       # How often the cleanup goroutine runs
+    maxsize: 100              # Max tenant cache instances (LRU-evicted)
+    idlettl: 15m              # Close caches idle longer than this
+    cleanupinterval: 5m       # How often the cleanup goroutine runs
   redis:
     host: localhost
     port: 6379
@@ -658,7 +658,7 @@ func (s *OrderService) CreateOrder(ctx context.Context, req CreateOrderReq) erro
 }
 ```
 
-The relay job polls for pending events every `poll_interval` (default 5s), publishes them to AMQP with an `x-outbox-event-id` header for deduplication, and a cleanup job removes published events after `retention_period` (default 72h). See [CLAUDE.md](CLAUDE.md) for full configuration options.
+The relay job polls for pending events every `pollinterval` (default 5s), publishes them to AMQP with an `x-outbox-event-id` header for deduplication, and a cleanup job removes published events after `retentionperiod` (default 72h). See [CLAUDE.md](CLAUDE.md) for full configuration options.
 
 ---
 

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -96,11 +96,11 @@ func NewCacheManager(cfg ManagerConfig, connector Connector) (*CacheManager, err
 	}
 
 	if cfg.MaxSize < 0 {
-		return nil, fmt.Errorf("max_size cannot be negative")
+		return nil, fmt.Errorf("maxsize cannot be negative")
 	}
 
 	if cfg.IdleTTL < 0 {
-		return nil, fmt.Errorf("idle_ttl cannot be negative")
+		return nil, fmt.Errorf("idlettl cannot be negative")
 	}
 
 	if cfg.CleanupInterval <= 0 {

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -144,7 +144,7 @@ func TestNewCacheManager(t *testing.T) {
 		mgr, err := cache.NewCacheManager(config, connector)
 		assert.Error(t, err)
 		assert.Nil(t, mgr)
-		assert.Contains(t, err.Error(), "max_size cannot be negative")
+		assert.Contains(t, err.Error(), "maxsize cannot be negative")
 	})
 
 	t.Run("NegativeIdleTTL", func(t *testing.T) {
@@ -158,7 +158,7 @@ func TestNewCacheManager(t *testing.T) {
 		mgr, err := cache.NewCacheManager(config, connector)
 		assert.Error(t, err)
 		assert.Nil(t, mgr)
-		assert.Contains(t, err.Error(), "idle_ttl cannot be negative")
+		assert.Contains(t, err.Error(), "idlettl cannot be negative")
 	})
 
 	t.Run("ZeroMaxSize_Unlimited", func(t *testing.T) {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -109,19 +109,19 @@ keystore:
 # Requires: database + messaging + scheduler modules
 outbox:
   enabled: false                     # Enable transactional outbox pattern
-  table_name: gobricks_outbox        # Outbox table name in database
-  auto_create_table: false           # Create table on first use (opt-in; true in dev, false with managed migrations)
-  default_exchange: ""               # Fallback AMQP exchange when Event.Exchange is empty
-  poll_interval: 5s                  # How often the relay checks for pending events
-  batch_size: 100                    # Maximum events processed per relay cycle
-  max_retries: 5                     # Max publish attempts before giving up
-  retention_period: 72h              # How long published events are kept (0 = disable cleanup)
+  tablename: gobricks_outbox        # Outbox table name in database
+  autocreatetable: false           # Create table on first use (opt-in; true in dev, false with managed migrations)
+  defaultexchange: ""               # Fallback AMQP exchange when Event.Exchange is empty
+  pollinterval: 5s                  # How often the relay checks for pending events
+  batchsize: 100                    # Maximum events processed per relay cycle
+  maxretries: 5                     # Max publish attempts before giving up
+  retentionperiod: 72h              # How long published events are kept (0 = disable cleanup)
 
 inbox:
   enabled: false                     # Enable consumer-side idempotency (inbox) ledger
-  table_name: gobricks_inbox         # Inbox ledger table name (unqualified)
-  auto_create_table: false           # Create table on first use (opt-in; true in dev, false with managed migrations)
-  retention_period: 168h             # How long processed-event records are kept; must exceed broker max redelivery window (0 = use default 168h)
+  tablename: gobricks_inbox         # Inbox ledger table name (unqualified)
+  autocreatetable: false           # Create table on first use (opt-in; true in dev, false with managed migrations)
+  retentionperiod: 168h             # How long processed-event records are kept; must exceed broker max redelivery window (0 = use default 168h)
 
 log:
   level: debug
@@ -129,14 +129,14 @@ log:
   output:
     format: json
     file: ""
-  # sensitive_fields extends logger.DefaultFilterConfig (password, api_key,
+  # sensitivefields extends logger.DefaultFilterConfig (password, api_key,
   # token, …) with extra field names whose values must be masked in every
   # log line — including framework middleware. Substring match,
   # case-insensitive. For PCI/PII workloads (PAN, CVV2, OTP). For full
   # control (custom mask value, opt-out, code composition) use
   # app.Options.LoggerFilterConfig instead — see
   # wiki/observability.md#sensitive-data-filtering.
-  sensitive_fields:
+  sensitivefields:
     - pan
     - primary_account_number
     - cvv

--- a/config/config.go
+++ b/config/config.go
@@ -195,7 +195,7 @@ func loadDefaults(k *koanf.Koanf) error {
 
 		// KeyStore defaults — symmetric secret floor (32 bytes). Set to 0 to
 		// disable the minimum-length check explicitly.
-		"keystore.secret_min_length": 32,
+		"keystore.secretminlength": 32,
 	}
 
 	return k.Load(confmap.Provider(defaults, "."), nil)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -423,6 +423,27 @@ func TestLoadCustomConfiguration(t *testing.T) {
 	})
 }
 
+// TestEnvOverrideReachesRenamedKeys verifies that the flat-smushed config keys
+// are settable from environment variables. Underscored keys (the old snake_case
+// form) were unreachable because the env loader maps "_"->"." (koanf nesting).
+func TestEnvOverrideReachesRenamedKeys(t *testing.T) {
+	clearEnvironmentVariables()
+	t.Setenv("OUTBOX_BATCHSIZE", "250")
+	t.Setenv("OUTBOX_AUTOCREATETABLE", "true")
+	t.Setenv("MESSAGING_RECONNECT_CONNECTIONTIMEOUT", "45s")
+	t.Setenv("KEYSTORE_SECRETMINLENGTH", "64")
+	t.Setenv("LOG_SENSITIVEFIELDS", "pan, cvv2 ,otp")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	assert.Equal(t, 250, cfg.Outbox.BatchSize)
+	assert.True(t, cfg.Outbox.AutoCreateTable)
+	assert.Equal(t, 45*time.Second, cfg.Messaging.Reconnect.ConnectionTimeout)
+	assert.Equal(t, 64, cfg.KeyStore.SecretMinLength)
+	assert.Equal(t, []string{"pan", "cvv2", "otp"}, cfg.Log.SensitiveFields)
+}
+
 // Helper function to clear environment variables that might affect tests
 func clearEnvironmentVariables() {
 	envVars := []string{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -238,7 +238,7 @@ func TestLoadDefaultsInternalFunction(t *testing.T) {
 	assert.Equal(t, "", k.String("log.output.file"))
 
 	// KeyStore symmetric-secret floor defaults to 32 bytes.
-	assert.Equal(t, 32, k.Int("keystore.secret_min_length"))
+	assert.Equal(t, 32, k.Int("keystore.secretminlength"))
 }
 
 func TestLoadEdgeCases(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -428,6 +428,7 @@ func TestLoadCustomConfiguration(t *testing.T) {
 // form) were unreachable because the env loader maps "_"->"." (koanf nesting).
 func TestEnvOverrideReachesRenamedKeys(t *testing.T) {
 	clearEnvironmentVariables()
+	defer clearEnvironmentVariables()
 	t.Setenv("OUTBOX_BATCHSIZE", "250")
 	t.Setenv("OUTBOX_AUTOCREATETABLE", "true")
 	t.Setenv("MESSAGING_RECONNECT_CONNECTIONTIMEOUT", "45s")

--- a/config/testkeys.go
+++ b/config/testkeys.go
@@ -13,8 +13,8 @@ const (
 	TestKeyCacheRedisHost  = "cache.redis.host"
 	TestKeyCacheRedisPort  = "cache.redis.port"
 	TestKeyCacheRedisDB    = "cache.redis.database"
-	TestKeyCacheManagerMax = "cache.manager.max_size"
-	TestKeyCacheManagerTTL = "cache.manager.idle_ttl"
+	TestKeyCacheManagerMax = "cache.manager.maxsize"
+	TestKeyCacheManagerTTL = "cache.manager.idlettl"
 
 	// Messaging Configuration Keys
 	TestKeyMessagingBrokerURL      = "messaging.broker.url"

--- a/config/types.go
+++ b/config/types.go
@@ -256,15 +256,15 @@ type CacheManagerConfig struct {
 	// MaxSize is the maximum number of active cache instances.
 	// 0 = use default (100); negative values are invalid.
 	// Set higher for applications with many tenants.
-	MaxSize int `koanf:"max_size" json:"max_size" yaml:"max_size" toml:"max_size" mapstructure:"max_size"`
+	MaxSize int `koanf:"maxsize" json:"maxsize" yaml:"maxsize" toml:"maxsize" mapstructure:"maxsize"`
 
 	// IdleTTL is the idle timeout before cache instances are closed.
 	// Default: 15m. Set lower for memory-constrained environments.
-	IdleTTL time.Duration `koanf:"idle_ttl" json:"idle_ttl" yaml:"idle_ttl" toml:"idle_ttl" mapstructure:"idle_ttl"`
+	IdleTTL time.Duration `koanf:"idlettl" json:"idlettl" yaml:"idlettl" toml:"idlettl" mapstructure:"idlettl"`
 
 	// CleanupInterval is how often the cleanup goroutine runs.
 	// Default: 5m. Should be less than IdleTTL for effective cleanup.
-	CleanupInterval time.Duration `koanf:"cleanup_interval" json:"cleanup_interval" yaml:"cleanup_interval" toml:"cleanup_interval" mapstructure:"cleanup_interval"`
+	CleanupInterval time.Duration `koanf:"cleanupinterval" json:"cleanupinterval" yaml:"cleanupinterval" toml:"cleanupinterval" mapstructure:"cleanupinterval"`
 }
 
 // RedisConfig holds Redis-specific cache settings.
@@ -296,7 +296,7 @@ type LogConfig struct {
 	// Go code. For full control over the FilterConfig (e.g., custom MaskValue
 	// or opting out of defaults), set app.Options.LoggerFilterConfig instead;
 	// that field takes precedence over this one.
-	SensitiveFields []string `koanf:"sensitive_fields" json:"sensitive_fields" yaml:"sensitive_fields" toml:"sensitive_fields" mapstructure:"sensitive_fields"`
+	SensitiveFields []string `koanf:"sensitivefields" json:"sensitivefields" yaml:"sensitivefields" toml:"sensitivefields" mapstructure:"sensitivefields"`
 }
 
 // OutputConfig holds log output settings.
@@ -339,19 +339,19 @@ type ReconnectConfig struct {
 
 	// ReinitDelay is the delay before channel reinitialization after failure.
 	// Default: 2s.
-	ReinitDelay time.Duration `koanf:"reinit_delay" json:"reinit_delay" yaml:"reinit_delay" toml:"reinit_delay" mapstructure:"reinit_delay"`
+	ReinitDelay time.Duration `koanf:"reinitdelay" json:"reinitdelay" yaml:"reinitdelay" toml:"reinitdelay" mapstructure:"reinitdelay"`
 
 	// ResendDelay is the delay before retrying a failed publish operation.
 	// Default: 5s.
-	ResendDelay time.Duration `koanf:"resend_delay" json:"resend_delay" yaml:"resend_delay" toml:"resend_delay" mapstructure:"resend_delay"`
+	ResendDelay time.Duration `koanf:"resenddelay" json:"resenddelay" yaml:"resenddelay" toml:"resenddelay" mapstructure:"resenddelay"`
 
 	// ConnectionTimeout is the timeout for connection establishment and publish confirmation.
 	// Default: 30s. Set higher for high-latency networks.
-	ConnectionTimeout time.Duration `koanf:"connection_timeout" json:"connection_timeout" yaml:"connection_timeout" toml:"connection_timeout" mapstructure:"connection_timeout"`
+	ConnectionTimeout time.Duration `koanf:"connectiontimeout" json:"connectiontimeout" yaml:"connectiontimeout" toml:"connectiontimeout" mapstructure:"connectiontimeout"`
 
 	// MaxDelay is the maximum delay for exponential backoff during reconnection.
 	// Default: 60s. Prevents unbounded delays during prolonged outages.
-	MaxDelay time.Duration `koanf:"max_delay" json:"max_delay" yaml:"max_delay" toml:"max_delay" mapstructure:"max_delay"`
+	MaxDelay time.Duration `koanf:"maxdelay" json:"maxdelay" yaml:"maxdelay" toml:"maxdelay" mapstructure:"maxdelay"`
 }
 
 // PublisherPoolConfig holds publisher cache/pool settings.
@@ -361,11 +361,11 @@ type ReconnectConfig struct {
 type PublisherPoolConfig struct {
 	// MaxCached is the maximum number of publisher clients to keep in the cache.
 	// Default: 50. Set higher for applications with many tenants.
-	MaxCached int `koanf:"max_cached" json:"max_cached" yaml:"max_cached" toml:"max_cached" mapstructure:"max_cached"`
+	MaxCached int `koanf:"maxcached" json:"maxcached" yaml:"maxcached" toml:"maxcached" mapstructure:"maxcached"`
 
 	// IdleTTL is the time after which idle publisher clients are evicted.
 	// Default: 10m. Set lower for memory-constrained environments.
-	IdleTTL time.Duration `koanf:"idle_ttl" json:"idle_ttl" yaml:"idle_ttl" toml:"idle_ttl" mapstructure:"idle_ttl"`
+	IdleTTL time.Duration `koanf:"idlettl" json:"idlettl" yaml:"idlettl" toml:"idlettl" mapstructure:"idlettl"`
 }
 
 // BrokerConfig holds message broker connection settings.
@@ -477,34 +477,34 @@ type OutboxConfig struct {
 
 	// TableName is the outbox table name in the database.
 	// Default: "gobricks_outbox".
-	TableName string `koanf:"table_name" json:"table_name" yaml:"table_name" toml:"table_name" mapstructure:"table_name"`
+	TableName string `koanf:"tablename" json:"tablename" yaml:"tablename" toml:"tablename" mapstructure:"tablename"`
 
 	// AutoCreateTable creates the outbox table on first use if it doesn't exist.
 	// Default: false (opt-in). Set true to auto-create (e.g. in development); leave
 	// false in production with managed migrations.
-	AutoCreateTable bool `koanf:"auto_create_table" json:"auto_create_table" yaml:"auto_create_table" toml:"auto_create_table" mapstructure:"auto_create_table"`
+	AutoCreateTable bool `koanf:"autocreatetable" json:"autocreatetable" yaml:"autocreatetable" toml:"autocreatetable" mapstructure:"autocreatetable"`
 
 	// DefaultExchange is the fallback AMQP exchange when Event.Exchange is empty.
 	// Default: "" (empty, which publishes to the default exchange).
-	DefaultExchange string `koanf:"default_exchange" json:"default_exchange" yaml:"default_exchange" toml:"default_exchange" mapstructure:"default_exchange"`
+	DefaultExchange string `koanf:"defaultexchange" json:"defaultexchange" yaml:"defaultexchange" toml:"defaultexchange" mapstructure:"defaultexchange"`
 
 	// PollInterval is how often the relay checks for pending events.
 	// Default: 5s. Lower values reduce latency but increase database load.
-	PollInterval time.Duration `koanf:"poll_interval" json:"poll_interval" yaml:"poll_interval" toml:"poll_interval" mapstructure:"poll_interval"`
+	PollInterval time.Duration `koanf:"pollinterval" json:"pollinterval" yaml:"pollinterval" toml:"pollinterval" mapstructure:"pollinterval"`
 
 	// BatchSize is the maximum number of events processed per relay cycle.
 	// Default: 100. Higher values improve throughput but increase memory usage.
-	BatchSize int `koanf:"batch_size" json:"batch_size" yaml:"batch_size" toml:"batch_size" mapstructure:"batch_size"`
+	BatchSize int `koanf:"batchsize" json:"batchsize" yaml:"batchsize" toml:"batchsize" mapstructure:"batchsize"`
 
 	// MaxRetries is the maximum number of publish attempts before giving up.
 	// Events exceeding this count remain in the table with status "pending" but are skipped by the relay.
 	// Default: 5.
-	MaxRetries int `koanf:"max_retries" json:"max_retries" yaml:"max_retries" toml:"max_retries" mapstructure:"max_retries"`
+	MaxRetries int `koanf:"maxretries" json:"maxretries" yaml:"maxretries" toml:"maxretries" mapstructure:"maxretries"`
 
 	// RetentionPeriod is how long published events are kept before cleanup.
 	// Set to 0 to disable automatic cleanup.
 	// Default: 72h.
-	RetentionPeriod time.Duration `koanf:"retention_period" json:"retention_period" yaml:"retention_period" toml:"retention_period" mapstructure:"retention_period"`
+	RetentionPeriod time.Duration `koanf:"retentionperiod" json:"retentionperiod" yaml:"retentionperiod" toml:"retentionperiod" mapstructure:"retentionperiod"`
 }
 
 // InboxConfig holds consumer-side idempotency (inbox) settings.
@@ -523,18 +523,18 @@ type InboxConfig struct {
 	// TableName is the inbox ledger table name in the database.
 	// Default: "gobricks_inbox". Must be unqualified (no schema prefix) because the
 	// Oracle store derives a primary-key constraint name from it.
-	TableName string `koanf:"table_name" json:"table_name" yaml:"table_name" toml:"table_name" mapstructure:"table_name"`
+	TableName string `koanf:"tablename" json:"tablename" yaml:"tablename" toml:"tablename" mapstructure:"tablename"`
 
 	// AutoCreateTable creates the inbox table on first use if it doesn't exist.
 	// Default: false (opt-in). Set true to auto-create (e.g. in development); leave
 	// false in production with managed migrations.
-	AutoCreateTable bool `koanf:"auto_create_table" json:"auto_create_table" yaml:"auto_create_table" toml:"auto_create_table" mapstructure:"auto_create_table"`
+	AutoCreateTable bool `koanf:"autocreatetable" json:"autocreatetable" yaml:"autocreatetable" toml:"autocreatetable" mapstructure:"autocreatetable"`
 
 	// RetentionPeriod is how long processed-event records are kept before cleanup.
 	// It MUST exceed the broker's maximum redelivery window, or a late redelivery
 	// could be reprocessed. A zero value is treated as unset and replaced by the
 	// default; increase it to retain longer. Default: 168h (7 days).
-	RetentionPeriod time.Duration `koanf:"retention_period" json:"retention_period" yaml:"retention_period" toml:"retention_period" mapstructure:"retention_period"`
+	RetentionPeriod time.Duration `koanf:"retentionperiod" json:"retentionperiod" yaml:"retentionperiod" toml:"retentionperiod" mapstructure:"retentionperiod"`
 }
 
 // SchedulerConfig holds job scheduler settings.
@@ -586,7 +586,7 @@ type KeyStoreConfig struct {
 	// entries at startup. The default (32) is applied via loadDefaults; an
 	// explicit 0 disables the check (opt-out for callers with a deliberate
 	// reason to allow shorter keys). Negative values are rejected at validation.
-	SecretMinLength int `koanf:"secret_min_length" json:"secret_min_length" yaml:"secret_min_length" toml:"secret_min_length" mapstructure:"secret_min_length"`
+	SecretMinLength int `koanf:"secretminlength" json:"secretminlength" yaml:"secretminlength" toml:"secretminlength" mapstructure:"secretminlength"`
 }
 
 // KeyPairConfig holds key material for one logical name. An entry is either an

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -47,10 +47,8 @@ func TestConfigKoanfTagsHaveNoUnderscore(t *testing.T) {
 			if strings.Contains(name, "_") {
 				offenders = append(offenders, key)
 			}
-			switch f.Type.Kind() {
-			case reflect.Struct, reflect.Pointer, reflect.Map, reflect.Slice:
-				walk(f.Type, key)
-			}
+			// Recurse into nested config types; walk is a no-op for scalar leaf kinds.
+			walk(f.Type, key)
 		}
 	}
 

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -11,55 +11,66 @@ import (
 // delimiter), so any koanf leaf tag containing "_" is unreachable from the
 // environment. Every koanf tag in the Config tree MUST be underscore-free.
 func TestConfigKoanfTagsHaveNoUnderscore(t *testing.T) {
-	var offenders []string
-	seen := map[reflect.Type]bool{}
-
-	var walk func(rt reflect.Type, prefix string)
-	walk = func(rt reflect.Type, prefix string) {
-		for rt.Kind() == reflect.Pointer {
-			rt = rt.Elem()
-		}
-		if rt.Kind() == reflect.Map || rt.Kind() == reflect.Slice {
-			el := rt.Elem()
-			for el.Kind() == reflect.Pointer {
-				el = el.Elem()
-			}
-			if el.Kind() == reflect.Struct {
-				walk(el, prefix)
-			}
-			return
-		}
-		if rt.Kind() != reflect.Struct || seen[rt] {
-			return
-		}
-		seen[rt] = true
-		for i := 0; i < rt.NumField(); i++ {
-			f := rt.Field(i)
-			name := strings.Split(f.Tag.Get("koanf"), ",")[0]
-			if name == "-" {
-				continue
-			}
-			// An untagged field (incl. anonymous/embedded structs) keeps the
-			// parent prefix so its tagged children are still reached and checked.
-			key := prefix
-			if name != "" {
-				if prefix != "" {
-					key = prefix + "." + name
-				} else {
-					key = name
-				}
-				if strings.Contains(name, "_") {
-					offenders = append(offenders, key)
-				}
-			}
-			// Recurse into every field type; walk is a no-op for scalar leaf kinds.
-			walk(f.Type, key)
-		}
-	}
-
-	walk(reflect.TypeOf(Config{}), "")
+	offenders := collectUnderscoredKoanfTags(reflect.TypeOf(Config{}), "", map[reflect.Type]bool{})
 	if len(offenders) > 0 {
 		t.Fatalf("koanf tags must be underscore-free (env vars nest on '_'); offenders:\n  %s",
 			strings.Join(offenders, "\n  "))
+	}
+}
+
+// collectUnderscoredKoanfTags walks the config struct tree (through pointers,
+// maps, slices, and nested/embedded structs) and returns the dotted key paths
+// whose koanf tag contains an underscore. seen prevents revisiting shared types.
+func collectUnderscoredKoanfTags(rt reflect.Type, prefix string, seen map[reflect.Type]bool) []string {
+	rt = koanfUnderlyingStruct(rt)
+	if rt == nil || seen[rt] {
+		return nil
+	}
+	seen[rt] = true
+
+	var offenders []string
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		name := strings.Split(f.Tag.Get("koanf"), ",")[0]
+		if name == "-" {
+			continue
+		}
+		// Untagged fields (incl. anonymous/embedded structs) keep the parent
+		// prefix so their tagged children are still reached and checked.
+		key := koanfChildKey(prefix, name)
+		if strings.Contains(name, "_") {
+			offenders = append(offenders, key)
+		}
+		offenders = append(offenders, collectUnderscoredKoanfTags(f.Type, key, seen)...)
+	}
+	return offenders
+}
+
+// koanfUnderlyingStruct dereferences pointers and unwraps map/slice element types,
+// returning the underlying struct type, or nil if the type bottoms out at a
+// non-struct (a scalar leaf).
+func koanfUnderlyingStruct(rt reflect.Type) reflect.Type {
+	for {
+		switch rt.Kind() {
+		case reflect.Pointer, reflect.Map, reflect.Slice:
+			rt = rt.Elem()
+		case reflect.Struct:
+			return rt
+		default:
+			return nil
+		}
+	}
+}
+
+// koanfChildKey joins a parent prefix with a leaf name, treating an empty name
+// (untagged/embedded field) as a pass-through of the parent prefix.
+func koanfChildKey(prefix, name string) string {
+	switch {
+	case name == "":
+		return prefix
+	case prefix == "":
+		return name
+	default:
+		return prefix + "." + name
 	}
 }

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -35,19 +35,24 @@ func TestConfigKoanfTagsHaveNoUnderscore(t *testing.T) {
 		seen[rt] = true
 		for i := 0; i < rt.NumField(); i++ {
 			f := rt.Field(i)
-			tag := f.Tag.Get("koanf")
-			if tag == "" || tag == "-" {
+			name := strings.Split(f.Tag.Get("koanf"), ",")[0]
+			if name == "-" {
 				continue
 			}
-			name := strings.Split(tag, ",")[0]
-			key := name
-			if prefix != "" {
-				key = prefix + "." + name
+			// An untagged field (incl. anonymous/embedded structs) keeps the
+			// parent prefix so its tagged children are still reached and checked.
+			key := prefix
+			if name != "" {
+				if prefix != "" {
+					key = prefix + "." + name
+				} else {
+					key = name
+				}
+				if strings.Contains(name, "_") {
+					offenders = append(offenders, key)
+				}
 			}
-			if strings.Contains(name, "_") {
-				offenders = append(offenders, key)
-			}
-			// Recurse into nested config types; walk is a no-op for scalar leaf kinds.
+			// Recurse into every field type; walk is a no-op for scalar leaf kinds.
 			walk(f.Type, key)
 		}
 	}

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestConfigKoanfTagsHaveNoUnderscore guards the whole "env var cannot reach an
+// underscored koanf key" bug class: the env loader maps "_"->"." (koanf's nesting
+// delimiter), so any koanf leaf tag containing "_" is unreachable from the
+// environment. Every koanf tag in the Config tree MUST be underscore-free.
+func TestConfigKoanfTagsHaveNoUnderscore(t *testing.T) {
+	var offenders []string
+	seen := map[reflect.Type]bool{}
+
+	var walk func(rt reflect.Type, prefix string)
+	walk = func(rt reflect.Type, prefix string) {
+		for rt.Kind() == reflect.Pointer {
+			rt = rt.Elem()
+		}
+		if rt.Kind() == reflect.Map || rt.Kind() == reflect.Slice {
+			el := rt.Elem()
+			for el.Kind() == reflect.Pointer {
+				el = el.Elem()
+			}
+			if el.Kind() == reflect.Struct {
+				walk(el, prefix)
+			}
+			return
+		}
+		if rt.Kind() != reflect.Struct || seen[rt] {
+			return
+		}
+		seen[rt] = true
+		for i := 0; i < rt.NumField(); i++ {
+			f := rt.Field(i)
+			tag := f.Tag.Get("koanf")
+			if tag == "" || tag == "-" {
+				continue
+			}
+			name := strings.Split(tag, ",")[0]
+			key := name
+			if prefix != "" {
+				key = prefix + "." + name
+			}
+			if strings.Contains(name, "_") {
+				offenders = append(offenders, key)
+			}
+			switch f.Type.Kind() {
+			case reflect.Struct, reflect.Pointer, reflect.Map, reflect.Slice:
+				walk(f.Type, key)
+			}
+		}
+	}
+
+	walk(reflect.TypeOf(Config{}), "")
+	if len(offenders) > 0 {
+		t.Fatalf("koanf tags must be underscore-free (env vars nest on '_'); offenders:\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}

--- a/config/validation.go
+++ b/config/validation.go
@@ -593,42 +593,42 @@ func applyMessagingDefaults(cfg *MessagingConfig) error {
 	if cfg.Reconnect.ReinitDelay == 0 {
 		cfg.Reconnect.ReinitDelay = defaultReinitDelay
 	} else if cfg.Reconnect.ReinitDelay < 0 {
-		return NewValidationError("messaging.reconnect.reinit_delay", errMustBeNonNegative)
+		return NewValidationError("messaging.reconnect.reinitdelay", errMustBeNonNegative)
 	}
 
 	// Reconnect.ResendDelay
 	if cfg.Reconnect.ResendDelay == 0 {
 		cfg.Reconnect.ResendDelay = defaultResendDelay
 	} else if cfg.Reconnect.ResendDelay < 0 {
-		return NewValidationError("messaging.reconnect.resend_delay", errMustBeNonNegative)
+		return NewValidationError("messaging.reconnect.resenddelay", errMustBeNonNegative)
 	}
 
 	// Reconnect.ConnectionTimeout
 	if cfg.Reconnect.ConnectionTimeout == 0 {
 		cfg.Reconnect.ConnectionTimeout = defaultConnectionTimeout
 	} else if cfg.Reconnect.ConnectionTimeout < 0 {
-		return NewValidationError("messaging.reconnect.connection_timeout", errMustBeNonNegative)
+		return NewValidationError("messaging.reconnect.connectiontimeout", errMustBeNonNegative)
 	}
 
 	// Reconnect.MaxDelay
 	if cfg.Reconnect.MaxDelay == 0 {
 		cfg.Reconnect.MaxDelay = defaultMaxReconnectDelay
 	} else if cfg.Reconnect.MaxDelay < 0 {
-		return NewValidationError("messaging.reconnect.max_delay", errMustBeNonNegative)
+		return NewValidationError("messaging.reconnect.maxdelay", errMustBeNonNegative)
 	}
 
 	// Publisher.MaxCached
 	if cfg.Publisher.MaxCached == 0 {
 		cfg.Publisher.MaxCached = defaultMaxPublishers
 	} else if cfg.Publisher.MaxCached < 0 {
-		return NewValidationError("messaging.publisher.max_cached", errMustBeNonNegative)
+		return NewValidationError("messaging.publisher.maxcached", errMustBeNonNegative)
 	}
 
 	// Publisher.IdleTTL
 	if cfg.Publisher.IdleTTL == 0 {
 		cfg.Publisher.IdleTTL = defaultPublisherIdleTTL
 	} else if cfg.Publisher.IdleTTL < 0 {
-		return NewValidationError("messaging.publisher.idle_ttl", errMustBeNonNegative)
+		return NewValidationError("messaging.publisher.idlettl", errMustBeNonNegative)
 	}
 
 	return nil
@@ -647,21 +647,21 @@ func applyCacheManagerDefaults(cfg *CacheConfig) error {
 	if cfg.Manager.MaxSize == 0 {
 		cfg.Manager.MaxSize = defaultCacheMaxSize
 	} else if cfg.Manager.MaxSize < 0 {
-		return NewValidationError("cache.manager.max_size", errMustBeNonNegative)
+		return NewValidationError("cache.manager.maxsize", errMustBeNonNegative)
 	}
 
 	// Manager.IdleTTL
 	if cfg.Manager.IdleTTL == 0 {
 		cfg.Manager.IdleTTL = defaultCacheIdleTTL
 	} else if cfg.Manager.IdleTTL < 0 {
-		return NewValidationError("cache.manager.idle_ttl", errMustBeNonNegative)
+		return NewValidationError("cache.manager.idlettl", errMustBeNonNegative)
 	}
 
 	// Manager.CleanupInterval
 	if cfg.Manager.CleanupInterval == 0 {
 		cfg.Manager.CleanupInterval = defaultCacheCleanupInterval
 	} else if cfg.Manager.CleanupInterval < 0 {
-		return NewValidationError("cache.manager.cleanup_interval", errMustBeNonNegative)
+		return NewValidationError("cache.manager.cleanupinterval", errMustBeNonNegative)
 	}
 
 	return nil
@@ -804,7 +804,7 @@ func validateOracleFields(cfg *DatabaseConfig) error {
 // symmetric secret — a mixed entry is rejected.
 func validateKeyStore(cfg *KeyStoreConfig) error {
 	if cfg.SecretMinLength < 0 {
-		return NewValidationError("keystore.secret_min_length", errMustBeNonNegative)
+		return NewValidationError("keystore.secretminlength", errMustBeNonNegative)
 	}
 
 	if len(cfg.Keys) == 0 {

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -1973,6 +1973,46 @@ func TestApplyMessagingDefaultsNegativeValues(t *testing.T) {
 			},
 			errorContains: "messaging.publisher.maxcached",
 		},
+		{
+			name: "negative_reinit_delay_rejected",
+			config: MessagingConfig{
+				Broker:    BrokerConfig{URL: testAMQPHost},
+				Reconnect: ReconnectConfig{ReinitDelay: -1 * time.Second},
+			},
+			errorContains: "messaging.reconnect.reinitdelay",
+		},
+		{
+			name: "negative_resend_delay_rejected",
+			config: MessagingConfig{
+				Broker:    BrokerConfig{URL: testAMQPHost},
+				Reconnect: ReconnectConfig{ResendDelay: -1 * time.Second},
+			},
+			errorContains: "messaging.reconnect.resenddelay",
+		},
+		{
+			name: "negative_connection_timeout_rejected",
+			config: MessagingConfig{
+				Broker:    BrokerConfig{URL: testAMQPHost},
+				Reconnect: ReconnectConfig{ConnectionTimeout: -1 * time.Second},
+			},
+			errorContains: "messaging.reconnect.connectiontimeout",
+		},
+		{
+			name: "negative_max_delay_rejected",
+			config: MessagingConfig{
+				Broker:    BrokerConfig{URL: testAMQPHost},
+				Reconnect: ReconnectConfig{MaxDelay: -1 * time.Second},
+			},
+			errorContains: "messaging.reconnect.maxdelay",
+		},
+		{
+			name: "negative_publisher_idle_ttl_rejected",
+			config: MessagingConfig{
+				Broker:    BrokerConfig{URL: testAMQPHost},
+				Publisher: PublisherPoolConfig{IdleTTL: -1 * time.Second},
+			},
+			errorContains: "messaging.publisher.idlettl",
+		},
 	}
 
 	for _, tt := range tests {
@@ -2070,6 +2110,16 @@ func TestApplyCacheManagerDefaultsNegativeValues(t *testing.T) {
 				Manager: CacheManagerConfig{IdleTTL: -1 * time.Minute},
 			},
 			errorContains: "cache.manager.idlettl",
+		},
+		{
+			name: "negative_cleanup_interval_rejected",
+			config: CacheConfig{
+				Enabled: true,
+				Type:    "redis",
+				Redis:   RedisConfig{Host: "localhost", Port: 6379, PoolSize: 10},
+				Manager: CacheManagerConfig{CleanupInterval: -1 * time.Minute},
+			},
+			errorContains: "cache.manager.cleanupinterval",
 		},
 	}
 

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -1971,7 +1971,7 @@ func TestApplyMessagingDefaultsNegativeValues(t *testing.T) {
 				Broker:    BrokerConfig{URL: testAMQPHost},
 				Publisher: PublisherPoolConfig{MaxCached: -1},
 			},
-			errorContains: "messaging.publisher.max_cached",
+			errorContains: "messaging.publisher.maxcached",
 		},
 	}
 
@@ -2025,7 +2025,7 @@ func TestApplyCacheManagerDefaults(t *testing.T) {
 				Type:    "redis",
 				Redis:   RedisConfig{Host: "localhost", Port: 6379, PoolSize: 10},
 				Manager: CacheManagerConfig{
-					MaxSize: 50, // Only max_size set
+					MaxSize: 50, // Only maxsize set
 				},
 			},
 			expectedMaxSize:         50,                          // Preserved
@@ -2059,7 +2059,7 @@ func TestApplyCacheManagerDefaultsNegativeValues(t *testing.T) {
 				Redis:   RedisConfig{Host: "localhost", Port: 6379, PoolSize: 10},
 				Manager: CacheManagerConfig{MaxSize: -1},
 			},
-			errorContains: "cache.manager.max_size",
+			errorContains: "cache.manager.maxsize",
 		},
 		{
 			name: "negative_idle_ttl_rejected",
@@ -2069,7 +2069,7 @@ func TestApplyCacheManagerDefaultsNegativeValues(t *testing.T) {
 				Redis:   RedisConfig{Host: "localhost", Port: 6379, PoolSize: 10},
 				Manager: CacheManagerConfig{IdleTTL: -1 * time.Minute},
 			},
-			errorContains: "cache.manager.idle_ttl",
+			errorContains: "cache.manager.idlettl",
 		},
 	}
 
@@ -3756,7 +3756,7 @@ func TestValidateKeyStoreMixedEntrySecretPlusPrivate(t *testing.T) {
 func TestValidateKeyStoreSecretMinLengthNegative(t *testing.T) {
 	cfg := &KeyStoreConfig{SecretMinLength: -1}
 	err := validateKeyStore(cfg)
-	assert.ErrorContains(t, err, "keystore.secret_min_length")
+	assert.ErrorContains(t, err, "keystore.secretminlength")
 	assert.ErrorContains(t, err, "must be non-negative")
 }
 

--- a/docs/superpowers/plans/2026-06-05-config-key-flatsmush-rename.md
+++ b/docs/superpowers/plans/2026-06-05-config-key-flatsmush-rename.md
@@ -1,0 +1,401 @@
+# Config Key Flat-Smush Rename — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the 21 snake_case koanf config keys to the framework's flat-smushed convention so they become settable via environment variables (the `_`→`.` env transform mis-nests underscored keys), with a permanent invariant test preventing the bug class from recurring.
+
+**Architecture:** Tag-only rename in `config/types.go` (Go field names unchanged) plus the one underscored default key and all string/doc references to those keys. No env-loading code change — once keys are underscore-free, the existing transform maps them natively. Clean break documented in ADR-024 + `wiki/migrations.md`.
+
+**Tech Stack:** Go 1.26, koanf v2 (`koanf` struct tag), go-viper/mapstructure, testify, reflection.
+
+**Delivered as two self-contained PRs:**
+- **PR1** (this plan, Tasks 1–10): the rename + ADR + migration + tests + doc updates for the renamed keys.
+- **PR2** (Task 11, separate branch off `main` after PR1 merges): unrelated ride-along doc-drift fixes.
+
+---
+
+## The 21-key rename table (token-level)
+
+Each token is replaced in all five tag namespaces (`koanf`/`json`/`yaml`/`toml`/`mapstructure`) by replacing the **quoted** form `"old"` → `"new"` (the quoted token appears only inside tags). Some tokens occur in two parents (e.g. `idle_ttl`, `table_name`); a global replace covers both.
+
+| # | old token | new token | parent(s) |
+|---|---|---|---|
+| 1 | `max_size` | `maxsize` | cache.manager |
+| 2 | `idle_ttl` | `idlettl` | cache.manager, messaging.publisher |
+| 3 | `cleanup_interval` | `cleanupinterval` | cache.manager |
+| 4 | `sensitive_fields` | `sensitivefields` | log |
+| 5 | `reinit_delay` | `reinitdelay` | messaging.reconnect |
+| 6 | `resend_delay` | `resenddelay` | messaging.reconnect |
+| 7 | `connection_timeout` | `connectiontimeout` | messaging.reconnect |
+| 8 | `max_delay` | `maxdelay` | messaging.reconnect |
+| 9 | `max_cached` | `maxcached` | messaging.publisher |
+| 10 | `table_name` | `tablename` | outbox, inbox |
+| 11 | `auto_create_table` | `autocreatetable` | outbox, inbox |
+| 12 | `default_exchange` | `defaultexchange` | outbox |
+| 13 | `poll_interval` | `pollinterval` | outbox |
+| 14 | `batch_size` | `batchsize` | outbox |
+| 15 | `max_retries` | `maxretries` | outbox |
+| 16 | `retention_period` | `retentionperiod` | outbox, inbox |
+| 17 | `secret_min_length` | `secretminlength` | keystore |
+
+**Do NOT rename (false-positive tokens):** `messaging/manager.go` `idle_ttl_seconds` (metric/log field); `database/*` SQL column `table_name`; any non-config use. The `"quoted"` replace in `types.go` is naturally scoped to tags; for other files, edit only verified config-key references.
+
+---
+
+### Task 1: No-underscore invariant test (the cornerstone guard)
+
+**Files:**
+- Create: `config/keyinvariant_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package config
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestConfigKoanfTagsHaveNoUnderscore guards the whole "env var cannot reach an
+// underscored koanf key" bug class: the env loader maps "_"->"." (koanf's nesting
+// delimiter), so any koanf leaf tag containing "_" is unreachable from the
+// environment. Every koanf tag in the Config tree MUST be underscore-free.
+func TestConfigKoanfTagsHaveNoUnderscore(t *testing.T) {
+	var offenders []string
+	seen := map[reflect.Type]bool{}
+
+	var walk func(rt reflect.Type, prefix string)
+	walk = func(rt reflect.Type, prefix string) {
+		for rt.Kind() == reflect.Pointer {
+			rt = rt.Elem()
+		}
+		if rt.Kind() == reflect.Map || rt.Kind() == reflect.Slice {
+			el := rt.Elem()
+			for el.Kind() == reflect.Pointer {
+				el = el.Elem()
+			}
+			if el.Kind() == reflect.Struct {
+				walk(el, prefix)
+			}
+			return
+		}
+		if rt.Kind() != reflect.Struct || seen[rt] {
+			return
+		}
+		seen[rt] = true
+		for i := 0; i < rt.NumField(); i++ {
+			f := rt.Field(i)
+			tag := f.Tag.Get("koanf")
+			if tag == "" || tag == "-" {
+				continue
+			}
+			name := strings.Split(tag, ",")[0]
+			key := name
+			if prefix != "" {
+				key = prefix + "." + name
+			}
+			if strings.Contains(name, "_") {
+				offenders = append(offenders, key)
+			}
+			switch f.Type.Kind() {
+			case reflect.Struct, reflect.Pointer, reflect.Map, reflect.Slice:
+				walk(f.Type, key)
+			}
+		}
+	}
+
+	walk(reflect.TypeOf(Config{}), "")
+	if len(offenders) > 0 {
+		t.Fatalf("koanf tags must be underscore-free (env vars nest on '_'); offenders:\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd config && go test -run TestConfigKoanfTagsHaveNoUnderscore -v .`
+Expected: FAIL listing 21 offenders (`cache.manager.max_size`, …, `keystore.secret_min_length`).
+
+- [ ] **Step 3: Commit the failing guard (red)**
+
+```bash
+git add config/keyinvariant_test.go
+git commit -m "test(config): add no-underscore koanf-tag invariant (red)"
+```
+
+---
+
+### Task 2: Env-reachability tests for renamed keys (red)
+
+**Files:**
+- Modify: `config/config_test.go` (append test)
+
+- [ ] **Step 1: Write the failing test** (uses the existing `clearEnvironmentVariables()` helper in `config_test.go` for env isolation)
+
+```go
+func TestEnvOverrideReachesRenamedKeys(t *testing.T) {
+	clearEnvironmentVariables()
+	t.Setenv("OUTBOX_BATCHSIZE", "250")
+	t.Setenv("OUTBOX_AUTOCREATETABLE", "true")
+	t.Setenv("MESSAGING_RECONNECT_CONNECTIONTIMEOUT", "45s")
+	t.Setenv("KEYSTORE_SECRETMINLENGTH", "64")
+	t.Setenv("LOG_SENSITIVEFIELDS", "pan, cvv2 ,otp")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	assert.Equal(t, 250, cfg.Outbox.BatchSize)
+	assert.True(t, cfg.Outbox.AutoCreateTable)
+	assert.Equal(t, 45*time.Second, cfg.Messaging.Reconnect.ConnectionTimeout)
+	assert.Equal(t, 64, cfg.KeyStore.SecretMinLength)
+	assert.Equal(t, []string{"pan", "cvv2", "otp"}, cfg.Log.SensitiveFields)
+}
+```
+
+(If `config_test.go` lacks `require`/`assert`/`time` imports, add them.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd config && go test -run TestEnvOverrideReachesRenamedKeys -v .`
+Expected: FAIL — fields hold defaults/zero (env landed at orphan smushed keys that no tag matches yet).
+
+- [ ] **Step 3: Commit (red)**
+
+```bash
+git add config/config_test.go
+git commit -m "test(config): assert env overrides reach renamed keys (red)"
+```
+
+---
+
+### Task 3: Rename the 21 koanf tags + the one default key (green)
+
+**Files:**
+- Modify: `config/types.go`
+- Modify: `config/config.go` (loadDefaults: `keystore.secret_min_length` → `keystore.secretminlength`)
+
+- [ ] **Step 1: Rename all 21 tags in `types.go`** (quoted-token replace covers all five tag namespaces; run from repo root)
+
+```bash
+cd config
+for pair in \
+  max_size:maxsize idle_ttl:idlettl cleanup_interval:cleanupinterval \
+  sensitive_fields:sensitivefields reinit_delay:reinitdelay resend_delay:resenddelay \
+  connection_timeout:connectiontimeout max_delay:maxdelay max_cached:maxcached \
+  table_name:tablename auto_create_table:autocreatetable default_exchange:defaultexchange \
+  poll_interval:pollinterval batch_size:batchsize max_retries:maxretries \
+  retention_period:retentionperiod secret_min_length:secretminlength; do
+  old="${pair%%:*}"; new="${pair##*:}"
+  perl -pi -e "s/\"\Q$old\E\"/\"$new\"/g" types.go
+done
+cd ..
+```
+
+- [ ] **Step 2: Update the underscored default key in `config.go`**
+
+Replace `"keystore.secret_min_length": 32,` with `"keystore.secretminlength": 32,` (loadDefaults map).
+
+- [ ] **Step 3: Run the cornerstone + env tests to verify they pass (green)**
+
+Run: `cd config && go test -run 'TestConfigKoanfTagsHaveNoUnderscore|TestEnvOverrideReachesRenamedKeys' -v .`
+Expected: both PASS.
+
+- [ ] **Step 4: Run the full config package (expect some existing tests to now fail)**
+
+Run: `cd config && go test ./... 2>&1 | tail -30`
+Expected: invariant + env tests PASS; some pre-existing tests that hardcode old keys FAIL (fixed in Task 4).
+
+- [ ] **Step 5: Commit (green for the new tests)**
+
+```bash
+git add config/types.go config/config.go
+git commit -m "fix(config): rename underscored koanf keys to flat-smushed convention
+
+The env loader maps '_'->'.' (koanf nesting), so underscored leaf keys like
+log.sensitive_fields / keystore.secret_min_length were unreachable from the
+environment. Rename all 21 to the framework's flat-smushed convention
+(connectionstring/poolsize/minretrybackoff style). Go field names unchanged.
+
+BREAKING: snake_case YAML/env keys no longer recognized. See ADR-024."
+```
+
+---
+
+### Task 4: Fix pre-existing config tests that hardcode old keys
+
+**Files:**
+- Modify: `config/config_test.go`, `config/validation_test.go` (and any other failing `config/*_test.go`)
+
+- [ ] **Step 1: Identify failures**
+
+Run: `cd config && go test ./... 2>&1 | grep -E 'FAIL|--- FAIL|secret_min_length|sensitive_fields|table_name|batch_size|_test.go' | head -40`
+
+- [ ] **Step 2: Update each failing test** — replace old koanf keys/env vars with the new smushed forms (e.g. YAML `secret_min_length:` → `secretminlength:`, env `KEYSTORE_SECRET_MIN_LENGTH` → `KEYSTORE_SECRETMINLENGTH`, `k.Get("outbox.batch_size")` → `k.Get("outbox.batchsize")`). Use the token table above.
+
+- [ ] **Step 3: Run config tests to verify green**
+
+Run: `cd config && go test ./... 2>&1 | tail -10`
+Expected: ok.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add config/*_test.go
+git commit -m "test(config): update tests to renamed flat-smushed keys"
+```
+
+---
+
+### Task 5: Update consistency strings (error messages + comments) and their tests
+
+**Files:**
+- Modify: `config/validation.go` (8 `NewValidationError("…reinit_delay"/…)` dotted key paths → smushed)
+- Modify: `outbox/config.go`, `inbox/config.go`, `cache/manager.go` (error-message strings naming the keys)
+- Modify: `keystore/keystore.go` (doc comment `secret_min_length: 32` → `secretminlength: 32`)
+- Modify: `outbox/config_test.go`, `inbox/config_test.go`, `cache/manager_test.go` (assertions on those error strings, if any)
+
+- [ ] **Step 1: Update `config/validation.go`** — replace the dotted key paths in `NewValidationError(...)` calls (lines ~596–657): `messaging.reconnect.reinit_delay`→`…reinitdelay`, `…resend_delay`→`…resenddelay`, `…connection_timeout`→`…connectiontimeout`, `…max_delay`→`…maxdelay`, `messaging.publisher.max_cached`→`…maxcached`, `messaging.publisher.idle_ttl`→`…idlettl`, `cache.manager.max_size`→`…maxsize`, `cache.manager.idle_ttl`→`…idlettl` (and `cleanup_interval` if present).
+
+- [ ] **Step 2: Update module error strings** — `outbox/config.go` (`poll_interval`/`batch_size`/`max_retries`/`retention_period` in `fmt.Errorf`), `inbox/config.go` (`retention_period`), `cache/manager.go` (`max_size`/`idle_ttl`) — change the human-readable token to the smushed key so messages match what users set.
+
+- [ ] **Step 3: Update `keystore/keystore.go` doc comment.**
+
+- [ ] **Step 4: Update any test asserting those exact strings** (grep first):
+
+Run: `grep -rnE 'poll_interval|batch_size|max_retries|retention_period|max_size|idle_ttl|reinit_delay|resend_delay|connection_timeout|max_delay|max_cached' outbox inbox cache config --include='*_test.go'`
+
+- [ ] **Step 5: Build + test affected packages**
+
+Run: `go test ./config/... ./outbox/... ./inbox/... ./cache/... 2>&1 | tail -15`
+Expected: ok.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add config/validation.go outbox/config.go inbox/config.go cache/manager.go keystore/keystore.go outbox/config_test.go inbox/config_test.go cache/manager_test.go
+git commit -m "fix(config): align error messages and comments with renamed keys"
+```
+
+---
+
+### Task 6: Update `config.example.yaml`
+
+**Files:**
+- Modify: `config.example.yaml`
+
+- [ ] **Step 1: Rename the keys** under `outbox:`, `inbox:`, and `log:` (lines ~112–139): `table_name`→`tablename`, `auto_create_table`→`autocreatetable`, `default_exchange`→`defaultexchange`, `poll_interval`→`pollinterval`, `batch_size`→`batchsize`, `max_retries`→`maxretries`, `retention_period`→`retentionperiod`, `sensitive_fields`→`sensitivefields`. (Leave the explanatory comment mentioning `password, api_key` — those are example sensitive field *values*, not config keys.)
+
+- [ ] **Step 2: Verify YAML still loads** (sanity)
+
+Run: `cd config && go test -run TestLoad -v . 2>&1 | tail -5` (existing load tests exercise example-style config)
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config.example.yaml
+git commit -m "docs(config): rename keys in config.example.yaml"
+```
+
+---
+
+### Task 7: Update documentation references to the renamed keys
+
+**Files:**
+- Modify: `README.md`, `llms.txt`, `CLAUDE.md`, and the relevant `wiki/*.md` (`outbox.md`, `keystore.md`, `observability.md`, `cache.md`, `messaging.md`, others as found)
+
+- [ ] **Step 1: Enumerate exact references** (read-only) — distinguish our config keys from unrelated tokens (e.g. httpclient's own `connection_timeout`, DB columns). For each candidate file, confirm the match is one of the 21 config keys before editing:
+
+Run: `grep -rnE '\b(max_size|idle_ttl|cleanup_interval|sensitive_fields|reinit_delay|resend_delay|connection_timeout|max_delay|max_cached|table_name|auto_create_table|default_exchange|poll_interval|batch_size|max_retries|retention_period|secret_min_length)\b' README.md llms.txt CLAUDE.md wiki --include='*.md' --include='llms.txt'`
+
+- [ ] **Step 2: Update only verified config-key references** to the smushed form. Watch for `wiki/outbox.md` documenting `auto_create_table` default as `true` — fix to `autocreatetable` AND correct the default to `false` (real default). Skip unrelated matches (e.g. `wiki/httpclient.md` connection-timeout prose about the HTTP client, `wiki/adr_019` audit-event field names) — verify each.
+
+- [ ] **Step 3: Sanity grep — no stray config-key underscores remain in docs**
+
+Run: `grep -rnE 'secret_min_length|sensitive_fields|auto_create_table|batch_size|poll_interval|retention_period' README.md llms.txt CLAUDE.md wiki --include='*.md' | grep -iv 'httpclient\|adr_019\|column'`
+Expected: no config-key hits (or only intentionally-excluded ones).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md llms.txt CLAUDE.md wiki
+git commit -m "docs: update config key references to flat-smushed names"
+```
+
+---
+
+### Task 8: ADR-024 + migration table
+
+**Files:**
+- Create: `wiki/adr_024_config_key_flatsmush.md`
+- Modify: `wiki/architecture_decisions.md` (add ADR-024 to the index)
+- Modify: `wiki/migrations.md` (add a before→after rename table)
+
+- [ ] **Step 1: Write ADR-024** — context (env `_`→`.` mis-nests underscored keys), decision (rename 21 keys to flat-smush, the framework's established convention; no mapping layer; no single-field wrapper structs per the audit), consequences (breaking; migration table; no-underscore invariant test guard). Match the format of `wiki/adr_023_scheduler_timezone.md`.
+
+- [ ] **Step 2: Add the ADR to `wiki/architecture_decisions.md` index.**
+
+- [ ] **Step 3: Add a migration table to `wiki/migrations.md`** with all 21 old→new keys (and the corresponding env vars) from the table above.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add wiki/adr_024_config_key_flatsmush.md wiki/architecture_decisions.md wiki/migrations.md
+git commit -m "docs(adr): ADR-024 flat-smush config key rename + migration table"
+```
+
+---
+
+### Task 9: Pre-push verification (make check + reviews)
+
+- [ ] **Step 1: Full check**
+
+Run: `make check`
+Expected: fmt + lint + tests pass, including `TestConfigKoanfTagsHaveNoUnderscore` and `TestEnvOverrideReachesRenamedKeys`.
+
+- [ ] **Step 2: Run `/code-review`** on the staged diff; apply findings (refactor, never nolint per repo precedent).
+
+- [ ] **Step 3: Run `/security-audit`** on the diff; apply findings.
+
+- [ ] **Step 4: Re-run `make check`** after any review fixes.
+
+---
+
+### Task 10: Push + open PR1 + babysit
+
+- [ ] **Step 1: Push the branch.**
+
+```bash
+git push -u origin feature/config-key-flatsmush-rename
+```
+
+- [ ] **Step 2: Open the PR** (`gh pr create`) — title `fix(config): rename underscored config keys to flat-smushed convention`; body: problem, the 21-key table, audit rationale (flat-smush is the standard; single-field structs are drift), BREAKING + ADR-024 link, "Closes #<finding issue if one exists>", and a note that Class 2 (InjectInto parity) is a deferred follow-up.
+
+- [ ] **Step 3: Babysit** — wait for CI; address CodeRabbit comments and SonarCloud NEW issues (fetch via `curl "https://sonarcloud.io/api/issues/search?componentKeys=gaborage_go-bricks&pullRequest=<N>&statuses=OPEN,CONFIRMED"`). Fix or document each skip in the commit. Push fixes. Re-check until quality gate green + reviews resolved.
+
+- [ ] **Step 4: Merge** when merge-ready (squash). Delete the remote branch; sync local `main`.
+
+---
+
+### Task 11 (PR2): Ride-along doc-drift fixes — separate branch off `main`
+
+**Precondition:** PR1 merged; `git checkout main && git pull`.
+
+**Files:** `README.md`, `.env.example`
+
+- [ ] **Step 1: Branch** — `git checkout -b fix/config-docs-env-drift`.
+- [ ] **Step 2: README server-path env vars** — `README.md:329-339`: `SERVER_BASE_PATH`→`SERVER_PATH_BASE`, `SERVER_HEALTH_ROUTE`→`SERVER_PATH_HEALTH`, `SERVER_READY_ROUTE`→`SERVER_PATH_READY`; fix the YAML block shape (`server.base.path`→`server.path.base`, etc.); `:226` soften the "auto-maps to dot notation" claim.
+- [ ] **Step 3: `.env.example`** — `DATABASE_TYPE=postgres`→`postgresql`. Verify the three `MULTITENANT_*` entries (`MULTITENANT_CACHE_TTL`, `MULTITENANT_LIMITS_CLEANUP_INTERVAL`, `MULTITENANT_VALIDATION_PATTERN`) against `MultitenantConfig`/`LimitsConfig` in `config/types.go`; for each with no matching field, remove it (or correct to the real key if one exists).
+- [ ] **Step 4:** `make check` (docs-only, but confirm nothing references removed examples in tests).
+- [ ] **Step 5:** Commit, push, open PR2 (`fix(docs): correct server-path env vars and .env.example orphans`), babysit to merge as in Task 10.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** rename (Tasks 1–6) ✓; consistency strings (Task 5) ✓; example yaml (Task 6) ✓; docs (Task 7) ✓; ADR + migration (Task 8) ✓; no-underscore invariant test (Task 1) ✓; env-reachability tests (Task 2) ✓; ride-along doc fixes (Task 11) ✓; Class 2 deferred (noted in PR1 body, Task 10). Follow-up Class 2 issue: file separately (best-effort; needs go-ahead per repo issue-permission note) — tracked outside this plan.
+- **Placeholder scan:** none — every step has exact commands/keys.
+- **Type consistency:** token table is the single source; all tasks reference it. Go field names unchanged throughout (only tags/keys/strings change).

--- a/docs/superpowers/specs/2026-06-05-config-key-flatsmush-rename-design.md
+++ b/docs/superpowers/specs/2026-06-05-config-key-flatsmush-rename-design.md
@@ -1,0 +1,109 @@
+# Design: Rename Underscored Config Keys to the Flat-Smushed Convention
+
+- **Date:** 2026-06-05
+- **Status:** Approved (design)
+- **Area:** `config` (+ docs, ADR-024)
+- **Follows:** PR #548 (comma-separated `[]string` env splitting) — fixes the sibling bug #548 surfaced (`LOG_SENSITIVE_FIELDS`).
+
+## Problem
+
+`config.Load()` loads env vars through koanf with this key transform (config/config.go:47-55):
+
+```go
+k = strings.ReplaceAll(strings.ToLower(k), "_", ".")
+```
+
+koanf nests on `.`, so **every** underscore becomes a nesting boundary. Any koanf leaf tag containing `_` is therefore unreachable from the environment: the env var lands at an orphan path no struct field claims, the value is silently dropped, and the default (or zero value) wins. No error.
+
+### Empirical confirmation
+
+| Env var | Lands at koanf key | Field result |
+|---|---|---|
+| `LOG_SENSITIVE_FIELDS=pan,cvv2,otp` | `log.sensitive.fields` (orphan) | `cfg.Log.SensitiveFields == nil` |
+| `KEYSTORE_SECRET_MIN_LENGTH=64` | `keystore.secret.min.length` (orphan) | `cfg.KeyStore.SecretMinLength == 32` (default) |
+
+Exactly **21** leaf keys are affected (underscore is the sole trigger — no koanf tag uses digits, hyphens, or uppercase).
+
+## Root cause: the keys drifted from the framework's own convention
+
+A 6-agent audit of `config/types.go` established the framework standard, with three independent proposal lenses converging:
+
+- **Compound scalar leaves are flat-smushed**, never underscored: `connectionstring` (16 chars), `minretrybackoff`/`maxretrybackoff` (15), `poolsize`, `virtualhost`, `slowjob`, `pathprefix`, `cidrallowlist`, `dialtimeout`, and `QueryLogConfig.MaxLength → koanf:"max"`.
+- **Sub-structs exist only to group multiple related leaves** under a shared namespace: `server.timeout.{read,write,idle,middleware,shutdown}`, `database.pool.{max,idle,lifetime,keepalive}`, `database.query.{slow,log}`.
+- **The single-field nested structs that exist** (`PoolMaxConfig{connections}`, `LifetimeConfig{max}`, `PostgreSQLConfig{schema}`, `OracleConfig{service}`, `LimitsConfig{tenants}`) are namespace anchors within a sibling family or vendor/extension boundaries — **never lone wrappers of an atomic compound concept**. Even the audit lens that was *permitted* to use single-field structs chose zero.
+
+Smushed leaves are env-reachable (no underscore → the `_`→`.` transform maps cleanly); snake_case leaves are not. The 21 keys are simply the ones that drifted into snake_case, and that drift *is* the bug.
+
+## Decision: clean-break rename to flat-smushed keys
+
+Rename all 21 snake_case koanf leaf tags to the underscore-free flat-smushed form. **No mapping layer, no new structs, no env-loading code change** — the existing transform works natively once keys are underscore-free. Only struct *tags* change; **Go field names stay the same**, so consumer code (`cfg.Outbox.BatchSize`, `cfg.KeyStore.SecretMinLength`) is untouched.
+
+`messaging.reconnect` stays flat (grouping would collide with its pre-existing flat `reconnect.delay` sibling and contradicts the `RedisConfig` flat-timeout precedent). The one arguably-groupable pair (`table_name`+`auto_create_table`) is also smushed, for maximum uniformity with `RedisConfig`.
+
+### The full mapping (all flat-smush)
+
+| old koanf key | new koanf key | old koanf key | new koanf key |
+|---|---|---|---|
+| `cache.manager.max_size` | `cache.manager.maxsize` | `outbox.table_name` | `outbox.tablename` |
+| `cache.manager.idle_ttl` | `cache.manager.idlettl` | `outbox.auto_create_table` | `outbox.autocreatetable` |
+| `cache.manager.cleanup_interval` | `cache.manager.cleanupinterval` | `outbox.default_exchange` | `outbox.defaultexchange` |
+| `log.sensitive_fields` | `log.sensitivefields` | `outbox.poll_interval` | `outbox.pollinterval` |
+| `messaging.reconnect.reinit_delay` | `messaging.reconnect.reinitdelay` | `outbox.batch_size` | `outbox.batchsize` |
+| `messaging.reconnect.resend_delay` | `messaging.reconnect.resenddelay` | `outbox.max_retries` | `outbox.maxretries` |
+| `messaging.reconnect.connection_timeout` | `messaging.reconnect.connectiontimeout` | `outbox.retention_period` | `outbox.retentionperiod` |
+| `messaging.reconnect.max_delay` | `messaging.reconnect.maxdelay` | `inbox.table_name` | `inbox.tablename` |
+| `messaging.publisher.max_cached` | `messaging.publisher.maxcached` | `inbox.auto_create_table` | `inbox.autocreatetable` |
+| `messaging.publisher.idle_ttl` | `messaging.publisher.idlettl` | `inbox.retention_period` | `inbox.retentionperiod` |
+| `keystore.secret_min_length` | `keystore.secretminlength` | | |
+
+### Why not the alternatives
+
+- **Schema-aware alias map** (flatten→canonical reflection): permanently papers over a key set that violates the standard; rejected — fix the keys, not the transform.
+- **Nested single-field wrapper structs** (`Cleanup{Interval}`, `Secret{MinLength}`): no framework precedent; the audit flagged this as drift.
+- **`__` escape convention**: the natural env name still silently fails.
+
+## Breaking change
+
+Renaming koanf keys breaks existing YAML/env using the snake_case form — old keys become unknown and fall back to defaults (silently). Acceptable pre-1.0 and consistent with framework practice (ADR-016, S8179, S8196). Documented in **ADR-024** + a `wiki/migrations.md` before→after table. A **no-underscore invariant test** prevents the bug class from recurring.
+
+## Components / files
+
+**Core (behavioral):**
+- `config/types.go` — rename `koanf`/`json`/`yaml`/`toml`/`mapstructure` tags on the 21 fields.
+- `config/config.go` — `loadDefaults`: `keystore.secret_min_length` → `keystore.secretminlength` (the only underscored default key).
+- `config.example.yaml` — the outbox/inbox/log keys.
+
+**Consistency (strings that name the key, updated for accuracy):**
+- `config/validation.go` — `NewValidationError("messaging.reconnect.reinit_delay", …)` and the other dotted key paths (8 sites).
+- `outbox/config.go`, `inbox/config.go`, `cache/manager.go` — error-message strings (`poll_interval`, `batch_size`, `max_size`, …).
+- `keystore/keystore.go` — doc comment.
+
+**Docs:** `README.md`, `llms.txt`, `CLAUDE.md`, `wiki/{outbox,keystore,observability,cache,messaging,…}.md` — update documented keys.
+
+**Governance:** `wiki/adr_024_*.md` (new) + `wiki/architecture_decisions.md` index + `wiki/migrations.md` entry.
+
+**Ride-along doc fixes** (independently misleading, found in the earlier audit):
+- `README.md:329-339` — wrong server-path env vars (`SERVER_BASE_PATH`→`SERVER_PATH_BASE`, `SERVER_HEALTH_ROUTE`→`SERVER_PATH_HEALTH`, `SERVER_READY_ROUTE`→`SERVER_PATH_READY`) + drifted YAML block shape; `:226` — soften the "auto-maps to dot notation" claim.
+- `.env.example` — `DATABASE_TYPE=postgres`→`postgresql`; verify-then-fix the 3 orphan `MULTITENANT_*` entries.
+
+**Explicit EXCLUSIONS** (false-positive tokens — do NOT rename):
+- `messaging/manager.go` `idle_ttl_seconds` (a metric/log field name).
+- `database/*` `table_name` etc. (SQL column names), and any other non-config use.
+- Implementation classifies each reference; `make check` + targeted tests catch mistakes.
+
+## Testing
+
+- **New env-reachability tests** (`t.Setenv`), one per affected type: `[]string` (`LOG_SENSITIVEFIELDS`), int (`OUTBOX_BATCHSIZE`), bool (`OUTBOX_AUTOCREATETABLE`), duration (`MESSAGING_RECONNECT_CONNECTIONTIMEOUT`), and `KEYSTORE_SECRETMINLENGTH` — assert the field populates.
+- **No-underscore invariant test** — reflect over `Config` (including nested structs and map/slice element struct types) and assert no `koanf` tag contains `_`. Permanent guard against the whole bug class.
+- **Update** existing tests using the old keys (YAML/env values and error-message assertions).
+- **Regression:** all existing `config` (and `outbox`/`inbox`/`cache`) tests green; full `make check`.
+
+## Scope
+
+- **In:** the rename (Class 1) + ride-along doc fixes (Class 3) + ADR-024.
+- **Out (follow-up issue, needs user go-ahead to file):** InjectInto↔Unmarshal decode parity (Class 2 — duration-from-int = 30ns, integer base, empty-string coercion, whitespace trimming).
+
+## Known limitations
+
+- Operators must migrate snake_case YAML/env to the smushed keys (migration table provided); old keys silently fall back to defaults (clean break).
+- The env var for a smushed key is itself smushed (`KEYSTORE_SECRETMINLENGTH`, not `…_SECRET_MIN_LENGTH`) — inherent to underscore-free keys; documented.

--- a/inbox/config.go
+++ b/inbox/config.go
@@ -30,7 +30,7 @@ func applyDefaults(c *config.InboxConfig) {
 // Called after applyDefaults, so zero values have already been replaced.
 func validateConfig(c *config.InboxConfig) error {
 	if c.RetentionPeriod < 0 {
-		return fmt.Errorf("inbox: retention_period must not be negative, got %s", c.RetentionPeriod)
+		return fmt.Errorf("inbox: retentionperiod must not be negative, got %s", c.RetentionPeriod)
 	}
 	if err := validateTableName(c.TableName); err != nil {
 		return err

--- a/inbox/config_test.go
+++ b/inbox/config_test.go
@@ -29,7 +29,7 @@ func TestValidateConfig(t *testing.T) {
 
 	err := validateConfig(&config.InboxConfig{TableName: "gobricks_inbox", RetentionPeriod: -time.Hour})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "retention_period must not be negative")
+	assert.Contains(t, err.Error(), "retentionperiod must not be negative")
 
 	err = validateConfig(&config.InboxConfig{TableName: "schema.inbox", RetentionPeriod: time.Hour})
 	require.Error(t, err, "qualified table name rejected")

--- a/inbox/store.go
+++ b/inbox/store.go
@@ -33,7 +33,7 @@ type Store interface {
 	DeleteProcessed(ctx context.Context, db dbtypes.Interface, before time.Time) (int64, error)
 
 	// CreateTable creates the inbox table and its index if they do not exist.
-	// Used for auto-migration when inbox.auto_create_table is true.
+	// Used for auto-migration when inbox.autocreatetable is true.
 	CreateTable(ctx context.Context, db dbtypes.Interface) error
 }
 

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -13,7 +13,7 @@
 // Keys are configured in YAML under the "keystore" section:
 //
 //	keystore:
-//	  secret_min_length: 32                        # default 32; 0 disables
+//	  secretminlength: 32                        # default 32; 0 disables
 //	  keys:
 //	    signing:
 //	      public:

--- a/llms.txt
+++ b/llms.txt
@@ -63,10 +63,10 @@ cache:
     port: 6379
 outbox:
   enabled: true
-  poll_interval: 5s
-  batch_size: 100
-  max_retries: 5
-  retention_period: 72h
+  pollinterval: 5s
+  batchsize: 100
+  maxretries: 5
+  retentionperiod: 72h
 observability:
   enabled: true
   service:
@@ -1587,9 +1587,9 @@ GoBricks uses CacheManager to handle per-tenant cache instances with automatic l
 cache:
   enabled: true
   manager:
-    max_size: 100          # Max tenant cache instances
-    idle_ttl: 15m          # Idle timeout per cache
-    cleanup_interval: 5m   # Cleanup goroutine frequency
+    maxsize: 100          # Max tenant cache instances
+    idlettl: 15m          # Idle timeout per cache
+    cleanupinterval: 5m   # Cleanup goroutine frequency
   redis:
     host: localhost
     port: 6379
@@ -2476,11 +2476,11 @@ messaging:
     x-environment: development
   reconnect:
     delay: 5s
-    max_delay: 60s                         # Exponential backoff cap
-    connection_timeout: 30s
+    maxdelay: 60s                         # Exponential backoff cap
+    connectiontimeout: 30s
   publisher:
-    max_cached: 50                         # Cached publisher channels (per tenant)
-    idle_ttl: 10m
+    maxcached: 50                         # Cached publisher channels (per tenant)
+    idlettl: 10m
 ```
 
 Omit the entire `messaging:` block to disable AMQP. Modules implementing `MessagingDeclarer` will fail-fast at startup if messaging isn't configured (no silent degradation). For multi-tenant setups, override per tenant via `tenants.<id>.messaging.url`.
@@ -2850,13 +2850,13 @@ func (h *Handler) Handle(ctx context.Context, delivery *amqp.Delivery) error {
 ```yaml
 outbox:
   enabled: true
-  table_name: gobricks_outbox       # Custom table name
-  auto_create_table: true           # DDL on first use
-  default_exchange: ""              # Fallback exchange
-  poll_interval: 5s                 # Relay frequency
-  batch_size: 100                   # Events per cycle
-  max_retries: 5                    # Before giving up
-  retention_period: 72h             # Cleanup threshold
+  tablename: gobricks_outbox       # Custom table name
+  autocreatetable: true           # DDL on first use
+  defaultexchange: ""              # Fallback exchange
+  pollinterval: 5s                 # Relay frequency
+  batchsize: 100                   # Events per cycle
+  maxretries: 5                    # Before giving up
+  retentionperiod: 72h             # Cleanup threshold
 ```
 
 ### Testing
@@ -2924,7 +2924,7 @@ keystore:
 
 # EKS deployment (base64-encoded DER via env vars)
 keystore:
-  secret_min_length: 32          # default 32; 0 disables the floor
+  secretminlength: 32          # default 32; 0 disables the floor
   keys:
     signing:
       public:
@@ -3021,7 +3021,7 @@ kstest.AssertKeyNotFound(t, mock, "nonexistent")
 - Symmetric `secret` entries are mutually exclusive with `public`/`private` — a
   mixed entry is a startup config error (structural detection, no discriminator)
 - `Secret(name)` returns a **defensive copy**; the caller owns it and may zeroize
-- `keystore.secret_min_length` (default 32) enforces a byte floor at startup; an
+- `keystore.secretminlength` (default 32) enforces a byte floor at startup; an
   explicit `0` disables it
 - Exactly one source per key: `file` (raw/DER path) or `value` (base64 string)
 - Fails fast at startup if any key cannot be loaded, parsed, or is too short
@@ -4263,7 +4263,7 @@ For regulated payloads (PAN, CVV2, OTP, account numbers) you extend the list at 
 ```yaml
 log:
   level: info
-  sensitive_fields:        # NEW: appended to logger.DefaultFilterConfig
+  sensitivefields:        # NEW: appended to logger.DefaultFilterConfig
     - pan
     - primary_account_number
     - cvv

--- a/outbox/config.go
+++ b/outbox/config.go
@@ -14,16 +14,16 @@ const DefaultTableName = "gobricks_outbox"
 // Called after applyDefaults, so zero values have already been replaced.
 func validateConfig(c *config.OutboxConfig) error {
 	if c.PollInterval <= 0 {
-		return fmt.Errorf("outbox: poll_interval must be positive, got %s", c.PollInterval)
+		return fmt.Errorf("outbox: pollinterval must be positive, got %s", c.PollInterval)
 	}
 	if c.BatchSize <= 0 {
-		return fmt.Errorf("outbox: batch_size must be positive, got %d", c.BatchSize)
+		return fmt.Errorf("outbox: batchsize must be positive, got %d", c.BatchSize)
 	}
 	if c.MaxRetries < 0 {
-		return fmt.Errorf("outbox: max_retries must not be negative, got %d", c.MaxRetries)
+		return fmt.Errorf("outbox: maxretries must not be negative, got %d", c.MaxRetries)
 	}
 	if c.RetentionPeriod < 0 {
-		return fmt.Errorf("outbox: retention_period must not be negative, got %s", c.RetentionPeriod)
+		return fmt.Errorf("outbox: retentionperiod must not be negative, got %s", c.RetentionPeriod)
 	}
 	return nil
 }

--- a/outbox/config_test.go
+++ b/outbox/config_test.go
@@ -77,7 +77,7 @@ func TestValidateConfigNegativePollInterval(t *testing.T) {
 	}
 	err := validateConfig(cfg)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "poll_interval")
+	assert.Contains(t, err.Error(), "pollinterval")
 }
 
 func TestValidateConfigZeroBatchSize(t *testing.T) {
@@ -87,7 +87,7 @@ func TestValidateConfigZeroBatchSize(t *testing.T) {
 	}
 	err := validateConfig(cfg)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "batch_size")
+	assert.Contains(t, err.Error(), "batchsize")
 }
 
 func TestValidateConfigNegativeMaxRetries(t *testing.T) {
@@ -98,7 +98,7 @@ func TestValidateConfigNegativeMaxRetries(t *testing.T) {
 	}
 	err := validateConfig(cfg)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "max_retries")
+	assert.Contains(t, err.Error(), "maxretries")
 }
 
 func TestValidateConfigNegativeRetentionPeriod(t *testing.T) {
@@ -109,5 +109,5 @@ func TestValidateConfigNegativeRetentionPeriod(t *testing.T) {
 	}
 	err := validateConfig(cfg)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "retention_period")
+	assert.Contains(t, err.Error(), "retentionperiod")
 }

--- a/outbox/store.go
+++ b/outbox/store.go
@@ -65,6 +65,6 @@ type Store interface {
 	DeletePublished(ctx context.Context, db dbtypes.Interface, before time.Time) (int64, error)
 
 	// CreateTable creates the outbox table if it does not exist.
-	// Used for auto-migration when outbox.auto_create_table is true.
+	// Used for auto-migration when outbox.autocreatetable is true.
 	CreateTable(ctx context.Context, db dbtypes.Interface) error
 }

--- a/wiki/adr_024_config_key_flatsmush.md
+++ b/wiki/adr_024_config_key_flatsmush.md
@@ -1,0 +1,112 @@
+# ADR-024: Flat-Smushed Config Keys (Underscore-Free for Env Reachability)
+
+**Status:** Accepted
+**Date:** 2026-06-05
+
+## Context
+
+`config.Load()` loads environment variables through koanf's env provider with a
+key transform that maps `UPPER_CASE` to `lower.case`:
+
+```go
+k = strings.ReplaceAll(strings.ToLower(k), "_", ".")
+```
+
+koanf uses `.` as its nesting delimiter, so the transform turns **every**
+underscore in an env var name into a nesting boundary. Any koanf leaf key whose
+struct tag contained an underscore was therefore **unreachable from the
+environment**: `LOG_SENSITIVE_FIELDS` landed at the orphan path
+`log.sensitive.fields` (which no struct field claims) instead of the intended
+`log.sensitive_fields`. The value was silently dropped and the default won — no
+error, no warning. The same affected `KEYSTORE_SECRET_MIN_LENGTH`,
+`OUTBOX_BATCH_SIZE`, and 18 other keys.
+
+This contradicts the documented configuration priority (environment variables >
+YAML > defaults) and the 12-Factor stance. The bug surfaced from issue #539 /
+PR #548 (`LOG_SENSITIVE_FIELDS`).
+
+A reflection audit of `config/types.go` found **exactly 21** affected leaf keys —
+all of them snake_case — and confirmed the framework's dominant convention is
+**flat-smushed** compound leaves: `connectionstring`, `minretrybackoff`,
+`maxretrybackoff`, `poolsize`, `virtualhost`, `slowjob`, `pathprefix`,
+`cidrallowlist`, `dialtimeout`, and `QueryLogConfig.MaxLength → koanf:"max"`.
+Sub-structs exist only to group **multiple** related leaves under a shared
+namespace (`server.timeout.{read,write,idle,…}`, `database.pool.{max,idle,…}`).
+The few single-field nested structs (`PoolMaxConfig{connections}`,
+`LifetimeConfig{max}`, `PostgreSQLConfig{schema}`) are namespace anchors within a
+sibling family or vendor boundaries — never lone wrappers of an atomic compound
+concept. The 21 snake_case keys were simply drift from this convention, and that
+drift is the bug.
+
+## Decision
+
+Rename all 21 snake_case koanf leaf tags to the framework's underscore-free
+flat-smushed convention. No env-loading code changes and no mapping layer — once
+keys contain no underscore, the existing transform maps them natively. Only
+struct tags change; **Go field names are unchanged** (`cfg.Outbox.BatchSize`,
+`cfg.KeyStore.SecretMinLength`), so consumer code is untouched.
+
+Rejected alternatives:
+
+- **Schema-aware alias map** (reflect over `Config`, alias the flattened env form
+  to the canonical underscored key): permanently papers over a key set that
+  violates the convention; rejected in favor of fixing the keys.
+- **Nested single-field wrapper structs** (`Secret{MinLength}`,
+  `Connection{Timeout}`): no framework precedent — the audit flagged this as
+  drift. Even an audit lens that was *permitted* to use single-field structs
+  chose zero.
+- **Double-underscore escape** (`LOG_SENSITIVE__FIELDS`): the natural env name
+  still fails silently.
+
+`messaging.reconnect` keeps its leaves flat (grouping the delays would collide
+with the pre-existing flat `reconnect.delay` sibling and contradicts the
+`RedisConfig` flat-timeout precedent).
+
+### The 21 renamed keys
+
+| old key | new key |
+|---|---|
+| `cache.manager.max_size` | `cache.manager.maxsize` |
+| `cache.manager.idle_ttl` | `cache.manager.idlettl` |
+| `cache.manager.cleanup_interval` | `cache.manager.cleanupinterval` |
+| `log.sensitive_fields` | `log.sensitivefields` |
+| `messaging.reconnect.reinit_delay` | `messaging.reconnect.reinitdelay` |
+| `messaging.reconnect.resend_delay` | `messaging.reconnect.resenddelay` |
+| `messaging.reconnect.connection_timeout` | `messaging.reconnect.connectiontimeout` |
+| `messaging.reconnect.max_delay` | `messaging.reconnect.maxdelay` |
+| `messaging.publisher.max_cached` | `messaging.publisher.maxcached` |
+| `messaging.publisher.idle_ttl` | `messaging.publisher.idlettl` |
+| `outbox.table_name` | `outbox.tablename` |
+| `outbox.auto_create_table` | `outbox.autocreatetable` |
+| `outbox.default_exchange` | `outbox.defaultexchange` |
+| `outbox.poll_interval` | `outbox.pollinterval` |
+| `outbox.batch_size` | `outbox.batchsize` |
+| `outbox.max_retries` | `outbox.maxretries` |
+| `outbox.retention_period` | `outbox.retentionperiod` |
+| `inbox.table_name` | `inbox.tablename` |
+| `inbox.auto_create_table` | `inbox.autocreatetable` |
+| `inbox.retention_period` | `inbox.retentionperiod` |
+| `keystore.secret_min_length` | `keystore.secretminlength` |
+
+## Consequences
+
+- **Breaking:** YAML/env using the old snake_case keys is no longer recognized —
+  old keys become unknown and fall back to defaults (silently, as koanf has no
+  unknown-key error). Consumers must migrate. See the migration table in
+  [migrations.md](migrations.md).
+- The env var for a smushed key is itself smushed (`KEYSTORE_SECRETMINLENGTH`,
+  not `…_SECRET_MIN_LENGTH`) — an inherent property of underscore-free keys.
+- **Guard against recurrence:** `TestConfigKoanfTagsHaveNoUnderscore`
+  (`config/types_test.go`) reflects over the whole `Config` tree and fails if any
+  koanf tag contains an underscore, so the bug class cannot return.
+- **Out of scope (follow-up):** service configs consumed via `InjectInto` that put
+  an underscore inside a `config:"…"` segment have the same env-reachability
+  limitation; the convention is to use dotted segments. A separate effort tracks
+  `InjectInto`↔`Unmarshal` decode-path parity gaps.
+
+## Related
+
+- ADR-016 (database session timezone) and ADR-022/ADR-023 — other small,
+  breaking config-convention changes.
+- PR #548 — comma-separated `[]string` env splitting (the sibling fix that
+  surfaced this bug).

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -241,6 +241,17 @@ the absence of any timezone knob for scheduled jobs and removes the vestigial
 `ScheduleConfiguration.Timezone` field. Breaking: an unset zone now means UTC
 instead of host-local.
 
+### [ADR-024: Flat-Smushed Config Keys (Underscore-Free for Env Reachability)](adr_024_config_key_flatsmush.md)
+
+Renames 21 snake_case koanf leaf keys (e.g. `log.sensitive_fields`,
+`keystore.secret_min_length`, `outbox.batch_size`) to the framework's
+flat-smushed convention (`log.sensitivefields`, …). The env loader maps `_`→`.`
+(koanf nesting), so underscored leaf keys were silently unreachable from
+environment variables — the value landed at an orphan path and the default won.
+Only struct tags change; Go field names are unchanged. A `Config`-tree reflection
+test enforces underscore-free koanf tags so the bug class cannot recur. Breaking:
+old snake_case YAML/env keys fall back to defaults.
+
 ---
 
 ## ADR Lifecycle
@@ -252,7 +263,7 @@ instead of host-local.
 
 ### Numbering Policy
 
-ADR numbers (ADR-001 through ADR-023) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
+ADR numbers (ADR-001 through ADR-024) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
 
 ## Writing New ADRs
 

--- a/wiki/cache.md
+++ b/wiki/cache.md
@@ -41,9 +41,9 @@ cache:
   enabled: true
   type: redis
   manager:
-    max_size: 100          # Max tenant cache instances
-    idle_ttl: 15m          # Idle timeout per cache
-    cleanup_interval: 5m   # Cleanup goroutine frequency
+    maxsize: 100          # Max tenant cache instances
+    idlettl: 15m          # Idle timeout per cache
+    cleanupinterval: 5m   # Cleanup goroutine frequency
   redis:
     host: localhost
     port: 6379
@@ -113,17 +113,17 @@ GoBricks applies production-safe cache manager defaults when cache is configured
 
 | Setting | Default | Purpose |
 |---------|---------|---------|
-| `manager.max_size` | 100 | Maximum tenant cache instances |
-| `manager.idle_ttl` | 15m | Close idle cache connections |
-| `manager.cleanup_interval` | 5m | Frequency of idle cache cleanup |
+| `manager.maxsize` | 100 | Maximum tenant cache instances |
+| `manager.idlettl` | 15m | Close idle cache connections |
+| `manager.cleanupinterval` | 5m | Frequency of idle cache cleanup |
 
 **Override defaults** in `config.yaml`:
 ```yaml
 cache:
   manager:
-    max_size: 200         # Support more tenants
-    idle_ttl: 30m         # Keep caches longer
-    cleanup_interval: 10m # Less frequent cleanup
+    maxsize: 200         # Support more tenants
+    idlettl: 30m         # Keep caches longer
+    cleanupinterval: 10m # Less frequent cleanup
 ```
 
 ---

--- a/wiki/cache.md
+++ b/wiki/cache.md
@@ -118,6 +118,7 @@ GoBricks applies production-safe cache manager defaults when cache is configured
 | `manager.cleanupinterval` | 5m | Frequency of idle cache cleanup |
 
 **Override defaults** in `config.yaml`:
+
 ```yaml
 cache:
   manager:

--- a/wiki/context_deadlines.md
+++ b/wiki/context_deadlines.md
@@ -15,12 +15,12 @@ Every operation that crosses an external boundary already has a configured timeo
 | HTTP server graceful shutdown | `server.timeout.shutdown` | 10s | Drain inflight requests on SIGTERM |
 | Outbound HTTP client | `httpclient.NewBuilder(...).WithTimeout(d)` | 30s | Per-request timeout on the underlying `http.Client` |
 | Cache (Redis) dial / read / write | `cache.redis.{dialtimeout,readtimeout,writetimeout}` | 5s / 3s / 3s | Per-operation socket timeouts |
-| AMQP connection establishment | `messaging.reconnect.connection_timeout` | 30s | Includes publish confirmation |
+| AMQP connection establishment | `messaging.reconnect.connectiontimeout` | 30s | Includes publish confirmation |
 | Scheduler — slow job warning | `scheduler.timeout.slowjob` | 25s | Logs WARN if a job exceeds this; does not cancel |
 | Scheduler — graceful shutdown | `scheduler.timeout.shutdown` | 30s | Wait for in-flight jobs on shutdown |
 | Observability export | `observability.trace.export.timeout` | 10s (dev) / 60s (prod) | OTLP export RPC |
 
-**Boundary maintenance / pool hygiene timeouts** — connection lifetime caps, idle eviction TTLs, and reconnect backoff caps don't propagate as deadlines on a request `ctx`. They live in the per-component reference docs: see [database.md](database.md) (`pool.idle.time`, `pool.lifetime.max`, `pool.keepalive.interval`), [cache.md](cache.md) (`manager.idle_ttl`), [messaging.md](messaging.md) (`reconnect.max_delay`, `publisher.idle_ttl`), [outbox.md](outbox.md), and [startup_defaults.md](startup_defaults.md).
+**Boundary maintenance / pool hygiene timeouts** — connection lifetime caps, idle eviction TTLs, and reconnect backoff caps don't propagate as deadlines on a request `ctx`. They live in the per-component reference docs: see [database.md](database.md) (`pool.idle.time`, `pool.lifetime.max`, `pool.keepalive.interval`), [cache.md](cache.md) (`manager.idlettl`), [messaging.md](messaging.md) (`reconnect.maxdelay`, `publisher.idlettl`), [outbox.md](outbox.md), and [startup_defaults.md](startup_defaults.md).
 
 ## The default pattern: do nothing
 

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -260,7 +260,7 @@ func TestModuleEmitsHTTPSpans(t *testing.T) {
 
 > **Warning:** payload logging is a debug aid for development/staging only. Enabling it in production widens the audit-log surface and may expose sensitive data to log pipelines.
 >
-> **PCI/PII workloads must extend the default sensitive-field list.** The framework ships defaults like `password`, `token`, `api_key`, `authorization`, but workload-specific fields (`pan`, `cvv2`, `cvv`, `otp`, `ssn`, …) need to be added via `log.sensitive_fields` in YAML or `app.Options.LoggerFilterConfig` in code before enabling payload logging — see [observability.md](observability.md#sensitive-data-filtering) for the full field list and customization seams.
+> **PCI/PII workloads must extend the default sensitive-field list.** The framework ships defaults like `password`, `token`, `api_key`, `authorization`, but workload-specific fields (`pan`, `cvv2`, `cvv`, `otp`, `ssn`, …) need to be added via `log.sensitivefields` in YAML or `app.Options.LoggerFilterConfig` in code before enabling payload logging — see [observability.md](observability.md#sensitive-data-filtering) for the full field list and customization seams.
 
 By default the client logs only request/response metadata (method, URL, status, elapsed, body size). Debug-level payload logging can be enabled via the builder:
 

--- a/wiki/keystore.md
+++ b/wiki/keystore.md
@@ -23,7 +23,7 @@ once at startup and held read-only in memory.
 
 ```yaml
 keystore:
-  secret_min_length: 32          # default 32; explicit 0 disables the floor
+  secretminlength: 32          # default 32; explicit 0 disables the floor
   keys:
     signing:                     # RSA pair (public required, private optional)
       public:
@@ -52,7 +52,7 @@ a clear `ConfigError`.
 
 ### Minimum-length floor
 
-`keystore.secret_min_length` (default **32**) is the byte floor enforced for
+`keystore.secretminlength` (default **32**) is the byte floor enforced for
 every symmetric secret after decoding. It is a defensive control against
 silently weak HMAC/HKDF keys. Set it to an explicit `0` to opt out (documented,
 deliberate); negative values are rejected at config validation.
@@ -138,7 +138,7 @@ the real store so tests exercise the same ownership contract.
   the logical name, key type, and file path only; the framework logger's
   `SensitiveDataFilter` covers any incidental log lines.
 - The minimum-length floor is on by default — keep it on for HMAC/HKDF keys;
-  only disable it (`secret_min_length: 0`) with a deliberate, documented reason.
+  only disable it (`secretminlength: 0`) with a deliberate, documented reason.
 - Derivation (HKDF expansion, etc.) is left to the consumer — the keystore
   intentionally exposes raw material rather than a built-in derive helper
   (smallest viable surface; can layer on later if demand appears).

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -181,20 +181,20 @@ GoBricks applies production-safe AMQP reconnection defaults when messaging is co
 | Setting | Default | Purpose |
 |---------|---------|---------|
 | `reconnect.delay` | 5s | Initial delay before reconnect attempts |
-| `reconnect.reinit_delay` | 2s | Delay between channel re-initialization |
-| `reconnect.resend_delay` | 5s | Delay before resending failed messages |
-| `reconnect.connection_timeout` | 30s | Timeout for connection establishment |
-| `reconnect.max_delay` | 60s | Maximum backoff cap for exponential retry |
-| `publisher.max_cached` | 50 | Maximum cached publisher channels |
-| `publisher.idle_ttl` | 10m | TTL for idle publisher channels |
+| `reconnect.reinitdelay` | 2s | Delay between channel re-initialization |
+| `reconnect.resenddelay` | 5s | Delay before resending failed messages |
+| `reconnect.connectiontimeout` | 30s | Timeout for connection establishment |
+| `reconnect.maxdelay` | 60s | Maximum backoff cap for exponential retry |
+| `publisher.maxcached` | 50 | Maximum cached publisher channels |
+| `publisher.idlettl` | 10m | TTL for idle publisher channels |
 
 **Override defaults** in `config.yaml`:
 ```yaml
 messaging:
   reconnect:
     delay: 10s            # Slower initial reconnect
-    max_delay: 120s       # Higher backoff cap
+    maxdelay: 120s       # Higher backoff cap
   publisher:
-    max_cached: 100       # More cached publishers for high-throughput
-    idle_ttl: 30m         # Keep publishers longer
+    maxcached: 100       # More cached publishers for high-throughput
+    idlettl: 30m         # Keep publishers longer
 ```

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -189,6 +189,7 @@ GoBricks applies production-safe AMQP reconnection defaults when messaging is co
 | `publisher.idlettl` | 10m | TTL for idle publisher channels |
 
 **Override defaults** in `config.yaml`:
+
 ```yaml
 messaging:
   reconnect:

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -2,6 +2,36 @@
 
 Historical migration tables for upgrading existing GoBricks-based applications. Greenfield work can ignore this file — the new APIs are the only ones documented in CLAUDE.md.
 
+## Config Keys — Flat-Smushed Rename (ADR-024)
+
+Per [ADR-024](adr_024_config_key_flatsmush.md), 21 snake_case config keys were renamed to the framework's underscore-free flat-smushed convention so they become settable via environment variables (the env loader maps `_`→`.`, koanf's nesting delimiter, so underscored leaf keys were silently unreachable from env). Update both your YAML and any environment variables. Go field names are unchanged.
+
+| Old key (YAML) | New key (YAML) | Old env var (broken) | New env var |
+|---|---|---|---|
+| `cache.manager.max_size` | `cache.manager.maxsize` | `CACHE_MANAGER_MAX_SIZE` | `CACHE_MANAGER_MAXSIZE` |
+| `cache.manager.idle_ttl` | `cache.manager.idlettl` | `CACHE_MANAGER_IDLE_TTL` | `CACHE_MANAGER_IDLETTL` |
+| `cache.manager.cleanup_interval` | `cache.manager.cleanupinterval` | `CACHE_MANAGER_CLEANUP_INTERVAL` | `CACHE_MANAGER_CLEANUPINTERVAL` |
+| `log.sensitive_fields` | `log.sensitivefields` | `LOG_SENSITIVE_FIELDS` | `LOG_SENSITIVEFIELDS` |
+| `messaging.reconnect.reinit_delay` | `messaging.reconnect.reinitdelay` | `MESSAGING_RECONNECT_REINIT_DELAY` | `MESSAGING_RECONNECT_REINITDELAY` |
+| `messaging.reconnect.resend_delay` | `messaging.reconnect.resenddelay` | `MESSAGING_RECONNECT_RESEND_DELAY` | `MESSAGING_RECONNECT_RESENDDELAY` |
+| `messaging.reconnect.connection_timeout` | `messaging.reconnect.connectiontimeout` | `MESSAGING_RECONNECT_CONNECTION_TIMEOUT` | `MESSAGING_RECONNECT_CONNECTIONTIMEOUT` |
+| `messaging.reconnect.max_delay` | `messaging.reconnect.maxdelay` | `MESSAGING_RECONNECT_MAX_DELAY` | `MESSAGING_RECONNECT_MAXDELAY` |
+| `messaging.publisher.max_cached` | `messaging.publisher.maxcached` | `MESSAGING_PUBLISHER_MAX_CACHED` | `MESSAGING_PUBLISHER_MAXCACHED` |
+| `messaging.publisher.idle_ttl` | `messaging.publisher.idlettl` | `MESSAGING_PUBLISHER_IDLE_TTL` | `MESSAGING_PUBLISHER_IDLETTL` |
+| `outbox.table_name` | `outbox.tablename` | `OUTBOX_TABLE_NAME` | `OUTBOX_TABLENAME` |
+| `outbox.auto_create_table` | `outbox.autocreatetable` | `OUTBOX_AUTO_CREATE_TABLE` | `OUTBOX_AUTOCREATETABLE` |
+| `outbox.default_exchange` | `outbox.defaultexchange` | `OUTBOX_DEFAULT_EXCHANGE` | `OUTBOX_DEFAULTEXCHANGE` |
+| `outbox.poll_interval` | `outbox.pollinterval` | `OUTBOX_POLL_INTERVAL` | `OUTBOX_POLLINTERVAL` |
+| `outbox.batch_size` | `outbox.batchsize` | `OUTBOX_BATCH_SIZE` | `OUTBOX_BATCHSIZE` |
+| `outbox.max_retries` | `outbox.maxretries` | `OUTBOX_MAX_RETRIES` | `OUTBOX_MAXRETRIES` |
+| `outbox.retention_period` | `outbox.retentionperiod` | `OUTBOX_RETENTION_PERIOD` | `OUTBOX_RETENTIONPERIOD` |
+| `inbox.table_name` | `inbox.tablename` | `INBOX_TABLE_NAME` | `INBOX_TABLENAME` |
+| `inbox.auto_create_table` | `inbox.autocreatetable` | `INBOX_AUTO_CREATE_TABLE` | `INBOX_AUTOCREATETABLE` |
+| `inbox.retention_period` | `inbox.retentionperiod` | `INBOX_RETENTION_PERIOD` | `INBOX_RETENTIONPERIOD` |
+| `keystore.secret_min_length` | `keystore.secretminlength` | `KEYSTORE_SECRET_MIN_LENGTH` | `KEYSTORE_SECRETMINLENGTH` |
+
+> The "old env var" column never worked (that is the bug ADR-024 fixes); it is shown only to help locate occurrences in existing deployment manifests.
+
 ## Go Naming Conventions (S8179) — Getter Methods
 
 Per [SonarCloud rule S8179](https://rules.sonarsource.com/go/RSPEC-8179/), getter methods should NOT have the `Get` prefix.

--- a/wiki/observability.md
+++ b/wiki/observability.md
@@ -70,7 +70,7 @@ For regulated payloads — PCI-DSS (PAN, CVV2), PII (SSN, account numbers), one-
 ```yaml
 log:
   level: info
-  sensitive_fields:                     # NEW: appended to DefaultFilterConfig
+  sensitivefields:                     # NEW: appended to DefaultFilterConfig
     - pan                               # masks "pan", "PAN", "card_pan"
     - primary_account_number            # masks the long-form variant too
     - cvv
@@ -119,7 +119,7 @@ fw, err = app.NewWithOptions(&app.Options{
 })
 ```
 
-**Precedence** when both are set: `Options.LoggerFilterConfig` wins. The YAML `log.sensitive_fields` value is **ignored entirely** in that case (no silent merge — the consumer is in full control). Mention this in your runbook if your deployment pattern mixes both.
+**Precedence** when both are set: `Options.LoggerFilterConfig` wins. The YAML `log.sensitivefields` value is **ignored entirely** in that case (no silent merge — the consumer is in full control). Mention this in your runbook if your deployment pattern mixes both.
 
 ### Matching semantics — what gets masked
 

--- a/wiki/outbox.md
+++ b/wiki/outbox.md
@@ -62,23 +62,23 @@ func (s *OrderService) CreateOrder(ctx context.Context, req CreateOrderReq) erro
 
 **How It Works:**
 1. `Publish()` writes an `OutboxRecord` to the outbox table within the caller's transaction
-2. The **relay job** (`outbox-relay` via scheduler) polls for pending events every `poll_interval`
+2. The **relay job** (`outbox-relay` via scheduler) polls for pending events every `pollinterval`
 3. Each pending event is published to the target AMQP exchange with `x-outbox-event-id` header
 4. Successfully published events are marked as `published`
-5. Failed events are retried up to `max_retries` times
-6. The **cleanup job** (`outbox-cleanup`) removes published events older than `retention_period`
+5. Failed events are retried up to `maxretries` times
+6. The **cleanup job** (`outbox-cleanup`) removes published events older than `retentionperiod`
 
 **Configuration:**
 ```yaml
 outbox:
   enabled: true
-  table_name: gobricks_outbox       # Default table name
-  auto_create_table: true           # Create table on first use
-  default_exchange: ""              # Fallback if Event.Exchange empty
-  poll_interval: 5s                 # Relay poll frequency
-  batch_size: 100                   # Events per relay cycle
-  max_retries: 5                    # Max attempts before giving up
-  retention_period: 72h             # Keep published events (0=disable cleanup)
+  tablename: gobricks_outbox       # Default table name
+  autocreatetable: true           # Create table on first use
+  defaultexchange: ""              # Fallback if Event.Exchange empty
+  pollinterval: 5s                 # Relay poll frequency
+  batchsize: 100                   # Events per relay cycle
+  maxretries: 5                    # Max attempts before giving up
+  retentionperiod: 72h             # Keep published events (0=disable cleanup)
 ```
 
 **Event Struct:**
@@ -89,7 +89,7 @@ outbox:
 | `AggregateID` | string | Yes | Entity identifier for idempotency (e.g., "order-123") |
 | `Payload` | any | Yes | `[]byte` stored as-is, otherwise JSON-marshaled |
 | `Headers` | map[string]any | No | Custom AMQP headers propagated to published message |
-| `Exchange` | string | No | Target AMQP exchange (falls back to `default_exchange` config) |
+| `Exchange` | string | No | Target AMQP exchange (falls back to `defaultexchange` config) |
 | `RoutingKey` | string | No | AMQP routing key (falls back to `EventType`) |
 
 ## Trace Propagation
@@ -122,18 +122,18 @@ GoBricks applies production-safe outbox defaults when outbox is enabled:
 
 | Setting | Default | Purpose |
 |---------|---------|---------|
-| `outbox.table_name` | `gobricks_outbox` | Outbox table name |
-| `outbox.auto_create_table` | `true` | Auto-create table on first use |
-| `outbox.poll_interval` | `5s` | Relay poll frequency |
-| `outbox.batch_size` | `100` | Events per relay cycle |
-| `outbox.max_retries` | `5` | Max publish attempts |
-| `outbox.retention_period` | `72h` | Published event retention |
+| `outbox.tablename` | `gobricks_outbox` | Outbox table name |
+| `outbox.autocreatetable` | `false` | Auto-create table on first use (opt-in) |
+| `outbox.pollinterval` | `5s` | Relay poll frequency |
+| `outbox.batchsize` | `100` | Events per relay cycle |
+| `outbox.maxretries` | `5` | Max publish attempts |
+| `outbox.retentionperiod` | `72h` | Published event retention |
 
 **Override defaults** in `config.yaml`:
 ```yaml
 outbox:
   enabled: true
-  poll_interval: 2s           # Lower latency
-  batch_size: 200             # Higher throughput
-  retention_period: 168h      # 7-day retention
+  pollinterval: 2s           # Lower latency
+  batchsize: 200             # Higher throughput
+  retentionperiod: 168h      # 7-day retention
 ```

--- a/wiki/outbox.md
+++ b/wiki/outbox.md
@@ -69,6 +69,7 @@ func (s *OrderService) CreateOrder(ctx context.Context, req CreateOrderReq) erro
 6. The **cleanup job** (`outbox-cleanup`) removes published events older than `retentionperiod`
 
 **Configuration:**
+
 ```yaml
 outbox:
   enabled: true
@@ -130,6 +131,7 @@ GoBricks applies production-safe outbox defaults when outbox is enabled:
 | `outbox.retentionperiod` | `72h` | Published event retention |
 
 **Override defaults** in `config.yaml`:
+
 ```yaml
 outbox:
   enabled: true

--- a/wiki/troubleshooting.md
+++ b/wiki/troubleshooting.md
@@ -111,8 +111,8 @@ database:
 # → Verify pool size adequate: cache.redis.pool_size >= NumCPU * 2
 
 # CacheManager eviction issues
-# → Increase max_size if seeing unexpected evictions: cache.manager.max_size
-# → Increase idle_ttl if caches closing too quickly: cache.manager.idle_ttl
+# → Increase maxsize if seeing unexpected evictions: cache.manager.maxsize
+# → Increase idlettl if caches closing too quickly: cache.manager.idlettl
 # → Monitor stats: cacheManager.Stats() — check Evictions/IdleCleanups counters
 ```
 
@@ -245,7 +245,7 @@ grep "Panic recovered in message handler" logs/app.log
 # → Use x-outbox-event-id header for idempotency in consumer handlers
 
 # Table creation fails
-# → Set outbox.auto_create_table: false and create table manually
+# → Set outbox.autocreatetable: false and create table manually
 # → DDL provided in outbox/store_postgres.go and outbox/store_oracle.go
 ```
 


### PR DESCRIPTION
## Problem

`config.Load()` maps env keys with `strings.ReplaceAll(strings.ToLower(k), "_", ".")`. Since koanf nests on `.`, **every** underscore in an env var name becomes a nesting boundary, so any koanf leaf tag containing `_` was **unreachable from the environment** — the value landed at an orphan path no struct field claims, was silently dropped, and the default won (no error).

Confirmed: `LOG_SENSITIVE_FIELDS=…` → orphan `log.sensitive.fields`, field stayed `nil`; `KEYSTORE_SECRET_MIN_LENGTH=64` → orphan `keystore.secret.min.length`, stayed at default `32`. This is the sibling bug surfaced by #548.

An audit of `config/types.go` found **exactly 21** affected leaf keys — all snake_case — and confirmed the framework's dominant convention is **flat-smushed** compound leaves (`connectionstring`, `minretrybackoff`, `poolsize`, `virtualhost`, `slowjob`, `QueryLogConfig.MaxLength → koanf:"max"`). The snake_case keys were drift from that convention, and the drift is the bug.

## Change

Rename all 21 snake_case koanf leaf tags to the underscore-free flat-smushed convention. **No env-loading code change and no mapping layer** — once keys contain no underscore the existing transform maps them natively. Only struct tags change; **Go field names are unchanged** (`cfg.Outbox.BatchSize`, `cfg.KeyStore.SecretMinLength`), so consumer code is untouched.

| old key | new key | | old key | new key |
|---|---|---|---|---|
| `cache.manager.max_size` | `…maxsize` | | `outbox.table_name` | `outbox.tablename` |
| `cache.manager.idle_ttl` | `…idlettl` | | `outbox.auto_create_table` | `outbox.autocreatetable` |
| `cache.manager.cleanup_interval` | `…cleanupinterval` | | `outbox.default_exchange` | `outbox.defaultexchange` |
| `log.sensitive_fields` | `log.sensitivefields` | | `outbox.poll_interval` | `outbox.pollinterval` |
| `messaging.reconnect.reinit_delay` | `…reinitdelay` | | `outbox.batch_size` | `outbox.batchsize` |
| `messaging.reconnect.resend_delay` | `…resenddelay` | | `outbox.max_retries` | `outbox.maxretries` |
| `messaging.reconnect.connection_timeout` | `…connectiontimeout` | | `outbox.retention_period` | `outbox.retentionperiod` |
| `messaging.reconnect.max_delay` | `…maxdelay` | | `inbox.table_name` | `inbox.tablename` |
| `messaging.publisher.max_cached` | `…maxcached` | | `inbox.auto_create_table` | `inbox.autocreatetable` |
| `messaging.publisher.idle_ttl` | `…idlettl` | | `inbox.retention_period` | `inbox.retentionperiod` |
| `keystore.secret_min_length` | `keystore.secretminlength` | | | |

## Why flat-smush (not nesting / alias map)

A 6-agent audit + three independent proposal lenses converged: the framework introduces a sub-struct only to group **multiple** related leaves under a shared namespace (`server.timeout.{read,write,idle}`, `database.pool.{max,idle}`); the few single-field nested structs (`PoolMaxConfig`, `LifetimeConfig`) are namespace anchors within a sibling family — **never lone wrappers of an atomic compound concept**. Even the audit lens *permitted* single-field structs chose zero. So nesting `secret_min_length` into `Secret{MinLength}` would itself be drift. An env-key alias map was rejected for the same reason — it papers over keys that violate the convention instead of fixing them. See **ADR-024**.

## Breaking change

Old snake_case YAML/env keys are no longer recognized (they become unknown keys → fall back to defaults, silently). Migration table: [`wiki/migrations.md`](../blob/feature/config-key-flatsmush-rename/wiki/migrations.md) + [ADR-024](../blob/feature/config-key-flatsmush-rename/wiki/adr_024_config_key_flatsmush.md). Consistent with pre-1.0 framework practice (ADR-016, ADR-022, ADR-023).

## Guard against recurrence

`TestConfigKoanfTagsHaveNoUnderscore` (`config/types_test.go`) reflects over the whole `Config` tree (incl. nested/map/slice/embedded types) and fails if any koanf tag contains `_`. The bug class cannot return.

## Tests

- New env-reachability test (`t.Setenv`) covering `[]string`/int/bool/duration/int keys end-to-end.
- The no-underscore invariant test above.
- Updated existing tests + error-message assertions to the new keys.
- `make check` green; `/code-review` and `/security-review` run (security: no findings; both keys with security relevance — `sensitivefields` masking, `secretminlength` floor — verified still wired via unchanged Go fields).

## Scope

In: the 21-key rename + consistency strings + docs/wiki + ADR-024 + migration table. **Out (follow-ups):** the unrelated README `SERVER_*` env-var doc drift and `.env.example` orphans (separate PR); `InjectInto`↔`Unmarshal` decode-path parity gaps (separate issue).

Follow-up to #548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Config keys renamed from underscore-separated names (e.g., max_size, poll_interval, sensitive_fields) to concatenated names (e.g., maxsize, pollinterval, sensitivefields). Old YAML/env keys will no longer be recognized—update configs.

* **Documentation**
  * All examples, guides, and migration docs updated to reflect the new key naming across cache, messaging, outbox, keystore, logging, and related docs.

* **Tests**
  * Added a reflection-based test ensuring config keys contain no underscores to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->