### PR TITLE
fix(database): correct Oracle identifier quoting in the query builder

### DIFF
--- a/database/internal/builder/join_filter_test.go
+++ b/database/internal/builder/join_filter_test.go
@@ -422,7 +422,7 @@ func TestJoinFilterComparisonWithExpressions(t *testing.T) {
 		{
 			name:        "Gte_expression",
 			filter:      jf.Gte("date", qb.MustExpr("SYSDATE")),
-			expectedSQL: "date >= SYSDATE",
+			expectedSQL: `"date" >= SYSDATE`, // DATE is an Oracle reserved word (M10) — auto-quoted
 		},
 	}
 
@@ -614,8 +614,9 @@ func TestJoinFilterBetween(t *testing.T) {
 		sql, args, err := filter.ToSQL()
 
 		require.NoError(t, err)
-		assert.Contains(t, sql, "date >= ?")
-		assert.Contains(t, sql, "date <= SYSDATE")
+		// DATE is an Oracle reserved word (M10) — auto-quoted on the Oracle vendor.
+		assert.Contains(t, sql, `"date" >= ?`)
+		assert.Contains(t, sql, `"date" <= SYSDATE`)
 		assert.Equal(t, []any{"2024-01-01"}, args)
 	})
 }

--- a/database/internal/builder/oracle.go
+++ b/database/internal/builder/oracle.go
@@ -372,11 +372,22 @@ func (qb *QueryBuilder) buildOracleMerge(table string, conflictColumns []string,
 		return "", nil, fmt.Errorf("conflict columns required for Oracle MERGE")
 	}
 
-	// Build the USING clause with values
+	// Every conflict column must be present in the insert columns. Otherwise the
+	// generated ON clause references source.<column> which does not exist in the
+	// USING SELECT, producing invalid SQL that would only fail at runtime.
+	for _, col := range conflictColumns {
+		if _, ok := insertColumns[col]; !ok {
+			return "", nil, fmt.Errorf("conflict column %q must be present in insert columns for Oracle MERGE", col)
+		}
+	}
+
+	// Build the USING clause with values. Use reserved-word-only quoting (the same
+	// quoting the DML paths use) so non-reserved identifiers stay unquoted and Oracle
+	// folds them to the uppercase form created by standard DDL.
 	insertKeys := sortedKeys(insertColumns)
-	escapedInsertCols := qb.escapeIdentifiers(insertKeys)
+	quotedInsertCols := qb.quoteOracleColumnsForDML(insertKeys...)
 	usingValues := make([]string, len(insertKeys))
