### PR TITLE
fix(observability): flat-smush underscored mapstructure config keys (#554)

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,7 +793,7 @@ See [MULTI_TENANT.md](MULTI_TENANT.md) for detailed architecture and [multitenan
        endpoint: otel-collector:4317
        protocol: grpc
        insecure: true
-       slow_request_threshold: 750ms   # requests slower than this become WARN result_code
+       slowrequestthreshold: 750ms   # requests slower than this become WARN result_code
        export:
          timeout: 5s
        batch:

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -6,21 +6,32 @@ import (
 	"testing"
 )
 
-// TestConfigKoanfTagsHaveNoUnderscore guards the whole "env var cannot reach an
-// underscored koanf key" bug class: the env loader maps "_"->"." (koanf's nesting
-// delimiter), so any koanf leaf tag containing "_" is unreachable from the
-// environment. Every koanf tag in the Config tree MUST be underscore-free.
+// TestConfigKoanfTagsHaveNoUnderscore guards the whole "config key cannot be
+// reached" bug class. Two mechanisms make an underscored leaf tag unreachable:
+//   - env vars: the env loader maps "_"->"." (koanf's nesting delimiter), so an
+//     underscored koanf tag is unreachable from the environment.
+//   - section Unmarshal: plain koanf.Unmarshal binds by koanf tag or the
+//     field-name fallback and never honors the mapstructure tag, so an
+//     underscored mapstructure tag lies about the key that actually binds (see
+//     #554, which hit the observability tree's mapstructure-only fields).
+//
+// Every koanf AND mapstructure tag in the Config tree MUST therefore be
+// underscore-free. The sibling observability tree (mapstructure-tagged, loaded
+// via Config.Unmarshal) is guarded by the parallel
+// observability.TestObservabilityConfigTagsHaveNoUnderscore.
 func TestConfigKoanfTagsHaveNoUnderscore(t *testing.T) {
 	offenders := collectUnderscoredKoanfTags(reflect.TypeOf(Config{}), "", map[reflect.Type]bool{})
 	if len(offenders) > 0 {
-		t.Fatalf("koanf tags must be underscore-free (env vars nest on '_'); offenders:\n  %s",
+		t.Fatalf("config tags must be underscore-free (env vars nest on '_'; section "+
+			"Unmarshal ignores mapstructure tags); offenders:\n  %s",
 			strings.Join(offenders, "\n  "))
 	}
 }
 
 // collectUnderscoredKoanfTags walks the config struct tree (through pointers,
 // maps, slices, and nested/embedded structs) and returns the dotted key paths
-// whose koanf tag contains an underscore. seen prevents revisiting shared types.
+// whose koanf OR mapstructure tag contains an underscore. seen prevents
+// revisiting shared types.
 func collectUnderscoredKoanfTags(rt reflect.Type, prefix string, seen map[reflect.Type]bool) []string {
 	rt = koanfUnderlyingStruct(rt)
 	if rt == nil || seen[rt] {
@@ -31,19 +42,41 @@ func collectUnderscoredKoanfTags(rt reflect.Type, prefix string, seen map[reflec
 	var offenders []string
 	for i := 0; i < rt.NumField(); i++ {
 		f := rt.Field(i)
-		name := strings.Split(f.Tag.Get("koanf"), ",")[0]
-		if name == "-" {
+		// Unexported fields (e.g. the cached *koanf.Koanf handle) never receive
+		// config values, so their tags are irrelevant to the binding invariant —
+		// and recursing into third-party internals could surface foreign tags.
+		if f.PkgPath != "" {
 			continue
 		}
+		koanfName := koanfTagName(&f, "koanf")
+		mapName := koanfTagName(&f, "mapstructure")
 		// Untagged fields (incl. anonymous/embedded structs) keep the parent
-		// prefix so their tagged children are still reached and checked.
-		key := koanfChildKey(prefix, name)
-		if strings.Contains(name, "_") {
-			offenders = append(offenders, key)
+		// prefix so their tagged children are still reached and checked. Prefer
+		// the koanf name for the path, falling back to the mapstructure name.
+		pathName := koanfName
+		if pathName == "" {
+			pathName = mapName
+		}
+		key := koanfChildKey(prefix, pathName)
+		if strings.Contains(koanfName, "_") {
+			offenders = append(offenders, key+` (koanf:"`+koanfName+`")`)
+		}
+		if strings.Contains(mapName, "_") {
+			offenders = append(offenders, key+` (mapstructure:"`+mapName+`")`)
 		}
 		offenders = append(offenders, collectUnderscoredKoanfTags(f.Type, key, seen)...)
 	}
 	return offenders
+}
+
+// koanfTagName returns the first segment of the named struct tag, treating the
+// explicit "-" skip marker as empty (no key contributed).
+func koanfTagName(f *reflect.StructField, tag string) string {
+	name := strings.Split(f.Tag.Get(tag), ",")[0]
+	if name == "-" {
+		return ""
+	}
+	return name
 }
 
 // koanfUnderlyingStruct dereferences pointers and unwraps map/slice element types,

--- a/llms.txt
+++ b/llms.txt
@@ -3992,7 +3992,7 @@ When `observability.enabled: true`, the framework auto-emits:
 | Stream | Marker | Sampling | Use case |
 |---|---|---|---|
 | Action logs | `log.type="action"` | Always 100% | One summary line per HTTP request (status, duration, route) |
-| Trace logs | `log.type="trace"` | `ERROR`/`WARN` always; `INFO`/`DEBUG` sampled by `observability.logs.sampling_rate` | Application logs from `logger.Info()/Error()/...` |
+| Trace logs | `log.type="trace"` | `ERROR`/`WARN` always; `INFO`/`DEBUG` sampled by `observability.logs.samplingrate` | Application logs from `logger.Info()/Error()/...` |
 | Trace correlation | `trace_id` / `span_id` fields | — | Auto-injected via `logger.WithContext(ctx)` |
 
 **Auto-wired health endpoints:**
@@ -4020,7 +4020,7 @@ observability:
     enabled: true               # No endpoint = stdout/disabled by build
   logs:
     enabled: true
-    slow_request_threshold: 750ms
+    slowrequestthreshold: 750ms
 
 logger:
   pretty: false                 # MUST be false when observability.logs.enabled = true
@@ -4046,13 +4046,13 @@ observability:
     protocol: grpc
     compression: gzip
     temporality: delta              # Lower memory; backend-friendly
-    histogram_aggregation: exponential
+    histogramaggregation: exponential
   logs:
     enabled: true
     endpoint: otel-collector:4317
     protocol: grpc
     compression: gzip
-    sampling_rate: 0.2              # 20% of INFO/DEBUG; ERROR/WARN always 100%
+    samplingrate: 0.2              # 20% of INFO/DEBUG; ERROR/WARN always 100%
 
 logger:
   pretty: false
@@ -4335,7 +4335,7 @@ GoBricks separates two log streams to keep volume under control without losing v
 | Stream | Marker (`log.type`) | Sampling | Purpose |
 |---|---|---|---|
 | **Action logs** | `"action"` | Always 100% (never sampled) | One synthesized summary per HTTP request (status code, route, latency, severity) |
-| **Trace logs** | `"trace"` | `ERROR`/`WARN` always; `INFO`/`DEBUG` sampled by `observability.logs.sampling_rate` | Application logs from `logger.Info()/Error()/...` calls inside handlers/services |
+| **Trace logs** | `"trace"` | `ERROR`/`WARN` always; `INFO`/`DEBUG` sampled by `observability.logs.samplingrate` | Application logs from `logger.Info()/Error()/...` calls inside handlers/services |
 
 **Why two streams?** A noisy `INFO`-level codebase shouldn't drown out request summaries — and dropping all `INFO` logs would hide context for the 1% you sample. Action logs guarantee you always have one row per request even when trace-log sampling is aggressive.
 
@@ -4345,8 +4345,8 @@ GoBricks separates two log streams to keep volume under control without losing v
 observability:
   logs:
     enabled: true
-    sampling_rate: 0.1            # Export 10% of INFO/DEBUG trace logs (default 0.0 drops them all)
-    slow_request_threshold: 750ms # Auto-escalate action log severity to WARN if request slower
+    samplingrate: 0.1            # Export 10% of INFO/DEBUG trace logs (default 0.0 drops them all)
+    slowrequestthreshold: 750ms # Auto-escalate action log severity to WARN if request slower
 ```
 
 **Sampling determinism:** within a single trace, all logs are sampled together (kept or dropped as a unit), so debugging a sampled trace shows the full picture; debugging a dropped trace shows only `ERROR`/`WARN` lines.
@@ -4357,7 +4357,7 @@ Action logs derive severity automatically:
 - HTTP `2xx`/`3xx` → `INFO`
 - HTTP `4xx` → `WARN`
 - HTTP `5xx` → `ERROR`
-- Slow requests (above `slow_request_threshold`) → `WARN`
+- Slow requests (above `slowrequestthreshold`) → `WARN`
 
 **Escalate explicitly** for cross-cutting concerns that aren't reflected in the status code (rate-limit hits, deprecated endpoint usage, suspicious tenant activity):
 
@@ -4899,8 +4899,8 @@ For application logs, exercise the production logger directly and capture into a
 | gRPC error: `frame too large, note that the frame header looked like an HTTP/1.1 header` | gRPC client connecting to an HTTP endpoint (e.g. port `4318` with `protocol: grpc`, or `https://...` scheme with gRPC) | Use `host:port` (no scheme) on port `4317` for gRPC; use `https://host:port/v1/...` on port `4318` for HTTP |
 | Spans appear in console (`endpoint: stdout`) but not in collector | App can't reach collector / TLS misconfiguration / batch hasn't flushed yet | Check connectivity, set `insecure: true` for in-cluster collectors, wait for batch flush (~5s prod) or trigger graceful shutdown |
 | Logs are emitted but `trace_id` field is empty | Logger called without trace context | Use `logger.WithContext(ctx).Info()...` (not `logger.Info()...`); ensure the handler context comes from `ctx.Echo.Request().Context()` |
-| Action logs missing for some requests | Slow request threshold not configured — only severity escalation produces non-INFO action logs | Set `observability.logs.slow_request_threshold` or call `server.EscalateSeverity(c, level)` |
-| INFO/DEBUG application logs are dropped | Default `sampling_rate: 0.0` drops all `INFO`/`DEBUG` trace logs (action logs still emit at 100%) | Raise `observability.logs.sampling_rate` (e.g. `0.1`); `ERROR`/`WARN` always export regardless |
+| Action logs missing for some requests | Slow request threshold not configured — only severity escalation produces non-INFO action logs | Set `observability.logs.slowrequestthreshold` or call `server.EscalateSeverity(c, level)` |
+| INFO/DEBUG application logs are dropped | Default `samplingrate: 0.0` drops all `INFO`/`DEBUG` trace logs (action logs still emit at 100%) | Raise `observability.logs.samplingrate` (e.g. `0.1`); `ERROR`/`WARN` always export regardless |
 | Custom metric is `nil` when recording | `observability.enabled: false` makes `deps.MeterProvider` a no-op, but the helper-returned instruments may still be `nil` if `Meter()` was never called | Always nil-check before recording: `if m.counter != nil { m.counter.Add(...) }` |
 | Noisy `[OBSERVABILITY]` debug output | `GOBRICKS_DEBUG` env var is set | Unset `GOBRICKS_DEBUG` |
 

--- a/observability/config.go
+++ b/observability/config.go
@@ -481,7 +481,7 @@ type MetricsConfig struct {
 	// Supported values: "exponential", "explicit".
 	// Default: "explicit" (OTEL SDK default).
 	// New Relic recommends "exponential" for better precision and lower memory overhead.
-	HistogramAggregation string `mapstructure:"histogram_aggregation"`
+	HistogramAggregation string `mapstructure:"histogramaggregation"`
 
 	// Interval specifies how often to export metrics.
 	// Shorter intervals provide more real-time data but increase overhead.
@@ -524,7 +524,7 @@ type LogsConfig struct {
 	// DisableStdout controls whether to disable stdout logging when OTLP is enabled.
 	// When false (default), logs go to both stdout and OTLP (useful for development).
 	// When true, logs only go to OTLP (production efficiency).
-	DisableStdout bool `mapstructure:"disable_stdout"`
+	DisableStdout bool `mapstructure:"disablestdout"`
 
 	// Headers allows custom HTTP headers for OTLP exporters.
 	// Useful for authentication tokens or API keys.
@@ -549,14 +549,14 @@ type LogsConfig struct {
 	// Requests exceeding this duration are logged with result_code="WARN" in action logs.
 	// This is a system-wide threshold (no per-route overrides).
 	// Default: 1 second.
-	SlowRequestThreshold time.Duration `mapstructure:"slow_request_threshold"`
+	SlowRequestThreshold time.Duration `mapstructure:"slowrequestthreshold"`
 
 	// SamplingRate controls what fraction of INFO/DEBUG trace logs to export (0.0 to 1.0).
 	// ERROR/WARN logs and action logs are always exported at 100%.
 	// Sampling is deterministic per trace (all logs in a trace are sampled together).
 	// 1.0 means export all INFO/DEBUG logs, 0.0 means export none (default).
 	// nil = apply default (0.0 for backward compatibility).
-	SamplingRate *float64 `mapstructure:"sampling_rate"`
+	SamplingRate *float64 `mapstructure:"samplingrate"`
 }
 
 // Validate checks the configuration for common errors.

--- a/observability/config_test.go
+++ b/observability/config_test.go
@@ -1,6 +1,8 @@
 package observability
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -388,6 +390,77 @@ metrics:
 	assert.Equal(t, "stdout", obsCfg.Metrics.Endpoint, "Metrics endpoint should be 'stdout'")
 	assert.Equal(t, 15*time.Second, obsCfg.Metrics.Interval, "Metrics interval should be 15s")
 	assert.Equal(t, 25*time.Second, obsCfg.Metrics.Export.Timeout, "Metrics export timeout should be 25s")
+}
+
+// TestConfigUnmarshalCompoundKeysBindFromYAML pins the user-facing #554 contract
+// for the four compound-word observability keys, which load via Config.Unmarshal
+// -> plain koanf.Unmarshal. koanf binds by koanf tag or the case-insensitive Go
+// field name and NEVER honors the mapstructure tag, so only the flat-smushed YAML
+// form binds; the pre-#554 underscored form is silently dropped (the bug).
+//
+// Because koanf ignores the mapstructure tag, a binding assertion alone cannot
+// detect the tag rename — reverting the tags to the underscored form leaves the
+// positive case green. The load-bearing rename guard is therefore
+// TestObservabilityConfigTagsHaveNoUnderscore; this test instead documents both
+// halves of the contract: the smushed form binds, the underscored form does not.
+func TestConfigUnmarshalCompoundKeysBindFromYAML(t *testing.T) {
+	t.Run("flat-smushed keys bind", func(t *testing.T) {
+		yamlContent := `
+metrics:
+  histogramaggregation: exponential
+logs:
+  disablestdout: true
+  slowrequestthreshold: 750ms
+  samplingrate: 0.2
+`
+		k := koanf.New(".")
+		require.NoError(t, k.Load(rawbytes.Provider([]byte(yamlContent)), yaml.Parser()))
+
+		var obsCfg Config
+		require.NoError(t, k.Unmarshal("", &obsCfg))
+
+		assert.Equal(t, HistogramAggregationExponential, obsCfg.Metrics.HistogramAggregation,
+			"metrics.histogramaggregation should bind from YAML")
+		assert.True(t, obsCfg.Logs.DisableStdout,
+			"logs.disablestdout should bind from YAML")
+		assert.Equal(t, 750*time.Millisecond, obsCfg.Logs.SlowRequestThreshold,
+			"logs.slowrequestthreshold should bind from YAML")
+		require.NotNil(t, obsCfg.Logs.SamplingRate, "logs.samplingrate should bind from YAML (not stay nil)")
+		assert.InDelta(t, 0.2, *obsCfg.Logs.SamplingRate, 1e-9,
+			"logs.samplingrate should bind from YAML")
+	})
+
+	t.Run("underscored keys are silently dropped", func(t *testing.T) {
+		// The pre-#554 underscored form matches neither a koanf tag nor the
+		// field-name fallback, so every field stays at its zero value and a
+		// service that set these in YAML silently got the framework default. This
+		// negative assertion encodes why the keys must be flat-smushed: it fails if
+		// someone later makes the underscored form bind (e.g. by switching the load
+		// path to honor mapstructure tags), which would reintroduce the env-var
+		// unreachability the smush convention exists to avoid.
+		yamlContent := `
+metrics:
+  histogram_aggregation: exponential
+logs:
+  disable_stdout: true
+  slow_request_threshold: 750ms
+  sampling_rate: 0.2
+`
+		k := koanf.New(".")
+		require.NoError(t, k.Load(rawbytes.Provider([]byte(yamlContent)), yaml.Parser()))
+
+		var obsCfg Config
+		require.NoError(t, k.Unmarshal("", &obsCfg))
+
+		assert.Empty(t, obsCfg.Metrics.HistogramAggregation,
+			"underscored metrics.histogram_aggregation must NOT bind (stays zero value)")
+		assert.False(t, obsCfg.Logs.DisableStdout,
+			"underscored logs.disable_stdout must NOT bind (stays zero value)")
+		assert.Zero(t, obsCfg.Logs.SlowRequestThreshold,
+			"underscored logs.slow_request_threshold must NOT bind (stays zero value)")
+		assert.Nil(t, obsCfg.Logs.SamplingRate,
+			"underscored logs.sampling_rate must NOT bind (stays nil)")
+	})
 }
 
 // TestConfigApplyDefaults validates that default values are correctly applied
@@ -1489,5 +1562,105 @@ func TestConfigTemporalityDefaults(t *testing.T) {
 			assert.Equal(t, tt.expectedTemporality, tt.config.Metrics.Temporality)
 			assert.Equal(t, tt.expectedHistogramAgg, tt.config.Metrics.HistogramAggregation)
 		})
+	}
+}
+
+// TestObservabilityConfigTagsHaveNoUnderscore guards the bug class from #554:
+// the observability tree is loaded via Config.Unmarshal("observability", ...),
+// which runs plain koanf.Unmarshal. koanf binds by koanf tag or, when absent,
+// the case-insensitive Go field name — it never honors the mapstructure tag.
+// An underscored mapstructure tag (e.g. "histogram_aggregation") therefore (a)
+// lies about the YAML key that actually binds (the field-name-smushed form), and
+// (b) is unreachable from env vars, which nest on "_". Every koanf/mapstructure
+// tag in the observability Config tree MUST be underscore-free, matching the
+// flat-smushed convention #549 established for the config tree.
+func TestObservabilityConfigTagsHaveNoUnderscore(t *testing.T) {
+	offenders := collectUnderscoredConfigTags(reflect.TypeOf(Config{}), "", map[reflect.Type]bool{})
+	if len(offenders) > 0 {
+		t.Fatalf("observability config tags must be underscore-free (koanf binds on the\n"+
+			"field-name fallback and env vars nest on '_'); offenders:\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}
+
+// collectUnderscoredConfigTags walks a config struct tree (through pointers, maps,
+// slices, and nested/embedded structs) and returns the dotted key paths whose
+// koanf OR mapstructure tag contains an underscore. seen prevents revisiting
+// shared types. This intentionally mirrors the config package's koanf-only walker
+// but also covers mapstructure, because the observability tree is mapstructure-
+// tagged; the logic is kept local to this package to avoid coupling observability
+// to config (the two packages do not import each other).
+func collectUnderscoredConfigTags(rt reflect.Type, prefix string, seen map[reflect.Type]bool) []string {
+	rt = configTagUnderlyingStruct(rt)
+	if rt == nil || seen[rt] {
+		return nil
+	}
+	seen[rt] = true
+
+	var offenders []string
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		// Unexported fields never receive config values, so their tags are
+		// irrelevant to the binding invariant.
+		if f.PkgPath != "" {
+			continue
+		}
+		koanfName := configTagName(&f, "koanf")
+		mapName := configTagName(&f, "mapstructure")
+		// Untagged fields (incl. anonymous/embedded structs) keep the parent prefix
+		// so their tagged children are still reached and checked. Prefer the koanf
+		// name for the path, falling back to the mapstructure name.
+		pathName := koanfName
+		if pathName == "" {
+			pathName = mapName
+		}
+		key := configTagChildKey(prefix, pathName)
+		if strings.Contains(koanfName, "_") {
+			offenders = append(offenders, key+` (koanf:"`+koanfName+`")`)
+		}
+		if strings.Contains(mapName, "_") {
+			offenders = append(offenders, key+` (mapstructure:"`+mapName+`")`)
+		}
+		offenders = append(offenders, collectUnderscoredConfigTags(f.Type, key, seen)...)
+	}
+	return offenders
+}
+
+// configTagName returns the first segment of the named struct tag, treating the
+// explicit "-" skip marker as empty (no key contributed).
+func configTagName(f *reflect.StructField, tag string) string {
+	name := strings.Split(f.Tag.Get(tag), ",")[0]
+	if name == "-" {
+		return ""
+	}
+	return name
+}
+
+// configTagUnderlyingStruct dereferences pointers and unwraps map/slice element
+// types, returning the underlying struct type, or nil if the type bottoms out at
+// a non-struct (a scalar leaf).
+func configTagUnderlyingStruct(rt reflect.Type) reflect.Type {
+	for {
+		switch rt.Kind() {
+		case reflect.Pointer, reflect.Map, reflect.Slice:
+			rt = rt.Elem()
+		case reflect.Struct:
+			return rt
+		default:
+			return nil
+		}
+	}
+}
+
+// configTagChildKey joins a parent prefix with a leaf name, treating an empty
+// name (untagged/embedded field) as a pass-through of the parent prefix.
+func configTagChildKey(prefix, name string) string {
+	switch {
+	case name == "":
+		return prefix
+	case prefix == "":
+		return name
+	default:
+		return prefix + "." + name
 	}
 }

--- a/tools/migration/internal/commands/common.go
+++ b/tools/migration/internal/commands/common.go
@@ -174,6 +174,11 @@ func loadTenantStoreFromFile(path string) (*config.TenantStore, error) {
 		return nil, fmt.Errorf("load config %q: %w", path, err)
 	}
 
+	// Plain Unmarshal binds by koanf tag / case-insensitive field name and
+	// ignores mapstructure tags, so it only reaches config.Config keys that are
+	// flat-smushed (underscore-free). That invariant is enforced by
+	// config.TestConfigKoanfTagsHaveNoUnderscore; if it ever regressed, an
+	// underscored key would silently fail to bind here (see issue #554).
 	var cfg config.Config
 	if err := k.Unmarshal("", &cfg); err != nil {
 		return nil, fmt.Errorf("unmarshal config %q: %w", path, err)

--- a/wiki/adr_006_otlp_log_export.md
+++ b/wiki/adr_006_otlp_log_export.md
@@ -73,7 +73,7 @@ type LogsConfig struct {
 - **Action logs** (`log.type="action"`): Always exported at 100% for request summaries
 - **Trace logs** (`log.type="trace"`):
   - ERROR/WARN: Always exported at 100%
-  - INFO/DEBUG: Controlled by `sampling_rate` (default 0.0 = drop all)
+  - INFO/DEBUG: Controlled by `samplingrate` (default 0.0 = drop all)
   - Sampling is deterministic per trace (all logs in same trace sampled together)
 
 **2. OTel Bridge** (`logger/otel_bridge.go`)
@@ -264,8 +264,8 @@ observability:
     endpoint: "localhost:4317"
     protocol: "grpc"
     insecure: true
-    disable_stdout: false  # Both stdout + OTLP for debugging
-    sampling_rate: 1.0     # 100% of INFO/DEBUG trace logs in dev
+    disablestdout: false  # Both stdout + OTLP for debugging
+    samplingrate: 1.0     # 100% of INFO/DEBUG trace logs in dev
     batch:
       timeout: 500ms       # Fast export for debugging
       size: 512
@@ -285,8 +285,8 @@ observability:
     endpoint: "otel-collector.prod:4317"
     protocol: "grpc"
     insecure: false         # TLS enabled
-    disable_stdout: true    # OTLP-only, reduce disk I/O
-    sampling_rate: 0.1      # 10% of INFO/DEBUG trace logs (ERROR/WARN always 100%)
+    disablestdout: true    # OTLP-only, reduce disk I/O
+    samplingrate: 0.1      # 10% of INFO/DEBUG trace logs (ERROR/WARN always 100%)
     headers:
       Authorization: "Bearer ${OTEL_API_KEY}"
     batch:
@@ -295,9 +295,9 @@ observability:
 ```
 
 **Sampling Behavior:**
-- `sampling_rate: 0.0` (default): Drop all INFO/DEBUG trace logs, keep ERROR/WARN
-- `sampling_rate: 0.1`: Export 10% of INFO/DEBUG, all ERROR/WARN
-- `sampling_rate: 1.0`: Export all trace logs (full visibility, higher volume)
+- `samplingrate: 0.0` (default): Drop all INFO/DEBUG trace logs, keep ERROR/WARN
+- `samplingrate: 0.1`: Export 10% of INFO/DEBUG, all ERROR/WARN
+- `samplingrate: 1.0`: Export all trace logs (full visibility, higher volume)
 - Action logs (request summaries) are always exported at 100% regardless of rate
 
 ## Consequences

--- a/wiki/adr_024_config_key_flatsmush.md
+++ b/wiki/adr_024_config_key_flatsmush.md
@@ -98,7 +98,13 @@ with the pre-existing flat `reconnect.delay` sibling and contradicts the
   not `…_SECRET_MIN_LENGTH`) — an inherent property of underscore-free keys.
 - **Guard against recurrence:** `TestConfigKoanfTagsHaveNoUnderscore`
   (`config/types_test.go`) reflects over the whole `Config` tree and fails if any
-  koanf tag contains an underscore, so the bug class cannot return.
+  tag contains an underscore. As first written it walked only `koanf` tags, which
+  left a blind spot: the `mapstructure`-tagged `observability` tree (loaded via a
+  separate section `Unmarshal`) was never visited, and four underscored keys there
+  stayed broken — see [#554](https://github.com/gaborage/go-bricks/issues/554). The
+  guard now also walks `mapstructure` tags, and a sibling
+  `observability.TestObservabilityConfigTagsHaveNoUnderscore` covers the
+  observability tree, so the bug class cannot return across either decode path.
 - **Out of scope (follow-up):** service configs consumed via `InjectInto` that put
   an underscore inside a `config:"…"` segment have the same env-reachability
   limitation; the convention is to use dotted segments. A separate effort tracks

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -32,6 +32,19 @@ Per [ADR-024](adr_024_config_key_flatsmush.md), 21 snake_case config keys were r
 
 > The "old env var" column never worked (that is the bug ADR-024 fixes); it is shown only to help locate occurrences in existing deployment manifests.
 
+## Observability Config Keys — Flat-Smushed Rename (#554)
+
+ADR-024 audited only the `koanf`-tagged keys in `config/types.go`. The `observability` config tree (`observability/config.go`) is tagged with `mapstructure` and loaded via a separate `config.Config.Unmarshal("observability", …)` path that binds by koanf tag or the case-insensitive Go field name and **never honors the `mapstructure` tag**. Four compound-word keys there carried underscores and so bound from neither YAML (the underscored key matched no field name) **nor** env (the loader maps `_`→`.`). [Issue #554](https://github.com/gaborage/go-bricks/issues/554) flat-smushed them to the same convention. Go field names are unchanged.
+
+| Old key (YAML, broken) | New key (YAML) | Old env var (broken) | New env var |
+|---|---|---|---|
+| `observability.metrics.histogram_aggregation` | `observability.metrics.histogramaggregation` | `OBSERVABILITY_METRICS_HISTOGRAM_AGGREGATION` | `OBSERVABILITY_METRICS_HISTOGRAMAGGREGATION` |
+| `observability.logs.disable_stdout` | `observability.logs.disablestdout` | `OBSERVABILITY_LOGS_DISABLE_STDOUT` | `OBSERVABILITY_LOGS_DISABLESTDOUT` |
+| `observability.logs.slow_request_threshold` | `observability.logs.slowrequestthreshold` | `OBSERVABILITY_LOGS_SLOW_REQUEST_THRESHOLD` | `OBSERVABILITY_LOGS_SLOWREQUESTTHRESHOLD` |
+| `observability.logs.sampling_rate` | `observability.logs.samplingrate` | `OBSERVABILITY_LOGS_SAMPLING_RATE` | `OBSERVABILITY_LOGS_SAMPLINGRATE` |
+
+> Unlike the ADR-024 keys (which still bound from YAML and broke only from env), these four never bound from YAML either — a service setting `observability.logs.sampling_rate` silently got the framework default. The recurrence guard now also walks `mapstructure` tags (`config.TestConfigKoanfTagsHaveNoUnderscore`) and a sibling `observability.TestObservabilityConfigTagsHaveNoUnderscore` covers the observability tree.
+
 ## Go Naming Conventions (S8179) — Getter Methods
 
 Per [SonarCloud rule S8179](https://rules.sonarsource.com/go/RSPEC-8179/), getter methods should NOT have the `Get` prefix.

--- a/wiki/new_relic_otlp.md
+++ b/wiki/new_relic_otlp.md
@@ -29,7 +29,7 @@ observability:
     protocol: grpc
     compression: gzip
     temporality: delta  # New Relic recommendation (lower memory, better performance)
-    histogram_aggregation: exponential  # Better precision, ~10x lower memory
+    histogramaggregation: exponential  # Better precision, ~10x lower memory
     headers:
       api-key: your-new-relic-license-key-here
 
@@ -39,7 +39,7 @@ observability:
     endpoint: otlp.nr-data.net:4317  # Reuse trace endpoint
     protocol: grpc
     compression: gzip
-    sampling_rate: 0.1  # Export 10% of INFO/DEBUG logs (ERROR/WARN always exported)
+    samplingrate: 0.1  # Export 10% of INFO/DEBUG logs (ERROR/WARN always exported)
     headers:
       api-key: your-new-relic-license-key-here
 ```
@@ -67,7 +67,7 @@ observability:
     protocol: http
     compression: gzip
     temporality: delta
-    histogram_aggregation: exponential
+    histogramaggregation: exponential
     headers:
       api-key: your-license-key
 
@@ -102,7 +102,7 @@ trace:
 |--------|--------|---------|--------------------------|
 | `compression` | `gzip`, `none` | `gzip` | **gzip** (~70% bandwidth reduction) |
 | `temporality` | `delta`, `cumulative` | `cumulative` | **delta** (lower memory, better performance) |
-| `histogram_aggregation` | `exponential`, `explicit` | `explicit` | **exponential** (better precision, ~10x lower memory) |
+| `histogramaggregation` | `exponential`, `explicit` | `explicit` | **exponential** (better precision, ~10x lower memory) |
 | `protocol` | `http`, `grpc` | `http` | **grpc** (lower latency, better performance) |
 
 ## Attribute Limits

--- a/wiki/observability.md
+++ b/wiki/observability.md
@@ -20,11 +20,11 @@ GoBricks provides production-grade observability built on OpenTelemetry: distrib
 
 **Dual-Mode Logging:** `DualModeLogProcessor` routes logs by `log.type`:
 - **Action logs** (`log.type="action"`): Always exported at 100% (request summaries)
-- **Trace logs** (`log.type="trace"`): ERROR/WARN always exported, INFO/DEBUG sampled by `sampling_rate`
-- Configure via `observability.logs.sampling_rate` (0.0-1.0, default 0.0 drops INFO/DEBUG)
+- **Trace logs** (`log.type="trace"`): ERROR/WARN always exported, INFO/DEBUG sampled by `samplingrate`
+- Configure via `observability.logs.samplingrate` (0.0-1.0, default 0.0 drops INFO/DEBUG)
 - Sampling is deterministic per trace (all logs in same trace sampled together)
 
-**Request Logging:** HTTP requests track severity escalation via `requestLogContext`. Automatic escalation from status codes (4xx→WARN, 5xx→ERROR). Explicit: `server.EscalateSeverity(c, zerolog.WarnLevel)`. Configure `observability.logs.slow_request_threshold` for slow request detection.
+**Request Logging:** HTTP requests track severity escalation via `requestLogContext`. Automatic escalation from status codes (4xx→WARN, 5xx→ERROR). Explicit: `server.EscalateSeverity(c, zerolog.WarnLevel)`. Configure `observability.logs.slowrequestthreshold` for slow request detection.
 
 **Testing:** Use `observability/testing` package:
 ```go

--- a/wiki/otel_collector.md
+++ b/wiki/otel_collector.md
@@ -162,7 +162,7 @@ observability:
     protocol: grpc
     compression: gzip
     temporality: delta  # Collector can convert if needed
-    histogram_aggregation: exponential
+    histogramaggregation: exponential
 
   logs:
     enabled: true


### PR DESCRIPTION
## Summary

Four observability config keys never bound from YAML and silently fell back to framework defaults:

| YAML key (broken) | Go field | Wrong result when set in YAML |
|---|---|---|
| `observability.metrics.histogram_aggregation` | `MetricsConfig.HistogramAggregation` | default `explicit` wins; exponential histograms never selected |
| `observability.logs.disable_stdout` | `LogsConfig.DisableStdout` | `disable_stdout: true` silently lost; stdout never disabled |
| `observability.logs.slow_request_threshold` | `LogsConfig.SlowRequestThreshold` | default `1s` wins |
| `observability.logs.sampling_rate` | `LogsConfig.SamplingRate` | default `0.0` wins |

**Root cause.** The observability tree loads via `Config.Unmarshal("observability", &obsCfg)` (`app/bootstrap.go`), which calls plain `koanf.Unmarshal`. Plain koanf binds by the `koanf` tag or, when absent, the case-insensitive Go **field name** — it never honors the `mapstructure` tag. The observability structs carry only `mapstructure` tags, so single-word keys bind by the field-name fallback, but the four underscored keys match neither a `koanf` tag nor the smushed field name and are dropped. (Empirically verified: underscored → zero values; smushed → bind.)

This is the same env-unreachable bug class PR #549 fixed for `config/types.go` — but worse: #549's keys still bound from YAML, these never did. #549's recurrence guard walked only `koanf` tags from `config.Config`, so it never visited the `mapstructure`-only observability tree — the invariant had a blind spot exactly here.

## Fix (issue options a + d)

- **Flat-smush the four `mapstructure` tags** (`histogramaggregation`, `disablestdout`, `slowrequestthreshold`, `samplingrate`) so the tag matches the key the field-name fallback actually binds, consistent with #549's framework-wide convention (`dialtimeout`, `connectiontimeout`, …). **Go field names unchanged → no consumer code changes.**
- **Broaden `config.TestConfigKoanfTagsHaveNoUnderscore`** to also walk `mapstructure` tags (skipping unexported fields), closing the blind spot.
- **Add `observability.TestObservabilityConfigTagsHaveNoUnderscore`** — the parallel, load-bearing rename guard over the observability tree.
- **Add `TestConfigUnmarshalCompoundKeysBindFromYAML`** pinning both halves of the contract: the smushed form binds, the underscored form is silently dropped.
- Note the second plain-`Unmarshal` load path (`tools/migration/.../common.go`) and its dependence on the invariant.
- Update docs (llms.txt, README, wiki) to the smushed keys; add a `migrations.md` entry; correct the now-true "cannot return" claim in ADR-024.

## Breaking change

The underscored YAML/env forms (which never worked from YAML) are replaced by the flat-smushed forms. Migration table added to `wiki/migrations.md`. Real-world impact is limited to configs that currently silently no-op.

## Verification

- `make check` passes (fmt + lint + race tests); the separate `tools/migration` module builds.
- New invariant test proven RED→GREEN (failed with exactly the 4 offenders, passes after the rename).
- Reviewed via `/code-review` and `/security-review`: no surviving findings.

Closes #554.

> Suggested labels (please apply on triage): `bug`, `area/observability`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Renamed observability configuration keys to flat-smushed format: `slow_request_threshold` → `slowrequestthreshold`, `sampling_rate` → `samplingrate`, `histogram_aggregation` → `histogramaggregation`, `disable_stdout` → `disablestdout`. Update your YAML and environment variables accordingly.

* **Tests**
  * Enhanced validation to prevent underscore-containing configuration keys from reoccurring.

* **Documentation**
  * Updated observability, configuration, and migration documentation to reflect new key names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->