### PR TITLE
perf(database): short-circuit DB-tracking debug log fields when level disabled

### DIFF
--- a/database/internal/tracking/utils.go
+++ b/database/internal/tracking/utils.go
@@ -25,6 +25,16 @@ const (
 	// Log field key for the SQL query string.
 	logFieldQuery = "query"
 
+	// Log message emitted for a successful (non-slow, error-free) DB operation.
+	// Extracted as a constant because it is also asserted in tests (goconst).
+	msgDBOperationExecuted = "Database operation executed"
+
+	// Log messages for the special-cased and error branches. Extracted as constants
+	// because they are also asserted in tests (goconst).
+	msgDBOperationNoRows = "Database operation returned no rows"
+	msgDBTxFinalized     = "Database transaction already finalized"
+	msgDBOperationError  = "Database operation error"
+
 	// Database vendor normalization constants matching OTel semantic conventions
 	dbVendorPostgreSQL = "postgresql"
 	dbVendorOracle     = "oracle.db" // OTel spec requires "oracle.db" not "oracle"
@@ -97,6 +107,9 @@ func TrackDBOperation(ctx context.Context, tc *Context, query string, args []any
 		logger.AddDBElapsed(ctx, elapsed.Nanoseconds())
 	}
 
+	// Counter/metric/span emission is intentionally ABOVE (and NOT gated by) the log-level
+	// short-circuit below, so DB counters, tracing and metrics are never affected by LOG_LEVEL.
+	//
 	// Create the OpenTelemetry span + metrics for the database operation — but only
 	// when observability is enabled. otel.Tracer/otel.Meter return non-nil no-ops
 	// when no provider is registered, so without this explicit gate the framework
@@ -107,43 +120,82 @@ func TrackDBOperation(ctx context.Context, tc *Context, query string, args []any
 		recordDBMetrics(ctx, tc, query, elapsed, rowsAffected, err)
 	}
 
+	// Select the log event (level + message) up front so field construction can be
+	// short-circuited when the level is disabled. WithContext binds first: a context-bound
+	// logger may carry a different level, so enablement is only accurate after binding.
+	//
+	// Treat sql.ErrNoRows and sql.ErrTxDone specially - not actual errors, log as debug.
+	// ErrTxDone is returned by the deferred Rollback of an already-committed transaction
+	// (e.g. the WithTx helper), which is benign. errors.Is(nil, target) is false, so a nil
+	// err correctly falls through to the slow/default branches.
+	//
+	// Request-severity note: the WARN (slow-query) and ERROR branches escalate request
+	// severity via the adapter's Msg/Msgf -> trackSeverity -> escalateSeverity hook (see
+	// logger/adapter.go and server/logger.go), which suppresses the per-request action
+	// summary. trackSeverity fires whenever the event level >= WarnLevel, independent of
+	// Enabled(), so a WARN/ERROR that is DISABLED at the active LOG_LEVEL must still reach
+	// Msg to escalate. The Enabled() short-circuit below preserves this exactly: it still
+	// calls event.Msg before returning, so severity escalation is unchanged; only the field
+	// construction is skipped (the allocation win).
+	log := tc.Logger.WithContext(ctx)
+	var event logger.LogEvent
+	var message string
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		event, message = log.Debug(), msgDBOperationNoRows
+	case errors.Is(err, sql.ErrTxDone):
+		event, message = log.Debug(), msgDBTxFinalized
+	case err != nil:
+		event, message = log.Error().Err(err), msgDBOperationError
+	case elapsed > tc.Settings.SlowQueryThreshold():
+		event, message = log.Warn(), fmt.Sprintf("Slow database operation detected (%s)", elapsed)
+	default:
+		event, message = log.Debug(), msgDBOperationExecuted
+	}
+
+	// Short-circuit before building any fields when the chosen level is disabled. This
+	// is below the metric/span/counter block so observability is never gated by LOG_LEVEL.
+	if !event.Enabled() {
+		// Preserve exact parity with the prior WithFields path: emitting a (dropped)
+		// WARN/ERROR still escalated request severity via the adapter's
+		// Msg -> trackSeverity hook, which suppresses the per-request action summary.
+		// Call Msg on the disabled event so that hook still fires; zerolog drops the
+		// line and no fields are built (the allocation win). For DEBUG (level < Warn)
+		// trackSeverity is a no-op, so the common success path stays free.
+		event.Msg(message)
+		return
+	}
+
 	// Truncate query string to safe max length to avoid unbounded payloads
 	truncatedQuery := query
 	if tc.Settings.MaxQueryLength() > 0 && len(query) > tc.Settings.MaxQueryLength() {
 		truncatedQuery = TruncateString(query, tc.Settings.MaxQueryLength())
 	}
 
