### PR TITLE
fix(outbox): resolve tenants in the relay & cleanup jobs (multi-tenant delivery)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -101,6 +102,30 @@ func resolveEnvOverlaySuffix(k *koanf.Koanf) string {
 // (UPPER_SNAKE), the inverse of the env provider's TransformFunc in Load.
 func keyToEnvVar(key string) string {
 	return strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
+}
+
+// PerTenantJobKeys returns the tenant keys a per-tenant background job (e.g. the outbox
+// relay or the outbox/inbox cleanup jobs) should iterate each cycle:
+//
+//   - single-tenant mode → a single "" key (one pass with no tenant in context;
+//     multitenant.SetTenant with "" is a no-op);
+//   - static multi-tenant mode → the configured tenant IDs, sorted for deterministic
+//     iteration.
+//
+// The result is empty ONLY for a degenerate static multi-tenant config with no tenants
+// (multitenant.enabled=true but multitenant.tenants omitted) — callers must reject that,
+// because a per-tenant job would otherwise silently iterate nothing. Dynamic multi-tenant
+// sources are not enumerable here; callers reject them before relying on this.
+func (c *Config) PerTenantJobKeys() []string {
+	if c == nil || !c.Multitenant.Enabled {
+		return []string{""}
+	}
+	ids := make([]string, 0, len(c.Multitenant.Tenants))
+	for id := range c.Multitenant.Tenants {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 // tryLoadYAMLFile attempts to load a YAML configuration file with both .yaml and .yml extensions.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -157,6 +157,31 @@ func TestLoadAppEnvRejectsMalformedOverlaySuffix(t *testing.T) {
 	assert.ErrorContains(t, err, fieldAppEnv, "malformed APP_ENV must be rejected by validation, not silently used as a file path")
 }
 
+func TestConfigPerTenantJobKeys(t *testing.T) {
+	t.Run("single_tenant_yields_one_empty_key", func(t *testing.T) {
+		cfg := &Config{}
+		assert.Equal(t, []string{""}, cfg.PerTenantJobKeys())
+	})
+
+	t.Run("nil_config_yields_one_empty_key", func(t *testing.T) {
+		var cfg *Config
+		assert.Equal(t, []string{""}, cfg.PerTenantJobKeys())
+	})
+
+	t.Run("static_multitenant_yields_sorted_keys", func(t *testing.T) {
+		cfg := &Config{Multitenant: MultitenantConfig{
+			Enabled: true,
+			Tenants: map[string]TenantEntry{"zeta": {}, "alpha": {}},
+		}}
+		assert.Equal(t, []string{"alpha", "zeta"}, cfg.PerTenantJobKeys())
+	})
+
+	t.Run("multitenant_enabled_without_tenants_yields_empty", func(t *testing.T) {
+		cfg := &Config{Multitenant: MultitenantConfig{Enabled: true}}
+		assert.Empty(t, cfg.PerTenantJobKeys(), "callers must reject this degenerate config")
+	})
+}
+
 func TestLoadMultiElementStringSliceEnv(t *testing.T) {
 	clearEnvironmentVariables()
 	t.Setenv("SCHEDULER_SECURITY_CIDRALLOWLIST", "10.0.0.0/8,192.168.0.0/16")

--- a/inbox/cleanup.go
+++ b/inbox/cleanup.go
@@ -2,8 +2,6 @@ package inbox
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"time"
 
 	dbtypes "github.com/gaborage/go-bricks/database/types"
@@ -16,7 +14,8 @@ import (
 //
 // It resolves the database through the tenant-aware getDB resolver and fans out
 // across the configured tenants in (static) multi-tenant mode, because the scheduler
-// builds the JobContext from a tenant-less context.
+// builds the JobContext from a tenant-less context (shared with the outbox cleanup
+// via multitenant.FanOutRetentionCleanup).
 type Cleanup struct {
 	store           Store
 	retentionPeriod time.Duration
@@ -25,36 +24,7 @@ type Cleanup struct {
 }
 
 func (c *Cleanup) Execute(jobCtx scheduler.JobContext) error {
-	log := jobCtx.Logger()
-	cutoff := time.Now().Add(-c.retentionPeriod)
-	var errs []error
-	for _, tenantID := range c.tenants {
-		ctx := multitenant.SetTenant(jobCtx, tenantID)
-		db, err := c.getDB(ctx)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("inbox cleanup: tenant %q: database not available: %w", tenantID, err))
-			continue
-		}
-		if db == nil {
-			errs = append(errs, fmt.Errorf("inbox cleanup: tenant %q: database not available", tenantID))
-			continue
-		}
-
-		deleted, err := c.store.DeleteProcessed(ctx, db, cutoff)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("inbox cleanup: tenant %q: delete failed: %w", tenantID, err))
-			continue
-		}
-
-		if deleted > 0 {
-			event := log.Info().
-				Int64("deleted", deleted).
-				Str("cutoff", cutoff.Format(time.RFC3339))
-			if tenantID != "" {
-				event = event.Str("tenant", tenantID)
-			}
-			event.Msg("Inbox cleanup completed")
-		}
-	}
-	return errors.Join(errs...)
+	return multitenant.FanOutRetentionCleanup(
+		jobCtx, jobCtx.Logger(), c.tenants, c.getDB, c.retentionPeriod, "inbox", c.store.DeleteProcessed,
+	)
 }

--- a/inbox/cleanup.go
+++ b/inbox/cleanup.go
@@ -1,38 +1,60 @@
 package inbox
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/multitenant"
 	"github.com/gaborage/go-bricks/scheduler"
 )
 
 // Cleanup is a scheduler.Executor that removes processed-event records older
 // than the configured retention period. Runs daily at 04:00 by default.
+//
+// It resolves the database through the tenant-aware getDB resolver and fans out
+// across the configured tenants in (static) multi-tenant mode, because the scheduler
+// builds the JobContext from a tenant-less context.
 type Cleanup struct {
 	store           Store
 	retentionPeriod time.Duration
+	getDB           func(context.Context) (dbtypes.Interface, error)
+	tenants         []string
 }
 
-func (c *Cleanup) Execute(ctx scheduler.JobContext) error {
-	db := ctx.DB()
-	if db == nil {
-		return fmt.Errorf("inbox cleanup: database not available")
-	}
-
+func (c *Cleanup) Execute(jobCtx scheduler.JobContext) error {
+	log := jobCtx.Logger()
 	cutoff := time.Now().Add(-c.retentionPeriod)
+	var errs []error
+	for _, tenantID := range c.tenants {
+		ctx := multitenant.SetTenant(jobCtx, tenantID)
+		db, err := c.getDB(ctx)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("inbox cleanup: tenant %q: database not available: %w", tenantID, err))
+			continue
+		}
+		if db == nil {
+			errs = append(errs, fmt.Errorf("inbox cleanup: tenant %q: database not available", tenantID))
+			continue
+		}
 
-	deleted, err := c.store.DeleteProcessed(ctx, db, cutoff)
-	if err != nil {
-		return fmt.Errorf("inbox cleanup: delete failed: %w", err)
+		deleted, err := c.store.DeleteProcessed(ctx, db, cutoff)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("inbox cleanup: tenant %q: delete failed: %w", tenantID, err))
+			continue
+		}
+
+		if deleted > 0 {
+			event := log.Info().
+				Int64("deleted", deleted).
+				Str("cutoff", cutoff.Format(time.RFC3339))
+			if tenantID != "" {
+				event = event.Str("tenant", tenantID)
+			}
+			event.Msg("Inbox cleanup completed")
+		}
 	}
