### PR TITLE
fix(config): select config.<env>.yaml overlay from APP_ENV

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,8 +34,11 @@ func Load() (*Config, error) {
 		return nil, err
 	}
 
-	// Load environment-specific YAML (if exists)
-	env := k.String(fieldAppEnv)
+	// Load environment-specific YAML (if exists). The suffix must honor APP_ENV from the
+	// environment so a 12-factor deployment (APP_ENV=production + config.production.yaml)
+	// selects the right overlay — the env provider is loaded only below (after this
+	// selection), so reading koanf alone would always see the default/config.yaml value.
+	env := resolveEnvOverlaySuffix(k)
 	if env != "" {
 		envFile := fmt.Sprintf("config.%s", env)
 		if err := tryLoadYAMLFile(k, envFile); err != nil {
@@ -71,6 +74,33 @@ func Load() (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+// resolveEnvOverlaySuffix determines the config.<env>.yaml overlay suffix. The APP_ENV
+// environment variable takes precedence, because the env provider is loaded only after
+// overlay selection — so without this a deployment that sets APP_ENV but ships only
+// config.<env>.yaml would silently load the default/config.yaml suffix instead. Falls back
+// to the koanf value (defaults / config.yaml) when APP_ENV is unset.
+//
+// The resolved suffix is interpolated into a filename, so it is validated against the same
+// envFormat as cfg.App.Env: a malformed value (path separators, etc.) returns "" so no
+// config.<garbage>.yaml read is attempted, leaving validateApp to reject it with a clear
+// error rather than an opaque YAML-parse failure.
+func resolveEnvOverlaySuffix(k *koanf.Koanf) string {
+	env := strings.TrimSpace(os.Getenv(keyToEnvVar(fieldAppEnv)))
+	if env == "" {
+		env = k.String(fieldAppEnv)
+	}
+	if !envFormat.MatchString(env) {
+		return ""
+	}
+	return env
+}
+
+// keyToEnvVar converts a koanf key (lower.dotted) to its environment-variable name
+// (UPPER_SNAKE), the inverse of the env provider's TransformFunc in Load.
+func keyToEnvVar(key string) string {
+	return strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
 }
 
 // tryLoadYAMLFile attempts to load a YAML configuration file with both .yaml and .yml extensions.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -109,6 +110,51 @@ func TestLoadWithEnvironmentVariables(t *testing.T) {
 	// Verify defaults still work for non-overridden values
 	assert.Equal(t, appVersion, cfg.App.Version)
 	assert.Equal(t, serverHost, cfg.Server.Host)
+}
+
+// TestLoadAppEnvSelectsEnvironmentOverlay verifies that the APP_ENV environment variable
+// selects the config.<env>.yaml overlay, honoring the documented precedence
+// (env vars > config.<env>.yaml > config.yaml > defaults). Regression test for the High
+// audit finding: the overlay suffix was read from koanf (k.String(app.env)) BEFORE the env
+// provider loaded, so APP_ENV=production silently loaded config.development.yaml (or none)
+// while cfg.App.Env still ended up "production" — production pods could run the dev overlay.
+func TestLoadAppEnvSelectsEnvironmentOverlay(t *testing.T) {
+	clearEnvironmentVariables()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, testConfigFileYAML),
+		[]byte("app:\n  name: base-app\n  env: development\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.production.yaml"),
+		[]byte("app:\n  name: prod-overlay-app\n"), 0o600))
+	t.Chdir(dir)
+
+	// APP_ENV reaches koanf only via the env provider, which loads AFTER overlay selection,
+	// so the suffix must be resolved from the environment variable directly.
+	t.Setenv("APP_ENV", EnvProduction)
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, EnvProduction, cfg.App.Env)
+	assert.Equal(t, "prod-overlay-app", cfg.App.Name,
+		"config.production.yaml overlay must be selected by APP_ENV (got the base config — overlay was not loaded)")
+}
+
+// TestLoadAppEnvRejectsMalformedOverlaySuffix verifies a malformed APP_ENV is not
+// interpolated into the overlay filename (no config.<traversal>.yaml read attempt);
+// the value is left for validateApp to reject with a clear app.env error.
+func TestLoadAppEnvRejectsMalformedOverlaySuffix(t *testing.T) {
+	clearEnvironmentVariables()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, testConfigFileYAML),
+		[]byte("app:\n  name: base-app\n  env: development\n"), 0o600))
+	t.Chdir(dir)
+
+	t.Setenv("APP_ENV", "../../etc/passwd")
+
+	_, err := Load()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, fieldAppEnv, "malformed APP_ENV must be rejected by validation, not silently used as a file path")
 }
 
 func TestLoadMultiElementStringSliceEnv(t *testing.T) {

--- a/config/injection.go
+++ b/config/injection.go
@@ -111,7 +111,7 @@ func (c *Config) resolveFieldValue(configKey string, required bool, defaultValue
 
 	if required {
 		// Convert config key to env var format (e.g., "custom.api.key" -> "CUSTOM_API_KEY")
-		envVar := strings.ToUpper(strings.ReplaceAll(configKey, ".", "_"))
+		envVar := keyToEnvVar(configKey)
 		return nil, false, &ConfigError{
 			Category: errCategoryMissing,
 			Field:    configKey,
@@ -206,7 +206,7 @@ func (c *Config) assignStringSliceField(field reflect.Value, configKey string, r
 		}
 	}
 	if required && len(slice) == 0 {
-		envVar := strings.ToUpper(strings.ReplaceAll(configKey, ".", "_"))
+		envVar := keyToEnvVar(configKey)
 		return &ConfigError{
 			Category: errCategoryMissing,
 			Field:    configKey,
@@ -225,7 +225,7 @@ func (c *Config) convertToString(value any, key string, required bool) (string, 
 	case string:
 		trimmed := strings.TrimSpace(v)
 		if required && trimmed == "" {
-			envVar := strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
+			envVar := keyToEnvVar(key)
 			return "", &ConfigError{
 				Category: errCategoryMissing,
 				Field:    key,

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -2,6 +2,14 @@
 
 Historical migration tables for upgrading existing GoBricks-based applications. Greenfield work can ignore this file — the new APIs are the only ones documented in CLAUDE.md.
 
+## `APP_ENV` Now Selects the `config.<env>.yaml` Overlay
+
+Previously the environment-specific YAML overlay suffix was read from koanf **before** the environment provider loaded, so the `APP_ENV` environment variable could not select it — the suffix always came from `config.yaml`/defaults (typically `development`). A 12-factor deployment that set `APP_ENV=production` and shipped `config.production.yaml` silently ran the development overlay (or none), even though `cfg.App.Env` still ended up `production`.
+
+`APP_ENV` now drives overlay selection, matching the documented precedence (env vars > `config.<env>.yaml` > `config.yaml` > defaults).
+
+**Action:** if you set `APP_ENV` and ship a `config.<env>.yaml` that was previously being ignored, that overlay is now loaded — review those files to confirm their values are correct for the environment. A malformed `APP_ENV` (not matching `^[a-z][a-z0-9-]{0,31}$`) is now rejected at startup with a clear `app.env` error instead of being interpolated into a config filename.
+
 ## Request-Path Zero-Overhead Changes (ADR-026)
 
 A set of perf changes that make the default-config request path allocate less. Several carry consumer-visible surface:


### PR DESCRIPTION
## Summary

Closes a **High-severity** finding from the 2026-06-10 full-repo security audit: the `APP_ENV` environment variable could not select the `config.<env>.yaml` overlay.

`Load()` resolved the overlay suffix via `k.String("app.env")` **before** the env provider runs, so the suffix always came from `config.yaml`/defaults (typically `development`). A 12-factor deployment that set `APP_ENV=production` and shipped `config.production.yaml` **silently loaded the development overlay (or none)** — while `cfg.App.Env` still ended up `production` (set later by the env pass). Production pods could run with the dev overlay's database hosts/debug flags, with no warning. This broke the documented precedence (`env vars > config.<env>.yaml > config.yaml > defaults`).

## Fix

- Resolve the overlay suffix from `APP_ENV` first (falling back to the koanf value when unset), via a new `resolveEnvOverlaySuffix`.
- **Defense-in-depth:** validate the resolved suffix against the same `envFormat` (`^[a-z][a-z0-9-]{0,31}$`) used for `cfg.App.Env` *before* interpolating it into the overlay filename. A malformed value (path separators, etc.) yields no suffix — so no `config.<garbage>.yaml` read is attempted — and `validateApp` rejects it with a clear `app.env` error instead of an opaque YAML-parse failure.
- Extract a shared `keyToEnvVar(key)` helper, deduping the three identical `strings.ToUpper(strings.ReplaceAll(...))` transforms in `injection.go` (my change would otherwise have added a 4th copy).

## ⚠️ Behavior change

If you set `APP_ENV` and ship a `config.<env>.yaml` that was previously being ignored, **that overlay is now loaded** — review those files to confirm their values are correct for the environment. Documented in `wiki/migrations.md`.

## Tests
- `TestLoadAppEnvSelectsEnvironmentOverlay` — proves *selection* (the overlay-only `app.name` value wins), not just the `app.env` string.
- `TestLoadAppEnvRejectsMalformedOverlaySuffix` — a path-traversal `APP_ENV` fails validation cleanly (no filename interpolation).

## Verification
- `make check` green (fmt + lint + race + govulncheck); `make sec` (gosec) 0 issues.
- Pre-push `/code-review` + `/security-audit`: the reviewer's two findings (the filename-interpolation defense-in-depth + the `keyToEnvVar` DRY dedup) are both applied here.
- Based on the latest `main` (rebased onto #577).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration overlay selection now respects environment variable precedence over configuration files.

* **Improvements**
  * Invalid configuration values are now rejected at startup with clear, actionable error messages.

* **Documentation**
  * Updated migration guide documenting configuration overlay precedence and validation behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->