### PR TITLE
fix(database)!: honor database.tls.cert/key/ca (fail closed on Oracle)

### DIFF
--- a/config/validation.go
+++ b/config/validation.go
@@ -769,18 +769,45 @@ func validateVendorSpecificFields(cfg *DatabaseConfig) error {
 	case Oracle:
 		return validateOracleFields(cfg)
 	case PostgreSQL:
-		// No vendor-specific validation needed for PostgreSQL currently
-		return nil
+		return validatePostgreSQLFields(cfg)
 	default:
 		// Unknown database type should have been caught by validateDatabaseType
 		return nil
 	}
 }
 
+// validatePostgreSQLFields validates PostgreSQL-specific configuration fields.
+func validatePostgreSQLFields(cfg *DatabaseConfig) error {
+	// Client-certificate (mTLS) auth requires BOTH sslcert and sslkey. pgx rejects a lone
+	// one at connect time, but under sslmode=disable it silently drops them — so validate
+	// the pairing up front rather than letting a half-configured cert be silently ignored.
+	if (cfg.TLS.CertFile != "") != (cfg.TLS.KeyFile != "") {
+		return &ConfigError{
+			Category: errCategoryInvalid,
+			Field:    "database.tls",
+			Message:  "sslcert and sslkey must be configured together for client-certificate (mTLS) auth",
+			Action:   "set both database.tls.cert and database.tls.key, or neither",
+		}
+	}
+	return nil
+}
+
 // validateOracleFields validates Oracle-specific configuration fields.
 // It ensures that exactly one of Service.Name, SID, or Database is configured,
 // mirroring the DSN selection logic in database/oracle/connection.go.
 func validateOracleFields(cfg *DatabaseConfig) error {
+	// Oracle TLS (tcps/wallet) is not implemented, so reject TLS material rather than
+	// silently ignoring it — otherwise an operator who configures database.tls.cert/key/ca
+	// for Oracle would believe the connection is authenticated/encrypted when it is not.
+	if cfg.TLS.CertFile != "" || cfg.TLS.KeyFile != "" || cfg.TLS.CAFile != "" {
+		return &ConfigError{
+			Category: errCategoryInvalid,
+			Field:    "database.tls",
+			Message:  "TLS cert/key/ca are not supported for Oracle (tcps/wallet is not implemented)",
+			Action:   "remove database.tls.cert, database.tls.key, and database.tls.ca for Oracle connections",
+		}
+	}
+
 	serviceSet := cfg.Oracle.Service.Name != ""
 	sidSet := cfg.Oracle.Service.SID != ""
 	databaseSet := cfg.Database != ""

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -3933,6 +3933,66 @@ func TestValidateSchedulerTimezoneWiredIntoValidate(t *testing.T) {
 	assert.ErrorContains(t, err, "scheduler.timezone")
 }
 
+func TestValidatePostgreSQLFieldsRejectsPartialClientCert(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*DatabaseConfig)
+	}{
+		{"cert_without_key", func(c *DatabaseConfig) { c.TLS.CertFile = "/etc/ssl/client.crt" }},
+		{"key_without_cert", func(c *DatabaseConfig) { c.TLS.KeyFile = "/etc/ssl/client.key" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &DatabaseConfig{Type: "postgresql", Host: "h", Database: "d"}
+			tc.mutate(cfg)
+			err := validatePostgreSQLFields(cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "sslcert and sslkey",
+				"a lone client cert/key is silently dropped under sslmode=disable, so reject the unpaired config up front")
+		})
+	}
+}
+
+func TestValidatePostgreSQLFieldsAllowsPairedOrCAOnly(t *testing.T) {
+	both := &DatabaseConfig{Type: "postgresql"}
+	both.TLS.CertFile = "/etc/ssl/client.crt"
+	both.TLS.KeyFile = "/etc/ssl/client.key"
+	require.NoError(t, validatePostgreSQLFields(both))
+
+	caOnly := &DatabaseConfig{Type: "postgresql"}
+	caOnly.TLS.CAFile = "/etc/ssl/ca.pem" // CA alone is valid (server auth, no client cert)
+	require.NoError(t, validatePostgreSQLFields(caOnly))
+}
+
+func TestValidateOracleFieldsRejectsTLSMaterial(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*DatabaseConfig)
+	}{
+		{"ca", func(c *DatabaseConfig) { c.TLS.CAFile = "/etc/ssl/ca.pem" }},
+		{"cert", func(c *DatabaseConfig) { c.TLS.CertFile = "/etc/ssl/client.crt" }},
+		{"key", func(c *DatabaseConfig) { c.TLS.KeyFile = "/etc/ssl/client.key" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &DatabaseConfig{Type: "oracle", Database: "PDB1"}
+			tc.mutate(cfg)
+			err := validateOracleFields(cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "not supported for Oracle",
+				"Oracle TLS material must be rejected, not silently dropped (which leaves the connection unauthenticated)")
+		})
+	}
+}
+
+func TestValidateOracleFieldsAllowsModeWithoutMaterial(t *testing.T) {
+	// sslmode alone is a no-op for Oracle today, so it passes; only cert/key/ca (which
+	// would falsely imply authenticated TLS) are rejected.
+	cfg := &DatabaseConfig{Type: "oracle", Database: "PDB1"}
+	cfg.TLS.Mode = "require"
+	require.NoError(t, validateOracleFields(cfg))
+}
+
 func TestValidateDebugTrustedProxiesRejectsAllInvalid(t *testing.T) {
 	cfg := &DebugConfig{TrustedProxies: []string{"garbage", "also-bad"}}
 	assertValidationError(t, validateDebug(cfg), "debug.trustedproxies")

--- a/database/postgresql/connection.go
+++ b/database/postgresql/connection.go
@@ -99,6 +99,38 @@ func quoteDSN(value string) string {
 	return "'" + escaped + "'"
 }
 
+// buildPostgresDSN assembles a libpq-style keyword/value DSN from cfg, quoting every value.
+// TLS material is wired so pgx actually honors it: sslmode plus sslrootcert (CAFile),
+// sslcert (CertFile), and sslkey (KeyFile) when configured — previously only sslmode was
+// emitted, so a `mode: require` + `ca:` config was encrypted but UNAUTHENTICATED (MITM-able)
+// and client certs (mTLS) were silently impossible. Every value (including sslmode) is run
+// through quoteDSN so a path or mode containing spaces/quotes cannot corrupt the DSN or
+// inject extra connection parameters.
+func buildPostgresDSN(cfg *config.DatabaseConfig) string {
+	parts := []string{
+		fmt.Sprintf("host=%s", quoteDSN(cfg.Host)),
+		fmt.Sprintf("port=%d", cfg.Port),
+		fmt.Sprintf("user=%s", quoteDSN(cfg.Username)),
+		fmt.Sprintf("password=%s", quoteDSN(cfg.Password)),
+		fmt.Sprintf("dbname=%s", quoteDSN(cfg.Database)),
+	}
+
+	if cfg.TLS.Mode != "" {
+		parts = append(parts, fmt.Sprintf("sslmode=%s", quoteDSN(cfg.TLS.Mode)))
+	}
+	if cfg.TLS.CAFile != "" {
+		parts = append(parts, fmt.Sprintf("sslrootcert=%s", quoteDSN(cfg.TLS.CAFile)))
+	}
+	if cfg.TLS.CertFile != "" {
+		parts = append(parts, fmt.Sprintf("sslcert=%s", quoteDSN(cfg.TLS.CertFile)))
+	}
+	if cfg.TLS.KeyFile != "" {
+		parts = append(parts, fmt.Sprintf("sslkey=%s", quoteDSN(cfg.TLS.KeyFile)))
+	}
+
+	return strings.Join(parts, " ")
+}
+
 // NewConnection creates and configures a PostgreSQL Connection using cfg and log.
 // It validates cfg, builds or uses the provided DSN, sets pool options, ensures connectivity with a ping, logs success, and returns the wrapped Connection or an error.
 func NewConnection(cfg *config.DatabaseConfig, log logger.Logger) (types.Interface, error) {
@@ -109,19 +141,7 @@ func NewConnection(cfg *config.DatabaseConfig, log logger.Logger) (types.Interfa
 	if cfg.ConnectionString != "" {
 		dsn = cfg.ConnectionString
 	} else {
-		parts := []string{
-			fmt.Sprintf("host=%s", quoteDSN(cfg.Host)),
-			fmt.Sprintf("port=%d", cfg.Port),
-			fmt.Sprintf("user=%s", quoteDSN(cfg.Username)),
-			fmt.Sprintf("password=%s", quoteDSN(cfg.Password)),
-			fmt.Sprintf("dbname=%s", quoteDSN(cfg.Database)),
-		}
-
-		if cfg.TLS.Mode != "" {
-			parts = append(parts, fmt.Sprintf("sslmode=%s", cfg.TLS.Mode))
-		}
-
-		dsn = strings.Join(parts, " ")
+		dsn = buildPostgresDSN(cfg)
 	}
 
 	// Parse config for pgx

--- a/database/postgresql/connection_test.go
+++ b/database/postgresql/connection_test.go
@@ -221,6 +221,33 @@ func TestConnectionNewConnectionWithHostConfigNoSSLMode(t *testing.T) {
 	testConnectionExpectedError(t, cfg)
 }
 
+func TestBuildPostgresDSNWiresTLSMaterial(t *testing.T) {
+	cfg := &config.DatabaseConfig{Host: "db.example.com", Port: 5432, Username: "u", Password: "p", Database: "app"}
+	cfg.TLS.Mode = "verify-full"
+	cfg.TLS.CAFile = "/etc/ssl/ca.pem"
+	cfg.TLS.CertFile = "/etc/ssl/client.crt"
+	cfg.TLS.KeyFile = "/etc/ssl/client.key"
+
+	dsn := buildPostgresDSN(cfg)
+	// CA/cert/key must be wired so pgx authenticates the server (and presents a client
+	// cert for mTLS) — not just sslmode. Paths contain '/', so quoteDSN wraps them.
+	assert.Contains(t, dsn, "sslmode=verify-full")
+	assert.Contains(t, dsn, "sslrootcert='/etc/ssl/ca.pem'")
+	assert.Contains(t, dsn, "sslcert='/etc/ssl/client.crt'")
+	assert.Contains(t, dsn, "sslkey='/etc/ssl/client.key'")
+}
+
+func TestBuildPostgresDSNOmitsUnsetTLSMaterialAndQuotesMode(t *testing.T) {
+	cfg := &config.DatabaseConfig{Host: "h", Port: 5432, Username: "u", Password: "p", Database: "app"}
+	cfg.TLS.Mode = "require"
+
+	dsn := buildPostgresDSN(cfg)
+	assert.Contains(t, dsn, "sslmode=require")
+	assert.NotContains(t, dsn, "sslrootcert")
+	assert.NotContains(t, dsn, "sslcert")
+	assert.NotContains(t, dsn, "sslkey")
+}
+
 func TestConnectionNewConnectionSuccess(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/tools/migration/internal/commands/quiesce.go
+++ b/tools/migration/internal/commands/quiesce.go
@@ -291,8 +291,10 @@ func openControlPlaneDB(ctx context.Context, flags *CommonFlags) (db *sql.DB, cl
 // connector: an explicit ConnectionString wins verbatim; otherwise the URL is
 // assembled from the discrete fields with credentials URL-encoded (so special
 // characters in the password can't corrupt the URL, and the password is never
-// logged). sslmode is set only when the operator configured TLS.Mode — never a
-// forced plaintext downgrade.
+// logged). TLS material (sslmode plus sslrootcert/sslcert/sslkey) is set only when
+// the operator configured it — never a forced plaintext downgrade. Wiring the CA
+// and client cert/key (not just sslmode) is required so the control-plane connection
+// is actually authenticated/mTLS, matching the framework connector (ADR-027).
 func controlPlaneDSN(c *config.DatabaseConfig) string {
 	if c.ConnectionString != "" {
 		return c.ConnectionString
@@ -303,8 +305,21 @@ func controlPlaneDSN(c *config.DatabaseConfig) string {
 		Host:   fmt.Sprintf("%s:%d", c.Host, c.Port),
 		Path:   c.Database,
 	}
+	q := url.Values{}
 	if c.TLS.Mode != "" {
-		u.RawQuery = url.Values{"sslmode": {c.TLS.Mode}}.Encode()
+		q.Set("sslmode", c.TLS.Mode)
+	}
+	if c.TLS.CAFile != "" {
+		q.Set("sslrootcert", c.TLS.CAFile)
+	}
+	if c.TLS.CertFile != "" {
+		q.Set("sslcert", c.TLS.CertFile)
+	}
+	if c.TLS.KeyFile != "" {
+		q.Set("sslkey", c.TLS.KeyFile)
+	}
+	if len(q) > 0 {
+		u.RawQuery = q.Encode()
 	}
 	return u.String()
 }

--- a/tools/migration/internal/commands/quiesce_test.go
+++ b/tools/migration/internal/commands/quiesce_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"context"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -112,6 +113,22 @@ func TestControlPlaneDSN(t *testing.T) {
 	withTLS := *base
 	withTLS.TLS.Mode = "require"
 	assert.Contains(t, controlPlaneDSN(&withTLS), "sslmode=require")
+
+	// Full TLS material (CA + client cert/key) must be wired so the control-plane
+	// connection is authenticated/mTLS — not just sslmode (ADR-027). url.Values encodes
+	// the paths, so parse and assert decoded values.
+	fullTLS := *base
+	fullTLS.TLS.Mode = "verify-full"
+	fullTLS.TLS.CAFile = "/etc/ssl/ca.pem"
+	fullTLS.TLS.CertFile = "/etc/ssl/client.crt"
+	fullTLS.TLS.KeyFile = "/etc/ssl/client.key"
+	u, err := url.Parse(controlPlaneDSN(&fullTLS))
+	require.NoError(t, err)
+	q := u.Query()
+	assert.Equal(t, "verify-full", q.Get("sslmode"))
+	assert.Equal(t, "/etc/ssl/ca.pem", q.Get("sslrootcert"))
+	assert.Equal(t, "/etc/ssl/client.crt", q.Get("sslcert"))
+	assert.Equal(t, "/etc/ssl/client.key", q.Get("sslkey"))
 
 	// An explicit ConnectionString wins verbatim.
 	assert.Equal(t, "postgres://verbatim/x",

--- a/wiki/adr_027_database_tls_material.md
+++ b/wiki/adr_027_database_tls_material.md
@@ -1,0 +1,40 @@
+# ADR-027: Wire `database.tls.cert/key/ca` Into the Drivers (Fail Closed on Oracle)
+
+**Status:** Accepted
+**Date:** 2026-06-10
+
+## Context
+
+`config.TLSConfig` advertises four fields — `mode`, `cert`, `key`, `ca` (documented in `config.example.yaml`) — but only `mode` was ever consumed. The PostgreSQL DSN builder appended `sslmode=<mode>` and nothing else; `CertFile`, `KeyFile`, and `CAFile` had **zero** non-test references. The Oracle connector referenced `cfg.TLS` nowhere at all.
+
+Security impact (a High finding from the 2026-06-10 audit):
+
+- An operator setting `mode: require` **plus** `ca: /etc/ssl/db-ca.pem` reasonably expects libpq-style upgrade to `verify-ca` (which pgx performs when `sslrootcert` is supplied). Instead the CA was dropped and the connection was **encrypted but unauthenticated** — i.e. MITM-able.
+- mTLS via `cert`/`key` was silently impossible on PostgreSQL.
+- For Oracle, even `mode` did nothing, and `cert/key/ca` were silently ignored.
+
+No validation rejected these fields, so the degradation was completely silent.
+
+Separately, the existing `sslmode=%s` interpolation was unquoted (Low finding: a `mode` value containing whitespace/quotes could inject extra DSN parameters).
+
+## Decision
+
+**PostgreSQL** — `buildPostgresDSN` now emits the full TLS material when configured: `sslrootcert` (CAFile), `sslcert` (CertFile), and `sslkey` (KeyFile) alongside `sslmode`, with **every** value (including `sslmode`) run through `quoteDSN`. pgx then loads the certs and performs the expected verification. Quoting closes the DSN-injection vector in the same change. The `ConnectionString` escape hatch is unchanged (the operator owns the full DSN there). The migration CLI's parallel control-plane DSN builder (`tools/migration` `controlPlaneDSN`) is fixed identically (it had the same sslmode-only gap), there via URL query params.
+
+Config validation also now rejects a **half-configured client certificate** for PostgreSQL — `sslcert` without `sslkey` or vice versa (`validatePostgreSQLFields`) — because pgx silently drops a lone one under `sslmode=disable`, so the pairing is checked up front rather than failing far from the config site.
+
+**Oracle** — TLS over `tcps`/wallet is not implemented, so rather than silently ignore TLS material, config validation now **rejects** `database.tls.cert/key/ca` for Oracle connections (`validateOracleFields`). `mode` alone is still accepted (it is a harmless no-op today) to avoid breaking existing Oracle configs that set it. Failing closed prevents an operator from believing an Oracle connection is authenticated when it is not.
+
+## Consequences
+
+**Breaking (intended):**
+
+- A PostgreSQL deployment that set `mode: require` + `ca:` and "worked" was connecting **unauthenticated**. It now upgrades to CA verification, so a wrong/missing/mismatched CA will now make the connection **fail** instead of silently succeeding. This is the correct behavior — review your `ca` path and server certificate before upgrading.
+- An Oracle deployment that set `database.tls.cert/key/ca` (which did nothing) now **fails validation at startup**. Remove those fields for Oracle.
+
+**Non-breaking:**
+
+- PostgreSQL configs without `cert/key/ca` are unaffected (only `sslmode` is emitted, now quoted).
+- `database.tls.mode` continues to work as before on both vendors (no-op on Oracle).
+
+See [migrations.md](migrations.md) for the upgrade note.

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -299,6 +299,25 @@ consumers must call `database.SetObservabilityEnabled(true)`.
 
 ---
 
+### [ADR-027: Wire `database.tls.cert/key/ca` Into the Drivers (Fail Closed on Oracle)](adr_027_database_tls_material.md)
+
+**Date:** 2026-06-10 | **Status:** Accepted
+
+`TLSConfig.cert/key/ca` were advertised but never consumed: the PostgreSQL DSN emitted
+only `sslmode`, so `mode: require` + `ca:` was encrypted-but-unauthenticated (MITM-able)
+and mTLS was impossible; Oracle ignored TLS entirely. PostgreSQL now wires
+`sslrootcert`/`sslcert`/`sslkey` (all values `quoteDSN`-quoted, which also closes an
+unquoted-`sslmode` DSN-injection vector); Oracle rejects `database.tls.cert/key/ca` at
+config validation (tcps/wallet not implemented) rather than silently dropping it.
+
+**Breaking:** a PostgreSQL deployment relying on the silent unauthenticated downgrade now
+upgrades to CA verification (a wrong/missing CA now fails the connection); an Oracle
+config that set `database.tls.cert/key/ca` now fails validation at startup.
+
+**Key Benefits:** TLS material is actually honored (server auth + mTLS), no silent security degradation, fail-closed on the unsupported vendor
+
+---
+
 ## ADR Lifecycle
 
 - **Proposed**: Under discussion, not yet implemented
@@ -308,7 +327,7 @@ consumers must call `database.SetObservabilityEnabled(true)`.
 
 ### Numbering Policy
 
-ADR numbers (ADR-001 through ADR-026) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
+ADR numbers (ADR-001 through ADR-027) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
 
 ## Writing New ADRs
 

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -2,6 +2,18 @@
 
 Historical migration tables for upgrading existing GoBricks-based applications. Greenfield work can ignore this file — the new APIs are the only ones documented in CLAUDE.md.
 
+## `database.tls.cert/key/ca` Now Wired Into the Drivers (ADR-027)
+
+Per [ADR-027](adr_027_database_tls_material.md), the `database.tls.cert`, `database.tls.key`, and `database.tls.ca` fields — previously advertised but never consumed — are now honored.
+
+**PostgreSQL:** the DSN now includes `sslrootcert` (ca), `sslcert` (cert), and `sslkey` (key) when set, so pgx authenticates the server and presents a client certificate for mTLS. A config that set `mode: require` + `ca:` was previously **encrypted but unauthenticated** (MITM-able); it now performs CA verification.
+
+**Action (PostgreSQL):** if you set `database.tls.ca` (or `cert`/`key`), the connection now verifies the server certificate against that CA. **A wrong, missing, or mismatched CA — or a server cert that doesn't match — will now make the connection fail** where it previously succeeded unauthenticated. Confirm the CA path and server certificate before upgrading. Configs without `cert/key/ca` are unaffected.
+
+**Oracle:** TLS via tcps/wallet is not implemented, so `database.tls.cert/key/ca` are now **rejected at startup validation** (rather than silently ignored). `database.tls.mode` alone still passes (no-op).
+
+**Action (Oracle):** remove `database.tls.cert`, `database.tls.key`, and `database.tls.ca` from Oracle configs — they never did anything and now fail validation.
+
 ## Migration `Config.DryRun` Is Now Honored
 
 `Config.DryRun` ("Only validate, do not execute") was documented and stamped into the `migration.applied` audit event, but **never consumed** — a `DryRun=true` `Migrate`/`MigrateAll` ran a real migration (mutating the schema across the whole tenant fleet) while the audit falsely recorded `dry_run=true`.


### PR DESCRIPTION
## Summary

Closes a **High-severity** finding from the 2026-06-10 audit. `config.TLSConfig` advertises `mode`/`cert`/`key`/`ca`, but only `mode` was ever consumed:

- **PostgreSQL** emitted only `sslmode`, so `mode: require` + `ca:` was **encrypted but unauthenticated** (MITM-able), and client certs (mTLS) were silently impossible.
- **Oracle** referenced TLS nowhere.
- No validation rejected the ignored fields — the degradation was completely silent.

## Fix

**PostgreSQL** — `buildPostgresDSN` now emits `sslrootcert` (ca), `sslcert` (cert), `sslkey` (key) alongside `sslmode`, every value run through `quoteDSN`. pgx loads the certs and performs verification. Quoting also closes an unquoted-`sslmode` DSN-injection vector (a separate Low finding). The migration CLI's parallel `controlPlaneDSN` builder had the identical sslmode-only gap and is fixed the same way (URL query params).

**Oracle** — tcps/wallet TLS isn't implemented, so config validation now **rejects** `database.tls.cert/key/ca` (fail closed) rather than silently ignoring it. `mode` alone still passes (no-op).

Also rejects a **half-configured** PostgreSQL client cert (`sslcert` without `sslkey` or vice versa), which pgx silently drops under `sslmode=disable`.

## ⚠️ Breaking (ADR-027)
- A PostgreSQL deployment relying on the silent unauthenticated downgrade now **upgrades to CA verification** — a wrong/missing/mismatched CA now **fails** the connection. Review your `ca` path + server cert before upgrading.
- An Oracle config setting `database.tls.cert/key/ca` now **fails validation at startup**. Remove those fields.

[ADR-027](wiki/adr_027_database_tls_material.md) + [migrations.md](wiki/migrations.md) document the upgrade.

## Verification
- `make check` green (root + tools/migration module); `make sec` (gosec) 0 issues.
- TDD: `buildPostgresDSN` TLS-material test, Oracle-rejection + mode-only tests, PG cert/key-pairing RED→GREEN, `controlPlaneDSN` full-TLS test.
- `/code-review` confirmed pgx consumes the libpq params + the quoted paths round-trip through `parseKeywordValueSettings`, and surfaced the `controlPlaneDSN` parallel gap (fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL now includes and uses configured TLS CA, client certificate, and key for DB connections.

* **Bug Fixes**
  * Validation enforces that PostgreSQL client certificate and key must be provided as a pair (both set or both empty).

* **Breaking Changes**
  * Misconfigured or mismatched PostgreSQL TLS material can cause connection failures.
  * Specifying TLS certificate/key/CA for Oracle is now rejected at startup.

* **Documentation**
  * ADR and migration notes added describing behavior and upgrade impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->