### PR TITLE
fix(database): number subquery filter placeholders contiguously

### DIFF
--- a/database/internal/builder/filter.go
+++ b/database/internal/builder/filter.go
@@ -435,11 +435,18 @@ func (ff *FilterFactory) buildExistsFilter(subquery dbtypes.SelectQueryBuilder, 
 		return Filter{sqlizer: errorSqlizer{err: err}}
 	}
 
-	// Extract the underlying squirrel.SelectBuilder using type assertion
-	// This avoids calling ToSQL() prematurely, allowing proper placeholder numbering
+	// Render the subquery with question-mark placeholders and embed the raw SQL, so the
+	// OUTER query's single final placeholder pass numbers the subquery's and the outer
+	// query's parameters consistently. Passing the SelectBuilder directly would let
+	// squirrel apply the vendor format ($1/:1) to the subquery early, colliding with the
+	// outer query's renumbering (duplicate $1 on PostgreSQL; duplicate :1 on Oracle).
 	if sqb, ok := subquery.(*SelectQueryBuilder); ok {
+		subSQL, subArgs, err := sqb.buildSelectBuilder().PlaceholderFormat(squirrel.Question).ToSql()
+		if err != nil {
+			return Filter{sqlizer: errorSqlizer{err: err}}
+		}
 		return Filter{sqlizer: &existsFilter{
-			sqlizer: squirrel.Expr(keyword+" (?)", sqb.buildSelectBuilder()),
+			sqlizer: squirrel.Expr(keyword+" ("+subSQL+")", subArgs...),
 		}}
 	}
 
@@ -478,10 +485,17 @@ func (ff *FilterFactory) InSubquery(column string, subquery dbtypes.SelectQueryB
 	// Quote column name for vendor-specific rules (e.g., Oracle reserved words)
 	quotedColumn := ff.qb.quoteColumnForQuery(column)
 
-	// Extract the underlying squirrel.SelectBuilder using type assertion
+	// Render the subquery with question-mark placeholders and embed the raw SQL so the
+	// outer query's single final placeholder pass numbers everything consistently (see
+	// buildExistsFilter for the rationale — passing the SelectBuilder directly causes
+	// duplicate placeholder numbers when combined with other parameterized filters).
 	if sqb, ok := subquery.(*SelectQueryBuilder); ok {
+		subSQL, subArgs, err := sqb.buildSelectBuilder().PlaceholderFormat(squirrel.Question).ToSql()
+		if err != nil {
+			return Filter{sqlizer: errorSqlizer{err: err}}
+		}
 		return Filter{sqlizer: &inSubqueryFilter{
-			sqlizer: squirrel.Expr(quotedColumn+" IN (?)", sqb.buildSelectBuilder()),
+			sqlizer: squirrel.Expr(quotedColumn+" IN ("+subSQL+")", subArgs...),
 		}}
 	}
 

--- a/database/internal/builder/filter_test.go
+++ b/database/internal/builder/filter_test.go
@@ -800,11 +800,15 @@ func TestFilterInSubquery(t *testing.T) {
 
 		sql, args, err := query.ToSQL()
 		require.NoError(t, err)
+		// Placeholders must be contiguous across the subquery AND the outer filters:
+		// region=$1 (subquery), quantity=$2, status=$3. A duplicate-numbering bug
+		// (subquery $1 colliding with the outer filters' $1/$2) makes pgx Bind fail with
+		// "bind message supplies 3 parameters, but prepared statement requires 2".
 		assert.Contains(t, sql, "supplier_id IN (SELECT supplier_id FROM verified_suppliers WHERE region = $1)")
-		assert.Contains(t, sql, "quantity >")
-		assert.Contains(t, sql, "status =")
-		// Squirrel may optimize placeholders, so just verify args content
-		assert.ElementsMatch(t, []any{"EU", 0, "available"}, args)
+		assert.Contains(t, sql, "quantity > $2")
+		assert.Contains(t, sql, "status = $3")
+		assert.NotContains(t, sql, "quantity > $1", "outer filter must not reuse the subquery's $1")
+		assert.Equal(t, []any{"EU", 0, "available"}, args)
 	})
 
 	t.Run("PostgreSQL vs Oracle placeholder handling", func(t *testing.T) {
@@ -828,6 +832,34 @@ func TestFilterInSubquery(t *testing.T) {
 
 		// Both should have same args
 		assert.Equal(t, argsPG, argsOracle)
+	})
+
+	t.Run("Oracle subquery with additional filters uses contiguous placeholders", func(t *testing.T) {
+		qb := NewQueryBuilder(dbtypes.Oracle)
+		f := qb.Filter()
+
+		subquery := qb.Select("supplier_id").
+			From("verified_suppliers").
+			Where(f.Eq("region", "EU"))
+
+		query := qb.Select("*").
+			From("inventory").
+			Where(f.And(
+				f.InSubquery("supplier_id", subquery),
+				f.Gt("quantity", 0),
+				f.Eq("status", "available"),
+			))
+
+		sql, args, err := query.ToSQL()
+		require.NoError(t, err)
+		// Oracle :N binds must be contiguous 1..3 with no duplicate :1 — go-ora treats :1
+		// as a named parameter, so a duplicate either errors or silently binds one value to
+		// two positions (filter corruption).
+		assert.Contains(t, sql, "region = :1")
+		assert.Contains(t, sql, "quantity > :2")
+		assert.Contains(t, sql, "status = :3")
+		assert.NotContains(t, sql, "quantity > :1", "outer filter must not reuse the subquery's :1")
+		assert.Equal(t, []any{"EU", 0, "available"}, args)
 	})
 }
 


