### PR TITLE
fix(migration): honor Config.DryRun by running validate instead of migrate

### DIFF
--- a/migration/flyway.go
+++ b/migration/flyway.go
@@ -240,12 +240,27 @@ func (fm *FlywayMigrator) ValidateFor(ctx context.Context, db *config.DatabaseCo
 	return err
 }
 
+// effectiveVerb downgrades a dry-run migrate to the validate verb so Config.DryRun
+// mutates nothing. Non-migrate verbs and non-dry-run migrates are returned unchanged.
+func effectiveVerb(cfg *Config, verb string) string {
+	if cfg.DryRun && verb == flywayCmdMigrate {
+		return flywayCmdValidate
+	}
+	return verb
+}
+
 func (fm *FlywayMigrator) runFor(ctx context.Context, db *config.DatabaseConfig, cfg *Config, verb string) (Result, error) {
 	startedAt := time.Now()
 
 	if cfg == nil {
 		cfg = fm.DefaultMigrationConfigForVendor(dbVendor(db, fm.config.Database.Type))
 	}
+
+	// Honor DryRun: downgrade a dry-run migrate to validate so no schema is mutated.
+	// validate takes the non-migrate path below, which emits no migration.applied audit
+	// (ADR-019 fires that only for actual applications) — so a dry run is never recorded
+	// as an application, and migration.dry_run stays accurate on real applications.
+	verb = effectiveVerb(cfg, verb)
 
 	vendor := dbVendor(db, fm.config.Database.Type)
 	fm.logger.Info().
@@ -356,7 +371,11 @@ func (fm *FlywayMigrator) emitMigrationApplied(ctx context.Context, db *config.D
 	}
 
 	attrs := map[string]string{
-		"migration.vendor":  run.Vendor,
+		"migration.vendor": run.Vendor,
+		// Always "false" in practice: a dry-run migrate is downgraded to validate (see
+		// effectiveVerb), which never reaches this emit path (ADR-019 — migration.applied
+		// fires only for actual applications). The attribute is retained so every emitted
+		// event positively asserts "this was a real application, not a rehearsal".
 		"migration.dry_run": strconv.FormatBool(cfg.DryRun),
 	}
 	if run.Result.FlywayVersion != "" {

--- a/migration/flyway_test.go
+++ b/migration/flyway_test.go
@@ -403,6 +403,66 @@ func TestRunMigrationsAtStartup(t *testing.T) {
 	}
 }
 
+// TestFlywayMigratorDryRunRunsValidate verifies that Config.DryRun is honored: a dry-run
+// Migrate must invoke the Flyway `validate` verb (no schema mutation), not `migrate`.
+// Regression test for the High audit finding — DryRun was documented ("Only validate, do
+// not execute") and stamped into the audit event but never consumed, so DryRun=true ran a
+// real migration while the audit recorded dry_run=true.
+func TestFlywayMigratorDryRunRunsValidate(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+
+	cases := []struct {
+		name         string
+		dryRun       bool
+		expectedCmd  string
+		forbiddenCmd string
+	}{
+		{name: "dry_run_substitutes_validate", dryRun: true, expectedCmd: "validate", forbiddenCmd: "migrate"},
+		{name: "non_dry_run_runs_migrate", dryRun: false, expectedCmd: "migrate"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Database: config.DatabaseConfig{
+					Type: "postgresql", Host: "h", Port: 5432,
+					Username: "u", Password: "p", Database: "d",
+				},
+				App: config.AppConfig{Env: "test"},
+			}
+			fm := NewFlywayMigrator(cfg, logger.New("disabled", true))
+
+			stub, capturePath := createCommandCapturingStub(t, "")
+			tempDir := t.TempDir()
+			configPath := filepath.Join(tempDir, "flyway.conf")
+			migrationPath := filepath.Join(tempDir, "migrations")
+			require.NoError(t, os.WriteFile(configPath, []byte(""), 0o644))
+			require.NoError(t, os.MkdirAll(migrationPath, 0o755))
+
+			mcfg := &Config{
+				FlywayPath:    stub,
+				ConfigPath:    configPath,
+				MigrationPath: migrationPath,
+				Timeout:       10 * time.Second,
+				DryRun:        tc.dryRun,
+			}
+
+			_, err := fm.MigrateFor(context.Background(), &cfg.Database, mcfg)
+			require.NoError(t, err)
+
+			captured, readErr := os.ReadFile(capturePath)
+			require.NoError(t, readErr)
+			assert.Contains(t, string(captured), tc.expectedCmd)
+			if tc.forbiddenCmd != "" {
+				assert.NotContains(t, string(captured), tc.forbiddenCmd,
+					"DryRun must not invoke the migrate verb (it would mutate the schema)")
+			}
+		})
+	}
+}
+
 // createCommandCapturingStub builds a flyway-stub that writes the verbatim
 // arg list to capturePath, then optionally emits stdoutPayload on stdout
 // before exiting 0. Pass an empty stdoutPayload for the args-only variant.

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -2,6 +2,14 @@
 
 Historical migration tables for upgrading existing GoBricks-based applications. Greenfield work can ignore this file — the new APIs are the only ones documented in CLAUDE.md.
 
