### PR TITLE
fix(docs): correct server-path env vars and .env.example orphans

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,7 +45,7 @@ SERVER_PATH_READY=/ready
 # ============================================================================
 
 # Database type and basic connection settings
-DATABASE_TYPE=postgres
+DATABASE_TYPE=postgresql
 DATABASE_HOST=localhost
 DATABASE_PORT=5432
 DATABASE_DATABASE=gobricks_db
@@ -117,15 +117,8 @@ MULTITENANT_RESOLVER_HEADER=X-Tenant-ID
 MULTITENANT_RESOLVER_DOMAIN=api.example.com
 MULTITENANT_RESOLVER_PROXIES=false
 
-# Tenant configuration cache
-MULTITENANT_CACHE_TTL=5m
-
-# Tenant connection limits and cleanup
+# Tenant connection limits
 MULTITENANT_LIMITS_TENANTS=100
-MULTITENANT_LIMITS_CLEANUP_INTERVAL=5m
-
-# Tenant ID validation
-MULTITENANT_VALIDATION_PATTERN=^[a-z0-9-]{1,64}$
 
 # ============================================================================
 # Custom Application Configuration Examples

--- a/README.md
+++ b/README.md
@@ -328,15 +328,13 @@ Request structs use tags for binding/validation (`path`, `query`, `header`, `val
 ### Routing Configuration
 ```yaml
 server:
-  base:
-    path: "/api/v1"    # All routes prefixed
-  health:
-    route: "/health"   # Liveness endpoint
-  ready:
-    route: "/ready"    # Readiness endpoint
+  path:
+    base: "/api/v1"     # All routes prefixed
+    health: "/health"   # Liveness endpoint
+    ready: "/ready"     # Readiness endpoint
 ```
 
-Override with environment variables: `SERVER_BASE_PATH`, `SERVER_HEALTH_ROUTE`, `SERVER_READY_ROUTE`.
+Override with environment variables: `SERVER_PATH_BASE`, `SERVER_PATH_HEALTH`, `SERVER_PATH_READY`.
 
 ---
 


### PR DESCRIPTION
Ride-along documentation fixes discovered during the config-key audit for #549. **Docs/example only — no code changes.**

## README — routing configuration was wrong

`README.md` documented the server routing config with the wrong structure and env vars:
- YAML showed `server.base.path` / `server.health.route` / `server.ready.route` — but the real keys are `server.path.{base,health,ready}` (`PathConfig` under `ServerConfig`, matching `loadDefaults` and `.env.example`).
- Env vars listed `SERVER_BASE_PATH` / `SERVER_HEALTH_ROUTE` / `SERVER_READY_ROUTE` — all of which silently map to non-existent keys. Corrected to `SERVER_PATH_BASE` / `SERVER_PATH_HEALTH` / `SERVER_PATH_READY`.

## `.env.example` — invalid value + orphan entries

- `DATABASE_TYPE=postgres` → `postgresql` (the config validator only accepts `postgresql`; `postgres` fails at startup).
- Removed three orphan env vars with no corresponding `MultitenantConfig` field (silently ignored): `MULTITENANT_CACHE_TTL`, `MULTITENANT_LIMITS_CLEANUP_INTERVAL`, `MULTITENANT_VALIDATION_PATTERN`. (`MultitenantConfig` exposes only `enabled`, `resolver.*`, `limits.tenants`, and the `tenants` map.)

Follow-up to #549.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated HTTP Server routing configuration documentation with new path structure examples
  * Updated environment variable documentation for routing configuration overrides

* **Chores**
  * Updated database configuration type identifier in setup template
  * Simplified multi-tenant configuration template by removing cache TTL, cleanup interval, and validation pattern configurations while preserving connection limit settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->