### PR TITLE
fix(database): default pool idle connections to track max (ADR-025)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -42,7 +42,8 @@ database:
     max:
       connections: 25
     idle:
-      connections: 5
+      # connections defaults to max.connections (idle cap; avoids connection churn under load).
+      # Override only to deliberately release idle connections back to the database.
       time: 4m                     # Recycle idle connections before NAT/LB timeout (AWS: 350s)
     lifetime:
       max: 30m

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -523,7 +523,9 @@ func TestLoadDatabaseCompleteConfig(t *testing.T) {
 	os.Setenv("DATABASE_PORT", "5432")
 	os.Setenv(testDatabaseDatabase, "testdb")
 	os.Setenv(testDatabaseUsername, "testuser")
-	os.Setenv(testDatabaseMaxConns, "25")
+	// Use a non-default max (40 != defaultPoolMaxConnections) so the idle-tracks-max
+	// assertion below proves idle follows the *configured* max, not a constant.
+	os.Setenv(testDatabaseMaxConns, "40")
 
 	cfg, err := Load()
 	require.NoError(t, err)
@@ -536,10 +538,10 @@ func TestLoadDatabaseCompleteConfig(t *testing.T) {
 	assert.Equal(t, 5432, cfg.Database.Port)
 	assert.Equal(t, "testdb", cfg.Database.Database)
 	assert.Equal(t, "testuser", cfg.Database.Username)
-	assert.Equal(t, int32(25), cfg.Database.Pool.Max.Connections)
+	assert.Equal(t, int32(40), cfg.Database.Pool.Max.Connections)
 
 	// Verify production-safe pool defaults are applied
-	assert.Equal(t, int32(2), cfg.Database.Pool.Idle.Connections)         // Default: warm connections
+	assert.Equal(t, int32(40), cfg.Database.Pool.Idle.Connections)        // Default: idle tracks the configured max (40), not a constant
 	assert.Equal(t, 5*time.Minute, cfg.Database.Pool.Idle.Time)           // Default: idle timeout
 	assert.Equal(t, 30*time.Minute, cfg.Database.Pool.Lifetime.Max)       // Default: max lifetime
 	assert.True(t, cfg.Database.Pool.KeepAlive.Enabled)                   // Default: keep-alive enabled

--- a/config/types.go
+++ b/config/types.go
@@ -139,7 +139,7 @@ type DatabaseConfig struct {
 // PoolConfig holds connection pool settings.
 // Production-safe defaults are applied automatically when database is configured:
 //   - Max.Connections: 25 (maximum open connections)
-//   - Idle.Connections: 2 (minimum warm connections)
+//   - Idle.Connections: tracks Max.Connections (idle cap, avoids connection churn)
 //   - Idle.Time: 5m (close idle connections before NAT/firewall timeout)
 //   - Lifetime.Max: 30m (periodic connection recycling)
 //   - KeepAlive.Enabled: true (TCP keep-alive probes)
@@ -160,8 +160,12 @@ type PoolMaxConfig struct {
 
 // PoolIdleConfig holds idle connections settings.
 type PoolIdleConfig struct {
-	// Connections is the minimum number of idle connections to maintain in the pool.
-	// Default: 2. Maintains warm connections to reduce cold-start latency.
+	// Connections is the maximum number of idle connections kept open in the pool.
+	// This is a cap (database/sql clamps it to Max.Connections), not a floor — the
+	// pool does not pre-warm connections.
+	// Default: tracks Max.Connections. Keeping idle below max causes the pool to
+	// churn physical connections under sustained load; set a lower value only when
+	// you deliberately want to release idle connections back to the database.
 	Connections int32 `koanf:"connections" json:"connections" yaml:"connections" toml:"connections" mapstructure:"connections"`
 
 	// Time is the maximum duration an idle connection may remain unused before closing.

--- a/config/validation.go
+++ b/config/validation.go
@@ -12,13 +12,13 @@ import (
 
 // Database pool defaults
 const (
-	defaultSlowQueryThreshold  = 200 * time.Millisecond
-	defaultMaxQueryLength      = 1000
-	defaultKeepAliveEnabled    = true
-	defaultKeepAliveInterval   = 60 * time.Second
-	defaultPoolIdleTime        = 5 * time.Minute  // Close idle connections before NAT/firewall timeout
-	defaultPoolLifetimeMax     = 30 * time.Minute // Force periodic connection recycling
-	defaultPoolIdleConnections = int32(2)         // Maintain minimal warm connections
+	defaultSlowQueryThreshold = 200 * time.Millisecond
+	defaultMaxQueryLength     = 1000
+	defaultKeepAliveEnabled   = true
+	defaultKeepAliveInterval  = 60 * time.Second
+	defaultPoolIdleTime       = 5 * time.Minute  // Close idle connections before NAT/firewall timeout
+	defaultPoolLifetimeMax    = 30 * time.Minute // Force periodic connection recycling
+	defaultPoolMaxConnections = int32(25)        // Maximum open connections (tune to workload/server capacity)
 )
 
 // Database session defaults
@@ -346,27 +346,15 @@ func validateRequiredDatabasePort(port int) error {
 	return nil
 }
 
-// applyDatabasePoolDefaults sets production-safe defaults and validates database pool/query/session settings.
-//
-// It modifies cfg in-place:
-// - Timezone: if empty, sets to "UTC"; validates with time.LoadLocation unless set to "-".
-// - Pool.Max.Connections: if 0, sets to 25; if negative, returns an error.
-// - Pool.Idle.Connections: if 0, sets to 2 (minimal warm connections); if negative, returns an error.
-// - Pool.Idle.Time: if 0, sets to 5m (closes idle connections before NAT/firewall timeout); if negative, returns an error.
-// - Pool.Lifetime.Max: if 0, sets to 30m (forces periodic connection recycling); if negative, returns an error.
-// - Pool.KeepAlive.Enabled: if Interval is 0, sets to true (recommended for cloud).
-// - Pool.KeepAlive.Interval: if 0, sets to 60s (below typical NAT timeouts).
-// - Query.Log.MaxLength: if negative, returns an error; if 0, sets to defaultMaxQueryLength.
-// - Query.Slow.Threshold: if negative, returns an error; if 0, sets to defaultSlowQueryThreshold.
-//
-// Returns an error when any value is invalid; otherwise returns nil.
-func applyDatabasePoolDefaults(cfg *DatabaseConfig) error {
-	if err := applyDatabaseTimezoneDefault(cfg); err != nil {
-		return err
-	}
-
+// applyPoolConnectionDefaults defaults and validates the max/idle connection
+// counts. Max is defaulted first; idle then defaults to — and is capped at — max
+// so the pool reuses warm connections instead of churning them (TCP+TLS+auth) on
+// every burst. database/sql caps idle at max-open, so an explicit idle above max
+// is clamped here to keep the reported value (startup log, Stats(), OTEL gauges)
+// truthful. An explicit idle below max is honored. See ADR-025.
+func applyPoolConnectionDefaults(cfg *DatabaseConfig) error {
 	if cfg.Pool.Max.Connections == 0 {
-		cfg.Pool.Max.Connections = 25
+		cfg.Pool.Max.Connections = defaultPoolMaxConnections
 	} else if cfg.Pool.Max.Connections < 0 {
 		return NewValidationError("database.pool.max.connections", errMustBeNonNegative)
 	}
@@ -374,9 +362,33 @@ func applyDatabasePoolDefaults(cfg *DatabaseConfig) error {
 	if cfg.Pool.Idle.Connections < 0 {
 		return NewValidationError("database.pool.idle.connections", errMustBeNonNegative)
 	}
-	// Apply default idle connections if not configured
-	if cfg.Pool.Idle.Connections == 0 {
-		cfg.Pool.Idle.Connections = defaultPoolIdleConnections
+	if cfg.Pool.Idle.Connections == 0 || cfg.Pool.Idle.Connections > cfg.Pool.Max.Connections {
+		cfg.Pool.Idle.Connections = cfg.Pool.Max.Connections
+	}
+	return nil
+}
+
+// applyDatabasePoolDefaults sets production-safe defaults and validates database pool/query/session settings.
+//
+// It modifies cfg in-place:
+//   - Timezone: if empty, sets to "UTC"; validates with time.LoadLocation unless set to "-".
+//   - Pool.Max.Connections / Pool.Idle.Connections: defaulted and validated by
+//     applyPoolConnectionDefaults (idle defaults to and is capped at max; see ADR-025).
+//   - Pool.Idle.Time: if 0, sets to 5m (closes idle connections before NAT/firewall timeout); if negative, returns an error.
+//   - Pool.Lifetime.Max: if 0, sets to 30m (forces periodic connection recycling); if negative, returns an error.
+//   - Pool.KeepAlive.Enabled: if Interval is 0, sets to true (recommended for cloud).
+//   - Pool.KeepAlive.Interval: if 0, sets to 60s (below typical NAT timeouts).
+//   - Query.Log.MaxLength: if negative, returns an error; if 0, sets to defaultMaxQueryLength.
+//   - Query.Slow.Threshold: if negative, returns an error; if 0, sets to defaultSlowQueryThreshold.
+//
+// Returns an error when any value is invalid; otherwise returns nil.
+func applyDatabasePoolDefaults(cfg *DatabaseConfig) error {
+	if err := applyDatabaseTimezoneDefault(cfg); err != nil {
+		return err
+	}
+
+	if err := applyPoolConnectionDefaults(cfg); err != nil {
+		return err
 	}
 
 	// Apply default idle time - closes connections before NAT/firewall timeout

--- a/config/validation.go
+++ b/config/validation.go
@@ -346,13 +346,13 @@ func validateRequiredDatabasePort(port int) error {
 	return nil
 }
 
-// applyPoolConnectionDefaults defaults and validates the max/idle connection
+// applyConnectionCountDefaults defaults and validates the max/idle connection
 // counts. Max is defaulted first; idle then defaults to — and is capped at — max
 // so the pool reuses warm connections instead of churning them (TCP+TLS+auth) on
 // every burst. database/sql caps idle at max-open, so an explicit idle above max
 // is clamped here to keep the reported value (startup log, Stats(), OTEL gauges)
 // truthful. An explicit idle below max is honored. See ADR-025.
-func applyPoolConnectionDefaults(cfg *DatabaseConfig) error {
+func applyConnectionCountDefaults(cfg *DatabaseConfig) error {
 	if cfg.Pool.Max.Connections == 0 {
 		cfg.Pool.Max.Connections = defaultPoolMaxConnections
 	} else if cfg.Pool.Max.Connections < 0 {
@@ -373,7 +373,7 @@ func applyPoolConnectionDefaults(cfg *DatabaseConfig) error {
 // It modifies cfg in-place:
 //   - Timezone: if empty, sets to "UTC"; validates with time.LoadLocation unless set to "-".
 //   - Pool.Max.Connections / Pool.Idle.Connections: defaulted and validated by
-//     applyPoolConnectionDefaults (idle defaults to and is capped at max; see ADR-025).
+//     applyConnectionCountDefaults (idle defaults to and is capped at max; see ADR-025).
 //   - Pool.Idle.Time: if 0, sets to 5m (closes idle connections before NAT/firewall timeout); if negative, returns an error.
 //   - Pool.Lifetime.Max: if 0, sets to 30m (forces periodic connection recycling); if negative, returns an error.
 //   - Pool.KeepAlive.Enabled: if Interval is 0, sets to true (recommended for cloud).
@@ -387,7 +387,7 @@ func applyDatabasePoolDefaults(cfg *DatabaseConfig) error {
 		return err
 	}
 
-	if err := applyPoolConnectionDefaults(cfg); err != nil {
+	if err := applyConnectionCountDefaults(cfg); err != nil {
 		return err
 	}
 

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -1607,7 +1607,7 @@ func TestApplyDatabasePoolDefaultsIdleAndLifetime(t *testing.T) {
 			},
 			expectedIdleTime:        defaultPoolIdleTime,
 			expectedLifetimeMax:     defaultPoolLifetimeMax,
-			expectedIdleConnections: defaultPoolIdleConnections,
+			expectedIdleConnections: defaultPoolMaxConnections,
 		},
 		{
 			name: "explicit_values_preserved",
@@ -1641,8 +1641,8 @@ func TestApplyDatabasePoolDefaultsIdleAndLifetime(t *testing.T) {
 				},
 			},
 			expectedIdleTime:        3 * time.Minute,
-			expectedLifetimeMax:     defaultPoolLifetimeMax,     // Default applied
-			expectedIdleConnections: defaultPoolIdleConnections, // Default applied
+			expectedLifetimeMax:     defaultPoolLifetimeMax,    // Default applied
+			expectedIdleConnections: defaultPoolMaxConnections, // Default applied
 		},
 		{
 			name: "only_idle_connections_set",
@@ -1672,9 +1672,42 @@ func TestApplyDatabasePoolDefaultsIdleAndLifetime(t *testing.T) {
 					Lifetime: LifetimeConfig{Max: 15 * time.Minute},
 				},
 			},
-			expectedIdleTime:        defaultPoolIdleTime,        // Default applied
-			expectedLifetimeMax:     15 * time.Minute,           // Explicit value preserved
-			expectedIdleConnections: defaultPoolIdleConnections, // Default applied
+			expectedIdleTime:        defaultPoolIdleTime,       // Default applied
+			expectedLifetimeMax:     15 * time.Minute,          // Explicit value preserved
+			expectedIdleConnections: defaultPoolMaxConnections, // Default applied
+		},
+		{
+			name: "idle_tracks_custom_max",
+			config: DatabaseConfig{
+				Type:     PostgreSQL,
+				Host:     "localhost",
+				Port:     5432,
+				Database: "testdb",
+				Username: "testuser",
+				Pool: PoolConfig{
+					Max: PoolMaxConfig{Connections: 10}, // Custom max, idle left unset
+				},
+			},
+			expectedIdleTime:        defaultPoolIdleTime,
+			expectedLifetimeMax:     defaultPoolLifetimeMax,
+			expectedIdleConnections: 10, // Idle defaults to track the configured max, never the old fixed 2
+		},
+		{
+			name: "explicit_idle_above_max_clamped",
+			config: DatabaseConfig{
+				Type:     PostgreSQL,
+				Host:     "localhost",
+				Port:     5432,
+				Database: "testdb",
+				Username: "testuser",
+				Pool: PoolConfig{
+					Max:  PoolMaxConfig{Connections: 10},
+					Idle: PoolIdleConfig{Connections: 50}, // Explicit idle above max
+				},
+			},
+			expectedIdleTime:        defaultPoolIdleTime,
+			expectedLifetimeMax:     defaultPoolLifetimeMax,
+			expectedIdleConnections: 10, // Clamped to max — database/sql caps idle at max-open anyway
 		},
 	}
 
@@ -1727,6 +1760,21 @@ func TestApplyDatabasePoolDefaultsNegativeValues(t *testing.T) {
 				},
 			},
 			errorContains: "database.pool.lifetime.max",
+		},
+		{
+			name: "negative_idle_connections_rejected",
+			config: DatabaseConfig{
+				Type:     PostgreSQL,
+				Host:     "localhost",
+				Port:     5432,
+				Database: "testdb",
+				Username: "testuser",
+				Pool: PoolConfig{
+					Max:  PoolMaxConfig{Connections: 25},
+					Idle: PoolIdleConfig{Connections: -1},
+				},
+			},
+			errorContains: "database.pool.idle.connections",
 		},
 	}
 

--- a/database/internal/tracking/metrics.go
+++ b/database/internal/tracking/metrics.go
@@ -31,9 +31,9 @@ const (
 	// metricDBConnectionIdleMin maps to OTEL semconv "db.client.connection.idle.min".
 	// Go's database/sql exposes a single idle knob (SetMaxIdleConns), so this gauge
 	// shares its source value (Pool.Idle.Connections) with idle.max; it is emitted under
-	// the semconv idle.min name because the framework treats Pool.Idle.Connections as the
-	// configured warm-pool target. See config.PoolIdleConfig.
-	metricDBConnectionIdleMin = "db.client.connection.idle.min" // Configured idle-connection target (semconv idle.min)
+	// the semconv idle.min name even though Pool.Idle.Connections is a cap, not a floor
+	// (database/sql does not pre-warm), and now defaults to tracking max. See config.PoolIdleConfig.
+	metricDBConnectionIdleMin = "db.client.connection.idle.min" // Configured idle-connection cap (semconv idle.min)
 	metricDBConnectionMax     = "db.client.connection.max"      // Max configured connections
 
 	// Pool saturation metrics per OTEL semconv

--- a/database/internal/wrapper/connection.go
+++ b/database/internal/wrapper/connection.go
@@ -85,8 +85,8 @@ func (c *Connection) Health(ctx context.Context) error {
 
 // Stats returns database connection statistics in a map suitable for logging
 // or metrics tracking. When Config is non-nil, the configured idle-connection
-// target is included for visibility (Go's sql.DB doesn't enforce a minimum
-// idle count; this is purely a configured target).
+// cap is included for visibility (Go's sql.DB treats the idle setting as a cap,
+// not a floor — it does not pre-warm or maintain a minimum idle count).
 func (c *Connection) Stats() (map[string]any, error) {
 	stats := c.DB.Stats()
 	result := map[string]any{
@@ -102,15 +102,28 @@ func (c *Connection) Stats() (map[string]any, error) {
 	}
 
 	if c.Config != nil {
-		// Go's database/sql exposes a single idle knob (SetMaxIdleConns). The tracking
-		// layer surfaces it under both OTEL semconv gauges -- idle.max (hard cap) and
-		// idle.min (configured warm-pool target) -- so both keys intentionally carry the
-		// same configured value. See database/internal/tracking/metrics.go.
+		// Go's database/sql exposes a single idle knob (SetMaxIdleConns), which is a
+		// cap (not a floor — the driver never pre-warms). The tracking layer surfaces
+		// it under both OTEL semconv gauges -- idle.max and idle.min -- so both keys
+		// intentionally carry the same configured value. See
+		// database/internal/tracking/metrics.go.
 		result["max_idle_connections"] = int(c.Config.Pool.Idle.Connections)
 		result["configured_idle_connections"] = int(c.Config.Pool.Idle.Connections)
 	}
 
 	return result, nil
+}
+
+// AppendPoolFields adds the effective connection-pool settings to a log event so
+// operators can confirm what the pool actually uses after defaulting. Shared by
+// the PostgreSQL and Oracle connection layers so the logged field set cannot
+// drift between vendors.
+func AppendPoolFields(ev logger.LogEvent, cfg *config.DatabaseConfig) logger.LogEvent {
+	return ev.
+		Int("pool_max_connections", int(cfg.Pool.Max.Connections)).
+		Int("pool_idle_connections", int(cfg.Pool.Idle.Connections)).
+		Dur("pool_max_lifetime", cfg.Pool.Lifetime.Max).
+		Dur("pool_idle_time", cfg.Pool.Idle.Time)
 }
 
 // Close closes the underlying *sql.DB, unregisters the metrics callback (if

--- a/database/internal/wrapper/connection_test.go
+++ b/database/internal/wrapper/connection_test.go
@@ -1,0 +1,49 @@
+package wrapper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gaborage/go-bricks/config"
+	"github.com/gaborage/go-bricks/logger"
+)
+
+// recordingLogEvent is a logger.LogEvent test double that records field values
+// instead of emitting them, so tests can assert on what AppendPoolFields adds.
+type recordingLogEvent struct {
+	fields map[string]any
+}
+
+func newRecordingLogEvent() *recordingLogEvent {
+	return &recordingLogEvent{fields: map[string]any{}}
+}
+
+func (e *recordingLogEvent) Msg(string)                                    {}
+func (e *recordingLogEvent) Msgf(string, ...any)                           {}
+func (e *recordingLogEvent) Err(error) logger.LogEvent                     { return e }
+func (e *recordingLogEvent) Str(k, v string) logger.LogEvent               { e.fields[k] = v; return e }
+func (e *recordingLogEvent) Int(k string, v int) logger.LogEvent           { e.fields[k] = v; return e }
+func (e *recordingLogEvent) Int64(k string, v int64) logger.LogEvent       { e.fields[k] = v; return e }
+func (e *recordingLogEvent) Uint64(k string, v uint64) logger.LogEvent     { e.fields[k] = v; return e }
+func (e *recordingLogEvent) Dur(k string, d time.Duration) logger.LogEvent { e.fields[k] = d; return e }
+func (e *recordingLogEvent) Interface(k string, i any) logger.LogEvent     { e.fields[k] = i; return e }
+func (e *recordingLogEvent) Bytes(k string, v []byte) logger.LogEvent      { e.fields[k] = v; return e }
+func (e *recordingLogEvent) Bool(k string, v bool) logger.LogEvent         { e.fields[k] = v; return e }
+
+func TestAppendPoolFields(t *testing.T) {
+	cfg := &config.DatabaseConfig{}
+	cfg.Pool.Max.Connections = 25
+	cfg.Pool.Idle.Connections = 25
+	cfg.Pool.Lifetime.Max = 30 * time.Minute
+	cfg.Pool.Idle.Time = 5 * time.Minute
+
+	ev := newRecordingLogEvent()
+	AppendPoolFields(ev, cfg).Msg("connected")
+
+	assert.Equal(t, 25, ev.fields["pool_max_connections"])
+	assert.Equal(t, 25, ev.fields["pool_idle_connections"])
+	assert.Equal(t, 30*time.Minute, ev.fields["pool_max_lifetime"])
+	assert.Equal(t, 5*time.Minute, ev.fields["pool_idle_time"])
+}

--- a/database/oracle/connection.go
+++ b/database/oracle/connection.go
@@ -296,7 +296,7 @@ func logConnectionSuccess(log logger.Logger, cfg *config.DatabaseConfig) {
 		ev = ev.Str("database", cfg.Database)
 	}
 
-	ev.Msg("Connected to Oracle database")
+	wrapper.AppendPoolFields(ev, cfg).Msg("Connected to Oracle database")
 }
 
 // Oracle re-exports the vendor-agnostic wrappers; see database/internal/wrapper.

--- a/database/postgresql/connection.go
+++ b/database/postgresql/connection.go
@@ -174,11 +174,11 @@ func NewConnection(cfg *config.DatabaseConfig, log logger.Logger) (types.Interfa
 		return nil, fmt.Errorf("failed to ping PostgreSQL database: %w", err)
 	}
 
-	log.Info().
+	ev := log.Info().
 		Str("host", cfg.Host).
 		Int("port", cfg.Port).
-		Str("database", cfg.Database).
-		Msg("Connected to PostgreSQL database")
+		Str("database", cfg.Database)
+	wrapper.AppendPoolFields(ev, cfg).Msg("Connected to PostgreSQL database")
 
 	conn := &Connection{
 		Connection: &wrapper.Connection{

--- a/llms.txt
+++ b/llms.txt
@@ -318,7 +318,7 @@ database:
     max:
       connections: 25                     # Max open connections (default 25)
     idle:
-      connections: 2                      # Min warm connections
+      # connections defaults to max.connections (idle cap, avoids churn); override only to release idle conns
       time: 5m                            # Recycle idle connections (NAT/firewall hygiene)
     lifetime:
       max: 30m                            # Force periodic reconnect (DNS rotation)

--- a/wiki/adr_025_pool_idle_tracks_max.md
+++ b/wiki/adr_025_pool_idle_tracks_max.md
@@ -43,9 +43,9 @@ so idle can never exceed max regardless of how it is configured.
 
 ## Decision
 
-In `applyDatabasePoolDefaults`, when `database.pool.idle.connections` is unset
-(zero), default it to the effective `database.pool.max.connections` instead of a
-fixed `2`. Max is defaulted first, so idle always tracks the resolved max. An
+In `applyPoolConnectionDefaults` (a helper called from `applyDatabasePoolDefaults`),
+when `database.pool.idle.connections` is unset (zero), default it to the effective
+`database.pool.max.connections` instead of a fixed `2`. Max is defaulted first, so idle always tracks the resolved max. An
 explicit idle *below* max is honored; an explicit idle *above* max is clamped to
 max (since `database/sql` caps idle at max-open, clamping keeps the value the
 framework reports — startup log, `Stats()`, OTEL idle gauges — equal to what the
@@ -57,6 +57,9 @@ Supporting changes:
   semantics never existed) and extract the previously-inline `25` into a named
   `defaultPoolMaxConnections` const, so both pool defaults are explicit and
   greppable (Explicit > Implicit).
+- Extract the max/idle defaulting and clamp into a focused
+  `applyPoolConnectionDefaults` helper, keeping the `applyDatabasePoolDefaults`
+  orchestrator within its cyclomatic-complexity budget.
 - Correct the misleading "minimum warm connections" wording in `config/types.go`
   and `wiki/database.md` to describe idle as a cap that tracks max.
 - Log the effective `pool_max_connections` / `pool_idle_connections` /

--- a/wiki/adr_025_pool_idle_tracks_max.md
+++ b/wiki/adr_025_pool_idle_tracks_max.md
@@ -43,7 +43,7 @@ so idle can never exceed max regardless of how it is configured.
 
 ## Decision
 
-In `applyPoolConnectionDefaults` (a helper called from `applyDatabasePoolDefaults`),
+In `applyConnectionCountDefaults` (a helper called from `applyDatabasePoolDefaults`),
 when `database.pool.idle.connections` is unset (zero), default it to the effective
 `database.pool.max.connections` instead of a fixed `2`. Max is defaulted first, so idle always tracks the resolved max. An
 explicit idle *below* max is honored; an explicit idle *above* max is clamped to
@@ -58,7 +58,7 @@ Supporting changes:
   `defaultPoolMaxConnections` const, so both pool defaults are explicit and
   greppable (Explicit > Implicit).
 - Extract the max/idle defaulting and clamp into a focused
-  `applyPoolConnectionDefaults` helper, keeping the `applyDatabasePoolDefaults`
+  `applyConnectionCountDefaults` helper, keeping the `applyDatabasePoolDefaults`
   orchestrator within its cyclomatic-complexity budget.
 - Correct the misleading "minimum warm connections" wording in `config/types.go`
   and `wiki/database.md` to describe idle as a cap that tracks max.

--- a/wiki/adr_025_pool_idle_tracks_max.md
+++ b/wiki/adr_025_pool_idle_tracks_max.md
@@ -1,0 +1,108 @@
+# ADR-025: Connection Pool Idle Connections Default to Track Max
+
+**Status:** Accepted
+**Date:** 2026-06-06
+
+## Context
+
+`applyDatabasePoolDefaults` (`config/validation.go`) applies production-safe pool
+defaults when the corresponding values are zero. Two of those defaults interacted
+badly:
+
+- `database.pool.max.connections` → **25** (maximum open connections)
+- `database.pool.idle.connections` → **2** (a fixed `defaultPoolIdleConnections`)
+
+Defaulting idle to a fixed `2` against a max of `25` means that under sustained
+load the pool opens up to 25 physical connections to serve concurrent work but
+keeps only 2 of them idle. Every connection beyond the second is **closed** as
+soon as it goes idle and **re-opened** (TCP + TLS + auth) on the next burst —
+continuous connection churn. The const name `defaultPoolIdleConnections` and the
+config docs called this "minimum warm connections," but `database/sql` has no
+floor concept: `SetMaxIdleConns` is a **cap**, not a minimum, and the driver
+never pre-warms connections.
+
+Profiling the framework with a connection-reusing read workload at 2000 req/s
+(70% list / 30% get, PostgreSQL) made the cost concrete. With the shipped
+default (idle 2 / max 25) the run showed connection-establishment failures
+surfacing as HTTP 500s and a long tail dominated by `pgx` connect / TLS handshake
+allocations. Raising idle to match max eliminated the churn:
+
+| Config | p95 | p99 | errors | warm backends |
+|---|---|---|---|---|
+| idle 2 / max 25 (shipped default) | 16.25 ms | 38.19 ms | 8.15% | 3 (churning) |
+| idle = max (A/B run at max 50) | 1.46 ms | 2.20 ms | 0% | 51 (warm) |
+
+That is a 91% p95 / 94% p99 reduction and errors to zero, achieved purely by not
+discarding warm connections. (The pooled A/B raised max to 50 and set idle = max,
+so the warm-backend count reflects the larger pool plus one system backend; the
+mechanism — reusing warm connections instead of churning them — is what removes
+the latency and errors, independent of the absolute pool size.) `database/sql`
+already guarantees the safety of the change: `SetMaxIdleConns` clamps the idle
+count to the open-connection max (verified in Go 1.26.4 `src/database/sql/sql.go`),
+so idle can never exceed max regardless of how it is configured.
+
+## Decision
+
+In `applyDatabasePoolDefaults`, when `database.pool.idle.connections` is unset
+(zero), default it to the effective `database.pool.max.connections` instead of a
+fixed `2`. Max is defaulted first, so idle always tracks the resolved max. An
+explicit idle *below* max is honored; an explicit idle *above* max is clamped to
+max (since `database/sql` caps idle at max-open, clamping keeps the value the
+framework reports — startup log, `Stats()`, OTEL idle gauges — equal to what the
+driver actually enforces). The negative-value validation is unchanged.
+
+Supporting changes:
+
+- Remove the `defaultPoolIdleConnections` const (its "minimum warm connections"
+  semantics never existed) and extract the previously-inline `25` into a named
+  `defaultPoolMaxConnections` const, so both pool defaults are explicit and
+  greppable (Explicit > Implicit).
+- Correct the misleading "minimum warm connections" wording in `config/types.go`
+  and `wiki/database.md` to describe idle as a cap that tracks max.
+- Log the effective `pool_max_connections` / `pool_idle_connections` /
+  `pool_max_lifetime` / `pool_idle_time` at `Info` on every successful
+  connection (both PostgreSQL and Oracle vendors), so the resolved pool shape is
+  observable at startup.
+
+The fix lives entirely in `config/validation.go`. Both vendor connection layers
+(`database/postgresql/connection.go`, `database/oracle/connection.go`) read the
+**defaulted** config value, and named / per-tenant databases route through the
+same `applyDatabasePoolDefaults` call site, so no vendor-specific edit is needed.
+
+Rejected alternatives:
+
+- **Keep idle at a fixed `2`:** preserves the churn pathology that motivated the
+  change; the perf win is unobtainable without idle tracking max.
+- **Default idle to `min(max, cap)` (e.g. cap at 10):** a partial fix — the pool
+  still churns connections between the cap and max under load, reintroducing the
+  problem the change exists to remove.
+- **Bump idle in each vendor's `connection.go`:** redundant. The vendors already
+  consume the config value; centralizing in config covers main, named, and
+  per-tenant databases with one edit.
+- **Make it opt-in (new flag, keep `2`):** leaves every default deployment on the
+  slow, error-prone path; the safe, churn-free behavior should be the default.
+
+## Consequences
+
+- **Behavioral / capacity change (apiImpact: none):** an application that left
+  `pool.idle.connections` unset previously settled to 2 idle connections and now
+  holds up to `pool.max.connections` (default 25), still reaped after
+  `pool.idle.time` (5m). For multi-tenant deployments the per-tenant idle ceiling
+  rises up to ~12.5×; operators should confirm their PostgreSQL `max_connections`
+  / Oracle session budget. Documented in [migrations.md](migrations.md#connection-pool-idle-default--tracks-max-adr-025).
+- **Observability shift:** the connection-pool idle gauges and the `Stats()`
+  `max_idle_connections` / `configured_idle_connections` keys now report the
+  effective max rather than `2`. Dashboards/alerts keyed to `idle == 2` must be
+  updated.
+- **Opt-out is explicit:** set `database.pool.idle.connections` to any value to
+  override; explicit configuration is unchanged by this ADR.
+- **Guard tests:** `TestApplyDatabasePoolDefaultsIdleAndLifetime` now asserts that
+  an unset idle tracks the resolved max (including a custom `max=10` case), and
+  that an explicit idle below max is preserved.
+
+## Related
+
+- ADR-016 (database session timezone), ADR-022/ADR-023/ADR-024 — other small,
+  breaking config-default/convention changes.
+- ADR-003 (database by intent) — pool defaults apply only when a database is
+  explicitly configured.

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -263,7 +263,7 @@ tracking `database.pool.max.connections` (default 25). A fixed idle of 2 against
 max of 25 made the pool churn physical connections (TCP+TLS+auth) under sustained
 load — profiling showed p95 16.25→1.46 ms and errors 8.15%→0% once idle tracked
 max. `database/sql` caps idle at max, so the change is safe; an explicit idle
-value still wins. Centralized in `applyDatabasePoolDefaults` (covers PostgreSQL,
+value still wins. Centralized in `applyPoolConnectionDefaults` (called from `applyDatabasePoolDefaults`, covers PostgreSQL,
 Oracle, named, and per-tenant DBs); effective pool settings are now logged at
 startup. Behavioral change: idle footprint rises (notably per-tenant) and idle
 metrics report max rather than 2.

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -263,7 +263,7 @@ tracking `database.pool.max.connections` (default 25). A fixed idle of 2 against
 max of 25 made the pool churn physical connections (TCP+TLS+auth) under sustained
 load — profiling showed p95 16.25→1.46 ms and errors 8.15%→0% once idle tracked
 max. `database/sql` caps idle at max, so the change is safe; an explicit idle
-value still wins. Centralized in `applyPoolConnectionDefaults` (called from `applyDatabasePoolDefaults`, covers PostgreSQL,
+value still wins. Centralized in `applyConnectionCountDefaults` (called from `applyDatabasePoolDefaults`, covers PostgreSQL,
 Oracle, named, and per-tenant DBs); effective pool settings are now logged at
 startup. Behavioral change: idle footprint rises (notably per-tenant) and idle
 metrics report max rather than 2.

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -254,6 +254,24 @@ old snake_case YAML/env keys fall back to defaults.
 
 ---
 
+### [ADR-025: Connection Pool Idle Connections Default to Track Max](adr_025_pool_idle_tracks_max.md)
+
+**Date:** 2026-06-06 | **Status:** Accepted
+
+Changes the default for `database.pool.idle.connections` from a fixed `2` to
+tracking `database.pool.max.connections` (default 25). A fixed idle of 2 against a
+max of 25 made the pool churn physical connections (TCP+TLS+auth) under sustained
+load — profiling showed p95 16.25→1.46 ms and errors 8.15%→0% once idle tracked
+max. `database/sql` caps idle at max, so the change is safe; an explicit idle
+value still wins. Centralized in `applyDatabasePoolDefaults` (covers PostgreSQL,
+Oracle, named, and per-tenant DBs); effective pool settings are now logged at
+startup. Behavioral change: idle footprint rises (notably per-tenant) and idle
+metrics report max rather than 2.
+
+**Key Benefits:** Eliminates connection churn, removes a class of connection-establishment errors, makes effective pool config observable
+
+---
+
 ## ADR Lifecycle
 
 - **Proposed**: Under discussion, not yet implemented
@@ -263,7 +281,7 @@ old snake_case YAML/env keys fall back to defaults.
 
 ### Numbering Policy
 
-ADR numbers (ADR-001 through ADR-024) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
+ADR numbers (ADR-001 through ADR-025) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
 
 ## Writing New ADRs
 

--- a/wiki/database.md
+++ b/wiki/database.md
@@ -232,11 +232,13 @@ Use WHERE with placeholders for dynamic values: `qb.Select("*").From("users").Wh
 | Setting | Default | Purpose |
 |---------|---------|---------|
 | `pool.max.connections` | 25 | Maximum open connections |
-| `pool.idle.connections` | 2 | Minimum warm connections |
+| `pool.idle.connections` | tracks `pool.max.connections` | Idle connection cap (not a floor — no pre-warming). Tracking max avoids connection churn under load; `database/sql` clamps it to max |
 | `pool.idle.time` | 5m | Close idle connections (prevents stale connections) |
 | `pool.lifetime.max` | 30m | Force periodic recycling (DNS, memory hygiene) |
 | `pool.keepalive.enabled` | true | TCP keep-alive probes |
 | `pool.keepalive.interval` | 60s | Probe interval (below NAT timeouts) |
+
+> **Idle defaults to max (changed in [ADR-025](adr_025_pool_idle_tracks_max.md)).** Earlier versions defaulted idle to a fixed `2`, which made the pool repeatedly open and close physical connections (TCP+TLS+auth) under sustained load. Idle now defaults to `pool.max.connections` so warm connections are reused. Set a lower `pool.idle.connections` explicitly only when you deliberately want idle connections released back to the database. See [migrations.md](migrations.md#connection-pool-idle-default--tracks-max-adr-025) for the footprint implications.
 
 **Cloud Provider Idle Timeouts:**
 | Provider | Component | Timeout |

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -2,6 +2,29 @@
 
 Historical migration tables for upgrading existing GoBricks-based applications. Greenfield work can ignore this file — the new APIs are the only ones documented in CLAUDE.md.
 
+## Connection Pool Idle Default — Tracks Max (ADR-025)
+
+Per [ADR-025](adr_025_pool_idle_tracks_max.md), the default for `database.pool.idle.connections` changed from a fixed **2** to **tracking `database.pool.max.connections`** (default 25). The old default kept only 2 idle connections against a max of 25, so under sustained load the pool continuously opened and closed physical connections (TCP+TLS+auth) — measured as a 91% p95 latency reduction (16.25 → 1.46 ms) and connection-establishment errors dropping from 8.15% to 0% once idle tracked max.
+
+**No code or config change is required.** This is a default-only change with `apiImpact: none`. But be aware of three behavioral consequences if you relied on the old default:
+
+| Area | Before | After |
+|---|---|---|
+| Idle connections held (idle unset) | up to 2 | up to `pool.max.connections` (default 25), still reaped after `pool.idle.time` (5m) |
+| Multi-tenant idle ceiling | 2 × tenants | up to ~12.5× higher per tenant — verify your PostgreSQL `max_connections` / Oracle session budget |
+| Pool idle metrics | OTEL idle gauges & `Stats()` `max_idle_connections`/`configured_idle_connections` reported `2` | now report the effective max — update dashboards/alerts keyed to `idle == 2` |
+
+**To keep the old behavior**, set the value explicitly — an explicit `database.pool.idle.connections` always wins over the default:
+
+```yaml
+database:
+  pool:
+    idle:
+      connections: 2   # opt back into the old conservative fixed idle cap of 2
+```
+
+The effective `pool_max_connections` / `pool_idle_connections` / `pool_max_lifetime` / `pool_idle_time` are now logged at `Info` on every successful connection, so you can confirm what the pool actually uses.
+
 ## Config Keys — Flat-Smushed Rename (ADR-024)
 
 Per [ADR-024](adr_024_config_key_flatsmush.md), 21 snake_case config keys were renamed to the framework's underscore-free flat-smushed convention so they become settable via environment variables (the env loader maps `_`→`.`, koanf's nesting delimiter, so underscored leaf keys were silently unreachable from env). Update both your YAML and any environment variables. Go field names are unchanged.


### PR DESCRIPTION
## What & why

The shipped DB pool default of a **fixed 2 idle connections against a max of 25** makes the pool churn physical connections (TCP+TLS+auth, then close) under sustained load. Profiling the framework with a connection-reusing read workload at 2000 req/s showed this as the single dominant cost:

| Config | p95 | p99 | errors | warm backends |
|---|---|---|---|---|
| idle 2 / max 25 (shipped default) | 16.25 ms | 38.19 ms | 8.15% | 3 (churning) |
| idle = max | 1.46 ms | 2.20 ms | 0% | 51 (warm) |

This is finding #1 of an iteration-1 performance analysis (the highest-impact item). `database/sql` caps idle at max-open (verified in Go 1.26.4 `sql.go`), so defaulting idle to track max is safe and never exceeds max.

## Change

Centralized in `config/validation.go` (`applyDatabasePoolDefaults` → new `applyPoolConnectionDefaults`), so it covers **PostgreSQL, Oracle, named, and per-tenant DBs in one edit** — no vendor connection.go change needed (both vendors read the defaulted config value):

- **Idle defaults to max** when unset. An explicit idle **below** max is honored; an explicit idle **above** max is **clamped to max** so the value the framework reports (startup log, `Stats()`, OTEL idle gauges) matches what `database/sql` actually enforces.
- Remove the misleading `defaultPoolIdleConnections` const (the "minimum warm connections" floor never existed — `SetMaxIdleConns` is a cap), extract `defaultPoolMaxConnections`.
- Log effective `pool_max/idle/lifetime/idle_time` at startup via a shared `wrapper.AppendPoolFields` helper (DRY across both vendors).
- Correct "minimum warm connections" / "warm-pool target" wording → "idle cap" in `config/types.go`, `tracking/metrics.go`, `wrapper/connection.go`, `llms.txt`, `config.example.yaml`.

## Behavioral change (apiImpact: none) — see [ADR-025](wiki/adr_025_pool_idle_tracks_max.md) + [migrations.md](wiki/migrations.md)

An app that left `pool.idle.connections` unset now holds up to `pool.max.connections` (default 25) idle connections instead of 2 (still reaped after `pool.idle.time`). **Multi-tenant** deployments see a per-tenant idle ceiling up to ~12.5× higher — verify your PostgreSQL `max_connections` / Oracle session budget. OTEL idle gauges now report the effective max rather than 2. Opt back in with an explicit `database.pool.idle.connections`.

## Tests

`make check` + lint green. Added: `idle_tracks_custom_max`, `explicit_idle_above_max_clamped`, the previously-missing `negative_idle_connections` guard, an `AppendPoolFields` unit test, and the integration `Load()` test now uses a non-default max (40) to prove idle tracks the *configured* max, not a constant.

## Reviews

Incorporates `/code-review` (xhigh, 9-angle) and `/security-audit` findings — chiefly the explicit-idle-above-max clamp, semantic doc-drift fixes, the shared log helper, and added test coverage. Pre-existing PG/Oracle `configureConnectionPool` `SetMax*` duplication was left out of this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Database pool idle connections now default to track the configured max (instead of a fixed 2), reducing connection churn under sustained load.

* **Documentation**
  * Added ADR, updated docs, migration guide, config examples, and architecture index describing the new idle-default behavior and override guidance.

* **Chores**
  * Connection success/startup logs now include effective pool fields for observability.

* **Tests**
  * Added/updated tests to validate idle-defaulting, clamping, and negative-value rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->