### PR TITLE
docs: fix query-builder examples using renamed cols.Cols() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,10 +433,10 @@ type User struct {
 cols := qb.Columns(&User{})
 f := qb.Filter()
 
-query := qb.Select(cols.Fields("ID", "Name")...).
+query := qb.Select(cols.Cols("ID", "Name")). // []string flattened by Select
     From("users").
     Where(f.Eq(cols.Col("Level"), 5))
-// Oracle: SELECT "ID", "NAME" FROM users WHERE "LEVEL" = :1
+// Oracle: SELECT id, name FROM users WHERE "level" = :1
 // PostgreSQL: SELECT id, name FROM users WHERE level = $1
 ```
 

--- a/database/internal/builder/query_builder.go
+++ b/database/internal/builder/query_builder.go
@@ -188,8 +188,8 @@ func (qb *QueryBuilder) MustExpr(sql string, alias ...string) dbtypes.RawExpress
 //	}
 //
 //	cols := qb.Columns(&User{})
-//	query := qb.Select(cols.Cols("ID", "Name")...).From("users")
-//	// Oracle: SELECT "ID", "NAME" FROM users
+//	query := qb.Select(cols.Cols("ID", "Name")).From("users") // []string flattened by Select
+//	// Oracle: SELECT id, name FROM users
 //	// PostgreSQL: SELECT id, name FROM users
 func (qb *QueryBuilder) Columns(structPtr any) dbtypes.Columns {
 	return colreg.RegisterColumns(qb.vendor, structPtr)


### PR DESCRIPTION
## Summary

Fixes the query-builder documentation drift tracked in #561 — and the same drift in two **sibling locations the issue (and #571's sweep) missed**.

### What #561 reported
- `CLAUDE.md` — `cols.Fields(...)` → `cols.Cols(...)` (drop the spread)
- `llms.txt` — `ToSQL()` 2-return → 3-return

Both of these were **already fixed** by #571's repo-wide doc-drift cleanup (verified on current `main`), so they need no change here.

### What this PR actually fixes (the missed siblings)
A repo-wide sweep surfaced the identical drift in two files the original cleanup overlooked:

| File | Problem |
|---|---|
| `README.md:436` | `qb.Select(cols.Fields("ID", "Name")...)` — won't compile (`Cols()` returns `[]string`, can't spread into `Select(...any)`) **+** stale Oracle output comment |
| `database/internal/builder/query_builder.go:191` (`Columns()` GoDoc) | Same `cols.Cols(...)...` spread **+** stale Oracle output comment — this is the IDE-surfaced example for the very method whose return-type change caused the issue |

### Two-layered fix
1. **API idiom:** drop the `...` spread — `Select` flattens `[]string` via `appendSelectColumn`.
2. **Output comments:** the stale Oracle comments claimed `SELECT "ID", "NAME" ... WHERE "LEVEL"`. That's wrong on two counts — non-reserved columns (`id`, `name`) are emitted **lowercase and unquoted**, and the reserved word is quoted preserving the `db`-tag case (`"level"`), not uppercased. Corrected to match runtime.

### Verification
Generated the SQL with the **real query builder** (throwaway test, since removed) for both vendors:

```
[oracle]     SELECT id, name FROM users WHERE "level" = :1   args=[5]
[postgresql] SELECT id, name FROM users WHERE level = $1     args=[5]
[oracle]     SELECT id, name FROM users        (Columns GoDoc, no WHERE)
[postgresql] SELECT id, name FROM users
```

The README Oracle line now matches the canonical (already-corrected) `CLAUDE.md` example exactly.

- `make check`: green (fmt + lint + race tests + govulncheck)
- Comment/documentation-only diff (8 lines, 2 files) — no behavior change

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated database examples in README and query builder documentation to reflect current API usage patterns for column selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->