### PR TITLE
fix(messaging): apply reconnect.connectiontimeout to the AMQP client (+ repo-wide doc-drift cleanup)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ make lint                       # Run golangci-lint
 - **multitenant/** — Tenant identifier resolution from incoming HTTP requests. Four resolver types: `header` (default `X-Tenant-ID`), `subdomain` (`<tenant>.<domain>`), `path` (1-indexed segment with optional prefix gate; e.g. `/itsp/{tenantID}/...`), and `composite` (header → subdomain → path fallback chain). All run before route matching so the resolved tenant is in `context.Context` for every middleware and handler. Per-tenant DB/cache/messaging accessors (`deps.DB(ctx)`, etc.) consume the value transparently. See [multi_tenant_resolvers.md](wiki/multi_tenant_resolvers.md).
 - **observability/** — OpenTelemetry tracing and metrics
 - **outbox/** — Transactional outbox for reliable event publishing (at-least-once delivery)
+- **inbox/** — Exactly-once consumer-side processing (`InboxProcessor`); consumer-side complement to the transactional outbox
 - **keystore/** — Named key-material management: RSA key pairs and raw symmetric secrets (HMAC/HKDF) from files or base64 env vars; per-entry RSA-or-secret with a startup mutual-exclusivity check. See [keystore.md](wiki/keystore.md)
 - **jose/** — Nested JWE-of-JWS protection on HTTP request and response bodies
 
@@ -174,9 +175,9 @@ type MessagingDeclarer interface {
 // Simplified — see app/module.go for the full struct (~12 fields including
 // Scheduler, Outbox, Tracer, MeterProvider, DBByName, etc.)
 type ModuleDeps struct {
-    DB        database.Interface
+    DB        func(context.Context) (database.Interface, error)
     Logger    logger.Logger
-    Messaging messaging.Client
+    Messaging func(context.Context) (messaging.AMQPClient, error)
     Config    *config.Config
 }
 ```
@@ -251,10 +252,10 @@ type User struct {
 cols := qb.Columns(&User{})  // Cached per vendor
 f := qb.Filter()
 
-query := qb.Select(cols.Fields("ID", "Name")...).
+query := qb.Select(cols.Cols("ID", "Name")).
     From("users").
     Where(f.Eq(cols.Col("Level"), 5))
-// Oracle: SELECT "ID", "NAME" FROM users WHERE "LEVEL" = :1
+// Oracle: SELECT id, name FROM users WHERE "level" = :1
 ```
 
 **Type-Safe Methods:** `f.Eq`, `f.NotEq`, `f.Lt/Lte/Gt/Gte`, `f.In/NotIn`, `f.Like`, `f.Regex*`, `f.JSONContains` (PG only), `f.Null/NotNull`, `f.Between`, `f.Exists`, `f.NotExists`, `f.InSubquery`. Use `qb.Expr()` for complex SQL inside type-safe methods (no placeholders).
@@ -320,8 +321,8 @@ type Executor interface {
     Execute(ctx JobContext) error  // JobContext gives JobID, TriggerType, Logger, DB, Messaging, Config
 }
 
-func (m *Module) Init(deps *app.ModuleDeps) error {
-    return deps.Scheduler.DailyAt("cleanup-job", &CleanupJob{}, mustParseTime("03:00"))
+func (m *Module) RegisterJobs(s app.JobRegistrar) error {
+    return s.DailyAt("cleanup-job", &CleanupJob{}, scheduler.ParseTime("03:00"))
 }
 ```
 
@@ -537,6 +538,7 @@ GoBricks has shipped several breaking changes for idiomatic Go conventions. Gree
 - **observability/testing/** — Test utilities for spans and metrics.
 - **outbox/** — Transactional outbox pattern (Publisher, Relay, Store, multi-vendor).
 - **outbox/testing/** — Outbox-specific testing (MockOutbox, assertion helpers).
+- **inbox/** — Exactly-once consumer-side processing (InboxProcessor, DB-vendor store, cleanup).
 - **keystore/** — Named RSA key pairs + symmetric secrets (DER/raw files + base64 env vars).
 - **keystore/testing/** — KeyStore-specific testing (MockKeyStore, assertion helpers).
 - **tools/** — Development tooling (`migration` CLI / `go-bricks-migrate`).
@@ -561,16 +563,18 @@ type Interface interface {
 type Client interface {
     Publish(ctx context.Context, destination string, data []byte) error
     Consume(ctx context.Context, destination string) (<-chan amqp.Delivery, error)
+    Close() error
     IsReady() bool
 }
 
 // Observability
 type Provider interface {
-    TracerProvider() *sdktrace.TracerProvider
-    MeterProvider() *sdkmetric.MeterProvider
+    TracerProvider() trace.TracerProvider
+    MeterProvider() metric.MeterProvider
     LoggerProvider() *sdklog.LoggerProvider
     ShouldDisableStdout() bool
     Shutdown(ctx context.Context) error
+    ForceFlush(ctx context.Context) error
 }
 
 // Outbox

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,7 +441,7 @@ For dual-mode log routing, runtime metrics, custom-metric patterns, vendor authe
 | HTTP server read / write / idle / shutdown | `server.timeout.{read,write,idle,shutdown}` | 15s / 30s / 60s / 10s |
 | Outbound HTTP client | `httpclient.NewBuilder(...).WithTimeout(d)` | 30s |
 | Cache (Redis) dial / read / write | `cache.redis.{dialtimeout,readtimeout,writetimeout}` | 5s / 3s / 3s |
-| AMQP connection establishment | `messaging.reconnect.connectiontimeout` | 30s |
+| AMQP publish confirmation | `messaging.reconnect.connectiontimeout` | 30s |
 | Scheduler slow-job WARN / shutdown | `scheduler.timeout.{slowjob,shutdown}` | 25s / 30s |
 | Observability export | `observability.trace.export.timeout` | 10s (dev) / 60s (prod) |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Thank you for your interest in contributing to GoBricks! This document provides 
    ```bash
    make check
    ```
-   This runs formatting, linting, and tests.
+   This runs formatting, linting, tests, and a vulnerability scan.
 
 ### Code Quality Standards
 
@@ -128,9 +128,9 @@ make test          # Run all tests
 make test-coverage # Run tests with coverage
 make lint          # Run golangci-lint
 make fmt           # Format Go code
-make tidy          # Tidy Go modules
+make update        # Update deps and tidy modules
 make clean         # Clean build cache
-make check         # Run fmt, lint, and test
+make check         # Run fmt, lint, test, and vuln scan
 ```
 
 ## Module Development

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ go test -run TestName   # Run specific test
 - **Redis cache integration** with type-safe serialization, multi-tenant isolation, and automatic lifecycle management
 - **Transactional outbox** for reliable at-least-once event publishing (dual-write problem solved)
 - **Job scheduler** with gocron, overlapping prevention, panic recovery, and system APIs
-- **Named RSA key pair management** from DER files or base64 environment variables
+- **Named RSA key pair and symmetric secret management** from DER/raw files or base64 environment variables
 - **JOSE middleware** for nested JWE-of-JWS protection on HTTP request/response bodies (Visa-style integrations)
 - **Multi-tenant architecture** with complete resource isolation and context propagation
 - **Flyway migration integration** for schema evolution
@@ -161,7 +161,7 @@ cache:
     host: localhost
     port: 6379
     database: 0
-    pool_size: 10
+    poolsize: 10
 
 log:
   level: info
@@ -220,7 +220,7 @@ func (m *Module) Init(deps *ModuleDeps) error {
 ```
 
 **Supported tags:** `config:"key.path"` (required), `required:"true"` (fail if missing), `default:"value"` (fallback).
-**Supported types:** string, int, int64, float64, bool, time.Duration.
+**Supported types:** string, int, int64, float64, bool, time.Duration, []string (comma-separated via env/`default`, native sequence via YAML).
 
 ### Environment Variables
 Environment variables use uppercase with underscores and automatically map to dot notation:
@@ -292,6 +292,7 @@ type ModuleDeps struct {
     MeterProvider metric.MeterProvider                                   // Custom metrics (no-op if disabled)
     Scheduler     JobRegistrar                                           // Job scheduling (nil if no scheduler module)
     Outbox        OutboxPublisher                                        // Transactional event publishing (nil if disabled)
+    Inbox         InboxProcessor                                         // Durable consumer-side idempotency (nil if inbox module not registered)
     KeyStore      KeyStore                                               // Named RSA key pairs (nil if not configured)
     DB            func(ctx context.Context) (database.Interface, error)  // Tenant-aware database
     DBByName      func(ctx context.Context, name string) (database.Interface, error) // Named databases
@@ -458,7 +459,8 @@ The `migration` package wraps the Flyway CLI for repeatable schema versioning. I
 
 ```go
 m := migration.NewFlywayMigrator(cfg, logger)
-if err := m.Migrate(ctx, nil); err != nil {     // nil → use vendor-aware defaults
+_, err := m.Migrate(ctx, nil)     // nil → use vendor-aware defaults
+if err != nil {
     log.Fatal(err)
 }
 ```
@@ -500,7 +502,7 @@ type UserService struct {
 
 func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
     // Cache(ctx) resolves the tenant from context automatically
-    cache, err := s.getCache(ctx)
+    c, err := s.getCache(ctx)
     if err != nil {
         return nil, err
     }
@@ -508,9 +510,9 @@ func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
     cacheKey := fmt.Sprintf("user:%d", id)
 
     // Try cache first
-    data, err := cache.Get(ctx, cacheKey)
+    data, err := c.Get(ctx, cacheKey)
     if err == nil {
-        return cache.Unmarshal[User](data)
+        return cache.Unmarshal[*User](data)
     }
 
     // Cache miss - query database
@@ -521,7 +523,7 @@ func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
 
     // Store in cache with TTL
     data, _ = cache.Marshal(user)
-    cache.Set(ctx, cacheKey, data, 5*time.Minute)
+    c.Set(ctx, cacheKey, data, 5*time.Minute)
 
     return user, nil
 }
@@ -550,7 +552,7 @@ cache:
     port: 6379
     password: ${CACHE_REDIS_PASSWORD}   # From environment
     database: 0
-    pool_size: 10              # Defaults to NumCPU * 2 if unset
+    poolsize: 10               # Default: 10
 ```
 
 The `manager.*` keys tune the per-tenant lifecycle; tune them up if you serve many tenants or want connections to live longer between bursts.
@@ -607,11 +609,11 @@ func TestMyService(t *testing.T) {
 
 ### Job Scheduler
 
-gocron-based job scheduling integrated with the module system. Lazy initialization, overlapping prevention (mutex per job), automatic panic recovery with stack trace logging, and system APIs (`GET /_sys/jobs`, `POST /_sys/job/:jobId`).
+gocron-based job scheduling integrated with the module system. Lazy initialization, overlapping prevention (mutex per job), automatic panic recovery with stack trace logging, and system APIs (`GET /_sys/job`, `POST /_sys/job/:jobId`).
 
 ```go
 func (m *Module) Init(deps *app.ModuleDeps) error {
-    return deps.Scheduler.DailyAt("cleanup-job", &CleanupJob{}, mustParseTime("03:00"))
+    return deps.Scheduler.DailyAt("cleanup-job", &CleanupJob{}, scheduler.ParseTime("03:00"))
 }
 
 // Implement the Executor interface
@@ -818,7 +820,11 @@ See [MULTI_TENANT.md](MULTI_TENANT.md) for detailed architecture and [multitenan
    )
 
    func wireLogging(cfg *config.Config, e *echo.Echo) (observability.Provider, logger.Logger, error) {
-       obsProvider, err := observability.NewProvider(&cfg.Observability)
+       var obsCfg observability.Config
+       if err := cfg.Unmarshal("observability", &obsCfg); err != nil {
+           return nil, nil, err
+       }
+       obsProvider, err := observability.NewProvider(&obsCfg)
        if err != nil {
            return nil, nil, err
        }
@@ -829,7 +835,7 @@ See [MULTI_TENANT.md](MULTI_TENANT.md) for detailed architecture and [multitenan
        e.Use(server.LoggerWithConfig(appLogger, server.LoggerConfig{
            HealthPath:           "/health",
            ReadyPath:            "/ready",
-           SlowRequestThreshold: cfg.Observability.Logs.SlowRequestThreshold,
+           SlowRequestThreshold: obsCfg.Logs.SlowRequestThreshold,
        }))
 
        return obsProvider, appLogger, nil

--- a/app/bootstrap.go
+++ b/app/bootstrap.go
@@ -35,6 +35,7 @@ func (b *appBootstrap) dependencies() *dependencyBundle {
 	// Create factory resolver and configuration builder
 	resolver := NewFactoryResolver(b.opts)
 	configBuilder := NewManagerConfigBuilder(b.cfg.Multitenant.Enabled, b.cfg.Multitenant.Limits.Tenants)
+	configBuilder.connectionTimeout = b.cfg.Messaging.Reconnect.ConnectionTimeout
 	factory := NewResourceManagerFactory(resolver, configBuilder, b.log)
 
 	// Log factory configuration for debugging

--- a/app/factory_resolver.go
+++ b/app/factory_resolver.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/gaborage/go-bricks/cache"
 	"github.com/gaborage/go-bricks/cache/redis"
@@ -35,8 +36,10 @@ func (f *FactoryResolver) DatabaseConnector() database.Connector {
 }
 
 // MessagingClientFactory returns the appropriate messaging client factory function.
-// If no custom factory is provided in options, returns a factory that creates AMQPClient instances.
-func (f *FactoryResolver) MessagingClientFactory() messaging.ClientFactory {
+// The default factory creates AMQPClient instances configured with the supplied per-publish
+// connection timeout. If a custom Options.MessagingClientFactory is set it owns construction
+// and receives only (url, log) — the connectionTimeout does not apply to it.
+func (f *FactoryResolver) MessagingClientFactory(connectionTimeout time.Duration) messaging.ClientFactory {
 	if f.opts != nil && f.opts.MessagingClientFactory != nil {
 		return func(url string, log logger.Logger) messaging.AMQPClient {
 			return f.opts.MessagingClientFactory(url, log)
@@ -44,7 +47,7 @@ func (f *FactoryResolver) MessagingClientFactory() messaging.ClientFactory {
 	}
 
 	return func(url string, log logger.Logger) messaging.AMQPClient {
-		return messaging.NewAMQPClient(url, log)
+		return messaging.NewAMQPClient(url, log, messaging.WithConnectionTimeout(connectionTimeout))
 	}
 }
 

--- a/app/factory_resolver_test.go
+++ b/app/factory_resolver_test.go
@@ -124,6 +124,20 @@ func TestFactoryResolverHasCustomFactories(t *testing.T) {
 	})
 }
 
+func TestFactoryResolverMessagingClientFactory(t *testing.T) {
+	t.Run("default factory builds an AMQP client", func(t *testing.T) {
+		resolver := NewFactoryResolver(nil)
+		factory := resolver.MessagingClientFactory(7 * time.Second)
+		assert.NotNil(t, factory)
+
+		// Port 1 refuses immediately, so the reconnect goroutine fails fast; Close is
+		// non-blocking and signals it to exit. No broker is required for this path.
+		client := factory("amqp://127.0.0.1:1", logger.New("error", true))
+		assert.NotNil(t, client)
+		t.Cleanup(func() { _ = client.Close() })
+	})
+}
+
 // mockCacheInstance is a minimal mock implementation of cache.Cache for testing
 type mockCacheInstance struct{}
 

--- a/app/managers.go
+++ b/app/managers.go
@@ -14,6 +14,9 @@ import (
 type ManagerConfigBuilder struct {
 	multiTenantEnabled bool
 	tenantLimit        int
+	// connectionTimeout is the per-publish AMQP broker confirmation timeout,
+	// sourced from messaging.reconnect.connectiontimeout and set by bootstrap.
+	connectionTimeout time.Duration
 }
 
 // NewManagerConfigBuilder creates a new manager configuration builder.
@@ -47,14 +50,16 @@ func (b *ManagerConfigBuilder) BuildDatabaseOptions() database.DbManagerOptions 
 func (b *ManagerConfigBuilder) BuildMessagingOptions() messaging.ManagerOptions {
 	if b.multiTenantEnabled {
 		return messaging.ManagerOptions{
-			MaxPublishers: b.tenantLimit,   // Use configured tenant limit
-			IdleTTL:       5 * time.Minute, // Shorter TTL for multi-tenant
+			MaxPublishers:     b.tenantLimit,   // Use configured tenant limit
+			IdleTTL:           5 * time.Minute, // Shorter TTL for multi-tenant
+			ConnectionTimeout: b.connectionTimeout,
 		}
 	}
 
 	return messaging.ManagerOptions{
-		MaxPublishers: 10,               // Small fixed size for single-tenant
-		IdleTTL:       30 * time.Minute, // Moderate TTL for single-tenant
+		MaxPublishers:     10,               // Small fixed size for single-tenant
+		IdleTTL:           30 * time.Minute, // Moderate TTL for single-tenant
+		ConnectionTimeout: b.connectionTimeout,
 	}
 }
 
@@ -140,8 +145,8 @@ func (f *ResourceManagerFactory) CreateMessagingManager(
 		f.logger.Info().Msg("Creating messaging manager for single-tenant mode")
 	}
 
-	clientFactory := f.factoryResolver.MessagingClientFactory()
 	msgOptions := f.configBuilder.BuildMessagingOptions()
+	clientFactory := f.factoryResolver.MessagingClientFactory(msgOptions.ConnectionTimeout)
 
 	return messaging.NewMessagingManager(resourceSource, f.logger, msgOptions, clientFactory)
 }

--- a/app/managers_test.go
+++ b/app/managers_test.go
@@ -151,6 +151,22 @@ func TestManagerConfigBuilderBuildMessagingOptions(t *testing.T) {
 		assert.Equal(t, largeLimit, options.MaxPublishers)
 		assert.Equal(t, 5*time.Minute, options.IdleTTL)
 	})
+
+	t.Run("connection_timeout_propagated_to_options", func(t *testing.T) {
+		// Single-tenant branch carries the configured per-publish timeout.
+		st := NewManagerConfigBuilder(false, 100)
+		st.connectionTimeout = 12 * time.Second
+		assert.Equal(t, 12*time.Second, st.BuildMessagingOptions().ConnectionTimeout)
+
+		// Multi-tenant branch carries it too.
+		mt := NewManagerConfigBuilder(true, 100)
+		mt.connectionTimeout = 8 * time.Second
+		assert.Equal(t, 8*time.Second, mt.BuildMessagingOptions().ConnectionTimeout)
+
+		// Unset leaves zero, so the client falls back to its 30s default.
+		zero := NewManagerConfigBuilder(false, 100)
+		assert.Equal(t, time.Duration(0), zero.BuildMessagingOptions().ConnectionTimeout)
+	})
 }
 
 func TestManagerConfigBuilderIsMultiTenant(t *testing.T) {

--- a/app/module.go
+++ b/app/module.go
@@ -166,9 +166,9 @@ type KeyStoreProvider interface {
 //
 //	type JobsModule struct{}
 //
-//	func (m *JobsModule) RegisterJobs(scheduler JobRegistrar) error {
-//	    scheduler.FixedRate("cleanup", &CleanupJob{}, 30*time.Minute)
-//	    scheduler.DailyAt("report", &ReportJob{}, time.Date(0, 0, 0, 3, 0, 0, 0, time.UTC))
+//	func (m *JobsModule) RegisterJobs(reg JobRegistrar) error {
+//	    reg.FixedRate("cleanup", &CleanupJob{}, 30*time.Minute)
+//	    reg.DailyAt("report", &ReportJob{}, scheduler.ParseTime("03:00"))
 //	    return nil
 //	}
 //

--- a/app/module.go
+++ b/app/module.go
@@ -168,7 +168,7 @@ type KeyStoreProvider interface {
 //
 //	func (m *JobsModule) RegisterJobs(scheduler JobRegistrar) error {
 //	    scheduler.FixedRate("cleanup", &CleanupJob{}, 30*time.Minute)
-//	    scheduler.DailyAt("report", &ReportJob{}, scheduler.ParseTime("03:00"))
+//	    scheduler.DailyAt("report", &ReportJob{}, time.Date(0, 0, 0, 3, 0, 0, 0, time.UTC))
 //	    return nil
 //	}
 //
@@ -179,8 +179,7 @@ type JobProvider interface {
 }
 
 // ModuleDeps contains the dependencies that are injected into each module.
-// It provides access to core services like database, logging, messaging, observability, and job scheduling.
-// All modules must use DB() and Messaging() functions for resource access.
+// It provides access to core services like database, logging, messaging, caching, observability, and job scheduling.
 type ModuleDeps struct {
 	Logger logger.Logger
 	Config *config.Config

--- a/app/module_registry.go
+++ b/app/module_registry.go
@@ -32,8 +32,9 @@ func NewModuleRegistry(deps *ModuleDeps) *ModuleRegistry {
 // Register adds a module to the registry and initializes it.
 // It calls the module's Init method with the injected dependencies.
 // Returns an error if a module with the same name is already registered.
-// Special handling: If the module implements app.JobRegistrar, it is automatically
-// wired into ModuleDeps.Scheduler for other modules to use.
+// Special handling: modules implementing JobRegistrar, OutboxProvider, InboxProvider,
+// or KeyStoreProvider are automatically wired into the corresponding ModuleDeps fields
+// (Scheduler, Outbox, Inbox, KeyStore) so subsequent modules can use them.
 //
 // IMPORTANT: Duplicate module errors are unrecoverable and must be handled with log.Fatal().
 func (r *ModuleRegistry) Register(module Module) error {

--- a/cache/redis/client.go
+++ b/cache/redis/client.go
@@ -310,7 +310,7 @@ func (c *Client) Stats() (map[string]any, error) {
 
 // Close closes the Redis client and releases resources.
 // After calling Close, the client should not be used.
-// Close is idempotent - calling it multiple times is safe.
+// Subsequent calls to Close return cache.ErrClosed.
 func (c *Client) Close() error {
 	// Use CompareAndSwap for idempotent close (only close once)
 	if !c.closed.CompareAndSwap(false, true) {

--- a/cache/testing/assertions.go
+++ b/cache/testing/assertions.go
@@ -335,8 +335,7 @@ func AssertNoError(t *testing.T, operation func() error) {
 	}
 }
 
-// AssertStats asserts that cache stats contain expected key-value pairs.
-// Only works with MockCache instances.
+// AssertStatsContains asserts that cache stats contain expected key-value pairs.
 //
 // Example:
 //

--- a/config/types.go
+++ b/config/types.go
@@ -354,7 +354,7 @@ type MessagingConfig struct {
 //   - Delay: 5s (initial delay between reconnection attempts)
 //   - ReinitDelay: 2s (delay before channel reinitialization)
 //   - ResendDelay: 5s (delay before retrying failed publishes)
-//   - ConnectionTimeout: 30s (timeout for connection/confirmation)
+//   - ConnectionTimeout: 30s (per-publish broker ACK/NACK confirmation wait)
 //   - MaxDelay: 60s (maximum delay for exponential backoff cap)
 type ReconnectConfig struct {
 	// Delay is the initial delay between reconnection attempts.
@@ -369,8 +369,10 @@ type ReconnectConfig struct {
 	// Default: 5s.
 	ResendDelay time.Duration `koanf:"resenddelay" json:"resenddelay" yaml:"resenddelay" toml:"resenddelay" mapstructure:"resenddelay"`
 
-	// ConnectionTimeout is the timeout for connection establishment and publish confirmation.
-	// Default: 30s. Set higher for high-latency networks.
+	// ConnectionTimeout is the per-publish broker confirmation timeout — how long a
+	// confirmed publish waits for the broker's ACK/NACK before the attempt is retried.
+	// The TCP/AMQP connection dial itself is bounded by amqp091-go's amqp.Dial default,
+	// not by this value. Default: 30s. Set higher for high-latency networks.
 	ConnectionTimeout time.Duration `koanf:"connectiontimeout" json:"connectiontimeout" yaml:"connectiontimeout" toml:"connectiontimeout" mapstructure:"connectiontimeout"`
 
 	// MaxDelay is the maximum delay for exponential backoff during reconnection.

--- a/config/validation.go
+++ b/config/validation.go
@@ -43,7 +43,7 @@ const (
 	defaultReconnectDelay    = 5 * time.Second  // Initial delay between reconnection attempts
 	defaultReinitDelay       = 2 * time.Second  // Delay before channel reinitialization
 	defaultResendDelay       = 5 * time.Second  // Delay before retrying failed publishes
-	defaultConnectionTimeout = 30 * time.Second // Timeout for connection/confirmation
+	defaultConnectionTimeout = 30 * time.Second // Per-publish broker confirmation (ACK/NACK) wait
 	defaultMaxReconnectDelay = 60 * time.Second // Maximum delay for exponential backoff cap
 	defaultMaxPublishers     = 50               // Maximum publisher clients in cache
 	defaultPublisherIdleTTL  = 10 * time.Minute // Time before idle publishers are evicted

--- a/database/internal/columns/metadata.go
+++ b/database/internal/columns/metadata.go
@@ -99,14 +99,14 @@ func (cm *ColumnMetadata) Alias() string {
 //	}
 //
 //	cols := qb.Columns(&User{})
-//	cols.Col("ID")    // Returns: "id" (PostgreSQL) or "ID" (Oracle)
-//	cols.Col("Level") // Returns: "level" (PostgreSQL) or "LEVEL" (Oracle, quoted)
+//	cols.Col("ID")    // Returns: "id" (PostgreSQL) or "id" (Oracle, not a reserved word)
+//	cols.Col("Level") // Returns: "level" (PostgreSQL) or "\"level\"" (Oracle, reserved word — double-quoted lowercase)
 //
 // Example (aliased):
 //
 //	u := cols.As("u")
-//	u.Col("ID")       // Returns: "u.id" (PostgreSQL) or "u.\"ID\"" (Oracle)
-//	u.Col("Level")    // Returns: "u.\"LEVEL\"" (Oracle reserved word with table qualification)
+//	u.Col("ID")    // Returns: "u.id" (PostgreSQL) or "u.id" (Oracle, not a reserved word)
+//	u.Col("Level") // Returns: "u.\"level\"" (Oracle reserved word, double-quoted lowercase, with table qualification)
 //
 // Panics if the field name is not found (fail-fast for development-time typos).
 func (cm *ColumnMetadata) Col(fieldName string) string {

--- a/database/internal/columns/registry.go
+++ b/database/internal/columns/registry.go
@@ -9,7 +9,8 @@ import (
 // ColumnRegistry maintains a cache of struct column metadata per database vendor.
 // It uses lazy initialization: struct types are parsed on first use and cached forever.
 //
-// Thread-safety: Uses sync.Map for lock-free reads after first write.
+// Thread-safety: Uses a sync.RWMutex (double-checked locking) for vendor-cache map access
+// and sync.Map for per-type column-metadata lookups within each vendor cache.
 // Memory overhead: ~1-2KB per registered struct type.
 // Performance: ~2µs first-use parsing, ~50ns cached access.
 type ColumnRegistry struct {
@@ -53,8 +54,8 @@ var globalColumnRegistry = &ColumnRegistry{
 //	}
 //
 //	cols := RegisterColumns(dbtypes.Oracle, &User{})
-//	cols.Col("ID")    // Returns: `"ID"` (Oracle, quoted)
-//	cols.Col("Level") // Returns: `"LEVEL"` (Oracle reserved word, quoted)
+//	cols.Col("ID")    // Returns: "id" (Oracle, not a reserved word — returned as-is)
+//	cols.Col("Level") // Returns: "\"level\"" (Oracle reserved word — double-quoted lowercase)
 func RegisterColumns(vendor string, structPtr any) *ColumnMetadata {
 	return globalColumnRegistry.Get(vendor, structPtr)
 }

--- a/database/internal/tracking/metrics.go
+++ b/database/internal/tracking/metrics.go
@@ -67,7 +67,7 @@ var (
 	dbDurationHistogram metric.Float64Histogram // Duration in seconds
 
 	// Connection pool metrics are registered per-connection via callbacks
-	// They use ObservableGauges which are registered externally
+	// using ObservableUpDownCounters and ObservableCounters per OTel semconv.
 )
 
 // logMetricError logs a metric initialization or registration error to stderr.

--- a/database/internal/tracking/utils.go
+++ b/database/internal/tracking/utils.go
@@ -228,7 +228,7 @@ func TruncateString(value string, maxLen int) string {
 	if len(r) <= maxLen {
 		return value
 	}
-	// Handle multi-byte characters correctly
+	// Not enough room to append "..." without exceeding maxLen.
 	if maxLen <= 3 {
 		return string(r[:maxLen])
 	}

--- a/database/testing/multitenant.go
+++ b/database/testing/multitenant.go
@@ -93,7 +93,7 @@ func (m *TenantDBMap) ForTenantWithVendor(tenantID, vendor string) *TestDB {
 	defer m.mu.Unlock()
 
 	if db, exists := m.databases[tenantID]; exists {
-		// Tenant already has a DB - warn if vendor mismatch
+		// Tenant already has a DB — panic if vendor mismatch to prevent silent misconfiguration
 		if db.DatabaseType() != vendor {
 			panic(fmt.Sprintf("tenant %q already has DB with vendor %q, cannot change to %q",
 				tenantID, db.DatabaseType(), vendor))
@@ -319,7 +319,7 @@ func (m *NamedDBMap) ForNameWithVendor(name, vendor string) *TestDB {
 	defer m.mu.Unlock()
 
 	if db, exists := m.databases[name]; exists {
-		// Name already has a DB - warn if vendor mismatch
+		// Name already has a DB — panic if vendor mismatch to prevent silent misconfiguration
 		if db.DatabaseType() != vendor {
 			panic(fmt.Sprintf("named database %q already has DB with vendor %q, cannot change to %q",
 				name, db.DatabaseType(), vendor))

--- a/database/types/interfaces.go
+++ b/database/types/interfaces.go
@@ -179,7 +179,7 @@ type InsertQueryBuilder interface {
 	Prefix(sql string, args ...any) InsertQueryBuilder
 	Suffix(sql string, args ...any) InsertQueryBuilder
 
-	// Select panics if sb is not the concrete *SelectQueryBuilder from this package.
+	// Select returns an error (deferred to ToSQL()) if sb is not the concrete *SelectQueryBuilder from this package.
 	Select(sb SelectQueryBuilder) InsertQueryBuilder
 
 	ToSQL() (sql string, args []any, err error)

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -1156,4 +1156,4 @@ func (c *client) logResponse(resp *Response, traceID string) {
 	}
 }
 
-// generator moved to http/interface.go for reuse by server
+// generator functions (GenerateTraceParent, EnsureTraceID, TraceIDFromContext) live in httpclient/interface.go and are also used by the server package

--- a/inbox/module.go
+++ b/inbox/module.go
@@ -82,7 +82,7 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 
 // ensureStoreInitialized creates the vendor-specific store on first use.
 // Lazy because the database vendor type is only known once a connection exists.
-// Uses double-check locking (mutex, not sync.Once) so a failed init can retry.
+// Uses mutex-guarded lazy initialization (not sync.Once) so a failed init can retry.
 func (m *Module) ensureStoreInitialized(ctx context.Context) error {
 	m.initMu.Lock()
 	defer m.initMu.Unlock()

--- a/internal/testutil/constants.go
+++ b/internal/testutil/constants.go
@@ -52,6 +52,6 @@ const (
 	// TestConfigKey is a generic configuration key for testing.
 	TestConfigKey = "test.key"
 
-	// TestConfigPort is a common port configuration key.
+	// TestConfigPort is a common port number used in test configurations.
 	TestConfigPort = "8080"
 )

--- a/jose/sealer.go
+++ b/jose/sealer.go
@@ -8,9 +8,11 @@ import (
 // private key, then encrypt that JWS as a compact JWE to the peer's public key. Returns
 // the compact JWE string.
 //
-// On any failure, returns an *Error with Code/Status mapped to JOSE_OUTBOUND_FAILED (500)
-// — outbound failures are framework/operator errors (missing keys, bad config), never
-// peer-induced. The Cause field carries the underlying detail for logging.
+// On failure, returns an *Error. Pre-flight guard failures (Status 500) use Code
+// JOSE_POLICY_DIRECTION_MISMATCH (nil or wrong-direction policy) or JOSE_KEYSTORE_UNAVAILABLE
+// (nil resolver); sign/encrypt failures (Status 500) use JOSE_OUTBOUND_FAILED. Key-resolution
+// failures propagate the resolver's *Error verbatim (e.g. JOSE_KID_UNKNOWN), whose Status is
+// resolver-defined. The Cause field carries the underlying detail for logging.
 func Seal(payload []byte, p *Policy, r KeyResolver) (string, error) {
 	if p == nil || p.Direction != DirectionOutbound {
 		return "", &Error{

--- a/llms.txt
+++ b/llms.txt
@@ -415,12 +415,18 @@ func (m *UserModule) FindActiveUsersBuilder(ctx context.Context) ([]User, error)
 	cols := qb.Columns(&User{})
 	f := qb.Filter()
 
-	sql, args := qb.Select(cols.All()...).
+	all := cols.All()
+	allAny := make([]any, len(all))
+	for i, c := range all { allAny[i] = c }
+	sql, args, err := qb.Select(allAny...).
 		From("users").
 		Where(f.Eq(cols.Col("Status"), "active")).
 		ToSQL()
+	if err != nil {
+		return nil, fmt.Errorf("build query: %w", err)
+	}
 	// PostgreSQL: SELECT id, name, email, status FROM users WHERE status = $1
-	// Oracle:     SELECT "ID", "NAME", "EMAIL", "STATUS" FROM users WHERE "STATUS" = :1
+	// Oracle:     SELECT id, name, email, status FROM users WHERE status = :1
 
 	rows, err := db.Query(ctx, sql, args...)
 	if err != nil {
@@ -445,7 +451,7 @@ func (m *UserModule) FindActiveUsersBuilder(ctx context.Context) ([]User, error)
 | Method | Returns | Purpose |
 |---|---|---|
 | `Query(ctx, sql, args...)` | `(*sql.Rows, error)` | Multi-row query — caller MUST `defer rows.Close()` |
-| `QueryRow(ctx, sql, args...)` | `*sql.Row` | Single-row query — call `.Scan(&dst...)` on the result |
+| `QueryRow(ctx, sql, args...)` | `types.Row` | Single-row query — call `.Scan(&dst...)` on the result |
 | `Exec(ctx, sql, args...)` | `(sql.Result, error)` | INSERT / UPDATE / DELETE / DDL |
 | `Begin(ctx)` | `(types.Tx, error)` | Start a transaction — `defer tx.Rollback(ctx)`, then `tx.Commit(ctx)` |
 | `Health(ctx)` | `error` | Liveness check — auto-wired into `/health` endpoint |
@@ -524,8 +530,10 @@ func (h *Handler) Create(req CreateUserReq, ctx server.HandlerContext) (server.R
 // === Simple HTTP GET Endpoints ===
 
 // Static message endpoint (simplest possible handler)
-func (h *Handler) Health(_ server.NoBody, ctx server.HandlerContext) (server.Result[string], server.IAPIError) {
-	return server.OK("Service is healthy"), nil
+type NoBodyReq struct{}
+
+func (h *Handler) Health(_ NoBodyReq, ctx server.HandlerContext) (server.Result[string], server.IAPIError) {
+	return server.NewResult(http.StatusOK, "Service is healthy"), nil
 }
 
 // Register: server.GET(hr, e, "/health", h.Health)
@@ -540,7 +548,7 @@ func (h *Handler) GetUser(req GetUserReq, ctx server.HandlerContext) (server.Res
 	if err != nil {
 		return server.Result[User]{}, server.NewNotFoundError("user")
 	}
-	return server.OK(user), nil
+	return server.NewResult(http.StatusOK, user), nil
 }
 
 // Register: server.GET(hr, e, "/users/:id", h.GetUser)
@@ -561,7 +569,7 @@ func (h *Handler) ListUsers(req ListUsersReq, ctx server.HandlerContext) (server
 	if err != nil {
 		return server.Result[[]User]{}, server.NewInternalServerError(err.Error())
 	}
-	return server.OK(users), nil
+	return server.NewResult(http.StatusOK, users), nil
 }
 
 // Register: server.GET(hr, e, "/users", h.ListUsers)
@@ -571,9 +579,9 @@ func (h *Handler) ListUsers(req ListUsersReq, ctx server.HandlerContext) (server
 | Pattern          | Request binding              | Success helper          | Notes                          |
 |------------------|------------------------------|-------------------------|--------------------------------|
 | POST create      | JSON struct w/ validators    | `server.Created(data)`  | 422 auto-emitted on validation |
-| GET lookup       | `server.NoBody` + `ctx.Param`| `server.OK(data)`       | Return domain errors as API    |
-| LIST with query  | `query:"..."` struct tags    | `server.OK(list)`       | Query params auto-bound        |
-| DELETE           | `server.NoBody`              | `server.NoContent()`    | Return typed API errors        |
+| GET lookup       | `struct{}` + `ctx.Param`     | `server.NewResult(http.StatusOK, data)` | Return domain errors as API |
+| LIST with query  | `query:"..."` struct tags    | `server.NewResult(http.StatusOK, list)` | Query params auto-bound     |
+| DELETE           | `struct{}`                   | `server.NoContent()`    | Return typed API errors        |
 | ASYNC acceptance | Request struct               | `server.Accepted(meta)` | For enqueue-style workflows    |
 | PAGINATED list   | `query:"..."` struct tags    | `server.ResultWithMeta` | Adds pagination keys to `meta` |
 
@@ -1001,13 +1009,19 @@ qb := database.NewQueryBuilder(db.DatabaseType())
 f := qb.Filter()
 cols := qb.Columns(&User{})
 
-sql, args := qb.Select(cols.Fields("ID", "Email")...).
+selected := cols.Cols("ID", "Email")
+selectedAny := make([]any, len(selected))
+for i, c := range selected { selectedAny[i] = c }
+sql, args, err := qb.Select(selectedAny...).
 	From("users").
 	Where(f.And(
 		f.Eq(cols.Col("Status"), "active"),
 		f.Like(cols.Col("Email"), "%@example.com"),
 	)).
 	ToSQL()
+if err != nil {
+	return nil, fmt.Errorf("build query: %w", err)
+}
 
 rows, err := db.Query(ctx, sql, args...)
 ```
@@ -1017,7 +1031,7 @@ rows, err := db.Query(ctx, sql, args...)
 | Filtering           | `f.Eq`, `f.And`, `f.Or`, `f.In`, `f.Between`                           |
 | Pattern matching    | `f.Like` (case-insensitive), `f.Regex`/`f.RegexI`/`f.NotRegex`/`f.NotRegexI` (POSIX regex; PG `~`/`~*`/`!~`/`!~*`, Oracle `REGEXP_LIKE` with `'i'` flag) |
 | JSON containment    | `f.JSONContains(col, value)` — PostgreSQL `@>` on `jsonb`; pass struct/map/slice (auto JSON-marshalled) or pre-encoded `string`/`[]byte`/`json.RawMessage`. Oracle is not yet supported. |
-| Sorting / grouping  | `qb.Select(...).From("...").OrderBy(qb.Expr("created_at DESC")).GroupBy("tenant_id")` |
+| Sorting / grouping  | `qb.Select(...).From("...").OrderBy(qb.MustExpr("created_at DESC")).GroupBy("tenant_id")` |
 | Mutations           | `qb.Insert`, `qb.Update`, `qb.Delete`, then `db.Exec`                  |
 | Joins               | `qb.JoinOn` with `qb.JoinFilter()`                                     |
 | Subqueries          | Compose another builder clause then `f.Exists(subQuery)`               |
@@ -1028,25 +1042,28 @@ rows, err := db.Query(ctx, sql, args...)
 
 ```go
 // INSERT
-sql, args := qb.Insert("users").
+sql, args, err := qb.Insert("users").
     Columns(cols.Col("Name"), cols.Col("Email")).
     Values("Alice", "alice@example.com").
     ToSQL()
+if err != nil { return err }
 result, err := db.Exec(ctx, sql, args...)
 
 // UPDATE
-sql, args := qb.Update("users").
+sql, args, err = qb.Update("users").
     Set(cols.Col("Name"), "Bob").
     Set(cols.Col("Email"), "bob@example.com").
     Where(f.Eq(cols.Col("ID"), 123)).
     ToSQL()
-result, err := db.Exec(ctx, sql, args...)
+if err != nil { return err }
+result, err = db.Exec(ctx, sql, args...)
 
 // DELETE
-sql, args := qb.Delete("users").
+sql, args, err = qb.Delete("users").
     Where(f.Eq(cols.Col("ID"), 123)).
     ToSQL()
-result, err := db.Exec(ctx, sql, args...)
+if err != nil { return err }
+result, err = db.Exec(ctx, sql, args...)
 ```
 
 Access to vendor quirks (Oracle quoting) routes through the same interface; switching drivers requires config only.
@@ -1063,11 +1080,15 @@ cols := qb.Columns(&User{})
 f := qb.Filter()
 
 // Case-sensitive: PG "email ~ ?", Oracle "REGEXP_LIKE(email, ?)"
-sql, args := qb.Select(cols.All()...).From("users").
+all := cols.All()
+allAny := make([]any, len(all))
+for i, c := range all { allAny[i] = c }
+sql, args, err := qb.Select(allAny...).From("users").
     Where(f.Regex(cols.Col("Email"), `^admin@`)).ToSQL()
+if err != nil { return nil, err }
 
 // Case-insensitive: PG "email ~* ?", Oracle "REGEXP_LIKE(email, ?, 'i')"
-qb.Select(cols.All()...).From("users").
+qb.Select(allAny...).From("users").
     Where(f.RegexI(cols.Col("Email"), `@example\.com$`))
 
 // Negation: f.NotRegex / f.NotRegexI
@@ -1089,9 +1110,10 @@ cols := qb.Columns(&User{})
 f := qb.Filter()
 
 // Pass any JSON-marshallable value; structs/maps/slices auto-encode.
-sql, args := qb.Select(cols.Col("ID")).From("users").
+sql, args, err := qb.Select(cols.Col("ID")).From("users").
     Where(f.JSONContains(cols.Col("Metadata"), map[string]any{"role": "admin"})).
     ToSQL()
+if err != nil { return nil, err }
 // SQL: SELECT id FROM users WHERE metadata @> $1::jsonb
 // args: [`{"role":"admin"}`]
 
@@ -1118,15 +1140,18 @@ type User struct {
 cols := qb.Columns(&User{})
 
 // SELECT with type-safe field references
-query := qb.Select(cols.Fields("ID", "Name")...).
+selected := cols.Cols("ID", "Name")
+selectedAny := make([]any, len(selected))
+for i, c := range selected { selectedAny[i] = c }
+query := qb.Select(selectedAny...).
     From("users").
     Where(f.Eq(cols.Col("Level"), 5))
-// Oracle: SELECT "ID", "NAME" FROM users WHERE "LEVEL" = :1
+// Oracle: SELECT id, name FROM users WHERE "level" = :1
 // PostgreSQL: SELECT id, name FROM users WHERE level = $1
 
 // All columns: cols.All()
 // Single column: cols.Col("FieldName")
-// Multiple columns: cols.Fields("ID", "Name", "Email")
+// Multiple columns: cols.Cols("ID", "Name", "Email")
 // Performance: ~0.6µs first parse, ~26ns cached access
 ```
 
@@ -1159,11 +1184,11 @@ query := qb.Select(
     u.Col("Name"),    // "u.name" or "u.\"NAME\"" for Oracle
     a.Col("Number"),  // "a.\"NUMBER\"" for Oracle (reserved word)
 ).
-    From(dbtypes.Table("users").As("u")).
-    JoinOn(dbtypes.Table("accounts").As("a"),
+    From(dbtypes.MustTable("users").MustAs("u")).
+    JoinOn(dbtypes.MustTable("accounts").MustAs("a"),
         jf.EqColumn(u.Col("ID"), a.Col("ID"))).
     Where(f.Eq(u.Col("Status"), "active"))
-// Oracle: SELECT u."ID", u."NAME", a."NUMBER" FROM users u JOIN accounts a ON u."ID" = a."ID" WHERE u."STATUS" = :1
+// Oracle: SELECT u.id, u.name, a."number" FROM users u JOIN accounts a ON u.id = a.id WHERE u.status = :1
 ```
 
 **Advanced JOIN Patterns:**
@@ -1174,15 +1199,15 @@ jf := qb.JoinFilter()
 f := qb.Filter()
 
 query := qb.Select("*").
-    From(dbtypes.Table("orders").As("o")).
-    JoinOn(dbtypes.Table("customers").As("c"), jf.And(
+    From(dbtypes.MustTable("orders").MustAs("o")).
+    JoinOn(dbtypes.MustTable("customers").MustAs("c"), jf.And(
         jf.EqColumn("c.id", "o.customer_id"),       // Column-to-column
         jf.Eq("c.status", "active"),                 // Column-to-value
         jf.In("c.tier", []string{"gold", "platinum"}),
     )).
-    JoinOn(dbtypes.Table("products").As("p"), jf.And(
+    JoinOn(dbtypes.MustTable("products").MustAs("p"), jf.And(
         jf.EqColumn("p.id", "o.product_id"),
-        jf.Eq("p.price", qb.Expr("TO_NUMBER(o.max_price)")), // Expression support
+        jf.Eq("p.price", qb.MustExpr("TO_NUMBER(o.max_price)")), // Expression support
     )).
     Where(f.Eq("o.status", "pending"))
 ```
@@ -1201,14 +1226,14 @@ cols := qb.Columns(&Product{})
 query := qb.Select(
     cols.Col("ProductID"),
     cols.Col("Price"),
-    qb.Expr("ROW_NUMBER() OVER (PARTITION BY category ORDER BY price DESC)", "rank"),
+    qb.MustExpr("ROW_NUMBER() OVER (PARTITION BY category ORDER BY price DESC)", "rank"),
 ).From("products")
 
 // Aggregations with GROUP BY
 query := qb.Select(
     cols.Col("Category"),
-    qb.Expr("COUNT(*)", "product_count"),
-    qb.Expr("AVG(price)", "avg_price"),
+    qb.MustExpr("COUNT(*)", "product_count"),
+    qb.MustExpr("AVG(price)", "avg_price"),
 ).From("products").GroupBy(cols.Col("Category"))
 ```
 
@@ -1377,7 +1402,7 @@ _, err = conn.Exec(ctx, "BEGIN update_customer(:1); END;", customer)
 ```go
 import dbtest "github.com/gaborage/go-bricks/database/testing"
 
-func TestProductService_FindActive(t *testing.T) {
+func TestProductServiceFindActive(t *testing.T) {
     // Setup (8 lines vs 30+ with sqlmock)
     db := dbtest.NewTestDB(dbtypes.PostgreSQL)
     db.ExpectQuery("SELECT").
@@ -1405,7 +1430,7 @@ dbtest.AssertQueryExecuted(t, db, "SELECT")
 **Iterating Rows with `Query`:**
 
 ```go
-func TestProductRepository_List(t *testing.T) {
+func TestProductRepositoryList(t *testing.T) {
     db := dbtest.NewTestDB(dbtypes.PostgreSQL)
     db.ExpectQuery("SELECT").
         WillReturnRows(
@@ -1433,7 +1458,7 @@ func TestProductRepository_List(t *testing.T) {
 **Transaction Test:**
 
 ```go
-func TestOrderService_CreateWithItems(t *testing.T) {
+func TestOrderServiceCreateWithItems(t *testing.T) {
     db := dbtest.NewTestDB(dbtypes.PostgreSQL)
     tx := db.ExpectTransaction().
         ExpectExec("INSERT INTO orders").WillReturnRowsAffected(1).
@@ -1485,7 +1510,7 @@ func TestMultiTenantService(t *testing.T) {
 **Named Databases Test (Single-Tenant Multi-Database):**
 
 ```go
-func TestCrossDatabase_LegacyMigration(t *testing.T) {
+func TestCrossDatabaseLegacyMigration(t *testing.T) {
     namedDBs := dbtest.NewNamedDBMap()
 
     // Setup default PostgreSQL database
@@ -1643,7 +1668,7 @@ type UserService struct {
 
 func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
     // Cache resolves tenant from context automatically
-    cache, err := s.getCache(ctx)
+    c, err := s.getCache(ctx)
     if err != nil {
         return nil, fmt.Errorf("cache not available: %w", err)
     }
@@ -1651,9 +1676,9 @@ func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
     cacheKey := fmt.Sprintf("user:%d", id)
 
     // Try cache first
-    data, err := cache.Get(ctx, cacheKey)
+    data, err := c.Get(ctx, cacheKey)
     if err == nil {
-        return cache.Unmarshal[User](data)
+        return cache.Unmarshal[*User](data)
     }
 
     // Cache miss - query database
@@ -1664,7 +1689,7 @@ func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
 
     // Store in cache
     serialized, _ := cache.Marshal(user)
-    cache.Set(ctx, cacheKey, serialized, 5*time.Minute)
+    c.Set(ctx, cacheKey, serialized, 5*time.Minute)
 
     return user, nil
 }
@@ -1715,21 +1740,19 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
     m.defaultTTL = cacheCfg.DefaultTTL
     m.keyPrefix = cacheCfg.KeyPrefix
 
-    deps.Logger.Info("Cache configured",
-        "default_ttl", m.defaultTTL,
-        "key_prefix", m.keyPrefix)
+    deps.Logger.Info().Dur("default_ttl", m.defaultTTL).Str("key_prefix", m.keyPrefix).Msg("Cache configured")
 
     return nil
 }
 
 // Use injected config in service methods
 func (m *Module) CacheUser(ctx context.Context, user *User) error {
-    cache, _ := m.getCache(ctx)
+    c, _ := m.getCache(ctx)
 
     key := fmt.Sprintf("%s:user:%d", m.keyPrefix, user.ID)  // Uses prefix
     data, _ := cache.Marshal(user)
 
-    return cache.Set(ctx, key, data, m.defaultTTL)  // Uses default TTL
+    return c.Set(ctx, key, data, m.defaultTTL)  // Uses default TTL
 }
 ```
 
@@ -1778,7 +1801,7 @@ func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
     // Try cache first
     data, err := s.cache.Get(ctx, cacheKey)
     if err == nil {
-        return cache.Unmarshal[User](data)
+        return cache.Unmarshal[*User](data)
     }
 
     // Cache miss - query database
@@ -1909,10 +1932,10 @@ func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
     cacheCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
     defer cancel()
 
-    if cache, err := s.getCache(cacheCtx); err == nil {
-        data, err := cache.Get(cacheCtx, cacheKey)
+    if c, err := s.getCache(cacheCtx); err == nil {
+        data, err := c.Get(cacheCtx, cacheKey)
         if err == nil {
-            user, err := cache.Unmarshal[User](data)
+            user, err := cache.Unmarshal[*User](data)
             if err == nil {
                 return user, nil  // Cache hit - return immediately
             }
@@ -1920,8 +1943,7 @@ func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
 
         // Log cache errors but don't fail the request
         if !errors.Is(err, cache.ErrNotFound) {
-            s.logger.Warn("Cache operation failed, falling back to database",
-                "error", err, "key", cacheKey)
+            s.logger.Warn().Err(err).Str("key", cacheKey).Msg("Cache operation failed, falling back to database")
         }
     }
 
@@ -1936,7 +1958,7 @@ defer cancel()
 data, err := cache.Get(ctx, key)
 if errors.Is(err, context.DeadlineExceeded) {
     // Cache too slow - fallback to database
-    s.logger.Warn("Cache timeout exceeded", "key", key)
+    s.logger.Warn().Str("key", key).Msg("Cache timeout exceeded")
 }
 
 // Error type checking
@@ -1948,10 +1970,7 @@ if errors.Is(err, cache.ErrNotFound) {
     // Developer error - negative or zero TTL provided
 } else if opErr, ok := err.(*cache.OperationError); ok {
     // Network/Redis error - includes operation, key, underlying error
-    s.logger.Error("Cache operation failed",
-        "operation", opErr.Op,
-        "key", opErr.Key,
-        "error", opErr.Err)
+    s.logger.Error().Str("operation", opErr.Op).Str("key", opErr.Key).Err(opErr.Err).Msg("Cache operation failed")
 }
 ```
 
@@ -2055,7 +2074,7 @@ No code changes required - observability hooks activate automatically when confi
 ```yaml
 cache:
   redis:
-    pool_size: 10  # Default: NumCPU * 2
+    pool_size: 10  # Default: 10
 ```
 
 **Rule:** `PoolSize >= (NumCPU * 2 * ConcurrentRequests) / 100`
@@ -2174,7 +2193,7 @@ func (m *MockCache) Close() error {
 }
 
 // Test example with MockCache
-func TestUserService_CacheHit(t *testing.T) {
+func TestUserServiceCacheHit(t *testing.T) {
     mockCache := NewMockCache()
 
     deps := &app.ModuleDeps{
@@ -2347,14 +2366,14 @@ mock := cachetest.NewMockCache().WithCloseCallback(func(id string) {
 cachetest.ResetMock(mockCache)  // Clears data + counters
 
 // Debugging
-counts := cachetest.GetOperationCounts(mockCache)
+counts := cachetest.OperationCounts(mockCache)
 fmt.Printf("Operations: %+v\n", counts)  // {Get:5, Set:3, Delete:1, ...}
 
 dump := cachetest.DumpCache(mockCache)
 t.Log(dump)  // Prints cache contents with expiration info
 
 // Check all stored keys
-keys := mockCache.GetAllKeys()
+keys := mockCache.AllKeys()
 assert.Contains(t, keys, "user:123")
 
 // Stats assertion
@@ -2395,8 +2414,10 @@ func TestCacheAsidePattern(t *testing.T) {
     cachetest.AssertOperationCount(t, mockCache, "Set", 1)
     dbtest.AssertQueryExecuted(t, mockDB, "SELECT")
 
-    // Second call - cache hit, no DB query
-    mockDB.ResetQueryLog()
+    // Second call - cache hit, no DB query.
+    // Record the query count first; the deps.DB closure captured mockDB, so
+    // don't reassign it — assert the cache hit adds no new query instead.
+    queriesBefore := len(mockDB.QueryLog())
     user2, err := svc.GetUser(ctx, 123)
     assert.NoError(t, err)
     assert.Equal(t, "Alice", user2.Name)
@@ -2404,7 +2425,7 @@ func TestCacheAsidePattern(t *testing.T) {
     // Verify cache hit
     cachetest.AssertOperationCount(t, mockCache, "Get", 2)
     cachetest.AssertOperationCount(t, mockCache, "Set", 1)  // Still 1
-    assert.Empty(t, mockDB.QueryLog(), "Should not query DB on cache hit")
+    assert.Len(t, mockDB.QueryLog(), queriesBefore, "Should not query DB on cache hit")
 }
 ```
 
@@ -2871,7 +2892,8 @@ func TestOrderServiceCreateOrder(t *testing.T) {
 
     mockOutbox := outboxtest.NewMockOutbox()
 
-    svc := NewOrderService(db.AsDBFunc(), mockOutbox)
+    dbFunc := func(_ context.Context) (database.Interface, error) { return db, nil }
+    svc := NewOrderService(dbFunc, mockOutbox)
     err := svc.CreateOrder(ctx, order)
 
     assert.NoError(t, err)
@@ -2883,8 +2905,10 @@ func TestOrderServiceCreateOrder(t *testing.T) {
 
 // Test outbox failure (transaction should roll back)
 func TestOrderServiceOutboxFailure(t *testing.T) {
+    db := dbtest.NewTestDB(dbtypes.PostgreSQL)
     mockOutbox := outboxtest.NewMockOutbox().WithError(fmt.Errorf("outbox down"))
-    svc := NewOrderService(db.AsDBFunc(), mockOutbox)
+    dbFunc := func(_ context.Context) (database.Interface, error) { return db, nil }
+    svc := NewOrderService(dbFunc, mockOutbox)
     err := svc.CreateOrder(ctx, order)
     assert.Error(t, err)
 }
@@ -3462,7 +3486,7 @@ func (h *Handler) GetUser(req GetUserReq, ctx server.HandlerContext) (server.Res
         return server.Result[User]{}, server.NewInternalServerError(err.Error())
     }
 
-    return server.OK(user), nil
+    return server.NewResult(http.StatusOK, user), nil
 }
 
 type GetUserReq struct {
@@ -3486,7 +3510,6 @@ type GetUserReq struct {
 | Error | HTTP Status | User Message |
 |-------|-------------|--------------|
 | `app.ErrNoTenantInContext` | 400 | "X-Tenant-ID header required" |
-| `app.ErrTenantNotFound` | 404 | "Tenant not configured" |
 | Database connection error | 503 | "Service temporarily unavailable" |
 | Query error | 500 | "Internal server error" |
 
@@ -3553,13 +3576,16 @@ func (s *UserService) FindByEmail(ctx context.Context, email string) (*User, err
     f := qb.Filter()
 
     // Always filter by tenant_id for data isolation
-    sql, args := qb.Select(cols.All()...).
+    sql, args, err := qb.Select(cols.All()).
         From("users").
         Where(f.And(
             f.Eq(cols.Col("TenantID"), tenantID),  // Tenant isolation
             f.Eq(cols.Col("Email"), email),
         )).
         ToSQL()
+    if err != nil {
+        return nil, err
+    }
 
     var user User
     err = db.QueryRow(ctx, sql, args...).Scan(&user.ID, &user.TenantID, &user.Email, &user.Name)
@@ -3580,14 +3606,17 @@ func (s *UserService) Create(ctx context.Context, email, name string) (*User, er
     cols := qb.Columns(&User{})
 
     // Always include tenant_id in INSERT
-    sql, args := qb.Insert("users").
+    sql, args, err := qb.Insert("users").
         Columns(cols.Col("TenantID"), cols.Col("Email"), cols.Col("Name")).
         Values(tenantID, email, name).
         Suffix("RETURNING id").
         ToSQL()
+    if err != nil {
+        return nil, err
+    }
 
     var id int64
-    err := db.QueryRow(ctx, sql, args...).Scan(&id)
+    err = db.QueryRow(ctx, sql, args...).Scan(&id)
     return &User{ID: id, TenantID: tenantID, Email: email, Name: name}, err
 }
 
@@ -3609,13 +3638,16 @@ func (s *UserService) List(ctx context.Context, status string) ([]User, error) {
     f := qb.Filter()
 
     // Tenant isolation + business filter
-    sql, args := qb.Select(cols.All()...).
+    sql, args, err := qb.Select(cols.All()).
         From("users").
         Where(f.And(
             f.Eq(cols.Col("TenantID"), tenantID),  // Always filter by tenant
             f.Eq(cols.Col("Status"), status),       // Business filter
         )).
         ToSQL()
+    if err != nil {
+        return nil, err
+    }
 
     rows, err := db.Query(ctx, sql, args...)
     if err != nil {
@@ -3677,13 +3709,16 @@ if !ok {
     return nil, errors.New("tenant context required")
 }
 
-sql, args := qb.Select(cols.All()...).
+sql, args, err := qb.Select(cols.All()).
     From("orders").
     Where(f.And(
         WithTenantFilter(ctx, f, cols),  // Tenant isolation
         f.Eq(cols.Col("Status"), "pending"),
     )).
     ToSQL()
+if err != nil {
+    return nil, err
+}
 ```
 
 **Strategy Comparison:**
@@ -3960,7 +3995,6 @@ When `observability.enabled: true`, the framework auto-emits:
 | Database | `db.query` / `db.exec` | `db.system`, `db.statement`, `db.namespace` | Every `Query`/`Exec`/`QueryRow` |
 | AMQP publish | `{destination} publish` | `messaging.system`, `messaging.destination.name`, `messaging.rabbitmq.routing_key` | Every `Publish`/`PublishToExchange` |
 | AMQP consume | `{destination} consume` | `messaging.system`, `messaging.destination.name`, `messaging.rabbitmq.queue` | Every message received |
-| Cache | `cache.{operation}` | `cache.operation`, `cache.key`, `cache.hit` | Every `Get`/`Set`/`Delete` |
 | Outbound HTTP | propagates `traceparent` | `http.url`, `http.method` | Via `httpclient` package |
 | JOSE | `jose.decode_request` / `jose.encode_response` | `jose.kid`, `jose.alg` | Every JOSE-tagged route |
 
@@ -3970,7 +4004,7 @@ When `observability.enabled: true`, the framework auto-emits:
 |---|---|---|---|
 | HTTP server | `http.server.request.duration` | Histogram (s) | `http.method`, `http.route`, `http.status_code` |
 | Database | `db.client.operation.duration` | Histogram (s) | `db.system.name`, `db.operation.name`, `db.collection.name`, `db.namespace`, `repository.method` (opt-in via `database.WithRepositoryMethod`) |
-| Database pool | `db.client.connection.count` | UpDownCounter | `state` (`open`/`idle`) |
+| Database pool | `db.client.connection.count` | UpDownCounter | `state` (`used`/`idle`) |
 | Database pool | `db.client.connection.max` / `.idle.max` / `.idle.min` | UpDownCounter | — |
 | Database pool | `db.client.connection.wait_count` / `.timeouts` | Counter | — |
 | Database pool | `db.client.connection.pending_requests` | UpDownCounter | — |
@@ -4139,7 +4173,9 @@ import (
 
 // === Basic Informational Log with Custom Fields ===
 
-logger.Info().
+log := logger.New("info", false)
+
+log.Info().
 	Str("user_id", "alice@example.com").
 	Str("action", "login").
 	Msg("User logged in successfully")
@@ -4147,7 +4183,7 @@ logger.Info().
 
 // === Multiple Field Types in Single Log ===
 
-logger.Info().
+log.Info().
 	Str("order_id", "ord_12345").
 	Int("item_count", 3).
 	Int64("total_cents", 4999).
@@ -4157,7 +4193,7 @@ logger.Info().
 
 // === Error Logging with Context ===
 
-logger.Error().
+log.Error().
 	Err(err).
 	Str("operation", "payment_process").
 	Str("payment_id", "pay_789").
@@ -4276,7 +4312,7 @@ log:
 // cfg.Log.SensitiveFields at startup and threads a SensitiveDataFilter
 // through the logger before any module or middleware captures a
 // reference to it.
-fw, err := app.New()
+fw, _, err := app.New()
 if err != nil { log.Fatal(err) }
 fw.RegisterModules(myModule)
 log.Fatal(fw.Run())
@@ -4306,7 +4342,7 @@ base.SensitiveFields = append(base.SensitiveFields,
 )
 base.MaskValue = "[REDACTED]"
 
-fw, err := app.NewWithOptions(&app.Options{
+fw, _, err := app.NewWithOptions(&app.Options{
     LoggerFilterConfig: base,
 })
 if err != nil { log.Fatal(err) }
@@ -4314,7 +4350,7 @@ fw.RegisterModules(myModule)
 log.Fatal(fw.Run())
 
 // Opt out entirely (e.g., test fixtures emitting deterministic payloads):
-fw, err = app.NewWithOptions(&app.Options{
+fw, _, err = app.NewWithOptions(&app.Options{
     LoggerFilterConfig: &logger.FilterConfig{SensitiveFields: nil},
 })
 ```
@@ -4372,9 +4408,9 @@ import (
 // Inside any middleware or handler — escalates the request's action-log severity.
 // Once escalated to WARN+, the action log is emitted at that level even on a 2xx response.
 func RateLimitMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
-    return func(c echo.Context) error {
+    return func(c *echo.Context) error {
         if exceededRateLimit(c) {
-            server.EscalateSeverity(&c, zerolog.WarnLevel) // request summary now logs at WARN
+            server.EscalateSeverity(c, zerolog.WarnLevel) // request summary now logs at WARN
             return c.JSON(429, map[string]string{"error": "rate limited"})
         }
         return next(c)

--- a/llms.txt
+++ b/llms.txt
@@ -2074,7 +2074,7 @@ No code changes required - observability hooks activate automatically when confi
 ```yaml
 cache:
   redis:
-    pool_size: 10  # Default: 10
+    poolsize: 10  # Default: 10
 ```
 
 **Rule:** `PoolSize >= (NumCPU * 2 * ConcurrentRequests) / 100`

--- a/messaging/amqp_client.go
+++ b/messaging/amqp_client.go
@@ -116,9 +116,24 @@ var (
 	errShutdown      = errors.New("AMQP client is shutting down")
 )
 
+// ClientOption configures an AMQPClientImpl at construction time.
+type ClientOption func(*AMQPClientImpl)
+
+// WithConnectionTimeout overrides the per-publish broker confirmation timeout —
+// the wait for an ACK/NACK after a confirmed publish (see PublishToExchange).
+// Non-positive values are ignored, leaving the 30s default in place.
+func WithConnectionTimeout(d time.Duration) ClientOption {
+	return func(c *AMQPClientImpl) {
+		if d > 0 {
+			c.connectionTimeout = d
+		}
+	}
+}
+
 // NewAMQPClient creates a new AMQP client instance.
 // It automatically attempts to connect to the broker and handles reconnections.
-func NewAMQPClient(brokerURL string, log logger.Logger) *AMQPClientImpl {
+// Optional Option values (e.g. WithConnectionTimeout) override the defaults.
+func NewAMQPClient(brokerURL string, log logger.Logger, opts ...ClientOption) *AMQPClientImpl {
 	client := &AMQPClientImpl{
 		m:                 &sync.RWMutex{},
 		brokerURL:         brokerURL,
@@ -130,6 +145,10 @@ func NewAMQPClient(brokerURL string, log logger.Logger) *AMQPClientImpl {
 		reInitDelay:       defaultReInitDelay,
 		resendDelay:       defaultResendDelay,
 		connectionTimeout: defaultConnectionTimeout,
+	}
+
+	for _, opt := range opts {
+		opt(client)
 	}
 
 	// Start connection management in background

--- a/messaging/amqp_client.go
+++ b/messaging/amqp_client.go
@@ -148,6 +148,9 @@ func NewAMQPClient(brokerURL string, log logger.Logger, opts ...ClientOption) *A
 	}
 
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		opt(client)
 	}
 

--- a/messaging/amqp_client_test.go
+++ b/messaging/amqp_client_test.go
@@ -724,6 +724,7 @@ func TestNewAMQPClientWithConnectionTimeout(t *testing.T) {
 		{name: "override_applied", opts: []ClientOption{WithConnectionTimeout(7 * time.Second)}, want: 7 * time.Second},
 		{name: "non_positive_ignored", opts: []ClientOption{WithConnectionTimeout(0)}, want: defaultConnectionTimeout},
 		{name: "negative_ignored", opts: []ClientOption{WithConnectionTimeout(-1 * time.Second)}, want: defaultConnectionTimeout},
+		{name: "nil_option_skipped", opts: []ClientOption{nil, WithConnectionTimeout(9 * time.Second)}, want: 9 * time.Second},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/messaging/amqp_client_test.go
+++ b/messaging/amqp_client_test.go
@@ -709,6 +709,33 @@ func TestNewAMQPClientConstructsAndStarts(t *testing.T) {
 	t.Cleanup(func() { closeAndWaitForReconnect(c) })
 }
 
+func TestNewAMQPClientWithConnectionTimeout(t *testing.T) {
+	// Stub the dialer so the reconnect goroutine never touches the network.
+	oldDial := getAmqpDialFunc()
+	setAmqpDialFunc(func(_ string) (amqpConnection, error) { return nil, errors.New(dialFailMsg) })
+	defer func() { setAmqpDialFunc(oldDial) }()
+
+	tests := []struct {
+		name string
+		opts []ClientOption
+		want time.Duration
+	}{
+		{name: "default_when_no_option", opts: nil, want: defaultConnectionTimeout},
+		{name: "override_applied", opts: []ClientOption{WithConnectionTimeout(7 * time.Second)}, want: 7 * time.Second},
+		{name: "non_positive_ignored", opts: []ClientOption{WithConnectionTimeout(0)}, want: defaultConnectionTimeout},
+		{name: "negative_ignored", opts: []ClientOption{WithConnectionTimeout(-1 * time.Second)}, want: defaultConnectionTimeout},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewAMQPClient("amqp://example", &stubLogger{}, tc.opts...)
+			t.Cleanup(func() { closeAndWaitForReconnect(c) })
+			if c.connectionTimeout != tc.want {
+				t.Errorf("connectionTimeout = %v, want %v", c.connectionTimeout, tc.want)
+			}
+		})
+	}
+}
+
 // ===== Enhanced Connection Management Tests =====
 
 // mockChannelConnection implements amqpConnection for testing

--- a/messaging/constants.go
+++ b/messaging/constants.go
@@ -40,7 +40,7 @@ const (
 // Registry readiness polling. Previously inline literals in registry.go's
 // "wait for AMQP client ready" loop.
 const (
-	// readyTimeoutDuration is how long DeclareConsumers waits for the
+	// readyTimeoutDuration is how long DeclareInfrastructure waits for the
 	// AMQP client to enter the isReady state before failing startup.
 	// Long enough to cover broker handshake + channel init; short enough
 	// that misconfigurations surface during deploy rather than hanging.

--- a/messaging/internal/tracking/metrics.go
+++ b/messaging/internal/tracking/metrics.go
@@ -75,8 +75,8 @@ func logMetricError(metricName string, err error) {
 }
 
 // initAMQPMeter initializes the OpenTelemetry meter and metric instruments.
-// This function is called lazily and only once using sync.Once to ensure
-// thread-safe initialization.
+// It is invoked via sync.Once in getAMQPMeter; the internal mutex guards
+// against any future direct calls that bypass that guarantee.
 func initAMQPMeter() {
 	meterInitMu.Lock()
 	defer meterInitMu.Unlock()

--- a/messaging/manager.go
+++ b/messaging/manager.go
@@ -73,6 +73,9 @@ type consumerEntry struct {
 type ManagerOptions struct {
 	MaxPublishers int           // Maximum number of publisher clients to keep cached
 	IdleTTL       time.Duration // Time after which idle publishers are evicted
+	// ConnectionTimeout is the per-publish broker confirmation timeout applied to
+	// clients created by the default factory. Zero leaves the client default (30s).
+	ConnectionTimeout time.Duration
 }
 
 // NewMessagingManager creates a new messaging manager
@@ -87,7 +90,7 @@ func NewMessagingManager(resourceSource BrokerURLProvider, log logger.Logger, op
 	// Default to real client factory if none provided
 	if clientFactory == nil {
 		clientFactory = func(url string, log logger.Logger) AMQPClient {
-			return NewAMQPClient(url, log)
+			return NewAMQPClient(url, log, WithConnectionTimeout(opts.ConnectionTimeout))
 		}
 	}
 

--- a/migration/flyway.go
+++ b/migration/flyway.go
@@ -57,7 +57,7 @@ type Config struct {
 	ConfigPath    string        // Path to the configuration file
 	MigrationPath string        // Path to migration scripts
 	Timeout       time.Duration // Timeout for migration operations
-	Environment   string        // Environment (development, testing, production)
+	Environment   string        // Environment (development, staging, production)
 	DryRun        bool          // Only validate, do not execute
 
 	// Audit carries the per-call audit-event context required by ADR-019.

--- a/migration/provisioning/state.go
+++ b/migration/provisioning/state.go
@@ -89,10 +89,11 @@ var allowedNext = map[State][]State{
 	StateFailed:        nil, // terminal
 }
 
-// nextForward maps each state to the single forward-progress state that the
+// nextForward maps each non-terminal, non-cleanup state to the single forward-progress state that the
 // Executor advances to when the corresponding step succeeds. Cleanup is the
 // fallback when the forward step errors and is therefore not represented
-// here. Terminal states map to themselves (the Executor never advances).
+// here. Terminal states (StateReady, StateFailed) are absent — the outer
+// Run loop's IsTerminal() gate ensures they never reach runForwardStep.
 var nextForward = map[State]State{
 	StatePending:       StateSchemaCreated,
 	StateSchemaCreated: StateRoleCreated,

--- a/migration/provisioning/store_memory.go
+++ b/migration/provisioning/store_memory.go
@@ -94,7 +94,7 @@ func (m *MemoryStore) Transition(
 	j.State = to
 	j.UpdatedAt = m.timestamp()
 	j.LastError = lastError
-	// Attempts increments on every forward transition (cleanup excluded)
+	// Attempts increments on every forward transition (cleanup and failed excluded)
 	// so consumers can correlate retries with audit events.
 	if to != StateCleanup && to != StateFailed {
 		j.Attempts++

--- a/migration/provisioning/testing/mock_store.go
+++ b/migration/provisioning/testing/mock_store.go
@@ -25,8 +25,8 @@ import (
 )
 
 // MockStateStore is a thread-safe StateStore implementation for unit tests.
-// It mirrors the semantics of provisioning.MemoryStore (which is the
-// production-side reference implementation) but adds configurable failure
+// It mirrors the semantics of provisioning.MemoryStore (the in-memory reference
+// implementation for tests and vendor authors) but adds configurable failure
 // injection for testing error paths.
 type MockStateStore struct {
 	mu       sync.Mutex

--- a/migration/roles.go
+++ b/migration/roles.go
@@ -27,7 +27,7 @@ var pgPasswordLiteralPattern = regexp.MustCompile(`(?i)(PASSWORD\s+)'(?:[^']|'')
 //
 // Migrator role: owns the per-tenant schema, holds DDL privileges, used
 // exclusively by the migration runner. Created with NOSUPERUSER NOCREATEDB
-// NOCREATEROLE NOBYPASSRLS NOREPLICATION so even a compromised migrator
+// NOCREATEROLE NOREPLICATION NOBYPASSRLS so even a compromised migrator
 // credential cannot escalate itself.
 //
 // Runtime role: per-tenant LOGIN role granted only DML on the tenant schema.

--- a/observability/README.md
+++ b/observability/README.md
@@ -51,7 +51,7 @@ func main() {
         log.Fatalf("Failed to load config: %v", err)
     }
     var obsCfg observability.Config
-    if err := cfg.InjectInto(&obsCfg); err != nil {
+    if err := cfg.Unmarshal("observability", &obsCfg); err != nil {
         panic(err)
     }
 
@@ -60,7 +60,7 @@ func main() {
     if err != nil {
         panic(err)
     }
-    defer observability.Shutdown(provider, 5*time.Second)
+    defer observability.MustShutdown(provider, 5*time.Second)
 
     // Create tracer
     tracer := provider.TracerProvider().Tracer("my-service")
@@ -206,11 +206,11 @@ observability:
 | `trace.enabled` | bool | `true` | Enable/disable tracing |
 | `trace.endpoint` | string | `"stdout"` | Endpoint for trace export (stdout, http, grpc) |
 | `trace.protocol` | string | `"http"` | OTLP protocol: "http" or "grpc" |
-| `trace.insecure` | bool | `true` | Use insecure connection (no TLS) |
+| `trace.insecure` | bool | `false` | Use insecure connection (no TLS) |
 | `trace.headers` | map[string]string | - | Custom headers for authentication |
 | `trace.sample.rate` | float64 | `1.0` | Sampling rate (0.0 = none, 1.0 = all) |
-| `trace.batch.timeout` | duration | `5s` | Time to wait before sending batch |
-| `trace.export.timeout` | duration | `30s` | Maximum time for export operation |
+| `trace.batch.timeout` | duration | `500ms (development/stdout) / 5s (production)` | Time to wait before sending batch |
+| `trace.export.timeout` | duration | `10s (development/stdout) / 60s (production)` | Maximum time for export operation |
 | `trace.max.queue.size` | int | `2048` | Maximum buffered spans |
 | `trace.max.batch.size` | int | `512` | Maximum spans per batch |
 
@@ -224,7 +224,7 @@ observability:
 | `metrics.insecure` | bool | Fallback to `trace.insecure` | Use insecure connection (no TLS) |
 | `metrics.headers` | map[string]string | Fallback to `trace.headers` | Custom headers for metrics authentication |
 | `metrics.interval` | duration | `10s` | Metric export interval |
-| `metrics.export.timeout` | duration | `30s` | Maximum time for metric export operation |
+| `metrics.export.timeout` | duration | `10s (development/stdout) / 60s (production)` | Maximum time for metric export operation |
 
 ## Advanced Usage
 
@@ -407,6 +407,6 @@ The observability package integrates seamlessly with other GoBricks components:
 - **HTTP Server**: Automatic trace propagation via W3C traceparent headers
 - **Database**: Database query spans (when using instrumented drivers)
 - **Messaging**: AMQP message tracing (when configured)
-- **Configuration**: Full support for config injection via `InjectInto()`
+- **Configuration**: Full support for config loading via `cfg.Unmarshal("observability", &obsCfg)` (koanf mapstructure-based unmarshaling)
 
 See the [go-bricks-demo-project](https://github.com/gaborage/go-bricks-demo-project) for complete examples.

--- a/observability/dual_processor.go
+++ b/observability/dual_processor.go
@@ -121,7 +121,7 @@ func (p *DualModeLogProcessor) shouldSample(rec *sdklog.Record) bool {
 
 // Shutdown shuts down both processors.
 func (p *DualModeLogProcessor) Shutdown(ctx context.Context) error {
-	// Shutdown both processors, return first error encountered
+	// Shutdown both processors, collecting all errors
 	errAction := p.actionProcessor.Shutdown(ctx)
 	errTrace := p.traceProcessor.Shutdown(ctx)
 
@@ -130,7 +130,7 @@ func (p *DualModeLogProcessor) Shutdown(ctx context.Context) error {
 
 // ForceFlush flushes both processors.
 func (p *DualModeLogProcessor) ForceFlush(ctx context.Context) error {
-	// Flush both processors, return first error encountered
+	// Flush both processors, collecting all errors
 	errAction := p.actionProcessor.ForceFlush(ctx)
 	errTrace := p.traceProcessor.ForceFlush(ctx)
 

--- a/outbox/relay.go
+++ b/outbox/relay.go
@@ -34,8 +34,8 @@ func (r *Relay) Execute(ctx scheduler.JobContext) error {
 	}
 
 	// Check broker readiness before fetching records.
-	// PublishToExchange returns nil (not error) when the client is not ready,
-	// which would cause events to be incorrectly marked as published.
+	// Avoids pulling a full batch only to have every publish fail with errNotConnected
+	// on the first not-ready cycle, which wastes a DB round-trip and retry increments.
 	if !msgClient.IsReady() {
 		return fmt.Errorf("outbox relay: messaging client not ready")
 	}

--- a/scheduler/metadata.go
+++ b/scheduler/metadata.go
@@ -22,7 +22,7 @@ type JobMetadata struct {
 	ScheduleType string `json:"scheduleType"`
 
 	// CronExpression is a cron-style representation of the schedule (e.g., "0 3 * * *" for daily at 3 AM)
-	// Generated from ScheduleConfiguration per data-model.md
+	// Generated from ScheduleConfiguration by ToCronExpression()
 	CronExpression string `json:"cronExpression"`
 
 	// HumanReadable is a user-friendly description (e.g., "Every Monday at 2:00 AM", "Every 30 minutes")

--- a/scheduler/module.go
+++ b/scheduler/module.go
@@ -43,7 +43,7 @@ const (
 // Example usage:
 //
 //	func (m *MyModule) Init(deps *app.ModuleDeps) error {
-//	    return deps.Scheduler.DailyAt("cleanup-job", &CleanupJob{}, mustParseTime("03:00"))
+//	    return deps.Scheduler.DailyAt("cleanup-job", &CleanupJob{}, scheduler.ParseTime("03:00"))
 //	}
 type Module struct {
 	// GoBricks dependencies

--- a/server/constants.go
+++ b/server/constants.go
@@ -44,8 +44,8 @@ var reservedMetaKeys = map[string]struct{}{
 
 // HTTP Server Default Timeouts
 //
-// These constants define default timeout values for the Echo HTTP server.
-// They are used in server configuration and tests to ensure consistent behavior.
+// The following constants are exported as a reference for the framework's default values
+// and for use by callers that configure the server programmatically.
 
 const (
 	// DefaultReadTimeout is the maximum duration for reading the entire request.
@@ -54,7 +54,7 @@ const (
 
 	// DefaultWriteTimeout is the maximum duration before timing out writes of the response.
 	// This is set from the start of the request handler to the end of the response write.
-	DefaultWriteTimeout = 15 * time.Second
+	DefaultWriteTimeout = 30 * time.Second
 
 	// DefaultIdleTimeout is the maximum amount of time to wait for the next request
 	// when keep-alives are enabled.
@@ -62,10 +62,9 @@ const (
 
 	// DefaultShutdownTimeout is the maximum time to wait for graceful shutdown.
 	// This allows in-flight requests to complete before forceful termination.
-	DefaultShutdownTimeout = 30 * time.Second
+	DefaultShutdownTimeout = 10 * time.Second
 
 	// DefaultAPITimeout is the maximum duration for external API calls.
-	// Used in HTTP client configurations for backend service communication.
 	DefaultAPITimeout = 30 * time.Second
 )
 

--- a/testing/containers/oracle.go
+++ b/testing/containers/oracle.go
@@ -184,7 +184,7 @@ func (o *OracleContainer) Host() string {
 	return o.host
 }
 
-// Port returns the mapped Oracle port (1521)
+// Port returns the host-side port Docker mapped to the container's 1521.
 func (o *OracleContainer) Port() int {
 	return o.port
 }

--- a/testing/containers/rabbitmq.go
+++ b/testing/containers/rabbitmq.go
@@ -114,7 +114,7 @@ func StartRabbitMQContainer(ctx context.Context, t *testing.T, cfg *RabbitMQCont
 	}, nil
 }
 
-// BrokerURL returns the AMQP connection URL (amqp://guest:guest@localhost:port/)
+// BrokerURL returns the AMQP connection URL for the running container.
 func (r *RabbitMQContainer) BrokerURL() string {
 	return r.brokerURL
 }
@@ -124,7 +124,7 @@ func (r *RabbitMQContainer) Host() string {
 	return r.host
 }
 
-// Port returns the mapped AMQP port (5672)
+// Port returns the host-side port Docker mapped to the container's 5672.
 func (r *RabbitMQContainer) Port() int {
 	return r.port
 }

--- a/testing/containers/redis.go
+++ b/testing/containers/redis.go
@@ -100,7 +100,7 @@ func (r *RedisContainer) Host() string {
 	return r.host
 }
 
-// Port returns the mapped Redis port (6379)
+// Port returns the host-side port Docker mapped to the container's 6379.
 func (r *RedisContainer) Port() int {
 	return r.port
 }

--- a/testing/fixtures/messaging.go
+++ b/testing/fixtures/messaging.go
@@ -38,9 +38,6 @@ const (
 	TestConsumerTag = "test-consumer"
 )
 
-// MessagingFixtures provides helper functions for creating pre-configured messaging mocks
-// and message builders for consistent testing.
-
 // NewWorkingMessagingClient creates a mock messaging client that operates successfully.
 // This is useful for testing happy path scenarios.
 func NewWorkingMessagingClient() *mocks.MockMessagingClient {

--- a/tools/migration/README.md
+++ b/tools/migration/README.md
@@ -228,7 +228,7 @@ go-bricks-migrate migrate \
 ## Development
 
 ```bash
-make check               # fmt + lint + test + CLI smoke
+make check               # fmt + lint + test + CLI smoke + vuln scan
 make test                # unit tests only
 make test-coverage       # writes coverage.html
 ```

--- a/tools/migration/internal/commands/list.go
+++ b/tools/migration/internal/commands/list.go
@@ -72,9 +72,9 @@ func requireExactlyOneSource(flags *CommonFlags) error {
 	return nil
 }
 
-// writeTenantIDs emits ids as NDJSON when asJSON is set or one-per-line text
-// otherwise, propagating writer errors so a broken pipe surfaces as a non-zero
-// exit instead of being silently dropped.
+// writeTenantIDs emits ids as a JSON object ({"tenants":[...]}) when asJSON is
+// set or one-per-line text otherwise, propagating writer errors so a broken
+// pipe surfaces as a non-zero exit instead of being silently dropped.
 func writeTenantIDs(out io.Writer, ids []string, asJSON bool) error {
 	if asJSON {
 		if err := json.NewEncoder(out).Encode(map[string]any{jsonKeyTenants: ids}); err != nil {

--- a/wiki/adr_001_enhanced_handler_system.md
+++ b/wiki/adr_001_enhanced_handler_system.md
@@ -89,7 +89,7 @@ Implement an enhanced handler system with the following characteristics (updated
 - **Details:**
   - `BaseAPIError` implements `error` for seamless integration with logging/middleware.
   - A unified Echo `HTTPErrorHandler` maps untyped errors and `echo.HTTPError` values into the standard `{ error, meta }` envelope and status.
-  - Error `details` are included only in development (`app.env=dev|development`).
+  - Error `details` are included only in development (`app.env=development|dev|local` — matched via `config.IsDevelopment()`; see ADR-022).
 
 ### 6. **Validation Integration Strategy**
 - **Decision:** Integrate `validator/v10` with automatic validation

--- a/wiki/adr_004_lazy_messaging_registry.md
+++ b/wiki/adr_004_lazy_messaging_registry.md
@@ -1,8 +1,10 @@
 # ADR-004: Lazy Messaging Registry Creation in ModuleRegistry
 
 **Date:** 2025-09-24
-**Status:** Accepted
+**Status:** Superseded
 **Context:** Multi-tenant messaging architecture and improved dependency resolution
+
+> **Superseded (2026-03-16):** The `initializeMessagingRegistry` / `RegisterMessaging` approach described below was replaced by the `MessagingDeclarer` duck-typing pattern (ADR-014). The singleflight protection moved to `messaging.Manager.EnsureConsumers()`. The `GetMessaging` field on `ModuleDeps` was renamed to `Messaging` per the S8179 breaking change. This ADR remains as a historical record of the original lazy-init design intent.
 
 ## Problem Statement
 
@@ -52,7 +54,7 @@ func (r *ModuleRegistry) initializeMessagingRegistry(ctx context.Context) (*mess
             return r.messagingRegistry, nil
         }
 
-        client, err := r.deps.GetMessaging(ctx)
+        client, err := r.deps.Messaging(ctx)
         if err != nil {
             return nil, err
         }

--- a/wiki/adr_006_otlp_log_export.md
+++ b/wiki/adr_006_otlp_log_export.md
@@ -349,14 +349,14 @@ observability:
 
 ### Testing Strategy
 
-1. **Unit Tests** (Phase 8 - Planned):
+1. **Unit Tests** (Implemented):
    - Config defaults and validation
    - Exporter selection (stdout/HTTP/gRPC)
    - Severity filter and sampling distribution
    - JSON→OTel conversion edge cases
    - Logger enhancement and context injection
 
-2. **Integration Tests** (Phase 8 - Planned):
+2. **Integration Tests** (Implemented):
    - End-to-end OTLP export with in-memory exporter
    - Trace correlation via WithContext()
    - Batching behavior under load

--- a/wiki/adr_008_database_testing_interface_segregation.md
+++ b/wiki/adr_008_database_testing_interface_segregation.md
@@ -105,7 +105,7 @@ AssertTransactionCommitted(t, db)
 
 ### Negative
 - **One more abstraction**: Developers must learn TestDB API (mitigated by clear examples in llms.txt)
-- **RowSet.toSQLRows() incomplete**: QueryRow works, Query needs enhancement for multi-row results
+- **RowSet.toSQLRows() complexity**: Full multi-row support requires a `sql.DB`-backed connector (`newRowSetConnector`), adding internal complexity (resolved in final implementation)
 - **Intentional code duplication**: TestDB.Query and TestTx.Query share implementation (~65 lines each, marked with `//nolint:dupl`)
 
 ### Trade-offs Accepted
@@ -140,7 +140,7 @@ AssertTransactionCommitted(t, db)
 - `database/testing/fake_db_test.go` - Comprehensive tests
 
 ### Files Modified
-- `database/types/interfaces.go:270` - Interface now embeds Querier + Transactor
+- `database/types/interfaces.go:304` - Interface now embeds Querier + Transactor
 
 ### Quality Metrics
 - **Linter**: 0 issues (golangci-lint passes)

--- a/wiki/adr_010_panic_to_error_conversion.md
+++ b/wiki/adr_010_panic_to_error_conversion.md
@@ -191,15 +191,16 @@ var (
 
 ## Additional Files Affected
 
-Beyond `database/types/`, these files also have panic-to-error conversions:
+Beyond `database/types/`, `database/internal/builder/query_builder.go` also had panic-to-error conversions applied.
 
-| File | Functions |
-|------|-----------|
-| `observability/dual_processor.go` | `NewDualModeLogProcessor()` constructor |
-| `database/testing/rowset.go` | `Scan()` methods on RowScanner |
-| `scheduler/helpers.go` | Job helper validation |
-| `testing/fixtures/database.go` | Test fixture setup |
-| `database/internal/builder/query_builder.go` | Query builder validation |
+The following files **intentionally retain panics** (suppressed with `//nolint:S8148 // NOSONAR`) because the panics represent startup-time configuration failures or test-helper programmer-error conditions that should crash immediately rather than return errors:
+
+| File | Reason panics are retained |
+|------|---------------------------|
+| `scheduler/helpers.go` | `ParseTime()` — invalid time format is a configuration error at startup (fail-fast) |
+| `observability/dual_processor.go` | `NewDualModeLogProcessor()` — nil processor arguments are a wiring bug, not a runtime condition |
+| `database/testing/rowset.go` | `AddRow` — test-helper misuse; panicking gives a clear programmer-error signal |
+| `testing/fixtures/database.go` | Test fixture setup — panic on fixture setup failure is intentional for test clarity |
 
 ## Testing Impact
 

--- a/wiki/adr_011_redis_cache.md
+++ b/wiki/adr_011_redis_cache.md
@@ -251,23 +251,23 @@ See main implementation plan for details (CBOR serialization, Redis client, conf
 ### Adoption Path
 ```go
 // Phase 1: Basic caching
-cache, _ := deps.Cache(ctx)
+c, _ := deps.Cache(ctx)
 data, _ := cache.Marshal(&user)
-cache.Set(ctx, "user:123", data, 5*time.Minute)
+c.Set(ctx, "user:123", data, 5*time.Minute)
 
 // Phase 2: Query result caching
-cached, err := cache.Get(ctx, cacheKey)
+cached, err := c.Get(ctx, cacheKey)
 if err == nil {
     return cache.Unmarshal[User](cached)
 }
 // Fall back to database
 
 // Phase 3: Distributed locking
-acquired, _ := cache.CompareAndSet(ctx, lockKey, nil, []byte("worker-1"), 30*time.Second)
+acquired, _ := c.CompareAndSet(ctx, lockKey, nil, []byte("worker-1"), 30*time.Second)
 if !acquired {
     return ErrLockHeld
 }
-defer cache.Delete(ctx, lockKey)
+defer c.Delete(ctx, lockKey)
 ```
 
 ## Security Considerations

--- a/wiki/adr_012_remove_mongodb_support.md
+++ b/wiki/adr_012_remove_mongodb_support.md
@@ -70,4 +70,4 @@ Applications using MongoDB with GoBricks must:
 
 - [ADR-003: Database by Intent Configuration](adr_003_database_by_intent.md) — database-only-when-configured principle
 - [ADR-007: Struct-Based Column Extraction](adr_007_struct_based_columns.md) — column system now only handles PostgreSQL and Oracle
-- [ADR-010: Panic-to-Error Conversion](adr_010_panic_to_error_conversion.md) — previously referenced MongoDB transactions
+- [ADR-010: Panic-to-Error Conversion](adr_010_panic_to_error_conversion.md) — converts panic-based validation in database/types to error returns

--- a/wiki/adr_015_echo_v5_migration.md
+++ b/wiki/adr_015_echo_v5_migration.md
@@ -61,8 +61,8 @@ Use `echo.UnwrapResponse(c.Response())` to access `.Committed` and `.Status` fie
 ### Server Lifecycle: `StartServer()`/`Shutdown()` Removed
 Replaced by `echo.StartConfig` with context-based graceful shutdown.
 
-### `NewContext`: Standalone Function
-Changed from `e.NewContext(req, rec)` method to `echo.NewContext(req, rec, e)` standalone function.
+### `NewContext`: Both Forms Available
+Echo v5 adds a standalone `echo.NewContext(req, rec, opts ...any)` package-level function (in `context.go`), where the `*Echo` instance can be passed as an optional variadic argument. The `e.NewContext(req, rec)` method on `*Echo` is retained unchanged. Either form works; the method form is used throughout this codebase.
 
 ### OpenTelemetry: `otelecho` to `echo-opentelemetry`
 The community `otelecho` package does not support Echo v5. The first-party `echo-opentelemetry` package provides equivalent functionality.

--- a/wiki/adr_016_database_session_timezone.md
+++ b/wiki/adr_016_database_session_timezone.md
@@ -83,7 +83,7 @@ Both implementations apply the timezone *per physical connection*, not once afte
 
 ### Code structure
 
-- **PostgreSQL**: a five-line `RuntimeParams` injection in `database/postgresql/connection.go` after `pgx.ParseConfig`. No new files.
+- **PostgreSQL**: a small `RuntimeParams` injection block in `database/postgresql/connection.go` after `pgx.ParseConfig`. No new files.
 - **Oracle**: a new `database/oracle/tz_connector.go` containing the wrapper, plus a small refactor in `connection.go` that branches by `cfg.Timezone`. The legacy `openOracleDB` / `openOracleDBWithDialer` paths are preserved for backward compatibility (used when `Timezone == "-"` or in tests that don't go through validation), so existing test infrastructure is undisturbed.
 
 ### Rejected alternatives

--- a/wiki/adr_021_provisioning_state_machine.md
+++ b/wiki/adr_021_provisioning_state_machine.md
@@ -151,9 +151,11 @@ this ADR achieves the informational goal at zero cost.
 **Negative:**
 
 - Two DDL constants, two tables, two `CreateTable` flows. Operators
-  managing schema externally must apply both. Mitigated by exporting both
-  as `[]string` (outbox) / `string` constant (provisioning) so external
-  migration tooling can consume them.
+  managing schema externally must apply both. The provisioning package
+  exports its DDL as `PostgresStateTableDDL` (a `string` constant) so
+  external migration tooling can consume it. The outbox DDL constants are
+  unexported; operators must apply the outbox schema via the
+  `Store.CreateTable` method or by copying the DDL from source.
 - Two retry-counter bookkeeping surfaces. Outbox's `MaxRetries` skip-and-
   retry pattern is orthogonal to the state machine's "errors are
   terminal, retry via new jobID" pattern. Documented in each package
@@ -167,8 +169,9 @@ that lands, it may reuse parts of outbox's relay-scheduling pattern
 (scheduler integration, slow-job warning thresholds). The dispatcher's
 package home is an open question at the time of writing.
 
-The **state transition audit events** (`state.transitioned`,
-`cleanup.completed`) referenced in #382 will hook into the existing
-ADR-019 audit-emitter seam once the state machine has a stable consumer.
-They are out of scope for #379 to keep this PR focused on the
-state-machine + storage contract.
+The **state transition audit events** (`state.transitioned`) referenced
+in #382 are now emitted by `provisioning.Executor.WithAudit` via the
+ADR-019 `Emitter` seam (shipped in PR #523). A separate
+`cleanup.completed` event type was considered but not implemented;
+cleanup-to-failed transitions emit a `state.transitioned` event with
+`Outcome: failed` and `ErrorClass: internal_error`.

--- a/wiki/adr_022_env_policy.md
+++ b/wiki/adr_022_env_policy.md
@@ -58,7 +58,7 @@ Two-part design:
 2. **Behavior switches go through predicates** with documented alias sets:
    - `func config.IsDevelopment(env string) bool` + `(*AppConfig).IsDevelopment()` — accepts `{development, dev, local}`.
    - `func config.IsProduction(env string) bool` + `(*AppConfig).IsProduction()` — accepts `{production, prod, prd}`.
-   - Any value not in either alias set is **neutral**: treated as non-dev (no dev conveniences like stack-trace capture or error-detail leakage) and non-prod (no CORS lockdown). Examples: `staging`, `stg`, `tst`, `qa`, `uat`, `production-eu`.
+   - Any value not in either alias set is **neutral**: treated as non-dev (no dev conveniences like stack-trace capture or error-detail leakage) and non-prod (fail-closed CORS — no `Access-Control-Allow-Origin` is emitted unless `CORS_ORIGINS` is set explicitly). Examples: `staging`, `stg`, `tst`, `qa`, `uat`, `production-eu` — all receive fail-closed CORS behavior, identical to production aliases.
 
 **Chosen because:**
 
@@ -122,7 +122,7 @@ Rejects: empty, `Production` (uppercase), `prd eu` (space), `1prod` (leading dig
 - `config/validation.go` — `validateApp` switches from `slices.Contains(validEnvs, cfg.Env)` to `envFormat.MatchString(cfg.Env)`.
 - `config/validation_test.go` — replace the `Env: "invalid"` failure case (which now passes the format check) with cases that genuinely fail it: empty, uppercase, embedded space, leading digit, too-long. Adds positive cases for `local`, `tst`, `prd`, `production-eu`.
 - `server/server.go`, `server/handler.go` — four call sites switched from `isDevelopmentEnv(cfg.App.Env)` to `cfg.App.IsDevelopment()`.
-- `server/cors.go` — `os.Getenv("APP_ENV") == config.EnvProduction` → `config.IsProduction(os.Getenv("APP_ENV"))`. **Behavior change:** `APP_ENV=prd` or `APP_ENV=prod` now triggers strict CORS, matching the alias map.
+- `server/cors.go` — `os.Getenv("APP_ENV") == config.EnvProduction` replaced by a three-branch switch: (1) `CORS_ORIGINS` set → strict allowlist; (2) `config.IsDevelopment(appEnv)` → permissive wildcard; (3) default → fail-closed (no `Access-Control-Allow-Origin` emitted). This is broader than an `IsProduction` check: every non-dev alias — including `staging`, `stg`, `qa`, `uat`, `production-eu` — falls through to the fail-closed branch.
 - `server/cors_test.go` — adds `TestCORSProductionAliasesTriggerStrictMode` covering `prd`, `prod`, `production`, plus `local` and `tst` as negative cases.
 - `migration/flyway.go` — `fm.config.App.Env == config.EnvDevelopment` → `fm.config.App.IsDevelopment()`. Auto-migrate now also fires for `APP_ENV=dev` or `APP_ENV=local`.
 - `app/app.go` — bootstrap logger replaces inline `strings.EqualFold` calls with `config.IsDevelopment(env)`. Preserves the legacy "empty/whitespace `APP_ENV` → dev defaults" behaviour.

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -56,7 +56,7 @@ Lazy initialization of messaging registry to support context-aware dependency re
 
 **Date:** 2025-09-27 | **Status:** Accepted
 
-Compile-time safe WHERE clause construction replacing string-based API. Introduces type-safe methods (`WhereEq`, `WhereLt`, etc.) with automatic Oracle identifier quoting.
+Compile-time safe WHERE clause construction replacing string-based API. Introduces type-safe filter methods (`f.Eq`, `f.Lt`, etc. on `FilterFactory`) with automatic Oracle identifier quoting.
 
 **Key Benefits:** Eliminates Oracle quoting bugs, compile-time safety, clear responsibility boundaries
 
@@ -112,7 +112,7 @@ Converts panic-based fail-fast validation to idiomatic error returns for SonarCl
 
 ---
 
-### [ADR-011: Redis Cache Backend with CBOR Serialization (ModuleDeps Extension)](adr_011_redis_cache.md)
+### [ADR-011: Redis Cache Backend with CBOR Serialization](adr_011_redis_cache.md)
 
 **Date:** 2025-11-09 | **Status:** Accepted
 
@@ -234,6 +234,8 @@ Resolves issue #435. Replaces the strict `{development, staging, production}` al
 
 ### [ADR-023: Scheduler Timezone Configuration](adr_023_scheduler_timezone.md)
 
+**Date:** 2026-06-02 | **Status:** Accepted
+
 Adds `scheduler.timezone`, a single config field applied scheduler-wide via
 gocron's `WithLocation`, mirroring the `database.timezone` contract from ADR-016
 (default UTC, `"-"` opt-out for host-local, IANA-validated, fail-fast). Resolves
@@ -241,7 +243,11 @@ the absence of any timezone knob for scheduled jobs and removes the vestigial
 `ScheduleConfiguration.Timezone` field. Breaking: an unset zone now means UTC
 instead of host-local.
 
+---
+
 ### [ADR-024: Flat-Smushed Config Keys (Underscore-Free for Env Reachability)](adr_024_config_key_flatsmush.md)
+
+**Date:** 2026-06-05 | **Status:** Accepted
 
 Renames 21 snake_case koanf leaf keys (e.g. `log.sensitive_fields`,
 `keystore.secret_min_length`, `outbox.batch_size`) to the framework's

--- a/wiki/cache.md
+++ b/wiki/cache.md
@@ -21,7 +21,7 @@ GoBricks provides Redis-based caching with type-safe serialization, multi-tenant
 - **Latency**: <1ms for Get/Set (localhost), ~2ms for atomic operations (Lua scripts)
 - **Throughput**: 100k reads/sec, 80k writes/sec (single Redis instance)
 - **CBOR Serialization**: ~83ns/op marshal, ~167ns/op unmarshal (simple structs)
-- **Connection Pool**: Default 10, configurable via `cache.redis.pool_size`
+- **Connection Pool**: Default 10, configurable via `cache.redis.poolsize`
 - **Network Impact**: +0.5-1ms (same datacenter), +50-200ms (cross-region, not recommended)
 
 **Benchmark Results** (Apple M4 Pro, localhost Redis):
@@ -49,7 +49,7 @@ cache:
     port: 6379
     password: ${CACHE_REDIS_PASSWORD}  # From environment
     database: 0
-    pool_size: 10
+    poolsize: 10
 ```
 
 **Module Setup Pattern:**
@@ -72,7 +72,7 @@ func (s *Service) GetUser(ctx context.Context, id int64) (*User, error) {
     // Try cache first
     data, err := c.Get(ctx, fmt.Sprintf("user:%d", id))
     if err == nil {
-        return cache.Unmarshal[User](data)
+        return cache.Unmarshal[*User](data)
     }
 
     // Cache miss - query database

--- a/wiki/context_deadlines.md
+++ b/wiki/context_deadlines.md
@@ -15,7 +15,7 @@ Every operation that crosses an external boundary already has a configured timeo
 | HTTP server graceful shutdown | `server.timeout.shutdown` | 10s | Drain inflight requests on SIGTERM |
 | Outbound HTTP client | `httpclient.NewBuilder(...).WithTimeout(d)` | 30s | Per-request timeout on the underlying `http.Client` |
 | Cache (Redis) dial / read / write | `cache.redis.{dialtimeout,readtimeout,writetimeout}` | 5s / 3s / 3s | Per-operation socket timeouts |
-| AMQP connection establishment | `messaging.reconnect.connectiontimeout` | 30s | Includes publish confirmation |
+| AMQP publish confirmation | `messaging.reconnect.connectiontimeout` | 30s | Per-publish timeout waiting for broker ACK/NACK; does **not** bound TCP/AMQP connection establishment (dial has no timeout) |
 | Scheduler — slow job warning | `scheduler.timeout.slowjob` | 25s | Logs WARN if a job exceeds this; does not cancel |
 | Scheduler — graceful shutdown | `scheduler.timeout.shutdown` | 30s | Wait for in-flight jobs on shutdown |
 | Observability export | `observability.trace.export.timeout` | 10s (dev) / 60s (prod) | OTLP export RPC |

--- a/wiki/context_deadlines.md
+++ b/wiki/context_deadlines.md
@@ -15,7 +15,7 @@ Every operation that crosses an external boundary already has a configured timeo
 | HTTP server graceful shutdown | `server.timeout.shutdown` | 10s | Drain inflight requests on SIGTERM |
 | Outbound HTTP client | `httpclient.NewBuilder(...).WithTimeout(d)` | 30s | Per-request timeout on the underlying `http.Client` |
 | Cache (Redis) dial / read / write | `cache.redis.{dialtimeout,readtimeout,writetimeout}` | 5s / 3s / 3s | Per-operation socket timeouts |
-| AMQP publish confirmation | `messaging.reconnect.connectiontimeout` | 30s | Per-publish timeout waiting for broker ACK/NACK; does **not** bound TCP/AMQP connection establishment (dial has no timeout) |
+| AMQP publish confirmation | `messaging.reconnect.connectiontimeout` | 30s | Per-publish wait for broker ACK/NACK. Connection dial uses `amqp091-go`'s `amqp.Dial` (its own ~30s TCP+handshake timeout), not this key |
 | Scheduler — slow job warning | `scheduler.timeout.slowjob` | 25s | Logs WARN if a job exceeds this; does not cancel |
 | Scheduler — graceful shutdown | `scheduler.timeout.shutdown` | 30s | Wait for in-flight jobs on shutdown |
 | Observability export | `observability.trace.export.timeout` | 10s (dev) / 60s (prod) | OTLP export RPC |

--- a/wiki/database.md
+++ b/wiki/database.md
@@ -54,8 +54,9 @@ func (h *Handler) MigrateLegacyData(ctx context.Context) error {
     mainDB, err := h.getDB(ctx)
     if err != nil { return err }
 
-    oracleQB := builder.NewQueryBuilder(dbtypes.Oracle)
-    rows, _ := legacyDB.Query(ctx, oracleQB.Select("*").From("OLD_USERS").Build())
+    oracleQB := database.NewQueryBuilder(database.Oracle)
+    query, args, _ := oracleQB.Select("*").From("OLD_USERS").ToSQL()
+    rows, _ := legacyDB.Query(ctx, query, args...)
     // ... process and write to mainDB ...
     return nil
 }
@@ -75,7 +76,7 @@ GoBricks eliminates column repetition through struct-based column management usi
 - **DRY:** Define columns once in struct tags, reference by field name
 - **Type Safety:** Compile-time field name validation (panics on typos)
 - **Vendor-Aware:** Automatic Oracle reserved word quoting
-- **Zero Overhead:** One-time reflection (~0.6µs), cached forever (~26ns access)
+- **Zero Overhead:** One-time reflection (~2µs), cached forever (~50ns access)
 - **Refactor-Friendly:** Rename struct fields → compiler catches all query references
 
 **Quick Example:**
@@ -88,14 +89,14 @@ type User struct {
 
 cols := qb.Columns(&User{})  // Cached per vendor
 
-query := qb.Select(cols.All()...).From("users")
+query := qb.Select(cols.All()).From("users")
 // or select specific fields:
-query = qb.Select(cols.Cols("ID", "Name")...).From("users")
+query = qb.Select(cols.Cols("ID", "Name")).From("users")
 
-query := qb.Select(cols.All()...).
+query := qb.Select(cols.All()).
     From("users").
     Where(f.Eq(cols.Col("Level"), 5))
-// Oracle: SELECT "ID", "NAME", "LEVEL" FROM users WHERE "LEVEL" = :1
+// Oracle: SELECT id, name, "level" FROM users WHERE "level" = :1
 
 qb.Update("users").
     Set(cols.Col("Name"), "Jane").
@@ -105,12 +106,12 @@ qb.Update("users").
 **Service-Level Caching Pattern:**
 ```go
 type ProductService struct {
-    qb   *builder.QueryBuilder
+    qb   *database.QueryBuilder
     cols dbtypes.Columns
 }
 
 func NewProductService(db database.Interface) *ProductService {
-    qb := builder.NewQueryBuilder(db.DatabaseType())
+    qb := database.NewQueryBuilder(db.DatabaseType())
     return &ProductService{
         qb:   qb,
         cols: qb.Columns(&Product{}),
@@ -118,7 +119,7 @@ func NewProductService(db database.Interface) *ProductService {
 }
 ```
 
-**Performance:** First use ~0.6µs (reflection), cached access ~26ns, thread-safe via `sync.Map`.
+**Performance:** First use ~2µs (reflection), cached access ~50ns, thread-safe via `sync.Map`.
 
 **Type-Safe Methods:** `f.Eq`, `f.NotEq`, `f.Lt/Lte/Gt/Gte`, `f.In/NotIn`, `f.Like`, `f.Regex/RegexI/NotRegex/NotRegexI`, `f.JSONContains` (PostgreSQL only), `f.Null/NotNull`, `f.Between`.
 
@@ -138,7 +139,7 @@ type Profile struct {
     Bio    string `db:"bio"`
 }
 
-qb := builder.NewQueryBuilder(dbtypes.Oracle)
+qb := database.NewQueryBuilder(database.Oracle)
 jf := qb.JoinFilter()
 f := qb.Filter()
 
@@ -196,8 +197,8 @@ productCols := qb.Columns(&Product{})
 p := productCols.As("p")
 
 subquery := qb.Select("1").From("reviews").
-    Where(jf.And(
-        jf.EqColumn("reviews."+reviewCols.Col("ProductID"), p.Col("ID")),
+    Where(f.And(
+        f.Eq("reviews."+reviewCols.Col("ProductID"), qb.MustExpr(p.Col("ID"))),
         f.Eq(reviewCols.Col("Rating"), 5),
     ))
 

--- a/wiki/handler_patterns.md
+++ b/wiki/handler_patterns.md
@@ -28,7 +28,7 @@ type LoginRequest struct {
     Password string `json:"password" validate:"required"`
 }
 
-func (h *Handler) login(req LoginRequest, ctx server.HandlerContext) (Result[Token], server.IAPIError) {
+func (h *Handler) login(req LoginRequest, ctx server.HandlerContext) (server.Result[Token], server.IAPIError) {
     token := h.authService.Authenticate(req)
     return server.NewResult(http.StatusOK, token), nil
 }
@@ -40,7 +40,7 @@ type FileUploadRequest struct {
     MimeType string `json:"mime_type"`
 }
 
-func (h *Handler) uploadFile(req *FileUploadRequest, ctx server.HandlerContext) (Result[UploadResponse], server.IAPIError) {
+func (h *Handler) uploadFile(req *FileUploadRequest, ctx server.HandlerContext) (server.Result[UploadResponse], server.IAPIError) {
     // Pointer avoids copying large byte slice
     fileID := h.storageService.Store(req.Data, req.Filename)
     return server.Created(UploadResponse{FileID: fileID}), nil
@@ -75,12 +75,13 @@ func (h *Handler) processBulk(req *BulkRequest, ctx server.HandlerContext) (Summ
 **Linter Configuration**:
 Configure `govet` to warn on large value copies:
 ```yaml
-# .golangci.yml
-linters-settings:
-  govet:
-    enable:
-      - copylocks
-      - composites
+# .golangci.yml  (add under the existing linters: block)
+linters:
+  settings:
+    govet:
+      enable:
+        - copylocks
+        - composites
 ```
 
 ## Raw Response Mode (Strangler Fig Migration)

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -95,6 +95,7 @@ The `httpclient` package emits five OpenTelemetry instruments under the meter na
 | `"tls_error"` | `*tls.RecordHeaderError` or `*tls.CertificateVerificationError` |
 | `"connection_error"` | `*net.OpError` with `Op == "dial"` (TCP connection refused / unreachable) |
 | `"interceptor_failed"` | `InterceptorError` from a request or response interceptor |
+| `"panic"` | Panic recovered in user-supplied code (interceptor or custom `RoundTripper`). Emitted on both the attempt span and the parent Do span. |
 | `"_OTHER"` | Any other `NetworkError` or unclassified error |
 
 ### `WithPeerName` Example
@@ -204,7 +205,7 @@ OTel HTTP **client** span status convention (different from server spans):
 | 4xx response (no err) | `codes.Unset` | no |
 | 5xx response (no err) | `codes.Error`, description `"HTTP {code}"` | no |
 | Transport error (no response) | `codes.Error`, description = error.type | yes — sanitized event |
-| Any response + non-nil err (interceptor/build failure on a 2xx, terminal HTTPError on a 5xx, …) | `codes.Error`, description = error.type or err message | yes — sanitized event |
+| Non-5xx response + non-nil err (interceptor/build failure on a 2xx/3xx/4xx) | `codes.Error`, description = error.type (or err.Error() when error.type is empty). Note: 5xx responses always take the row-3 path regardless of whether err is non-nil — `codes.Error`, description `"HTTP {code}"`. | yes — sanitized event |
 
 Rationale for the 4xx-as-OK convention: client spans treat 4xx as a normal flow-control signal (the server told you something legitimate about the request). 5xx signals a server-side failure; transport errors signal a network-side failure on the path between us and the server. Any err alongside a response (e.g. a response interceptor failing on a 200) takes the error path so the span doesn't silently look like a success.
 
@@ -267,7 +268,7 @@ By default the client logs only request/response metadata (method, URL, status, 
 ```go
 client := httpclient.NewBuilder(logger).
     WithLogPayloads(true).
-    WithMaxPayloadLogBytes(2048). // default 1024; must be > 0
+    WithMaxPayloadLogBytes(2048). // default 1024; values ≤ 0 are ignored and the default applies
     Build()
 ```
 

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -183,7 +183,7 @@ GoBricks applies production-safe AMQP reconnection defaults when messaging is co
 | `reconnect.delay` | 5s | Initial delay before reconnect attempts |
 | `reconnect.reinitdelay` | 2s | Delay between channel re-initialization |
 | `reconnect.resenddelay` | 5s | Delay before resending failed messages |
-| `reconnect.connectiontimeout` | 30s | Timeout for connection establishment |
+| `reconnect.connectiontimeout` | 30s | Per-publish broker confirmation (ACK/NACK) timeout |
 | `reconnect.maxdelay` | 60s | Maximum backoff cap for exponential retry |
 | `publisher.maxcached` | 50 | Maximum cached publisher channels |
 | `publisher.idlettl` | 10m | TTL for idle publisher channels |

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -52,14 +52,14 @@ func (m *Module) DeclareMessaging(decls *messaging.Declarations) {
         Queue:     "events.queue",
         Consumer:  "discover-pending",
         EventType: "discover-pending-events",
-        Handler:   m.discoverHandler.Handle,
+        Handler:   m.discoverHandler,
     }, nil)
 
     decls.DeclareConsumer(&messaging.ConsumerOptions{
         Queue:     "events.queue",
         Consumer:  "process-batch",  // Different consumer tag - OK
         EventType: "process-batch-events",
-        Handler:   m.processHandler.Handle,
+        Handler:   m.processHandler,
     }, nil)
 }
 ```

--- a/wiki/migration_provisioning.md
+++ b/wiki/migration_provisioning.md
@@ -101,6 +101,9 @@ if err := exec.Run(ctx, job.ID); err != nil {
 | `provisioning.NewMemoryStore` | In-memory reference implementation (unit tests, alt-vendor template) |
 | `provisioning.PostgresStateTableDDL` | Exported DDL constant for external migration tooling |
 | `provisioning.ErrJobNotFound` / `ErrIllegalTransition` / `ErrStaleRead` | Sentinel errors |
+| `provisioning.ErrQuiesced` | Returned by `Run` when the deployment quiesce flag is set; callers should treat it as "retry later" |
+| `Executor.WithQuiesce(g migration.QuiesceGate)` | Enables the deployment quiesce gate; `Run` returns `ErrQuiesced` instead of advancing while the flag is set |
+| `Executor.WithAudit(emitter migration.Emitter, cfg AuditContext)` | Opt-in `state.transitioned` audit-event emission via the shared OTel seam (ADR-019) |
 
 ## Crash-recovery contract
 
@@ -191,11 +194,6 @@ subpackage provides `MockStateStore` with `WithGetError`, `WithUpsertError`,
 - **The dispatcher** that polls for `StatePending` jobs and calls `Run`
   on them: deferred to a follow-up after the state machine itself is
   solid (issue body, "Out of scope").
-- **Quiesce-flag interaction** that pauses the dispatcher during
-  deployments: tracked under #380.
-- **State-transition audit events** (`state.transitioned`,
-  `cleanup.completed`): tracked under #382. The existing ADR-019
-  audit-emitter seam is the integration point.
 
 ## Related
 
@@ -203,8 +201,8 @@ subpackage provides `MockStateStore` with `WithGetError`, `WithUpsertError`,
   the `CreateSchema` / `CreateRole` steps invoke.
 - [multi_tenant_migration.md](multi_tenant_migration.md) — the `MigrateAll`
   orchestrator the `Migrate` step typically calls.
-- [migration_audit.md](migration_audit.md) — the audit-event seam future
-  state-transition events will use.
+- [migration_audit.md](migration_audit.md) — the audit-event seam that
+  `state.transitioned` events are emitted through (ADR-019).
 - [ADR-021](adr_021_provisioning_state_machine.md) — the reuse-vs-divergence
   decision that put this package in `migration/provisioning/` rather than
   inside `outbox/`.

--- a/wiki/migration_quiesce.md
+++ b/wiki/migration_quiesce.md
@@ -35,7 +35,7 @@ _, _ = ctrl.Set(ctx, migration.QuiesceSetOptions{
     Reason: "deploy-2026.06", // operator-supplied "why" (safe to audit)
     TTL:    time.Hour,
 })
-st, _ := ctrl.Query(ctx)     // QuiesceStatus{Active, SetBy, Reason, ExpiresAt, ClearedAt, Expired}
+st, _ := ctrl.Query(ctx)     // QuiesceStatus{Active, SetAt, SetBy, Reason, ExpiresAt, ClearedAt, Expired}
 _, _ = ctrl.Clear(ctx, "ops-oncall")
 
 // Worker (per-tenant provisioning):
@@ -54,13 +54,13 @@ migration.MigrateAll(ctx, fm, lister, configs, migration.ActionMigrate,
 A single control-plane table (zero new dependencies), one row per scope (v1 uses the single `"global"` scope):
 
 ```sql
-CREATE TABLE quiesce_flags (
+CREATE TABLE IF NOT EXISTS quiesce_flags (
     id          VARCHAR(64)  PRIMARY KEY,
     set_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     set_by      VARCHAR(255) NOT NULL DEFAULT '',
     reason      TEXT NOT NULL DEFAULT '',
     expires_at  TIMESTAMP WITH TIME ZONE NOT NULL,
-    cleared_at  TIMESTAMP WITH TIME ZONE  -- NULL = uncleared
+    cleared_at  TIMESTAMP WITH TIME ZONE
 )
 ```
 

--- a/wiki/migration_roles.md
+++ b/wiki/migration_roles.md
@@ -54,7 +54,7 @@ DML-accessible to the runtime role.
 ```go
 import "github.com/gaborage/go-bricks/migration"
 
-spec := migration.PGRoleSpec{
+spec := &migration.PGRoleSpec{
     Schema:           "tenant_a",
     MigratorRole:     "migrator",
     MigratorPassword: os.Getenv("MIGRATOR_PASSWORD"), // optional, omit if managed externally
@@ -180,7 +180,8 @@ role helpers directly against PostgreSQL.
 - **Oracle.** Tracked under #385. Oracle's user-as-schema model and
   privilege grants are fundamentally different — likely a separate
   `OracleRoleSpec` and `ProvisionOracleRoles` rather than an extension here.
-- **Provisioning state machine.** #379 will add a durable, crash-recoverable
-  state machine that orchestrates the full per-tenant provisioning flow
-  (schema_created → role_created → migrated → seeded → ready). Today the
-  helper is a single idempotent call; the state machine will wrap it.
+- **Provisioning state machine.** Shipped in PR #429. A durable,
+  crash-recoverable state machine (`migration/provisioning/`) orchestrates the
+  full per-tenant provisioning flow (`pending → schema_created → role_created →
+  migrated → seeded → ready`, with `cleanup → failed` branches) and wraps the
+  role-provisioning helper. See [migration_provisioning.md](migration_provisioning.md).

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -128,7 +128,6 @@ Per [SonarCloud rule S8179](https://rules.sonarsource.com/go/RSPEC-8179/), gette
 | `app.Builder` | `GetError()` | `Error()` |
 | `messaging.Manager` | `GetPublisher()` | `Publisher()` |
 | `server.Validator` | `GetValidator()` | `Validator()` |
-| `validation.TagInfo` | `GetMin()`, `GetMax()`, `GetMinLength()`, `GetMaxLength()`, `GetPattern()`, `GetEnum()`, `GetConstraints()` | `Min()`, `Max()`, `MinLength()`, `MaxLength()`, `Pattern()`, `Enum()`, `AllConstraints()` |
 | `migration.FlywayMigrator` | `GetDefaultMigrationConfig()` | `DefaultMigrationConfig()` |
 | `config.TenantStore` | `GetTenants()` | `Tenants()` |
 | `app.MetadataRegistry` | `GetModules()`, `GetModule()` | `Modules()`, `Module()` |
@@ -136,7 +135,6 @@ Per [SonarCloud rule S8179](https://rules.sonarsource.com/go/RSPEC-8179/), gette
 | `database.Interface` | `GetMigrationTable()` | `MigrationTable()` |
 | `database/testing.TestDB` | `GetQueryLog()`, `GetExecLog()` | `QueryLog()`, `ExecLog()` |
 | `database/testing.TenantDBMap` | `GetTenantDB()` | `TenantDB()` |
-| `messaging.Registry` | `GetDeclarations()` | `Declarations()` |
 | `server.RouteRegistry` | `GetRoutes()` | `Routes()` |
 
 **Example:**

--- a/wiki/multi_tenant_migration.md
+++ b/wiki/multi_tenant_migration.md
@@ -180,7 +180,14 @@ go-bricks-migrate migrate \
   --source-url https://control-plane.example.com/api \
   --aws-region us-east-1 \
   --json
+
+# Manage the deployment quiesce flag (pauses worker pickup and tenant fan-out)
+go-bricks-migrate quiesce set    --source-url https://control-plane.example.com/api
+go-bricks-migrate quiesce status --source-url https://control-plane.example.com/api
+go-bricks-migrate quiesce clear  --source-url https://control-plane.example.com/api
 ```
+
+> See [wiki/migration_quiesce.md](migration_quiesce.md) for the full `quiesce set|clear|status` subcommand reference, TTL auto-release, and fail-open behaviour.
 
 ### Flag reference
 
@@ -201,6 +208,11 @@ go-bricks-migrate migrate \
 | `--parallel <N>`         | `1`                    | Concurrent tenants (1 = sequential, max 32)         |
 | `--tenant <id>`          |                        | Run for a single tenant; bypasses listing           |
 | `--json`                 | `false`                | NDJSON progress + summary records                   |
+| `--applied-by`           | `$GOBRICKS_MIGRATE_APPLIED_BY`      | Principal recorded in `migration.applied` audit events   |
+| `--git-sha`              | `$GOBRICKS_MIGRATE_GIT_SHA`         | Source commit SHA recorded in the audit event            |
+| `--pipeline-run-id`      | `$GOBRICKS_MIGRATE_PIPELINE_RUN_ID` | CI/CD run ID recorded in the audit event                 |
+| `--allow-insecure-scheme` | `false`               | Allow `http://` base URLs for `--source-url` (dev/LocalStack only; bearer token would be cleartext) |
+| `--verbose` / `-v`       | `false`                | Enable debug-level logging                          |
 
 ## CI/CD recipe (GitHub Actions, OIDC → AWS)
 
@@ -220,7 +232,7 @@ jobs:
   migrate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/wiki/observability.md
+++ b/wiki/observability.md
@@ -15,7 +15,7 @@ GoBricks provides production-grade observability built on OpenTelemetry: distrib
 **Export Timeout Configuration:** GoBricks uses environment-aware export timeouts to balance fail-fast feedback (development) with network resilience (production):
 - **Development/stdout:** 10s (quick failure detection for debugging)
 - **Production:** 60s (accommodates network latency, TLS handshake, batch transmission)
-- **Override via YAML:** `observability.trace.export.timeout: "90s"` (applies to traces/metrics/logs)
+- **Override via YAML:** `observability.trace.export.timeout: "90s"` (trace only); use `observability.metrics.export.timeout` and `observability.logs.export.timeout` for the other subsystems
 - **Why 60s?** Real-world production scenarios involve cross-region latency, TLS negotiation, and 512-span batch transmission to remote OTLP endpoints
 
 **Dual-Mode Logging:** `DualModeLogProcessor` routes logs by `log.type`:
@@ -105,16 +105,16 @@ base.SensitiveFields = append(base.SensitiveFields,
 )
 base.MaskValue = "[REDACTED]"
 
-fw, err := app.NewWithOptions(&app.Options{
+fw, _, err := app.NewWithOptions(&app.Options{
     LoggerFilterConfig: base,
 })
 if err != nil { log.Fatal(err) }
-fw.RegisterModules(myModule)
+fw.RegisterModule(myModule)
 log.Fatal(fw.Run())
 
 // Opt-out variant (no masking at all — use only for test fixtures or
 // environments where structured logs are sandboxed):
-fw, err = app.NewWithOptions(&app.Options{
+fw, _, err = app.NewWithOptions(&app.Options{
     LoggerFilterConfig: &logger.FilterConfig{SensitiveFields: nil},
 })
 ```

--- a/wiki/observability_headers_auth.md
+++ b/wiki/observability_headers_auth.md
@@ -56,16 +56,16 @@ The actual secret lives in the deployment environment (Kubernetes Secret, AWS Se
    - `config.production.yaml` — Production overrides (committed; references `${VAR}`)
    - `config.development.yaml` — Dev settings (committed; references `${VAR}` or default literals for local-only test keys)
 
-3. **Programmatic override from a secret manager** (when env-var injection isn't enough — e.g., rotating tokens):
+3. **Programmatic secret injection** (when a sidecar or secret manager provides the value at process start — e.g., rotating tokens): set the environment variable before `app.Run()` so Koanf's env-var layer resolves the `${VAR}` placeholder declared in YAML.
    ```go
-   // In main.go before app.Run()
+   // In main.go, before app.Run()
    apiKey, err := vault.GetSecret(ctx, "otel/api-key")
    if err != nil { return err }
-
-   cfg.Observability.Trace.Headers = map[string]string{
-       "api-key": apiKey,
-   }
+   os.Setenv("NEW_RELIC_API_KEY", apiKey)
+   // config.production.yaml already declares: api-key: ${NEW_RELIC_API_KEY}
+   // Koanf resolves the placeholder at startup — no config struct mutation needed.
    ```
+   Note: `config.Config` has no `Observability` struct field; the header keys must be declared in YAML — only the secret *value* can come from the environment.
 
 ## Vendor-Specific Header Examples
 

--- a/wiki/outbox.md
+++ b/wiki/outbox.md
@@ -74,7 +74,7 @@ func (s *OrderService) CreateOrder(ctx context.Context, req CreateOrderReq) erro
 outbox:
   enabled: true
   tablename: gobricks_outbox       # Default table name
-  autocreatetable: true           # Create table on first use
+  autocreatetable: false          # Auto-create table on first use (default: false; enable for development only)
   defaultexchange: ""              # Fallback if Event.Exchange empty
   pollinterval: 5s                 # Relay poll frequency
   batchsize: 100                   # Events per relay cycle
@@ -88,7 +88,7 @@ outbox:
 |-------|------|----------|-------------|
 | `EventType` | string | Yes | Event routing key (e.g., "order.created") |
 | `AggregateID` | string | Yes | Entity identifier for idempotency (e.g., "order-123") |
-| `Payload` | any | Yes | `[]byte` stored as-is, otherwise JSON-marshaled |
+| `Payload` | any | No | Event data. `[]byte` stored as-is, otherwise JSON-marshaled. Nil is accepted and stored as JSON `null`. |
 | `Headers` | map[string]any | No | Custom AMQP headers propagated to published message |
 | `Exchange` | string | No | Target AMQP exchange (falls back to `defaultexchange` config) |
 | `RoutingKey` | string | No | AMQP routing key (falls back to `EventType`) |

--- a/wiki/startup_defaults.md
+++ b/wiki/startup_defaults.md
@@ -8,15 +8,15 @@ GoBricks applies component-specific startup timeouts for graceful initialization
 
 | Setting | Default | Purpose |
 |---------|---------|---------|
-| `startup.timeout` | 10s | Overall startup timeout (also serves as fallback for unset components) |
-| `startup.database` | 10s | Database connection establishment |
-| `startup.messaging` | 10s | AMQP broker connection |
-| `startup.cache` | 5s | Redis connection |
-| `startup.observability` | 15s | OTLP endpoint connection (higher for TLS handshake) |
+| `app.startup.timeout` | 10s | Overall startup timeout (also serves as fallback for unset components) |
+| `app.startup.database` | 10s | Database connection establishment |
+| `app.startup.messaging` | 10s | AMQP broker connection |
+| `app.startup.cache` | 5s | Redis connection |
+| `app.startup.observability` | 15s | OTLP endpoint connection (higher for TLS handshake) |
 
 **Fallback Hierarchy:**
-1. Explicit component value (e.g., `startup.database: 15s`) → preserved
-2. Global timeout (if set): `startup.timeout: 30s` → applied to all unset components
+1. Explicit component value (e.g., `app.startup.database: 15s`) → preserved
+2. Global timeout (if set): `app.startup.timeout: 30s` → applied to all unset components
 3. Per-component default (shown in table) → used when neither is set
 
 **Example - Global fallback:**

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -46,7 +46,7 @@ func Test_Filter_Eq(t *testing.T) { }
 **Exception:** Test case descriptions in table-driven tests use snake_case for readability (e.g., `name: "with_invalid_credentials"`)
 
 ## Testing Strategy
-- **Unit tests:** testify, database/testing (database), httptest (server), fake adapters (messaging)
+- **Unit tests:** testify, `database/testing` (DB mocking), `cache/testing` (cache mocking), `outbox/testing` (outbox mocking), httptest (server), fake adapters (messaging)
 - **Integration tests:** testcontainers, `-tags=integration` flag
 - **Race detection:** All tests run with `-race` in CI
 - **Coverage target:** 80% (SonarCloud)
@@ -59,7 +59,7 @@ GoBricks provides `database/testing` package for easy database mocking without s
 ```go
 import dbtest "github.com/gaborage/go-bricks/database/testing"
 
-func TestProductService_FindActive(t *testing.T) {
+func TestProductServiceFindActive(t *testing.T) {
     // Setup (8 lines vs 30+ with sqlmock)
     db := dbtest.NewTestDB(dbtypes.PostgreSQL)
     db.ExpectQuery("SELECT").
@@ -118,7 +118,7 @@ result, err := svc.Process(ctx)  // Uses acme's TestDB
 - Vendor-agnostic RowSet builder
 - Partial SQL matching by default (or strict with StrictSQLMatching())
 
-See [database/testing](../database/testing/) package and [llms.txt:294](../llms.txt) for full examples.
+See [database/testing](../database/testing/) package and [llms.txt:1393](../llms.txt) for full examples.
 
 ## Cache Testing
 
@@ -179,7 +179,7 @@ result, err := svc.Process(acmeCtx)  // Uses acme's MockCache
 **Key Features:**
 - Fluent configuration API (`WithGetFailure`, `WithDelay`, `WithCloseCallback`)
 - Operation tracking (Get/Set/Delete/GetOrSet/CompareAndSet counts)
-- 20+ assertion helpers (`AssertCacheHit`, `AssertOperationCount`, `AssertValue`)
+- 17 assertion helpers (`AssertCacheHit`, `AssertOperationCount`, `AssertValue`)
 - TTL expiration testing (real time-based expiration)
 - Multi-tenant isolation support
 
@@ -262,7 +262,7 @@ The `database/oracle` integration suite provisions exactly one Oracle container 
 - **MUST** acquire its schema via `setupTestSchema(t)` (which delegates to `(*containers.OracleContainer).NewSchema(t)`).
 - **MUST NOT** create globally-named objects. No `CREATE PUBLIC SYNONYM`, no `CREATE TYPE` outside the test's own schema — fully qualify with the per-test schema name (`CREATE TYPE <schema>.PRODUCT_TYPE`) so `DROP USER ... CASCADE` reclaims them on cleanup.
 - **MUST NOT** rely on dropping its own tables/sequences/UDTs by name. `DROP USER ... CASCADE` is the cleanup primitive; tests that try to `DROP TABLE` explicitly will see no-op or already-dropped errors.
-- **MAY** opt into `t.Parallel()` once the refactor is stable (separate follow-up after ADR-020 lands).
+- **MAY** opt into `t.Parallel()` as a separate follow-up (not yet done).
 
 Tests that need a *different* `DatabaseConfig` (pool sizing, keep-alive, timezone, connection-string format variants) call `packageOracleContainer().NewSchema(t)` directly and build their own `cfg` from the returned `*containers.OracleSchema` credentials — still on the shared container, just with custom wiring.
 

--- a/wiki/troubleshooting.md
+++ b/wiki/troubleshooting.md
@@ -31,7 +31,7 @@ docker run -d --name gobricks-oracle-dev \
     -e ORACLE_PASSWORD=testpass \
     -e APP_USER=testuser \
     -e APP_USER_PASSWORD=testpass \
-    gvenzl/oracle-free:23-slim
+    gvenzl/oracle-free:23.26.2-slim
 docker logs -f gobricks-oracle-dev | grep -m1 "DATABASE IS READY TO USE!"
 
 # 2) Wrap go test in a script that exports the existing endpoint
@@ -51,7 +51,7 @@ Currently this is a documented developer convenience: TestMain always spins up a
 # → Check placeholder numbering (PostgreSQL: $1,$2; Oracle: :1,:2)
 
 # "database not configured" errors
-# → Set database.type, database.host OR database.connection_string (see ADR-003)
+# → Set database.type, database.host OR database.connectionstring (see ADR-003)
 ```
 
 ## Connection Pool Issues (ORA-01013, connection reset)
@@ -108,7 +108,7 @@ database:
 # Cache timeout errors
 # → Increase operation timeout: ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 # → Check network latency if Redis on different host
-# → Verify pool size adequate: cache.redis.pool_size >= NumCPU * 2
+# → Verify pool size adequate: cache.redis.poolsize >= NumCPU * 2
 
 # CacheManager eviction issues
 # → Increase maxsize if seeing unexpected evictions: cache.manager.maxsize


### PR DESCRIPTION
## What

Two things, the second discovered while reviewing the first:

1. **Repo-wide documentation & code-comment drift remediation** (the bulk) — produced by the `doc-drift` detect → fix → review pipeline.
2. **`fix(messaging)`: wire `reconnect.connectiontimeout` into the AMQP client** — a real behavior bug surfaced during the review of the `context_deadlines.md` drift fix.

## The fix (release-noteworthy)

`messaging.reconnect.connectiontimeout` was **validated** (rejects negatives, defaults to 30s) but **never wired into the AMQP client** — `NewAMQPClient` hardcoded a 30s default and no path applied the configured value, so setting the key in YAML had **no effect**. Now threaded end-to-end:

- `messaging`: new `WithConnectionTimeout` `ClientOption` + variadic `NewAMQPClient(url, log, opts...)` (backward-compatible; non-positive ignored → 30s default). `ManagerOptions.ConnectionTimeout` applied by the default factory.
- `app`: `ManagerConfigBuilder` carries the value (set in bootstrap from `cfg.Messaging.Reconnect.ConnectionTimeout`); `MessagingClientFactory(timeout)` injects it. A custom `Options.MessagingClientFactory` still owns construction (documented).
- `config` + docs: corrected the `ConnectionTimeout` comments and the CLAUDE.md / `wiki/messaging.md` / `wiki/context_deadlines.md` rows (it's the per-publish broker ACK/NACK wait; the dial is bounded by amqp091-go's `amqp.Dial` default, not this key).

**No default change** (still 30s); operators who set the key now get effect. Tests cover option application (default / override / non-positive), builder propagation, and the default factory path.

## The doc-drift cleanup

380 confirmed findings from `doc-drift`; applied all 136 documentation + 44 High/Medium comment findings (skipped 200 Low "redundant-narration"). Highlights: query-builder examples (`ToSQL` 3-value, `cols.Cols`, no `[]string` spread), `app.New`/`NewWithOptions` 3-value returns, `RegisterModule` (singular), cache `Marshal`/`Unmarshal` as package generics, koanf flat-smush keys (`poolsize`, `connectionstring`), corrected Oracle quoting comments, migration docs caught up to shipped features.

A `/code-review` pass found **15 confirmed issues** the per-file fixers introduced/under-fixed (incl. a clipped `nil`-guard in `server/timing.go`) — all remediated.

## Verification

- `make check` ✅ — fmt, lint **0 issues**, tests `-race`, `govulncheck` clean.
- `/code-review` ✅ on both the doc-drift diff and the wiring fix (the latter verified correct hop-by-hop).
- `/security-audit` ✅ — no secrets, no SQL surface, and no "disable-the-timeout" footgun (config rejects negatives; option ignores non-positive).

## Notes

- Branched during PR #566's review; rebased onto `main` after #566/#567/#568 merged — clean standalone change.
- The `fix(messaging)` part is the release-noteworthy change; the doc cleanup is housekeeping. Adjust the squash title at merge if you'd prefer a different changelog framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inbox processor for consumer-side exactly-once processing.
  * Deployment quiesce control (pause/resume) and optional state-transition audit events.

* **Changes**
  * Server defaults: write timeout → 30s, shutdown timeout → 10s.
  * Messaging: configurable per-publish confirmation timeout.
  * Module dependency access moved to context-aware provider functions.

* **Documentation**
  * Broad updates to README, guides, ADRs, examples, toolchain checks (vulnerability scan), cache/config naming, and outbox defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->