### PR TITLE
perf(logger): reuse LogEventAdapter across chained setters (drop per-field wrapEvent alloc)

### DIFF
--- a/logger/adapter.go
+++ b/logger/adapter.go
@@ -15,17 +15,15 @@ type LogEventAdapter struct {
 	hook   func(zerolog.Level)
 }
 
-// wrapEvent creates a new LogEventAdapter reusing the current filter/level/hook.
-func (lea *LogEventAdapter) wrapEvent(e *zerolog.Event) *LogEventAdapter {
-	return &LogEventAdapter{event: e, filter: lea.filter, level: lea.level, hook: lea.hook}
-}
-
-// maskIfSensitive returns a masked adapter when the key is sensitive, signalling via ok.
+// maskIfSensitive masks the key in place when it is sensitive, signalling via ok.
 // Centralizes the typed-method mask check so adding a new typed slot (e.g. Float64) cannot
 // silently bypass the privacy boundary by forgetting to wire the same conditional.
+// zerolog's *Event.Interface mutates the event in place and returns the same pointer, so
+// reusing the receiver here avoids allocating a wrapper per masked field.
 func (lea *LogEventAdapter) maskIfSensitive(key string) (LogEvent, bool) {
 	if lea.filter != nil && lea.filter.isSensitiveField(key) {
-		return lea.wrapEvent(lea.event.Interface(key, lea.filter.config.MaskValue)), true
+		lea.event = lea.event.Interface(key, lea.filter.config.MaskValue)
+		return lea, true
 	}
 	return nil, false
 }