-	// Log query execution details
-	logEvent := tc.Logger.WithContext(ctx).WithFields(map[string]any{
-		"vendor":      tc.Vendor,
-		"duration_ms": elapsed.Milliseconds(),
-		"duration_ns": elapsed.Nanoseconds(),
-		logFieldQuery: truncatedQuery,
-	})
+	// Typed setters avoid the map alloc; Str routes through SensitiveDataFilter.FilterString and
+	// Interface through FilterValue, preserving the same privacy boundary as the old WithFields(map)
+	// for the framework-default config (none of vendor/duration_ms/duration_ns/query/args are
+	// sensitive by default, so both paths emit the raw value).
+	//
+	// Privacy note for vendor/query: these are framework-controlled, non-secret fields (vendor is
+	// "postgresql"/"oracle.db"; query is already-truncated SQL) and are intentionally kept OFF the
+	// sensitive surface. If an operator marks them sensitive via log.sensitivefields, the typed Str
+	// path masks via FilterString -> maskString, which is URL-aware and reveals strictly more for a
+	// URL-shaped value (scheme/user/host/path, password masked) than the old WithFields -> FilterValue
+	// path did (full "***"). That divergence is by design for the typed-setter path and unreachable
+	// for these two keys under the default config; do not add vendor/query to the sensitive list to
+	// avoid relying on full masking here.
+	event = event.
+		Str("vendor", tc.Vendor).
+		Int64("duration_ms", elapsed.Milliseconds()).
+		Int64("duration_ns", elapsed.Nanoseconds()).
+		Str(logFieldQuery, truncatedQuery)
 
 	if tc.Settings.LogQueryParameters() && len(args) > 0 {
-		logEvent = logEvent.WithFields(map[string]any{
-			"args": SanitizeArgs(args, tc.Settings.MaxQueryLength()),
-		})
+		event = event.Interface("args", SanitizeArgs(args, tc.Settings.MaxQueryLength()))
 	}
 
-	if err != nil {
-		// Treat sql.ErrNoRows and sql.ErrTxDone specially - not actual errors,
-		// log as debug. ErrTxDone is returned by the deferred Rollback of an
-		// already-committed transaction (e.g. the WithTx helper), which is benign.
-		switch {
-		case errors.Is(err, sql.ErrNoRows):
-			logEvent.Debug().Msg("Database operation returned no rows")
-		case errors.Is(err, sql.ErrTxDone):
-			logEvent.Debug().Msg("Database transaction already finalized")
-		default:
-			logEvent.Error().Err(err).Msg("Database operation error")
-		}
-	} else if elapsed > tc.Settings.SlowQueryThreshold() {
-		logEvent.Warn().Msgf("Slow database operation detected (%s)", elapsed)
-	} else {
-		logEvent.Debug().Msg("Database operation executed")
-	}
+	event.Msg(message)
 }
 
 // extractRowsAffected safely extracts the number of rows affected from a sql.Result.

--- a/database/internal/tracking/utils_test.go
+++ b/database/internal/tracking/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,9 +24,20 @@ type eventRecord struct {
 	Fields map[string]any
 }
 
