### PR TITLE
fix(lint): enable correctness linters and fix surfaced defects

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,30 +3,44 @@ run:
   tests: true
 linters:
   enable:
-    - bodyclose          # checks whether HTTP response body is closed successfully
-    - dogsled            # checks assignments with too many blank identifiers
-    - dupl               # code clone detection  
-    - errcheck           # checks for unchecked errors
-    - exhaustive         # checks exhaustiveness of enum switch statements
-    - gochecknoinits     # checks that no init functions are present
-    - goconst            # finds repeated strings that could be replaced by a constant
-    - gocritic           # provides diagnostics that check for bugs, performance and style issues
-    - gocyclo            # computes and checks the cyclomatic complexity of functions
-    - goprintffuncname   # checks that printf-like functions are named with f at the end
-    - gosec              # inspects source code for security problems
-    - govet              # reports suspicious constructs (go vet)
-    - ineffassign        # detects when assignments to existing variables are not used
-    - lll                # reports long lines
-    - nakedret           # finds naked returns in functions greater than a specified function length
-    - noctx              # finds sending HTTP request without context.Context
-    - nolintlint         # reports ill-formed or insufficient nolint directives
-    - prealloc           # finds slice declarations that could potentially be preallocated
-    - revive             # fast, configurable, extensible, flexible, and beautiful linter for Go
-    - rowserrcheck       # checks whether Err of rows is checked successfully
-    - staticcheck        # staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - unconvert          # removes unnecessary type conversions
-    - unparam            # reports unused function parameters
-    - whitespace         # detection of leading and trailing whitespace
+    - bodyclose                 # checks whether HTTP response body is closed successfully
+    - copyloopvar               # checks for unnecessary loop-variable copies (Go 1.22+ per-iteration vars)
+    - dogsled                   # checks assignments with too many blank identifiers
+    - dupl                      # code clone detection
+    - durationcheck             # checks for two durations multiplied together
+    - errcheck                  # checks for unchecked errors
+    - errname                   # checks that error variables/types follow the errFoo/FooError convention
+    - errorlint                 # finds code that may cause problems with the Go 1.13 error wrapping scheme
+    - exhaustive                # checks exhaustiveness of enum switch statements
+    - gocheckcompilerdirectives # validates go compiler directive comments (//go:)
+    - gochecknoinits            # checks that no init functions are present
+    - goconst                   # finds repeated strings that could be replaced by a constant
+    - gocritic                  # provides diagnostics that check for bugs, performance and style issues
+    - gocyclo                   # computes and checks the cyclomatic complexity of functions
+    - goprintffuncname          # checks that printf-like functions are named with f at the end
+    - gosec                     # inspects source code for security problems
+    - govet                     # reports suspicious constructs (go vet)
+    - ineffassign               # detects when assignments to existing variables are not used
+    - lll                       # reports long lines
+    - loggercheck               # checks key-value pairs for common logger libraries (zap, zerolog, ...)
+    - makezero                  # finds slice declarations with non-zero initial length used with append
+    - misspell                  # finds commonly misspelled English words in comments
+    - musttag                   # enforces field tags in (un)marshaled structs
+    - nakedret                  # finds naked returns in functions greater than a specified function length
+    - nilerr                    # finds code that returns nil even if it checks that the error is not nil
+    - noctx                     # finds sending HTTP request without context.Context
+    - nolintlint                # reports ill-formed or insufficient nolint directives
+    - prealloc                  # finds slice declarations that could potentially be preallocated
+    - revive                    # fast, configurable, extensible, flexible, and beautiful linter for Go
+    - rowserrcheck              # checks whether Err of rows is checked successfully
+    - spancheck                 # checks for mistakes with OpenTelemetry/Census spans
+    - sqlclosecheck             # checks that sql.Rows and sql.Stmt are closed
+    - staticcheck               # staticcheck is a go vet on steroids, applying a ton of static analysis checks
+    - unconvert                 # removes unnecessary type conversions
+    - unparam                   # reports unused function parameters
+    - wastedassign              # finds wasted assignment statements
+    - whitespace                # detection of leading and trailing whitespace
+    - zerologlint               # detects the wrong usage of zerolog that a user forgets to dispatch with Send or Msg
   settings:
     dupl:
       threshold: 100
@@ -50,13 +64,8 @@ linters:
     gocyclo:
       min-complexity: 15
     govet:
-      settings:
-        printf:
-          funcs:
-            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+      enable:
+        - shadow  # reports shadowed variables (disabled by default)
     lll:
       line-length: 215
     misspell:
@@ -92,25 +101,17 @@ linters:
           - gosec
           - ineffassign
           - rowserrcheck
-          - govet  # Allow unkeyed bson.D fields in tests
         path: _test\.go
-      - linters:
-          - gocyclo
-          - ineffassign
-        path: pkg/mock/
       - linters:
           - lll
         source: '^//go:generate '
       - linters:
           - staticcheck
         text: 'SA9003:'
+      # zerologlint cannot follow the LogEventAdapter wrapper which dispatches via its own Send/Msg
       - linters:
-          - ineffassign
-        path: cmd/.*/main\.go
-      - linters:
-          - gocyclo
-        path: pkg/parser/
-        text: cyclomatic complexity
+          - zerologlint
+        path: logger/adapter\.go
       # Intentional "testing" subpackages for test utilities (imported with aliases)
       - linters:
           - revive

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ docker-check: ## Check if Docker is available
 	@docker info >/dev/null 2>&1 || (echo "Error: Docker is not running. Integration tests require Docker Desktop or Docker daemon." && echo "Install Docker: https://www.docker.com/products/docker-desktop" && exit 1)
 
 lint: ## Run golangci-lint (pinned v2.12.2 + GOWORK=off, mirroring CI lint-framework's mechanism)
-	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) cache clean
-	GOWORK=off go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run
+	GOWORK=off go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) cache clean
+	GOWORK=off go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run --timeout=5m
 
 fmt: ## Format Go code
 	go fmt ./...

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ GOVULNCHECK_VERSION := v1.3.0
 # Keep in sync with the other module's Makefile.
 # renovate: datasource=go depName=github.com/securego/gosec/v2
 GOSEC_VERSION := v2.27.1
+# Keep in sync with the other module's Makefile and CI (ci-v2.yml golangci-lint-action version).
+# renovate: datasource=go depName=github.com/golangci/golangci-lint/v2
+GOLANGCI_LINT_VERSION := v2.12.2
 # Default target
 help: ## Show this help message
 	@echo "Available targets:"
@@ -57,9 +60,9 @@ coverage-report: ## Generate HTML coverage report from coverage.out
 docker-check: ## Check if Docker is available
 	@docker info >/dev/null 2>&1 || (echo "Error: Docker is not running. Integration tests require Docker Desktop or Docker daemon." && echo "Install Docker: https://www.docker.com/products/docker-desktop" && exit 1)
 
-lint: ## Run golangci-lint
-	golangci-lint cache clean
-	golangci-lint run
+lint: ## Run golangci-lint (pinned + GOWORK=off; identical to CI lint-framework)
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) cache clean
+	GOWORK=off go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run
 
 fmt: ## Format Go code
 	go fmt ./...

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ coverage-report: ## Generate HTML coverage report from coverage.out
 docker-check: ## Check if Docker is available
 	@docker info >/dev/null 2>&1 || (echo "Error: Docker is not running. Integration tests require Docker Desktop or Docker daemon." && echo "Install Docker: https://www.docker.com/products/docker-desktop" && exit 1)
 
-lint: ## Run golangci-lint (pinned + GOWORK=off; identical to CI lint-framework)
+lint: ## Run golangci-lint (pinned v2.12.2 + GOWORK=off, mirroring CI lint-framework's mechanism)
 	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) cache clean
 	GOWORK=off go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run
 

--- a/app/bootstrap_test.go
+++ b/app/bootstrap_test.go
@@ -283,8 +283,8 @@ observability:
 	originalDir, err := os.Getwd()
 	require.NoError(t, err)
 	defer func() {
-		err := os.Chdir(originalDir)
-		require.NoError(t, err)
+		cerr := os.Chdir(originalDir)
+		require.NoError(t, cerr)
 	}()
 
 	err = os.Chdir(tmpDir)
@@ -388,8 +388,8 @@ observability:
 	originalDir, err := os.Getwd()
 	require.NoError(t, err)
 	defer func() {
-		err := os.Chdir(originalDir)
-		require.NoError(t, err)
+		cerr := os.Chdir(originalDir)
+		require.NoError(t, cerr)
 	}()
 
 	err = os.Chdir(tmpDir)
@@ -470,8 +470,8 @@ observability:
 	originalDir, err := os.Getwd()
 	require.NoError(t, err)
 	defer func() {
-		err := os.Chdir(originalDir)
-		require.NoError(t, err)
+		cerr := os.Chdir(originalDir)
+		require.NoError(t, cerr)
 	}()
 
 	err = os.Chdir(tmpDir)
@@ -529,8 +529,8 @@ debug:
 	originalDir, err := os.Getwd()
 	require.NoError(t, err)
 	defer func() {
-		err := os.Chdir(originalDir)
-		require.NoError(t, err)
+		cerr := os.Chdir(originalDir)
+		require.NoError(t, cerr)
 	}()
 
 	err = os.Chdir(tmpDir)

--- a/app/debug_handlers_test.go
+++ b/app/debug_handlers_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gaborage/go-bricks/config"
 	"github.com/gaborage/go-bricks/logger"
@@ -104,9 +105,8 @@ func TestIPWhitelistMiddlewareTrustedProxy(t *testing.T) {
 			} else {
 				assert.Error(t, err)
 				var httpErr *echo.HTTPError
-				if errors.As(err, &httpErr) {
-					assert.Equal(t, tc.wantStatus, httpErr.Code)
-				}
+				require.True(t, errors.As(err, &httpErr))
+				assert.Equal(t, tc.wantStatus, httpErr.Code)
 			}
 		})
 	}
@@ -206,9 +206,8 @@ func TestAuthMiddleware(t *testing.T) {
 
 				// Check if it's an echo.HTTPError
 				var httpErr *echo.HTTPError
-				if errors.As(err, &httpErr) {
-					assert.Equal(t, tt.expectedStatusCode, httpErr.Code)
-				}
+				require.True(t, errors.As(err, &httpErr))
+				assert.Equal(t, tt.expectedStatusCode, httpErr.Code)
 			}
 		})
 	}