+## Migration `Config.DryRun` Is Now Honored
+
+`Config.DryRun` ("Only validate, do not execute") was documented and stamped into the `migration.applied` audit event, but **never consumed** — a `DryRun=true` `Migrate`/`MigrateAll` ran a real migration (mutating the schema across the whole tenant fleet) while the audit falsely recorded `dry_run=true`.
+
+`DryRun=true` now downgrades a `migrate` to the Flyway `validate` verb, so no schema is mutated. Because `validate` is not an application, it emits no `migration.applied` audit event (per ADR-019) — so the `migration.dry_run` attribute is now always `false` on emitted events, accurately asserting "this was a real application."
+
+**Action:** if any pipeline set `DryRun=true` and relied on it actually applying migrations (contrary to the field's documentation), it now only validates. Remove `DryRun` (or set it `false`) for runs that must apply schema changes.
+
 ## `APP_ENV` Now Selects the `config.<env>.yaml` Overlay
 
 Previously the environment-specific YAML overlay suffix was read from koanf **before** the environment provider loaded, so the `APP_ENV` environment variable could not select it — the suffix always came from `config.yaml`/defaults (typically `development`). A 12-factor deployment that set `APP_ENV=production` and shipped `config.production.yaml` silently ran the development overlay (or none), even though `cfg.App.Env` still ended up `production`.


### PR DESCRIPTION
## Summary

Closes a **High-severity** finding from the 2026-06-10 full-repo security audit: `Config.DryRun` was documented as validation-only but **never consumed**.

`Config.DryRun` ("Only validate, do not execute") was merged through the multi-tenant config merge and stamped into every `migration.applied` audit event — but no code path acted on it. `runFor`/`MigrateFor` ran `flyway migrate` regardless. A consumer setting `DryRun=true` on `Migrate`/`MigrateAll` expecting a rehearsal **mutated production schemas across the entire tenant fleet**, and the compliance audit trail falsely recorded `migration.dry_run=true` for runs that actually applied DDL — on the exact pipeline ADR-019 exists to make trustworthy.

## Fix

`runFor` now downgrades a dry-run `migrate` to the `validate` verb (`effectiveVerb`), so no schema is mutated. `validate` takes the non-migrate path and emits **no** `migration.applied` event (ADR-019 fires that only for actual applications) — so `migration.dry_run` is now always `false` on emitted events, with every event positively asserting "this was a real application, not a rehearsal."

Covers **all** migrate entry points: `Migrate` → `MigrateFor` → `runFor`, and multi-tenant `MigrateAll` → `MigrateFor` → `runFor` (so DryRun is honored fleet-wide).

## ⚠️ Behavior change

If any pipeline set `DryRun=true` and relied on it actually applying migrations (contrary to the field's documentation), it now only validates. Documented in `wiki/migrations.md`.

## Tests
`TestFlywayMigratorDryRunRunsValidate` uses an arg-capturing Flyway stub to assert `DryRun=true` sends the `validate` verb (not `migrate`), with a non-dry-run `migrate` control.

## Verification
- `make check` green; `make sec` (gosec) 0 issues.
- `/code-review` confirmed coverage (all migrate paths route through `runFor`), nil-safety, audit semantics, and Result contract; its one note (the now-always-false `migration.dry_run` attribute) is addressed with a clarifying comment.
- Based on the latest `main` (off #579).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dry-run migrations to properly prevent schema changes and audit event emission when enabled.

* **Documentation**
  * Added breaking change notice: pipelines relying on DryRun for actual migration execution must be updated.

* **Tests**
  * Added comprehensive test coverage for dry-run migration behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->