### PR TITLE
feat(server)!: make X-Response-Time header opt-in (default off)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -29,6 +29,8 @@ server:
     ready: /ready     # Custom readiness endpoint path
   gzip:
     minlength: 1024   # Min response size (bytes) before gzip applies; smaller responses skip compression
+  responsetime:
+    enabled: false    # Opt-in X-Response-Time header (per-request processing time); off by default — OTel provides richer latency telemetry. SERVER_RESPONSETIME_ENABLED=true to restore.
 
 database:
   type: postgresql

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -48,6 +48,7 @@ func TestLoadWithDefaults(t *testing.T) {
 	assert.Equal(t, 5*time.Second, cfg.Server.Timeout.Middleware)
 	assert.Equal(t, 10*time.Second, cfg.Server.Timeout.Shutdown)
 	assert.Equal(t, 1024, cfg.Server.Gzip.MinLength)
+	assert.False(t, cfg.Server.ResponseTime.Enabled, "X-Response-Time header must default to opt-out")
 
 	// Database should be disabled by default (no defaults provided)
 	assert.False(t, IsDatabaseConfigured(&cfg.Database))
@@ -132,6 +133,25 @@ func TestLoadSingleElementStringSliceEnv(t *testing.T) {
 	cfg, err := Load()
 	require.NoError(t, err)
 	assert.Equal(t, []string{"10.0.0.0/8"}, cfg.Scheduler.Security.CIDRAllowlist)
+}
+
+// TestLoadResponseTimeEnabledEnv verifies the opt-in X-Response-Time header flag
+// is off by default and flips to true when SERVER_RESPONSETIME_ENABLED is set.
+func TestLoadResponseTimeEnabledEnv(t *testing.T) {
+	t.Run("default_disabled", func(t *testing.T) {
+		clearEnvironmentVariables()
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.False(t, cfg.Server.ResponseTime.Enabled)
+	})
+
+	t.Run("env_enables", func(t *testing.T) {
+		clearEnvironmentVariables()
+		t.Setenv("SERVER_RESPONSETIME_ENABLED", "true")
+		cfg, err := Load()
+		require.NoError(t, err)
+		assert.True(t, cfg.Server.ResponseTime.Enabled)
+	})
 }
 
 func TestLoadInvalidEnvironmentVariables(t *testing.T) {
@@ -454,6 +474,7 @@ func clearEnvironmentVariables() {
 		"SERVER_HOST", "SERVER_PORT", "SERVER_TIMEOUT_READ", "SERVER_TIMEOUT_WRITE",
 		"SERVER_TIMEOUT_IDLE", "SERVER_TIMEOUT_MIDDLEWARE", "SERVER_TIMEOUT_SHUTDOWN",
 		"SERVER_PATH_BASE", "SERVER_PATH_HEALTH", "SERVER_PATH_READY", "SERVER_GZIP_MINLENGTH",
+		"SERVER_RESPONSETIME_ENABLED",
 		"DATABASE_TYPE", "DATABASE_HOST", "DATABASE_PORT", testDatabaseDatabase,
 		testDatabaseUsername, "DATABASE_PASSWORD", "DATABASE_TLS_MODE",
 		testDatabaseMaxConns, "DATABASE_POOL_IDLE_CONNECTIONS",

--- a/config/types.go
+++ b/config/types.go
@@ -92,6 +92,8 @@ type ServerConfig struct {
 	Timeout TimeoutConfig `koanf:"timeout" json:"timeout" yaml:"timeout" toml:"timeout" mapstructure:"timeout"`
 	Path    PathConfig    `koanf:"path" json:"path" yaml:"path" toml:"path" mapstructure:"path"`
 	Gzip    GzipConfig    `koanf:"gzip" json:"gzip" yaml:"gzip" toml:"gzip" mapstructure:"gzip"`
+
+	ResponseTime ResponseTimeConfig `koanf:"responsetime" json:"responsetime" yaml:"responsetime" toml:"responsetime" mapstructure:"responsetime"`
 }
 
 // TimeoutConfig holds various timeout durations for the server.
@@ -116,6 +118,15 @@ type GzipConfig struct {
 	// applied. Responses smaller than this are sent uncompressed, since the gzip
 	// header/overhead can exceed the savings for small payloads. Default: 1024.
 	MinLength int `koanf:"minlength" json:"minlength" yaml:"minlength" toml:"minlength" mapstructure:"minlength"`
+}
+
+// ResponseTimeConfig controls the optional X-Response-Time diagnostic header.
+type ResponseTimeConfig struct {
+	// Enabled adds an X-Response-Time response header (per-request processing
+	// time) when true. Default false: the header costs a per-response header
+	// allocation and OTel provides richer latency telemetry. Opt in for local
+	// debugging or when a consumer depends on the header.
+	Enabled bool `koanf:"enabled" json:"enabled" yaml:"enabled" toml:"enabled" mapstructure:"enabled"`
 }
 
 // DatabaseConfig holds database connection settings.

--- a/server/cors.go
+++ b/server/cors.go
@@ -28,7 +28,17 @@ import (
 // Koanf default of EnvDevelopment when APP_ENV is unset). When omitted,
 // CORS falls back to os.Getenv("APP_ENV") — preserving call sites that
 // existed before the parameter was added.
-func CORS(envOverride ...string) echo.MiddlewareFunc {
+//
+// exposeResponseTime advertises X-Response-Time in Access-Control-Expose-Headers
+// only when the Timing middleware actually emits the header (server.responsetime.
+// enabled). Advertising an expose-header the server never sends is harmless but
+// misleading, so this keeps the CORS contract aligned with what is on the wire.
+func CORS(exposeResponseTime bool, envOverride ...string) echo.MiddlewareFunc {
+	exposeHeaders := []string{echo.HeaderXRequestID}
+	if exposeResponseTime {
+		exposeHeaders = append(exposeHeaders, HeaderXResponseTime)
+	}
+
 	cfg := middleware.CORSConfig{
 		AllowMethods: []string{
 			http.MethodGet,
@@ -45,10 +55,7 @@ func CORS(envOverride ...string) echo.MiddlewareFunc {
 			echo.HeaderAuthorization,
 			echo.HeaderXRequestID,
 		},
-		ExposeHeaders: []string{
-			echo.HeaderXRequestID,
-			HeaderXResponseTime,
-		},
+		ExposeHeaders:    exposeHeaders,
 		AllowCredentials: true,
 		MaxAge:           86400,
 	}

--- a/server/cors_test.go
+++ b/server/cors_test.go
@@ -27,7 +27,7 @@ func TestCORSDevelopmentEnvironment(t *testing.T) {
 
 	// Setup Echo
 	e := echo.New()
-	corsMiddleware := CORS()
+	corsMiddleware := CORS(false)
 
 	// Create a simple handler
 	handler := corsMiddleware(func(c *echo.Context) error {
@@ -76,7 +76,7 @@ func TestCORSProductionEnvironmentWithCustomOrigins(t *testing.T) {
 
 	// Setup Echo
 	e := echo.New()
-	corsMiddleware := CORS()
+	corsMiddleware := CORS(false)
 
 	// Create a simple handler
 	handler := corsMiddleware(func(c *echo.Context) error {
@@ -153,7 +153,7 @@ func TestCORSProductionEnvironmentWithoutCustomOrigins(t *testing.T) {
 
 	// Setup Echo
 	e := echo.New()
-	corsMiddleware := CORS()
+	corsMiddleware := CORS(false)
 
 	// Create a simple handler
 	handler := corsMiddleware(func(c *echo.Context) error {
@@ -197,7 +197,7 @@ func TestCORSNeutralEnvWithoutCustomOriginsFailsClosed(t *testing.T) {
 			os.Unsetenv("CORS_ORIGINS")
 
 			e := echo.New()
-			handler := CORS()(func(c *echo.Context) error {
+			handler := CORS(false)(func(c *echo.Context) error {
 				return c.String(http.StatusOK, "test")
 			})
 
@@ -225,7 +225,7 @@ func TestCORSAllowedHeaders(t *testing.T) {
 
 	// Setup Echo
 	e := echo.New()
-	corsMiddleware := CORS()
+	corsMiddleware := CORS(false)
 
 	// Create a simple handler
 	handler := corsMiddleware(func(c *echo.Context) error {
@@ -262,9 +262,9 @@ func TestCORSExposedHeaders(t *testing.T) {
 
 	os.Setenv("APP_ENV", "development")
 
-	// Setup Echo
+	// Setup Echo — exposeResponseTime=true mirrors server.responsetime.enabled.
 	e := echo.New()
-	corsMiddleware := CORS()
+	corsMiddleware := CORS(true)
 
 	// Create a simple handler that sets response headers
 	handler := corsMiddleware(func(c *echo.Context) error {
@@ -289,6 +289,40 @@ func TestCORSExposedHeaders(t *testing.T) {
 	assert.Contains(t, exposedHeaders, HeaderXResponseTime)
 }
 
+// TestCORSExposedHeadersResponseTimeDisabled verifies that when the Timing
+// middleware is opt-out (exposeResponseTime=false, the default), CORS does not
+// advertise X-Response-Time in Access-Control-Expose-Headers — keeping the CORS
+// contract aligned with what the server actually emits. X-Request-ID stays.
+func TestCORSExposedHeadersResponseTimeDisabled(t *testing.T) {
+	originalAppEnv := os.Getenv("APP_ENV")
+	defer func() {
+		os.Setenv("APP_ENV", originalAppEnv)
+	}()
+
+	os.Setenv("APP_ENV", "development")
+
+	e := echo.New()
+	corsMiddleware := CORS(false)
+
+	handler := corsMiddleware(func(c *echo.Context) error {
+		c.Response().Header().Set("X-Request-ID", "test-123")
+		return c.String(http.StatusOK, "test")
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
+	req.Header.Set("Origin", "http://localhost:3000")
+
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, handler(c))
+
+	exposedHeaders := rec.Header().Get(HeaderAccessControlExposeHeaders)
+	assert.Contains(t, exposedHeaders, echo.HeaderXRequestID)
+	assert.NotContains(t, exposedHeaders, HeaderXResponseTime,
+		"X-Response-Time must not be advertised when the Timing middleware is disabled")
+}
+
 func TestCORSActualRequestHandling(t *testing.T) {
 	// Save original env vars
 	originalAppEnv := os.Getenv("APP_ENV")
@@ -300,7 +334,7 @@ func TestCORSActualRequestHandling(t *testing.T) {
 
 	// Setup Echo
 	e := echo.New()
-	corsMiddleware := CORS()
+	corsMiddleware := CORS(false)
 
 	// Create a handler that returns JSON
 	handler := corsMiddleware(func(c *echo.Context) error {
@@ -349,7 +383,7 @@ func TestCORSMaxAge(t *testing.T) {
 
 	// Setup Echo
 	e := echo.New()
-	corsMiddleware := CORS()
+	corsMiddleware := CORS(false)
 
 	handler := corsMiddleware(func(c *echo.Context) error {
 		return c.String(http.StatusOK, "test")
@@ -381,7 +415,7 @@ func TestCORSCredentialsEnabled(t *testing.T) {
 
 	// Setup Echo
 	e := echo.New()
-	corsMiddleware := CORS()
+	corsMiddleware := CORS(false)
 
 	handler := corsMiddleware(func(c *echo.Context) error {
 		return c.String(http.StatusOK, "test")
@@ -420,7 +454,7 @@ func TestCORSEmptyOriginsList(t *testing.T) {
 
 	// Setup Echo
 	e := echo.New()
-	corsMiddleware := CORS()
+	corsMiddleware := CORS(false)
 
 	handler := corsMiddleware(func(c *echo.Context) error {
 		return c.String(http.StatusOK, "test")
@@ -455,7 +489,7 @@ func TestCORSSingleOrigin(t *testing.T) {
 
 	// Setup Echo
 	e := echo.New()
-	corsMiddleware := CORS()
+	corsMiddleware := CORS(false)
 
 	handler := corsMiddleware(func(c *echo.Context) error {
 		return c.String(http.StatusOK, "test")
@@ -510,7 +544,7 @@ func TestCORSMiddlewareIntegration(t *testing.T) {
 
 	// Setup Echo with CORS middleware
 	e := echo.New()
-	e.Use(CORS())
+	e.Use(CORS(false))
 
 	// Add a route
 	e.GET("/api/test", func(c *echo.Context) error {
@@ -569,7 +603,7 @@ func TestCORSProductionAliasesTriggerStrictMode(t *testing.T) {
 			}
 
 			e := echo.New()
-			corsMiddleware := CORS()
+			corsMiddleware := CORS(false)
 			handler := corsMiddleware(func(c *echo.Context) error {
 				return c.String(http.StatusOK, "test")
 			})
@@ -616,7 +650,7 @@ func TestCORSEnvOverrideHonorsConfigValue(t *testing.T) {
 	os.Unsetenv("CORS_ORIGINS")
 
 	e := echo.New()
-	handler := CORS("development")(func(c *echo.Context) error {
+	handler := CORS(false, "development")(func(c *echo.Context) error {
 		return c.String(http.StatusOK, "test")
 	})
 
@@ -647,7 +681,7 @@ func TestCORSStrictBranchRejectsWildcardEntry(t *testing.T) {
 
 	// Must not panic at construction time.
 	e := echo.New()
-	handler := CORS()(func(c *echo.Context) error {
+	handler := CORS(false)(func(c *echo.Context) error {
 		return c.String(http.StatusOK, "test")
 	})
 
@@ -679,7 +713,7 @@ func TestCORSStrictBranchTolerantOfTrailingComma(t *testing.T) {
 
 	// Must not panic at construction time.
 	e := echo.New()
-	handler := CORS()(func(c *echo.Context) error {
+	handler := CORS(false)(func(c *echo.Context) error {
 		return c.String(http.StatusOK, "test")
 	})
 
@@ -709,7 +743,7 @@ func TestCORSStrictBranchAllWildcardFailsClosed(t *testing.T) {
 
 	// Must not panic.
 	e := echo.New()
-	handler := CORS()(func(c *echo.Context) error {
+	handler := CORS(false)(func(c *echo.Context) error {
 		return c.String(http.StatusOK, "test")
 	})
 

--- a/server/headers.go
+++ b/server/headers.go
@@ -13,7 +13,8 @@ package server
 
 const (
 	// HeaderXResponseTime is used to report request processing duration.
-	// Set by the timing middleware on all responses.
+	// Set by the optional timing middleware only when server.responsetime.enabled
+	// is true (off by default); see ADR-026.
 	HeaderXResponseTime = "X-Response-Time"
 
 	// HeaderXRealIP contains the client's real IP address when behind a proxy.

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -91,7 +91,7 @@ func SetupMiddlewares(e *echo.Echo, log logger.Logger, cfg *config.Config, obser
 	// CORS — pass cfg.App.Env so the policy honors the Koanf default of
 	// EnvDevelopment (instead of falling back to os.Getenv which is empty
 	// when the operator relies on config.yaml / framework defaults).
-	e.Use(CORS(cfg.App.Env))
+	e.Use(CORS(cfg.Server.ResponseTime.Enabled, cfg.App.Env))
 
 	// IP pre-guard rate limiting (runs before tenant resolution for attack prevention)
 	if cfg.App.Rate.IPPreGuard.Enabled {
@@ -146,8 +146,13 @@ func SetupMiddlewares(e *echo.Echo, log logger.Logger, cfg *config.Config, obser
 	// Rate limit
 	e.Use(RateLimit(cfg.App.Rate.Limit))
 
-	// Timing
-	e.Use(Timing())
+	// Timing — opt-in. The X-Response-Time header costs a per-response header
+	// allocation (net/textproto.MIMEHeader.Set allocates a []string per Set) and
+	// OTel provides richer latency telemetry, so it defaults off. Enable via
+	// server.responsetime.enabled for local debugging or consumer compatibility.
+	if cfg.Server.ResponseTime.Enabled {
+		e.Use(Timing())
+	}
 }
 
 var defaultTenantIDRegex = regexp.MustCompile(`^[a-z0-9-]{1,64}$`)

--- a/server/middleware_test.go
+++ b/server/middleware_test.go
@@ -108,13 +108,64 @@ func TestSetupMiddlewares(t *testing.T) {
 			// Verify request ID is set
 			assert.NotEmpty(t, rec.Header().Get(echo.HeaderXRequestID))
 
-			// Verify timing header is set
-			assert.NotEmpty(t, rec.Header().Get(HeaderXResponseTime))
+			// Timing header is opt-in (server.responsetime.enabled); the test
+			// configs leave it at the zero-value default (disabled), so the
+			// X-Response-Time header must be absent.
+			assert.Empty(t, rec.Header().Get(HeaderXResponseTime))
 
 			// Response should be successful
 			assert.Equal(t, http.StatusOK, rec.Code)
 		})
 	}
+}
+
+// TestSetupMiddlewaresResponseTimeHeader verifies the X-Response-Time header is
+// opt-in: absent under the default (disabled) config and present once
+// server.responsetime.enabled is true.
+func TestSetupMiddlewaresResponseTimeHeader(t *testing.T) {
+	newCfg := func(enabled bool) *config.Config {
+		return &config.Config{
+			App: config.AppConfig{Rate: config.RateConfig{Limit: 100}},
+			Server: config.ServerConfig{
+				Timeout:      config.TimeoutConfig{Middleware: 30 * time.Second},
+				ResponseTime: config.ResponseTimeConfig{Enabled: enabled},
+			},
+		}
+	}
+
+	t.Run("disabled_by_default_omits_header", func(t *testing.T) {
+		e := echo.New()
+		log := logger.New("disabled", false)
+		SetupMiddlewares(e, log, newCfg(false), true, testHealthPath, testReadyPath)
+		e.GET("/test", func(c *echo.Context) error {
+			return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+		})
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", http.NoBody)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Empty(t, rec.Header().Get(HeaderXResponseTime),
+			"X-Response-Time must be absent when server.responsetime.enabled is false")
+	})
+
+	t.Run("enabled_sets_header", func(t *testing.T) {
+		e := echo.New()
+		log := logger.New("disabled", false)
+		SetupMiddlewares(e, log, newCfg(true), true, testHealthPath, testReadyPath)
+		e.GET("/test", func(c *echo.Context) error {
+			return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+		})
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", http.NoBody)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.NotEmpty(t, rec.Header().Get(HeaderXResponseTime),
+			"X-Response-Time must be present when server.responsetime.enabled is true")
+	})
 }
 
 func TestBuildTenantResolver(t *testing.T) {

--- a/wiki/adr_026_zero_overhead_request_path.md
+++ b/wiki/adr_026_zero_overhead_request_path.md
@@ -48,6 +48,13 @@ enrichment:
   combining trace enrichment and counter seeding. `TraceContext`/`PerformanceStats`
   remain exported and share the trace-enrichment helper.
 - **Add `server.gzip.minlength`** (default 1024) so tiny responses skip compression.
+- **Make the `X-Response-Time` header opt-in** via `server.responsetime.enabled`
+  (default false). The always-on `Timing` middleware set the header on every
+  response, and each `Header().Set` allocates a `[]string` in
+  `net/textproto.MIMEHeader.Set` — ~2.4% of total allocations on the default read
+  workload (perf iteration-2). The middleware is registered only when enabled, and
+  `server.CORS` advertises the header in `Access-Control-Expose-Headers` only when
+  it is actually emitted. `X-Request-ID` and `traceparent` stay unconditional.
 
 ### Breaking changes
 
@@ -55,6 +62,9 @@ enrichment:
   (Interface evolution, same class as the S8179/S8196 changes in ADR-013.)
 - `server.SetupMiddlewares` gains an `observabilityEnabled bool` parameter.
 - `server.gzip.minlength` defaults to 1024 (was effectively 0 = compress all).
+- `X-Response-Time` is no longer emitted by default — opt in with
+  `server.responsetime.enabled: true`. Direct callers of `server.CORS(...)` gain a
+  leading `exposeResponseTime bool` parameter.
 - Consumers using the `database` package **without** the app bootstrap must call
   `database.SetObservabilityEnabled(true)` to emit DB spans/metrics.
 

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -37,6 +37,18 @@ The OTel HTTP middleware is registered only when the flag is true (zero per-requ
 
 `server.gzip.minlength` now defaults to **1024** bytes (previously gzip compressed everything). Responses smaller than this are sent uncompressed, avoiding gzip header overhead on tiny JSON. Set `server.gzip.minlength: 0` to restore always-compress behavior.
 
+### `X-Response-Time` header is now opt-in (`server.responsetime.enabled`)
+
+The diagnostic `X-Response-Time` response header (per-request processing time) is **no longer emitted by default**. The `Timing` middleware that set it on every response is now gated behind `server.responsetime.enabled` (default **false**). Each per-response `Header().Set` allocates a `[]string` in `net/textproto.MIMEHeader.Set` — measured at ~2.4% of total allocations on the default read workload — and OTel provides richer latency telemetry. `X-Request-ID` and `traceparent` are unaffected. To restore the header, set:
+
+```yaml
+server:
+  responsetime:
+    enabled: true   # or SERVER_RESPONSETIME_ENABLED=true
+```
+
+When disabled, CORS also stops advertising `X-Response-Time` in `Access-Control-Expose-Headers`, keeping the CORS contract aligned with what is on the wire. Direct callers of `server.CORS(...)` get a new leading `exposeResponseTime bool` parameter (`CORS(cfg.Server.ResponseTime.Enabled, cfg.App.Env)`); apps using the normal server bootstrap are unaffected.
+
 ## Connection Pool Idle Default — Tracks Max (ADR-025)
 
 Per [ADR-025](adr_025_pool_idle_tracks_max.md), the default for `database.pool.idle.connections` changed from a fixed **2** to **tracking `database.pool.max.connections`** (default 25). The old default kept only 2 idle connections against a max of 25, so under sustained load the pool continuously opened and closed physical connections (TCP+TLS+auth) — measured as a 91% p95 latency reduction (16.25 → 1.46 ms) and connection-establishment errors dropping from 8.15% to 0% once idle tracked max.


### PR DESCRIPTION
## What

Makes the `X-Response-Time` response header **opt-in** (default off).

The `Timing` middleware set `X-Response-Time` (per-request processing time) on **every** response. Each `resp.Header().Set` allocates a fresh `[]string{value}` in `net/textproto.MIMEHeader.Set`; `Timing` is ~59% of that allocation node — **~60 MB / ~2.4% of total allocations** in perf iteration 2. The header is purely diagnostic (`X-Request-ID` and `traceparent` are untouched), and OTel provides richer latency telemetry.

## How

New `server.responsetime.enabled` toggle (mirrors `server.gzip.minlength`), **default `false`**:

- `Timing()` middleware is registered only when enabled (`server/middleware.go`);
- the CORS `Access-Control-Expose-Headers` advertises `X-Response-Time` only when enabled (`CORS()` gains a leading `exposeResponseTime bool`), keeping the advertised list aligned with what is actually emitted.

Part of the **ADR-026** zero-overhead-request-path effort (iteration 2) — ADR-026's Decision and breaking-changes lists are extended rather than minting a new ADR, and `wiki/migrations.md` gets a row. `config.example.yaml` documents the new key.

## Breaking change

`X-Response-Time` is no longer emitted by default. Restore it with `server.responsetime.enabled: true` (or `SERVER_RESPONSETIME_ENABLED=true`). The exported `server.CORS(...)` helper signature also changes (gains a leading `exposeResponseTime bool`; Go requires it before the existing variadic `envOverride`).

## Tests

`make check` green (fmt + lint + `-race`). Added:
- config: `ResponseTime.Enabled` defaults false; `SERVER_RESPONSETIME_ENABLED=true` enables it (and the var added to the test env-clear helper for deterministic isolation);
- `SetupMiddlewares`: response omits `X-Response-Time` by default, sets it when enabled;
- CORS: expose-header excludes `X-Response-Time` when disabled, includes it when enabled.

Source: perf iteration 2 finding #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The `X-Response-Time` response header is no longer emitted by default. Enable it via the `server.responsetime.enabled` configuration option (defaults to `false`).

* **New Features**
  * The `X-Response-Time` response header can now be controlled through configuration, allowing users to enable it when needed for performance monitoring and debugging.

* **Documentation**
  * Updated configuration examples and migration guide to document the new opt-in behavior for response-time headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->