-	for i, col := range escapedInsertCols {
+	for i, col := range quotedInsertCols {
 		usingValues[i] = fmt.Sprintf(":%d AS %s", i+1, col)
 	}
 	usingArgs := valuesByKeyOrder(insertColumns, insertKeys)
@@ -384,32 +395,32 @@ func (qb *QueryBuilder) buildOracleMerge(table string, conflictColumns []string,
 	// Build ON clause for conflict detection
 	orderedConflicts := append([]string(nil), conflictColumns...)
 	sort.Strings(orderedConflicts)
-	escapedConflicts := qb.escapeIdentifiers(orderedConflicts)
-	onConditions := make([]string, len(escapedConflicts))
-	for i, col := range escapedConflicts {
+	quotedConflicts := qb.quoteOracleColumnsForDML(orderedConflicts...)
+	onConditions := make([]string, len(quotedConflicts))
+	for i, col := range quotedConflicts {
 		onConditions[i] = fmt.Sprintf("target.%s = source.%s", col, col)
 	}
 
 	// Build UPDATE SET clause
 	updateKeys := sortedKeys(updateColumns)
-	escapedUpdateCols := qb.escapeIdentifiers(updateKeys)
+	quotedUpdateCols := qb.quoteOracleColumnsForDML(updateKeys...)
 	updateSets := make([]string, len(updateKeys))
 	baseIndex := len(insertKeys) + 1
-	for i, col := range escapedUpdateCols {
+	for i, col := range quotedUpdateCols {
 		updateSets[i] = fmt.Sprintf("%s = :%d", col, baseIndex+i)
 	}
 	updateArgs := valuesByKeyOrder(updateColumns, updateKeys)
 
 	// Build INSERT clause
-	insertCols := make([]string, len(escapedInsertCols))
-	insertVals := make([]string, len(escapedInsertCols))
-	for i, col := range escapedInsertCols {
+	insertCols := make([]string, len(quotedInsertCols))
+	insertVals := make([]string, len(quotedInsertCols))
+	for i, col := range quotedInsertCols {
 		insertCols[i] = col
 		insertVals[i] = "source." + col
 	}
 
 	query = fmt.Sprintf(`MERGE INTO %s target USING (SELECT %s FROM dual) source ON (%s)`,
-		table,
+		qb.quoteTableForQuery(table),
 		strings.Join(usingValues, ", "),
 		strings.Join(onConditions, " AND "))
 

--- a/database/internal/builder/oracle_test.go
+++ b/database/internal/builder/oracle_test.go
@@ -64,13 +64,15 @@ func TestBuildUpsertOracleGeneratesMergeStatement(t *testing.T) {
 	if !strings.HasPrefix(sql, "MERGE INTO users") {
 		t.Fatalf("expected MERGE statement, got %s", sql)
 	}
-	if !strings.Contains(sql, "SELECT :1 AS \"id\", :2 AS \"name\" FROM dual") {
+	// Non-reserved identifiers stay unquoted so Oracle folds them to the uppercase
+	// form created by standard DDL (reserved-word-only quoting).
+	if !strings.Contains(sql, "SELECT :1 AS id, :2 AS name FROM dual") {
 		t.Fatalf("expected using clause with positional binds, got %s", sql)
 	}
-	if !strings.Contains(sql, "WHEN MATCHED THEN UPDATE SET \"name\" = :3") {
+	if !strings.Contains(sql, "WHEN MATCHED THEN UPDATE SET name = :3") {
 		t.Fatalf("expected update clause, got %s", sql)
 	}
-	if !strings.Contains(sql, "WHEN NOT MATCHED THEN INSERT (\"id\", \"name\") VALUES (source.\"id\", source.\"name\")") {
+	if !strings.Contains(sql, "WHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name)") {
 		t.Fatalf("expected insert clause, got %s", sql)
 	}
 
@@ -1195,4 +1197,80 @@ func TestOracleDeleteWithoutWhereQuoting(t *testing.T) {
 			assert.Equal(t, tt.expectedSQL, sql, "SQL should match expected DELETE FROM clause")
 		})
 	}
+}
+
+// TestBuildUpsertOracleUsesReservedWordOnlyQuoting verifies the Oracle MERGE
+// statement applies reserved-word-only quoting (preserving Oracle's case-folding
+// semantics) rather than unconditionally double-quoting lowercase identifiers.
+// Standard DDL creates uppercase ID/NAME columns, so emitting quoted lowercase
+// "id"/"name" would fail at runtime with ORA-00904 (M7 bug #1).
+func TestBuildUpsertOracleUsesReservedWordOnlyQuoting(t *testing.T) {
+	qb := NewQueryBuilder(dbtypes.Oracle)
+
+	insertColumns := map[string]any{
+		"id":   1,
+		"name": "alice",
+	}
+	updateColumns := map[string]any{
+		"name": "bob",
+	}
+	conflictColumns := []string{"id"}
+
+	sql, args, err := qb.BuildUpsert("users", conflictColumns, insertColumns, updateColumns)
+	require.NoError(t, err)
+
+	// Non-reserved identifiers must stay unquoted so Oracle folds them to the
+	// uppercase form created by standard DDL.
+	assert.Equal(t,
+		"MERGE INTO users target USING (SELECT :1 AS id, :2 AS name FROM dual) source "+
+			"ON (target.id = source.id) "+
+			"WHEN MATCHED THEN UPDATE SET name = :3 "+
+			"WHEN NOT MATCHED THEN INSERT (id, name) VALUES (source.id, source.name)",
+		sql,
+		"Oracle MERGE must use reserved-word-only quoting for non-reserved identifiers")
+
+	require.Len(t, args, 3)
+	assert.Equal(t, 1, args[0])
+	assert.Equal(t, "alice", args[1])
+	assert.Equal(t, "bob", args[2])
+}
+
+// TestBuildUpsertOracleQuotesReservedWordColumnsAndTable verifies reserved words
+// used as column or table names ARE quoted (preserving case) while the table name
+// is routed through the same quoting the DML paths use. The "level" table is a
+// reserved word and must become "level"; an unquoted MERGE INTO level fails with
+// ORA-00905 (M7 bug #2). Reserved-word columns ("number") must be quoted too.
+func TestBuildUpsertOracleQuotesReservedWordColumnsAndTable(t *testing.T) {
+	qb := NewQueryBuilder(dbtypes.Oracle)
+
+	insertColumns := map[string]any{
+		"id":     1,
+		"number": 7,
+	}
+	conflictColumns := []string{"id"}
+
+	sql, args, err := qb.BuildUpsert("level", conflictColumns, insertColumns, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		`MERGE INTO "level" target USING (SELECT :1 AS id, :2 AS "number" FROM dual) source `+
+			`ON (target.id = source.id) `+
+			`WHEN NOT MATCHED THEN INSERT (id, "number") VALUES (source.id, source."number")`,
+		sql,
+		"reserved-word table and column names must be quoted while preserving case")
+
+	require.Len(t, args, 2)
+}
+
+// TestBuildUpsertOracleRejectsUnknownConflictColumns verifies the MERGE builder
+// fails fast when a conflict column is absent from the insert columns. Otherwise
+// the generated ON clause references source.<missing> which does not exist in the
+// USING SELECT, producing invalid SQL with no error (M7 bug #3).
+func TestBuildUpsertOracleRejectsUnknownConflictColumns(t *testing.T) {
+	qb := NewQueryBuilder(dbtypes.Oracle)
+
+	_, _, err := qb.BuildUpsert("users", []string{"id", "tenant_id"}, map[string]any{"id": 1}, nil)
+	require.Error(t, err, "conflict column missing from insert columns must be rejected")
+	assert.Contains(t, err.Error(), "tenant_id",
+		"error should name the offending conflict column")
 }

--- a/database/internal/builder/query_builder.go
+++ b/database/internal/builder/query_builder.go
@@ -250,21 +250,24 @@ func (qb *QueryBuilder) Select(columns ...any) *SelectQueryBuilder {
 // Insert creates an INSERT query builder for the specified table.
 // The returned InsertQueryBuilder exposes ToSQL() (idiomatic Go, per S8179)
 // consistent with Select/Update/Delete builders.
+// Table names are automatically quoted according to database vendor rules to handle reserved words.
 func (qb *QueryBuilder) Insert(table string) dbtypes.InsertQueryBuilder {
-	return &InsertQueryBuilder{insertBuilder: qb.statementBuilder.Insert(table)}
+	return &InsertQueryBuilder{insertBuilder: qb.statementBuilder.Insert(qb.quoteTableForQuery(table))}
 }
 
 // InsertWithColumns creates an INSERT query builder with pre-specified columns.
 // It applies vendor-specific column quoting to the provided column list.
+// Table names are automatically quoted according to database vendor rules to handle reserved words.
 func (qb *QueryBuilder) InsertWithColumns(table string, columns ...string) dbtypes.InsertQueryBuilder {
 	return &InsertQueryBuilder{
-		insertBuilder: qb.statementBuilder.Insert(table).Columns(qb.quoteColumnsForDML(columns...)...),
+		insertBuilder: qb.statementBuilder.Insert(qb.quoteTableForQuery(table)).Columns(qb.quoteColumnsForDML(columns...)...),
 	}
 }
 
 // InsertStruct creates an INSERT query by extracting all fields from a struct instance.
 // Zero-value ID fields (int64 or string type with field name "ID") are automatically excluded
 // to support auto-increment primary keys.
+// Table names are automatically quoted according to database vendor rules to handle reserved words.
 //
 // Example:
 //
@@ -297,7 +300,7 @@ func (qb *QueryBuilder) InsertStruct(table string, instance any) dbtypes.InsertQ
 	}
 
 	return &InsertQueryBuilder{
-		insertBuilder: qb.statementBuilder.Insert(table).
+		insertBuilder: qb.statementBuilder.Insert(qb.quoteTableForQuery(table)).
 			Columns(qb.quoteColumnsForDML(columns...)...).
 			Values(values...),
 	}
@@ -305,6 +308,7 @@ func (qb *QueryBuilder) InsertStruct(table string, instance any) dbtypes.InsertQ
 
 // InsertFields creates an INSERT query by extracting only specified fields from a struct instance.
 // This is useful for partial inserts or when you need explicit control over which fields to include.
+// Table names are automatically quoted according to database vendor rules to handle reserved words.
 //
 // Example:
 //
@@ -332,7 +336,7 @@ func (qb *QueryBuilder) InsertFields(table string, instance any, fields ...strin
 	}
 
 	return &InsertQueryBuilder{
-		insertBuilder: qb.statementBuilder.Insert(table).
+		insertBuilder: qb.statementBuilder.Insert(qb.quoteTableForQuery(table)).
 			Columns(qb.quoteColumnsForDML(columns...)...).
 			Values(values...),
 	}

--- a/database/internal/builder/query_builder_test.go
+++ b/database/internal/builder/query_builder_test.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 
@@ -79,6 +80,7 @@ const (
 	tableProducts = "products"
 	tableOrders   = "orders"
 	tableAccounts = "accounts"
+	tableLevel    = "level" // Oracle reserved word, used as a table name
 
 	// Column names (commonly used)
 	colID       = "id"
@@ -2017,17 +2019,78 @@ func TestInsertStructOracleReservedWords(t *testing.T) {
 		Size:   "large",
 	}
 
-	query := qb.InsertStruct(tableAccounts, &account)
+	// Use a reserved-word table name to verify both table and column quoting.
+	query := qb.InsertStruct(tableLevel, &account)
 	sql, args, err := query.ToSQL()
 
 	require.NoError(t, err)
-	// Oracle should quote reserved words
-	assert.Contains(t, sql, `"number"`)
-	assert.Contains(t, sql, `"level"`)
-	assert.Contains(t, sql, `"size"`)
+	// Oracle should quote the reserved-word table name (finding M8) and reserved-word columns.
+	assert.Contains(t, sql, `INSERT INTO "level"`)
+	// Assert the column-list portion specifically so the reserved-word column quoting is
+	// genuinely exercised — checking the whole SQL for `"level"` alone would be trivially
+	// satisfied by the quoted table name above. The column order is reflection-driven and
+	// not deterministic, so assert each column within the list rather than a fixed string.
+	openParen := strings.Index(sql, "(")
+	valuesIdx := strings.Index(sql, "VALUES")
+	require.GreaterOrEqual(t, openParen, 0, "expected a column list in %q", sql)
+	require.Greater(t, valuesIdx, openParen, "expected VALUES after the column list in %q", sql)
+	columnList := sql[openParen:valuesIdx]
+	assert.Contains(t, columnList, `"number"`)
+	assert.Contains(t, columnList, `"level"`)
+	assert.Contains(t, columnList, `"size"`)
 	assert.Contains(t, args, testAccountID)
 	assert.Contains(t, args, 5)
 	assert.Contains(t, args, "large")
+}
+
+// TestInsertOracleReservedWordTableName verifies that all four INSERT entry points
+// quote a reserved-word table name on Oracle (matching Update/Delete/From), and that
+// PostgreSQL leaves the table name unquoted. Regression guard for finding M8.
+func TestInsertOracleReservedWordTableName(t *testing.T) {
+	const quotedLevel = `INSERT INTO "level"`
+
+	t.Run("oracle_insert", func(t *testing.T) {
+		qb := NewQueryBuilder(dbtypes.Oracle)
+		query := qb.Insert(tableLevel).Columns(colName).Values("test")
+		sql, _, err := query.ToSQL()
+		require.NoError(t, err)
+		assert.Contains(t, sql, quotedLevel)
+	})
+
+	t.Run("oracle_insert_with_columns", func(t *testing.T) {
+		qb := NewQueryBuilder(dbtypes.Oracle)
+		query := qb.InsertWithColumns(tableLevel, colName).Values("test")
+		sql, _, err := query.ToSQL()
+		require.NoError(t, err)
+		assert.Contains(t, sql, quotedLevel)
+	})
+
+	t.Run("oracle_insert_struct", func(t *testing.T) {
+		qb := NewQueryBuilder(dbtypes.Oracle)
+		account := IntegrationAccount{ID: 0, Number: testAccountID, Level: 5, Size: "large"}
+		query := qb.InsertStruct(tableLevel, &account)
+		sql, _, err := query.ToSQL()
+		require.NoError(t, err)
+		assert.Contains(t, sql, quotedLevel)
+	})
+
+	t.Run("oracle_insert_fields", func(t *testing.T) {
+		qb := NewQueryBuilder(dbtypes.Oracle)
+		account := IntegrationAccount{ID: 0, Number: testAccountID, Level: 5, Size: "large"}
+		query := qb.InsertFields(tableLevel, &account, fieldNumber)
+		sql, _, err := query.ToSQL()
+		require.NoError(t, err)
+		assert.Contains(t, sql, quotedLevel)
+	})
+
+	t.Run("postgresql_insert_unquoted", func(t *testing.T) {
+		qb := NewQueryBuilder(dbtypes.PostgreSQL)
+		query := qb.Insert(tableLevel).Columns(colName).Values("test")
+		sql, _, err := query.ToSQL()
+		require.NoError(t, err)
+		assert.Contains(t, sql, "INSERT INTO level")
+		assert.NotContains(t, sql, quotedLevel)
+	})
 }
 
 func TestSetStructAllFields(t *testing.T) {

--- a/database/internal/sqllex/oracle_reserved.go
+++ b/database/internal/sqllex/oracle_reserved.go
@@ -14,21 +14,42 @@ const (
 // This is the canonical source of truth for Oracle reserved word detection across the GoBricks framework.
 // Both the query builder and column parser rely on this list for automatic identifier quoting.
 //
-// Source: Oracle Database SQL Language Reference
+// The map is kept in parity with the full official Oracle 19c reserved-word list
+// (V$RESERVED_WORDS where reserved='Y'); parity is enforced by
+// TestOracleReservedWordsMatchOfficial19cList. A small, intentional superset is also quoted
+// defensively (BEGIN, CASE, WHEN, EXCLUDE) — see that test for the rationale of each entry.
+//
+// Source: Oracle Database SQL Language Reference 19c, "Oracle SQL Reserved Words".
 // https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/Oracle-SQL-Reserved-Words.html
 //
 // Note: This list uses struct{} for zero-memory overhead in the map value.
+//
+//nolint:goconst // Literal reserved-word data table; extracting each keyword to a named constant would harm readability and defeat the purpose of a flat lookup set.
 var OracleReservedWords = map[string]struct{}{
+	// Official Oracle 19c reserved words.
 	"ACCESS": {}, "ADD": {}, "ALL": {}, "ALTER": {}, "AND": {}, "ANY": {}, "AS": {}, "ASC": {},
-	"BEGIN": {}, "BETWEEN": {}, "BY": {}, "CASE": {}, "CHECK": {}, "COLUMN": {}, "COMMENT": {},
-	"CONNECT": {}, "CREATE": {}, "CURRENT": {}, "DELETE": {}, "DESC": {}, "DISTINCT": {},
-	"DROP": {}, "ELSE": {}, "EXCLUDE": {}, "EXISTS": {}, "FOR": {}, "FROM": {}, "GRANT": {},
-	"GROUP": {}, "HAVING": {}, "IN": {}, "INDEX": {}, "INSERT": {}, "INTERSECT": {}, "INTO": {},
-	"IS": {}, oracleReservedLevel: {}, "LIKE": {}, "LOCK": {}, "MINUS": {}, "MODE": {}, "NOCOMPRESS": {},
-	"NOT": {}, "NULL": {}, oracleReservedNumber: {}, "OF": {}, "ON": {}, "OPTION": {}, "OR": {}, "ORDER": {},
-	"ROW": {}, "ROWNUM": {}, "SELECT": {}, "SET": {}, "SHARE": {}, oracleReservedSize: {}, "START": {},
-	"TABLE": {}, "THEN": {}, "TO": {}, "TRIGGER": {}, "UNION": {}, "UNIQUE": {}, "UPDATE": {},
-	"VALUES": {}, "VIEW": {}, "WHEN": {}, "WHERE": {}, "WITH": {},
+	"AUDIT": {}, "BETWEEN": {}, "BY": {}, "CHAR": {}, "CHECK": {}, "CLUSTER": {}, "COLUMN": {},
+	"COMMENT": {}, "COMPRESS": {}, "CONNECT": {}, "CREATE": {}, "CURRENT": {}, "DATE": {},
+	"DECIMAL": {}, "DEFAULT": {}, "DELETE": {}, "DESC": {}, "DISTINCT": {}, "DROP": {}, "ELSE": {},
+	"EXCLUSIVE": {}, "EXISTS": {}, "FILE": {}, "FLOAT": {}, "FOR": {}, "FROM": {}, "GRANT": {},
+	"GROUP": {}, "HAVING": {}, "IDENTIFIED": {}, "IMMEDIATE": {}, "IN": {}, "INCREMENT": {},
+	"INDEX": {}, "INITIAL": {}, "INSERT": {}, "INTEGER": {}, "INTERSECT": {}, "INTO": {}, "IS": {},
+	oracleReservedLevel: {}, "LIKE": {}, "LOCK": {}, "LONG": {}, "MAXEXTENTS": {}, "MINUS": {},
+	"MLSLABEL": {}, "MODE": {}, "MODIFY": {}, "NOAUDIT": {}, "NOCOMPRESS": {}, "NOT": {},
+	"NOWAIT": {}, "NULL": {}, oracleReservedNumber: {}, "OF": {}, "OFFLINE": {}, "ON": {},
+	"ONLINE": {}, "OPTION": {}, "OR": {}, "ORDER": {}, "PCTFREE": {}, "PRIOR": {}, "PUBLIC": {},
+	"RAW": {}, "RENAME": {}, "RESOURCE": {}, "REVOKE": {}, "ROW": {}, "ROWID": {}, "ROWNUM": {},
+	"ROWS": {}, "SELECT": {}, "SESSION": {}, "SET": {}, "SHARE": {}, oracleReservedSize: {},
+	"SMALLINT": {}, "START": {}, "SUCCESSFUL": {}, "SYNONYM": {}, "SYSDATE": {}, "TABLE": {},
+	"THEN": {}, "TO": {}, "TRIGGER": {}, "UID": {}, "UNION": {}, "UNIQUE": {}, "UPDATE": {},
+	"USER": {}, "VALIDATE": {}, "VALUES": {}, "VARCHAR": {}, "VARCHAR2": {}, "VIEW": {},
+	"WHENEVER": {}, "WHERE": {}, "WITH": {},
+
+	// Intentional supersets (not on the official V$RESERVED_WORDS list, quoted defensively).
+	"BEGIN":   {}, // PL/SQL block keyword; hazardous as an unquoted identifier.
+	"CASE":    {}, // SQL CASE expression keyword.
+	"WHEN":    {}, // SQL CASE/WHEN keyword.
+	"EXCLUDE": {}, // Reserved in analytic windowing (WINDOW frame EXCLUDE clause).
 }
 
 // IsOracleReservedWord checks if a word is an Oracle reserved keyword.

--- a/database/internal/sqllex/oracle_reserved_test.go
+++ b/database/internal/sqllex/oracle_reserved_test.go
@@ -103,7 +103,7 @@ func TestOracleReservedWordsSpecificKeywords(t *testing.T) {
 		"ROW":      true,
 		"ROWNUM":   true,
 		"OPTION":   true,
-		"COMPRESS": false, // Not in the list
+		"COMPRESS": true, // Official Oracle 19c reserved word (M10 fix)
 	}
 
 	for word, shouldExist := range criticalWords {
@@ -122,4 +122,82 @@ func TestIsOracleReservedWordAllEntries(t *testing.T) {
 		count++
 	}
 	assert.Greater(t, count, 0, "Should have tested at least one reserved word")
+}
+
+// TestOracleQuotingFailureWithMissingReservedWords reproduces M10: the map was missing
+// 41 official Oracle 19c reserved keywords, so identifiers like DATE/VARCHAR2/USER were
+// emitted unquoted, triggering ORA-00936/ORA-00904 against Oracle 19c. Every word below
+// is a V$RESERVED_WORDS (reserved='Y') keyword in Oracle 19c and MUST be quoted.
+func TestOracleQuotingFailureWithMissingReservedWords(t *testing.T) {
+	previouslyMissing := []string{
+		"AUDIT", "CHAR", "CLUSTER", "COMPRESS", "DATE", "DECIMAL", "DEFAULT",
+		"EXCLUSIVE", "FILE", "FLOAT", "IDENTIFIED", "IMMEDIATE", "INCREMENT",
+		"INITIAL", "INTEGER", "LONG", "MODIFY", "NOAUDIT", "NOWAIT", "OFFLINE",
+		"ONLINE", "PCTFREE", "PRIOR", "PUBLIC", "RAW", "RENAME", "RESOURCE",
+		"REVOKE", "ROWID", "ROWS", "SESSION", "SMALLINT", "SUCCESSFUL", "SYNONYM",
+		"SYSDATE", "UID", "USER", "VALIDATE", "VARCHAR", "VARCHAR2", "WHENEVER",
+	}
+
+	for _, word := range previouslyMissing {
+		t.Run(word, func(t *testing.T) {
+			assert.True(t, IsOracleReservedWord(word),
+				"Oracle 19c reserved word %q must be detected so identifiers are quoted (ORA-00936/ORA-00904 otherwise)", word)
+		})
+	}
+}
+
+// TestOracleReservedWordsMatchOfficial19cList asserts parity between the map and a vendored
+// copy of the official Oracle 19c reserved-word list (V$RESERVED_WORDS where reserved='Y').
+// HARDEN: the map must cover the full official list; any intentional superset entry must be
+// explicitly documented here so it cannot silently mask a parity regression.
+func TestOracleReservedWordsMatchOfficial19cList(t *testing.T) {
+	// official19cReserved is the canonical Oracle 19c reserved-word set.
+	// Source: Oracle Database SQL Language Reference 19c, "Oracle SQL Reserved Words".
+	official19cReserved := map[string]struct{}{
+		"ACCESS": {}, "ADD": {}, "ALL": {}, "ALTER": {}, "AND": {}, "ANY": {},
+		"AS": {}, "ASC": {}, "AUDIT": {}, "BETWEEN": {}, "BY": {}, "CHAR": {},
+		"CHECK": {}, "CLUSTER": {}, "COLUMN": {}, "COMMENT": {}, "COMPRESS": {},
+		"CONNECT": {}, "CREATE": {}, "CURRENT": {}, "DATE": {}, "DECIMAL": {},
+		"DEFAULT": {}, "DELETE": {}, "DESC": {}, "DISTINCT": {}, "DROP": {},
+		"ELSE": {}, "EXCLUSIVE": {}, "EXISTS": {}, "FILE": {}, "FLOAT": {},
+		"FOR": {}, "FROM": {}, "GRANT": {}, "GROUP": {}, "HAVING": {},
+		"IDENTIFIED": {}, "IMMEDIATE": {}, "IN": {}, "INCREMENT": {}, "INDEX": {},
+		"INITIAL": {}, "INSERT": {}, "INTEGER": {}, "INTERSECT": {}, "INTO": {},
+		"IS": {}, "LEVEL": {}, "LIKE": {}, "LOCK": {}, "LONG": {}, "MAXEXTENTS": {},
+		"MINUS": {}, "MLSLABEL": {}, "MODE": {}, "MODIFY": {}, "NOAUDIT": {},
+		"NOCOMPRESS": {}, "NOT": {}, "NOWAIT": {}, "NULL": {}, "NUMBER": {},
+		"OF": {}, "OFFLINE": {}, "ON": {}, "ONLINE": {}, "OPTION": {}, "OR": {},
+		"ORDER": {}, "PCTFREE": {}, "PRIOR": {}, "PUBLIC": {}, "RAW": {},
+		"RENAME": {}, "RESOURCE": {}, "REVOKE": {}, "ROW": {}, "ROWID": {},
+		"ROWNUM": {}, "ROWS": {}, "SELECT": {}, "SESSION": {}, "SET": {},
+		"SHARE": {}, "SIZE": {}, "SMALLINT": {}, "START": {}, "SUCCESSFUL": {},
+		"SYNONYM": {}, "SYSDATE": {}, "TABLE": {}, "THEN": {}, "TO": {},
+		"TRIGGER": {}, "UID": {}, "UNION": {}, "UNIQUE": {}, "UPDATE": {},
+		"USER": {}, "VALIDATE": {}, "VALUES": {}, "VARCHAR": {}, "VARCHAR2": {},
+		"VIEW": {}, "WHENEVER": {}, "WHERE": {}, "WITH": {},
+	}
+
+	// Intentional supersets: keywords NOT on the official V$RESERVED_WORDS list that the
+	// framework still quotes defensively (reserved in newer versions, PL/SQL contexts, or
+	// common DDL/DML hazards). Documenting them here keeps the parity assertion meaningful.
+	intentionalSupersets := map[string]struct{}{
+		"BEGIN":   {}, // PL/SQL block keyword; hazardous as an unquoted identifier.
+		"CASE":    {}, // SQL CASE expression keyword.
+		"WHEN":    {}, // SQL CASE/WHEN keyword.
+		"EXCLUDE": {}, // Reserved in analytic windowing (WINDOW frame EXCLUDE clause).
+	}
+
+	// Every official reserved word must be present in the map.
+	for word := range official19cReserved {
+		_, exists := OracleReservedWords[word]
+		assert.True(t, exists, "official Oracle 19c reserved word %q is missing from OracleReservedWords", word)
+	}
+
+	// Every map entry must be either an official reserved word or a documented superset.
+	for word := range OracleReservedWords {
+		_, official := official19cReserved[word]
+		_, superset := intentionalSupersets[word]
+		assert.True(t, official || superset,
+			"OracleReservedWords contains %q which is neither an official 19c reserved word nor a documented intentional superset", word)
+	}
 }


### PR DESCRIPTION
## Summary

Three **Oracle identifier-quoting** correctness findings from the 2026-06-10 security audit (`VULNERABILITIES.md` Mediums **M7**, **M8**, **M10**). Third PR of the Medium-remediation effort (PR1 #600, PR2 #601 merged). **No API change**; PostgreSQL is unaffected.

## Findings fixed

### M7 — `BuildUpsert` (Oracle MERGE) mis-quoted columns + table (`database/internal/builder/oracle.go`)
`buildOracleMerge` ran every column through `escapeIdentifiers` (unconditional lowercase double-quoting), so a standard uppercase-DDL column (`ID`) failed `ORA-00904` through MERGE even though it worked via `Select`/`Update`. The MERGE table name was interpolated **unquoted** (reserved-word tables broke), and a conflict column absent from the insert columns silently produced SQL referencing a non-existent `source.<col>`.
**Fix:** use `quoteOracleColumnsForDML` (reserved-word-only quoting — identical to the DML paths, so non-reserved identifiers stay unquoted and fold to the uppercase DDL form); route the table through `quoteTableForQuery`; validate every conflict column is present in the insert columns (explicit error).

### M8 — Insert builders skipped table quoting (`database/internal/builder/query_builder.go`)
`Insert` / `InsertWithColumns` / `InsertStruct` / `InsertFields` passed the table name straight to the statement builder, while `Update`/`Delete`/`From` all apply `quoteTableForQuery`. A reserved-word table (`level`) was readable/updatable/deletable but every INSERT failed `ORA-00903`. All four now quote consistently.

### M10 — incomplete Oracle reserved-word list (`database/internal/sqllex/oracle_reserved.go`)
The map was missing **41** official Oracle 19c reserved words (`DATE`, `DEFAULT`, `USER`, `RAW`, `ROWID`, `ROWS`, `PRIOR`, `SESSION`, `VARCHAR2`, `UID`, …), so those identifiers were emitted unquoted and failed at runtime. Synced to the official list (kept `BEGIN`/`CASE`/`WHEN`/`EXCLUDE` as a **documented defensive superset**) with a parity test against a vendored copy of the reference list.

## Emitted-SQL change (Oracle only)

This corrects generated SQL for Oracle reserved-word and standard identifiers — all in the direction of *matching the already-working SELECT/UPDATE behavior*. No migration action is required: the old output threw `ORA-009xx` for the affected identifiers, so no working deployment depended on it. Non-Oracle vendors are unchanged.

## Testing

TDD repros per finding; masking tests updated (`TestBuildUpsertOracleGeneratesMergeStatement` now expects case-correct quoting; `TestInsertStructOracleReservedWords` asserts both table and reserved-word column quoting). `make check` green — `go build`, `go vet`, `go test -race ./...`, `golangci-lint` (0 issues), `govulncheck` (clean). Authoritative cross-vendor confirmation also runs under the Oracle integration matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Oracle database support with proper quoting of reserved column and table names in INSERT, UPSERT, and MERGE operations.
  * Expanded Oracle 19c reserved-word recognition to prevent SQL generation errors.
  * Added validation for UPSERT conflict columns to ensure they exist in insert operations.

* **Tests**
  * Added comprehensive Oracle-specific test coverage for reserved-word handling and UPSERT operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->