-
-	if deleted > 0 {
-		ctx.Logger().Info().
-			Int64("deleted", deleted).
-			Str("cutoff", cutoff.Format(time.RFC3339)).
-			Msg("Inbox cleanup completed")
-	}
-
-	return nil
+	return errors.Join(errs...)
 }

--- a/inbox/coverage_test.go
+++ b/inbox/coverage_test.go
@@ -11,9 +11,58 @@ import (
 	dbtypes "github.com/gaborage/go-bricks/database/types"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/multitenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// captureStore records the tenant present in the context of each DeleteProcessed call,
+// so cleanup fan-out tests can assert per-tenant resolution without a real database.
+type captureStore struct {
+	tenants      []string
+	deleteErrFor string
+}
+
+func (s *captureStore) MarkProcessed(context.Context, dbtypes.Tx, Record) (bool, error) {
+	return false, nil
+}
+
+func (s *captureStore) DeleteProcessed(ctx context.Context, _ dbtypes.Interface, _ time.Time) (int64, error) {
+	tid, _ := multitenant.GetTenant(ctx)
+	s.tenants = append(s.tenants, tid)
+	if tid == s.deleteErrFor {
+		return 0, errors.New("delete boom")
+	}
+	return 0, nil
+}
+
+func (s *captureStore) CreateTable(context.Context, dbtypes.Interface) error { return nil }
+
+func TestInboxCleanupFansOutAcrossStaticTenants(t *testing.T) {
+	store := &captureStore{}
+	c := &Cleanup{
+		store:           store,
+		retentionPeriod: time.Hour,
+		getDB:           func(context.Context) (dbtypes.Interface, error) { return dbtesting.NewTestDB(dbtypes.PostgreSQL), nil },
+		tenants:         []string{"tenant-a", "tenant-b"},
+	}
+	require.NoError(t, c.Execute(fakeJobCtx{Context: context.Background()}))
+	assert.Equal(t, []string{"tenant-a", "tenant-b"}, store.tenants, "cleanup must run once per configured tenant, in order")
+}
+
+func TestInboxCleanupIsolatesPerTenantFailures(t *testing.T) {
+	store := &captureStore{deleteErrFor: "bad"}
+	c := &Cleanup{
+		store:           store,
+		retentionPeriod: time.Hour,
+		getDB:           func(context.Context) (dbtypes.Interface, error) { return dbtesting.NewTestDB(dbtypes.PostgreSQL), nil },
+		tenants:         []string{"good", "bad"},
+	}
+	err := c.Execute(fakeJobCtx{Context: context.Background()})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `tenant "bad"`)
+	assert.Equal(t, []string{"good", "bad"}, store.tenants, "both tenants are attempted despite one failing")
+}
 
 // fakeJobCtx is a minimal scheduler.JobContext backed by a test DB.
 type fakeJobCtx struct {
@@ -69,13 +118,23 @@ func TestCleanupExecute(t *testing.T) {
 	db.ExpectExec(`DELETE FROM gobricks_inbox`).WillReturnRowsAffected(5)
 	m := newCoverageModule(db, config.InboxConfig{Enabled: true, TableName: "gobricks_inbox"})
 
-	c := &Cleanup{store: &lazyStore{module: m}, retentionPeriod: time.Hour}
+	c := &Cleanup{
+		store:           &lazyStore{module: m},
+		retentionPeriod: time.Hour,
+		getDB:           func(context.Context) (dbtypes.Interface, error) { return db, nil },
+		tenants:         []string{""},
+	}
 	ctx := fakeJobCtx{Context: context.Background(), db: db}
 	require.NoError(t, c.Execute(ctx))
 }
 
 func TestCleanupExecuteErrorsWithoutDB(t *testing.T) {
-	c := &Cleanup{store: &lazyStore{module: &Module{}}, retentionPeriod: time.Hour}
+	c := &Cleanup{
+		store:           &lazyStore{module: &Module{}},
+		retentionPeriod: time.Hour,
+		getDB:           func(context.Context) (dbtypes.Interface, error) { return nil, nil },
+		tenants:         []string{""},
+	}
 	ctx := fakeJobCtx{Context: context.Background(), db: nil}
 	err := c.Execute(ctx)
 	require.Error(t, err)

--- a/inbox/module.go
+++ b/inbox/module.go
@@ -137,9 +137,29 @@ func (m *Module) RegisterJobs(registrar app.JobRegistrar) error {
 		return nil
 	}
 
+	// Fail fast on multi-tenant configurations the cleanup job cannot fan out across, so
+	// it does not silently never prune any tenant's ledger. ProcessOnce itself is
+	// unaffected (it resolves the tenant from the request context), which is why this
+	// guard lives here — failing only when the cleanup job would actually be registered —
+	// rather than in Init, so ProcessOnce-only deployments (no scheduler) still work:
+	//   - dynamic sources: the tenant set is not enumerable at registration time;
+	//   - static sources with no tenants: there is nothing to fan out to.
+	if m.config != nil && m.config.Multitenant.Enabled {
+		switch {
+		case m.config.Source.Type == config.SourceTypeDynamic:
+			return fmt.Errorf("inbox: retention cleanup is not supported with dynamic multi-tenant sources " +
+				"(source.type=dynamic); use static multitenant.tenants config, or run without the scheduler to use ProcessOnce only")
+		case len(m.config.Multitenant.Tenants) == 0:
+			return fmt.Errorf("inbox: multi-tenant is enabled but no static multitenant.tenants are configured; " +
+				"the cleanup job would prune nothing. Configure multitenant.tenants, or run without the scheduler to use ProcessOnce only")
+		}
+	}
+
 	cleanup := &Cleanup{
 		store:           &lazyStore{module: m},
 		retentionPeriod: m.cfg.RetentionPeriod,
+		getDB:           m.getDB,
+		tenants:         m.config.PerTenantJobKeys(),
 	}
 
 	// DailyAt uses only the time-of-day (04:00) and applies the scheduler's

--- a/inbox/module_test.go
+++ b/inbox/module_test.go
@@ -101,6 +101,23 @@ func TestRegisterJobsFailsFastForDynamicMultitenant(t *testing.T) {
 	assert.Empty(t, reg.dailyJobs, "no cleanup job is registered for dynamic multi-tenant")
 }
 
+func TestRegisterJobsFailsFastForEmptyStaticMultitenant(t *testing.T) {
+	m := NewModule()
+	deps := testDeps()
+	deps.Config = &config.Config{
+		Inbox:       config.InboxConfig{Enabled: true, RetentionPeriod: time.Hour},
+		Multitenant: config.MultitenantConfig{Enabled: true}, // static (default) but no tenants configured
+	}
+	require.NoError(t, m.Init(deps), "Init succeeds; the guard is in RegisterJobs")
+
+	reg := &fakeRegistrar{}
+	err := m.RegisterJobs(reg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no static multitenant.tenants",
+		"the cleanup job would fan out across zero tenants and prune nothing, so RegisterJobs must fail fast")
+	assert.Empty(t, reg.dailyJobs, "no cleanup job is registered when static multi-tenant has no tenants")
+}
+
 func TestInitSucceedsForDynamicMultitenantProcessOnceOnly(t *testing.T) {
 	// ProcessOnce resolves the tenant from the request context, so it works in dynamic
 	// multi-tenant mode. Init must succeed; the dynamic-MT guard lives in RegisterJobs,

--- a/inbox/module_test.go
+++ b/inbox/module_test.go
@@ -83,6 +83,40 @@ func TestModuleInitRejectsBadTableName(t *testing.T) {
 	assert.Contains(t, err.Error(), "unqualified")
 }
 
+func TestRegisterJobsFailsFastForDynamicMultitenant(t *testing.T) {
+	m := NewModule()
+	deps := testDeps()
+	deps.Config = &config.Config{
+		Inbox:       config.InboxConfig{Enabled: true, RetentionPeriod: time.Hour},
+		Multitenant: config.MultitenantConfig{Enabled: true},
+		Source:      config.SourceConfig{Type: config.SourceTypeDynamic},
+	}
+	require.NoError(t, m.Init(deps), "Init succeeds — ProcessOnce works in multi-tenant mode")
+
+	reg := &fakeRegistrar{}
+	err := m.RegisterJobs(reg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dynamic multi-tenant",
+		"the cleanup job cannot enumerate dynamic tenants, so RegisterJobs must fail fast")
+	assert.Empty(t, reg.dailyJobs, "no cleanup job is registered for dynamic multi-tenant")
+}
+
+func TestInitSucceedsForDynamicMultitenantProcessOnceOnly(t *testing.T) {
+	// ProcessOnce resolves the tenant from the request context, so it works in dynamic
+	// multi-tenant mode. Init must succeed; the dynamic-MT guard lives in RegisterJobs,
+	// which only runs when the scheduler is present and the cleanup job would register.
+	m := NewModule()
+	deps := testDeps()
+	deps.Config = &config.Config{
+		Inbox:       config.InboxConfig{Enabled: true, RetentionPeriod: time.Hour},
+		Multitenant: config.MultitenantConfig{Enabled: true},
+		Source:      config.SourceConfig{Type: config.SourceTypeDynamic},
+	}
+
+	require.NoError(t, m.Init(deps))
+	require.NotNil(t, m.InboxProcessor())
+}
+
 func TestRegisterJobsRegistersCleanup(t *testing.T) {
 	m := NewModule()
 	deps := testDeps()

--- a/multitenant/cleanup.go
+++ b/multitenant/cleanup.go
@@ -17,9 +17,9 @@ type RetentionDelete func(ctx context.Context, db dbtypes.Interface, cutoff time
 
 // FanOutRetentionCleanup runs a retention delete once per tenant, resolving each tenant's
 // database via getDB with that tenant injected into the context (SetTenant). Per-tenant
-// errors are collected with errors.Join so one unhealthy tenant cannot block the others.
-// Single-tenant callers pass tenants=[""] (SetTenant("") is a no-op). name labels the job in
-// log and error messages (e.g. "outbox", "inbox").
+// errors AND panics are collected with errors.Join so one unhealthy tenant cannot block the
+// others. Single-tenant callers pass tenants=[""] (SetTenant("") is a no-op). name labels
+// the job in log and error messages (e.g. "outbox", "inbox").
 //
 // This is shared by the outbox and inbox cleanup jobs, whose Execute bodies are otherwise
 // identical — only the store delete and the label differ.
@@ -35,32 +35,53 @@ func FanOutRetentionCleanup(
 	cutoff := time.Now().Add(-retention)
 	var errs []error
 	for _, tenantID := range tenants {
-		tctx := SetTenant(ctx, tenantID)
-		db, err := getDB(tctx)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s cleanup: tenant %q: database not available: %w", name, tenantID, err))
-			continue
-		}
-		if db == nil {
-			errs = append(errs, fmt.Errorf("%s cleanup: tenant %q: database not available", name, tenantID))
-			continue
-		}
-
-		deleted, err := del(tctx, db, cutoff)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s cleanup: tenant %q: delete failed: %w", name, tenantID, err))
-			continue
-		}
-
-		if deleted > 0 {
-			event := log.Info().
-				Int64("deleted", deleted).
-				Str("cutoff", cutoff.Format(time.RFC3339))
-			if tenantID != "" {
-				event = event.Str("tenant", tenantID)
-			}
-			event.Msg(name + " cleanup completed")
+		if err := cleanupTenant(SetTenant(ctx, tenantID), log, tenantID, getDB, cutoff, name, del); err != nil {
+			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// cleanupTenant runs the retention delete for a single (already tenant-scoped) context. It
+// recovers panics from getDB/del and converts them to an error so a single bad tenant cannot
+// abort the fan-out for the remaining tenants (the scheduler's job-level recovery would
+// otherwise unwind the whole loop). Returns nil on success.
+func cleanupTenant(
+	ctx context.Context,
+	log logger.Logger,
+	tenantID string,
+	getDB func(context.Context) (dbtypes.Interface, error),
+	cutoff time.Time,
+	name string,
+	del RetentionDelete,
+) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%s cleanup: tenant %q: panic: %v", name, tenantID, r)
+		}
+	}()
+
+	db, err := getDB(ctx)
+	if err != nil {
+		return fmt.Errorf("%s cleanup: tenant %q: database not available: %w", name, tenantID, err)
+	}
+	if db == nil {
+		return fmt.Errorf("%s cleanup: tenant %q: database not available", name, tenantID)
+	}
+
+	deleted, err := del(ctx, db, cutoff)
+	if err != nil {
+		return fmt.Errorf("%s cleanup: tenant %q: delete failed: %w", name, tenantID, err)
+	}
+
+	if deleted > 0 {
+		event := log.Info().
+			Int64("deleted", deleted).
+			Str("cutoff", cutoff.Format(time.RFC3339))
+		if tenantID != "" {
+			event = event.Str("tenant", tenantID)
+		}
+		event.Msg(name + " cleanup completed")
+	}
+	return nil
 }

--- a/multitenant/cleanup.go
+++ b/multitenant/cleanup.go
@@ -1,0 +1,66 @@
+package multitenant
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/logger"
+)
+
+// RetentionDelete removes rows older than cutoff from the resolved tenant database. It is
+// the per-vendor delete a retention-cleanup job runs (e.g. the outbox's DeletePublished or
+// the inbox's DeleteProcessed) and matches those store methods' signatures directly.
+type RetentionDelete func(ctx context.Context, db dbtypes.Interface, cutoff time.Time) (int64, error)
+
+// FanOutRetentionCleanup runs a retention delete once per tenant, resolving each tenant's
+// database via getDB with that tenant injected into the context (SetTenant). Per-tenant
+// errors are collected with errors.Join so one unhealthy tenant cannot block the others.
+// Single-tenant callers pass tenants=[""] (SetTenant("") is a no-op). name labels the job in
+// log and error messages (e.g. "outbox", "inbox").
+//
+// This is shared by the outbox and inbox cleanup jobs, whose Execute bodies are otherwise
+// identical — only the store delete and the label differ.
+func FanOutRetentionCleanup(
+	ctx context.Context,
+	log logger.Logger,
+	tenants []string,
+	getDB func(context.Context) (dbtypes.Interface, error),
+	retention time.Duration,
+	name string,
+	del RetentionDelete,
+) error {
+	cutoff := time.Now().Add(-retention)
+	var errs []error
+	for _, tenantID := range tenants {
+		tctx := SetTenant(ctx, tenantID)
+		db, err := getDB(tctx)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s cleanup: tenant %q: database not available: %w", name, tenantID, err))
+			continue
+		}
+		if db == nil {
+			errs = append(errs, fmt.Errorf("%s cleanup: tenant %q: database not available", name, tenantID))
+			continue
+		}
+
+		deleted, err := del(tctx, db, cutoff)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s cleanup: tenant %q: delete failed: %w", name, tenantID, err))
+			continue
+		}
+
+		if deleted > 0 {
+			event := log.Info().
+				Int64("deleted", deleted).
+				Str("cutoff", cutoff.Format(time.RFC3339))
+			if tenantID != "" {
+				event = event.Str("tenant", tenantID)
+			}
+			event.Msg(name + " cleanup completed")
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/multitenant/cleanup_test.go
+++ b/multitenant/cleanup_test.go
@@ -49,6 +49,26 @@ func TestFanOutRetentionCleanupSingleTenantRunsOnce(t *testing.T) {
 	assert.Equal(t, 1, calls, "single-tenant runs the delete exactly once")
 }
 
+func TestFanOutRetentionCleanupRecoversPerTenantPanic(t *testing.T) {
+	log := logger.New("disabled", true)
+	getDB := func(context.Context) (dbtypes.Interface, error) { return stubDB{}, nil }
+
+	var seen []string
+	del := func(ctx context.Context, _ dbtypes.Interface, _ time.Time) (int64, error) {
+		tid, _ := GetTenant(ctx)
+		seen = append(seen, tid)
+		if tid == "boom" {
+			panic("kaboom")
+		}
+		return 0, nil
+	}
+
+	err := FanOutRetentionCleanup(context.Background(), log, []string{"boom", "ok"}, getDB, time.Hour, "outbox", del)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `outbox cleanup: tenant "boom": panic: kaboom`)
+	assert.Equal(t, []string{"boom", "ok"}, seen, "a panicking tenant must not abort the remaining tenants")
+}
+
 func TestFanOutRetentionCleanupReportsDBUnavailable(t *testing.T) {
 	log := logger.New("disabled", true)
 

--- a/multitenant/cleanup_test.go
+++ b/multitenant/cleanup_test.go
@@ -1,0 +1,65 @@
+package multitenant
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubDB is a non-nil dbtypes.Interface whose methods are never called by
+// FanOutRetentionCleanup (it only nil-checks the db and hands it to the delete
+// closure, which ignores it). The embedded nil interface keeps the stub one line;
+// importing database/testing here would create an import cycle (it imports multitenant).
+type stubDB struct{ dbtypes.Interface }
+
+func TestFanOutRetentionCleanupFansOutAndIsolatesErrors(t *testing.T) {
+	log := logger.New("disabled", true)
+	getDB := func(context.Context) (dbtypes.Interface, error) { return stubDB{}, nil }
+
+	var seen []string
+	del := func(ctx context.Context, _ dbtypes.Interface, _ time.Time) (int64, error) {
+		tid, _ := GetTenant(ctx)
+		seen = append(seen, tid)
+		if tid == "bad" {
+			return 0, errors.New("boom")
+		}
+		return 0, nil
+	}
+
+	err := FanOutRetentionCleanup(context.Background(), log, []string{"good", "bad"}, getDB, time.Hour, "outbox", del)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `outbox cleanup: tenant "bad": delete failed: boom`)
+	assert.Equal(t, []string{"good", "bad"}, seen, "every tenant is attempted despite one failing")
+}
+
+func TestFanOutRetentionCleanupSingleTenantRunsOnce(t *testing.T) {
+	log := logger.New("disabled", true)
+	getDB := func(context.Context) (dbtypes.Interface, error) { return stubDB{}, nil }
+
+	calls := 0
+	del := func(context.Context, dbtypes.Interface, time.Time) (int64, error) { calls++; return 5, nil }
+
+	require.NoError(t, FanOutRetentionCleanup(context.Background(), log, []string{""}, getDB, time.Hour, "inbox", del))
+	assert.Equal(t, 1, calls, "single-tenant runs the delete exactly once")
+}
+
+func TestFanOutRetentionCleanupReportsDBUnavailable(t *testing.T) {
+	log := logger.New("disabled", true)
+
+	nilDB := func(context.Context) (dbtypes.Interface, error) { return nil, nil }
+	err := FanOutRetentionCleanup(context.Background(), log, []string{""}, nilDB, time.Hour, "outbox", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database not available")
+
+	errDB := func(context.Context) (dbtypes.Interface, error) { return nil, errors.New("conn refused") }
+	err = FanOutRetentionCleanup(context.Background(), log, []string{""}, errDB, time.Hour, "outbox", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database not available")
+	assert.Contains(t, err.Error(), "conn refused")
+}

--- a/outbox/cleanup.go
+++ b/outbox/cleanup.go
@@ -2,8 +2,6 @@ package outbox
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"time"
 
 	dbtypes "github.com/gaborage/go-bricks/database/types"
@@ -16,7 +14,8 @@ import (
 //
 // Runs daily at 04:00 by default (registered via scheduler.DailyAt).
 // Like the relay, it resolves the database through the tenant-aware getDB
-// resolver and fans out across the configured tenants in multi-tenant mode.
+// resolver and fans out across the configured tenants in multi-tenant mode
+// (shared with the inbox cleanup via multitenant.FanOutRetentionCleanup).
 type Cleanup struct {
 	store           Store
 	retentionPeriod time.Duration
@@ -25,36 +24,7 @@ type Cleanup struct {
 }
 
 func (c *Cleanup) Execute(jobCtx scheduler.JobContext) error {
-	log := jobCtx.Logger()
-	cutoff := time.Now().Add(-c.retentionPeriod)
-	var errs []error
-	for _, tenantID := range c.tenants {
-		ctx := multitenant.SetTenant(jobCtx, tenantID)
-		db, err := c.getDB(ctx)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("outbox cleanup: tenant %q: database not available: %w", tenantID, err))
-			continue
-		}
-		if db == nil {
-			errs = append(errs, fmt.Errorf("outbox cleanup: tenant %q: database not available", tenantID))
-			continue
-		}
-
-		deleted, err := c.store.DeletePublished(ctx, db, cutoff)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("outbox cleanup: tenant %q: delete failed: %w", tenantID, err))
-			continue
-		}
-
-		if deleted > 0 {
-			event := log.Info().
-				Int64("deleted", deleted).
-				Str("cutoff", cutoff.Format(time.RFC3339))
-			if tenantID != "" {
-				event = event.Str("tenant", tenantID)
-			}
-			event.Msg("Outbox cleanup completed")
-		}
-	}
-	return errors.Join(errs...)
+	return multitenant.FanOutRetentionCleanup(
+		jobCtx, jobCtx.Logger(), c.tenants, c.getDB, c.retentionPeriod, "outbox", c.store.DeletePublished,
+	)
 }

--- a/outbox/cleanup.go
+++ b/outbox/cleanup.go
@@ -1,9 +1,13 @@
 package outbox
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/multitenant"
 	"github.com/gaborage/go-bricks/scheduler"
 )
 
@@ -11,30 +15,46 @@ import (
 // older than the configured retention period.
 //
 // Runs daily at 04:00 by default (registered via scheduler.DailyAt).
+// Like the relay, it resolves the database through the tenant-aware getDB
+// resolver and fans out across the configured tenants in multi-tenant mode.
 type Cleanup struct {
 	store           Store
 	retentionPeriod time.Duration
+	getDB           func(context.Context) (dbtypes.Interface, error)
+	tenants         []string
 }
 
-func (c *Cleanup) Execute(ctx scheduler.JobContext) error {
-	db := ctx.DB()
-	if db == nil {
-		return fmt.Errorf("outbox cleanup: database not available")
-	}
-
+func (c *Cleanup) Execute(jobCtx scheduler.JobContext) error {
+	log := jobCtx.Logger()
 	cutoff := time.Now().Add(-c.retentionPeriod)
+	var errs []error
+	for _, tenantID := range c.tenants {
+		ctx := multitenant.SetTenant(jobCtx, tenantID)
+		db, err := c.getDB(ctx)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("outbox cleanup: tenant %q: database not available: %w", tenantID, err))
+			continue
+		}
+		if db == nil {
+			errs = append(errs, fmt.Errorf("outbox cleanup: tenant %q: database not available", tenantID))
+			continue
+		}
 
-	deleted, err := c.store.DeletePublished(ctx, db, cutoff)
-	if err != nil {
-		return fmt.Errorf("outbox cleanup: delete failed: %w", err)
+		deleted, err := c.store.DeletePublished(ctx, db, cutoff)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("outbox cleanup: tenant %q: delete failed: %w", tenantID, err))
+			continue
+		}
+
+		if deleted > 0 {
+			event := log.Info().
+				Int64("deleted", deleted).
+				Str("cutoff", cutoff.Format(time.RFC3339))
+			if tenantID != "" {
+				event = event.Str("tenant", tenantID)
+			}
+			event.Msg("Outbox cleanup completed")
+		}
 	}
-
-	if deleted > 0 {
-		ctx.Logger().Info().
-			Int64("deleted", deleted).
-			Str("cutoff", cutoff.Format(time.RFC3339)).
-			Msg("Outbox cleanup completed")
-	}
-
-	return nil
+	return errors.Join(errs...)
 }

--- a/outbox/cleanup_test.go
+++ b/outbox/cleanup_test.go
@@ -1,6 +1,7 @@
 package outbox
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -9,10 +10,25 @@ import (
 	"github.com/stretchr/testify/require"
 
 	dbtesting "github.com/gaborage/go-bricks/database/testing"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/scheduler"
 )
 
+// newCleanupWithFakes wires a single-tenant Cleanup. tenants is [""], so SetTenant is a
+// no-op and getDB type-asserts the context back to the fake JobContext to read the db
+// supplied via newFakeJobCtx (preserving the existing per-test ergonomics).
 func newCleanupWithFakes(store *fakeStore, retention time.Duration) *Cleanup {
-	return &Cleanup{store: store, retentionPeriod: retention}
+	return &Cleanup{
+		store:           store,
+		retentionPeriod: retention,
+		getDB: func(ctx context.Context) (dbtypes.Interface, error) {
+			if jc, ok := ctx.(scheduler.JobContext); ok {
+				return jc.DB(), nil
+			}
+			return nil, nil
+		},
+		tenants: []string{""},
+	}
 }
 
 func TestCleanupExecuteReturnsErrorWhenDBUnavailable(t *testing.T) {

--- a/outbox/module.go
+++ b/outbox/module.go
@@ -11,7 +11,6 @@ import (
 	dbtypes "github.com/gaborage/go-bricks/database/types"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
-	"github.com/gaborage/go-bricks/scheduler"
 )
 
 // Module implements the GoBricks Module interface for transactional outbox.
@@ -89,6 +88,22 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 	if m.config != nil && !m.config.Multitenant.Enabled && !config.IsMessagingConfigured(&m.config.Messaging) {
 		return fmt.Errorf("outbox: messaging is not configured but outbox.enabled=true; " +
 			"set messaging.broker.url (or env MESSAGING_BROKER_URL) or set outbox.enabled=false")
+	}
+
+	// Fail fast on multi-tenant configurations the relay cannot fan out across, rather
+	// than silently never relaying events (the prior behavior: the relay's tenant-less
+	// context could not resolve any tenant's database):
+	//   - dynamic sources: the tenant set is not enumerable at job-registration time;
+	//   - static sources with no tenants: there is nothing to fan out to.
+	if m.config != nil && m.config.Multitenant.Enabled {
+		switch {
+		case m.config.Source.Type == config.SourceTypeDynamic:
+			return fmt.Errorf("outbox: relay is not supported with dynamic multi-tenant sources " +
+				"(source.type=dynamic); use static multitenant.tenants config, or set outbox.enabled=false")
+		case len(m.config.Multitenant.Tenants) == 0:
+			return fmt.Errorf("outbox: multi-tenant is enabled but no static multitenant.tenants are configured; " +
+				"the relay would never deliver any events. Configure multitenant.tenants, or set outbox.enabled=false")
+		}
 	}
 
 	// Store creation is deferred until first use (lazy init like scheduler)
@@ -170,20 +185,15 @@ func (m *Module) RegisterJobs(registrar app.JobRegistrar) error {
 		return nil
 	}
 
+	tenants := m.config.PerTenantJobKeys()
+
 	// Register relay job
 	relay := &Relay{
-		store:  &lazyStore{module: m},
-		config: m.cfg,
-		getMessaging: func(ctx scheduler.JobContext) messaging.AMQPClient {
-			client := ctx.Messaging()
-			if client == nil {
-				return nil
-			}
-			if amqpClient, ok := client.(messaging.AMQPClient); ok {
-				return amqpClient
-			}
-			return nil
-		},
+		store:        &lazyStore{module: m},
+		config:       m.cfg,
+		getDB:        m.getDB,
+		getMessaging: m.getMsg,
+		tenants:      tenants,
 	}
 
 	if err := registrar.FixedRate("outbox-relay", relay, m.cfg.PollInterval); err != nil {
@@ -195,6 +205,8 @@ func (m *Module) RegisterJobs(registrar app.JobRegistrar) error {
 		cleanup := &Cleanup{
 			store:           &lazyStore{module: m},
 			retentionPeriod: m.cfg.RetentionPeriod,
+			getDB:           m.getDB,
+			tenants:         tenants,
 		}
 
 		cleanupTime := time.Date(0, 1, 1, 4, 0, 0, 0, time.Local)

--- a/outbox/module_test.go
+++ b/outbox/module_test.go
@@ -181,8 +181,13 @@ func TestModuleInitEnabledMessagingUnconfiguredMultiTenant(t *testing.T) {
 	deps := &app.ModuleDeps{
 		Logger: logger.New("info", false),
 		Config: &config.Config{
-			Outbox:      config.OutboxConfig{Enabled: true},
-			Multitenant: config.MultitenantConfig{Enabled: true},
+			Outbox: config.OutboxConfig{Enabled: true},
+			Multitenant: config.MultitenantConfig{
+				Enabled: true,
+				// Static tenants are required for the relay to fan out; messaging is
+				// resolved per-tenant, so the global broker URL stays intentionally empty.
+				Tenants: map[string]config.TenantEntry{"tenant-a": {}},
+			},
 			// Messaging.Broker.URL intentionally empty.
 		},
 		DB: func(_ context.Context) (dbtypes.Interface, error) {
@@ -195,7 +200,46 @@ func TestModuleInitEnabledMessagingUnconfiguredMultiTenant(t *testing.T) {
 
 	err := m.Init(deps)
 	require.NoError(t, err)
-	assert.NotNil(t, m.publisher, "Publisher should be initialized in multi-tenant mode even with empty global broker URL")
+	assert.NotNil(t, m.publisher, "Publisher should be initialized in static multi-tenant mode even with empty global broker URL")
+}
+
+func TestModuleInitFailsFastForDynamicMultitenant(t *testing.T) {
+	m := NewModule()
+	deps := &app.ModuleDeps{
+		Logger: logger.New("disabled", true),
+		Config: &config.Config{
+			Outbox:      config.OutboxConfig{Enabled: true},
+			Multitenant: config.MultitenantConfig{Enabled: true},
+			Source:      config.SourceConfig{Type: config.SourceTypeDynamic},
+		},
+		DB:        func(_ context.Context) (dbtypes.Interface, error) { return nil, nil },
+		Messaging: func(_ context.Context) (messaging.AMQPClient, error) { return nil, nil },
+	}
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dynamic multi-tenant",
+		"the relay cannot enumerate dynamic tenants, so Init must fail fast rather than silently never relaying")
+}
+
+func TestModuleInitFailsFastForEmptyStaticMultitenant(t *testing.T) {
+	// multitenant enabled + static source (the default) but no tenants configured: the
+	// relay would fan out across zero tenants and silently deliver nothing, so Init must
+	// fail fast rather than register a no-op relay.
+	m := NewModule()
+	deps := &app.ModuleDeps{
+		Logger: logger.New("disabled", true),
+		Config: &config.Config{
+			Outbox:      config.OutboxConfig{Enabled: true},
+			Multitenant: config.MultitenantConfig{Enabled: true}, // Tenants intentionally omitted
+		},
+		DB:        func(_ context.Context) (dbtypes.Interface, error) { return nil, nil },
+		Messaging: func(_ context.Context) (messaging.AMQPClient, error) { return nil, nil },
+	}
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no static multitenant.tenants")
 }
 
 // initEnabledModule returns an outbox Module that has gone through Init

--- a/outbox/relay.go
+++ b/outbox/relay.go
@@ -1,12 +1,16 @@
 package outbox
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/gaborage/go-bricks/config"
 	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/multitenant"
 	"github.com/gaborage/go-bricks/scheduler"
 	gobrickstrace "github.com/gaborage/go-bricks/trace"
 )
@@ -16,33 +20,68 @@ import (
 //
 // The relay runs as a scheduled job (registered via scheduler.FixedRate),
 // getting overlapping prevention, panic recovery, and OTel metrics for free.
+//
+// Resources are resolved through the tenant-aware getDB/getMessaging resolvers
+// (the module's deps.DB/deps.Messaging) rather than the scheduler JobContext,
+// because the scheduler builds the JobContext from a tenant-less context — so
+// in multi-tenant mode the relay must inject each tenant into the context
+// itself before resolving that tenant's database and broker.
 type Relay struct {
 	store        Store
 	config       config.OutboxConfig
-	getMessaging func(scheduler.JobContext) messaging.AMQPClient
+	getDB        func(context.Context) (dbtypes.Interface, error)
+	getMessaging func(context.Context) (messaging.AMQPClient, error)
+	// tenants lists the tenant keys to relay each cycle. Always non-empty: a single
+	// "" entry for single-tenant mode (multitenant.SetTenant with "" is a no-op), or
+	// the configured static multitenant tenant IDs. Dynamic multi-tenant sources are
+	// rejected at module Init (their tenant set is not enumerable at registration time).
+	tenants []string
 }
 
-func (r *Relay) Execute(ctx scheduler.JobContext) error {
-	db := ctx.DB()
+// Execute runs one relay cycle per configured tenant. In single-tenant mode this is a
+// single pass with no tenant in context; in static multi-tenant mode it fans out across
+// the configured tenants, resolving each tenant's database and broker independently.
+// Per-tenant failures are collected so one unhealthy tenant does not block the others.
+func (r *Relay) Execute(jobCtx scheduler.JobContext) error {
+	log := jobCtx.Logger()
+	var errs []error
+	for _, tenantID := range r.tenants {
+		ctx := multitenant.SetTenant(jobCtx, tenantID)
+		if err := r.relayTenant(ctx, log, tenantID); err != nil {
+			errs = append(errs, fmt.Errorf("outbox relay: tenant %q: %w", tenantID, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// relayTenant runs a single relay cycle for the given (tenant-scoped) context.
+func (r *Relay) relayTenant(ctx context.Context, log logger.Logger, tenantID string) error {
+	db, err := r.getDB(ctx)
+	if err != nil {
+		return fmt.Errorf("database not available: %w", err)
+	}
 	if db == nil {
-		return fmt.Errorf("outbox relay: database not available")
+		return fmt.Errorf("database not available")
 	}
 
-	msgClient := r.getMessaging(ctx)
+	msgClient, err := r.getMessaging(ctx)
+	if err != nil {
+		return fmt.Errorf("messaging not available: %w", err)
+	}
 	if msgClient == nil {
-		return fmt.Errorf("outbox relay: messaging not available")
+		return fmt.Errorf("messaging not available")
 	}
 
 	// Check broker readiness before fetching records.
 	// Avoids pulling a full batch only to have every publish fail with errNotConnected
 	// on the first not-ready cycle, which wastes a DB round-trip and retry increments.
 	if !msgClient.IsReady() {
-		return fmt.Errorf("outbox relay: messaging client not ready")
+		return fmt.Errorf("messaging client not ready")
 	}
 
 	records, err := r.store.FetchPending(ctx, db, r.config.BatchSize, r.config.MaxRetries)
 	if err != nil {
-		return fmt.Errorf("outbox relay: fetch failed: %w", err)
+		return fmt.Errorf("fetch failed: %w", err)
 	}
 
 	if len(records) == 0 {
@@ -51,29 +90,32 @@ func (r *Relay) Execute(ctx scheduler.JobContext) error {
 
 	var published, failed int
 	for i := range records {
-		if r.publishRecord(ctx, db, msgClient, &records[i]) {
+		if r.publishRecord(ctx, log, db, msgClient, &records[i]) {
 			published++
 		} else {
 			failed++
 		}
 	}
 
-	ctx.Logger().Info().
+	event := log.Info().
 		Int("published", published).
 		Int("failed", failed).
-		Int("total", len(records)).
-		Msg("Outbox relay cycle completed")
+		Int("total", len(records))
+	if tenantID != "" {
+		event = event.Str("tenant", tenantID)
+	}
+	event.Msg("Outbox relay cycle completed")
 
 	return nil
 }
 
 // publishRecord attempts to publish a single outbox record to the message broker.
 // Returns true on success, false on failure (record is marked as failed).
-func (r *Relay) publishRecord(ctx scheduler.JobContext, db dbtypes.Interface, msgClient messaging.AMQPClient, record *Record) bool {
+func (r *Relay) publishRecord(ctx context.Context, log logger.Logger, db dbtypes.Interface, msgClient messaging.AMQPClient, record *Record) bool {
 	// Decode headers — treat corrupted headers as a publish failure
 	headers, decodeErr := decodeHeaders(record.Headers)
 	if decodeErr != nil {
-		r.markRecordFailed(ctx, db, record.ID, decodeErr.Error())
+		r.markRecordFailed(ctx, log, db, record.ID, decodeErr.Error())
 		return false
 	}
 
@@ -98,12 +140,12 @@ func (r *Relay) publishRecord(ctx scheduler.JobContext, db dbtypes.Interface, ms
 	}
 
 	if err := msgClient.PublishToExchange(pubCtx, opts, record.Payload); err != nil {
-		r.markRecordFailed(ctx, db, record.ID, err.Error())
+		r.markRecordFailed(ctx, log, db, record.ID, err.Error())
 		return false
 	}
 
 	if err := r.store.MarkPublished(ctx, db, record.ID); err != nil {
-		ctx.Logger().Error().
+		log.Error().
 			Err(err).
 			Str("eventID", record.ID).
 			Msg("Failed to mark outbox event as published")
@@ -114,9 +156,9 @@ func (r *Relay) publishRecord(ctx scheduler.JobContext, db dbtypes.Interface, ms
 }
 
 // markRecordFailed marks an outbox record as failed, logging any secondary errors.
-func (r *Relay) markRecordFailed(ctx scheduler.JobContext, db dbtypes.Interface, eventID, errMsg string) {
+func (r *Relay) markRecordFailed(ctx context.Context, log logger.Logger, db dbtypes.Interface, eventID, errMsg string) {
 	if markErr := r.store.MarkFailed(ctx, db, eventID, errMsg); markErr != nil {
-		ctx.Logger().Error().
+		log.Error().
 			Err(markErr).
 			Str("eventID", eventID).
 			Msg("Failed to mark outbox event as failed")

--- a/outbox/relay_test.go
+++ b/outbox/relay_test.go
@@ -1,6 +1,7 @@
 package outbox
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -9,7 +10,9 @@ import (
 
 	"github.com/gaborage/go-bricks/config"
 	dbtesting "github.com/gaborage/go-bricks/database/testing"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/multitenant"
 	"github.com/gaborage/go-bricks/scheduler"
 	gobrickstrace "github.com/gaborage/go-bricks/trace"
 )
@@ -36,9 +39,10 @@ func TestDecodeHeadersInvalidJSON(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid headers JSON")
 }
 
-// newRelayWithFakes wires a Relay with the supplied fake store and AMQP
-// client. The getMessaging closure always returns the fake AMQP regardless
-// of JobContext content.
+// newRelayWithFakes wires a single-tenant Relay with the supplied fake store and AMQP
+// client. tenants is [""], so multitenant.SetTenant is a no-op and the per-tenant context
+// the relay resolves with is the fake JobContext itself — getDB type-asserts it back to
+// read the db supplied via newFakeJobCtx, preserving the existing test ergonomics.
 func newRelayWithFakes(store *fakeStore, amqp *fakeAMQP) *Relay {
 	return &Relay{
 		store: store,
@@ -46,7 +50,14 @@ func newRelayWithFakes(store *fakeStore, amqp *fakeAMQP) *Relay {
 			BatchSize:  10,
 			MaxRetries: 3,
 		},
-		getMessaging: func(_ scheduler.JobContext) messaging.AMQPClient { return amqp },
+		getDB: func(ctx context.Context) (dbtypes.Interface, error) {
+			if jc, ok := ctx.(scheduler.JobContext); ok {
+				return jc.DB(), nil
+			}
+			return nil, nil
+		},
+		getMessaging: func(context.Context) (messaging.AMQPClient, error) { return amqp, nil },
+		tenants:      []string{""},
 	}
 }
 
@@ -60,13 +71,15 @@ func TestRelayExecuteReturnsErrorWhenDBUnavailable(t *testing.T) {
 }
 
 func TestRelayExecuteReturnsErrorWhenMessagingUnavailable(t *testing.T) {
+	db := dbtesting.NewTestDB("postgresql")
 	r := &Relay{
 		store:  &fakeStore{},
 		config: config.OutboxConfig{BatchSize: 10, MaxRetries: 3},
+		getDB:  func(context.Context) (dbtypes.Interface, error) { return db, nil },
 		// getMessaging deliberately returns nil to simulate misconfigured tenant.
-		getMessaging: func(_ scheduler.JobContext) messaging.AMQPClient { return nil },
+		getMessaging: func(context.Context) (messaging.AMQPClient, error) { return nil, nil },
+		tenants:      []string{""},
 	}
-	db := dbtesting.NewTestDB("postgresql")
 	ctx := newFakeJobCtx(db, nil)
 
 	err := r.Execute(ctx)
@@ -161,7 +174,7 @@ func TestPublishRecordMarksFailedOnInvalidHeaders(t *testing.T) {
 	ctx := newFakeJobCtx(db, amqp)
 
 	rec := &Record{ID: "evt-bad-hdr", Headers: []byte(`{not valid json}`)}
-	ok := r.publishRecord(ctx, db, amqp, rec)
+	ok := r.publishRecord(ctx, ctx.Logger(), db, amqp, rec)
 
 	assert.False(t, ok, "publishRecord returns false when headers can't be decoded")
 	assert.Equal(t, 0, amqp.PublishCalls, "publish never attempted with bad headers")
@@ -184,7 +197,7 @@ func TestPublishRecordInjectsOutboxMetadataHeaders(t *testing.T) {
 		RoutingKey: "created",
 		Headers:    []byte(`{"x-correlation-id":"abc"}`),
 	}
-	ok := r.publishRecord(ctx, db, amqp, rec)
+	ok := r.publishRecord(ctx, ctx.Logger(), db, amqp, rec)
 	require.True(t, ok)
 
 	require.NotNil(t, amqp.LastPublishHdrs)
@@ -203,7 +216,7 @@ func TestPublishRecordInjectsHeadersWhenRecordHasNone(t *testing.T) {
 	ctx := newFakeJobCtx(db, amqp)
 
 	rec := &Record{ID: "evt-7", EventType: "x.y", Exchange: "ex", RoutingKey: "rk"}
-	require.True(t, r.publishRecord(ctx, db, amqp, rec))
+	require.True(t, r.publishRecord(ctx, ctx.Logger(), db, amqp, rec))
 	require.NotNil(t, amqp.LastPublishHdrs)
 	assert.Equal(t, "evt-7", amqp.LastPublishHdrs[HeaderEventID])
 }
@@ -216,7 +229,7 @@ func TestPublishRecordReturnsFalseWhenMarkPublishedFails(t *testing.T) {
 	ctx := newFakeJobCtx(db, amqp)
 
 	rec := &Record{ID: "evt-mp-fail", Exchange: "ex", RoutingKey: "rk"}
-	ok := r.publishRecord(ctx, db, amqp, rec)
+	ok := r.publishRecord(ctx, ctx.Logger(), db, amqp, rec)
 
 	assert.False(t, ok, "MarkPublished failure makes the cycle treat the record as failed")
 	assert.Equal(t, 1, amqp.PublishCalls)
@@ -245,7 +258,7 @@ func TestPublishRecordRehydratesTraceContextForPublish(t *testing.T) {
 		RoutingKey: "created",
 		Headers:    []byte(`{"traceparent":"` + inboundTraceparent + `","X-Request-ID":"` + inboundTraceID + `"}`),
 	}
-	require.True(t, r.publishRecord(ctx, db, amqp, rec))
+	require.True(t, r.publishRecord(ctx, ctx.Logger(), db, amqp, rec))
 
 	require.NotNil(t, amqp.LastPublishCtx, "publish context must be captured")
 	tp, ok := gobrickstrace.ParentFromContext(amqp.LastPublishCtx)
@@ -264,7 +277,60 @@ func TestMarkRecordFailedLogsButDoesNotPanicOnStoreError(t *testing.T) {
 	ctx := newFakeJobCtx(db, amqp)
 
 	require.NotPanics(t, func() {
-		r.markRecordFailed(ctx, db, "evt-id", "publish err")
+		r.markRecordFailed(ctx, ctx.Logger(), db, "evt-id", "publish err")
 	})
 	assert.Equal(t, 1, store.MarkFailedCalls)
+}
+
+// TestRelayExecuteFansOutAcrossStaticTenants verifies the multi-tenant fix: the relay
+// resolves the database once per configured tenant (with that tenant injected into the
+// context) and relays each tenant's pending events — rather than the prior tenant-less
+// resolution that returned ErrNoTenantInContext and relayed nothing.
+func TestRelayExecuteFansOutAcrossStaticTenants(t *testing.T) {
+	var resolved []string
+	store := &fakeStore{FetchPendingResult: []Record{{ID: "e1", Exchange: "ex", RoutingKey: "rk"}}}
+	amqp := newFakeAMQP()
+	r := &Relay{
+		store:  store,
+		config: config.OutboxConfig{BatchSize: 10, MaxRetries: 3},
+		getDB: func(ctx context.Context) (dbtypes.Interface, error) {
+			tid, _ := multitenant.GetTenant(ctx)
+			resolved = append(resolved, tid)
+			return dbtesting.NewTestDB("postgresql"), nil
+		},
+		getMessaging: func(context.Context) (messaging.AMQPClient, error) { return amqp, nil },
+		tenants:      []string{"tenant-a", "tenant-b"},
+	}
+	ctx := newFakeJobCtx(nil, amqp)
+
+	require.NoError(t, r.Execute(ctx))
+	assert.Equal(t, []string{"tenant-a", "tenant-b"}, resolved, "relay must resolve the DB once per configured tenant, in order")
+	assert.Equal(t, 2, store.FetchPendingCalls, "FetchPending runs once per tenant")
+	assert.Equal(t, 2, amqp.PublishCalls, "each tenant's pending record is published")
+}
+
+// TestRelayExecuteIsolatesPerTenantFailures verifies one unhealthy tenant does not block
+// the others: its error is collected (naming the tenant) while healthy tenants still run.
+func TestRelayExecuteIsolatesPerTenantFailures(t *testing.T) {
+	store := &fakeStore{}
+	amqp := newFakeAMQP()
+	r := &Relay{
+		store:  store,
+		config: config.OutboxConfig{BatchSize: 10, MaxRetries: 3},
+		getDB: func(ctx context.Context) (dbtypes.Interface, error) {
+			if tid, _ := multitenant.GetTenant(ctx); tid == "bad" {
+				return nil, errors.New("tenant db down")
+			}
+			return dbtesting.NewTestDB("postgresql"), nil
+		},
+		getMessaging: func(context.Context) (messaging.AMQPClient, error) { return amqp, nil },
+		tenants:      []string{"good", "bad"},
+	}
+	ctx := newFakeJobCtx(nil, amqp)
+
+	err := r.Execute(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `tenant "bad"`)
+	assert.Contains(t, err.Error(), "tenant db down")
+	assert.Equal(t, 1, store.FetchPendingCalls, "the healthy tenant is still relayed despite the other failing")
 }

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -2,6 +2,17 @@
 
 Historical migration tables for upgrading existing GoBricks-based applications. Greenfield work can ignore this file — the new APIs are the only ones documented in CLAUDE.md.
 
+## Outbox/Inbox Multi-Tenant Relay & Cleanup
+
+The outbox relay, outbox-cleanup, and inbox-cleanup jobs run from the scheduler's tenant-less context, so in multi-tenant mode they could not resolve any tenant's database — outbox events accumulated per tenant and were **never delivered**, and inbox ledgers were never pruned. These jobs now **fan out across the configured static tenants** (`multitenant.tenants`), resolving each tenant's database independently, so multi-tenant outbox delivery and cleanup now work.
+
+For **dynamic** tenant sources (`source.type: dynamic`), the tenant set is not enumerable at job-registration time, so the framework now **fails fast** rather than silently never relaying:
+
+- **Outbox** + `multitenant.enabled` + `source.type: dynamic` → module **Init fails** (the relay is the whole point of the outbox).
+- **Inbox** + `multitenant.enabled` + `source.type: dynamic` → **`RegisterJobs` fails** when the cleanup job would register (i.e. when the scheduler is present). `ProcessOnce` is unaffected and still works — run without the scheduler to use the inbox without retention cleanup.
+
+**Action:** a dynamic-multi-tenant deployment with outbox/inbox cleanup enabled now fails at startup instead of silently losing events. Use static `multitenant.tenants` config, or (for inbox) drop the scheduler to keep `ProcessOnce` without cleanup.
+
 ## `database.tls.cert/key/ca` Now Wired Into the Drivers (ADR-027)
 
 Per [ADR-027](adr_027_database_tls_material.md), the `database.tls.cert`, `database.tls.key`, and `database.tls.ca` fields — previously advertised but never consumed — are now honored.

--- a/wiki/outbox.md
+++ b/wiki/outbox.md
@@ -139,3 +139,9 @@ outbox:
   batchsize: 200             # Higher throughput
   retentionperiod: 168h      # 7-day retention
 ```
+
+## Multi-Tenant
+
+In multi-tenant mode the relay and cleanup jobs **fan out across the configured static tenants** (`multitenant.tenants`): each poll cycle resolves every tenant's database independently (via `multitenant.SetTenant` + `deps.DB`), relays that tenant's pending events, and prunes its published rows. A failure for one tenant is logged and does not block the others.
+
+**Dynamic tenant sources are not supported** for the relay/cleanup: because the tenant set is not enumerable at job-registration time, the framework fails fast rather than silently never relaying. With `multitenant.enabled` and `source.type: dynamic`, enabling the outbox is rejected at module `Init` (and the inbox cleanup job at `RegisterJobs`). Use static `multitenant.tenants` config for outbox/inbox relay and cleanup.


### PR DESCRIPTION
## Summary

Closes a **High-severity** finding from the 2026-06-10 full-repo security audit: in multi-tenant mode the outbox relay, outbox-cleanup, and inbox-cleanup jobs never resolved a tenant, so events accumulated undelivered.

These jobs run from the scheduler's **tenant-less** context, so `ctx.DB()`/`ctx.Messaging()` resolved via `MultiTenantResourceProvider` and returned `ErrNoTenantInContext` every cycle. Outbox events accumulated per tenant and were **never delivered** (at-least-once silently void); inbox ledgers were never pruned. Multi-tenant outbox had **never actually worked**.

## Fix (you chose: fan-out static + fail-fast dynamic)

Resolve resources through the module's **tenant-aware** `deps.DB`/`deps.Messaging` resolvers with each tenant injected via `multitenant.SetTenant`, **fanning out** across the configured static tenants. Per-tenant failures are collected (`errors.Join`) so one unhealthy tenant can't block the others. Single-tenant behavior is unchanged (`SetTenant("")` is a no-op; tenant list is `[""]`).

**Dynamic** tenant sources can't be enumerated at job-registration time, so the framework now **fails fast** rather than silently never relaying:
- outbox: module **Init** fails for dynamic MT — or static MT with **no tenants** configured (which would also silently relay nothing).
- inbox: **RegisterJobs** fails (only when the cleanup job would register); `ProcessOnce` is unaffected and still works per-request, so ProcessOnce-only (no scheduler) deployments keep working with dynamic sources.

Extracts the shared tenant-key enumeration to `config.PerTenantJobKeys()`. Documents the behavior + the single-vendor-per-fleet assumption in `wiki/outbox.md` / `wiki/migrations.md`.

## ⚠️ Behavior change
A dynamic-multi-tenant (or empty-static-MT) deployment with outbox/inbox cleanup enabled now fails fast at startup instead of silently losing events.

## Verification
- `make check` green; `make sec` (gosec) 0 issues.
- `/code-review` (2 parallel finder agents) caught and I fixed: the **empty-static silent-no-relay** gap (now guarded), the duplicated tenant-enumeration (extracted to `config.PerTenantJobKeys`), a missing **inbox cleanup fan-out test** (added, with per-tenant isolation), and a doc-comment drift. New tests cover fan-out, per-tenant failure isolation, the dynamic/empty fail-fast, and `PerTenantJobKeys`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-tenant execution for outbox relay/cleanup and inbox cleanup with per-tenant DB/messaging resolution and a shared tenant-scoped retention cleanup flow.
  * Added ability to enumerate per-tenant job keys for tenant-aware jobs.

* **Bug Fixes**
  * One tenant’s failures no longer block others; per-tenant errors are isolated and aggregated.
  * Startup now fail-fast rejects unsupported dynamic multitenant cleanup/relay configurations.

* **Tests**
  * Added unit tests for per-tenant fan-out, isolation, error aggregation, panic handling.

* **Documentation**
  * Expanded multi-tenant guidance and migration notes for outbox/inbox operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->