### PR TITLE
fix(database)!: validate direct-string identifier arguments in the query builder (close M9 SQLi)

### DIFF
--- a/database/internal/builder/identifiers.go
+++ b/database/internal/builder/identifiers.go
@@ -1,0 +1,98 @@
+package builder
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// SQL identifier grammar used to validate the direct-string builder APIs
+// (From, OrderBy, GroupBy, Set, SetMap) BEFORE the value is interpolated into the
+// SQL string. Validation runs on ALL vendors so these APIs cannot be used as a
+// SQL injection vector (M9 / ADR-031). Complex expressions must go through
+// qb.Expr() / Raw(), which carry an explicit security annotation.
+const (
+	// identifierSegment is a single unquoted identifier: a leading letter or
+	// underscore followed by letters, digits, underscore, $ or # — the same
+	// alphabet enforced for db-tag struct fields by the columns package.
+	identifierSegment = `[A-Za-z_][A-Za-z0-9_$#]*`
+
+	// quotedSegment is a single double-quoted identifier with NO embedded quotes
+	// or escapes. This is exactly the shape the framework's own vendor quoting
+	// emits for reserved words (e.g. Oracle "level"); allowing it lets the
+	// type-safe Columns()/cols.Col() output flow through Set/Where unchanged while
+	// still rejecting attacker-supplied quote payloads (which would contain spaces,
+	// additional quotes, semicolons, or comment markers).
+	quotedSegment = `"` + identifierSegment + `"`
+
+	// segment matches either form.
+	segment = `(?:` + identifierSegment + `|` + quotedSegment + `)`
+
+	// qualified matches a simple or dot-qualified identifier: "col", "table.col",
+	// "schema.table.col", and the quoted variants ("schema"."number", u."level").
+	qualified = segment + `(\.` + segment + `)*`
+)
+
+// validIdentifierPattern matches a simple or qualified identifier.
+var validIdentifierPattern = regexp.MustCompile(`^` + qualified + `$`)
+
+// validClauseIdentifierPattern extends validIdentifierPattern with the bounded
+// ORDER BY / GROUP BY direction grammar the public API documents and accepts:
+//
+//	col
+//	col ASC | col DESC
+//	col ASC NULLS FIRST | col DESC NULLS LAST   (and the other combinations)
+//
+// Anything outside this grammar (additional whitespace-separated tokens,
+// semicolons, comment sequences, parentheses) is rejected so attacker-controlled
+// clause arguments cannot smuggle a second statement or comment.
+var validClauseIdentifierPattern = regexp.MustCompile(
+	`^` + qualified + `( (?i:ASC|DESC))?( (?i:NULLS) (?i:FIRST|LAST))?$`,
+)
+
+// validTableNamePattern extends validIdentifierPattern with an optional trailing
+// table alias ("users u", "schema.users u") — the inline-alias form the From/JOIN
+// string APIs already accept alongside the explicit Table("users").As("u") helper.
+// The alias is a bare identifier; anything beyond a single trailing identifier is
+// rejected so the table argument cannot smuggle additional SQL.
+var validTableNamePattern = regexp.MustCompile(
+	`^` + qualified + `( ` + segment + `)?$`,
+)
+
+// validateIdentifier rejects identifier arguments (column names, UPDATE SET
+// targets) that fall outside the safe simple/qualified-identifier grammar.
+// Returns a descriptive error naming the rejected value.
+func validateIdentifier(context, identifier string) error {
+	trimmed := strings.TrimSpace(identifier)
+	if !validIdentifierPattern.MatchString(trimmed) {
+		return fmt.Errorf("invalid %s identifier %q: must be a simple or qualified identifier "+
+			"matching %s — use qb.Expr()/Raw() for complex expressions", context, identifier, identifierSegment)
+	}
+	return nil
+}
+
+// validateTableName rejects table-name arguments that fall outside the safe
+// simple/qualified-identifier grammar plus an optional inline alias ("users u").
+func validateTableName(identifier string) error {
+	trimmed := strings.TrimSpace(identifier)
+	if !validTableNamePattern.MatchString(trimmed) {
+		return fmt.Errorf("invalid table identifier %q: must be a simple or qualified identifier "+
+			"with an optional alias (e.g. \"users\" or \"users u\") — use qb.Expr()/Raw() for complex expressions",
+			identifier)
+	}
+	return nil
+}
+
+// validateClauseIdentifier rejects ORDER BY / GROUP BY arguments that fall
+// outside the safe identifier-plus-optional-direction grammar. The bounded
+// trailing direction (ASC/DESC [NULLS FIRST|LAST]) is permitted; everything
+// else — extra tokens, semicolons, comment markers — is rejected.
+func validateClauseIdentifier(context, identifier string) error {
+	trimmed := strings.TrimSpace(identifier)
+	if !validClauseIdentifierPattern.MatchString(trimmed) {
+		return fmt.Errorf("invalid %s identifier %q: must be a simple or qualified identifier with an "+
+			"optional ASC/DESC [NULLS FIRST|LAST] direction — use qb.Expr()/Raw() for complex expressions",
+			context, identifier)
+	}
+	return nil
+}

