### PR TITLE
fix(app): consume validated startup-budget and manager-tuning config keys

### DIFF
--- a/app/app_builder.go
+++ b/app/app_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gaborage/go-bricks/config"
 	"github.com/gaborage/go-bricks/logger"
@@ -240,36 +241,112 @@ func (b *Builder) ConfigureRuntimeHelpers() *Builder {
 
 // performPreInitialization attempts to establish connections during app startup.
 // This reduces cold-start latency for single-tenant applications.
+//
+// Each component is pre-initialized under its OWN context budget sourced from
+// app.startup.{database,messaging,cache}, honoring the documented three-level
+// fallback hierarchy (component value > app.startup.timeout > built-in default,
+// resolved earlier in config.applyStartupDefaults). Database and messaging
+// failures are fatal (a misconfigured backing store should fail fast at startup);
+// cache pre-init is best-effort, matching the manager-creation contract where a
+// failing cache is disabled rather than crashing the app.
 func (b *Builder) performPreInitialization() {
 	if b.err != nil {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), b.cfg.App.Startup.Timeout)
-	defer cancel()
+	startup := b.cfg.App.Startup
 	b.logger.Debug().Msg("Performing pre-initialization for static single-tenant mode")
 
-	// Pre-initialize database if configured
-	if b.bundle.dbManager != nil && config.IsDatabaseConfigured(&b.cfg.Database) {
-		if _, err := b.bundle.dbManager.Get(ctx, ""); err != nil {
-			b.err = fmt.Errorf("database connection failed during startup: %w", err)
-			return
-		}
-		b.logger.Debug().Msg("Pre-initialized database connection")
-	} else if b.bundle.dbManager != nil {
-		b.logger.Debug().Msg("Skipping database pre-initialization: not configured")
+	if !b.preInitDatabase(startup.Database) {
+		return
+	}
+	if !b.preInitMessaging(startup.Messaging) {
+		return
+	}
+	b.preInitCache(startup.Cache)
+}
+
+// preInitDatabase pre-initializes the database connection under its own startup
+// budget. Returns false (and sets b.err) on a fatal failure so the caller stops.
+func (b *Builder) preInitDatabase(timeout time.Duration) bool {
+	if b.bundle.dbManager == nil {
+		return true
+	}
+	return b.preInitFatalComponent(
+		"database",
+		timeout,
+		config.IsDatabaseConfigured(&b.cfg.Database),
+		func(ctx context.Context) error {
+			_, err := b.bundle.dbManager.Get(ctx, "")
+			return err
+		},
+	)
+}
+
+// preInitMessaging pre-initializes the messaging publisher under its own startup
+// budget. Returns false (and sets b.err) on a fatal failure so the caller stops.
+func (b *Builder) preInitMessaging(timeout time.Duration) bool {
+	if b.bundle.messagingManager == nil {
+		return true
+	}
+	return b.preInitFatalComponent(
+		"messaging",
+		timeout,
+		config.IsMessagingConfigured(&b.cfg.Messaging),
+		func(ctx context.Context) error {
+			_, err := b.bundle.messagingManager.Publisher(ctx, "")
+			return err
+		},
+	)
+}
+
+// preInitFatalComponent pre-initializes a startup-fatal component (database or
+// messaging) under its own per-component budget. The component is skipped when
+// not configured; a connection failure is fatal (sets b.err) and stops the
+// remaining pre-init steps by returning false.
+func (b *Builder) preInitFatalComponent(
+	name string,
+	timeout time.Duration,
+	configured bool,
+	connect func(ctx context.Context) error,
+) bool {
+	if !configured {
+		b.logger.Debug().Msgf("Skipping %s pre-initialization: not configured", name)
+		return true
 	}
 
-	// Pre-initialize messaging if configured
-	if b.bundle.messagingManager != nil && config.IsMessagingConfigured(&b.cfg.Messaging) {
-		if _, err := b.bundle.messagingManager.Publisher(ctx, ""); err != nil {
-			b.err = fmt.Errorf("messaging connection failed during startup: %w", err)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := connect(ctx); err != nil {
+		b.err = fmt.Errorf("%s connection failed during startup: %w", name, err)
+		return false
+	}
+	b.logger.Debug().Msgf("Pre-initialized %s connection", name)
+	return true
+}
+
+// preInitCache pre-initializes the cache connection under its own startup budget.
+// Cache is optional: a not-configured cache is skipped silently and any other
+// failure is logged as a warning without aborting startup, mirroring the
+// manager-creation contract (a failing cache is disabled, not fatal).
+func (b *Builder) preInitCache(timeout time.Duration) {
+	if b.bundle.cacheManager == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if _, err := b.bundle.cacheManager.Get(ctx, ""); err != nil {
+		if config.IsNotConfigured(err) {
+			b.logger.Debug().Msg("Skipping cache pre-initialization: not configured")
 			return
 		}
-		b.logger.Debug().Msg("Pre-initialized messaging publisher")
-	} else if b.bundle.messagingManager != nil {
-		b.logger.Debug().Msg("Skipping messaging pre-initialization: not configured")
+		b.logger.Warn().Err(err).Msg("Failed to pre-initialize cache connection (non-fatal)")
+		return
 	}
+	b.logger.Debug().Msg("Pre-initialized cache connection")
 }
 
 // CreateHealthProbes creates health check probes for all managers.

--- a/app/app_builder_test.go
+++ b/app/app_builder_test.go
@@ -1,10 +1,19 @@
 package app
 
 import (
+	"context"
+	"errors"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/gaborage/go-bricks/cache"
+	cachetesting "github.com/gaborage/go-bricks/cache/testing"
 	"github.com/gaborage/go-bricks/config"
+	"github.com/gaborage/go-bricks/database"
 	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/messaging"
+	testmocks "github.com/gaborage/go-bricks/testing/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -513,6 +522,163 @@ func TestAppBuilderChainValidation(t *testing.T) {
 		assert.Nil(t, result.bundle)
 		assert.Nil(t, result.app)
 	})
+}
+
+// deadlineCapturingResource is a static TenantStore that records the context
+// deadline observed during single-tenant pre-initialization for each component.
+// It lets tests assert that DB, messaging, and cache pre-init each receive their
+// own per-component startup budget rather than a single shared global timeout.
+type deadlineCapturingResource struct {
+	mu            sync.Mutex
+	dbDeadline    time.Time
+	dbHadDL       bool
+	msgDeadline   time.Time
+	msgHadDL      bool
+	cacheDeadline time.Time
+	cacheHadDL    bool
+}
+
+func (r *deadlineCapturingResource) DBConfig(ctx context.Context, _ string) (*config.DatabaseConfig, error) {
+	r.mu.Lock()
+	r.dbDeadline, r.dbHadDL = ctx.Deadline()
+	r.mu.Unlock()
+	return &config.DatabaseConfig{Type: dbTypePostgres, Host: localHost, Port: 5432}, nil
+}
+
+func (r *deadlineCapturingResource) BrokerURL(ctx context.Context, _ string) (string, error) {
+	r.mu.Lock()
+	r.msgDeadline, r.msgHadDL = ctx.Deadline()
+	r.mu.Unlock()
+	return "amqp://guest:guest@localhost:5672/", nil
+}
+
+func (r *deadlineCapturingResource) CacheConfig(_ context.Context, _ string) (*config.CacheConfig, error) {
+	return &config.CacheConfig{Enabled: true, Redis: config.RedisConfig{Host: localHost, Port: 6379}}, nil
+}
+
+func (r *deadlineCapturingResource) IsDynamic() bool { return false }
+
+func (r *deadlineCapturingResource) captureCacheDeadline(ctx context.Context) {
+	r.mu.Lock()
+	r.cacheDeadline, r.cacheHadDL = ctx.Deadline()
+	r.mu.Unlock()
+}
+
+// TestPerformPreInitializationUsesPerComponentTimeouts verifies that single-tenant
+// pre-initialization derives each component's context deadline from its own
+// app.startup.{database,messaging,cache} budget, not from the shared
+// app.startup.timeout fallback. The global Timeout is set small and the
+// per-component budgets large and distinct so a regression to the shared timeout
+// is unambiguous.
+func TestPerformPreInitializationUsesPerComponentTimeouts(t *testing.T) {
+	const (
+		globalBudget = 2 * time.Second
+		dbBudget     = 30 * time.Second
+		msgBudget    = 45 * time.Second
+		cacheBudget  = 8 * time.Second
+	)
+
+	cfg := defaultTestConfig()
+	cfg.App.Startup = config.StartupConfig{
+		Timeout:       globalBudget,
+		Database:      dbBudget,
+		Messaging:     msgBudget,
+		Cache:         cacheBudget,
+		Observability: 15 * time.Second,
+	}
+
+	resource := &deadlineCapturingResource{}
+	opts := &Options{
+		ResourceSource: resource,
+		DatabaseConnector: func(*config.DatabaseConfig, logger.Logger) (database.Interface, error) {
+			return &testmocks.MockDatabase{}, nil
+		},
+		MessagingClientFactory: func(string, logger.Logger) messaging.AMQPClient {
+			return testmocks.NewMockAMQPClient()
+		},
+		CacheConnector: func(ctx context.Context, _ string) (cache.Cache, error) {
+			resource.captureCacheDeadline(ctx)
+			return cachetesting.NewMockCache(), nil
+		},
+	}
+
+	start := time.Now()
+	_, _, err := NewWithConfig(cfg, opts)
+	require.NoError(t, err)
+
+	resource.mu.Lock()
+	defer resource.mu.Unlock()
+
+	require.True(t, resource.dbHadDL, "database pre-init context must carry a deadline")
+	require.True(t, resource.msgHadDL, "messaging pre-init context must carry a deadline")
+	require.True(t, resource.cacheHadDL, "cache pre-init context must carry a deadline")
+
+	const tolerance = 3 * time.Second
+	assert.InDelta(t, dbBudget.Seconds(), resource.dbDeadline.Sub(start).Seconds(), tolerance.Seconds(),
+		"database pre-init must use app.startup.database, not the global timeout")
+	assert.InDelta(t, msgBudget.Seconds(), resource.msgDeadline.Sub(start).Seconds(), tolerance.Seconds(),
+		"messaging pre-init must use app.startup.messaging, not the global timeout")
+	assert.InDelta(t, cacheBudget.Seconds(), resource.cacheDeadline.Sub(start).Seconds(), tolerance.Seconds(),
+		"cache pre-init must use app.startup.cache, not the global timeout")
+}
+
+// TestPreInitCacheFailureIsNonFatal verifies that a cache pre-initialization
+// failure does not abort startup. Both error shapes are exercised:
+//   - a non-NotConfigured error hits the WARN ("non-fatal") branch
+//   - a NotConfigured error hits the silent skip (Debug) branch
+//
+// In both cases NewWithConfig must still succeed, proving cache pre-init is
+// best-effort while database/messaging remain startup-fatal.
+func TestPreInitCacheFailureIsNonFatal(t *testing.T) {
+	cases := []struct {
+		name      string
+		cacheErr  error
+		wantCalls bool
+	}{
+		{
+			name:      "non_configured_error_is_skipped_silently",
+			cacheErr:  config.NewNotConfiguredError("cache", "CACHE_REDIS_HOST", "cache.redis.host"),
+			wantCalls: true,
+		},
+		{
+			name:      "other_error_is_logged_and_continues",
+			cacheErr:  errors.New("dial timeout"),
+			wantCalls: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := defaultTestConfig()
+			cfg.App.Startup = config.StartupConfig{
+				Timeout:       2 * time.Second,
+				Database:      2 * time.Second,
+				Messaging:     2 * time.Second,
+				Cache:         2 * time.Second,
+				Observability: 2 * time.Second,
+			}
+
+			var cacheCalled bool
+			opts := &Options{
+				ResourceSource: &deadlineCapturingResource{},
+				DatabaseConnector: func(*config.DatabaseConfig, logger.Logger) (database.Interface, error) {
+					return &testmocks.MockDatabase{}, nil
+				},
+				MessagingClientFactory: func(string, logger.Logger) messaging.AMQPClient {
+					return testmocks.NewMockAMQPClient()
+				},
+				CacheConnector: func(context.Context, string) (cache.Cache, error) {
+					cacheCalled = true
+					return nil, tc.cacheErr
+				},
+			}
+
+			app, _, err := NewWithConfig(cfg, opts)
+			require.NoError(t, err, "cache pre-init failure must not abort startup")
+			require.NotNil(t, app)
+			assert.Equal(t, tc.wantCalls, cacheCalled, "cache connector should be invoked during pre-init")
+		})
+	}
 }
 
 func TestAppBuilderErrorRecovery(t *testing.T) {

--- a/app/bootstrap.go
+++ b/app/bootstrap.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/gaborage/go-bricks/config"
@@ -15,6 +16,11 @@ type appBootstrap struct {
 	cfg  *config.Config
 	log  logger.Logger
 	opts *Options
+
+	// newProvider constructs the observability provider under the supplied
+	// context. Defaults to observability.NewProviderWithContext; overridable
+	// in tests to drive the startup-budget timeout path deterministically.
+	newProvider func(context.Context, *observability.Config) (observability.Provider, error)
 }
 
 // newAppBootstrap creates a new bootstrap helper with the provided configuration.
@@ -36,6 +42,8 @@ func (b *appBootstrap) dependencies() *dependencyBundle {
 	resolver := NewFactoryResolver(b.opts)
 	configBuilder := NewManagerConfigBuilder(b.cfg.Multitenant.Enabled, b.cfg.Multitenant.Limits.Tenants)
 	configBuilder.connectionTimeout = b.cfg.Messaging.Reconnect.ConnectionTimeout
+	configBuilder.publisherConfig = b.cfg.Messaging.Publisher
+	configBuilder.cacheConfig = b.cfg.Cache.Manager
 	factory := NewResourceManagerFactory(resolver, configBuilder, b.log)
 
 	// Log factory configuration for debugging
@@ -142,8 +150,24 @@ func (b *appBootstrap) initializeObservability() observability.Provider {
 		Str("logs_disable_stdout", strconv.FormatBool(obsCfg.Logs.DisableStdout)).
 		Msg("Observability config after applying defaults")
 
-	// Create provider (will be no-op if Enabled is false)
-	provider, err := observability.NewProvider(&obsCfg)
+	// Create provider (will be no-op if Enabled is false) under the
+	// app.startup.observability budget. The budget is enforced by threading a
+	// deadline-bound context through provider construction (resource detection
+	// and OTLP exporter setup), so a slow resource probe or exporter setup fails
+	// fast instead of blocking the whole startup on the shared global timeout.
+	budget := b.cfg.App.Startup.Observability
+	construct := b.newProvider
+	if construct == nil {
+		construct = observability.NewProviderWithContext
+	}
+	ctx := context.Background()
+	if budget > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, budget)
+		defer cancel()
+	}
+
+	provider, err := construct(ctx, &obsCfg)
 	if err != nil {
 		b.log.Warn().Err(err).Msg("Failed to initialize observability, using no-op provider")
 		return observability.MustNewProvider(&observability.Config{Enabled: false})

--- a/app/bootstrap_test.go
+++ b/app/bootstrap_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/gaborage/go-bricks/config"
 	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/observability"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric"
@@ -560,4 +562,114 @@ debug:
 	// Cleanup (should not error)
 	err = obsProvider.Shutdown(context.Background())
 	assert.NoError(t, err)
+}
+
+// TestInitializeObservabilityThreadsBudgetContext verifies that when
+// app.startup.observability is positive, the construction seam receives a
+// non-nil context whose deadline is set roughly the budget into the future.
+// This is the context-threading replacement for the old goroutine-race budget
+// enforcement: the deadline is what bounds resource detection and exporter
+// setup inside NewProviderWithContext.
+func TestInitializeObservabilityThreadsBudgetContext(t *testing.T) {
+	const budget = 7 * time.Second
+
+	want := &testObservabilityProvider{}
+	var (
+		gotCtx context.Context
+		gotCfg *observability.Config
+	)
+
+	cfg := loadConfigFromYAML(t, `
+app:
+  name: test-app
+  version: 1.0.0
+  env: development
+  startup:
+    observability: 7s
+server:
+  host: localhost
+  port: 8080
+database:
+  type: postgresql
+  host: localhost
+  port: 5432
+  database: testdb
+  username: testuser
+  password: testpass
+log:
+  level: info
+observability:
+  enabled: true
+  service:
+    name: budget-test
+`)
+
+	bootstrap := newAppBootstrap(cfg, logger.New("info", false), &Options{})
+	bootstrap.newProvider = func(ctx context.Context, c *observability.Config) (observability.Provider, error) {
+		gotCtx = ctx
+		gotCfg = c
+		return want, nil
+	}
+
+	start := time.Now()
+	got := bootstrap.initializeObservability()
+
+	assert.Same(t, want, got, "the provider returned by the seam should be installed verbatim")
+	require.NotNil(t, gotCtx, "seam must receive a non-nil context")
+	require.NotNil(t, gotCfg, "seam must receive the observability config")
+
+	deadline, ok := gotCtx.Deadline()
+	require.True(t, ok, "seam context must carry a deadline derived from the startup budget")
+
+	const tolerance = 2 * time.Second
+	assert.InDelta(t, budget.Seconds(), deadline.Sub(start).Seconds(), tolerance.Seconds(),
+		"seam context deadline must be ~app.startup.observability from now")
+}
+
+// TestInitializeObservabilityConstructorErrorFallsBackToNoop verifies that when
+// the construction seam returns an error, initializeObservability installs the
+// no-op fallback provider (functional tracer/meter providers, nil logger
+// provider) and logs a WARN rather than crashing.
+func TestInitializeObservabilityConstructorErrorFallsBackToNoop(t *testing.T) {
+	cfg := loadConfigFromYAML(t, `
+app:
+  name: test-app
+  version: 1.0.0
+  env: development
+  startup:
+    observability: 5s
+server:
+  host: localhost
+  port: 8080
+database:
+  type: postgresql
+  host: localhost
+  port: 5432
+  database: testdb
+  username: testuser
+  password: testpass
+log:
+  level: info
+observability:
+  enabled: true
+  service:
+    name: error-fallback-test
+`)
+
+	mockLog := &mockLogger{}
+	bootstrap := newAppBootstrap(cfg, mockLog, &Options{})
+	bootstrap.newProvider = func(context.Context, *observability.Config) (observability.Provider, error) {
+		return nil, errors.New("exporter dial failed")
+	}
+
+	got := bootstrap.initializeObservability()
+
+	require.NotNil(t, got, "a no-op provider must be installed on constructor error")
+	assert.NotNil(t, got.TracerProvider(), "no-op provider must expose a tracer provider")
+	assert.NotNil(t, got.MeterProvider(), "no-op provider must expose a meter provider")
+	assert.Nil(t, got.LoggerProvider(), "no-op provider has no OTLP logger provider")
+	assert.True(t, mockLog.warnCalled, "constructor failure must be logged as a WARN")
+
+	// The fallback provider must shut down cleanly (no-op).
+	assert.NoError(t, got.Shutdown(context.Background()))
 }

--- a/app/managers.go
+++ b/app/managers.go
@@ -4,9 +4,22 @@ import (
 	"time"
 
 	"github.com/gaborage/go-bricks/cache"
+	"github.com/gaborage/go-bricks/config"
 	"github.com/gaborage/go-bricks/database"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+)
+
+// Documented operator-configurable defaults. These mirror the values applied by
+// config validation (see config/validation.go: applyMessagingDefaults and
+// applyCacheManagerDefaults) so the builder honors the same documented behavior
+// even when invoked without a fully-validated config (e.g. in unit tests).
+const (
+	defaultPublisherMaxCached   = 50
+	defaultPublisherIdleTTL     = 10 * time.Minute
+	defaultCacheMaxSize         = 100
+	defaultCacheIdleTTL         = 15 * time.Minute
+	defaultCacheCleanupInterval = 5 * time.Minute
 )
 
 // ManagerConfigBuilder creates configuration options for database and messaging managers
@@ -17,6 +30,14 @@ type ManagerConfigBuilder struct {
 	// connectionTimeout is the per-publish AMQP broker confirmation timeout,
 	// sourced from messaging.reconnect.connectiontimeout and set by bootstrap.
 	connectionTimeout time.Duration
+	// publisherConfig carries operator-configurable messaging publisher pool
+	// settings (messaging.publisher.*), sourced from validated config by bootstrap.
+	// When unset, documented defaults are applied as fallbacks.
+	publisherConfig config.PublisherPoolConfig
+	// cacheConfig carries operator-configurable cache manager settings
+	// (cache.manager.*), sourced from validated config by bootstrap.
+	// When unset, documented defaults are applied as fallbacks.
+	cacheConfig config.CacheManagerConfig
 }
 
 // NewManagerConfigBuilder creates a new manager configuration builder.
@@ -48,17 +69,29 @@ func (b *ManagerConfigBuilder) BuildDatabaseOptions() database.DbManagerOptions 
 // Multi-tenant mode uses tenant limits and shorter TTL for dynamic scaling.
 // Single-tenant mode uses smaller fixed limits and moderate TTL.
 func (b *ManagerConfigBuilder) BuildMessagingOptions() messaging.ManagerOptions {
-	if b.multiTenantEnabled {
-		return messaging.ManagerOptions{
-			MaxPublishers:     b.tenantLimit,   // Use configured tenant limit
-			IdleTTL:           5 * time.Minute, // Shorter TTL for multi-tenant
-			ConnectionTimeout: b.connectionTimeout,
+	// Operator config (messaging.publisher.*) is the source of truth. Mode-specific
+	// values are only fallbacks when the operator left the key unset (zero).
+	maxPublishers := b.publisherConfig.MaxCached
+	if maxPublishers == 0 {
+		if b.multiTenantEnabled {
+			maxPublishers = b.tenantLimit // Scale publisher pool with tenant limit
+		} else {
+			maxPublishers = defaultPublisherMaxCached // Documented single-tenant default
+		}
+	}
+
+	idleTTL := b.publisherConfig.IdleTTL
+	if idleTTL == 0 {
+		if b.multiTenantEnabled {
+			idleTTL = 5 * time.Minute // Shorter TTL for multi-tenant churn
+		} else {
+			idleTTL = defaultPublisherIdleTTL // Documented single-tenant default
 		}
 	}
 
 	return messaging.ManagerOptions{
-		MaxPublishers:     10,               // Small fixed size for single-tenant
-		IdleTTL:           30 * time.Minute, // Moderate TTL for single-tenant
+		MaxPublishers:     maxPublishers,
+		IdleTTL:           idleTTL,
 		ConnectionTimeout: b.connectionTimeout,
 	}
 }
@@ -67,18 +100,31 @@ func (b *ManagerConfigBuilder) BuildMessagingOptions() messaging.ManagerOptions 
 // Multi-tenant mode uses tenant limits and shorter TTL for dynamic scaling.
 // Single-tenant mode uses smaller fixed limits and longer TTL.
 func (b *ManagerConfigBuilder) BuildCacheOptions() cache.ManagerConfig {
-	if b.multiTenantEnabled {
-		return cache.ManagerConfig{
-			MaxSize:         b.tenantLimit,    // Use configured tenant limit
-			IdleTTL:         15 * time.Minute, // Moderate TTL for multi-tenant
-			CleanupInterval: 5 * time.Minute,  // Cleanup interval
+	// Operator config (cache.manager.*) is the source of truth. Mode-specific
+	// values are only fallbacks when the operator left the key unset (zero).
+	maxSize := b.cacheConfig.MaxSize
+	if maxSize == 0 {
+		if b.multiTenantEnabled {
+			maxSize = b.tenantLimit // Scale cache instances with tenant limit
+		} else {
+			maxSize = defaultCacheMaxSize // Documented single-tenant default
 		}
 	}
 
+	idleTTL := b.cacheConfig.IdleTTL
+	if idleTTL == 0 {
+		idleTTL = defaultCacheIdleTTL // Documented default (same for both modes)
+	}
+
+	cleanupInterval := b.cacheConfig.CleanupInterval
+	if cleanupInterval == 0 {
+		cleanupInterval = defaultCacheCleanupInterval // Documented default (same for both modes)
+	}
+
 	return cache.ManagerConfig{
-		MaxSize:         10,               // Small fixed size for single-tenant
-		IdleTTL:         1 * time.Hour,    // Longer TTL for single-tenant
-		CleanupInterval: 15 * time.Minute, // Less frequent cleanup
+		MaxSize:         maxSize,
+		IdleTTL:         idleTTL,
+		CleanupInterval: cleanupInterval,
 	}
 }
 

--- a/app/managers_test.go
+++ b/app/managers_test.go
@@ -110,8 +110,10 @@ func TestManagerConfigBuilderBuildMessagingOptions(t *testing.T) {
 
 		options := builder.BuildMessagingOptions()
 
-		assert.Equal(t, 10, options.MaxPublishers)
-		assert.Equal(t, 30*time.Minute, options.IdleTTL)
+		// With no operator override, single-tenant falls back to the documented
+		// messaging.publisher defaults (maxcached=50, idlettl=10m).
+		assert.Equal(t, 50, options.MaxPublishers)
+		assert.Equal(t, 10*time.Minute, options.IdleTTL)
 	})
 
 	t.Run("multi-tenant messaging options", func(t *testing.T) {
@@ -169,6 +171,73 @@ func TestManagerConfigBuilderBuildMessagingOptions(t *testing.T) {
 	})
 }
 
+func TestManagerConfigBuilderHonorsConfigDefaults(t *testing.T) {
+	// Config validation applies defaults: messaging.publisher.maxcached=50, messaging.publisher.idlettl=10m
+	// cache.manager.maxsize=100, cache.manager.idlettl=15m, cache.manager.cleanupinterval=5m
+
+	t.Run("single-tenant BuildMessagingOptions should honor config defaults not hardcoded 10", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(false, 100)
+		// Currently hardcodes MaxPublishers=10, should instead read from cfg.Messaging.Publisher.MaxCached
+		opts := builder.BuildMessagingOptions()
+		assert.Equal(t, 50, opts.MaxPublishers, "should honor messaging.publisher.maxcached config default of 50, not hardcode 10")
+	})
+
+	t.Run("single-tenant BuildMessagingOptions IdleTTL should honor config default 10m not hardcoded 30m", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(false, 100)
+		opts := builder.BuildMessagingOptions()
+		assert.Equal(t, 10*time.Minute, opts.IdleTTL, "should honor messaging.publisher.idlettl config default of 10m, not hardcode 30m")
+	})
+
+	t.Run("single-tenant BuildCacheOptions should honor config defaults not hardcoded 10", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(false, 100)
+		opts := builder.BuildCacheOptions()
+		assert.Equal(t, 100, opts.MaxSize, "should honor cache.manager.maxsize config default of 100, not hardcode 10")
+	})
+
+	t.Run("single-tenant BuildCacheOptions IdleTTL should honor config default 15m not hardcoded 1h", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(false, 100)
+		opts := builder.BuildCacheOptions()
+		assert.Equal(t, 15*time.Minute, opts.IdleTTL, "should honor cache.manager.idlettl config default of 15m, not hardcode 1h")
+	})
+
+	t.Run("single-tenant BuildCacheOptions CleanupInterval should honor config default 5m not hardcoded 15m", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(false, 100)
+		opts := builder.BuildCacheOptions()
+		assert.Equal(t, 5*time.Minute, opts.CleanupInterval, "should honor cache.manager.cleanupinterval config default of 5m, not hardcode 15m")
+	})
+
+	t.Run("operator override reaches messaging options", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(false, 100)
+		builder.publisherConfig = config.PublisherPoolConfig{MaxCached: 77, IdleTTL: 3 * time.Minute}
+		opts := builder.BuildMessagingOptions()
+		assert.Equal(t, 77, opts.MaxPublishers, "operator messaging.publisher.maxcached override must reach ManagerOptions")
+		assert.Equal(t, 3*time.Minute, opts.IdleTTL, "operator messaging.publisher.idlettl override must reach ManagerOptions")
+	})
+
+	t.Run("operator override reaches cache options", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(false, 100)
+		builder.cacheConfig = config.CacheManagerConfig{MaxSize: 42, IdleTTL: 2 * time.Minute, CleanupInterval: 90 * time.Second}
+		opts := builder.BuildCacheOptions()
+		assert.Equal(t, 42, opts.MaxSize, "operator cache.manager.maxsize override must reach ManagerConfig")
+		assert.Equal(t, 2*time.Minute, opts.IdleTTL, "operator cache.manager.idlettl override must reach ManagerConfig")
+		assert.Equal(t, 90*time.Second, opts.CleanupInterval, "operator cache.manager.cleanupinterval override must reach ManagerConfig")
+	})
+
+	t.Run("multi-tenant cache MaxSize honors operator override over tenant limit", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(true, 250)
+		builder.cacheConfig = config.CacheManagerConfig{MaxSize: 999}
+		opts := builder.BuildCacheOptions()
+		assert.Equal(t, 999, opts.MaxSize, "operator cache.manager.maxsize override must win over tenant limit")
+	})
+
+	t.Run("multi-tenant messaging MaxPublishers honors operator override over tenant limit", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(true, 250)
+		builder.publisherConfig = config.PublisherPoolConfig{MaxCached: 888}
+		opts := builder.BuildMessagingOptions()
+		assert.Equal(t, 888, opts.MaxPublishers, "operator messaging.publisher.maxcached override must win over tenant limit")
+	})
+}
+
 func TestManagerConfigBuilderIsMultiTenant(t *testing.T) {
 	t.Run("single-tenant returns false", func(t *testing.T) {
 		builder := NewManagerConfigBuilder(false, 50)
@@ -210,9 +279,11 @@ func TestManagerConfigBuilderBuildCacheOptions(t *testing.T) {
 
 		options := builder.BuildCacheOptions()
 
-		assert.Equal(t, 10, options.MaxSize)
-		assert.Equal(t, 1*time.Hour, options.IdleTTL)
-		assert.Equal(t, 15*time.Minute, options.CleanupInterval)
+		// With no operator override, single-tenant falls back to the documented
+		// cache.manager defaults (maxsize=100, idlettl=15m, cleanupinterval=5m).
+		assert.Equal(t, 100, options.MaxSize)
+		assert.Equal(t, 15*time.Minute, options.IdleTTL)
+		assert.Equal(t, 5*time.Minute, options.CleanupInterval)
 	})
 
 	t.Run("multi-tenant cache options", func(t *testing.T) {
@@ -265,11 +336,12 @@ func TestManagerConfigBuilderConsistency(t *testing.T) {
 		dbOptions := builder.BuildDatabaseOptions()
 		msgOptions := builder.BuildMessagingOptions()
 
-		// Single-tenant always uses fixed values, regardless of tenantLimit
+		// Single-tenant ignores tenantLimit: DB keeps its fixed size, messaging
+		// falls back to the documented messaging.publisher.maxcached default (50).
 		assert.Equal(t, 10, dbOptions.MaxSize)
-		assert.Equal(t, 10, msgOptions.MaxPublishers)
+		assert.Equal(t, 50, msgOptions.MaxPublishers)
 
-		// Database has longer TTL than messaging in single-tenant mode
+		// Database has longer TTL (1h) than messaging (10m) in single-tenant mode
 		assert.True(t, dbOptions.IdleTTL > msgOptions.IdleTTL)
 	})
 

--- a/observability/logs.go
+++ b/observability/logs.go
@@ -20,21 +20,21 @@ var grpcInsecureCredentials = insecure.NewCredentials
 var logInitHook func() error
 
 // initLogProvider initializes the OpenTelemetry logger provider with dual-mode logging.
-func (p *provider) initLogProvider() error {
+func (p *provider) initLogProvider(ctx context.Context) error {
 	// Create resource with service information (reuse from trace provider)
-	res, err := p.createResource()
+	res, err := p.createResource(ctx)
 	if err != nil {
 		return fmt.Errorf(errCreateResourceFmt, err)
 	}
 
 	// Create log exporter
-	exporter, err := p.createLogExporter()
+	exporter, err := p.createLogExporter(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create log exporter: %w", err)
 	}
 
 	// Create dual-mode processor (action logs + trace logs)
-	processor, err := p.createDualModeProcessor(exporter)
+	processor, err := p.createDualModeProcessor(ctx, exporter)
 	if err != nil {
 		return fmt.Errorf("failed to create dual-mode processor: %w", err)
 	}
@@ -55,7 +55,7 @@ func (p *provider) initLogProvider() error {
 }
 
 // createLogExporter creates a log exporter based on the configured endpoint.
-func (p *provider) createLogExporter() (sdklog.Exporter, error) {
+func (p *provider) createLogExporter(ctx context.Context) (sdklog.Exporter, error) {
 	endpoint := p.config.Logs.Endpoint
 	debugLogger.Printf("Creating log exporter for endpoint: %s", endpoint)
 
@@ -79,13 +79,13 @@ func (p *provider) createLogExporter() (sdklog.Exporter, error) {
 
 	switch protocol {
 	case ProtocolHTTP:
-		exporter, err := p.createOTLPHTTPLogExporter()
+		exporter, err := p.createOTLPHTTPLogExporter(ctx)
 		if err != nil {
 			return nil, err
 		}
 		return getLogExporterWrapper()(exporter), nil
 	case ProtocolGRPC:
-		exporter, err := p.createOTLPGRPCLogExporter()
+		exporter, err := p.createOTLPGRPCLogExporter(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -97,7 +97,7 @@ func (p *provider) createLogExporter() (sdklog.Exporter, error) {
 }
 
 // createOTLPHTTPLogExporter creates an OTLP HTTP log exporter.
-func (p *provider) createOTLPHTTPLogExporter() (sdklog.Exporter, error) {
+func (p *provider) createOTLPHTTPLogExporter(ctx context.Context) (sdklog.Exporter, error) {
 	useInsecure := false
 	if p.config.Logs.Insecure != nil {
 		useInsecure = *p.config.Logs.Insecure
@@ -131,7 +131,7 @@ func (p *provider) createOTLPHTTPLogExporter() (sdklog.Exporter, error) {
 		opts = append(opts, otlploghttp.WithHeaders(p.config.Logs.Headers))
 	}
 
-	exporter, err := otlploghttp.New(context.Background(), opts...)
+	exporter, err := otlploghttp.New(ctx, opts...)
 	if err != nil {
 		debugLogger.Printf("Failed to create OTLP HTTP log exporter: %v", err)
 		return nil, err
@@ -142,7 +142,7 @@ func (p *provider) createOTLPHTTPLogExporter() (sdklog.Exporter, error) {
 }
 
 // createOTLPGRPCLogExporter creates an OTLP gRPC log exporter.
-func (p *provider) createOTLPGRPCLogExporter() (sdklog.Exporter, error) {
+func (p *provider) createOTLPGRPCLogExporter(ctx context.Context) (sdklog.Exporter, error) {
 	useInsecure := false
 	if p.config.Logs.Insecure != nil {
 		useInsecure = *p.config.Logs.Insecure
@@ -173,7 +173,7 @@ func (p *provider) createOTLPGRPCLogExporter() (sdklog.Exporter, error) {
 		debugLogger.Printf("Added %d custom headers to logs gRPC exporter", len(p.config.Logs.Headers))
 	}
 
-	exporter, err := otlploggrpc.New(context.Background(), opts...)
+	exporter, err := otlploggrpc.New(ctx, opts...)
 	if err != nil {
 		debugLogger.Printf("Failed to create OTLP gRPC log exporter: %v", err)
 		return nil, err
@@ -184,17 +184,17 @@ func (p *provider) createOTLPGRPCLogExporter() (sdklog.Exporter, error) {
 }
 
 // createDualModeProcessor creates a dual-mode log processor with separate processors for action and trace logs.
-func (p *provider) createDualModeProcessor(baseExporter sdklog.Exporter) (sdklog.Processor, error) {
+func (p *provider) createDualModeProcessor(ctx context.Context, baseExporter sdklog.Exporter) (sdklog.Processor, error) {
 	debugLogger.Println("Creating dual-mode log processor (action logs + trace logs)")
 
 	// Create resource for action logs (log.type="action")
-	actionResource, err := p.createLogResource("action")
+	actionResource, err := p.createLogResource(ctx, "action")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create action log resource: %w", err)
 	}
 
 	// Create resource for trace logs (log.type="trace")
-	traceResource, err := p.createLogResource("trace")
+	traceResource, err := p.createLogResource(ctx, "trace")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create trace log resource: %w", err)
 	}
@@ -217,8 +217,8 @@ func (p *provider) createDualModeProcessor(baseExporter sdklog.Exporter) (sdklog
 
 // createLogResource creates a resource with the specified log.type attribute.
 // This merges the base service resource with log-type-specific attributes.
-func (p *provider) createLogResource(logType string) (*resource.Resource, error) {
-	baseRes, err := p.createResource()
+func (p *provider) createLogResource(ctx context.Context, logType string) (*resource.Resource, error) {
+	baseRes, err := p.createResource(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/observability/logs_test.go
+++ b/observability/logs_test.go
@@ -109,7 +109,7 @@ func TestCreateOTLPHTTPLogExporter(t *testing.T) {
 				},
 			}
 
-			exporter, err := p.createOTLPHTTPLogExporter()
+			exporter, err := p.createOTLPHTTPLogExporter(context.Background())
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -224,7 +224,7 @@ func TestCreateOTLPGRPCLogExporter(t *testing.T) {
 				},
 			}
 
-			exporter, err := p.createOTLPGRPCLogExporter()
+			exporter, err := p.createOTLPGRPCLogExporter(context.Background())
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -255,7 +255,7 @@ func TestCreateLogExporterInvalidProtocol(t *testing.T) {
 		},
 	}
 
-	exporter, err := p.createLogExporter()
+	exporter, err := p.createLogExporter(context.Background())
 	assert.Error(t, err)
 	assert.Nil(t, exporter)
 	assert.ErrorIs(t, err, ErrInvalidProtocol)
@@ -271,7 +271,7 @@ func TestCreateLogExporterStdout(t *testing.T) {
 		},
 	}
 
-	exporter, err := p.createLogExporter()
+	exporter, err := p.createLogExporter(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, exporter)
 
@@ -343,11 +343,11 @@ func TestCreateDualModeProcessor(t *testing.T) {
 			}
 
 			// Create a mock exporter (stdout for simplicity)
-			baseExporter, err := p.createLogExporter()
+			baseExporter, err := p.createLogExporter(context.Background())
 			require.NoError(t, err)
 			require.NotNil(t, baseExporter)
 
-			processor, err := p.createDualModeProcessor(baseExporter)
+			processor, err := p.createDualModeProcessor(context.Background(), baseExporter)
 			assert.NoError(t, err)
 
 			if tt.expectedNotNil {
@@ -410,7 +410,7 @@ func TestCreateLogResource(t *testing.T) {
 // attribute matching expectedType.
 func checkLogResourceHasType(expectedType string) func(*testing.T, *provider) {
 	return func(t *testing.T, p *provider) {
-		res, err := p.createLogResource(expectedType)
+		res, err := p.createLogResource(context.Background(), expectedType)
 		require.NoError(t, err)
 		require.NotNil(t, res)
 
@@ -451,13 +451,13 @@ func TestCreateBatchProcessorWithResource(t *testing.T) {
 		},
 	}
 
-	baseExporter, err := p.createLogExporter()
+	baseExporter, err := p.createLogExporter(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, baseExporter)
 	defer baseExporter.Shutdown(context.Background())
 
 	// Create resource
-	res, err := p.createLogResource("action")
+	res, err := p.createLogResource(context.Background(), "action")
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
@@ -503,7 +503,7 @@ func TestInitLogProviderSuccess(t *testing.T) {
 		},
 	}
 
-	err := p.initLogProvider()
+	err := p.initLogProvider(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, p.loggerProvider)
 
@@ -543,7 +543,7 @@ func TestInitLogProviderWithHookFailure(t *testing.T) {
 		},
 	}
 
-	err := p.initLogProvider()
+	err := p.initLogProvider(context.Background())
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, expectedErr)
 	assert.Nil(t, p.loggerProvider)

--- a/observability/metrics.go
+++ b/observability/metrics.go
@@ -18,15 +18,15 @@ import (
 var metricInitHook func() error
 
 // initMeterProvider initializes the OpenTelemetry meter provider.
-func (p *provider) initMeterProvider() error {
+func (p *provider) initMeterProvider(ctx context.Context) error {
 	// Create resource with service information (reuse from trace provider)
-	res, err := p.createResource()
+	res, err := p.createResource(ctx)
 	if err != nil {
 		return fmt.Errorf(errCreateResourceFmt, err)
 	}
 
 	// Create metric exporter
-	exporter, err := p.createMetricExporter()
+	exporter, err := p.createMetricExporter(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create metric exporter: %w", err)
 	}
@@ -86,7 +86,7 @@ func (p *provider) initMeterProvider() error {
 }
 
 // createMetricExporter creates a metric exporter based on the configured endpoint.
-func (p *provider) createMetricExporter() (sdkmetric.Exporter, error) {
+func (p *provider) createMetricExporter(ctx context.Context) (sdkmetric.Exporter, error) {
 	endpoint := p.config.Metrics.Endpoint
 	debugLogger.Printf("Creating metric exporter for endpoint: %s", endpoint)
 
@@ -110,13 +110,13 @@ func (p *provider) createMetricExporter() (sdkmetric.Exporter, error) {
 
 	switch protocol {
 	case ProtocolHTTP:
-		exporter, err := p.createOTLPHTTPMetricExporter(useInsecure, headers)
+		exporter, err := p.createOTLPHTTPMetricExporter(ctx, useInsecure, headers)
 		if err != nil {
 			return nil, err
 		}
 		return getMetricExporterWrapper()(exporter), nil
 	case ProtocolGRPC:
-		exporter, err := p.createOTLPGRPCMetricExporter(useInsecure, headers)
+		exporter, err := p.createOTLPGRPCMetricExporter(ctx, useInsecure, headers)
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +128,7 @@ func (p *provider) createMetricExporter() (sdkmetric.Exporter, error) {
 }
 
 // createOTLPHTTPMetricExporter creates an OTLP HTTP metric exporter.
-func (p *provider) createOTLPHTTPMetricExporter(useInsecure bool, headers map[string]string) (sdkmetric.Exporter, error) {
+func (p *provider) createOTLPHTTPMetricExporter(ctx context.Context, useInsecure bool, headers map[string]string) (sdkmetric.Exporter, error) {
 	debugLogger.Printf("Creating OTLP HTTP metric exporter: endpoint=%s, insecure=%v, compression=%s, temporality=%s, headers_count=%d",
 		p.config.Metrics.Endpoint, useInsecure, p.config.Metrics.Compression, p.config.Metrics.Temporality, len(headers))
 
@@ -165,7 +165,7 @@ func (p *provider) createOTLPHTTPMetricExporter(useInsecure bool, headers map[st
 		opts = append(opts, otlpmetrichttp.WithHeaders(headers))
 	}
 
-	exporter, err := otlpmetrichttp.New(context.Background(), opts...)
+	exporter, err := otlpmetrichttp.New(ctx, opts...)
 	if err != nil {
 		debugLogger.Printf("Failed to create OTLP HTTP metric exporter: %v", err)
 		return nil, err
@@ -176,7 +176,7 @@ func (p *provider) createOTLPHTTPMetricExporter(useInsecure bool, headers map[st
 }
 
 // createOTLPGRPCMetricExporter creates an OTLP gRPC metric exporter.
-func (p *provider) createOTLPGRPCMetricExporter(useInsecure bool, headers map[string]string) (sdkmetric.Exporter, error) {
+func (p *provider) createOTLPGRPCMetricExporter(ctx context.Context, useInsecure bool, headers map[string]string) (sdkmetric.Exporter, error) {
 	debugLogger.Printf("Creating OTLP gRPC metric exporter: endpoint=%s, insecure=%v, compression=%s, temporality=%s, headers_count=%d",
 		p.config.Metrics.Endpoint, useInsecure, p.config.Metrics.Compression, p.config.Metrics.Temporality, len(headers))
 
@@ -210,7 +210,7 @@ func (p *provider) createOTLPGRPCMetricExporter(useInsecure bool, headers map[st
 		debugLogger.Printf("Added %d custom headers to metrics gRPC exporter", len(headers))
 	}
 
-	exporter, err := otlpmetricgrpc.New(context.Background(), opts...)
+	exporter, err := otlpmetricgrpc.New(ctx, opts...)
 	if err != nil {
 		debugLogger.Printf("Failed to create OTLP gRPC metric exporter: %v", err)
 		return nil, err

--- a/observability/metrics_test.go
+++ b/observability/metrics_test.go
@@ -571,7 +571,7 @@ func TestInitMeterProviderWithDeltaTemporality(t *testing.T) {
 		},
 	}
 
-	err := p.initMeterProvider()
+	err := p.initMeterProvider(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, p.meterProvider)
 
@@ -611,7 +611,7 @@ func TestInitMeterProviderWithExponentialHistogram(t *testing.T) {
 		},
 	}
 
-	err := p.initMeterProvider()
+	err := p.initMeterProvider(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, p.meterProvider)
 
@@ -705,7 +705,7 @@ func TestCreateOTLPHTTPMetricExporterWithCompression(t *testing.T) {
 				useInsecure = *tt.config.Insecure
 			}
 
-			exporter, err := p.createOTLPHTTPMetricExporter(useInsecure, tt.config.Headers)
+			exporter, err := p.createOTLPHTTPMetricExporter(context.Background(), useInsecure, tt.config.Headers)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -799,7 +799,7 @@ func TestCreateOTLPGRPCMetricExporterWithCompression(t *testing.T) {
 				useInsecure = *tt.config.Insecure
 			}
 
-			exporter, err := p.createOTLPGRPCMetricExporter(useInsecure, tt.config.Headers)
+			exporter, err := p.createOTLPGRPCMetricExporter(context.Background(), useInsecure, tt.config.Headers)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/observability/provider.go
+++ b/observability/provider.go
@@ -133,8 +133,34 @@ type provider struct {
 // IMPORTANT: This function applies default values before validation to ensure
 // safe configuration (e.g., sample rate defaults to 1.0). Callers do NOT need
 // to call ApplyDefaults() first - it's handled internally.
+//
+// NewProvider uses a context.Background() for construction. Use
+// NewProviderWithContext to bound resource detection and exporter setup by a
+// deadline (e.g. an app.startup.observability budget).
 func NewProvider(cfg *Config) (Provider, error) {
-	debugLogger.Printf("NewProvider called - enabled=%v, service=%s", cfg.Enabled, cfg.Service.Name)
+	return NewProviderWithContext(context.Background(), cfg)
+}
+
+// NewProviderWithContext creates a new observability provider, threading ctx
+// through resource detection (resource.New) and OTLP exporter construction so
+// the caller can bound those steps with a deadline.
+//
+// What the context bounds: the synchronous setup work performed here —
+// resource attribute detection and the OTLP exporter constructors
+// (otlptracehttp/grpc, otlpmetrichttp/grpc, otlploghttp/grpc). It does NOT
+// bound steady-state telemetry export, which the SDK governs via its own
+// per-export timeouts.
+//
+// Note: OTLP gRPC dialing is lazy (the connection is established on first
+// export, not at construction), so for the gRPC transports the deadline
+// mainly bounds resource detection and exporter object setup rather than any
+// network round-trip. The HTTP transports likewise connect lazily.
+//
+// Like NewProvider, this applies defaults before validation; callers do NOT
+// need to call ApplyDefaults() first. If observability is disabled, a no-op
+// provider is returned regardless of ctx.
+func NewProviderWithContext(ctx context.Context, cfg *Config) (Provider, error) {
+	debugLogger.Printf("NewProviderWithContext called - enabled=%v, service=%s", cfg.Enabled, cfg.Service.Name)
 
 	// Create a defensive copy and apply defaults BEFORE validation
 	// This ensures zero sample rates or missing timeouts get safe defaults
@@ -175,7 +201,9 @@ func NewProvider(cfg *Config) (Provider, error) {
 	traceEnabled := isProviderEnabled(safeCfg.Trace.Enabled)
 	traceConfig := fmt.Sprintf("enabled=%v, endpoint=%s, protocol=%s, insecure=%v",
 		traceEnabled, safeCfg.Trace.Endpoint, safeCfg.Trace.Protocol, safeCfg.Trace.Insecure)
-	if err := initializeProvider("Trace", traceEnabled, traceConfig, p.initTraceProvider); err != nil {
+	if err := initializeProvider("Trace", traceEnabled, traceConfig, func() error {
+		return p.initTraceProvider(ctx)
+	}); err != nil {
 		return nil, err
 	}
 
@@ -183,7 +211,9 @@ func NewProvider(cfg *Config) (Provider, error) {
 	metricsEnabled := isProviderEnabled(safeCfg.Metrics.Enabled)
 	metricsConfig := fmt.Sprintf("enabled=%v, endpoint=%s, protocol=%s",
 		metricsEnabled, safeCfg.Metrics.Endpoint, safeCfg.Metrics.Protocol)
-	if err := initializeProvider("Metrics", metricsEnabled, metricsConfig, p.initMeterProvider); err != nil {
+	if err := initializeProvider("Metrics", metricsEnabled, metricsConfig, func() error {
+		return p.initMeterProvider(ctx)
+	}); err != nil {
 		return nil, err
 	}
 
@@ -191,7 +221,9 @@ func NewProvider(cfg *Config) (Provider, error) {
 	logsEnabled := isProviderEnabled(safeCfg.Logs.Enabled)
 	logsConfig := fmt.Sprintf("enabled=%v, endpoint=%s, protocol=%s",
 		logsEnabled, safeCfg.Logs.Endpoint, safeCfg.Logs.Protocol)
-	if err := initializeProvider("Logs", logsEnabled, logsConfig, p.initLogProvider); err != nil {
+	if err := initializeProvider("Logs", logsEnabled, logsConfig, func() error {
+		return p.initLogProvider(ctx)
+	}); err != nil {
 		return nil, err
 	}
 
@@ -266,15 +298,15 @@ func (p *provider) registerGlobalProviders() {
 }
 
 // initTraceProvider initializes the OpenTelemetry trace provider.
-func (p *provider) initTraceProvider() error {
+func (p *provider) initTraceProvider(ctx context.Context) error {
 	// Create resource with service information
-	res, err := p.createResource()
+	res, err := p.createResource(ctx)
 	if err != nil {
 		return fmt.Errorf(errCreateResourceFmt, err)
 	}
 
 	// Create trace exporter
-	exporter, err := p.createTraceExporter()
+	exporter, err := p.createTraceExporter(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create trace exporter: %w", err)
 	}
@@ -313,13 +345,14 @@ func (p *provider) initTraceProvider() error {
 }
 
 // createResource creates an OpenTelemetry resource with service information.
-func (p *provider) createResource() (*resource.Resource, error) {
+// The provided ctx bounds resource detection (resource.New).
+func (p *provider) createResource(ctx context.Context) (*resource.Resource, error) {
 	// Use default resource and add our attributes without schema URL to avoid conflicts
 	defaultRes := resource.Default()
 
 	// Create our custom attributes
 	customRes, err := resource.New(
-		context.Background(),
+		ctx,
 		resource.WithAttributes(
 			semconv.ServiceName(p.config.Service.Name),
 			semconv.ServiceVersion(p.config.Service.Version),
@@ -335,7 +368,7 @@ func (p *provider) createResource() (*resource.Resource, error) {
 }
 
 // createTraceExporter creates a trace exporter based on the configured endpoint.
-func (p *provider) createTraceExporter() (sdktrace.SpanExporter, error) {
+func (p *provider) createTraceExporter(ctx context.Context) (sdktrace.SpanExporter, error) {
 	endpoint := p.config.Trace.Endpoint
 	debugLogger.Printf("Creating trace exporter for endpoint: %s", endpoint)
 
@@ -359,13 +392,13 @@ func (p *provider) createTraceExporter() (sdktrace.SpanExporter, error) {
 
 	switch protocol {
 	case ProtocolHTTP:
-		exporter, err := p.createOTLPHTTPExporter()
+		exporter, err := p.createOTLPHTTPExporter(ctx)
 		if err != nil {
 			return nil, err
 		}
 		return getTraceExporterWrapper()(exporter), nil
 	case ProtocolGRPC:
-		exporter, err := p.createOTLPGRPCExporter()
+		exporter, err := p.createOTLPGRPCExporter(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -385,7 +418,7 @@ func stripScheme(endpoint string) string {
 }
 
 // createOTLPHTTPExporter creates an OTLP HTTP trace exporter.
-func (p *provider) createOTLPHTTPExporter() (sdktrace.SpanExporter, error) {
+func (p *provider) createOTLPHTTPExporter(ctx context.Context) (sdktrace.SpanExporter, error) {
 	debugLogger.Printf("Creating OTLP HTTP trace exporter: endpoint=%s, insecure=%v, compression=%s, headers_count=%d",
 		p.config.Trace.Endpoint, p.config.Trace.Insecure, p.config.Trace.Compression, len(p.config.Trace.Headers))
 
@@ -414,7 +447,7 @@ func (p *provider) createOTLPHTTPExporter() (sdktrace.SpanExporter, error) {
 		opts = append(opts, otlptracehttp.WithHeaders(p.config.Trace.Headers))
 	}
 
-	exporter, err := otlptracehttp.New(context.Background(), opts...)
+	exporter, err := otlptracehttp.New(ctx, opts...)
 	if err != nil {
 		debugLogger.Printf("Failed to create OTLP HTTP trace exporter: %v", err)
 		return nil, err
@@ -425,7 +458,7 @@ func (p *provider) createOTLPHTTPExporter() (sdktrace.SpanExporter, error) {
 }
 
 // createOTLPGRPCExporter creates an OTLP gRPC trace exporter.
-func (p *provider) createOTLPGRPCExporter() (sdktrace.SpanExporter, error) {
+func (p *provider) createOTLPGRPCExporter(ctx context.Context) (sdktrace.SpanExporter, error) {
 	debugLogger.Printf("Creating OTLP gRPC trace exporter: endpoint=%s, insecure=%v, compression=%s, headers_count=%d",
 		p.config.Trace.Endpoint, p.config.Trace.Insecure, p.config.Trace.Compression, len(p.config.Trace.Headers))
 
@@ -451,7 +484,7 @@ func (p *provider) createOTLPGRPCExporter() (sdktrace.SpanExporter, error) {
 		debugLogger.Printf("Added %d custom headers to gRPC exporter", len(p.config.Trace.Headers))
 	}
 
-	exporter, err := otlptracegrpc.New(context.Background(), opts...)
+	exporter, err := otlptracegrpc.New(ctx, opts...)
 	if err != nil {
 		debugLogger.Printf("Failed to create OTLP gRPC trace exporter: %v", err)
 		return nil, err

--- a/observability/provider_test.go
+++ b/observability/provider_test.go
@@ -39,6 +39,44 @@ func TestNewProviderDisabled(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestNewProviderDelegatesToWithContext verifies that NewProvider still works
+// end-to-end after being reduced to a NewProviderWithContext(background, cfg)
+// delegation: a disabled config yields the no-op provider.
+func TestNewProviderDelegatesToWithContext(t *testing.T) {
+	cfg := &Config{Enabled: false}
+
+	provider, err := NewProvider(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	_, ok := provider.(*noopProvider)
+	assert.True(t, ok, "NewProvider must still return the no-op provider when disabled")
+
+	assert.NoError(t, provider.Shutdown(context.Background()))
+}
+
+// TestNewProviderWithContextDisabledIgnoresContext verifies that when
+// observability is disabled, NewProviderWithContext returns the no-op provider
+// regardless of the supplied context — even an already-canceled one. Disabled
+// short-circuits before any resource detection or exporter setup, so the
+// deadline is never consulted.
+func TestNewProviderWithContextDisabledIgnoresContext(t *testing.T) {
+	cfg := &Config{Enabled: false}
+
+	// An already-canceled context must NOT cause an error on the disabled path.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	provider, err := NewProviderWithContext(ctx, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	_, ok := provider.(*noopProvider)
+	assert.True(t, ok, "disabled config must yield the no-op provider regardless of ctx")
+
+	assert.NoError(t, provider.Shutdown(context.Background()))
+}
+
 func TestNewProviderInvalidConfig(t *testing.T) {
 	cfg := &Config{
 		Enabled: true,


### PR DESCRIPTION
## Summary

Two **validated-but-unwired config** classes from the 2026-06-10 security audit (`VULNERABILITIES.md` Mediums **M1** and **M2**) are now consumed as documented. First PR of the follow-on Medium-remediation effort after the 10 Highs (#575–#585).

## Findings fixed

### M1 — per-component startup timeouts never consumed
`app.startup.{database,messaging,cache,observability}` were validated, defaulted, and wiki-documented, but only `app.startup.timeout` was ever used — for a single shared DB+messaging pre-init context. Cache and observability had no budget at all (`app/app_builder.go`, `config/validation.go`, `wiki/startup_defaults.md`).

- `performPreInitialization` now gives **database**, **messaging**, and **cache** each their own context budget — `preInitFatalComponent` for the fatal DB/messaging paths, best-effort `preInitCache` that WARNs instead of aborting startup.
- **observability** is bounded by threading a real `context.Context` through construction: new additive `observability.NewProviderWithContext(ctx, cfg)` passes the budget into `resource.New` and every OTLP exporter constructor (which already accept a context but hardcoded `context.Background()`). `NewProvider(cfg)` now delegates with `context.Background()` — **non-breaking**. This honors the framework's Context-First Design and avoids racing construction on a goroutine (which would orphan the constructed provider and clobber global OTel state on timeout).

### M2 — manager tuning config never consumed
`messaging.publisher.{maxcached,idlettl}` and `cache.manager.{maxsize,idlettl,cleanupinterval}` were validated/defaulted with tuning docs, but `ManagerConfigBuilder` hardcoded different values (`app/managers.go`). `BuildMessagingOptions`/`BuildCacheOptions` now consume `cfg.Messaging.Publisher` and `cfg.Cache.Manager`, falling back to the mode-specific values only when a key is unset.

## Testing

TDD repros for each finding: per-component budget derivation for all three pre-init components; both cache best-effort failure shapes (NotConfigured silent-skip + generic WARN); observability budget-context threading + no-op fallback; and manager override propagation (single- and multi-tenant). `make check` green — `go build`, `go vet`, `go test -race ./...` (46/46), `golangci-lint` (0 issues), `govulncheck` (clean).

## Breaking change

None. `observability.NewProviderWithContext` is purely additive; `NewProvider` retains its signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-component startup timeout budgets for database, messaging, and cache initialization
  * Operator-configurable messaging publisher and cache manager settings with documented defaults

* **Improvements**
  * Observability provider initialization now uses deadline-bound context for faster failure detection
  * Cache initialization failures are non-fatal and no longer halt application startup

* **Tests**
  * Added comprehensive test coverage for per-component timeout behavior and initialization failure scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->