### PR TITLE
fix(app): stop inbound work before module teardown on shutdown

### DIFF
--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -323,6 +323,19 @@ func capitalizeFirst(s string) string {
 	return strings.ToUpper(string(r[0])) + string(r[1:])
 }
 
+// shutdownConsumers stops AMQP consumers from accepting NEW messages before modules are
+// torn down, so the framework stops handing fresh work to modules that are shutting down.
+// It cancels each consumer's context (which propagates to in-flight handlers) but does not
+// synchronously join them, and does NOT close the underlying connections — the
+// messaging-manager closer does that later. No-op when messaging is not configured.
+func (a *App) shutdownConsumers() {
+	if a.messagingManager == nil {
+		return
+	}
+	a.logger.Info().Msg("Stopping messaging consumers")
+	a.messagingManager.StopConsumers()
+}
+
 // shutdownManagers stops cleanup loops for database and messaging managers
 func (a *App) shutdownManagers() {
 	managerStart := time.Now()
@@ -383,12 +396,12 @@ func (a *App) Shutdown(ctx context.Context) error {
 	var errs []error
 	shutdownStart := time.Now()
 
-	// Shutdown modules first
-	a.shutdownPhase("modules", func() error {
-		return a.registry.Shutdown()
-	}, &errs)
+	// Order matters. Stop inbound work BEFORE tearing down what it depends on, so the
+	// framework stops handing new HTTP requests and AMQP messages to modules/resources that
+	// are shutting down (the previous order shut modules down first, while the server was
+	// still serving and consumers still delivering — so handlers ran against dead modules).
 
-	// Shutdown server
+	// 1. Stop accepting new HTTP requests; the server drains its in-flight handlers within ctx.
 	if a.server != nil {
 		a.shutdownPhase("HTTP server", func() error {
 			if err := a.server.Shutdown(ctx); err != nil {
@@ -398,13 +411,23 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}, &errs)
 	}
 
-	// Flush and shutdown observability (export pending telemetry)
+	// 2. Stop AMQP consumers from accepting new messages (connections are closed later via
+	//    the messaging-manager closer). Done before module shutdown so the framework stops
+	//    delivering fresh messages to modules that are about to be torn down.
+	a.shutdownConsumers()
+
+	// 3. Shut down modules — now that no HTTP or AMQP handler is running.
+	a.shutdownPhase("modules", func() error {
+		return a.registry.Shutdown()
+	}, &errs)
+
+	// 4. Flush and shutdown observability (export pending telemetry).
 	a.shutdownObservability(ctx, &errs)
 
-	// Stop cleanup loops for managers
+	// 5. Stop cleanup loops for managers.
 	a.shutdownManagers()
 
-	// Close remaining resources
+	// 6. Close remaining resources (DB pools, messaging connections, etc.).
 	a.shutdownClosers(&errs)
 
 	a.logger.Info().Dur("total_duration", time.Since(shutdownStart)).Msg("Application shutdown complete")

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -416,7 +416,8 @@ func (a *App) Shutdown(ctx context.Context) error {
 	//    delivering fresh messages to modules that are about to be torn down.
 	a.shutdownConsumers()
 
-	// 3. Shut down modules — now that no HTTP or AMQP handler is running.
+	// 3. Shut down modules — no new HTTP requests or AMQP deliveries are admitted at this
+	//    point. AMQP handlers already in flight may still be unwinding after cancellation.
 	a.shutdownPhase("modules", func() error {
 		return a.registry.Shutdown()
 	}, &errs)

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -94,8 +94,9 @@ func TestShutdownStopsServerBeforeModules(t *testing.T) {
 
 	require.NoError(t, fixture.app.Shutdown(context.Background()))
 
-	// The HTTP server must be drained before modules are torn down, so in-flight request
-	// handlers complete against live modules rather than half-shut-down ones.
+	// The HTTP server must be shut down before modules are torn down: http.Server.Shutdown
+	// synchronously drains in-flight HTTP handlers, so they finish against live modules
+	// rather than racing module teardown.
 	assert.Equal(t, 1, serverShutdownsAtModuleTeardown,
 		"server must shut down before modules")
 }

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -67,6 +67,39 @@ func TestShutdownTimeouts(t *testing.T) {
 	}
 }
 
+// recordingModule runs a hook when its Shutdown is invoked, letting tests observe what
+// other shutdown phases have already run at module-teardown time.
+type recordingModule struct {
+	onShutdown func()
+}
+
+func (recordingModule) Name() string           { return "recording" }
+func (recordingModule) Init(*ModuleDeps) error { return nil }
+func (m recordingModule) Shutdown() error {
+	if m.onShutdown != nil {
+		m.onShutdown()
+	}
+	return nil
+}
+
+func TestShutdownStopsServerBeforeModules(t *testing.T) {
+	fixture := newTestAppFixture(t)
+	fixture.messaging.ExpectClose(nil)
+	fixture.db.On(methodClose).Return(nil)
+
+	serverShutdownsAtModuleTeardown := -1
+	require.NoError(t, fixture.app.registry.Register(&recordingModule{onShutdown: func() {
+		serverShutdownsAtModuleTeardown = fixture.server.shutdownCount()
+	}}))
+
+	require.NoError(t, fixture.app.Shutdown(context.Background()))
+
+	// The HTTP server must be drained before modules are torn down, so in-flight request
+	// handlers complete against live modules rather than half-shut-down ones.
+	assert.Equal(t, 1, serverShutdownsAtModuleTeardown,
+		"server must shut down before modules")
+}
+
 func TestShutdownTiming(t *testing.T) {
 	// Test that the shutdown process completes within reasonable time
 	cfg := &config.Config{

--- a/messaging/manager.go
+++ b/messaging/manager.go
@@ -438,7 +438,6 @@ func (m *Manager) cleanupIdlePublishers() {
 	}
 }
 
-// Close closes all clients and stops cleanup
 // StopConsumers stops every consumer registry from accepting new messages (cancelling their
 // consume contexts) WITHOUT closing the underlying AMQP connections — Close does that. The
 // framework calls this during shutdown before tearing down modules so it stops delivering
@@ -456,6 +455,7 @@ func (m *Manager) StopConsumers() {
 	}
 }
 
+// Close closes all clients and stops cleanup.
 func (m *Manager) Close() error {
 	m.StopCleanup()
 

--- a/messaging/manager.go
+++ b/messaging/manager.go
@@ -439,6 +439,23 @@ func (m *Manager) cleanupIdlePublishers() {
 }
 
 // Close closes all clients and stops cleanup
+// StopConsumers stops every consumer registry from accepting new messages (cancelling their
+// consume contexts) WITHOUT closing the underlying AMQP connections — Close does that. The
+// framework calls this during shutdown before tearing down modules so it stops delivering
+// fresh messages to modules that are about to shut down. Cancellation propagates to in-flight
+// handlers via their context, but they are not synchronously joined here. Idempotent:
+// Registry.StopConsumers guards on its active flag, so a subsequent Close (which also stops
+// consumers) is safe.
+func (m *Manager) StopConsumers() {
+	m.consMu.Lock()
+	defer m.consMu.Unlock()
+	for _, entry := range m.consumers {
+		if entry.registry != nil {
+			entry.registry.StopConsumers()
+		}
+	}
+}
+
 func (m *Manager) Close() error {
 	m.StopCleanup()
 

--- a/messaging/manager_test.go
+++ b/messaging/manager_test.go
@@ -103,6 +103,26 @@ func (s *stubAMQPClient) IsReady() bool {
 	return !s.closed
 }
 
+func TestManagerStopConsumersStopsRegistriesWithoutClosing(t *testing.T) {
+	log := logger.New("error", false)
+	cancelled := false
+	reg := &Registry{logger: log, consumersActive: true, cancelConsumers: func() { cancelled = true }}
+	client := &stubAMQPClient{}
+	m := &Manager{
+		logger:    log,
+		consumers: map[string]*consumerEntry{"": {client: client, registry: reg}},
+	}
+
+	m.StopConsumers()
+
+	assert.True(t, cancelled, "consume context must be cancelled so no new messages are delivered")
+	assert.False(t, reg.consumersActive, "registry must mark consumers stopped")
+	assert.False(t, client.closed, "StopConsumers must NOT close the AMQP connection — Close does that later")
+
+	// Idempotent: a second call must be a safe no-op (Close also stops consumers).
+	require.NotPanics(t, m.StopConsumers)
+}
+
 func TestMessagingManagerCachesPublishersPerKey(t *testing.T) {
 	ctx := context.Background()
 	log := logger.New("error", false)

--- a/wiki/adr_029_graceful_shutdown_order.md
+++ b/wiki/adr_029_graceful_shutdown_order.md
@@ -1,0 +1,41 @@
+# ADR-029: Graceful Shutdown Phase Ordering (Stop Inbound Work Before Teardown)
+
+**Status:** Accepted
+**Date:** 2026-06-10
+
+## Context
+
+`App.Shutdown` tore phases down in this order:
+
+1. **modules** (`registry.Shutdown()`)
+2. HTTP server (`server.Shutdown`)
+3. observability flush/shutdown
+4. manager cleanup loops
+5. closers (DB pools, **messaging connections — which is where consumers were stopped**, inside `Manager.Close()`)
+
+So modules were shut down **first**, while the HTTP server was still serving requests and AMQP consumers were still delivering messages. In-flight HTTP handlers and message handlers then ran against **already-shut-down modules** — nil services, closed caches, released resources — producing panics and errors precisely during the shutdown window (a High finding from the 2026-06-10 audit). The longer module/observability/closer teardown took, the wider the window in which consumers kept handing work to dead modules.
+
+## Decision
+
+Reorder `App.Shutdown` to stop **inbound work first**, then tear down what it depends on:
+
+1. **HTTP server** — stop accepting new requests; drain in-flight handlers.
+2. **AMQP consumers** — stop delivering new messages (new `App.shutdownConsumers()` → `Manager.StopConsumers()`), *without* closing connections.
+3. **modules** — now safe; no HTTP or AMQP handler is running.
+4. **observability** — flush and shut down.
+5. **manager cleanup loops**, then **closers** (DB pools, messaging connections).
+
+`Manager.StopConsumers()` is a new public method that cancels each consumer registry's consume context (idempotent — `Registry.StopConsumers` guards on its active flag) without closing the AMQP clients. `Manager.Close()` (run later via the messaging-manager closer) still stops consumers and closes connections, so the two compose safely.
+
+## Consequences
+
+**Behavioral change (not an API break):**
+
+- Shutdown now drains the HTTP server and stops consumers **before** modules are torn down. Applications whose module `Shutdown()` implicitly relied on the server still serving, or on consumers still running, will see the corrected order. No application code must change; `Manager.StopConsumers` is purely additive.
+- The framework stops handing **new** HTTP requests and AMQP messages to modules before they shut down — closing the dominant race (a message pulled and handled entirely against a shut-down module during a slow shutdown). `Manager.StopConsumers` cancels each consumer's context, which propagates to in-flight handlers, but does **not** synchronously join them; a handler already executing at the moment of cancellation may still briefly overlap module teardown. A fully synchronous drain (joining worker goroutines, with a bounded deadline so a stuck handler cannot hang shutdown) is possible future work.
+
+**Additive API:**
+
+- `messaging.Manager` gains `StopConsumers()` for callers that want to quiesce consumers without tearing down the manager.
+
+See [migrations.md](migrations.md) for the operator-facing note.

--- a/wiki/adr_029_graceful_shutdown_order.md
+++ b/wiki/adr_029_graceful_shutdown_order.md
@@ -21,7 +21,7 @@ Reorder `App.Shutdown` to stop **inbound work first**, then tear down what it de
 
 1. **HTTP server** — stop accepting new requests; drain in-flight handlers.
 2. **AMQP consumers** — stop delivering new messages (new `App.shutdownConsumers()` → `Manager.StopConsumers()`), *without* closing connections.
-3. **modules** — now safe; no HTTP or AMQP handler is running.
+3. **modules** — no new HTTP requests or AMQP deliveries are admitted; in-flight handlers may still be unwinding after cancellation, but no fresh work is handed to modules being torn down.
 4. **observability** — flush and shut down.
 5. **manager cleanup loops**, then **closers** (DB pools, messaging connections).
 

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -343,8 +343,8 @@ insert) — those now apply the caller's intended value.
 `App.Shutdown` tore down modules **first**, while the HTTP server was still serving and AMQP
 consumers were still delivering — so in-flight handlers ran against already-shut-down modules
 (shutdown-window panics). Reordered to stop inbound work first: **server → consumers →
-modules → observability → closers**, with a new additive `Manager.StopConsumers()` that
-quiesces consumers (idempotent) without closing connections.
+modules → observability → manager cleanup loops → closers**, with a new additive
+`Manager.StopConsumers()` that quiesces consumers (idempotent) without closing connections.
 
 **Behavioral change (not an API break):** the framework stops admitting new HTTP requests and
 AMQP deliveries before modules are torn down (consumers are cancelled, not synchronously

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -336,6 +336,23 @@ insert) — those now apply the caller's intended value.
 
 ---
 
+### [ADR-029: Graceful Shutdown Phase Ordering (Stop Inbound Work Before Teardown)](adr_029_graceful_shutdown_order.md)
+
+**Date:** 2026-06-10 | **Status:** Accepted
+
+`App.Shutdown` tore down modules **first**, while the HTTP server was still serving and AMQP
+consumers were still delivering — so in-flight handlers ran against already-shut-down modules
+(shutdown-window panics). Reordered to stop inbound work first: **server → consumers →
+modules → observability → closers**, with a new additive `Manager.StopConsumers()` that
+quiesces consumers (idempotent) without closing connections.
+
+**Behavioral change (not an API break):** in-flight HTTP/AMQP handlers now complete against
+live modules; no application code must change. `messaging.Manager.StopConsumers()` is additive.
+
+**Key Benefits:** No shutdown-window panics, in-flight work drains against live modules, consumer-quiesce hook
+
+---
+
 ## ADR Lifecycle
 
 - **Proposed**: Under discussion, not yet implemented
@@ -345,7 +362,7 @@ insert) — those now apply the caller's intended value.
 
 ### Numbering Policy
 
-ADR numbers (ADR-001 through ADR-028) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
+ADR numbers (ADR-001 through ADR-029) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
 
 ## Writing New ADRs
 

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -346,8 +346,10 @@ consumers were still delivering — so in-flight handlers ran against already-sh
 modules → observability → closers**, with a new additive `Manager.StopConsumers()` that
 quiesces consumers (idempotent) without closing connections.
 
-**Behavioral change (not an API break):** in-flight HTTP/AMQP handlers now complete against
-live modules; no application code must change. `messaging.Manager.StopConsumers()` is additive.
+**Behavioral change (not an API break):** the framework stops admitting new HTTP requests and
+AMQP deliveries before modules are torn down (consumers are cancelled, not synchronously
+joined, so in-flight handlers may briefly overlap teardown); no application code must change.
+`messaging.Manager.StopConsumers()` is additive.
 
 **Key Benefits:** No shutdown-window panics, in-flight work drains against live modules, consumer-quiesce hook
 

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -2,6 +2,15 @@
 
 Historical migration tables for upgrading existing GoBricks-based applications. Greenfield work can ignore this file — the new APIs are the only ones documented in CLAUDE.md.
 
+## Graceful Shutdown Now Stops Inbound Work First (ADR-029)
+
+Per [ADR-029](adr_029_graceful_shutdown_order.md), `App.Shutdown` reordered its phases. **Before:** modules were torn down first, while the HTTP server was still serving and AMQP consumers were still delivering — so in-flight handlers could run against already-shut-down modules (panics/errors during the shutdown window). **After:** `server → consumers → modules → observability → closers`.
+
+**No code or config change is required** — this is an internal behavioral correction. Two things to be aware of:
+
+- If a module's `Shutdown()` implicitly relied on the HTTP server still serving or on consumers still delivering, it will now see the corrected order (server drained and consumers stopped before module teardown). This was the buggy case the reorder fixes.
+- `messaging.Manager` gains an additive `StopConsumers()` method (quiesce consumers without closing connections); existing code is unaffected.
+
 ## PostgreSQL `BuildUpsert` Now Binds Update Values (ADR-028)
 
 Per [ADR-028](adr_028_pg_upsert_binds_update_values.md), `QueryBuilder.BuildUpsert` on PostgreSQL now binds the `updateColumns` values as parameters instead of emitting `col = EXCLUDED.col`.

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -4,7 +4,7 @@ Historical migration tables for upgrading existing GoBricks-based applications. 
 
 ## Graceful Shutdown Now Stops Inbound Work First (ADR-029)
 
-Per [ADR-029](adr_029_graceful_shutdown_order.md), `App.Shutdown` reordered its phases. **Before:** modules were torn down first, while the HTTP server was still serving and AMQP consumers were still delivering — so in-flight handlers could run against already-shut-down modules (panics/errors during the shutdown window). **After:** `server → consumers → modules → observability → closers`.
+Per [ADR-029](adr_029_graceful_shutdown_order.md), `App.Shutdown` reordered its phases. **Before:** modules were torn down first, while the HTTP server was still serving and AMQP consumers were still delivering — so in-flight handlers could run against already-shut-down modules (panics/errors during the shutdown window). **After:** `server → consumers → modules → observability → manager cleanup loops → closers`.
 
 **No code or config change is required** — this is an internal behavioral correction. Two things to be aware of:
 


### PR DESCRIPTION
## Summary

Closes the final **High-severity** finding from the 2026-06-10 audit. `App.Shutdown` tore down **modules first**, while the HTTP server was still serving and AMQP consumers were still delivering (consumers stopped only at the very end inside `Manager.Close`). In-flight HTTP and message handlers therefore ran against **already-shut-down modules** — nil services, closed caches — producing panics/errors during the shutdown window.

## Fix

Reorder the phases to stop inbound work first:

```
server.Shutdown → stop consumers → modules → observability → manager cleanup → closers
```

Adds `App.shutdownConsumers()` backed by a new additive `messaging.Manager.StopConsumers()`, which cancels each consumer registry's consume context (idempotent — `Close` still stops + closes consumers) **without** closing connections.

This stops the framework from handing **new** HTTP requests and AMQP messages to modules that are about to shut down — closing the dominant race. Cancellation propagates to in-flight handlers via their context but does not synchronously join them (a bounded synchronous drain is noted as **future work** in ADR-029).

## Classification: behavioral change, not an API break
No application code must change; `messaging.Manager.StopConsumers()` is purely additive. [ADR-029](wiki/adr_029_graceful_shutdown_order.md) + [migrations.md](wiki/migrations.md) document the reordered lifecycle.

## Verification
- `make check` green; `make sec` (gosec) 0.
- TDD: RED→GREEN order test (`recordingModule` asserts the HTTP server is already shut down when modules tear down), plus a `Manager.StopConsumers` unit test (stops consumers, leaves connections open, idempotent).
- `/code-review` confirmed idempotency (the `consumersActive` guard), no lock-order inversion vs `Close`, nil-safety, preserved error aggregation, no other old-order shutdown paths — and flagged that the original comments over-claimed a synchronous "drain"; wording corrected across code + ADR to state the actual guarantee (stops *new* work; in-flight handlers are not synchronously joined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shutdown now halts inbound work (HTTP draining, then message intake) before tearing down modules to avoid in-flight handlers running against shut-down components.

* **New Features**
  * Added ability to quiesce message consumers (stop intake) without closing underlying connections so intake can be stopped earlier in shutdown.

* **Tests**
  * Added tests verifying server shutdown precedes module shutdown and consumer quiescing is idempotent and doesn't close clients.

* **Documentation**
  * Updated ADRs and migration notes describing the revised graceful-shutdown ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->