### PR TITLE
perf(database): hoist per-vendor statement builders to package init

### DIFF
--- a/database/internal/builder/query_builder.go
+++ b/database/internal/builder/query_builder.go
@@ -77,21 +77,29 @@ var _ dbtypes.DeleteQueryBuilder = (*DeleteQueryBuilder)(nil)
 
 // ========== QueryBuilder Methods ==========
 
-// NewQueryBuilder creates a new query builder for the specified database vendor.
-// It configures placeholder formats and prepares for vendor-specific SQL generation.
-func NewQueryBuilder(vendor dbtypes.Vendor) *QueryBuilder {
-	var sb squirrel.StatementBuilderType
+// Per-vendor statement builders, built once at package load instead of on every
+// NewQueryBuilder call. squirrel's StatementBuilderType wraps a persistent
+// (copy-on-write) map: every fluent call (.Select(), .From(), …) clones the
+// receiver rather than mutating it, and the placeholder formats stored here
+// (Dollar/Colon/Question) are stateless. Sharing one value per vendor across
+// goroutines is therefore safe and avoids a PlaceholderFormat clone + reflect
+// allocation per NewQueryBuilder call. Treat these as immutable: never assign back
+// through a method (e.g. RunWith) and never store a stateful PlaceholderFormat.
+var (
+	pgStatementBuilder    = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar)   // PostgreSQL: $1, $2, ...
+	oraStatementBuilder   = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Colon)    // Oracle: :1, :2, ...
+	qmarkStatementBuilder = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Question) // Default: ?, ?, ...
+)
 
+// NewQueryBuilder creates a new query builder for the specified database vendor.
+// It selects the vendor's shared, immutable placeholder-format statement builder.
+func NewQueryBuilder(vendor dbtypes.Vendor) *QueryBuilder {
+	sb := qmarkStatementBuilder // default to question mark placeholders
 	switch vendor {
 	case dbtypes.PostgreSQL:
-		// PostgreSQL uses $1, $2, ... placeholders
-		sb = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar)
+		sb = pgStatementBuilder
 	case dbtypes.Oracle:
-		// Oracle uses :1, :2, ... placeholders
-		sb = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Colon)
-	default:
-		// Default to question mark placeholders
-		sb = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Question)
+		sb = oraStatementBuilder
 	}
 
 	return &QueryBuilder{

--- a/database/internal/builder/query_builder_test.go
+++ b/database/internal/builder/query_builder_test.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/Masterminds/squirrel"
@@ -10,6 +11,27 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestNewQueryBuilderConcurrentSharedBuilders exercises the per-vendor package-level
+// statement builders from many goroutines. They are shared values, so this locks in
+// the immutability invariant under -race: concurrent NewQueryBuilder + query
+// construction must neither race nor corrupt the shared builders.
+func TestNewQueryBuilderConcurrentSharedBuilders(t *testing.T) {
+	vendors := []dbtypes.Vendor{dbtypes.PostgreSQL, dbtypes.Oracle, dbtypes.Vendor("sqlite")}
+	var wg sync.WaitGroup
+	for _, vendor := range vendors {
+		for range 30 {
+			wg.Add(1)
+			go func(v dbtypes.Vendor) {
+				defer wg.Done()
+				sql, _, err := NewQueryBuilder(v).Select("id").From("users").ToSQL()
+				assert.NoError(t, err)
+				assert.NotEmpty(t, sql)
+			}(vendor)
+		}
+	}
+	wg.Wait()
+}
 
 const (
 	joinFilterErrorMsg = "mock join filter error"

--- a/database/internal/builder/query_builder_test.go
+++ b/database/internal/builder/query_builder_test.go
@@ -24,9 +24,19 @@ func TestNewQueryBuilderConcurrentSharedBuilders(t *testing.T) {
 			wg.Add(1)
 			go func(v dbtypes.Vendor) {
 				defer wg.Done()
-				sql, _, err := NewQueryBuilder(v).Select("id").From("users").ToSQL()
+				qb := NewQueryBuilder(v)
+				// Use a bind-producing Where so the rendered placeholder validates the
+				// correct per-vendor builder was selected (not just that SQL is non-empty).
+				sql, _, err := qb.Select("id").From("users").Where(qb.Filter().Eq("id", 1)).ToSQL()
 				assert.NoError(t, err)
-				assert.NotEmpty(t, sql)
+				switch v {
+				case dbtypes.PostgreSQL:
+					assert.Contains(t, sql, "$1")
+				case dbtypes.Oracle:
+					assert.Contains(t, sql, ":1")
+				default:
+					assert.Contains(t, sql, "?")
+				}
 			}(vendor)
 		}
 	}


### PR DESCRIPTION
## What & why

Perf iteration-1 finding **#3** (sub-claim 1). `NewQueryBuilder` rebuilt the per-vendor `squirrel.StatementBuilderType` on **every call** via `squirrel.StatementBuilder.PlaceholderFormat(...)`, which clones squirrel's persistent (HAMT) map and reflect-allocates a builder struct each time. This hoists the three vendor builders (Dollar / Colon / Question) to package-level values built **once at package load**.

squirrel's `StatementBuilderType` is a persistent, copy-on-write value — every fluent call (`.Select()`, `.From()`, …) clones rather than mutates the receiver — so sharing one immutable value per vendor across goroutines is safe and skips the per-call `PlaceholderFormat` clone + reflect allocation.

## Scope

- **Behavior-neutral, zero public API change.** PostgreSQL→`$n`, Oracle→`:n`, everything else→`?` (the unknown-vendor default is preserved). The ~200 golden `ToSQL` assertions across the builder/filter/join/oracle/postgres suites stay **byte-identical** — they're the regression guard.
- The opt-in `CompiledQuery` API (finding #3, sub-claim 2) is **deferred to its own design** — it's infeasible as originally worded because filter values bind eagerly at `f.Eq()` construction, not at render.

## Tests

`make check` + lint green. Added `TestNewQueryBuilderConcurrentSharedBuilders` — exercises the shared per-vendor builders from many goroutines under `-race` to lock in the immutability invariant (a future squirrel/lann regression that mutated in place would now be caught).

## Reviews

Incorporates `/code-review` (focused, 4-angle) + `/security-audit`: added the concurrency test, and corrected the code comment to state squirrel/lann's actual *conditional* immutability contract (rather than implying an unconditional guarantee). No SQL/secret/dependency/input-boundary surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reused shared vendor-specific query builders to reduce allocations and improve runtime efficiency.
* **Tests**
  * Added concurrency tests to validate race-safety of building queries across multiple database vendors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->