### PR DESCRIPTION
## Summary

Closes a **High-severity** finding from the 2026-06-10 full-repo security audit: subquery filters (`Exists`/`NotExists`/`InSubquery`) produce **duplicate placeholder numbers** when combined with any other parameterized condition.

`buildExistsFilter`/`InSubquery` embedded the subquery via `squirrel.Expr(keyword+" (?)", sqb.buildSelectBuilder())`. squirrel expands a nested `Sqlizer` arg by calling its `ToSql()` during the **outer** query's render, which applies the vendor `PlaceholderFormat` (`$1`/`:1`) to the subquery **early**. The outer query then renumbers its own `?` from 1 again — colliding with the already-numbered subquery placeholders.

Concretely, `SELECT * FROM inventory WHERE InSubquery(...) AND quantity>0 AND status='available'` produced:
`... WHERE (supplier_id IN (SELECT ... WHERE region = $1) AND quantity > $1 AND status = $2)` with **3 args but max placeholder `$2`** → pgx Bind fails (`bind message supplies 3 parameters, but prepared statement requires 2`) on **every** such query. Oracle emits a duplicate `:1` named bind → go-ora errors or silently binds one value to two positions (filter corruption).

## Fix

Render the subquery with `squirrel.Question` placeholders and embed the raw SQL, so the **outer query's single final placeholder pass** numbers the subquery's and the outer query's parameters consistently. Applies to `EXISTS`, `NOT EXISTS`, and `IN (subquery)`.

## Tests

- Tightened the existing masking test (`filter_test.go`), which previously asserted only `ElementsMatch` on args with the comment *"Squirrel may optimize placeholders, so just verify args content"* — it now asserts **contiguous** `$1`/`$2`/`$3` and that the outer filter does not reuse the subquery's `$1`.
- Added an Oracle mixed-filter case asserting `:1`/`:2`/`:3` (no duplicate `:1`).
- Existing `TestFilterExists` PG/Oracle numbering + `TestFilterNestedSubqueries` (3-level) continue to pass.

## Verification
- `make check` green; `make sec` (gosec) 0 issues.
- `/code-review` empirically verified contiguous numbering across subquery+filters, EXISTS/NOT EXISTS, InSubquery, correlated (no-arg), nested (3-level), pagination, and arg ordering — returned clean.
- Based on the latest `main` (off #577).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database query placeholder numbering to prevent conflicts when subquery-based filters are combined with additional query conditions.
  * Enhanced test verification to ensure placeholder consistency across supported database systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->