@@ -44,7 +42,8 @@ func (lea *LogEventAdapter) Msgf(format string, args ...any) {
 
 // Err adds an error to the log event
 func (lea *LogEventAdapter) Err(err error) LogEvent {
-	return lea.wrapEvent(lea.event.Err(err))
+	lea.event = lea.event.Err(err)
+	return lea
 }
 
 // Str adds a string field to the log event
@@ -52,7 +51,8 @@ func (lea *LogEventAdapter) Str(key, value string) LogEvent {
 	if lea.filter != nil {
 		value = lea.filter.FilterString(key, value)
 	}
-	return lea.wrapEvent(lea.event.Str(key, value))
+	lea.event = lea.event.Str(key, value)
+	return lea
 }
 
 // Int adds an integer field to the log event
@@ -60,7 +60,8 @@ func (lea *LogEventAdapter) Int(key string, value int) LogEvent {
 	if masked, ok := lea.maskIfSensitive(key); ok {
 		return masked
 	}
-	return lea.wrapEvent(lea.event.Int(key, value))
+	lea.event = lea.event.Int(key, value)
+	return lea
 }
 
 // Int64 adds an int64 field to the log event
@@ -68,7 +69,8 @@ func (lea *LogEventAdapter) Int64(key string, value int64) LogEvent {
 	if masked, ok := lea.maskIfSensitive(key); ok {
 		return masked
 	}
-	return lea.wrapEvent(lea.event.Int64(key, value))
+	lea.event = lea.event.Int64(key, value)
+	return lea
 }
 
 // Uint64 adds a uint64 field to the log event
@@ -76,7 +78,8 @@ func (lea *LogEventAdapter) Uint64(key string, value uint64) LogEvent {
 	if masked, ok := lea.maskIfSensitive(key); ok {
 		return masked
 	}
-	return lea.wrapEvent(lea.event.Uint64(key, value))
+	lea.event = lea.event.Uint64(key, value)
+	return lea
 }
 
 // Dur adds a duration field to the log event
@@ -84,7 +87,8 @@ func (lea *LogEventAdapter) Dur(key string, d time.Duration) LogEvent {
 	if masked, ok := lea.maskIfSensitive(key); ok {
 		return masked
 	}
-	return lea.wrapEvent(lea.event.Dur(key, d))
+	lea.event = lea.event.Dur(key, d)
+	return lea
 }
 
 // Interface adds an any field to the log event
@@ -92,7 +96,8 @@ func (lea *LogEventAdapter) Interface(key string, i any) LogEvent {
 	if lea.filter != nil {
 		i = lea.filter.FilterValue(key, i)
 	}
-	return lea.wrapEvent(lea.event.Interface(key, i))
+	lea.event = lea.event.Interface(key, i)
+	return lea
 }
 
 // Bytes adds a byte slice field to the log event
@@ -100,7 +105,8 @@ func (lea *LogEventAdapter) Bytes(key string, val []byte) LogEvent {
 	if masked, ok := lea.maskIfSensitive(key); ok {
 		return masked
 	}
-	return lea.wrapEvent(lea.event.Bytes(key, val))
+	lea.event = lea.event.Bytes(key, val)
+	return lea
 }
 
 // Bool adds a boolean field to the log event
@@ -108,12 +114,15 @@ func (lea *LogEventAdapter) Bool(key string, value bool) LogEvent {
 	if lea.filter != nil {
 		filtered := lea.filter.FilterValue(key, value)
 		if b, ok := filtered.(bool); ok {
-			return lea.wrapEvent(lea.event.Bool(key, b))
+			lea.event = lea.event.Bool(key, b)
+			return lea
 		}
 		// Sensitive field was masked to a string — fall back to Interface to preserve the mask
-		return lea.wrapEvent(lea.event.Interface(key, filtered))
+		lea.event = lea.event.Interface(key, filtered)
+		return lea
 	}
-	return lea.wrapEvent(lea.event.Bool(key, value))
+	lea.event = lea.event.Bool(key, value)
+	return lea
 }
 
 // Enabled reports whether the underlying zerolog event will be emitted. It is

--- a/logger/adapter_test.go
+++ b/logger/adapter_test.go
@@ -258,6 +258,105 @@ func TestLogEventAdapterChainedFields(t *testing.T) {
 	assert.Equal(t, "error", logEntry["level"])
 }
 
+// TestLogEventAdapterMutateInPlaceDisabledChainIsNilSafe exercises the surface the
+// mutate-and-return-receiver change newly stresses: chaining typed setters (incl. a
+// sensitive masked key) on a level-DISABLED event whose underlying *zerolog.Event is
+// nil. Every setter (and maskIfSensitive) must be a nil-safe no-op, the adapter must
+// stay disabled, and nothing may be emitted.
+func TestLogEventAdapterMutateInPlaceDisabledChainIsNilSafe(t *testing.T) {
+	var buf bytes.Buffer
+	zl := zerolog.New(&buf).Level(zerolog.WarnLevel)
+	filterConfig := &FilterConfig{
+		SensitiveFields: []string{"password"},
+		MaskValue:       "[MASKED]",
+	}
+	logger := &ZeroLogger{zlog: &zl, filter: NewSensitiveDataFilter(filterConfig)}
+
+	// Debug is disabled at WarnLevel -> zerolog returns a nil *Event.
+	start := logger.Debug()
+	assert.False(t, start.Enabled())
+
+	// A long chain (incl. the sensitive mask path) must not panic and must stay disabled.
+	event := start.
+		Err(errors.New("boom")).
+		Str("user", "alice").
+		Int("attempt", 3).
+		Int64("timestamp", 1640995200).
+		Uint64("size", 1024).
+		Dur("duration", 250*time.Millisecond).
+		Interface("data", map[string]string{"k": "v"}).
+		Bytes("payload", []byte("hello")).
+		Bool("active", true).
+		Int("password", 9999) // sensitive key on a disabled event
+
+	assert.False(t, event.Enabled(), "chaining must not re-enable a disabled event")
+	event.Msg("dropped")
+
+	assert.Empty(t, buf.String(), "a disabled event must emit nothing even after a full setter chain")
+}
+
+// TestLogEventAdapterMutateInPlaceAccumulatesAllFields proves that reusing the receiver
+// across chained typed setters (instead of allocating a fresh wrapper per field) preserves
+// full field accumulation AND the privacy boundary. It chains many typed setters — including
+// a sensitive key that must be masked — and asserts every field lands in the emitted JSON
+// with the correct value while the sensitive one is masked. It also locks in the no-alloc
+// intent by asserting the chain returns the same underlying adapter (pointer identity).
+func TestLogEventAdapterMutateInPlaceAccumulatesAllFields(t *testing.T) {
+	var buf bytes.Buffer
+	zl := zerolog.New(&buf)
+	filterConfig := &FilterConfig{
+		SensitiveFields: []string{"password"},
+		MaskValue:       "[MASKED]",
+	}
+	logger := &ZeroLogger{zlog: &zl, filter: NewSensitiveDataFilter(filterConfig)}
+
+	testErr := errors.New(testutil.TestError)
+	start := logger.Info()
+
+	// Chain every typed setter, including a sensitive key (password) that must be masked.
+	event := start.
+		Err(testErr).
+		Str("user", "alice").
+		Int("attempt", 3).
+		Int64("timestamp", 1640995200).
+		Uint64("size", 1024).
+		Dur("duration", 250*time.Millisecond).
+		Interface("data", map[string]string{"k": "v"}).
+		Bytes("payload", []byte("hello")).
+		Bool("active", true).
+		Int("password", 9999) // sensitive — Int routes through maskIfSensitive, emitted as the mask value
+
+	// Identity: every setter returns the same underlying receiver (no per-field wrapper).
+	startAdapter, ok := start.(*LogEventAdapter)
+	require.True(t, ok)
+	eventAdapter, ok := event.(*LogEventAdapter)
+	require.True(t, ok)
+	assert.Same(t, startAdapter, eventAdapter, "chained setters must reuse the same adapter (no per-field alloc)")
+
+	event.Msg("mutate in place")
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+
+	// All fields accumulated with correct values despite mutate-and-return.
+	assert.Equal(t, testutil.TestError, entry["error"])
+	assert.Equal(t, "alice", entry["user"])
+	assert.Equal(t, float64(3), entry["attempt"])
+	assert.Equal(t, float64(1640995200), entry["timestamp"])
+	assert.Equal(t, float64(1024), entry["size"])
+	assert.Equal(t, float64(250), entry["duration"])
+	data, ok := entry["data"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "v", data["k"])
+	assert.NotEmpty(t, entry["payload"])
+	assert.Equal(t, true, entry["active"])
+	assert.Equal(t, "mutate in place", entry["message"])
+
+	// Privacy boundary preserved: sensitive key masked, raw value absent.
+	assert.Equal(t, "[MASKED]", entry["password"], "sensitive key must be masked, not the raw int")
+	assert.NotContains(t, buf.String(), "9999")
+}
+
 func TestZeroLoggerInfo(t *testing.T) {
 	logger, buf := createTestLogger()
 


### PR DESCRIPTION
## What

Stops `LogEventAdapter` from heap-allocating a fresh wrapper struct on every typed setter call.

Each setter (`Str`/`Int`/`Int64`/…) called `wrapEvent`, which allocated a new `*LogEventAdapter` per field — even though the underlying `*zerolog.Event` is mutated in place and returned by identity. The default INFO action-summary line (`server/logger.go` `buildLogEvent`) chains ~17 setters, so every healthy 2xx request paid **~17 redundant adapter allocations**.

**Impact** (perf iteration 3, default config, obs off): `wrapEvent` is **~1.6 M objects/run = 4.38% of all allocated objects — the #1 object producer** (~49.5 MB). This is the per-field analog of the shipped `LogEvent.Enabled()` short-circuit (#559), which only skips the summary when the level is *disabled*; at default INFO the summary **is** emitted and paid full per-field cost.

## How

Each setter now mutates the receiver and returns it (and `wrapEvent` is deleted):

```go
lea.event = lea.event.X(args)
return lea
```

An N-setter chain goes from **N+1 adapters to 1**. zerolog's `*Event` setters mutate `e.buf` in place and return the same pointer (verified in v1.35.1), so this is behavior-neutral.

## Correctness — behavior-neutral

- **Branching audit (repo-wide):** the only pattern this could affect is a caller holding an intermediate `LogEvent` and emitting two *independent* branches from it — which was **already** broken under the old code (the wrapper adapters shared the same mutated `*zerolog.Event`). Audited every framework `LogEvent` call site (`server/logger.go`, `database/tracking`, `httpclient`, `messaging`, `migration`, `scheduler`, `jose`, pg/oracle connections): **all chain linearly or reassign `event = event.X(...)` and emit exactly once. No branch-and-emit-both exists.**
- **Privacy boundary unchanged:** every `FilterString`/`FilterValue`/`maskIfSensitive` check stays *before* the zerolog call, on the same keys/values — a sensitive key is masked identically.
- **No public API / JSON-output change:** `*LogEventAdapter` still satisfies `LogEvent`; setters still return `LogEvent`.

## Tests

`make check` green. Added:
- `TestLogEventAdapterMutateInPlaceAccumulatesAllFields` — a ~10-setter chain (incl. a masked sensitive key) accumulates all fields with correct values **and** returns the same adapter (`assert.Same`), locking in the no-alloc intent.
- `TestLogEventAdapterMutateInPlaceDisabledChainIsNilSafe` — chaining the full setter + mask path on a level-disabled (nil) event is a nil-safe no-op and emits nothing.

Existing chained-field/masking tests pass unchanged.

Source: perf iteration 3 (go-bricks-demo-project `wiki/PERF_FINDINGS_ITERATION_3.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Event adapter now mutates in place when chaining field setters to reduce allocations and improve performance; boolean handling and sensitive-field masking behavior preserved.

* **Tests**
  * Added tests ensuring nil-safe chaining from disabled events, correct accumulation of all field types, reuse of the same adapter instance, and proper masking of sensitive values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->