@@ -265,9 +264,8 @@ func TestAuthMiddlewareConstantTimeComparison(t *testing.T) {
 			} else {
 				assert.Error(t, err)
 				var httpErr *echo.HTTPError
-				if errors.As(err, &httpErr) {
-					assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
-				}
+				require.True(t, errors.As(err, &httpErr))
+				assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
 			}
 		})
 	}

--- a/app/debug_handlers_test.go
+++ b/app/debug_handlers_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -102,7 +103,8 @@ func TestIPWhitelistMiddlewareTrustedProxy(t *testing.T) {
 				assert.Equal(t, http.StatusOK, rec.Code)
 			} else {
 				assert.Error(t, err)
-				if httpErr, ok := err.(*echo.HTTPError); ok {
+				var httpErr *echo.HTTPError
+				if errors.As(err, &httpErr) {
 					assert.Equal(t, tc.wantStatus, httpErr.Code)
 				}
 			}
@@ -203,7 +205,8 @@ func TestAuthMiddleware(t *testing.T) {
 				assert.Error(t, err)
 
 				// Check if it's an echo.HTTPError
-				if httpErr, ok := err.(*echo.HTTPError); ok {
+				var httpErr *echo.HTTPError
+				if errors.As(err, &httpErr) {
 					assert.Equal(t, tt.expectedStatusCode, httpErr.Code)
 				}
 			}
@@ -261,7 +264,8 @@ func TestAuthMiddlewareConstantTimeComparison(t *testing.T) {
 				assert.Equal(t, http.StatusOK, rec.Code)
 			} else {
 				assert.Error(t, err)
-				if httpErr, ok := err.(*echo.HTTPError); ok {
+				var httpErr *echo.HTTPError
+				if errors.As(err, &httpErr) {
 					assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
 				}
 			}

--- a/app/prewarm.go
+++ b/app/prewarm.go
@@ -46,7 +46,7 @@ func (w *ConnectionPreWarmer) PreWarmSingleTenant(
 
 	// Return combined errors but don't fail startup
 	if len(errs) > 0 {
-		return fmt.Errorf("pre-warming issues (non-fatal): %v", errors.Join(errs...))
+		return fmt.Errorf("pre-warming issues (non-fatal): %w", errors.Join(errs...))
 	}
 
 	return nil

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -425,8 +425,8 @@ func TestCacheManagerIdleCleanup(t *testing.T) {
 		for {
 			select {
 			case <-ticker.C:
-				_, err := mgr.Get(ctx, tenantOne)
-				if err != nil {
+				_, gerr := mgr.Get(ctx, tenantOne)
+				if gerr != nil {
 					return // Manager may be closed during test cleanup
 				}
 			case <-done:
@@ -882,9 +882,9 @@ func TestCacheManagerConcurrentAccessDuringClose(t *testing.T) {
 	// Start a goroutine that will trigger eviction (slow close)
 	go func() {
 		// Triggers eviction of tenant-1 (200ms close) - error intentionally ignored in background goroutine
-		if _, err := mgr.Get(ctx, tenantThree); err != nil {
+		if _, gerr := mgr.Get(ctx, tenantThree); gerr != nil {
 			// Log but don't fail - background operation
-			t.Logf("background Get error (may be expected during cleanup): %v", err)
+			t.Logf("background Get error (may be expected during cleanup): %v", gerr)
 		}
 	}()
 
@@ -961,14 +961,14 @@ func TestCacheManagerConcurrentRemoveDuringGet(t *testing.T) {
 			// These should all complete quickly - errors ignored as concurrent operations may race
 			stats := mgr.Stats()
 			_ = stats // intentionally unused - just checking non-blocking behavior
-			c2, err := mgr.Get(ctx, tenantTwo)
-			if err != nil {
+			c2, gerr := mgr.Get(ctx, tenantTwo)
+			if gerr != nil {
 				t.Fail()
 			}
 			_ = c2 // intentionally unused
 
-			c3, err := mgr.Get(ctx, tenantThree)
-			if err != nil {
+			c3, gerr := mgr.Get(ctx, tenantThree)
+			if gerr != nil {
 				t.Fail()
 			}
 

--- a/config/injection.go
+++ b/config/injection.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -65,7 +66,8 @@ func (c *Config) InjectInto(target any) error {
 		// Set field value based on config
 		if err := c.setFieldValue(field, configKey, required, defaultValue, hasDefault); err != nil {
 			// Enhance error with field name if not already present
-			if cerr, ok := err.(*ConfigError); ok && cerr.Field == configKey {
+			var cerr *ConfigError
+			if errors.As(err, &cerr) && cerr.Field == configKey {
 				return err
 			}
 			return fmt.Errorf("field %s: %w", fieldType.Name, err)

--- a/database/internal/builder/filter.go
+++ b/database/internal/builder/filter.go
@@ -202,7 +202,7 @@ func (ff *FilterFactory) NotRegexI(column, pattern string) dbtypes.Filter {
 //
 // On PostgreSQL emits "column @> ?::jsonb" with the value JSON-encoded.
 // Strings, []byte, and json.RawMessage are passed through as-is (assumed
-// already-valid JSON); everything else is marshalled via encoding/json so
+// already-valid JSON); everything else is marshaled via encoding/json so
 // callers can pass structs, maps, or slices directly.
 //
 // Oracle is not yet supported and returns a filter that surfaces an error

--- a/database/internal/builder/query_builder.go
+++ b/database/internal/builder/query_builder.go
@@ -480,9 +480,9 @@ func (qb *QueryBuilder) BuildRegex(column, pattern string, caseInsensitive, nega
 
 // BuildJSONContains creates a JSON containment expression.
 //
-// PostgreSQL emits "column @> ?::jsonb" with the value marshalled to JSON.
+// PostgreSQL emits "column @> ?::jsonb" with the value marshaled to JSON.
 // Strings, []byte, and json.RawMessage values are passed through as-is
-// (caller-provided JSON); other values are marshalled via encoding/json so
+// (caller-provided JSON); other values are marshaled via encoding/json so
 // that callers can pass structs, maps, or slices directly.
 //
 // Oracle has no clean equivalent (JSON_EQUAL is exact-equality, JSON_EXISTS

--- a/database/internal/columns/metadata_test.go
+++ b/database/internal/columns/metadata_test.go
@@ -389,7 +389,7 @@ func TestColumnMetadataMultipleAliasesPanic(t *testing.T) {
 	})
 }
 
-// TestAsPanicsOnEmptyAlias pins the documented fail-fast behaviour: the
+// TestAsPanicsOnEmptyAlias pins the documented fail-fast behavior: the
 // As() helper panics rather than returning an unaliased clone, so a
 // caller passing an empty string sees the bug at development time.
 func TestAsPanicsOnEmptyAlias(t *testing.T) {

--- a/database/internal/columns/registry.go
+++ b/database/internal/columns/registry.go
@@ -114,8 +114,8 @@ func (cr *ColumnRegistry) getOrCreateVendorCache(vendor string) *vendorCache {
 	defer cr.mu.Unlock()
 
 	// Double-check: another goroutine might have created it
-	if cache, ok := cr.vendorCaches[vendor]; ok {
-		return cache
+	if existing, ok := cr.vendorCaches[vendor]; ok {
+		return existing
 	}
 
 	// Create new vendor cache

--- a/database/internal/tracking/connection_test.go
+++ b/database/internal/tracking/connection_test.go
@@ -181,6 +181,7 @@ func TestNewDBQueryContextTracksOperations(t *testing.T) {
 	if rows == nil {
 		t.Fatalf("expected rows result")
 	}
+	defer rows.Close()
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf(unmetExpectationsErrMsg, err)

--- a/database/internal/tracking/metrics.go
+++ b/database/internal/tracking/metrics.go
@@ -440,7 +440,12 @@ type poolMetricsRegistration struct {
 func (r *poolMetricsRegistration) observePoolStats(_ context.Context, observer metric.Observer) error {
 	stats, err := r.conn.Stats()
 	if err != nil {
-		return nil // Best-effort - don't fail metrics collection
+		// Best-effort: log the failure but return nil so a transient Stats() error
+		// (e.g. a closed pool) does not poison the whole metrics-collection batch.
+		// Returning the error here would propagate through Reader.Collect and abort
+		// every other observable in the same callback cycle.
+		logMetricError("pool_metrics_stats", err)
+		return nil
 	}
 
 	ps := extractPoolStats(stats)

--- a/database/internal/tracking/statement_test.go
+++ b/database/internal/tracking/statement_test.go
@@ -89,6 +89,10 @@ func TestStatementQueryDelegatesAndLogs(t *testing.T) {
 	recLogger := newRecordingLogger()
 	statement := NewStatement(underlying, recLogger, "postgresql", "SELECT 1", settings)
 
+	// stubStatement returns a bare new(sql.Rows) with a nil driver connection;
+	// calling Close() on it panics. These are not real DB rows, so there is
+	// nothing to release here.
+	//nolint:sqlclosecheck // stub-returned *sql.Rows is not closeable (nil driverConn)
 	rows, err := statement.Query(ctx, "param")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)

--- a/database/internal/tracking/transaction_test.go
+++ b/database/internal/tracking/transaction_test.go
@@ -81,6 +81,10 @@ func TestTransactionQueryLogs(t *testing.T) {
 	settings := Settings{slowQueryThreshold: time.Second}
 	tx := NewTransaction(underlying, recLogger, "postgresql", settings)
 
+	// stubTx returns a bare new(sql.Rows) with a nil driver connection; calling
+	// Close() on it panics. These are not real DB rows, so there is nothing to
+	// release here.
+	//nolint:sqlclosecheck // stub-returned *sql.Rows is not closeable (nil driverConn)
 	rows, err := tx.Query(ctx, "SELECT", 1)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)

--- a/database/internal/tracking/utils_test.go
+++ b/database/internal/tracking/utils_test.go
@@ -375,7 +375,7 @@ func TestTrackDBOperationDisabledErrorStillEscalates(t *testing.T) {
 	if len(event.Fields) != 0 {
 		t.Fatalf("expected no fields built when error level disabled, got %v", event.Fields)
 	}
-	if event.Err != failure {
+	if !errors.Is(event.Err, failure) {
 		t.Fatalf("expected error to be attached on disabled ERROR, got %v", event.Err)
 	}
 	if event.Msg != msgDBOperationError {
@@ -562,7 +562,7 @@ func TestTrackDBOperationLogsErrors(t *testing.T) {
 	if event.Level != levelError {
 		t.Fatalf("expected error level, got %s", event.Level)
 	}
-	if event.Err != failure {
+	if !errors.Is(event.Err, failure) {
 		t.Fatalf("expected error to be recorded")
 	}
 	if event.Msg != msgDBOperationError {

--- a/database/oracle/connection_test.go
+++ b/database/oracle/connection_test.go
@@ -163,10 +163,12 @@ func TestConnectionBasicMethodsWithSQLMock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Execute Query operation
-	rs, err := c.Query(ctx, "SELECT id FROM t")
-	require.NoError(t, err)
-	assert.True(t, rs.Next())
-	_ = rs.Close()
+	func() {
+		rs, qerr := c.Query(ctx, "SELECT id FROM t")
+		require.NoError(t, qerr)
+		defer rs.Close()
+		assert.True(t, rs.Next())
+	}()
 
 	// Execute QueryRow operation
 	row := c.QueryRow(ctx, "SELECT CURRENT_TIMESTAMP")
@@ -185,9 +187,11 @@ func TestConnectionBasicMethodsWithSQLMock(t *testing.T) {
 	tx, err := c.Begin(ctx)
 	require.NoError(t, err)
 	defer tx.Rollback(ctx) // No-op if committed
-	rs2, err := tx.Query(ctx, "SELECT 1 FROM dual")
-	require.NoError(t, err)
-	_ = rs2.Close()
+	func() {
+		rs2, qerr := tx.Query(ctx, "SELECT 1 FROM dual")
+		require.NoError(t, qerr)
+		defer rs2.Close()
+	}()
 	require.NoError(t, tx.Commit(ctx))
 
 	// Execute BeginTx + rollback
@@ -337,10 +341,12 @@ func TestOracleStatementQueryAndQueryRow(t *testing.T) {
 	require.NoError(t, err)
 	ps := wrapper.NewStatement(stmt)
 
-	rows, err := ps.Query(context.Background(), true)
-	require.NoError(t, err)
-	require.True(t, rows.Next())
-	rows.Close()
+	func() {
+		rows, qerr := ps.Query(context.Background(), true)
+		require.NoError(t, qerr)
+		defer rows.Close()
+		require.True(t, rows.Next())
+	}()
 	require.NoError(t, ps.Close())
 
 	mock.ExpectPrepare(regexp.QuoteMeta(selectQuery)).
@@ -375,9 +381,11 @@ func TestOracleTransactionQueryPrepareExec(t *testing.T) {
 		WithArgs("X").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(11))
 
-	rows, err := trx.Query(context.Background(), "SELECT id FROM dual WHERE code = :1", "X")
-	require.NoError(t, err)
-	rows.Close()
+	func() {
+		rows, qerr := trx.Query(context.Background(), "SELECT id FROM dual WHERE code = :1", "X")
+		require.NoError(t, qerr)
+		defer rows.Close()
+	}()
 
 	mock.ExpectQuery(regexp.QuoteMeta(selectQuery)).
 		WithArgs(11).

--- a/database/postgresql/connection_test.go
+++ b/database/postgresql/connection_test.go
@@ -146,10 +146,12 @@ func TestConnectionBasicMethodsWithSQLMock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Execute Query operation
-	rs, err := c.Query(ctx, "SELECT id, name FROM items")
-	require.NoError(t, err)
-	assert.True(t, rs.Next())
-	_ = rs.Close()
+	func() {
+		rs, qerr := c.Query(ctx, "SELECT id, name FROM items")
+		require.NoError(t, qerr)
+		defer rs.Close()
+		assert.True(t, rs.Next())
+	}()
 
 	// Execute QueryRow operation
 	row := c.QueryRow(ctx, "SELECT NOW()")
@@ -453,10 +455,12 @@ func TestStatementQueryAndQueryRow(t *testing.T) {
 	require.NoError(t, err)
 	ps := wrapper.NewStatement(stmt)
 
-	rows, err := ps.Query(ctx, true)
-	require.NoError(t, err)
-	require.True(t, rows.Next())
-	rows.Close()
+	func() {
+		rows, qerr := ps.Query(ctx, true)
+		require.NoError(t, qerr)
+		defer rows.Close()
+		require.True(t, rows.Next())
+	}()
 	require.NoError(t, ps.Close())
 
 	mock.ExpectPrepare(regexp.QuoteMeta("SELECT name FROM widgets WHERE id = $1")).
@@ -492,9 +496,11 @@ func TestTransactionQueryPrepareAndExec(t *testing.T) {
 		WithArgs("A-1").
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(9))
 
-	resultRows, err := trx.Query(ctx, "SELECT id FROM parts WHERE sku = $1", "A-1")
-	require.NoError(t, err)
-	resultRows.Close()
+	func() {
+		resultRows, qerr := trx.Query(ctx, "SELECT id FROM parts WHERE sku = $1", "A-1")
+		require.NoError(t, qerr)
+		defer resultRows.Close()
+	}()
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT name FROM parts WHERE id = $1")).
 		WithArgs(9).

--- a/database/tracking_test.go
+++ b/database/tracking_test.go
@@ -291,9 +291,11 @@ func TestTrackedConnectionContextWithoutCounter(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta(selectOne)).WillReturnRows(rows)
 
 	// This should not panic even without DB counter in context
-	resultRows, err := tracked.Query(context.Background(), selectOne)
-	require.NoError(t, err)
-	resultRows.Close()
+	func() {
+		resultRows, err := tracked.Query(context.Background(), selectOne)
+		require.NoError(t, err)
+		defer resultRows.Close()
+	}()
 }
 
 func TestTrackDBOperation(t *testing.T) {
@@ -536,7 +538,7 @@ func TestTrackedDBQueryContext(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotNil(t, resultRows)
-	resultRows.Close()
+	defer resultRows.Close()
 
 	assertDBCounter(ctx, t, 1)
 	assertDBElapsedPositive(ctx, t)
@@ -736,7 +738,7 @@ func TestTrackedStmtQuery(t *testing.T) {
 	resultRows, err := stmt.Query(ctx, 1)
 	require.NoError(t, err)
 	assert.NotNil(t, resultRows)
-	resultRows.Close()
+	defer resultRows.Close()
 	assertDBCounter(ctx, t, 2)
 }
 

--- a/database/types/interfaces.go
+++ b/database/types/interfaces.go
@@ -227,7 +227,7 @@ const (
 	Oracle     Vendor = "oracle"
 )
 
-// Row represents a single result set row with basic scanning behaviour.
+// Row represents a single result set row with basic scanning behavior.
 type Row interface {
 	Scan(dest ...any) error
 	Err() error

--- a/database/types/subquery.go
+++ b/database/types/subquery.go
@@ -44,7 +44,7 @@ func ValidateSubquery(subquery SelectQueryBuilder) error {
 
 	if validator, ok := subquery.(subqueryValidator); ok {
 		if err := validator.ValidateForSubquery(); err != nil {
-			return fmt.Errorf("%w: %v", ErrInvalidSubquery, err)
+			return fmt.Errorf("%w: %w", ErrInvalidSubquery, err)
 		}
 		return nil
 	}
@@ -52,7 +52,7 @@ func ValidateSubquery(subquery SelectQueryBuilder) error {
 	// Test ToSQL() to catch construction errors early
 	sql, _, err := subquery.ToSQL()
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrInvalidSubquery, err)
+		return fmt.Errorf("%w: %w", ErrInvalidSubquery, err)
 	}
 	if sql == "" {
 		return ErrEmptySubquerySQL

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -544,7 +544,7 @@ func (c *client) handleExecutionError(ctx context.Context, err error, attempt, m
 		// Derive retry.reason from classifyError so it agrees with the
 		// error.type attribute recorded on the duration histogram. Using a
 		// separate isTimeout call here previously caused divergence: a dial
-		// timeout was labelled error.type="connection_error" but
+		// timeout was labeled error.type="connection_error" but
 		// retry.reason="timeout" because isTimeout matches net.Error.Timeout().
 		errType := classifyError(err)
 		reason := retryReasonNetwork
@@ -953,13 +953,13 @@ func (c *client) isRetryableStatus(code int) bool {
 //     interceptorError.Unwrap() exposes its cause; without this guard,
 //     errors.As would traverse the chain and match the wrapped net type
 //     (e.g. *net.DNSError inside an interceptor failure would be
-//     mis-labelled "name_resolution_error" instead of "interceptor_failed").
+//     mis-labeled "name_resolution_error" instead of "interceptor_failed").
 //  5. *net.DNSError — must precede the generic net.Error.Timeout() check
 //     because *net.DNSError implements net.Error and Timeout() can return
 //     true for timed-out lookups; matching it here keeps the label specific.
 //  6. TLS errors.
 //  7. Dial OpError — must precede the generic net.Error.Timeout() check so
-//     a dial that times out is labelled "connection_error", not "timeout".
+//     a dial that times out is labeled "connection_error", not "timeout".
 //  8. Generic net.Error.Timeout() — read-deadline exceeded and similar.
 //  9. Catch-all → "_OTHER".
 func classifyError(err error) string {
@@ -976,7 +976,7 @@ func classifyError(err error) string {
 	}
 	// Interceptor failure — must precede all errors.As network-type checks so
 	// that an interceptor wrapping a *net.DNSError/*net.OpError/tls error is
-	// labelled "interceptor_failed", not the wrapped cause's type.
+	// labeled "interceptor_failed", not the wrapped cause's type.
 	if IsErrorType(err, InterceptorError) {
 		return errorTypeInterceptorFailed
 	}
@@ -997,7 +997,7 @@ func classifyError(err error) string {
 		return errorTypeTLS
 	}
 	// Dial connection failure — must precede the generic net.Error.Timeout() check
-	// so a dial that times out is labelled "connection_error", not "timeout".
+	// so a dial that times out is labeled "connection_error", not "timeout".
 	var opErr *net.OpError
 	if errors.As(err, &opErr) && opErr.Op == netOpDial {
 		return errorTypeConnection

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -976,7 +976,7 @@ func TestTraceIDUtilities(t *testing.T) {
 }
 
 // setupClientTestMeterProvider creates a TestMeterProvider, sets it as the global OTel
-// provider, resets tracking meter state, and initialises the instruments. Returns the
+// provider, resets tracking meter state, and initializes the instruments. Returns the
 // provider for metric collection and a cleanup function that must be deferred.
 func setupClientTestMeterProvider(t *testing.T) (mp *obtest.TestMeterProvider, cleanup func()) {
 	t.Helper()
@@ -1282,14 +1282,14 @@ func TestBackoffDelayFallbacks(t *testing.T) {
 	})
 }
 
-// netTimeoutErr is a minimal net.Error implementation used to exercise the
+// netTimeoutError is a minimal net.Error implementation used to exercise the
 // generic net.Error.Timeout() branch in classifyError without matching any of
 // the more specific error types (DNSError, OpError, etc.).
-type netTimeoutErr struct{}
+type netTimeoutError struct{}
 
-func (netTimeoutErr) Error() string   { return "simulated net timeout" }
-func (netTimeoutErr) Timeout() bool   { return true }
-func (netTimeoutErr) Temporary() bool { return true }
+func (netTimeoutError) Error() string   { return "simulated net timeout" }
+func (netTimeoutError) Timeout() bool   { return true }
+func (netTimeoutError) Temporary() bool { return true }
 
 // TestClassifyError is a white-box table-driven test that verifies every branch
 // of classifyError, including the DNS-timeout regression (a timed-out
@@ -1352,7 +1352,7 @@ func TestClassifyError(t *testing.T) {
 			// A read-deadline net.Error (not a DNSError or dial OpError) must fall
 			// through to the generic net.Error.Timeout() branch → errorTypeTimeout.
 			name:     "generic_net_timeout",
-			err:      netTimeoutErr{},
+			err:      netTimeoutError{},
 			expected: errorTypeTimeout,
 		},
 		{
@@ -1688,7 +1688,7 @@ func TestClientDoRetrySequenceEmitsParentPlusChildrenWithResendCounts(t *testing
 
 	// First two attempts (503) → Error status, last (200) → Unset.
 	// codes.Ok is unused for client spans per OTel HTTP semconv (4xx-as-OK
-	// is signalled by Unset, not Ok).
+	// is signaled by Unset, not Ok).
 	errorCount, unsetCount := 0, 0
 	for i := range children {
 		switch children[i].Status.Code {

--- a/httpclient/constants.go
+++ b/httpclient/constants.go
@@ -51,7 +51,7 @@ const (
 	retryReason5xx           = "5xx"
 )
 
-// netOpDial is the net.OpError.Op value for TCP dial operations. Centralised
+// netOpDial is the net.OpError.Op value for TCP dial operations. Centralized
 // as a constant because classifyError and its tests reference it in four places.
 const netOpDial = "dial"
 
@@ -60,7 +60,7 @@ const netOpDial = "dial"
 // and http.client.request.failed counter — kept as named constants so that
 // both classifyError and its tests can reference them without duplication.
 const (
-	// errorTypeContextCanceled indicates the request was cancelled by the caller.
+	// errorTypeContextCanceled indicates the request was canceled by the caller.
 	errorTypeContextCanceled = "context_canceled"
 
 	// errorTypeTimeout covers framework TimeoutError, context.DeadlineExceeded,

--- a/httpclient/internal/tracking/metrics_test.go
+++ b/httpclient/internal/tracking/metrics_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 // setupTestMeterProvider creates a test meter provider, sets it as the global provider,
-// resets meter state, and initialises the instruments. Returns the provider for metric
+// resets meter state, and initializes the instruments. Returns the provider for metric
 // collection and a cleanup function.
 func setupTestMeterProvider(t *testing.T) (mp *obtest.TestMeterProvider, cleanup func()) {
 	t.Helper()
@@ -427,7 +427,7 @@ func TestEmptyPeerNameOmitsPeerServiceAttribute(t *testing.T) {
 	assertNoAttribute(t, retrySumData.DataPoints[0].Attributes.ToSlice(), attrPeerService)
 }
 
-// TestUnknownMethodNormalizedToOther verifies that an unrecognised HTTP method is
+// TestUnknownMethodNormalizedToOther verifies that an unrecognized HTTP method is
 // normalised to "_OTHER" in the http.request.method attribute.
 func TestUnknownMethodNormalizedToOther(t *testing.T) {
 	mp, cleanup := setupTestMeterProvider(t)

--- a/httpclient/internal/tracking/testing.go
+++ b/httpclient/internal/tracking/testing.go
@@ -21,7 +21,7 @@ func ResetMeterForTesting() {
 
 // ResetTracerForTesting resets the package-level tracer state so each test
 // starts with a fresh tracer. Mirrors ResetMeterForTesting. Safe to call
-// concurrently with InitHTTPTracer — the mutex serialises both paths.
+// concurrently with InitHTTPTracer — the mutex serializes both paths.
 func ResetTracerForTesting() {
 	tracerInitMu.Lock()
 	defer tracerInitMu.Unlock()

--- a/httpclient/internal/tracking/tracing.go
+++ b/httpclient/internal/tracking/tracing.go
@@ -102,8 +102,14 @@ func StartHTTPClientSpan(ctx context.Context, info *HTTPSpanInfo) (context.Conte
 		info = &HTTPSpanInfo{}
 	}
 	method := canonicalMethod(info.Method)
+	// Span-factory pattern: the started span is returned to the caller, which is
+	// responsible for ending it via EndHTTPClientSpan (see client.go). Ending it
+	// here would terminate the span at ~0 duration and break HTTP-client tracing.
+	// spancheck cannot model this cross-function ownership transfer.
+	//nolint:spancheck // span ownership intentionally transferred to caller (EndHTTPClientSpan)
 	ctx, span := httpTracer.Start(ctx, spanName(info, method), trace.WithSpanKind(trace.SpanKindClient))
 	span.SetAttributes(spanStartAttributes(info, method)...)
+	//nolint:spancheck // span ownership intentionally transferred to caller (EndHTTPClientSpan)
 	return ctx, span
 }
 

--- a/httpclient/internal/tracking/tracing_test.go
+++ b/httpclient/internal/tracking/tracing_test.go
@@ -395,7 +395,7 @@ func TestStartHTTPClientSpanNilInfoIsSafe(t *testing.T) {
 	})
 
 	got := obtest.NewSpanCollector(t, tp.Exporter).First()
-	// Empty method canonicalises to _OTHER per the package's existing behaviour;
+	// Empty method canonicalises to _OTHER per the package's existing behavior;
 	// the span name therefore uses the HTTP-METHOD template since PeerName is
 	// also empty.
 	assert.Equal(t, "HTTP _OTHER", got.Name)

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -245,7 +245,7 @@ func parsePrivateKey(der []byte, keyName string) (*rsa.PrivateKey, error) {
 	// Fallback to PKCS1 (legacy format)
 	rsaKey, err2 := x509.ParsePKCS1PrivateKey(der)
 	if err2 != nil {
-		return nil, fmt.Errorf("keystore: key %q private: PKCS8 failed (%v), PKCS1 fallback also failed: %w", keyName, err, err2)
+		return nil, fmt.Errorf("keystore: key %q private: PKCS8 failed (%w), PKCS1 fallback also failed: %w", keyName, err, err2)
 	}
 	return rsaKey, nil
 }

--- a/logger/adapter.go
+++ b/logger/adapter.go
@@ -15,7 +15,7 @@ type LogEventAdapter struct {
 	hook   func(zerolog.Level)
 }
 
-// maskIfSensitive masks the key in place when it is sensitive, signalling via ok.
+// maskIfSensitive masks the key in place when it is sensitive, signaling via ok.
 // Centralizes the typed-method mask check so adding a new typed slot (e.g. Float64) cannot
 // silently bypass the privacy boundary by forgetting to wire the same conditional.
 // zerolog's *Event.Interface mutates the event in place and returns the same pointer, so

--- a/logger/otel_bridge.go
+++ b/logger/otel_bridge.go
@@ -40,7 +40,11 @@ func (b *OTelBridge) Write(p []byte) (n int, err error) {
 
 	var entry map[string]interface{}
 	if json.Unmarshal(p, &entry) != nil {
-		// Ignore malformed or non-JSON entries (e.g., pretty logs)
+		// Ignore malformed or non-JSON entries (e.g., pretty/console logs). As an
+		// io.Writer we MUST report the bytes as consumed (len(p), nil); surfacing the
+		// parse error would break zerolog's writer chain and could drop or duplicate
+		// log lines. The swallow is intentional, hence the nilerr suppression.
+		//nolint:nilerr // deliberate pass-through of non-JSON writes; see comment above
 		return len(p), nil
 	}
 

--- a/messaging/amqp_client.go
+++ b/messaging/amqp_client.go
@@ -892,7 +892,10 @@ func (a *amqpHeaderAccessor) Set(key string, value any) {
 func StartConsumeSpan(ctx context.Context, delivery *amqp.Delivery, queueName string) (context.Context, trace.Span) {
 	tracer := otel.Tracer(messagingTracerName)
 	if delivery == nil {
-		// No delivery, return a no-op span
+		// No delivery, return a no-op span. Span-factory pattern: ownership of the
+		// span is transferred to the caller, which must end it (see doc comment).
+		// spancheck cannot model this cross-function transfer.
+		//nolint:spancheck // span ownership intentionally transferred to caller
 		return tracer.Start(ctx, queueName+" "+operationReceive, trace.WithSpanKind(trace.SpanKindConsumer))
 	}
 	// Extract trace context from message headers

--- a/messaging/amqp_client_test.go
+++ b/messaging/amqp_client_test.go
@@ -986,7 +986,7 @@ func TestConnectDialFailure(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected connection error")
 	}
-	if err != expectedErr {
+	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected dial error, got: %v", err)
 	}
 	if conn != nil {
@@ -1007,7 +1007,7 @@ func TestPublishToExchangeShutdownDuringPublish(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected shutdown error")
 	}
-	if err != errShutdown {
+	if !errors.Is(err, errShutdown) {
 		t.Fatalf("expected errShutdown, got: %v", err)
 	}
 }
@@ -1026,7 +1026,7 @@ func TestPublishToExchangeShutdownDuringConfirmation(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected shutdown error")
 	}
-	if err != errShutdown {
+	if !errors.Is(err, errShutdown) {
 		t.Fatalf("expected errShutdown, got: %v", err)
 	}
 }
@@ -1043,7 +1043,7 @@ func TestPublishToExchangeRetryLogicWithUnsafePublishFailure(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected context timeout error")
 	}
-	if err != context.DeadlineExceeded {
+	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected context deadline exceeded, got: %v", err)
 	}
 }
@@ -1207,7 +1207,7 @@ func TestUnsafePublishNotReady(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected errNotConnected when not ready")
 	}
-	if err != errNotConnected {
+	if !errors.Is(err, errNotConnected) {
 		t.Fatalf("expected errNotConnected, got: %v", err)
 	}
 }

--- a/messaging/manager.go
+++ b/messaging/manager.go
@@ -438,7 +438,7 @@ func (m *Manager) cleanupIdlePublishers() {
 	}
 }
 
-// StopConsumers stops every consumer registry from accepting new messages (cancelling their
+// StopConsumers stops every consumer registry from accepting new messages (canceling their
 // consume contexts) WITHOUT closing the underlying AMQP connections — Close does that. The
 // framework calls this during shutdown before tearing down modules so it stops delivering
 // fresh messages to modules that are about to shut down. Cancellation propagates to in-flight

--- a/messaging/manager_test.go
+++ b/messaging/manager_test.go
@@ -105,8 +105,8 @@ func (s *stubAMQPClient) IsReady() bool {
 
 func TestManagerStopConsumersStopsRegistriesWithoutClosing(t *testing.T) {
 	log := logger.New("error", false)
-	cancelled := false
-	reg := &Registry{logger: log, consumersActive: true, cancelConsumers: func() { cancelled = true }}
+	canceled := false
+	reg := &Registry{logger: log, consumersActive: true, cancelConsumers: func() { canceled = true }}
 	client := &stubAMQPClient{}
 	m := &Manager{
 		logger:    log,
@@ -115,7 +115,7 @@ func TestManagerStopConsumersStopsRegistriesWithoutClosing(t *testing.T) {
 
 	m.StopConsumers()
 
-	assert.True(t, cancelled, "consume context must be cancelled so no new messages are delivered")
+	assert.True(t, canceled, "consume context must be canceled so no new messages are delivered")
 	assert.False(t, reg.consumersActive, "registry must mark consumers stopped")
 	assert.False(t, client.closed, "StopConsumers must NOT close the AMQP connection — Close does that later")
 
@@ -330,7 +330,7 @@ func TestMessagingManagerConsumersSurviveCallerContextCancellation(t *testing.T)
 	decls.RegisterQueue(&QueueDeclaration{Name: testQueue})
 	decls.RegisterConsumer(&ConsumerDeclaration{Queue: testQueue, Consumer: testConsumer, Handler: &mockMessageHandler{}})
 
-	// Lazy startup driven by a request-scoped context that is cancelled when the request ends.
+	// Lazy startup driven by a request-scoped context that is canceled when the request ends.
 	callerCtx, cancel := context.WithCancel(context.Background())
 	require.NoError(t, manager.EnsureConsumers(callerCtx, testTenantID, decls))
 
@@ -339,11 +339,11 @@ func TestMessagingManagerConsumersSurviveCallerContextCancellation(t *testing.T)
 	consumerCtx := client.lastConsumeCtx()
 	require.NotNil(t, consumerCtx)
 
-	// Request ends: cancelling the caller context must NOT cancel the consumer.
+	// Request ends: canceling the caller context must NOT cancel the consumer.
 	cancel()
 	select {
 	case <-consumerCtx.Done():
-		t.Fatal("consumer context was cancelled when the caller/request context ended — consumers stop after one request and never restart")
+		t.Fatal("consumer context was canceled when the caller/request context ended — consumers stop after one request and never restart")
 	case <-time.After(100 * time.Millisecond):
 		// Consumer context is detached from the request lifecycle, as required.
 	}

--- a/messaging/otel_test.go
+++ b/messaging/otel_test.go
@@ -360,6 +360,26 @@ func TestConsumeSpanWithMinimalDelivery(t *testing.T) {
 	assertAttribute(t, attrs, string(semconv.MessagingDestinationNameKey), "minimal-queue")
 }
 
+func TestStartConsumeSpanNilDelivery(t *testing.T) {
+	exporter, cleanup := setupTestTracing(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// A nil delivery (e.g. a drained/closed consume channel) must still yield a
+	// usable consumer span whose ownership transfers to the caller to end —
+	// the span-factory no-op branch.
+	spanCtx, span := StartConsumeSpan(ctx, nil, "nil-delivery-queue")
+	require.NotNil(t, spanCtx)
+	require.NotNil(t, span)
+	span.End()
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "nil-delivery-queue receive", spans[0].Name)
+	assert.Equal(t, trace.SpanKindConsumer, spans[0].SpanKind)
+}
+
 // Helper functions
 
 func setupReadyClient(t *testing.T) (*AMQPClientImpl, *fakeConnAdapter, *fakeChannel) {

--- a/messaging/registry.go
+++ b/messaging/registry.go
@@ -275,7 +275,7 @@ func (r *Registry) DeclareInfrastructure(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("context cancelled while waiting for AMQP client: %w", ctx.Err())
+			return fmt.Errorf("context canceled while waiting for AMQP client: %w", ctx.Err())
 		case <-timeout.C:
 			return fmt.Errorf("timeout waiting for AMQP client to be ready")
 		case <-ticker.C:
@@ -483,17 +483,17 @@ func (r *Registry) startSingleConsumer(ctx context.Context, consumer *ConsumerDe
 
 // superviseConsumer runs consumer sessions back-to-back, re-subscribing after
 // the broker drops the delivery channel, until the consumer context is
-// cancelled (StopConsumers / shutdown). This is the consumer-side counterpart
+// canceled (StopConsumers / shutdown). This is the consumer-side counterpart
 // to the client's reconnection supervisor: the publisher path recovers because
 // every publish re-reads the live channel under lock, whereas a consumer
 // captures its delivery channel once, so it needs an explicit re-subscribe.
 func (r *Registry) superviseConsumer(ctx context.Context, consumer *ConsumerDeclaration, deliveries <-chan amqp.Delivery) {
 	for {
 		// Run one subscription session until the delivery channel closes
-		// (reconnect needed) or the context is cancelled (stop for good).
+		// (reconnect needed) or the context is canceled (stop for good).
 		sessionStart := time.Now()
 		if !r.handleMessages(ctx, consumer, deliveries) {
-			return // context cancelled → stop for good
+			return // context canceled → stop for good
 		}
 
 		// Rapid-flap guard: if the session barely lasted, the broker is handing
@@ -508,14 +508,14 @@ func (r *Registry) superviseConsumer(ctx context.Context, consumer *ConsumerDecl
 
 		next, ok := r.resubscribe(ctx, consumer)
 		if !ok {
-			return // context cancelled while waiting to re-subscribe
+			return // context canceled while waiting to re-subscribe
 		}
 		deliveries = next
 	}
 }
 
-// sleepCtx waits for d, or until ctx is cancelled, whichever comes first. It
-// returns true if the full duration elapsed and false if ctx was cancelled.
+// sleepCtx waits for d, or until ctx is canceled, whichever comes first. It
+// returns true if the full duration elapsed and false if ctx was canceled.
 func sleepCtx(ctx context.Context, d time.Duration) bool {
 	if d <= 0 {
 		return ctx.Err() == nil
@@ -545,7 +545,7 @@ func consumerLogFields(consumer *ConsumerDeclaration) map[string]any {
 // closed. It attempts immediately so a routine channel-only flap (the client's
 // connection is still up) recovers without added downtime, then on failure
 // backs off with full jitter before retrying, until ConsumeFromQueue succeeds
-// or the context is cancelled. Returns (channel, true) on success and
+// or the context is canceled. Returns (channel, true) on success and
 // (nil, false) on cancellation.
 //
 // A success-then-immediately-closing channel cannot become a tight spin: the
@@ -587,7 +587,7 @@ func (r *Registry) resubscribe(ctx context.Context, consumer *ConsumerDeclaratio
 // handleMessages runs a single consumer session: it spawns a worker pool
 // (v0.17+) and feeds deliveries to it until the session ends. It returns true
 // when the broker closed the delivery channel (the caller should re-subscribe)
-// and false when the context was cancelled (shut down for good).
+// and false when the context was canceled (shut down for good).
 func (r *Registry) handleMessages(ctx context.Context, consumer *ConsumerDeclaration, deliveries <-chan amqp.Delivery) bool {
 	workers := consumer.Workers
 	if workers <= 0 {
@@ -617,12 +617,12 @@ func (r *Registry) handleMessages(ctx context.Context, consumer *ConsumerDeclara
 
 	// Main loop: feed jobs to worker pool. reconnect=true means the broker
 	// closed the delivery channel (the caller should re-subscribe); false means
-	// the context was cancelled (shut down for good).
+	// the context was canceled (shut down for good).
 	reconnect := func() bool {
 		for {
 			select {
 			case <-ctx.Done():
-				log.Info().Msg("Consumer context cancelled, stopping message handler")
+				log.Info().Msg("Consumer context canceled, stopping message handler")
 				return false
 
 			case delivery, ok := <-deliveries:
@@ -640,7 +640,7 @@ func (r *Registry) handleMessages(ctx context.Context, consumer *ConsumerDeclara
 				select {
 				case jobs <- &d:
 				case <-ctx.Done():
-					log.Info().Msg("Consumer context cancelled, stopping message handler")
+					log.Info().Msg("Consumer context canceled, stopping message handler")
 					return false
 				}
 			}
@@ -672,7 +672,7 @@ func (r *Registry) worker(ctx context.Context, consumer *ConsumerDeclaration, jo
 	for {
 		select {
 		case <-ctx.Done():
-			log.Debug().Msg("Worker context cancelled")
+			log.Debug().Msg("Worker context canceled")
 			return
 
 		case delivery, ok := <-jobs:

--- a/messaging/registry_test.go
+++ b/messaging/registry_test.go
@@ -224,10 +224,10 @@ func TestRegistryDeclareInfrastructureClientNotReadyTimeoutSimple(t *testing.T) 
 	err := registry.DeclareInfrastructure(ctx)
 
 	assert.Error(t, err)
-	// Could be either timeout or context cancelled depending on timing
+	// Could be either timeout or context canceled depending on timing
 	assert.True(t,
 		strings.Contains(err.Error(), "timeout waiting for AMQP client") ||
-			strings.Contains(err.Error(), "context cancelled while waiting for AMQP client"),
+			strings.Contains(err.Error(), "context canceled while waiting for AMQP client"),
 		"Expected timeout or context cancellation error, got: %s", err.Error())
 }
 
@@ -299,12 +299,12 @@ func TestRegistryStopConsumersSuccessSimple(t *testing.T) {
 	assert.False(t, registry.consumersActive)
 	assert.Nil(t, registry.cancelConsumers)
 
-	// Verify context was cancelled
+	// Verify context was canceled
 	select {
 	case <-ctx.Done():
-		// Expected - context should be cancelled
+		// Expected - context should be canceled
 	default:
-		t.Fatal("Expected context to be cancelled")
+		t.Fatal("Expected context to be canceled")
 	}
 }
 
@@ -738,7 +738,7 @@ func TestRegistryDeclareInfrastructureContextCancellation(t *testing.T) {
 	err := registry.DeclareInfrastructure(ctx)
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "context cancelled while waiting for AMQP client")
+	assert.Contains(t, err.Error(), "context canceled while waiting for AMQP client")
 }
 
 func TestRegistryDeclareInfrastructureClientBecomesReady(t *testing.T) {
@@ -2167,7 +2167,7 @@ func TestRegistryConsumerSupervisorStopsOnContextCancel(t *testing.T) {
 	require.NoError(t, registry.StartConsumers(ctx))
 
 	// Flap, then wait until the supervisor is actively retrying (it has called
-	// ConsumeFromQueue again and is failing into backoff) before cancelling, so
+	// ConsumeFromQueue again and is failing into backoff) before canceling, so
 	// this exercises cancellation from inside the retry/backoff path.
 	close(ch1)
 	require.Eventually(t, func() bool {

--- a/migration/audit.go
+++ b/migration/audit.go
@@ -120,7 +120,7 @@ type AuditEvent struct {
 // not synchronize concurrent reads if a sink decides to mutate.
 //
 // The framework calls Record with a fresh background context that may be
-// cancelled by FlywayMigrator.Close. Implementations SHOULD respect
+// canceled by FlywayMigrator.Close. Implementations SHOULD respect
 // ctx.Done() for prompt cancellation, but the framework does not retry on
 // the sink's behalf — sink owners requiring zero-loss audit must back their
 // implementation with a durable buffer (Kafka commit-log, S3 staging, etc.).

--- a/migration/audit_emitter.go
+++ b/migration/audit_emitter.go
@@ -25,7 +25,7 @@ const (
 	auditSinkQueueCap = 256
 )
 
-// Audit attribute keys are centralised here so the span path and the
+// Audit attribute keys are centralized here so the span path and the
 // structured-log path emit identical names — schema drift between the two
 // paths would silently break downstream alerting that pivots across them.
 const (
@@ -292,7 +292,7 @@ func (e *auditEmitter) consumeSink(ctx context.Context) {
 // no-op. Honors ctx for shutdown deadline; events still in the queue when
 // ctx expires are silently dropped (their OTel emission already succeeded).
 //
-// The defer here matters: on the timeout branch, cancelling the consumer
+// The defer here matters: on the timeout branch, canceling the consumer
 // context propagates a Done() signal into any in-flight sink.Record call so
 // a well-behaved sink bails immediately instead of running past Close's
 // deadline. On the drain-completed branch the cancel is a cleanup no-op.

--- a/migration/provisioning/state_test.go
+++ b/migration/provisioning/state_test.go
@@ -41,7 +41,6 @@ func TestValidateTransitionForwardGraph(t *testing.T) {
 func TestValidateTransitionCleanupBranches(t *testing.T) {
 	cases := []State{StatePending, StateSchemaCreated, StateRoleCreated, StateMigrated, StateSeeded}
 	for _, from := range cases {
-		from := from
 		t.Run(string(from), func(t *testing.T) {
 			assert.NoError(t, ValidateTransition(from, StateCleanup))
 		})
@@ -68,7 +67,6 @@ func TestValidateTransitionRejectsIllegalEdges(t *testing.T) {
 		{State("bogus"), StatePending},
 	}
 	for _, c := range illegal {
-		c := c
 		t.Run(fmt.Sprintf("%s->%s", c.from, c.to), func(t *testing.T) {
 			err := ValidateTransition(c.from, c.to)
 			require.Error(t, err)
@@ -93,7 +91,6 @@ func TestStepsValidate(t *testing.T) {
 		{"missing_cleanup", func(s *Steps) { s.Cleanup = nil }, "Cleanup"},
 	}
 	for _, m := range mutators {
-		m := m
 		t.Run(m.name, func(t *testing.T) {
 			s := okSteps(t)
 			m.mutate(&s)

--- a/migration/provisioning/store_postgres_test.go
+++ b/migration/provisioning/store_postgres_test.go
@@ -44,7 +44,6 @@ func TestNewPostgresStoreAcceptsValidNames(t *testing.T) {
 		{strings.Repeat("a", maxPGTableSegment), `"` + strings.Repeat("a", maxPGTableSegment) + `"`, strings.Repeat("a", maxPGTableSegment)},
 	}
 	for _, c := range cases {
-		c := c
 		t.Run(c.in, func(t *testing.T) {
 			s, err := NewPostgresStore(db, c.in)
 			require.NoError(t, err)
@@ -70,7 +69,6 @@ func TestNewPostgresStoreRejectsInvalidNames(t *testing.T) {
 		strings.Repeat("a", 64),
 	}
 	for _, name := range invalid {
-		name := name
 		t.Run(name, func(t *testing.T) {
 			_, err := NewPostgresStore(db, name)
 			require.Error(t, err)

--- a/migration/roles_test.go
+++ b/migration/roles_test.go
@@ -22,7 +22,6 @@ func TestPGRoleSpecValidateAccepts(t *testing.T) {
 		},
 	}
 	for _, s := range specs {
-		s := s
 		t.Run(s.Schema, func(t *testing.T) {
 			assert.NoError(t, s.Validate())
 		})

--- a/migration/secrets.go
+++ b/migration/secrets.go
@@ -138,12 +138,12 @@ func parseSecretPayload(raw []byte) (*config.DatabaseConfig, error) {
 
 	var cfg config.DatabaseConfig
 	if err := json.Unmarshal(raw, &cfg); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrSecretMalformed, err)
+		return nil, fmt.Errorf("%w: %w", ErrSecretMalformed, err)
 	}
 
 	var aliases rdsRotationAliases
 	if err := json.Unmarshal(raw, &aliases); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrSecretMalformed, err)
+		return nil, fmt.Errorf("%w: %w", ErrSecretMalformed, err)
 	}
 
 	if cfg.Type == "" {

--- a/observability/provider.go
+++ b/observability/provider.go
@@ -561,11 +561,11 @@ func (p *provider) ForceFlush(ctx context.Context) error {
 // cleanupPartialInit safely shuts down any partially initialized providers.
 // Called when provider initialization fails mid-way to prevent resource leaks.
 // Uses a background context with timeout to ensure cleanup completes even if the
-// initialization context was cancelled.
+// initialization context was canceled.
 func (p *provider) cleanupPartialInit() {
 	debugLogger.Println("Cleaning up partially initialized providers due to init error")
 
-	// Use background context with timeout for cleanup (don't inherit cancelled context)
+	// Use background context with timeout for cleanup (don't inherit canceled context)
 	ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
 	defer cancel()
 

--- a/observability/provider_test.go
+++ b/observability/provider_test.go
@@ -329,7 +329,7 @@ func TestNewProviderTracingSampleRate(t *testing.T) {
 
 func TestProviderShutdownTimeout(t *testing.T) {
 	// This test verifies that Shutdown respects context timeout.
-	// We use a blocking exporter that only unblocks when context is cancelled,
+	// We use a blocking exporter that only unblocks when context is canceled,
 	// ensuring deterministic timeout behavior.
 
 	// Create a custom blocking exporter
@@ -365,7 +365,7 @@ func TestProviderShutdownTimeout(t *testing.T) {
 	close(blockingExporter.blockUntilCancel)
 }
 
-// blockingSpanExporter is a test exporter that blocks in Shutdown until context is cancelled
+// blockingSpanExporter is a test exporter that blocks in Shutdown until context is canceled
 type blockingSpanExporter struct {
 	blockUntilCancel chan struct{}
 }

--- a/outbox/cleanup_test.go
+++ b/outbox/cleanup_test.go
@@ -73,7 +73,7 @@ func TestCleanupExecuteUsesRetentionCutoff(t *testing.T) {
 
 func TestCleanupExecuteSucceedsWhenNothingDeleted(t *testing.T) {
 	// deleted == 0 must not log an Info line (only logs when > 0) but the
-	// Execute function still returns nil. We assert behaviour via the
+	// Execute function still returns nil. We assert behavior via the
 	// store's call count + error.
 	store := &fakeStore{DeletePublishedN: 0}
 	c := newCleanupWithFakes(store, 24*time.Hour)

--- a/outbox/testing/mock_outbox_test.go
+++ b/outbox/testing/mock_outbox_test.go
@@ -74,8 +74,8 @@ func TestMockOutboxEventsByType(t *testing.T) {
 	created := mock.EventsByType("order.created")
 	assert.Len(t, created, 2)
 
-	cancelled := mock.EventsByType("order.cancelled")
-	assert.Len(t, cancelled, 1)
+	canceled := mock.EventsByType("order.cancelled")
+	assert.Len(t, canceled, 1)
 
 	unknown := mock.EventsByType("unknown")
 	assert.Empty(t, unknown)

--- a/scheduler/cidr_middleware_test.go
+++ b/scheduler/cidr_middleware_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -70,7 +71,8 @@ func TestCIDRMiddlewareLocalhostOnly(t *testing.T) {
 				assert.Equal(t, http.StatusOK, rec.Code)
 			} else {
 				assert.Error(t, err)
-				httpErr, ok := err.(*echo.HTTPError)
+				var httpErr *echo.HTTPError
+				ok := errors.As(err, &httpErr)
 				assert.True(t, ok)
 				assert.Equal(t, tt.expectCode, httpErr.Code)
 			}
@@ -139,7 +141,8 @@ func TestCIDRMiddlewareAllowlistMode(t *testing.T) {
 				assert.Equal(t, http.StatusOK, rec.Code)
 			} else {
 				assert.Error(t, err)
-				httpErr, ok := err.(*echo.HTTPError)
+				var httpErr *echo.HTTPError
+				ok := errors.As(err, &httpErr)
 				assert.True(t, ok)
 				assert.Equal(t, tt.expectCode, httpErr.Code)
 			}
@@ -221,7 +224,8 @@ func TestCIDRMiddlewareProxyHeaders(t *testing.T) {
 				assert.Equal(t, http.StatusOK, rec.Code)
 			} else {
 				assert.Error(t, err, tt.description)
-				httpErr, ok := err.(*echo.HTTPError)
+				var httpErr *echo.HTTPError
+				ok := errors.As(err, &httpErr)
 				assert.True(t, ok)
 				assert.Equal(t, tt.expectCode, httpErr.Code)
 			}
@@ -324,7 +328,8 @@ func TestCIDRMiddlewareHeaderSpoofingPrevention(t *testing.T) {
 				assert.Equal(t, http.StatusOK, rec.Code)
 			} else {
 				assert.Error(t, err, tt.description)
-				httpErr, ok := err.(*echo.HTTPError)
+				var httpErr *echo.HTTPError
+				ok := errors.As(err, &httpErr)
 				assert.True(t, ok)
 				assert.Equal(t, tt.expectCode, httpErr.Code)
 			}
@@ -360,7 +365,8 @@ func TestCIDRMiddlewareInvalidCIDR(t *testing.T) {
 
 	err2 := handler(c2)
 	assert.Error(t, err2)
-	httpErr, ok := err2.(*echo.HTTPError)
+	var httpErr *echo.HTTPError
+	ok := errors.As(err2, &httpErr)
 	assert.True(t, ok)
 	assert.Equal(t, http.StatusForbidden, httpErr.Code)
 }

--- a/scheduler/cidr_middleware_test.go
+++ b/scheduler/cidr_middleware_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gaborage/go-bricks/server"
 	"github.com/labstack/echo/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -73,7 +74,7 @@ func TestCIDRMiddlewareLocalhostOnly(t *testing.T) {
 				assert.Error(t, err)
 				var httpErr *echo.HTTPError
 				ok := errors.As(err, &httpErr)
-				assert.True(t, ok)
+				require.True(t, ok)
 				assert.Equal(t, tt.expectCode, httpErr.Code)
 			}
 		})
@@ -143,7 +144,7 @@ func TestCIDRMiddlewareAllowlistMode(t *testing.T) {
 				assert.Error(t, err)
 				var httpErr *echo.HTTPError
 				ok := errors.As(err, &httpErr)
-				assert.True(t, ok)
+				require.True(t, ok)
 				assert.Equal(t, tt.expectCode, httpErr.Code)
 			}
 		})
@@ -226,7 +227,7 @@ func TestCIDRMiddlewareProxyHeaders(t *testing.T) {
 				assert.Error(t, err, tt.description)
 				var httpErr *echo.HTTPError
 				ok := errors.As(err, &httpErr)
-				assert.True(t, ok)
+				require.True(t, ok)
 				assert.Equal(t, tt.expectCode, httpErr.Code)
 			}
 		})
@@ -330,7 +331,7 @@ func TestCIDRMiddlewareHeaderSpoofingPrevention(t *testing.T) {
 				assert.Error(t, err, tt.description)
 				var httpErr *echo.HTTPError
 				ok := errors.As(err, &httpErr)
-				assert.True(t, ok)
+				require.True(t, ok)
 				assert.Equal(t, tt.expectCode, httpErr.Code)
 			}
 		})
@@ -367,7 +368,7 @@ func TestCIDRMiddlewareInvalidCIDR(t *testing.T) {
 	assert.Error(t, err2)
 	var httpErr *echo.HTTPError
 	ok := errors.As(err2, &httpErr)
-	assert.True(t, ok)
+	require.True(t, ok)
 	assert.Equal(t, http.StatusForbidden, httpErr.Code)
 }
 

--- a/scheduler/integration_test.go
+++ b/scheduler/integration_test.go
@@ -83,7 +83,7 @@ func TestSchedulerLifecycleGracefulShutdown(t *testing.T) {
 
 	assert.NoError(t, err, "Shutdown should succeed")
 
-	// Verify job completed (not cancelled mid-execution)
+	// Verify job completed (not canceled mid-execution)
 	assert.True(t, job.Completed(), "Job should have completed")
 
 	// Verify shutdown waited for job

--- a/scheduler/job_test.go
+++ b/scheduler/job_test.go
@@ -204,7 +204,7 @@ func TestJobContextContextBehavior(t *testing.T) {
 		// Wait for timeout
 		time.Sleep(20 * time.Millisecond)
 
-		// Should be cancelled
+		// Should be canceled
 		assert.Error(t, ctx.Err())
 		assert.Equal(t, context.DeadlineExceeded, ctx.Err())
 	})

--- a/scheduler/module_test.go
+++ b/scheduler/module_test.go
@@ -133,8 +133,8 @@ func TestJobSkippedDuringShutdown(t *testing.T) {
 
 // TestCreateJobWrapperBalancesAddDoneOnShutdownPath asserts that the wrapper's
 // wg.Add(1)/wg.Done() pair stays balanced when the closure bails because the
-// shutdown context is already cancelled. The pre-fix code did Add AFTER the
-// shutdown check, so a shutdown-cancelled invocation never incremented wg —
+// shutdown context is already canceled. The pre-fix code did Add AFTER the
+// shutdown check, so a shutdown-canceled invocation never incremented wg —
 // allowing wg.Wait() in Shutdown() to return before the closure had even
 // observed the cancellation. The fix moves Add to the first statement; this
 // test locks in the invariant that every bail path balances Add and Done.

--- a/server/handler.go
+++ b/server/handler.go
@@ -96,8 +96,8 @@ func newContextChecker(cfg *config.Config) *contextChecker {
 	return &contextChecker{cfg: cfg}
 }
 
-// checkCancellation checks if the request context has been cancelled or timed out.
-// Returns an API error if cancelled, nil otherwise.
+// checkCancellation checks if the request context has been canceled or timed out.
+// Returns an API error if canceled, nil otherwise.
 func (cc *contextChecker) checkCancellation(c *echo.Context, stage string) IAPIError {
 	if c.Request().Context().Err() != nil {
 		msg := fmt.Sprintf("Request timeout %s", stage)
@@ -310,7 +310,7 @@ func (hw *handlerWrapper[T, R]) wrap(handlerFunc HandlerFunc[T, R]) echo.Handler
 		}
 		formatErr := hw.selectErrorFormatter()
 
-		if apiErr := hw.checker.checkCancellation(c, "or cancelled"); apiErr != nil {
+		if apiErr := hw.checker.checkCancellation(c, "or canceled"); apiErr != nil {
 			return formatErr(c, apiErr, hw.responder.cfg)
 		}
 		if apiErr := hw.runJOSEInbound(c); apiErr != nil {
@@ -321,13 +321,13 @@ func (hw *handlerWrapper[T, R]) wrap(handlerFunc HandlerFunc[T, R]) echo.Handler
 		if apiErr != nil {
 			return formatErr(c, apiErr, hw.responder.cfg)
 		}
-		if apiErr := hw.checker.checkCancellation(c, "during validation"); apiErr != nil {
-			return formatErr(c, apiErr, hw.responder.cfg)
+		if cancelErr := hw.checker.checkCancellation(c, "during validation"); cancelErr != nil {
+			return formatErr(c, cancelErr, hw.responder.cfg)
 		}
 
 		response, apiErr := handlerFunc(request, HandlerContext{Echo: c, Config: hw.responder.cfg})
 		if c.Request().Context().Err() != nil {
-			return formatErr(c, NewServiceUnavailableError("Request timeout or cancelled during handler execution"), hw.responder.cfg)
+			return formatErr(c, NewServiceUnavailableError("Request timeout or canceled during handler execution"), hw.responder.cfg)
 		}
 		return hw.dispatchResponse(c, response, apiErr)
 	}

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -138,17 +138,17 @@ func TestWrapHandlerValidationError(t *testing.T) {
 }
 
 type advancedBindReq struct {
-	ID         int       `param:"id" validate:"min=1"`
-	Names      []string  `query:"names"`
-	Active     *bool     `query:"active"`
-	When       time.Time `query:"when"`
-	HeaderVals []string  `header:"X-Items"`
+	ID         int       `param:"id" json:"id" validate:"min=1"`
+	Names      []string  `query:"names" json:"names"`
+	Active     *bool     `query:"active" json:"active"`
+	When       time.Time `query:"when" json:"when"`
+	HeaderVals []string  `header:"X-Items" json:"headerVals"`
 }
 
 type numericRequest struct {
-	AccountID uint    `param:"accountID"`
-	Limit     uint16  `query:"limit"`
-	Ratio     float32 `query:"ratio"`
+	AccountID uint    `param:"accountID" json:"accountID"`
+	Limit     uint16  `query:"limit" json:"limit"`
+	Ratio     float32 `query:"ratio" json:"ratio"`
 }
 
 func TestRequestBinderAdvancedBinding(t *testing.T) {

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -130,7 +130,7 @@ func SetupMiddlewares(e *echo.Echo, log logger.Logger, cfg *config.Config, obser
 	}))
 
 	// Timeout - add a request-scoped deadline without swapping the response writer.
-	// This prevents goroutine panics when the context is cancelled mid-flight.
+	// This prevents goroutine panics when the context is canceled mid-flight.
 	e.Use(Timeout(cfg.Server.Timeout.Middleware))
 
 	// Body limit

--- a/server/request_enrich.go
+++ b/server/request_enrich.go
@@ -14,14 +14,14 @@ import (
 //
 // Behavior is the union of both originals: the resolved trace ID and any inbound
 // W3C trace headers are attached for outbound propagation, and the shared AMQP/DB
-// counters are seeded. TraceContext's cancelled-context early-return is adopted so
-// an already-cancelled inbound request short-circuits before any enrichment.
+// counters are seeded. TraceContext's canceled-context early-return is adopted so
+// an already-canceled inbound request short-circuits before any enrichment.
 func RequestEnrich() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
 			req := c.Request()
 
-			// SAFETY: if the request context is already cancelled (e.g. by timeout),
+			// SAFETY: if the request context is already canceled (e.g. by timeout),
 			// return early to avoid touching potentially invalidated Echo state.
 			select {
 			case <-req.Context().Done():

--- a/server/request_enrich_test.go
+++ b/server/request_enrich_test.go
@@ -72,8 +72,8 @@ func TestRequestEnrichPropagatesW3CHeaders(t *testing.T) {
 	assert.Equal(t, tracestate, gotTS)
 }
 
-// TestRequestEnrichShortCircuitsOnCancelledContext verifies the cancelled-context
-// guard: an already-cancelled inbound request returns the context error without
+// TestRequestEnrichShortCircuitsOnCancelledContext verifies the canceled-context
+// guard: an already-canceled inbound request returns the context error without
 // invoking the next handler. (This guard path was previously untested.)
 func TestRequestEnrichShortCircuitsOnCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -93,5 +93,5 @@ func TestRequestEnrichShortCircuitsOnCancelledContext(t *testing.T) {
 	err := handler(c)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
-	assert.False(t, nextCalled, "next handler must not run for an already-cancelled context")
+	assert.False(t, nextCalled, "next handler must not run for an already-canceled context")
 }

--- a/server/timeout.go
+++ b/server/timeout.go
@@ -29,7 +29,7 @@ func Timeout(duration time.Duration) echo.MiddlewareFunc {
 		return func(c *echo.Context) error {
 			parent := c.Request().Context()
 
-			// Short-circuit if the upstream context is already cancelled.
+			// Short-circuit if the upstream context is already canceled.
 			select {
 			case <-parent.Done():
 				return parent.Err()

--- a/server/timeout_test.go
+++ b/server/timeout_test.go
@@ -124,7 +124,7 @@ func TestContextDeadlineDetectionBeforeBinding(t *testing.T) {
 
 	GET(hr, registrar, "/test", handler)
 
-	// Create request with already-cancelled context
+	// Create request with already-canceled context
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", http.NoBody)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
@@ -136,7 +136,7 @@ func TestContextDeadlineDetectionBeforeBinding(t *testing.T) {
 
 	// Assert
 	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
-	assert.False(t, handlerCalled, "Handler should not be called when context is already cancelled")
+	assert.False(t, handlerCalled, "Handler should not be called when context is already canceled")
 	assert.Contains(t, rec.Body.String(), "timeout")
 }
 
@@ -207,8 +207,8 @@ func TestTimeoutDuringValidation(t *testing.T) {
 	// Wait for context to expire
 	time.Sleep(5 * time.Millisecond)
 
-	// Explicitly verify context is cancelled (defensive test assertion)
-	require.Error(t, ctx.Err(), "Context should be cancelled after timeout")
+	// Explicitly verify context is canceled (defensive test assertion)
+	require.Error(t, ctx.Err(), "Context should be canceled after timeout")
 
 	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
@@ -311,7 +311,7 @@ func TestTimeoutWithLoggerMiddleware(t *testing.T) {
 		case <-time.After(100 * time.Millisecond): // Exceeds 50ms timeout
 			return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 		case <-c.Request().Context().Done():
-			// Context cancelled - return the error to trigger timeout handling
+			// Context canceled - return the error to trigger timeout handling
 			return c.Request().Context().Err()
 		}
 	})
@@ -363,7 +363,7 @@ func TestTimeoutWithLoggerHighConcurrency(t *testing.T) {
 	e.GET("/endpoint", func(c *echo.Context) error {
 		// Simulate slow operation that checks context.
 		// Handler delay (200ms) is 10x the timeout (20ms) to ensure
-		// the context is always cancelled first, even under CI load.
+		// the context is always canceled first, even under CI load.
 		select {
 		case <-time.After(200 * time.Millisecond):
 			return c.JSON(http.StatusOK, map[string]string{"status": "ok"})

--- a/server/trace_context.go
+++ b/server/trace_context.go
@@ -31,11 +31,11 @@ func TraceContext() echo.MiddlewareFunc {
 		return func(c *echo.Context) error {
 			req := c.Request()
 
-			// SAFETY: Check if the request context has already been cancelled (e.g., by timeout).
+			// SAFETY: Check if the request context has already been canceled (e.g., by timeout).
 			// If so, we should return early to avoid accessing potentially invalidated Echo state.
 			select {
 			case <-req.Context().Done():
-				// Context already cancelled, return the error without processing
+				// Context already canceled, return the error without processing
 				return req.Context().Err()
 			default:
 				// Context still active, proceed normally

--- a/testing/fixtures/database.go
+++ b/testing/fixtures/database.go
@@ -221,7 +221,12 @@ func NewMockRows(columns []string, rows [][]any) *sql.Rows {
 	// Setup the expectation
 	sqlMock.ExpectQuery(".*").WillReturnRows(sqlRows)
 
-	// Execute the query to get the actual rows
+	// Execute the query to get the actual rows. The *sql.Rows is intentionally
+	// returned (not closed here) so the caller/mock can consume it as a fixture;
+	// closing it in this factory would yield an unusable, drained result set. The
+	// sqlmock-backed connection is released when the returned rows are eventually
+	// drained or the mock is torn down — sqlclosecheck cannot model this transfer.
+	//nolint:sqlclosecheck // fixture rows are returned for the caller to own; see comment above
 	result, err := db.QueryContext(context.Background(), "SELECT")
 	if err != nil {
 		panic(err) //nolint:S8148 // NOSONAR: Test fixture - panic on setup failure is intentional

--- a/tools/migration/Makefile
+++ b/tools/migration/Makefile
@@ -8,6 +8,9 @@ GOVULNCHECK_VERSION := v1.3.0
 # Keep in sync with the other module's Makefile.
 # renovate: datasource=go depName=github.com/securego/gosec/v2
 GOSEC_VERSION := v2.27.1
+# Keep in sync with the other module's Makefile and CI (ci-v2.yml golangci-lint-action version).
+# renovate: datasource=go depName=github.com/golangci/golangci-lint/v2
+GOLANGCI_LINT_VERSION := v2.12.2
 
 help: ## Show this help message
 	@echo "go-bricks-migrate tool commands:"
@@ -23,8 +26,8 @@ test-coverage: ## Run tests with coverage
 	go test -race -coverprofile=coverage.out ./cmd/... ./internal/...
 	go tool cover -html=coverage.out -o coverage.html
 
-lint: ## Run golangci-lint
-	golangci-lint run
+lint: ## Run golangci-lint (pinned; identical to CI)
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run
 
 fmt: ## Format Go code
 	go fmt ./...
@@ -48,7 +51,7 @@ validate-cli: build ## Validate CLI commands work correctly
 check: fmt lint test validate-cli vuln ## Run fmt, lint, test, CLI validation, and vuln scan (pre-commit checks)
 
 dev-deps: ## Install development dependencies
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 vuln: ## Run govulncheck vulnerability scan (pinned; identical to CI)
 	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...

--- a/tools/migration/internal/commands/quiesce_test.go
+++ b/tools/migration/internal/commands/quiesce_test.go
@@ -234,7 +234,7 @@ func TestRunQuiesceStatusReportsClearedState(t *testing.T) {
 }
 
 func TestRunQuiesceWrapsControllerErrors(t *testing.T) {
-	boom := erroringController{err: assertErr}
+	boom := erroringController{err: errAssert}
 	var out bytes.Buffer
 
 	require.Error(t, runQuiesceStatus(context.Background(), &out, boom, false))
@@ -243,11 +243,11 @@ func TestRunQuiesceWrapsControllerErrors(t *testing.T) {
 	require.Error(t, runQuiesceSet(context.Background(), &out, boom, flags))
 }
 
-var assertErr = errorString("control-plane unavailable")
+var errAssert = stringError("control-plane unavailable")
 
-type errorString string
+type stringError string
 
-func (e errorString) Error() string { return string(e) }
+func (e stringError) Error() string { return string(e) }
 
 func TestRunQuiesceStatusReportsExpiredState(t *testing.T) {
 	now := time.Now().UTC()
@@ -280,7 +280,7 @@ type createTableErrController struct {
 	*migration.MemoryQuiesceController
 }
 
-func (createTableErrController) CreateTable(context.Context) error { return errorString("ddl failed") }
+func (createTableErrController) CreateTable(context.Context) error { return stringError("ddl failed") }
 
 func TestWithControlPlaneControllerCreateTableError(t *testing.T) {
 	orig := controllerOpener


### PR DESCRIPTION
## What & why

Closes the highest-leverage **linter gap** from the quality audit: enable a curated set of correctness linters whose absence each contradicted a documented manifesto rule, fix every finding they surface, and remove dead lint config + local/CI version drift.

The audit's raw "4945 findings" was dominated by two noisy linters deferred to dedicated follow-ups (`paralleltest` 3694 — needs race-detector validation across 800+ tests; `testifylint` 910 — mostly style). This PR ships the **high-signal tier (~51 real fixes)**.

## Linters enabled (14 + govet `shadow`)
| Linter | Findings fixed | Notes |
|---|---|---|
| errorlint | 22 | `err ==` → `errors.Is`; type-assert → `errors.As`; `%v`→`%w` |
| sqlclosecheck | 14 | `defer rows.Close()` after error checks |
| copyloopvar | 6 | drop redundant `x := x` (Go 1.22+) |
| spancheck | 3 | **real OTel issues** + documented factory nolints |
| nilerr | 2 | **real logic improvements** (see below) |
| errname / musttag | 3 / 2 | test-only renames / json tags |
| govet shadow | 9 | inner-scope renames |
| misspell | 80 | `--fix`, US locale — **event types/keys preserved** |
| durationcheck, makezero, wastedassign, loggercheck, gocheckcompilerdirectives, zerologlint | 0 | zero-cost safety nets |

## Real defects fixed (not just lint noise)
- **`database/internal/tracking/metrics.go`** — `observePoolStats` silently swallowed `conn.Stats()` errors; now logs via `logMetricError` before the best-effort `return nil` (propagating would abort the whole OTel metrics batch).
- **`logger/otel_bridge.go`** — documented why a non-JSON `Write` correctly returns `(len(p), nil)` (io.Writer contract; an error breaks zerolog's chain). Explained `//nolint:nilerr`.
- **spancheck** — `StartHTTPClientSpan`/`StartConsumeSpan` are span *factories*; ownership transfers to callers (`EndHTTPClientSpan` / consumer). Calling `.End()` in the factory would zero every span's duration. Documented `//nolint:spancheck` (genuine linter FP — it can't model cross-function ownership; the "never nolint" precedent is for S8179/S8196 naming, not real FPs).

## Hygiene
- Removed dead `.golangci.yml` config: 3 nonexistent-dir exclusions, the dead govet/logutils `printf` block, the stale `govet` test-exclusion line (bson.D — MongoDB gone via ADR-012).
- Enabled `misspell` (settings existed but linter wasn't on); scoped `zerologlint` off `logger/adapter.go` (wrapper FP).
- **Version drift**: pinned `make lint` to `go run …/golangci-lint/v2@v2.12.2` **+ `GOWORK=off`** for exact parity with CI's `lint-framework`; fixed `tools/migration` `dev-deps` from the wrong v1 module path `@latest` to the v2 path pinned to CI's version. Added renovate-annotated `GOLANGCI_LINT_VERSION` to both Makefiles.

## Deferred (follow-up PRs)
`forcetypeassert` (216), `nilnil` (50), errcheck `check-type-assertions` (85), `contextcheck` (18) — "enable after sweep" tier; `testifylint` (curated subset); `paralleltest` (dedicated race-validated initiative); config tightenings (`exhaustive` default flip, `nolintlint` strict, `lll`→140).

## Testing
`make check` (fmt + lint + test -race + vuln) → **exit 0**; `make lint` target → 0 issues; both modules clean. Reviewed with `/code-review` (high; 0 findings) and `/security-audit` (no new raw-SQL/secrets, `validate` tags intact, gosec+govulncheck clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable error wrapping/matching across the codebase to improve error inspection and unwrapping.
  * Ensured query/result sets and background resources are closed consistently to avoid leaks and panics.

* **Chores**
  * Expanded lint rules, narrowed exemptions, and pinned the linter version; updated lint invocation for consistent CI runs.
  * Standardized American English in user-visible messages and docs.

* **Tests**
  * Strengthened tests to use robust error comparisons and added a test validating span creation for nil deliveries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->