### PR TITLE
fix(database)!: bind PostgreSQL upsert update values (Oracle MERGE parity)

### DIFF
--- a/database/internal/builder/postgres.go
+++ b/database/internal/builder/postgres.go
@@ -32,14 +32,21 @@ func (qb *QueryBuilder) buildPostgreSQLUpsert(table string, conflictColumns []st
 	updateCols := sortedKeys(updateKeys)
 
 	var conflictClause string
+	var updateVals []any
 	if len(updateCols) == 0 {
 		// If no update columns are provided, do nothing on conflict
 		conflictClause = "ON CONFLICT (" + strings.Join(escapedCC, ", ") + ") DO NOTHING"
 	} else {
-		var setParts = make([]string, 0, len(updateCols))
-		for _, col := range updateCols {
+		// Bind the caller's update values as parameters rather than reusing EXCLUDED (the
+		// proposed-insert values). EXCLUDED silently ignored the updateColumns values —
+		// diverging from Oracle's MERGE — and broke update columns absent from the insert
+		// set (EXCLUDED.<not-inserted> references a non-existent column). The update
+		// placeholders continue numbering after the insert placeholders ($len(vals)+i).
+		updateVals = valuesByKeyOrder(updateKeys, updateCols)
+		setParts := make([]string, 0, len(updateCols))
+		for i, col := range updateCols {
 			escapedCol := qb.EscapeIdentifier(col)
-			setParts = append(setParts, escapedCol+" = EXCLUDED."+escapedCol)
+			setParts = append(setParts, fmt.Sprintf("%s = $%d", escapedCol, len(vals)+1+i))
 		}
 		conflictClause = "ON CONFLICT (" + strings.Join(escapedCC, ", ") + ") DO UPDATE SET " + strings.Join(setParts, ", ")
 	}
@@ -49,6 +56,9 @@ func (qb *QueryBuilder) buildPostgreSQLUpsert(table string, conflictColumns []st
 	if err != nil {
 		return "", nil, err
 	}
+
+	// Append the update values (bound by the placeholders above) after the insert args.
+	args = append(args, updateVals...)
 
 	// Append the conflict clause to the INSERT statement
 	query = sql + " " + conflictClause

--- a/database/internal/builder/postgres_test.go
+++ b/database/internal/builder/postgres_test.go
@@ -25,13 +25,42 @@ func TestBuildPostgreSQLUpsertProducesDeterministicSql(t *testing.T) {
 	sql, args, err := qb.buildPostgreSQLUpsert("users", conflictColumns, insertColumns, updateColumns)
 	require.NoError(t, err)
 
-	expectedSQL := "INSERT INTO users (\"id\",\"name\",\"updated_at\") VALUES ($1,$2,$3) ON CONFLICT (\"id\", \"tenant_id\") DO UPDATE SET \"name\" = EXCLUDED.\"name\", \"updated_at\" = EXCLUDED.\"updated_at\""
+	// The on-conflict UPDATE must bind the caller's update values ("bob"/"2023-06-01") as
+	// parameters — NOT reuse EXCLUDED (the insert values), which silently ignored them and
+	// diverged from Oracle's MERGE. Update placeholders follow the insert placeholders.
+	expectedSQL := "INSERT INTO users (\"id\",\"name\",\"updated_at\") VALUES ($1,$2,$3) ON CONFLICT (\"id\", \"tenant_id\") DO UPDATE SET \"name\" = $4, \"updated_at\" = $5"
 	if sql != expectedSQL {
 		t.Fatalf("unexpected SQL generated: %s", sql)
 	}
 
-	require.Len(t, args, 3)
-	if args[0] != 42 || args[1] != "alice" || args[2] != "2023-05-01" {
+	// Insert values first (sorted id,name,updated_at), then update values (sorted name,updated_at).
+	require.Len(t, args, 5)
+	if args[0] != 42 || args[1] != "alice" || args[2] != "2023-05-01" || args[3] != "bob" || args[4] != "2023-06-01" {
 		t.Fatalf("unexpected argument ordering: %v", args)
 	}
+}
+
+func TestBuildPostgreSQLUpsertBindsUpdateOnlyColumnAbsentFromInsert(t *testing.T) {
+	qb := NewQueryBuilder(dbtypes.PostgreSQL)
+
+	// "version" is updated but NOT inserted. Under the old EXCLUDED behavior this produced
+	// EXCLUDED."version", referencing a column absent from the insert (a runtime SQL error).
+	// Binding the value makes it valid.
+	insertColumns := map[string]any{"id": 1, "name": "a"}
+	updateColumns := map[string]any{"version": 7}
+
+	sql, args, err := qb.buildPostgreSQLUpsert("t", []string{"id"}, insertColumns, updateColumns)
+	require.NoError(t, err)
+	require.NotContains(t, sql, "EXCLUDED")
+	require.Contains(t, sql, "\"version\" = $3")
+	require.Equal(t, []any{1, "a", 7}, args)
+}
+
+func TestBuildPostgreSQLUpsertDoNothingWhenNoUpdateColumns(t *testing.T) {
+	qb := NewQueryBuilder(dbtypes.PostgreSQL)
+
+	sql, args, err := qb.buildPostgreSQLUpsert("t", []string{"id"}, map[string]any{"id": 1}, map[string]any{})
+	require.NoError(t, err)
+	require.Contains(t, sql, "DO NOTHING")
+	require.Equal(t, []any{1}, args, "no update values appended for DO NOTHING")
 }

--- a/wiki/adr_028_pg_upsert_binds_update_values.md
+++ b/wiki/adr_028_pg_upsert_binds_update_values.md
@@ -1,0 +1,46 @@
+# ADR-028: PostgreSQL `BuildUpsert` Binds Update Values (Parity With Oracle MERGE)
+
+**Status:** Accepted
+**Date:** 2026-06-10
+
+## Context
+
+`QueryBuilder.BuildUpsert(table, conflictColumns, insertColumns, updateColumns)` takes the insert values and the on-conflict update values as **two separate maps**. Oracle's `MERGE` implementation honors both: the `USING` clause binds the insert values and `WHEN MATCHED THEN UPDATE SET col = :N` binds the update values as separate parameters.
+
+The PostgreSQL implementation did not. It generated:
+
+```sql
+ON CONFLICT (...) DO UPDATE SET "col" = EXCLUDED."col"
+```
+
+`EXCLUDED` is the row *proposed for insertion*, so the on-conflict update always reused the **insert** value and **silently ignored the caller's `updateColumns` values** (a High finding from the 2026-06-10 audit). Two concrete failures:
+
+1. **Wrong data on conflict.** Insert `{count: 1}` with on-conflict update `{count: 5}` updated the row to `1`, not `5` — a silent data-integrity divergence from the same call on Oracle.
+2. **Broken update-only columns.** An update column absent from the insert set produced `EXCLUDED."col"`, which references a column not in the inserted row — a runtime SQL error.
+
+The divergence was silent: existing tests asserted only on `ON CONFLICT`/`DO UPDATE SET` substrings (or codified the `EXCLUDED` output as "expected"), never that the update values were honored.
+
+## Decision
+
+`buildPostgreSQLUpsert` now binds the `updateColumns` values as parameters, numbering the update placeholders after the insert placeholders:
+
+```sql
+INSERT INTO t ("id","name") VALUES ($1,$2)
+ON CONFLICT ("id") DO UPDATE SET "name" = $3
+```
+
+The update values are appended to the args slice after the insert values. The `DO NOTHING` path (empty `updateColumns`) is unchanged.
+
+## Consequences
+
+**Breaking (intended):**
+
+- The generated SQL changes: `DO UPDATE SET col = EXCLUDED.col` → `DO UPDATE SET col = $N`. Callers asserting on the exact SQL string must update their expectations.
+- The runtime behavior changes **only** when `updateColumns` values differ from the corresponding `insertColumns` values (or when an update column is absent from the insert set): those calls now apply the caller's intended update value (correct), where they previously applied the insert value or errored.
+
+**Non-breaking:**
+
+- The common case — `updateColumns` carrying the same values as `insertColumns` — produces the same row result as before (the bound value equals the EXCLUDED value), only via a parameter instead of `EXCLUDED`.
+- Oracle behavior is unchanged; PostgreSQL now matches it.
+
+See [migrations.md](migrations.md) for the upgrade note.

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -318,6 +318,24 @@ config that set `database.tls.cert/key/ca` now fails validation at startup.
 
 ---
 
+### [ADR-028: PostgreSQL `BuildUpsert` Binds Update Values (Parity With Oracle MERGE)](adr_028_pg_upsert_binds_update_values.md)
+
+**Date:** 2026-06-10 | **Status:** Accepted
+
+`BuildUpsert` takes separate insert/update value maps; Oracle's MERGE bound both, but the
+PostgreSQL path emitted `DO UPDATE SET col = EXCLUDED.col`, silently ignoring the caller's
+update values (updated to the *insert* value) and breaking update columns absent from the
+insert set (`EXCLUDED.<not-inserted>`). PostgreSQL now binds the update values as
+parameters (`col = $N`, numbered after the insert placeholders), matching Oracle.
+
+**Breaking:** the generated SQL changes (`EXCLUDED.col` → `$N`); runtime behavior changes
+only when update values differ from insert values (or an update column is absent from the
+insert) — those now apply the caller's intended value.
+
+**Key Benefits:** PostgreSQL/Oracle upsert parity, no silent data divergence, update-only columns work
+
+---
+
 ## ADR Lifecycle
 
 - **Proposed**: Under discussion, not yet implemented
@@ -327,7 +345,7 @@ config that set `database.tls.cert/key/ca` now fails validation at startup.
 
 ### Numbering Policy
 
-ADR numbers (ADR-001 through ADR-027) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
+ADR numbers (ADR-001 through ADR-028) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
 
 ## Writing New ADRs
 

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -2,6 +2,19 @@
 
 Historical migration tables for upgrading existing GoBricks-based applications. Greenfield work can ignore this file — the new APIs are the only ones documented in CLAUDE.md.
 
+## PostgreSQL `BuildUpsert` Now Binds Update Values (ADR-028)
+
+Per [ADR-028](adr_028_pg_upsert_binds_update_values.md), `QueryBuilder.BuildUpsert` on PostgreSQL now binds the `updateColumns` values as parameters instead of emitting `col = EXCLUDED.col`.
+
+**Before:** `ON CONFLICT (...) DO UPDATE SET "col" = EXCLUDED."col"` — the on-conflict update silently reused the *insert* value and ignored the `updateColumns` values entirely (diverging from Oracle's MERGE).
+
+**After:** `ON CONFLICT (...) DO UPDATE SET "col" = $N` — the caller's update value is bound (Oracle parity).
+
+**Action:**
+- If you assert on the exact generated SQL, update expectations (`EXCLUDED.col` → `$N`).
+- If you relied on the old behavior of updating to the *inserted* value, pass the same value in both `insertColumns` and `updateColumns` (the result is then identical).
+- Calls that passed differing update values (or update columns absent from the insert set) were silently wrong before and now apply the intended value — no action needed beyond verifying the corrected behavior is what you want.
+
 ## Outbox/Inbox Multi-Tenant Relay & Cleanup
 
 The outbox relay, outbox-cleanup, and inbox-cleanup jobs run from the scheduler's tenant-less context, so in multi-tenant mode they could not resolve any tenant's database — outbox events accumulated per tenant and were **never delivered**, and inbox ledgers were never pruned. These jobs now **fan out across the configured static tenants** (`multitenant.tenants`), resolving each tenant's database independently, so multi-tenant outbox delivery and cleanup now work.


### PR DESCRIPTION
## Summary

Closes a **High-severity** finding from the 2026-06-10 audit. `QueryBuilder.BuildUpsert(table, conflictColumns, insertColumns, updateColumns)` takes the insert and on-conflict-update values as **separate maps**. Oracle's MERGE binds both; the PostgreSQL path emitted:

```sql
ON CONFLICT (...) DO UPDATE SET "col" = EXCLUDED."col"
```

`EXCLUDED` is the proposed-insert row, so the on-conflict update **silently ignored the caller's `updateColumns` values** and reused the insert value — diverging from Oracle. Two concrete failures:
1. Insert `{count: 1}` + on-conflict update `{count: 5}` → updated to `1`, not `5` (silent data divergence).
2. An update column **absent from the insert set** → `EXCLUDED."col"` references a non-inserted column → runtime SQL error.

The divergence was silent — existing tests asserted only substrings, and the builder test codified the `EXCLUDED` output as "expected".

## Fix

`buildPostgreSQLUpsert` now binds the update values as parameters (`col = $N`), numbering the update placeholders after the insert placeholders and appending the update values to args. `DO NOTHING` (empty `updateColumns`) is unchanged. Oracle MERGE is untouched.

```sql
INSERT INTO t ("id","name") VALUES ($1,$2) ON CONFLICT ("id") DO UPDATE SET "name" = $3
```

## ⚠️ Breaking (ADR-028)
- Generated SQL changes (`EXCLUDED.col` → `$N`) — update exact-SQL assertions.
- Runtime behavior changes **only** when update values differ from insert values (or an update column is absent from the insert): those now apply the caller's intended value. To keep the old "update to inserted value" behavior, pass the same value in both maps.

[ADR-028](wiki/adr_028_pg_upsert_binds_update_values.md) + [migrations.md](wiki/migrations.md) document it.

## Verification
- `make check` green; `make sec` (gosec) 0.
- TDD: updated the builder test (RED on the `EXCLUDED` output → GREEN on bound `$N`), plus new tests for an update-only column absent from the insert and the `DO NOTHING` path.
- `/code-review` verified the placeholder numbering (`$len(vals)+1+i`), arg ordering, base offset, and Oracle isolation are all correct — returned clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL upsert now binds caller-provided update values as SQL parameters (placed after insert placeholders), ensuring update-only columns are applied and preserving DO NOTHING when no update columns.

* **Tests**
  * Added tests validating parameterized update assignments, exact argument ordering, handling of update-only columns, and DO NOTHING behavior.

* **Documentation**
  * Added ADR and migration guidance documenting the upsert SQL change and upgrade considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->