### PR TITLE
fix(messaging): detach lazily-started consumers from the caller/request context

### DIFF
--- a/messaging/manager.go
+++ b/messaging/manager.go
@@ -171,9 +171,15 @@ func (m *Manager) ensureConsumersInternal(ctx context.Context, key string, decls
 		return fmt.Errorf("failed to declare messaging infrastructure: %w", err)
 	}
 
-	// Start consumers with tenant-aware context
-	tenantCtx := multitenant.SetTenant(ctx, key)
-	if err := registry.StartConsumers(tenantCtx); err != nil {
+	// Start consumers with a tenant-aware context whose lifetime is detached from the
+	// caller. In multi-tenant mode consumers start lazily from the HTTP request context
+	// (a ~5s-deadline, cancel-on-finish context); threading that into the long-lived
+	// supervisor goroutines would stop every consumer when the first request ends, and
+	// they would never restart. context.WithoutCancel severs the request's cancellation
+	// and deadline while preserving values (trace/tenant), so consumer lifetime is
+	// governed solely by StopConsumers/Close. (Setup calls above keep the caller deadline.)
+	consumerCtx := multitenant.SetTenant(context.WithoutCancel(ctx), key)
+	if err := registry.StartConsumers(consumerCtx); err != nil {
 		m.closeClientOnRollback(client, key, "start_consumers")
 		return fmt.Errorf("failed to start messaging consumers: %w", err)
 	}

--- a/messaging/manager_test.go
+++ b/messaging/manager_test.go
@@ -30,6 +30,7 @@ type stubAMQPClient struct {
 	closedMu      sync.Mutex
 	lastPublish   PublishOptions
 	consumers     int
+	consumeCtx    context.Context //nolint:containedctx // test-only: captures the ctx the supervisor subscribes with, to assert its lifecycle
 	closeCallback func()
 	closeErr      error
 }
@@ -49,9 +50,10 @@ func (s *stubAMQPClient) Consume(_ context.Context, _ string) (<-chan amqp.Deliv
 	return ch, nil
 }
 
-func (s *stubAMQPClient) ConsumeFromQueue(_ context.Context, _ ConsumeOptions) (<-chan amqp.Delivery, error) {
+func (s *stubAMQPClient) ConsumeFromQueue(ctx context.Context, _ ConsumeOptions) (<-chan amqp.Delivery, error) {
 	s.closedMu.Lock()
 	s.consumers++
+	s.consumeCtx = ctx
 	s.closedMu.Unlock()
 	// Return an open delivery channel (never closed) so the consumer supervisor
 	// parks waiting for deliveries instead of treating an immediately-closed
@@ -68,6 +70,14 @@ func (s *stubAMQPClient) consumerCount() int {
 	s.closedMu.Lock()
 	defer s.closedMu.Unlock()
 	return s.consumers
+}
+
+// lastConsumeCtx returns the context the supervisor most recently subscribed
+// with (read under the same lock), so tests can assert its cancellation lifecycle.
+func (s *stubAMQPClient) lastConsumeCtx() context.Context {
+	s.closedMu.Lock()
+	defer s.closedMu.Unlock()
+	return s.consumeCtx
 }
 
 func (s *stubAMQPClient) DeclareQueue(string, bool, bool, bool, bool) error            { return nil }
@@ -281,6 +291,42 @@ func TestMessagingManagerInjectsTenantIntoConsumerContext(t *testing.T) {
 	// importing multitenant package and checking the context in the handler
 	// For this test, we verify that EnsureConsumers completed successfully
 	// which means it called StartConsumers with the tenant-injected context
+}
+
+// TestMessagingManagerConsumersSurviveCallerContextCancellation guards the High audit
+// finding: in multi-tenant mode consumers start lazily from the HTTP request context
+// (a 5s-deadline, cancel-on-finish context). If that context is threaded into the
+// long-lived consumer supervisor, the consumers die when the first request ends and
+// never restart. EnsureConsumers must detach request cancellation so consumer lifetime
+// is governed only by StopConsumers/Close.
+func TestMessagingManagerConsumersSurviveCallerContextCancellation(t *testing.T) {
+	log := logger.New("error", false)
+	client := &stubAMQPClient{}
+	factory := func(string, logger.Logger) AMQPClient { return client }
+	manager := NewMessagingManager(&stubMessagingSource{urls: map[string]string{testTenantID: amqpHost}}, log, ManagerOptions{MaxPublishers: 5, IdleTTL: time.Minute}, factory)
+	defer func() { _ = manager.Close() }()
+
+	decls := NewDeclarations()
+	decls.RegisterQueue(&QueueDeclaration{Name: testQueue})
+	decls.RegisterConsumer(&ConsumerDeclaration{Queue: testQueue, Consumer: testConsumer, Handler: &mockMessageHandler{}})
+
+	// Lazy startup driven by a request-scoped context that is cancelled when the request ends.
+	callerCtx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, manager.EnsureConsumers(callerCtx, testTenantID, decls))
+
+	// Wait until the supervisor goroutine has subscribed (and captured its context).
+	require.Eventually(t, func() bool { return client.consumerCount() >= 1 }, time.Second, 5*time.Millisecond)
+	consumerCtx := client.lastConsumeCtx()
+	require.NotNil(t, consumerCtx)
+
+	// Request ends: cancelling the caller context must NOT cancel the consumer.
+	cancel()
+	select {
+	case <-consumerCtx.Done():
+		t.Fatal("consumer context was cancelled when the caller/request context ended — consumers stop after one request and never restart")
+	case <-time.After(100 * time.Millisecond):
+		// Consumer context is detached from the request lifecycle, as required.
+	}
 }
 
 func TestMessagingManagerHashBasedIdempotency(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes a **High-severity** finding from the 2026-06-10 full-repo security audit: in multi-tenant mode, AMQP consumers silently die seconds after first use and never restart.

Consumers start **lazily** via `MultiTenantResourceProvider.Messaging`, which threads the **HTTP request context** into `Manager.ensureConsumersInternal` → `registry.StartConsumers`. That context carries the 5s timeout-middleware deadline and is cancelled when the request finishes, so every consumer supervisor goroutine sees `ctx.Done()` and exits permanently. Because the `consumerEntry` stays `started=true` with its declarations recorded, later `EnsureConsumers` calls short-circuit — the tenant **never resumes consuming until process restart**, while messages pile up. The single-tenant boot-recovery path (broker briefly down at startup → lazy init on first request) hits the same trap.

## Fix

Wrap the consumer context with `context.WithoutCancel(ctx)` (the framework's documented pattern for work that must outlive a request) before `SetTenant` + `StartConsumers`, so consumer lifetime is governed **solely** by `StopConsumers`/`Close`. Values (trace ID, tenant) still propagate; only the request's cancellation and deadline are severed.

The fix is surgical — only the `StartConsumers` context is detached. The setup calls above it (`createAMQPClient`, `DeclareInfrastructure`) deliberately keep the caller's deadline so a hung broker fails fast within the request instead of blocking forever.

`StopConsumers`/`Close` still work: the registry derives its own `context.WithCancel` child and owns that cancel — `WithCancel` of a non-cancellable parent still yields a working child cancel.

## Tests

`TestMessagingManagerConsumersSurviveCallerContextCancellation` starts consumers from a cancellable caller context (simulating the request), then cancels it and asserts the consumer's subscription context is **not** `Done` — i.e. the supervisor stays alive. (Fails before the fix: the consumer context was cancelled with the caller.)

## Verification
- `make check` green (fmt + lint + race + govulncheck); full `messaging` package race-clean.
- `make sec` (pinned gosec): 0 issues.
- `/code-review` (2 parallel finder agents: correctness + related-bug sweep) returned **clean** — confirmed `StopConsumers`/`Close` still terminate consumers (no goroutine leak), setup calls keep the caller deadline, and the fix is correctly centralized at the single chokepoint covering all `EnsureConsumers` call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message consumer lifecycle management to ensure consumers remain active after the initiating request completes.
  * Improved resilience of consumer supervision against unexpected context cancellations.

* **Tests**
  * Added test coverage to verify consumer stability during context lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->