+// recordingLogger is a recording SPY: it records every adapter method call —
+// including calls made on disabled events (e.g. Msg on a dropped WARN) — so tests
+// can assert exactly what production invoked. Enabled() faithfully reports the
+// per-level state (via disabledLevels), but the spy intentionally does NOT emulate
+// zerolog's drop-the-line behavior: a disabled event still records its Msg and any
+// fields set on it, letting tests verify the severity-escalation path (Msg is called
+// on a disabled WARN/ERROR) while also asserting the field-build short-circuit.
 type recordingLogger struct {
 	sink   *recordingSink
 	fields map[string]any
+	// disabledLevels holds level names for which the produced event reports
+	// Enabled() == false and records no fields — emulating zerolog dropping
+	// events below the configured threshold (e.g. debug at LOG_LEVEL=info).
+	disabledLevels map[string]bool
 }
 
 type recordingSink struct {
@@ -33,23 +45,41 @@ type recordingSink struct {
 }
 
 type recordingEvent struct {
-	record *eventRecord
+	record  *eventRecord
+	enabled bool
 }
 
 func newRecordingLogger() *recordingLogger {
 	return &recordingLogger{
-		sink:   &recordingSink{},
-		fields: map[string]any{},
+		sink:           &recordingSink{},
+		fields:         map[string]any{},
+		disabledLevels: map[string]bool{},
 	}
+}
+
+// newRecordingLoggerWithDisabled returns a recordingLogger whose events at the given
+// levels report Enabled() == false (and therefore must not have fields built on them).
+func newRecordingLoggerWithDisabled(levels ...string) *recordingLogger {
+	l := newRecordingLogger()
+	for _, lvl := range levels {
+		l.disabledLevels[lvl] = true
+	}
+	return l
 }
 
 func (l *recordingLogger) clone() *recordingLogger {
 	cloned := &recordingLogger{
-		sink:   l.sink,
-		fields: make(map[string]any, len(l.fields)),
+		sink:           l.sink,
+		fields:         make(map[string]any, len(l.fields)),
+		disabledLevels: make(map[string]bool, len(l.disabledLevels)),
 	}
 	for k, v := range l.fields {
 		cloned.fields[k] = v
+	}
+	// Deep-copy disabledLevels too (symmetry with fields); avoids a clone sharing
+	// the parent's level map and decoupling the spy's enablement state.
+	for k, v := range l.disabledLevels {
+		cloned.disabledLevels[k] = v
 	}
 	return cloned
 }
@@ -63,7 +93,7 @@ func (l *recordingLogger) newEvent(level string) logger.LogEvent {
 		record.Fields[k] = v
 	}
 	l.sink.events = append(l.sink.events, record)
-	return &recordingEvent{record: record}
+	return &recordingEvent{record: record, enabled: !l.disabledLevels[level]}
 }
 
 func (l *recordingLogger) Info() logger.LogEvent  { return l.newEvent(levelInfo) }
@@ -140,7 +170,7 @@ func (e *recordingEvent) Bool(key string, value bool) logger.LogEvent {
 	return e
 }
 