--- a/database/internal/builder/identifiers_test.go
+++ b/database/internal/builder/identifiers_test.go
@@ -1,0 +1,313 @@
+package builder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+)
+
+// TestValidateIdentifierAcceptsSafeForms verifies the column/SET-target validator
+// accepts simple, qualified, and framework-quoted identifiers (M9 / ADR-031).
+func TestValidateIdentifierAcceptsSafeForms(t *testing.T) {
+	cases := []string{
+		"id",
+		"user_id",
+		"_internal",
+		"col$",
+		"col#",
+		"table.col",
+		"schema.table.col",
+		`"level"`,       // framework-quoted Oracle reserved word
+		`table."level"`, // qualified + quoted segment
+		`schema."number"`,
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			require.NoError(t, validateIdentifier("column", c), "expected %q to be accepted", c)
+		})
+	}
+}
+
+// TestValidateIdentifierRejectsInjection verifies the column/SET-target validator
+// rejects injection vectors and complex expressions.
+func TestValidateIdentifierRejectsInjection(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"semicolon_statement", "name; DROP TABLE users--"},
+		{"line_comment", "name--"},
+		{"block_comment", "name/* x */"},
+		{"embedded_space", "name DESC"},
+		{"unbalanced_quote", `name" = "x`},
+		{"function_call", "COUNT(*)"},
+		{"leading_digit", "1col"},
+		{"empty", ""},
+		{"or_injection", "1 OR 1=1"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Error(t, validateIdentifier("column", c.input), "expected %q to be rejected", c.input)
+		})
+	}
+}
+
+// TestValidateClauseIdentifierAcceptsDirections verifies ORDER BY / GROUP BY
+// arguments may carry the bounded ASC/DESC [NULLS FIRST|LAST] direction grammar.
+func TestValidateClauseIdentifierAcceptsDirections(t *testing.T) {
+	cases := []string{
+		"name",
+		"name ASC",
+		"name DESC",
+		"name asc",
+		"created_at DESC",
+		"u.name ASC",
+		"name ASC NULLS FIRST",
+		"name DESC NULLS LAST",
+		"name NULLS FIRST",
+		`"level" DESC`,
+		`u."level" ASC`,
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			require.NoError(t, validateClauseIdentifier("orderBy", c), "expected %q to be accepted", c)
+		})
+	}
+}
+
+// TestValidateClauseIdentifierRejectsInjection verifies ORDER BY / GROUP BY
+// arguments reject injection vectors while still allowing legitimate directions.
+func TestValidateClauseIdentifierRejectsInjection(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"semicolon_drop", "name; DROP TABLE users--"},
+		{"line_comment", "name--"},
+		{"block_comment", "name /* x */ DESC"},
+		{"function_call", "COUNT(*)"},
+		{"extra_token", "name DESC, id"},
+		{"bogus_direction", "name SIDEWAYS"},
+		{"subselect", "name) UNION SELECT password FROM users--"},
+		{"nulls_without_position", "name NULLS"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Error(t, validateClauseIdentifier("orderBy", c.input), "expected %q to be rejected", c.input)
+		})
+	}
+}
+
+// TestValidateTableNameAcceptsAliasForms verifies the table validator accepts the
+// inline-alias and qualified forms the From/JOIN string APIs support.
+func TestValidateTableNameAcceptsAliasForms(t *testing.T) {
+	cases := []string{
+		"users",
+		"users u",
+		"schema.users",
+		"schema.users u",
+		`"user"`,
+		`"user" u`,
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			require.NoError(t, validateTableName(c), "expected %q to be accepted", c)
+		})
+	}
+}
+
+// TestValidateTableNameRejectsInjection verifies the table validator rejects
+// injection vectors and multi-token payloads.
+func TestValidateTableNameRejectsInjection(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"semicolon_drop", "users; DROP TABLE accounts--"},
+		{"subselect", "users WHERE 1=1--"},
+		{"too_many_tokens", "users u extra"},
+		{"comment", "users--"},
+		{"empty", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Error(t, validateTableName(c.input), "expected %q to be rejected", c.input)
+		})
+	}
+}
+
+// TestBuilderRejectsIdentifierInjectionBothVendors exercises the end-to-end public
+// builder API for PostgreSQL and Oracle: injection vectors surface as a ToSQL()
+// error and never reach the generated SQL, while legitimate identifiers, qualified
+// names, aliases, and ORDER BY directions build successfully.
+func TestBuilderRejectsIdentifierInjectionBothVendors(t *testing.T) {
+	vendors := []string{dbtypes.PostgreSQL, dbtypes.Oracle}
+
+	for _, vendor := range vendors {
+		t.Run(vendor, func(t *testing.T) {
+			t.Run("order_by_injection_rejected", func(t *testing.T) {
+				qb := NewQueryBuilder(vendor)
+				sql, _, err := qb.Select(selectAll).From(tableUsers).
+					OrderBy("name; DROP TABLE users--").ToSQL()
+				require.Error(t, err)
+				assert.NotContains(t, sql, "DROP TABLE")
+				assert.NotContains(t, sql, "--")
+			})
+
+			t.Run("group_by_function_string_rejected", func(t *testing.T) {
+				qb := NewQueryBuilder(vendor)
+				_, _, err := qb.Select(selectAll).From(tableUsers).
+					GroupBy("COUNT(*)").ToSQL()
+				require.Error(t, err, "function expressions must go through qb.Expr()")
+			})
+
+			t.Run("from_injection_rejected", func(t *testing.T) {
+				qb := NewQueryBuilder(vendor)
+				sql, _, err := qb.Select(selectAll).
+					From("users; DROP TABLE accounts--").ToSQL()
+				require.Error(t, err)
+				assert.NotContains(t, sql, "DROP TABLE")
+			})
+
+			t.Run("set_injection_rejected", func(t *testing.T) {
+				qb := NewQueryBuilder(vendor)
+				f := qb.Filter()
+				_, _, err := qb.Update(tableUsers).
+					Set("name = 'x'; DROP TABLE users--", "y").
+					Where(f.Eq(colID, 1)).ToSQL()
+				require.Error(t, err)
+			})
+
+			t.Run("set_map_injection_rejected", func(t *testing.T) {
+				qb := NewQueryBuilder(vendor)
+				f := qb.Filter()
+				_, _, err := qb.Update(tableUsers).
+					SetMap(map[string]any{"name); DROP TABLE users--": "y"}).
+					Where(f.Eq(colID, 1)).ToSQL()
+				require.Error(t, err)
+			})
+
+			t.Run("join_injection_rejected", func(t *testing.T) {
+				// The JOIN table argument shares From()'s verbatim-interpolation
+				// path, so it must be validated identically (M9 / ADR-031).
+				joinCases := []struct {
+					name string
+					join func(b dbtypes.SelectQueryBuilder, table any, jf dbtypes.JoinFilter) dbtypes.SelectQueryBuilder
+				}{
+					{"JoinOn", func(b dbtypes.SelectQueryBuilder, table any, jf dbtypes.JoinFilter) dbtypes.SelectQueryBuilder {
+						return b.JoinOn(table, jf)
+					}},
+					{"LeftJoinOn", func(b dbtypes.SelectQueryBuilder, table any, jf dbtypes.JoinFilter) dbtypes.SelectQueryBuilder {
+						return b.LeftJoinOn(table, jf)
+					}},
+					{"RightJoinOn", func(b dbtypes.SelectQueryBuilder, table any, jf dbtypes.JoinFilter) dbtypes.SelectQueryBuilder {
+						return b.RightJoinOn(table, jf)
+					}},
+					{"InnerJoinOn", func(b dbtypes.SelectQueryBuilder, table any, jf dbtypes.JoinFilter) dbtypes.SelectQueryBuilder {
+						return b.InnerJoinOn(table, jf)
+					}},
+				}
+				const injection = "profiles p ON 1=1; DROP TABLE users--"
+				for _, jc := range joinCases {
+					t.Run(jc.name, func(t *testing.T) {
+						qb := NewQueryBuilder(vendor)
+						jf := qb.JoinFilter().EqColumn("users.id", "p.user_id")
+						b := qb.Select(selectAll).From(tableUsers)
+						sql, _, err := jc.join(b, injection, jf).ToSQL()
+						require.Error(t, err)
+						assert.NotContains(t, sql, "DROP TABLE")
+						assert.NotContains(t, sql, "--")
+					})
+				}
+
+				t.Run("CrossJoinOn", func(t *testing.T) {
+					qb := NewQueryBuilder(vendor)
+					sql, _, err := qb.Select(selectAll).From(tableUsers).
+						CrossJoinOn(injection).ToSQL()
+					require.Error(t, err)
+					assert.NotContains(t, sql, "DROP TABLE")
+					assert.NotContains(t, sql, "--")
+				})
+			})
+
+			t.Run("join_tableref_injection_rejected", func(t *testing.T) {
+				// A *TableRef carrying a crafted Name() must also be rejected: the
+				// name is interpolated verbatim, so validateTableReference's name
+				// branch guards it independently of the string path.
+				qb := NewQueryBuilder(vendor)
+				jf := qb.JoinFilter().EqColumn("users.id", "p.user_id")
+				badRef := dbtypes.MustTable("profiles; DROP TABLE users--").MustAs("p")
+				sql, _, err := qb.Select(selectAll).From(tableUsers).
+					JoinOn(badRef, jf).ToSQL()
+				require.Error(t, err)
+				assert.NotContains(t, sql, "DROP TABLE")
+			})
+
+			t.Run("from_tableref_injection_rejected", func(t *testing.T) {
+				// Covers validateTableReference's *TableRef name-error branch via From.
+				qb := NewQueryBuilder(vendor)
+				sql, _, err := qb.Select(selectAll).
+					From(dbtypes.MustTable("users; DROP TABLE accounts--")).ToSQL()
+				require.Error(t, err)
+				assert.NotContains(t, sql, "DROP TABLE")
+			})
+
+			t.Run("delete_order_by_injection_rejected", func(t *testing.T) {
+				qb := NewQueryBuilder(vendor)
+				f := qb.Filter()
+				sql, _, err := qb.Delete(tableUsers).
+					OrderBy("name; DROP TABLE users--").
+					Where(f.Eq(colID, 1)).ToSQL()
+				require.Error(t, err)
+				assert.NotContains(t, sql, "DROP TABLE")
+				assert.NotContains(t, sql, "--")
+			})
+
+			t.Run("legitimate_delete_order_by_builds", func(t *testing.T) {
+				qb := NewQueryBuilder(vendor)
+				f := qb.Filter()
+				sql, _, err := qb.Delete(tableUsers).
+					OrderBy("created_at DESC").
+					Where(f.Eq(colID, 1)).ToSQL()
+				require.NoError(t, err)
+				assert.Contains(t, sql, "ORDER BY")
+			})
+
+			t.Run("legitimate_join_builds", func(t *testing.T) {
+				qb := NewQueryBuilder(vendor)
+				jf := qb.JoinFilter().EqColumn("users.id", "p.user_id")
+				sql, _, err := qb.Select(selectAll).From("users u").
+					JoinOn("profiles p", jf).ToSQL()
+				require.NoError(t, err)
+				assert.Contains(t, sql, "JOIN")
+				assert.NotContains(t, sql, "DROP TABLE")
+			})
+
+			t.Run("legitimate_query_builds", func(t *testing.T) {
+				qb := NewQueryBuilder(vendor)
+				sql, _, err := qb.Select(colID, colName).
+					From("users u").
+					GroupBy(colName).
+					OrderBy("u.name ASC", "id DESC").ToSQL()
+				require.NoError(t, err)
+				assert.Contains(t, sql, "ORDER BY")
+				assert.Contains(t, sql, "GROUP BY")
+			})
+
+			t.Run("legitimate_update_builds", func(t *testing.T) {
+				qb := NewQueryBuilder(vendor)
+				f := qb.Filter()
+				sql, args, err := qb.Update(tableUsers).
+					Set(colName, "Jane").
+					SetMap(map[string]any{"email": "jane@example.com"}).
+					Where(f.Eq(colID, 1)).ToSQL()
+				require.NoError(t, err)
+				assert.Contains(t, sql, "UPDATE users SET")
+				assert.NotEmpty(t, args)
+			})
+		})
+	}
+}

--- a/database/internal/builder/identifiers_test.go
+++ b/database/internal/builder/identifiers_test.go
@@ -255,6 +255,25 @@ func TestBuilderRejectsIdentifierInjectionBothVendors(t *testing.T) {
 				assert.NotContains(t, sql, "DROP TABLE")
 			})
 
+			t.Run("update_table_injection_rejected", func(t *testing.T) {
+				qb := NewQueryBuilder(vendor)
+				f := qb.Filter()
+				sql, _, err := qb.Update("users; DROP TABLE users--").
+					Set(colID, 1).
+					Where(f.Eq(colID, 1)).ToSQL()
+				require.Error(t, err)
+				assert.NotContains(t, sql, "DROP TABLE")
+			})
+
+			t.Run("delete_table_injection_rejected", func(t *testing.T) {
+				qb := NewQueryBuilder(vendor)
+				f := qb.Filter()
+				sql, _, err := qb.Delete("users; DROP TABLE users--").
+					Where(f.Eq(colID, 1)).ToSQL()
+				require.Error(t, err)
+				assert.NotContains(t, sql, "DROP TABLE")
+			})
+
 			t.Run("delete_order_by_injection_rejected", func(t *testing.T) {
 				qb := NewQueryBuilder(vendor)
 				f := qb.Filter()

--- a/database/internal/builder/oracle_test.go
+++ b/database/internal/builder/oracle_test.go
@@ -930,32 +930,36 @@ func TestOracleOrderByGroupByQuoting(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		orderBy     []string
-		groupBy     []string
+		orderBy     []any
+		groupBy     []any
 		expectedSQL []string
 	}{
 		{
 			name:        "reserved_word_column",
-			orderBy:     []string{"number"},
-			groupBy:     []string{"level"},
+			orderBy:     []any{"number"},
+			groupBy:     []any{"level"},
 			expectedSQL: []string{`ORDER BY "number"`, `GROUP BY "level"`},
 		},
 		{
 			name:        "column_with_direction",
-			orderBy:     []string{"number ASC", "size DESC"},
-			groupBy:     []string{"access"},
+			orderBy:     []any{"number ASC", "size DESC"},
+			groupBy:     []any{"access"},
 			expectedSQL: []string{`ORDER BY "number" ASC, "size" DESC`, `GROUP BY "access"`},
 		},
 		{
 			name:        "mixed_reserved_and_normal",
-			orderBy:     []string{"name", "number DESC"},
-			groupBy:     []string{"category", "level"},
+			orderBy:     []any{"name", "number DESC"},
+			groupBy:     []any{"category", "level"},
 			expectedSQL: []string{`ORDER BY name, "number" DESC`, `GROUP BY category, "level"`},
 		},
 		{
-			name:        "sql_functions_preserved",
-			orderBy:     []string{countClause, sumClause},
-			groupBy:     []string{"COUNT(items)", "user_id"},
+			// HARDEN (ADR-031): SQL function expressions are no longer accepted as
+			// plain strings through OrderBy/GroupBy — they must go through qb.Expr()
+			// (the developer-controlled raw-SQL escape hatch). Plain strings are
+			// validated as bare identifiers to close the M9 injection vector.
+			name:        "sql_functions_via_expr_preserved",
+			orderBy:     []any{qb.MustExpr(countClause), qb.MustExpr(sumClause)},
+			groupBy:     []any{qb.MustExpr("COUNT(items)"), "user_id"},
 			expectedSQL: []string{`ORDER BY COUNT(*), SUM(amount)`, `GROUP BY COUNT(items), user_id`},
 		},
 	}
@@ -964,10 +968,10 @@ func TestOracleOrderByGroupByQuoting(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			query := qb.Select("*").From("users")
 			if len(tt.groupBy) > 0 {
-				query = query.GroupBy(toAny(tt.groupBy)...)
+				query = query.GroupBy(tt.groupBy...)
 			}
 			if len(tt.orderBy) > 0 {
-				query = query.OrderBy(toAny(tt.orderBy)...)
+				query = query.OrderBy(tt.orderBy...)
 			}
 
 			sql, _, err := query.ToSQL()

--- a/database/internal/builder/query_builder.go
+++ b/database/internal/builder/query_builder.go
@@ -400,11 +400,16 @@ func (qb *QueryBuilder) isZeroValueIDField(column string, value any) bool {
 //	    Set("updated_at", time.Now()).
 //	    Where(f.Eq("id", 123))
 func (qb *QueryBuilder) Update(table string) dbtypes.UpdateQueryBuilder {
-	quotedTable := qb.quoteTableForQuery(table)
-	return &UpdateQueryBuilder{
-		qb:            qb,
-		updateBuilder: qb.statementBuilder.Update(quotedTable),
+	uqb := &UpdateQueryBuilder{qb: qb}
+	// Validate the table identifier before interpolation (all vendors): on
+	// PostgreSQL quoteTableForQuery returns the name verbatim, so an unvalidated
+	// table is a raw-interpolation (M9) vector. Surface a violation from ToSQL().
+	if err := validateTableName(table); err != nil {
+		uqb.err = fmt.Errorf("Update: %w", err)
+		return uqb
 	}
+	uqb.updateBuilder = qb.statementBuilder.Update(qb.quoteTableForQuery(table))
+	return uqb
 }
 
 // Delete creates a DELETE query builder for the specified table with Filter API support.
@@ -419,11 +424,15 @@ func (qb *QueryBuilder) Update(table string) dbtypes.UpdateQueryBuilder {
 //	    f.Lt("deleted_at", threshold),
 //	))
 func (qb *QueryBuilder) Delete(table string) dbtypes.DeleteQueryBuilder {
-	quotedTable := qb.quoteTableForQuery(table)
-	return &DeleteQueryBuilder{
-		qb:            qb,
-		deleteBuilder: qb.statementBuilder.Delete(quotedTable),
+	dqb := &DeleteQueryBuilder{qb: qb}
+	// Validate the table identifier before interpolation (all vendors) — same M9
+	// raw-interpolation guard as Update/From. Surface a violation from ToSQL().
+	if err := validateTableName(table); err != nil {
+		dqb.err = fmt.Errorf("Delete: %w", err)
+		return dqb
 	}
+	dqb.deleteBuilder = qb.statementBuilder.Delete(qb.quoteTableForQuery(table))
+	return dqb
 }
 
 // BuildCaseInsensitiveLike creates a case-insensitive LIKE expression.
@@ -751,8 +760,9 @@ func (qb *QueryBuilder) GtOrEq(column string, value any) squirrel.GtOrEq {
 // SECURITY: Table identifiers must be developer-controlled, not user input. They
 // are validated against a safe identifier grammar (simple/qualified name with an
 // optional alias) on ALL vendors BEFORE interpolation; anything else surfaces as a
-// ToSQL() error. For dynamic table expressions use qb.Expr()/Raw() (which require
-// an explicit security annotation). See ADR-031.
+// ToSQL() error. The table argument accepts only a string name or *TableRef — it
+// is not an expression slot, so there is no Expr()/Raw() escape hatch for tables.
+// See ADR-031.
 //
 // Examples:
 //
@@ -846,7 +856,8 @@ func (sqb *SelectQueryBuilder) Where(filter dbtypes.Filter) dbtypes.SelectQueryB
 //
 // SECURITY: JOIN table identifiers must be developer-controlled, not user input.
 // They are validated against the same safe grammar as From() on ALL vendors before
-// interpolation. For dynamic table expressions use qb.Expr()/Raw(). See ADR-031.
+// interpolation. The table argument accepts only a string name or *TableRef (no
+// Expr()/Raw() expression slot for tables). See ADR-031.
 func (sqb *SelectQueryBuilder) validateJoinTable(method string, table any) (quoted string, ok bool) {
 	if err := sqb.qb.validateTableReference(table); err != nil {
 		if sqb.err == nil {

--- a/database/internal/builder/query_builder.go
+++ b/database/internal/builder/query_builder.go
@@ -60,6 +60,7 @@ var _ dbtypes.InsertQueryBuilder = (*InsertQueryBuilder)(nil)
 type UpdateQueryBuilder struct {
 	qb            *QueryBuilder
 	updateBuilder squirrel.UpdateBuilder
+	err           error // deferred error surfaced by ToSQL()
 }
 
 // check if UpdateQueryBuilder implements dbtypes.UpdateQueryBuilder
@@ -70,6 +71,7 @@ var _ dbtypes.UpdateQueryBuilder = (*UpdateQueryBuilder)(nil)
 type DeleteQueryBuilder struct {
 	qb            *QueryBuilder
 	deleteBuilder squirrel.DeleteBuilder
+	err           error // deferred error surfaced by ToSQL()
 }
 
 // check if DeleteQueryBuilder implements dbtypes.DeleteQueryBuilder
@@ -647,6 +649,32 @@ func (qb *QueryBuilder) quoteTableForQuery(table string) string {
 	}
 }
 
+// validateTableReference validates the identifier(s) carried by a FROM/JOIN
+// table argument BEFORE interpolation. The plain table name (and the alias, when
+// a *TableRef carries one) are interpolated verbatim into the SQL string, so both
+// must satisfy the safe identifier grammar on ALL vendors (M9). Unsupported types
+// fail fast — mirroring quoteTableReference's panic — via the returned error.
+func (qb *QueryBuilder) validateTableReference(table any) error {
+	switch t := table.(type) {
+	case string:
+		// Plain string table names may carry an inline alias ("users u").
+		return validateTableName(t)
+	case *dbtypes.TableRef:
+		// TableRef carries name and alias separately; each is a bare identifier.
+		if err := validateIdentifier("table", t.Name()); err != nil {
+			return err
+		}
+		if t.HasAlias() {
+			return validateIdentifier("table alias", t.Alias())
+		}
+		return nil
+	default:
+		// Unsupported type is a programming error, not attacker input — defer to
+		// quoteTableReference's fail-fast panic rather than masking it as an error.
+		return nil
+	}
+}
+
 // quoteTableReference handles vendor-specific table quoting for both string names and TableRef instances.
 // Returns quoted table name with optional alias (e.g., "customers" c for PostgreSQL, "LEVEL" lvl for Oracle).
 // Accepts either string or *TableRef. Panics for invalid types (fail-fast validation).
@@ -720,6 +748,12 @@ func (qb *QueryBuilder) GtOrEq(column string, value any) squirrel.GtOrEq {
 // Accepts either string table names or *TableRef instances with optional aliases.
 // Table names are automatically quoted according to database vendor rules to handle reserved words.
 //
+// SECURITY: Table identifiers must be developer-controlled, not user input. They
+// are validated against a safe identifier grammar (simple/qualified name with an
+// optional alias) on ALL vendors BEFORE interpolation; anything else surfaces as a
+// ToSQL() error. For dynamic table expressions use qb.Expr()/Raw() (which require
+// an explicit security annotation). See ADR-031.
+//
 // Examples:
 //
 //	From("users")                                // Simple table
@@ -734,6 +768,12 @@ func (sqb *SelectQueryBuilder) From(from ...any) dbtypes.SelectQueryBuilder {
 	// Quote all tables and join with commas for multi-table FROM clause
 	quotedTables := make([]string, len(from))
 	for i, table := range from {
+		// Validate table-name identifiers BEFORE interpolation (all vendors) so
+		// the FROM clause cannot be used as a SQL injection vector (M9).
+		if err := sqb.qb.validateTableReference(table); err != nil {
+			sqb.err = fmt.Errorf("From: %w", err)
+			return sqb
+		}
 		quotedTables[i] = sqb.qb.quoteTableReference(table)
 	}
 
@@ -798,16 +838,41 @@ func (sqb *SelectQueryBuilder) Where(filter dbtypes.Filter) dbtypes.SelectQueryB
 	return sqb
 }
 
+// validateJoinTable validates a JOIN table argument BEFORE interpolation (all
+// vendors) and quotes it. The table name/alias are interpolated verbatim into the
+// JOIN clause, so they must satisfy the safe identifier grammar to close the M9
+// injection vector. On failure the first error is captured (deferred to ToSQL,
+// mirroring From) and ok is false so the caller short-circuits.
+//
+// SECURITY: JOIN table identifiers must be developer-controlled, not user input.
+// They are validated against the same safe grammar as From() on ALL vendors before
+// interpolation. For dynamic table expressions use qb.Expr()/Raw(). See ADR-031.
+func (sqb *SelectQueryBuilder) validateJoinTable(method string, table any) (quoted string, ok bool) {
+	if err := sqb.qb.validateTableReference(table); err != nil {
+		if sqb.err == nil {
+			sqb.err = fmt.Errorf("%s: %w", method, err)
+		}
+		return "", false
+	}
+	return sqb.qb.quoteTableReference(table), true
+}
+
 // JoinOn adds a type-safe JOIN clause to the query using JoinFilter for column comparisons.
 // Accepts either a string table name or *TableRef instance with optional alias.
 // The table name is automatically quoted according to vendor rules.
+//
+// SECURITY: see validateJoinTable — JOIN table identifiers are validated on ALL
+// vendors before interpolation (M9 / ADR-031).
 //
 // Example:
 //
 //	jf := qb.JoinFilter()
 //	query.JoinOn(Table("profiles").As("p"), jf.EqColumn("users.id", "p.user_id"))
 func (sqb *SelectQueryBuilder) JoinOn(table any, filter dbtypes.JoinFilter) dbtypes.SelectQueryBuilder {
-	quotedTable := sqb.qb.quoteTableReference(table)
+	quotedTable, ok := sqb.validateJoinTable("JoinOn", table)
+	if !ok {
+		return sqb
+	}
 	condition, args, err := filter.ToSQL()
 	if err != nil {
 		// Capture error to be returned from ToSQL()
@@ -824,7 +889,10 @@ func (sqb *SelectQueryBuilder) JoinOn(table any, filter dbtypes.JoinFilter) dbty
 // Accepts either a string table name or *TableRef instance with optional alias.
 // The table name is automatically quoted according to vendor rules.
 func (sqb *SelectQueryBuilder) LeftJoinOn(table any, filter dbtypes.JoinFilter) dbtypes.SelectQueryBuilder {
-	quotedTable := sqb.qb.quoteTableReference(table)
+	quotedTable, ok := sqb.validateJoinTable("LeftJoinOn", table)
+	if !ok {
+		return sqb
+	}
 	condition, args, err := filter.ToSQL()
 	if err != nil {
 		// Capture error to be returned from ToSQL()
@@ -841,7 +909,10 @@ func (sqb *SelectQueryBuilder) LeftJoinOn(table any, filter dbtypes.JoinFilter) 
 // Accepts either a string table name or *TableRef instance with optional alias.
 // The table name is automatically quoted according to vendor rules.
 func (sqb *SelectQueryBuilder) RightJoinOn(table any, filter dbtypes.JoinFilter) dbtypes.SelectQueryBuilder {
-	quotedTable := sqb.qb.quoteTableReference(table)
+	quotedTable, ok := sqb.validateJoinTable("RightJoinOn", table)
+	if !ok {
+		return sqb
+	}
 	condition, args, err := filter.ToSQL()
 	if err != nil {
 		// Capture error to be returned from ToSQL()
@@ -858,7 +929,10 @@ func (sqb *SelectQueryBuilder) RightJoinOn(table any, filter dbtypes.JoinFilter)
 // Accepts either a string table name or *TableRef instance with optional alias.
 // The table name is automatically quoted according to vendor rules.
 func (sqb *SelectQueryBuilder) InnerJoinOn(table any, filter dbtypes.JoinFilter) dbtypes.SelectQueryBuilder {
-	quotedTable := sqb.qb.quoteTableReference(table)
+	quotedTable, ok := sqb.validateJoinTable("InnerJoinOn", table)
+	if !ok {
+		return sqb
+	}
 	condition, args, err := filter.ToSQL()
 	if err != nil {
 		// Capture error to be returned from ToSQL()
@@ -876,7 +950,10 @@ func (sqb *SelectQueryBuilder) InnerJoinOn(table any, filter dbtypes.JoinFilter)
 // Cross joins do not have ON conditions, so no JoinFilter is needed.
 // The table name is automatically quoted according to vendor rules.
 func (sqb *SelectQueryBuilder) CrossJoinOn(table any) dbtypes.SelectQueryBuilder {
-	quotedTable := sqb.qb.quoteTableReference(table)
+	quotedTable, ok := sqb.validateJoinTable("CrossJoinOn", table)
+	if !ok {
+		return sqb
+	}
 	sqb.selectBuilder = sqb.selectBuilder.CrossJoin(quotedTable)
 	return sqb
 }
@@ -884,6 +961,13 @@ func (sqb *SelectQueryBuilder) CrossJoinOn(table any) dbtypes.SelectQueryBuilder
 // OrderBy adds an ORDER BY clause to the query.
 // Column names are automatically quoted according to database vendor rules.
 // Accepts both string column names (with optional ASC/DESC) and RawExpression instances (v2.1+).
+//
+// SECURITY: String ORDER BY arguments must be developer-controlled, not user
+// input. They are validated on ALL vendors against a safe grammar — a
+// simple/qualified identifier with an optional ASC/DESC [NULLS FIRST|LAST]
+// direction — BEFORE interpolation; anything else (functions, multiple tokens,
+// comments, semicolons) surfaces as a ToSQL() error. Use qb.Expr() for function
+// or computed orderings (e.g. COUNT(*) DESC). See ADR-031.
 //
 // Examples:
 //
@@ -898,6 +982,10 @@ func (sqb *SelectQueryBuilder) OrderBy(orderBys ...any) dbtypes.SelectQueryBuild
 		sqb.appendClauseValue(&processedOrderBys, orderBy, "orderBy", sqb.qb.quoteIdentifierForClause)
 	}
 
+	if sqb.err != nil {
+		return sqb
+	}
+
 	sqb.selectBuilder = sqb.selectBuilder.OrderBy(processedOrderBys...)
 	return sqb
 }
@@ -905,6 +993,12 @@ func (sqb *SelectQueryBuilder) OrderBy(orderBys ...any) dbtypes.SelectQueryBuild
 // GroupBy adds a GROUP BY clause to the query.
 // Column names are automatically quoted according to database vendor rules.
 // Accepts both string column names and RawExpression instances (v2.1+).
+//
+// SECURITY: String GROUP BY arguments must be developer-controlled, not user
+// input. They are validated on ALL vendors against a safe identifier grammar
+// BEFORE interpolation; anything else (functions, comments, semicolons) surfaces
+// as a ToSQL() error. Use qb.Expr() for computed groupings (e.g.
+// DATE(created_at)). See ADR-031.
 //
 // Examples:
 //
@@ -918,6 +1012,10 @@ func (sqb *SelectQueryBuilder) GroupBy(groupBys ...any) dbtypes.SelectQueryBuild
 		sqb.appendClauseValue(&processedGroupBys, groupBy, "groupBy", sqb.qb.quoteIdentifierForClause)
 	}
 
+	if sqb.err != nil {
+		return sqb
+	}
+
 	sqb.selectBuilder = sqb.selectBuilder.GroupBy(processedGroupBys...)
 	return sqb
 }
@@ -927,6 +1025,16 @@ func (sqb *SelectQueryBuilder) appendClauseValue(processed *[]string, value any,
 	case nil:
 		panic(fmt.Sprintf("nil %s in %s", clauseName, clauseName))
 	case string:
+		// Validate the identifier (with its optional ASC/DESC [NULLS …] direction)
+		// BEFORE quoting/interpolation on ALL vendors so a crafted clause argument
+		// cannot inject a second statement or comment (M9). Use qb.Expr() for
+		// complex expressions that legitimately need raw SQL.
+		if err := validateClauseIdentifier(clauseName, v); err != nil {
+			if sqb.err == nil {
+				sqb.err = err
+			}
+			return
+		}
 		*processed = append(*processed, stringFormatter(v))
 	case dbtypes.RawExpression:
 		*processed = append(*processed, v.SQL)
@@ -1012,7 +1120,21 @@ func (sqb *SelectQueryBuilder) ToSQL() (sql string, args []any, err error) {
 
 // Set sets a column to a value in the UPDATE statement.
 // Column names are automatically quoted according to database vendor rules.
+//
+// SECURITY: The column identifier must be developer-controlled, not user input.
+// It is validated against a safe identifier grammar on ALL vendors BEFORE
+// interpolation; anything else surfaces as a ToSQL() error. The value side is
+// parameterized. See ADR-031.
 func (uqb *UpdateQueryBuilder) Set(column string, value any) dbtypes.UpdateQueryBuilder {
+	// Validate the SET target identifier BEFORE interpolation (all vendors) so the
+	// column name cannot be used as a SQL injection vector (M9). The value side is
+	// already parameterized by squirrel.
+	if err := validateIdentifier("Set column", column); err != nil {
+		if uqb.err == nil {
+			uqb.err = err
+		}
+		return uqb
+	}
 	quotedColumn := uqb.qb.quoteColumnForQuery(column)
 	uqb.updateBuilder = uqb.updateBuilder.Set(quotedColumn, value)
 	return uqb
@@ -1020,9 +1142,20 @@ func (uqb *UpdateQueryBuilder) Set(column string, value any) dbtypes.UpdateQuery
 
 // SetMap sets multiple columns to values in the UPDATE statement.
 // Column names are automatically quoted according to database vendor rules.
+//
+// SECURITY: Column identifiers (the map keys) must be developer-controlled, not
+// user input. Each is validated against a safe identifier grammar on ALL vendors
+// BEFORE interpolation; anything else surfaces as a ToSQL() error. See ADR-031.
 func (uqb *UpdateQueryBuilder) SetMap(clauses map[string]any) dbtypes.UpdateQueryBuilder {
 	quotedClauses := make(map[string]any, len(clauses))
 	for k, v := range clauses {
+		// Validate each SET target identifier BEFORE interpolation (all vendors, M9).
+		if err := validateIdentifier("SetMap column", k); err != nil {
+			if uqb.err == nil {
+				uqb.err = err
+			}
+			return uqb
+		}
 		quotedClauses[uqb.qb.quoteColumnForQuery(k)] = v
 	}
 	uqb.updateBuilder = uqb.updateBuilder.SetMap(quotedClauses)
@@ -1082,6 +1215,9 @@ func (uqb *UpdateQueryBuilder) Where(filter dbtypes.Filter) dbtypes.UpdateQueryB
 
 // ToSQL generates the final SQL query and arguments.
 func (uqb *UpdateQueryBuilder) ToSQL() (sql string, args []any, err error) {
+	if uqb.err != nil {
+		return "", nil, uqb.err
+	}
 	return uqb.updateBuilder.ToSql()
 }
 
@@ -1104,9 +1240,17 @@ func (dqb *DeleteQueryBuilder) Limit(limit uint64) dbtypes.DeleteQueryBuilder {
 // OrderBy adds ORDER BY clauses to the DELETE statement.
 // Note: ORDER BY in DELETE is not standard SQL and may not be supported by all databases.
 func (dqb *DeleteQueryBuilder) OrderBy(orderBys ...string) dbtypes.DeleteQueryBuilder {
-	quotedOrderBys := make([]string, len(orderBys))
-	for i, orderBy := range orderBys {
-		quotedOrderBys[i] = dqb.qb.quoteIdentifierForClause(orderBy)
+	quotedOrderBys := make([]string, 0, len(orderBys))
+	for _, orderBy := range orderBys {
+		// Validate the ORDER BY identifier (with optional ASC/DESC [NULLS …])
+		// BEFORE interpolation on ALL vendors so it cannot inject SQL (M9).
+		if err := validateClauseIdentifier("orderBy", orderBy); err != nil {
+			if dqb.err == nil {
+				dqb.err = err
+			}
+			return dqb
+		}
+		quotedOrderBys = append(quotedOrderBys, dqb.qb.quoteIdentifierForClause(orderBy))
 	}
 	dqb.deleteBuilder = dqb.deleteBuilder.OrderBy(quotedOrderBys...)
 	return dqb
@@ -1114,6 +1258,9 @@ func (dqb *DeleteQueryBuilder) OrderBy(orderBys ...string) dbtypes.DeleteQueryBu
 
 // ToSQL generates the final SQL query and arguments.
 func (dqb *DeleteQueryBuilder) ToSQL() (sql string, args []any, err error) {
+	if dqb.err != nil {
+		return "", nil, dqb.err
+	}
 	return dqb.deleteBuilder.ToSql()
 }
 

--- a/database/query_builder_test.go
+++ b/database/query_builder_test.go
@@ -881,3 +881,29 @@ func TestQueryBuilderComplexQueryWithSqlmock(t *testing.T) {
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+// TestPostgreSQLOrderBySQLInjection reproduces M9: the direct-string identifier
+// APIs (OrderBy, GroupBy, From, Set, ...) passed user-controlled identifiers
+// verbatim to squirrel on PostgreSQL (the default, non-Oracle branch), so a
+// crafted ORDER BY argument is interpolated directly into the SQL string.
+//
+// Concrete exploit: .OrderBy(req.Query("sort")) with a value of
+// "name; DROP TABLE users--" injects a second statement plus a line comment.
+//
+// HARDEN posture (ADR-031): identifier arguments are validated against a safe
+// pattern on ALL vendors BEFORE interpolation. The injection vector must be
+// rejected as a ToSQL() error and must NEVER appear in the generated SQL.
+func TestPostgreSQLOrderBySQLInjection(t *testing.T) {
+	qb := NewQueryBuilder(PostgreSQL)
+
+	query := qb.Select("*").From("users").OrderBy("name; DROP TABLE users--")
+
+	sql, _, err := query.ToSQL()
+
+	// The injection must be rejected at build time, not interpolated.
+	require.Error(t, err, "ORDER BY injection must be rejected as a ToSQL() error")
+	assert.NotContains(t, sql, "DROP TABLE",
+		"generated SQL must not contain the injected statement")
+	assert.NotContains(t, sql, "--",
+		"generated SQL must not contain the injected comment sequence")
+}

--- a/database/types/interfaces.go
+++ b/database/types/interfaces.go
@@ -137,9 +137,17 @@ type JoinFilterFactory interface {
 // SelectQueryBuilder defines the interface for enhanced SELECT query building with type safety.
 // This interface extends basic squirrel.SelectBuilder functionality with additional methods
 // for composable filters, JOIN operations, and vendor-specific query features.
+// SECURITY: The string-identifier arguments of From, the JOIN table methods
+// (JoinOn/LeftJoinOn/RightJoinOn/InnerJoinOn/CrossJoinOn), OrderBy, and GroupBy
+// must be developer-controlled, not user input. They are validated against a safe
+// identifier grammar on ALL vendors BEFORE interpolation; values outside that
+// grammar surface as a ToSQL() error. Route dynamic/computed expressions through
+// qb.Expr()/Raw() (which require an explicit security annotation) and pass user
+// values through the parameterized Filter API. See ADR-031.
 type SelectQueryBuilder interface {
 	// Core SELECT builder methods
-	// From accepts either string table names or *TableRef instances with optional aliases
+	// From accepts either string table names or *TableRef instances with optional aliases.
+	// String table identifiers are validated before interpolation (see ADR-031).
 	From(from ...any) SelectQueryBuilder
 
 	// Type-safe JOIN methods with JoinFilter (v2.0+)
@@ -187,6 +195,12 @@ type InsertQueryBuilder interface {
 
 // UpdateQueryBuilder defines the interface for UPDATE query building with type-safe filtering.
 // This interface wraps squirrel.UpdateBuilder with Filter API support and vendor-specific quoting.
+// SECURITY: The string-identifier arguments of Set and SetMap (the SET targets)
+// must be developer-controlled, not user input. They are validated against a safe
+// identifier grammar on ALL vendors BEFORE interpolation; values outside that
+// grammar surface as a ToSQL() error. Route dynamic/computed expressions through
+// qb.Expr()/Raw() (which require an explicit security annotation) and pass user
+// values through the value side of Set/SetMap. See ADR-031.
 type UpdateQueryBuilder interface {
 	// Data modification
 	Set(column string, value any) UpdateQueryBuilder
@@ -207,6 +221,11 @@ type UpdateQueryBuilder interface {
 
 // DeleteQueryBuilder defines the interface for DELETE query building with type-safe filtering.
 // This interface wraps squirrel.DeleteBuilder with Filter API support.
+// SECURITY: The string-identifier arguments of OrderBy must be developer-controlled,
+// not user input. They are validated against a safe identifier grammar on ALL
+// vendors BEFORE interpolation; values outside that grammar surface as a ToSQL()
+// error. Route dynamic/computed orderings through qb.Expr()/Raw() (which require an
+// explicit security annotation) and pass user values through the Filter API. See ADR-031.
 type DeleteQueryBuilder interface {
 	// Filtering
 	Where(filter Filter) DeleteQueryBuilder

--- a/wiki/adr_031_query_builder_identifier_validation.md
+++ b/wiki/adr_031_query_builder_identifier_validation.md
@@ -1,0 +1,47 @@
+# ADR-031: Validate Direct-String Identifier Arguments in the Query Builder (Close M9 SQL Injection)
+
+**Status:** Accepted
+**Date:** 2026-06-16
+
+## Context
+
+The query builder's direct-string APIs — `SelectQueryBuilder.From`, `OrderBy`, `GroupBy`, the JOIN family (`JoinOn`, `LeftJoinOn`, `RightJoinOn`, `InnerJoinOn`, `CrossJoinOn`), `UpdateQueryBuilder.Set`/`SetMap`, and `DeleteQueryBuilder.OrderBy` — interpolate their string identifier arguments (table names, aliases, columns) directly into the generated SQL. Identifier quoting was applied **only for Oracle** (`quoteColumnForQuery`/`quoteTableForQuery`/`quoteIdentifierForClause` had a vendor switch where the `default`/PostgreSQL branch returned the argument **verbatim**).
+
+This meant a user-controlled identifier passed to one of these APIs on PostgreSQL was interpolated with no validation or escaping (the M9 finding from the 2026-06-10 audit). Concrete exploit:
+
+```go
+qb.Select("*").From("users").OrderBy(req.Query("sort")) // sort = "name; DROP TABLE users--"
+// → SELECT * FROM users ORDER BY name; DROP TABLE users--
+```
+
+The generated SQL was directly executable and would drop the table. Quoting on PostgreSQL is **not** an acceptable fix on its own: PostgreSQL folds unquoted identifiers to lowercase, so blanket-quoting valid identifiers would change which physical column is referenced — a case-folding regression class (cf. ADR-007/Oracle M7). The values flowing through the *Filter* API (`f.Eq`, etc.) were never affected — those are already parameterized.
+
+## Decision
+
+Validate the string identifier arguments of `From`, the JOIN family (`JoinOn`/`LeftJoinOn`/`RightJoinOn`/`InnerJoinOn`/`CrossJoinOn`), `OrderBy`, `GroupBy`, `Set`, `SetMap`, and `DeleteQueryBuilder.OrderBy` against a safe grammar on **all vendors** *before* interpolation:
+
+- **Table context** (`From` table names, JOIN table args): a simple or qualified identifier (`col`, `table.col`, `schema.table.col`) plus one optional inline alias (`"users u"`). When a `*TableRef` is passed instead of a string, its name and alias are each validated as bare/qualified identifiers (the `Table("users").As("u")` helper).
+- **Identifier context** (`Set`/`SetMap` columns): a simple or qualified identifier, where each segment is either a bare identifier matching `[A-Za-z_][A-Za-z0-9_$#]*` (the same alphabet the `columns` package enforces for `db` tags) **or** a single double-quoted identifier with no embedded quotes (the shape the framework's own reserved-word quoting emits, e.g. Oracle `"level"`).
+- **Clause context** (`OrderBy`, `GroupBy`, `DeleteQueryBuilder.OrderBy`): the above plus an optional bounded direction grammar — `col ASC|DESC [NULLS FIRST|LAST]`.
+
+Anything outside the grammar — injection quotes, embedded whitespace, semicolons, `--` / `/* */` comment sequences, function calls, parentheses, or extra tokens — is **rejected**. Because the fluent builder methods cannot return an error, the violation is captured and surfaced from `ToSQL()` (mirroring the existing deferred-error pattern for `JoinOn` filter errors and `InsertQueryBuilder.Select`). The deferred error lives on each builder (`SelectQueryBuilder`/`UpdateQueryBuilder`/`DeleteQueryBuilder` each carry an `err` field); the first violation wins and short-circuits later mutations. The methods **never panic** on bad identifier content — a panic is reserved for genuine programming errors (an unsupported table-reference *type*).
+
+Valid identifiers on PostgreSQL remain **unquoted** (no case-folding change). Complex or computed expressions must go through `qb.Expr()`/`Raw()`, which already carry an explicit `// SECURITY:` annotation requirement.
+
+## Consequences
+
+**Breaking (intended):**
+
+- Identifier arguments that were previously accepted but are not bare/qualified identifiers (with an optional alias or direction) now produce a `ToSQL()` error. In practice this is:
+  - SQL **function expressions** passed as plain strings to `OrderBy`/`GroupBy` (e.g. `OrderBy("COUNT(*) DESC")`) — must move to `qb.Expr("COUNT(*) DESC")`.
+  - Any computed/parenthesized identifier expression — must move to `qb.Expr()`/`Raw()`.
+  - **Positional ordinals** (`GroupBy("1")`, `OrderBy("1")`) and the rarer `ORDER BY col USING <operator>` form, which are not identifiers under the grammar — must move to `qb.Expr()`/`Raw()` (or use the column name).
+- Attacker-controlled identifiers (the M9 vector) are now rejected rather than interpolated.
+
+**Non-breaking:**
+
+- Bare and qualified column/table names, inline table aliases (`"users u"`), the `Table().As()` helper (in `From` and every JOIN), framework-quoted Oracle reserved words (`cols.Col("Level")` → `"level"`), and `ORDER BY`/`GROUP BY` with a trailing `ASC`/`DESC` (and `NULLS FIRST`/`LAST`) continue to build unchanged on both vendors.
+- The Filter API (`f.Eq`, `f.In`, …) and parameterized values are unaffected.
+- PostgreSQL identifier quoting behavior is unchanged (valid identifiers stay unquoted).
+
+See [database.md](database.md#identifier-validation-adr-031) for the developer-facing grammar and [migrations.md](migrations.md) for the upgrade note.

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -373,6 +373,27 @@ use a `*bool` and reads must go through `IsEnabled()`. YAML/env config is unchan
 
 ---
 
+### [ADR-031: Validate Direct-String Identifier Arguments in the Query Builder (Close M9 SQL Injection)](adr_031_query_builder_identifier_validation.md)
+
+**Date:** 2026-06-16 | **Status:** Accepted
+
+The query builder's direct-string APIs (`From`, the JOIN family, `OrderBy`, `GroupBy`, `Set`, `SetMap`,
+`DeleteQueryBuilder.OrderBy`) interpolated their string identifier arguments directly into the SQL, with
+quoting applied **only for Oracle** — the PostgreSQL/default branch returned the argument verbatim. A
+user-controlled identifier passed to one of
+these APIs on PostgreSQL was therefore a SQL-injection vector (M9): `.OrderBy("name; DROP TABLE users--")`
+was interpolated as an executable second statement. These identifier args are now validated against a safe
+grammar (simple/qualified identifier, optional inline alias for `From`, optional `ASC/DESC [NULLS FIRST|LAST]`
+for clauses) on **all vendors** before interpolation; violations surface as a `ToSQL()` error (never a panic).
+Valid identifiers on PostgreSQL stay **unquoted** to avoid a case-folding regression.
+
+**Breaking:** Identifiers outside the grammar — notably SQL **function expressions** passed as plain strings to
+`OrderBy`/`GroupBy` — now error from `ToSQL()` and must move to `qb.Expr()`/`Raw()`.
+
+**Key Benefits:** Closes the M9 injection vector on both vendors, no PostgreSQL case-folding regression, forces computed expressions through the annotated `Expr()`/`Raw()` escape hatch
+
+---
+
 ## ADR Lifecycle
 
 - **Proposed**: Under discussion, not yet implemented
@@ -382,7 +403,7 @@ use a `*bool` and reads must go through `IsEnabled()`. YAML/env config is unchan
 
 ### Numbering Policy
 
-ADR numbers (ADR-001 through ADR-030) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
+ADR numbers (ADR-001 through ADR-031) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
 
 ## Writing New ADRs
 

--- a/wiki/database.md
+++ b/wiki/database.md
@@ -228,6 +228,24 @@ qb.MustExpr(fmt.Sprintf("UPPER(%s)", userInput))  // SQL INJECTION
 
 Use WHERE with placeholders for dynamic values: `qb.Select("*").From("users").Where(f.Eq(userColumn, userValue))`.
 
+## Identifier Validation (ADR-031)
+
+The string-identifier arguments of `From`, the JOIN family (`JoinOn`/`LeftJoinOn`/`RightJoinOn`/`InnerJoinOn`/`CrossJoinOn`), `OrderBy`, `GroupBy`, `Set`, `SetMap`, and `DeleteQueryBuilder.OrderBy` must be **developer-controlled, not user input**. As of ADR-031 these arguments are validated against a safe identifier grammar on **all vendors** (PostgreSQL and Oracle) *before* interpolation:
+
+- **Table args** (`From`, JOIN tables): a simple or qualified identifier — `col`, `table.col`, `schema.table.col` — plus an optional inline alias (`"users u"`). A `*TableRef` from `Table("users").As("u")` validates its name and alias separately.
+- **Identifier args** (`Set`, `SetMap` columns): a simple or qualified identifier plus the framework's own quoted reserved-word output (`"level"`).
+- **Clause args** (`OrderBy`, `GroupBy`, `DeleteQueryBuilder.OrderBy`): the above plus an optional bounded direction — `col ASC|DESC [NULLS FIRST|LAST]`.
+
+Anything outside the grammar — quotes used for injection, embedded whitespace, semicolons, `--` / `/* */` comment sequences, function calls, or extra tokens — is **rejected as a `ToSQL()` error** (the fluent methods cannot return errors, so the violation is deferred to `ToSQL()`; they never panic on bad identifier content). This closes the injection vector where `.OrderBy(userInput)` with a value like `"name; DROP TABLE users--"` was previously interpolated verbatim on PostgreSQL.
+
+```go
+qb.Select("*").From("users").OrderBy("name ASC")                 // SAFE
+qb.Select("*").From("users").OrderBy("COUNT(*) DESC")            // REJECTED → use qb.MustExpr("COUNT(*) DESC")
+qb.Select("*").From("users").OrderBy(req.Query("sort"))          // REJECTED if the value isn't a bare column+direction
+```
+
+Valid identifiers on PostgreSQL are left **unquoted** (PG folds unquoted identifiers to lowercase; quoting would change which physical column is referenced). Complex or computed expressions must go through `qb.Expr()`/`Raw()`, which carry an explicit `// SECURITY:` annotation. Pass user **values** through the parameterized Filter API (`f.Eq`, etc.).
+
 ## Connection Pool Defaults
 
 | Setting | Default | Purpose |

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -2,6 +2,34 @@
 
 Historical migration tables for upgrading existing GoBricks-based applications. Greenfield work can ignore this file — the new APIs are the only ones documented in CLAUDE.md.
 
+## Query Builder Validates Direct-String Identifiers (ADR-031)
+
+Per [ADR-031](adr_031_query_builder_identifier_validation.md), the string identifier arguments of `SelectQueryBuilder.From`, the JOIN family (`JoinOn`/`LeftJoinOn`/`RightJoinOn`/`InnerJoinOn`/`CrossJoinOn`), `OrderBy`, `GroupBy`, `UpdateQueryBuilder.Set`/`SetMap`, and `DeleteQueryBuilder.OrderBy` are now validated against a safe identifier grammar on **all vendors** before interpolation (previously only Oracle quoted them; PostgreSQL interpolated verbatim — the M9 SQL-injection vector). Values outside the grammar are surfaced as a `ToSQL()` error (the methods never panic on bad identifier content).
+
+**Before:**
+
+```go
+// Silently interpolated on PostgreSQL — executable injection:
+qb.Select("*").From("users").OrderBy("name; DROP TABLE users--")
+// → SELECT * FROM users ORDER BY name; DROP TABLE users--
+
+// SQL functions accepted as plain strings:
+qb.Select("*").From("orders").OrderBy("COUNT(*) DESC")
+```
+
+**After:**
+
+```go
+// Injection rejected — ToSQL() returns an error, no SQL emitted:
+_, _, err := qb.Select("*").From("users").OrderBy("name; DROP TABLE users--").ToSQL()
+// err != nil
+
+// Function expressions must go through the Expr() escape hatch:
+qb.Select("*").From("orders").OrderBy(qb.MustExpr("COUNT(*) DESC"))
+```
+
+**What still works unchanged:** bare/qualified column and table names, inline table aliases (`"users u"`), the `Table().As()` helper (in `From` and every JOIN), framework-quoted Oracle reserved words (`cols.Col("Level")`), and `ORDER BY`/`GROUP BY` with a trailing `ASC`/`DESC` (and optional `NULLS FIRST`/`LAST`) direction. Pass user **values** through the parameterized Filter API (`f.Eq`, …) — those were never affected.
+
 ## `PoolKeepAliveConfig.Enabled` Is Now `*bool` (ADR-030)
 
 Per [ADR-030](adr_030_keepalive_enabled_optional.md), `config.PoolKeepAliveConfig.Enabled` changed from `bool` to `*bool` so that an explicit `database.pool.keepalive.enabled: false` is honored even when `interval` is left at its zero default. Previously a zero `interval` flipped `Enabled` back to `true`, silently overriding the opt-out (M5).


### PR DESCRIPTION
## Summary

Closes the **M9** SQL-injection footgun (`VULNERABILITIES.md`). Fourth PR of the Medium-remediation effort (PR1 #600, PR2 #601, PR3 #603 merged). **Breaking** — see ADR-031.

## The vulnerability

The type-safe builder documents identifier args as *"automatically quoted according to database vendor rules"*, and frames `Raw()`/`Expr()` as the only SQLi-bypassing paths. But `quoteColumnForQuery` / `quoteTableForQuery` / `quoteIdentifierForClause` were **vendor-gated to Oracle** — on PostgreSQL (the primary pgx vendor) they returned the identifier **verbatim**. So the direct-string API (`From`, the JOIN methods, `OrderBy`, `GroupBy`, `Set`/`SetMap`, `Delete.OrderBy`) interpolated user-controlled identifiers raw:

```go
qb.Select("*").From("users").OrderBy(req.Query("sort")) // sort = "name; DROP TABLE users--"
```

Sort-column-from-query-param is a top real-world SQLi vector, and the "type-safe"/"auto-quoted" framing actively encouraged it.

## The fix (HARDEN — validate)

Identifier arguments are now **validated on all vendors before interpolation** against the safe db-tag grammar (`^[A-Za-z_][A-Za-z0-9_$#]*$`), plus the forms the API legitimately supports:
- qualified names (`schema.table.col`), inline table alias (`"users u"`), `Table().As()`
- framework-quoted reserved words (`cols.Col("Level")` → `"level"`)
- the **bounded** `ORDER BY`/`GROUP BY` direction grammar (`ASC|DESC [NULLS FIRST|LAST]`)

Quotes, embedded whitespace, semicolons, and comment sequences (`-- /* */`) are **rejected**. Violations surface as a **`ToSQL()` error, never a panic**. Valid PostgreSQL identifiers remain **unquoted** (no case-folding regression). Docstrings on the type-safe methods + the query-builder interfaces + `wiki/database.md` now state identifier args must be developer-controlled.

> All **five** JOIN methods route through the same `validateTableReference` path as `From()`. (The initial implementation left them open — caught by the multi-lens review; the JOIN table arg was an identical, still-exploitable vector.)

## Testing

TDD repro (`TestPostgreSQLOrderBySQLInjection`) + a dedicated `identifiers_test.go` suite: injection vectors rejected (semicolon, comment, quotes, subquery), legitimate bare/qualified/aliased identifiers + ORDER BY directions accepted, on both vendors. `make check` green — build, vet, `test -race ./...`, `golangci-lint` (0), `govulncheck` (clean).

## Breaking change (ADR-031)

Previously-accepted **non-identifier** strings now error: function expressions (`OrderBy("COUNT(*) DESC")`), positional ordinals (`GroupBy("1")`), and `ORDER BY … USING` — route these through `qb.Expr()`/`Raw()`. Full migration in `wiki/migrations.md` + [ADR-031](wiki/adr_031_query_builder_identifier_validation.md). The `!` title acknowledges the apidiff gate (covers this and the inherited #601 break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SQL injection defense with strict identifier validation across PostgreSQL and Oracle for `From`, JOIN targets, `OrderBy`/`GroupBy`, `Set`/`SetMap`, and `Delete` `OrderBy`.

* **Bug Fixes**
  * Invalid identifier-like inputs now fail during SQL generation (`ToSQL()`) instead of being interpolated.

* **Breaking Changes**
  * Non-identifier expressions (including function/computed fragments and positional ordinals) must use `Expr()`/`Raw()`.

* **Documentation / Tests**
  * Added ADR-031 and migration guidance; expanded coverage with vendor-specific and injection-focused tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->