-func (e *recordingEvent) Enabled() bool { return true }
+func (e *recordingEvent) Enabled() bool { return e.enabled }
 
 func TestTruncateStringNoTruncation(t *testing.T) {
 	original := "short"
@@ -217,7 +247,7 @@ func TestTrackDBOperationRecordsSuccess(t *testing.T) {
 	if event.Level != levelDebug {
 		t.Fatalf("expected debug level, got %s", event.Level)
 	}
-	if event.Msg != "Database operation executed" {
+	if event.Msg != msgDBOperationExecuted {
 		t.Fatalf("unexpected log message: %q", event.Msg)
 	}
 	if event.Fields["query"] != selectOne {
@@ -225,6 +255,193 @@ func TestTrackDBOperationRecordsSuccess(t *testing.T) {
 	}
 	if _, exists := event.Fields["args"]; exists {
 		t.Fatalf("did not expect args when LogQueryParameters is false")
+	}
+}
+
+// TestTrackDBOperationSkipsFieldBuildWhenDebugDisabled verifies the success fast path:
+// when the debug level is disabled (e.g. LOG_LEVEL=info on a healthy query), no log
+// fields are built, yet the DB counter/elapsed metrics still fire — proving the level
+// short-circuit never gates observability. Msg is still called on the disabled event so
+// the severity-parity path runs (a no-op at debug level, but exercised identically to
+// the WARN/ERROR branches, where escalation must be preserved).
+func TestTrackDBOperationSkipsFieldBuildWhenDebugDisabled(t *testing.T) {
+	ctx := logger.WithDBCounter(context.Background())
+	recLogger := newRecordingLoggerWithDisabled(levelDebug)
+	settings := Settings{
+		slowQueryThreshold: time.Second,
+		maxQueryLength:     50,
+		logQueryParameters: true,
+	}
+
+	start := time.Now().Add(-25 * time.Millisecond)
+	TrackDBOperation(ctx, &Context{Logger: recLogger, Vendor: "postgresql", Settings: settings}, selectOne, []any{"param"}, start, 0, nil)
+
+	// Metrics/counters must still fire even though the debug log is disabled.
+	if logger.GetDBCounter(ctx) != 1 {
+		t.Fatalf("expected db counter to increment even when debug log is disabled")
+	}
+	if logger.GetDBElapsed(ctx) <= 0 {
+		t.Fatalf("expected elapsed time to be recorded even when debug log is disabled")
+	}
+
+	events := recLogger.events()
+	if len(events) != 1 {
+		t.Fatalf(singleEventExpected, len(events))
+	}
+	event := events[0]
+	if event.Level != levelDebug {
+		t.Fatalf("expected debug level event, got %s", event.Level)
+	}
+	// Short-circuit must prevent any field construction.
+	if len(event.Fields) != 0 {
+		t.Fatalf("expected no fields built when level disabled, got %v", event.Fields)
+	}
+	// Msg must still be called on the disabled event so the severity-parity path runs.
+	if event.Msg != msgDBOperationExecuted {
+		t.Fatalf("expected success message even when level disabled (Msg still called), got %q", event.Msg)
+	}
+}
+
+// TestTrackDBOperationDisabledWarnStillEscalates verifies the disabled-WARN slow-query
+// path: when the warn level is disabled, no log fields are built (the allocation win),
+// but event.Msg is still called with the slow-query message — proving severity escalation
+// is preserved (the adapter's Msg -> trackSeverity hook fires regardless of Enabled()).
+func TestTrackDBOperationDisabledWarnStillEscalates(t *testing.T) {
+	ctx := logger.WithDBCounter(context.Background())
+	recLogger := newRecordingLoggerWithDisabled(levelWarn)
+	settings := Settings{
+		slowQueryThreshold: 5 * time.Millisecond,
+		maxQueryLength:     100,
+		logQueryParameters: true,
+	}
+
+	start := time.Now().Add(-20 * time.Millisecond)
+	TrackDBOperation(ctx, &Context{Logger: recLogger, Vendor: "postgresql", Settings: settings}, selectOne, []any{"param"}, start, 0, nil)
+
+	if logger.GetDBCounter(ctx) != 1 {
+		t.Fatalf("expected db counter to increment even when warn log is disabled")
+	}
+
+	events := recLogger.events()
+	if len(events) != 1 {
+		t.Fatalf(singleEventExpected, len(events))
+	}
+	event := events[0]
+	if event.Level != levelWarn {
+		t.Fatalf("expected warn level event, got %s", event.Level)
+	}
+	// Field construction must be short-circuited.
+	if len(event.Fields) != 0 {
+		t.Fatalf("expected no fields built when warn level disabled, got %v", event.Fields)
+	}
+	// Msg must still be called so the WARN escalates request severity.
+	elapsed := logger.GetDBElapsed(ctx)
+	if elapsed <= 0 {
+		t.Fatalf("expected elapsed time to be recorded")
+	}
+	expectedMsg := fmt.Sprintf("Slow database operation detected (%s)", time.Duration(elapsed))
+	if event.Msg != expectedMsg {
+		t.Fatalf("expected slow-query message on disabled WARN, got %q", event.Msg)
+	}
+}
+
+// TestTrackDBOperationDisabledErrorStillEscalates verifies the disabled-ERROR path:
+// when the error level is disabled, no fields are built but event.Msg is still called
+// with the error message and the error is attached — proving severity escalation is
+// preserved on a dropped ERROR line.
+func TestTrackDBOperationDisabledErrorStillEscalates(t *testing.T) {
+	ctx := logger.WithDBCounter(context.Background())
+	recLogger := newRecordingLoggerWithDisabled(levelError)
+	settings := Settings{slowQueryThreshold: time.Second}
+
+	failure := errors.New("boom")
+	start := time.Now().Add(-10 * time.Millisecond)
+	TrackDBOperation(ctx, &Context{Logger: recLogger, Vendor: "postgresql", Settings: settings}, selectOne, nil, start, 0, failure)
+
+	if logger.GetDBCounter(ctx) != 1 {
+		t.Fatalf("expected db counter to increment even when error log is disabled")
+	}
+
+	events := recLogger.events()
+	if len(events) != 1 {
+		t.Fatalf(singleEventExpected, len(events))
+	}
+	event := events[0]
+	if event.Level != levelError {
+		t.Fatalf("expected error level event, got %s", event.Level)
+	}
+	// The error is attached via .Err(err) before the Enabled() short-circuit; the
+	// fields map itself must remain empty (no vendor/duration/query built).
+	if len(event.Fields) != 0 {
+		t.Fatalf("expected no fields built when error level disabled, got %v", event.Fields)
+	}
+	if event.Err != failure {
+		t.Fatalf("expected error to be attached on disabled ERROR, got %v", event.Err)
+	}
+	if event.Msg != msgDBOperationError {
+		t.Fatalf("expected error message on disabled ERROR, got %q", event.Msg)
+	}
+}
+
+// TestTrackDBOperationDisabledDebugErrNoRows verifies the disabled-DEBUG sql.ErrNoRows
+// path short-circuits field construction yet still records its benign message and
+// increments the counter (trackSeverity is a no-op below WarnLevel).
+func TestTrackDBOperationDisabledDebugErrNoRows(t *testing.T) {
+	ctx := logger.WithDBCounter(context.Background())
+	recLogger := newRecordingLoggerWithDisabled(levelDebug)
+	settings := Settings{slowQueryThreshold: time.Second}
+
+	start := time.Now().Add(-10 * time.Millisecond)
+	TrackDBOperation(ctx, &Context{Logger: recLogger, Vendor: "postgresql", Settings: settings}, selectOne, nil, start, 0, sql.ErrNoRows)
+
+	if logger.GetDBCounter(ctx) != 1 {
+		t.Fatalf("expected db counter to increment even when debug log is disabled")
+	}
+
+	events := recLogger.events()
+	if len(events) != 1 {
+		t.Fatalf(singleEventExpected, len(events))
+	}
+	event := events[0]
+	if event.Level != levelDebug {
+		t.Fatalf("expected debug level for sql.ErrNoRows, got %s", event.Level)
+	}
+	if len(event.Fields) != 0 {
+		t.Fatalf("expected no fields built when debug level disabled, got %v", event.Fields)
+	}
+	if event.Msg != msgDBOperationNoRows {
+		t.Fatalf("unexpected message on disabled ErrNoRows: %q", event.Msg)
+	}
+}
+
+// TestTrackDBOperationDisabledDebugErrTxDone verifies the disabled-DEBUG sql.ErrTxDone
+// path short-circuits field construction yet still records its benign message and
+// increments the counter.
+func TestTrackDBOperationDisabledDebugErrTxDone(t *testing.T) {
+	ctx := logger.WithDBCounter(context.Background())
+	recLogger := newRecordingLoggerWithDisabled(levelDebug)
+	settings := Settings{slowQueryThreshold: time.Second}
+
+	start := time.Now().Add(-10 * time.Millisecond)
+	TrackDBOperation(ctx, &Context{Logger: recLogger, Vendor: "postgresql", Settings: settings}, "ROLLBACK", nil, start, 0, sql.ErrTxDone)
+
+	if logger.GetDBCounter(ctx) != 1 {
+		t.Fatalf("expected db counter to increment even when debug log is disabled")
+	}
+
+	events := recLogger.events()
+	if len(events) != 1 {
+		t.Fatalf(singleEventExpected, len(events))
+	}
+	event := events[0]
+	if event.Level != levelDebug {
+		t.Fatalf("expected debug level for sql.ErrTxDone, got %s", event.Level)
+	}
+	if len(event.Fields) != 0 {
+		t.Fatalf("expected no fields built when debug level disabled, got %v", event.Fields)
+	}
+	if event.Msg != msgDBTxFinalized {
+		t.Fatalf("unexpected message on disabled ErrTxDone: %q", event.Msg)
 	}
 }
 
@@ -279,7 +496,7 @@ func TestTrackDBOperationLogsSlowQuery(t *testing.T) {
 	if event.Level != levelWarn {
 		t.Fatalf("expected warn level for slow query, got %s", event.Level)
 	}
-	if event.Msg == "" || event.Msg == "Database operation executed" {
+	if !strings.HasPrefix(event.Msg, "Slow database operation detected (") {
 		t.Fatalf("expected slow query warning message, got %q", event.Msg)
 	}
 }
@@ -300,7 +517,7 @@ func TestTrackDBOperationHandlesSqlErrNoRows(t *testing.T) {
 	if event.Level != levelDebug {
 		t.Fatalf("expected debug level for sql.ErrNoRows, got %s", event.Level)
 	}
-	if event.Msg != "Database operation returned no rows" {
+	if event.Msg != msgDBOperationNoRows {
 		t.Fatalf("unexpected message: %q", event.Msg)
 	}
 }
@@ -323,7 +540,7 @@ func TestTrackDBOperationHandlesSqlErrTxDone(t *testing.T) {
 	if event.Level != levelDebug {
 		t.Fatalf("expected debug level for sql.ErrTxDone, got %s", event.Level)
 	}
-	if event.Msg != "Database transaction already finalized" {
+	if event.Msg != msgDBTxFinalized {
 		t.Fatalf("unexpected message: %q", event.Msg)
 	}
 }
@@ -348,7 +565,7 @@ func TestTrackDBOperationLogsErrors(t *testing.T) {
 	if event.Err != failure {
 		t.Fatalf("expected error to be recorded")
 	}
-	if event.Msg != "Database operation error" {
+	if event.Msg != msgDBOperationError {
 		t.Fatalf("unexpected message: %q", event.Msg)
 	}
 }


### PR DESCRIPTION
## What

Short-circuits DB-operation log-field construction when the log level is disabled.

`TrackDBOperation` (`database/internal/tracking`) built a `WithFields(map[string]any)` on **every** `db.Query/Exec/QueryRow/tx.Exec` *before* choosing the log level. The common success path logs at `Debug`, which zerolog drops at the default `info` level — so the map + sensitive-data filter pass + zerolog context clone was wasted work on every query.

**Impact** (perf iteration 2, measured against the demo at a clean 2000 req/s, obs off, default config): the `WithFields` map is ~169 MB = **~6.7% of all process allocations** — the single largest framework-attributable, safely-removable allocation node remaining after #558/#559/#560.

## How

Mirrors the already-shipped `LogEvent.Enabled()` short-circuit from #559 (`server/logger.go`):

- pick the level + message up front (same 5 branches: `ErrNoRows`/`ErrTxDone` → Debug, other err → Error, slow → Warn, else → Debug);
- `if !event.Enabled() { … return }` **before** building fields;
- attach fields with typed setters (`Str`/`Int64`/`Interface`) — no `map[string]any`.

Counters (`IncrementDBCounter`/`AddDBElapsed`) and the observability span/metric block stay **above** the short-circuit — never gated by `LOG_LEVEL`.

## Behavior parity (zero change)

- **Severity escalation preserved exactly.** The disabled branch still calls `event.Msg(message)`, so a dropped WARN/ERROR fires the adapter's `Msg → trackSeverity → escalateSeverity` hook (which suppresses the per-request action summary) exactly as the old `WithFields → Msg/Msgf` path did. For `Debug` (level &lt; Warn) `trackSeverity` is a no-op, so the common path stays free. New tests assert this for the disabled WARN/ERROR paths.
- **Sensitive-data masking.** Typed setters route through the same `SensitiveDataFilter` (`Str→FilterString`, `Interface→FilterValue`, `Int64→maskIfSensitive`). Under `DefaultFilterConfig` none of `vendor`/`duration_ms`/`duration_ns`/`query`/`args` are sensitive, so output is byte-identical by default. ⚠️ One documented, **unreachable-by-default** divergence: if an operator explicitly adds `query`/`vendor` to `log.sensitivefields`, the typed `Str` path uses URL-aware `FilterString` (masks only a URL password) vs the old `FilterValue` full `***`. The in-code comment warns against this; switching to `.Interface` was rejected because `json.Marshal` HTML-escapes `<`/`>`/`&` in SQL, which would change normal query-log output.

## Tests

`make check` green (fmt + lint + `-race`). Added faithful disabled-path coverage:
- disabled-Debug success still increments the DB counter/elapsed with **no** fields built;
- disabled-WARN slow-query and disabled-ERROR still escalate severity (Msg called) with no fields;
- disabled-Debug `ErrNoRows`/`ErrTxDone`;
- strengthened the slow-query message assertion.

Source: perf iteration 2 finding #1 (go-bricks-demo-project `wiki/PERF_FINDINGS_ITERATION_2.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored database operation logging to use typed fluent event construction with optimized field handling, reducing overhead when log levels are disabled.
  * Enhanced parameter handling and query logging with improved sanitization and truncation capabilities to better protect sensitive data.

* **Tests**
  * Expanded test coverage for database logging behavior across different log levels and operational scenarios, verifying consistent metric tracking and proper severity escalation in all cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->