### PR TITLE
fix: close evicted resource handles outside the manager lock; warn on under-provisioned pools

### DIFF
--- a/app/bootstrap.go
+++ b/app/bootstrap.go
@@ -44,6 +44,16 @@ func (b *appBootstrap) dependencies(startupCtx context.Context) *dependencyBundl
 	configBuilder.connectionTimeout = b.cfg.Messaging.Reconnect.ConnectionTimeout
 	configBuilder.publisherConfig = b.cfg.Messaging.Publisher
 	configBuilder.cacheConfig = b.cfg.Cache.Manager
+	// Only count statically-configured tenants when multitenancy is enabled. Koanf
+	// populates Multitenant.Tenants from YAML regardless of the enabled flag, but
+	// those entries are meaningless in single-tenant mode (mirrors the guard in
+	// config/tenant_store.go). Without this gate, leftover/shared tenants entries
+	// would trip a spurious pool-below-tenant-count WARN even though single-tenant
+	// pools are never per-tenant keyed — and would contradict StaticTenantCount's
+	// documented "0 for single-tenant" contract.
+	if b.cfg.Multitenant.Enabled {
+		configBuilder.staticTenantCount = len(b.cfg.Multitenant.Tenants)
+	}
 	factory := NewResourceManagerFactory(resolver, configBuilder, b.log)
 
 	// Log factory configuration for debugging

--- a/app/managers.go
+++ b/app/managers.go
@@ -27,6 +27,11 @@ const (
 type ManagerConfigBuilder struct {
 	multiTenantEnabled bool
 	tenantLimit        int
+	// staticTenantCount is the number of tenants statically configured under
+	// multitenant.tenants (0 for single-tenant or dynamic tenant sources). It is
+	// used only to emit a startup WARN when a resource pool's MaxSize is below the
+	// known tenant count, signaling per-request eviction thrash. Set by bootstrap.
+	staticTenantCount int
 	// connectionTimeout is the per-publish AMQP broker confirmation timeout,
 	// sourced from messaging.reconnect.connectiontimeout and set by bootstrap.
 	connectionTimeout time.Duration
@@ -138,6 +143,12 @@ func (b *ManagerConfigBuilder) TenantLimit() int {
 	return b.tenantLimit
 }
 
+// StaticTenantCount returns the number of statically-configured tenants
+// (multitenant.tenants). It is 0 for single-tenant or dynamic tenant sources.
+func (b *ManagerConfigBuilder) StaticTenantCount() int {
+	return b.staticTenantCount
+}
+
 // ResourceManagerFactory creates database and messaging managers using
 // resolved factories and configuration options.
 type ResourceManagerFactory struct {
@@ -175,7 +186,45 @@ func (f *ResourceManagerFactory) CreateDatabaseManager(
 	dbConnector := f.factoryResolver.DatabaseConnector()
 	dbOptions := f.configBuilder.BuildDatabaseOptions()
 
+	f.warnIfPoolBelowTenantCount("database", dbOptions.MaxSize)
+
 	return database.NewDbManager(resourceSource, f.logger, dbOptions, dbConnector)
+}
+
+// warnIfPoolBelowTenantCount emits a startup WARN when a per-tenant resource pool's
+// MaxSize is below the number of statically-configured tenants. With fewer cached
+// handles than tenants, the LRU manager evicts and recreates a connection on every
+// request that targets a not-currently-cached tenant — head-of-line thrash that
+// silently degrades latency. This is advisory (non-fatal) to stay non-breaking: an
+// operator may intentionally under-provision, and dynamic tenant sources have no
+// static count (staticTenantCount == 0), in which case the check is skipped.
+func (f *ResourceManagerFactory) warnIfPoolBelowTenantCount(resource string, maxSize int) {
+	tenantCount := f.configBuilder.StaticTenantCount()
+	if !poolBelowTenantCount(maxSize, tenantCount) {
+		return
+	}
+
+	f.logger.Warn().
+		Str("resource", resource).
+		Int("pool_max_size", maxSize).
+		Int("configured_tenants", tenantCount).
+		Msg("Resource pool max size is below the number of configured tenants; " +
+			"the LRU manager will evict and recreate handles on requests for uncached tenants " +
+			"(eviction thrash). Raise the pool size for this resource " +
+			"(cache.manager.maxsize, messaging.publisher.maxcached, or multitenant.limits.tenants " +
+			"for the database) to at least the tenant count.")
+}
+
+// poolBelowTenantCount reports whether a per-tenant pool of the given maxSize is
+// too small to hold every statically-configured tenant simultaneously. It returns
+// false (no warning) when there is no static tenant count (0, e.g. dynamic sources
+// or single-tenant) or when maxSize is non-positive (unbounded / default sentinel),
+// so the advisory only fires on a genuine under-provisioning.
+func poolBelowTenantCount(maxSize, tenantCount int) bool {
+	if tenantCount <= 0 || maxSize <= 0 {
+		return false
+	}
+	return maxSize < tenantCount
 }
 
 // CreateMessagingManager creates a messaging manager using the resolved factory
@@ -193,6 +242,8 @@ func (f *ResourceManagerFactory) CreateMessagingManager(
 
 	msgOptions := f.configBuilder.BuildMessagingOptions()
 	clientFactory := f.factoryResolver.MessagingClientFactory(msgOptions.ConnectionTimeout)
+
+	f.warnIfPoolBelowTenantCount("messaging", msgOptions.MaxPublishers)
 
 	return messaging.NewMessagingManager(resourceSource, f.logger, msgOptions, clientFactory)
 }
@@ -212,6 +263,8 @@ func (f *ResourceManagerFactory) CreateCacheManager(
 
 	cacheConnector := f.factoryResolver.CacheConnector(resourceSource, f.logger)
 	cacheOptions := f.configBuilder.BuildCacheOptions()
+
+	f.warnIfPoolBelowTenantCount("cache", cacheOptions.MaxSize)
 
 	manager, err := cache.NewCacheManager(cacheOptions, cacheConnector)
 	if err != nil {

--- a/app/managers_test.go
+++ b/app/managers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gaborage/go-bricks/messaging"
 	testmocks "github.com/gaborage/go-bricks/testing/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -271,6 +272,68 @@ func TestManagerConfigBuilderTenantLimit(t *testing.T) {
 
 		assert.Equal(t, -20, builder.TenantLimit())
 	})
+}
+
+func TestManagerConfigBuilderStaticTenantCount(t *testing.T) {
+	t.Run("defaults to zero", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(true, 100)
+		assert.Equal(t, 0, builder.StaticTenantCount())
+	})
+
+	t.Run("reflects assigned value", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(true, 100)
+		builder.staticTenantCount = 3
+		assert.Equal(t, 3, builder.StaticTenantCount())
+	})
+}
+
+// TestPoolBelowTenantCount guards the M3 non-breaking startup mitigation: an
+// advisory WARN fires only when a per-tenant pool's MaxSize is genuinely below the
+// number of statically-configured tenants. Dynamic sources (tenantCount == 0) and
+// unbounded pools (maxSize <= 0) must never trip the warning.
+func TestPoolBelowTenantCount(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxSize     int
+		tenantCount int
+		want        bool
+	}{
+		{name: "pool_below_tenants_warns", maxSize: 2, tenantCount: 5, want: true},
+		{name: "pool_equals_tenants_ok", maxSize: 5, tenantCount: 5, want: false},
+		{name: "pool_above_tenants_ok", maxSize: 10, tenantCount: 5, want: false},
+		{name: "no_static_tenants_skipped", maxSize: 1, tenantCount: 0, want: false},
+		{name: "negative_static_tenants_skipped", maxSize: 1, tenantCount: -3, want: false},
+		{name: "unbounded_pool_skipped", maxSize: 0, tenantCount: 5, want: false},
+		{name: "negative_pool_skipped", maxSize: -1, tenantCount: 5, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, poolBelowTenantCount(tc.maxSize, tc.tenantCount))
+		})
+	}
+}
+
+// TestResourceManagerFactoryWarnsOnUnderProvisionedPool exercises the WARN path
+// end-to-end through the factory: an under-provisioned static-tenant deployment must
+// still create a working manager (advisory, non-fatal) without panicking.
+func TestResourceManagerFactoryWarnsOnUnderProvisionedPool(t *testing.T) {
+	configBuilder := NewManagerConfigBuilder(true, 2) // tenant limit (pool MaxSize) = 2
+	configBuilder.staticTenantCount = 5               // but 5 tenants statically configured
+	factoryResolver := createTestFactoryResolver(t)
+	log := logger.New("error", false)
+	factory := NewResourceManagerFactory(factoryResolver, configBuilder, log)
+
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{Type: "postgresql", Host: "localhost", Port: 5432},
+	}
+	resourceSource := config.NewTenantStore(cfg)
+
+	var manager *database.DbManager
+	require.NotPanics(t, func() {
+		manager = factory.CreateDatabaseManager(resourceSource)
+	})
+	assert.NotNil(t, manager, "under-provisioned pool must still yield a working manager (WARN is advisory)")
 }
 
 func TestManagerConfigBuilderBuildCacheOptions(t *testing.T) {

--- a/database/manager.go
+++ b/database/manager.go
@@ -147,19 +147,21 @@ func (m *DbManager) createConnection(ctx context.Context, key string) (Interface
 
 	// Store in cache with LRU tracking
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	// Check if connection was created by another goroutine while we were waiting
 	if existing, exists := m.conns[key]; exists {
-		// Close our new connection and return the existing one
-		conn.Close()
 		existing.lastUsed = time.Now()
 		m.lru.MoveToFront(existing.element)
-		return existing.conn, nil
+		existingConn := existing.conn
+		m.mu.Unlock()
+
+		// Close our new connection outside the lock and return the existing one.
+		conn.Close()
+		return existingConn, nil
 	}
 
-	// Ensure we don't exceed max size
-	m.evictIfNeeded()
+	// Ensure we don't exceed max size (returns the evicted entry to close outside the lock)
+	evicted := m.evictIfNeeded()
 
 	// Add to cache
 	element := m.lru.PushFront(key)
@@ -170,6 +172,13 @@ func (m *DbManager) createConnection(ctx context.Context, key string) (Interface
 		key:      key,
 	}
 	m.conns[key] = entry
+	m.mu.Unlock()
+
+	// Close the evicted connection outside the lock so a slow Close() on the LRU
+	// victim does not block concurrent Get() calls for other keys.
+	if evicted != nil {
+		m.closeEvicted(evicted, "Error closing evicted database connection")
+	}
 
 	m.logger.Info().
 		Str("key", key).
@@ -179,36 +188,43 @@ func (m *DbManager) createConnection(ctx context.Context, key string) (Interface
 	return conn, nil
 }
 
-// evictIfNeeded removes the least recently used connection if at capacity
-func (m *DbManager) evictIfNeeded() {
+// evictIfNeeded removes the least recently used connection from the manager's
+// bookkeeping if at capacity. Must be called with m.mu held. It returns the
+// evicted entry (or nil) so the caller can close it OUTSIDE the lock.
+func (m *DbManager) evictIfNeeded() *dbEntry {
 	if len(m.conns) < m.maxSize {
-		return
+		return nil
 	}
 
 	// Remove the least recently used connection
 	oldest := m.lru.Back()
 	if oldest == nil {
-		return
+		return nil
 	}
 
 	key := oldest.Value.(string)
 	entry := m.conns[key]
 
-	// Close the connection
-	if err := entry.conn.Close(); err != nil {
-		m.logger.Error().
-			Err(err).
-			Str("key", key).
-			Msg("Error closing evicted database connection")
-	}
-
-	// Remove from cache
+	// Remove from cache (close happens outside the lock)
 	delete(m.conns, key)
 	m.lru.Remove(oldest)
 
 	m.logger.Debug().
 		Str("key", key).
 		Msg("Evicted database connection due to LRU limit")
+
+	return entry
+}
+
+// closeEvicted closes an evicted/idle connection and logs any close error.
+// It is always called WITHOUT m.mu held so a slow Close() cannot block other callers.
+func (m *DbManager) closeEvicted(entry *dbEntry, logMsg string) {
+	if err := entry.conn.Close(); err != nil {
+		m.logger.Error().
+			Err(err).
+			Str("key", entry.key).
+			Msg(logMsg)
+	}
 }
 
 // StartCleanup starts the background cleanup routine for idle connections
@@ -256,41 +272,33 @@ func (m *DbManager) cleanupLoop(interval time.Duration, done <-chan struct{}) {
 	}
 }
 
-// cleanupIdleConnections removes connections that have been idle longer than idleTTL
+// cleanupIdleConnections removes connections that have been idle longer than idleTTL.
+// Idle entries are detached from the manager's bookkeeping under the lock, then their
+// Close() calls run outside the lock so a slow teardown cannot block concurrent Get()s.
 func (m *DbManager) cleanupIdleConnections() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	now := time.Now()
-	var toRemove []string
+	var toClose []*dbEntry
 
-	// Find connections to remove
+	// Detach idle connections from bookkeeping under the lock.
 	for key, entry := range m.conns {
 		if now.Sub(entry.lastUsed) > m.idleTTL {
-			toRemove = append(toRemove, key)
+			delete(m.conns, key)
+			m.lru.Remove(entry.element)
+			toClose = append(toClose, entry)
+
+			m.logger.Debug().
+				Str("key", key).
+				Dur("idle_time", now.Sub(entry.lastUsed)).
+				Msg("Cleaned up idle database connection")
 		}
 	}
+	m.mu.Unlock()
 
-	// Remove idle connections
-	for _, key := range toRemove {
-		entry := m.conns[key]
-
-		// Close the connection
-		if err := entry.conn.Close(); err != nil {
-			m.logger.Error().
-				Err(err).
-				Str("key", key).
-				Msg("Error closing idle database connection")
-		}
-
-		// Remove from cache
-		delete(m.conns, key)
-		m.lru.Remove(entry.element)
-
-		m.logger.Debug().
-			Str("key", key).
-			Dur("idle_time", now.Sub(entry.lastUsed)).
-			Msg("Cleaned up idle database connection")
+	// Close detached connections outside the lock.
+	for _, entry := range toClose {
+		m.closeEvicted(entry, "Error closing idle database connection")
 	}
 }
 

--- a/database/manager.go
+++ b/database/manager.go
@@ -156,7 +156,12 @@ func (m *DbManager) createConnection(ctx context.Context, key string) (Interface
 		m.mu.Unlock()
 
 		// Close our new connection outside the lock and return the existing one.
-		conn.Close()
+		if err := conn.Close(); err != nil {
+			m.logger.Error().
+				Err(err).
+				Str("key", key).
+				Msg("Error closing redundant database connection")
+		}
 		return existingConn, nil
 	}
 

--- a/database/manager_test.go
+++ b/database/manager_test.go
@@ -59,11 +59,12 @@ func (s *stubTx) Commit(_ context.Context) error   { return nil }
 func (s *stubTx) Rollback(_ context.Context) error { return nil }
 
 type stubDB struct {
-	key      string
-	closedMu sync.Mutex
-	closed   bool
-	closeErr error
-	onClosed func(string)
+	key       string
+	closedMu  sync.Mutex
+	closed    bool
+	closeErr  error
+	onClosed  func(string)
+	closeHook func() // optional: invoked at the start of Close (e.g. to simulate a slow close)
 }
 
 func (s *stubDB) Query(_ context.Context, _ string, _ ...any) (*sql.Rows, error) { return nil, nil }
@@ -77,6 +78,12 @@ func (s *stubDB) BeginTx(_ context.Context, _ *sql.TxOptions) (Tx, error) { retu
 func (s *stubDB) Health(_ context.Context) error                          { return nil }
 func (s *stubDB) Stats() (map[string]any, error)                          { return map[string]any{"key": s.key}, nil }
 func (s *stubDB) Close() error {
+	s.closedMu.Lock()
+	hook := s.closeHook
+	s.closedMu.Unlock()
+	if hook != nil {
+		hook()
+	}
 	s.closedMu.Lock()
 	s.closed = true
 	callback := s.onClosed
@@ -146,12 +153,19 @@ func TestDbManagerEvictsLRU(t *testing.T) {
 
 	var mu sync.Mutex
 	evicted := []string{}
+	// The LRU victim "a" uses a slow Close to assert eviction detaches bookkeeping
+	// under the lock and closes OUTSIDE it: a concurrent Get must not block on it.
+	releaseClose := make(chan struct{})
 	connector := func(cfg *config.DatabaseConfig, _ logger.Logger) (Interface, error) {
-		return &stubDB{key: cfg.Database, onClosed: func(key string) {
+		db := &stubDB{key: cfg.Database, onClosed: func(key string) {
 			mu.Lock()
 			defer mu.Unlock()
 			evicted = append(evicted, key)
-		}}, nil
+		}}
+		if cfg.Database == "a" {
+			db.closeHook = func() { <-releaseClose }
+		}
+		return db, nil
 	}
 
 	resource := &stubResourceSource{configs: map[string]*config.DatabaseConfig{
@@ -166,10 +180,24 @@ func TestDbManagerEvictsLRU(t *testing.T) {
 	require.NoError(t, err)
 	_, err = manager.Get(ctx, "b")
 	require.NoError(t, err)
-	_, err = manager.Get(ctx, "c")
-	require.NoError(t, err)
 
-	assert.Equal(t, 2, manager.Size())
+	// Get("c") evicts "a"; its Close blocks until releaseClose, so run it in the
+	// background. With close-under-lock this would hold m.mu and stall every Get.
+	done := make(chan struct{})
+	go func() {
+		_, gErr := manager.Get(ctx, "c")
+		assert.NoError(t, gErr)
+		close(done)
+	}()
+
+	// Bookkeeping is detached under the lock, so Size drops to 2 even though the
+	// victim's Close is still blocked. This would deadlock under close-under-lock.
+	assert.Eventually(t, func() bool { return manager.Size() == 2 }, time.Second, 5*time.Millisecond)
+
+	// Release the slow Close and let the eviction finish.
+	close(releaseClose)
+	<-done
+
 	mu.Lock()
 	defer mu.Unlock()
 	assert.Contains(t, evicted, "a")
@@ -181,8 +209,11 @@ func TestDbManagerCleanupRemovesIdleConnections(t *testing.T) {
 
 	var mu sync.Mutex
 	evicted := []string{}
+	// Slow Close on the idle connection proves idle cleanup detaches bookkeeping
+	// under the lock and closes OUTSIDE it.
+	releaseClose := make(chan struct{})
 	connector := func(cfg *config.DatabaseConfig, _ logger.Logger) (Interface, error) {
-		return &stubDB{key: cfg.Database, onClosed: func(key string) {
+		return &stubDB{key: cfg.Database, closeHook: func() { <-releaseClose }, onClosed: func(key string) {
 			mu.Lock()
 			defer mu.Unlock()
 			evicted = append(evicted, key)
@@ -198,7 +229,22 @@ func TestDbManagerCleanupRemovesIdleConnections(t *testing.T) {
 	require.NoError(t, err)
 
 	time.Sleep(20 * time.Millisecond)
-	manager.cleanupIdleConnections()
+
+	// Run cleanup in the background: the idle connection's Close blocks until
+	// releaseClose. With close-under-lock this would stall every Size()/Get().
+	done := make(chan struct{})
+	go func() {
+		manager.cleanupIdleConnections()
+		close(done)
+	}()
+
+	// Bookkeeping is detached under the lock, so Size drops to 0 even while the
+	// idle connection's Close is still blocked.
+	assert.Eventually(t, func() bool { return manager.Size() == 0 }, time.Second, 5*time.Millisecond)
+
+	// Release the slow Close and let cleanup finish.
+	close(releaseClose)
+	<-done
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -410,6 +456,68 @@ func TestStartCleanupAppliesDefaultIntervalForNonPositive(t *testing.T) {
 
 	require.NotPanics(t, func() { m.StartCleanup(-5 * time.Second) })
 	m.StopCleanup()
+}
+
+// TestDbManagerEvictionWithSlowCloseDoesNotBlockConcurrentGet guards the M3 audit
+// finding: evictIfNeeded must NOT hold the manager mutex while closing the evicted
+// connection. A slow Close() on an evicted tenant's connection must not block a
+// concurrent Get() that targets a different, still-cached tenant (head-of-line
+// blocking). Mirrors the safe collect-then-close pattern in cache/manager.go.
+func TestDbManagerEvictionWithSlowCloseDoesNotBlockConcurrentGet(t *testing.T) {
+	ctx := context.Background()
+	log := newErrorTestLogger()
+
+	const slowClose = 200 * time.Millisecond
+	closeStarted := make(chan struct{})
+
+	connector := func(cfg *config.DatabaseConfig, _ logger.Logger) (Interface, error) {
+		db := &stubDB{key: cfg.Database}
+		if cfg.Database == "a" {
+			// Tenant "a" is the LRU victim. Its Close blocks for slowClose to simulate
+			// a stuck connection teardown. Signal once so the test can race a Get.
+			var once sync.Once
+			db.closeHook = func() {
+				once.Do(func() { close(closeStarted) })
+				time.Sleep(slowClose)
+			}
+		}
+		return db, nil
+	}
+
+	resource := &stubResourceSource{configs: map[string]*config.DatabaseConfig{
+		"a": {Type: "postgresql", Database: "a"},
+		"b": {Type: "postgresql", Database: "b"},
+		"c": {Type: "postgresql", Database: "c"},
+	}}
+
+	manager := NewDbManager(resource, log, DbManagerOptions{MaxSize: 2, IdleTTL: time.Minute}, connector)
+
+	_, err := manager.Get(ctx, "a")
+	require.NoError(t, err)
+	_, err = manager.Get(ctx, "b")
+	require.NoError(t, err)
+
+	// Creating "c" evicts the LRU victim "a", whose Close blocks for slowClose.
+	go func() {
+		_, _ = manager.Get(ctx, "c")
+	}()
+
+	// Wait until the slow Close has actually begun before measuring.
+	select {
+	case <-closeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("eviction Close never started")
+	}
+
+	// "b" is still cached: this Get only needs getExisting's lock. If eviction holds
+	// the manager mutex across Close (the M3 bug), this blocks for ~slowClose.
+	start := time.Now()
+	_, err = manager.Get(ctx, "b")
+	require.NoError(t, err)
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, slowClose/2,
+		"Get on a cached tenant must not block on another tenant's slow eviction Close (close-under-lock)")
 }
 
 func TestCleanupIdleConnectionsLogsCloseError(t *testing.T) {

--- a/messaging/manager.go
+++ b/messaging/manager.go
@@ -258,19 +258,21 @@ func (m *Manager) createPublisher(ctx context.Context, key string) (AMQPClient, 
 
 	// Store in cache with LRU tracking
 	m.pubMu.Lock()
-	defer m.pubMu.Unlock()
 
 	// Check if publisher was created by another goroutine while we were waiting
 	if existing, exists := m.publishers[key]; exists {
-		// Close our new client and return the existing one
-		m.closeClientOnRollback(client, key, "publisher_double_create_race")
 		existing.lastUsed = time.Now()
 		m.pubLru.MoveToFront(existing.element)
-		return existing.client, nil
+		existingClient := existing.client
+		m.pubMu.Unlock()
+
+		// Close our new client outside the lock and return the existing one.
+		m.closeClientOnRollback(client, key, "publisher_double_create_race")
+		return existingClient, nil
 	}
 
-	// Ensure we don't exceed max size
-	m.evictPublisherIfNeeded()
+	// Ensure we don't exceed max size (returns the evicted entry to close outside the lock)
+	evicted := m.evictPublisherIfNeeded()
 
 	// Add to cache
 	element := m.pubLru.PushFront(key)
@@ -281,6 +283,13 @@ func (m *Manager) createPublisher(ctx context.Context, key string) (AMQPClient, 
 		key:      key,
 	}
 	m.publishers[key] = entry
+	m.pubMu.Unlock()
+
+	// Close the evicted client outside the lock so a slow Close() on the LRU victim
+	// does not block concurrent Publisher() calls for other keys.
+	if evicted != nil {
+		m.closeEvictedPublisher(evicted, "Error closing evicted publisher client")
+	}
 
 	m.logger.Info().
 		Str("key", key).
@@ -323,36 +332,44 @@ func (m *Manager) closeClientOnRollback(client AMQPClient, key, phase string) {
 	}
 }
 
-// evictPublisherIfNeeded removes the least recently used publisher if at capacity
-func (m *Manager) evictPublisherIfNeeded() {
+// evictPublisherIfNeeded removes the least recently used publisher from the
+// manager's bookkeeping if at capacity. Must be called with m.pubMu held. It
+// returns the evicted entry (or nil) so the caller can close it OUTSIDE the lock.
+func (m *Manager) evictPublisherIfNeeded() *publisherEntry {
 	if len(m.publishers) < m.maxPubs {
-		return
+		return nil
 	}
 
 	// Remove the least recently used publisher
 	oldest := m.pubLru.Back()
 	if oldest == nil {
-		return
+		return nil
 	}
 
 	key := oldest.Value.(string)
 	entry := m.publishers[key]
 
-	// Close the client
-	if err := entry.client.Close(); err != nil {
-		m.logger.Error().
-			Err(err).
-			Str("key", key).
-			Msg("Error closing evicted publisher client")
-	}
-
-	// Remove from cache
+	// Remove from cache (close happens outside the lock)
 	delete(m.publishers, key)
 	m.pubLru.Remove(oldest)
 
 	m.logger.Debug().
 		Str("key", key).
 		Msg("Evicted publisher client due to LRU limit")
+
+	return entry
+}
+
+// closeEvictedPublisher closes an evicted/idle publisher client and logs any close
+// error. It is always called WITHOUT m.pubMu held so a slow Close() cannot block
+// other callers.
+func (m *Manager) closeEvictedPublisher(entry *publisherEntry, logMsg string) {
+	if err := entry.client.Close(); err != nil {
+		m.logger.Error().
+			Err(err).
+			Str("key", entry.key).
+			Msg(logMsg)
+	}
 }
 
 // StartCleanup starts the background cleanup routine for idle publishers
@@ -400,41 +417,34 @@ func (m *Manager) cleanupLoop(interval time.Duration, done <-chan struct{}) {
 	}
 }
 
-// cleanupIdlePublishers removes publishers that have been idle longer than idleTTL
+// cleanupIdlePublishers removes publishers that have been idle longer than idleTTL.
+// Idle entries are detached from the manager's bookkeeping under the lock, then their
+// Close() calls run outside the lock so a slow teardown cannot block concurrent
+// Publisher() calls.
 func (m *Manager) cleanupIdlePublishers() {
 	m.pubMu.Lock()
-	defer m.pubMu.Unlock()
 
 	now := time.Now()
-	var toRemove []string
+	var toClose []*publisherEntry
 
-	// Find publishers to remove
+	// Detach idle publishers from bookkeeping under the lock.
 	for key, entry := range m.publishers {
 		if now.Sub(entry.lastUsed) > m.idleTTL {
-			toRemove = append(toRemove, key)
+			delete(m.publishers, key)
+			m.pubLru.Remove(entry.element)
+			toClose = append(toClose, entry)
+
+			m.logger.Debug().
+				Str("key", key).
+				Dur("idle_time", now.Sub(entry.lastUsed)).
+				Msg("Cleaned up idle publisher client")
 		}
 	}
+	m.pubMu.Unlock()
 
-	// Remove idle publishers
-	for _, key := range toRemove {
-		entry := m.publishers[key]
-
-		// Close the client
-		if err := entry.client.Close(); err != nil {
-			m.logger.Error().
-				Err(err).
-				Str("key", key).
-				Msg("Error closing idle publisher client")
-		}
-
-		// Remove from cache
-		delete(m.publishers, key)
-		m.pubLru.Remove(entry.element)
-
-		m.logger.Debug().
-			Str("key", key).
-			Dur("idle_time", now.Sub(entry.lastUsed)).
-			Msg("Cleaned up idle publisher client")
+	// Close detached publishers outside the lock.
+	for _, entry := range toClose {
+		m.closeEvictedPublisher(entry, "Error closing idle publisher client")
 	}
 }
 

--- a/messaging/manager_test.go
+++ b/messaging/manager_test.go
@@ -32,6 +32,7 @@ type stubAMQPClient struct {
 	consumers     int
 	consumeCtx    context.Context //nolint:containedctx // test-only: captures the ctx the supervisor subscribes with, to assert its lifecycle
 	closeCallback func()
+	closeHook     func() // optional: invoked at the start of Close (e.g. to simulate a slow close)
 	closeErr      error
 }
 
@@ -85,6 +86,13 @@ func (s *stubAMQPClient) DeclareExchange(string, string, bool, bool, bool, bool)
 func (s *stubAMQPClient) BindQueue(string, string, string, bool) error                 { return nil }
 
 func (s *stubAMQPClient) Close() error {
+	s.closedMu.Lock()
+	hook := s.closeHook
+	s.closedMu.Unlock()
+	if hook != nil {
+		hook()
+	}
+
 	s.closedMu.Lock()
 	defer s.closedMu.Unlock()
 	if s.closed {
@@ -201,9 +209,20 @@ func TestMessagingManagerCleanupEvictsIdlePublishers(t *testing.T) {
 	ctx := context.Background()
 	log := logger.New("error", false)
 
-	var closed int
+	var mu sync.Mutex
+	closed := 0
+	// Slow Close on the idle publisher proves idle cleanup detaches bookkeeping
+	// under the lock and closes OUTSIDE it.
+	releaseClose := make(chan struct{})
 	factory := func(string, logger.Logger) AMQPClient {
-		return &stubAMQPClient{closeCallback: func() { closed++ }}
+		return &stubAMQPClient{
+			closeHook: func() { <-releaseClose },
+			closeCallback: func() {
+				mu.Lock()
+				defer mu.Unlock()
+				closed++
+			},
+		}
 	}
 
 	manager := NewMessagingManager(&stubMessagingSource{urls: map[string]string{"idle": amqpURLIdle}}, log, ManagerOptions{MaxPublishers: 5, IdleTTL: 10 * time.Millisecond}, factory)
@@ -211,7 +230,29 @@ func TestMessagingManagerCleanupEvictsIdlePublishers(t *testing.T) {
 	require.NoError(t, err)
 
 	time.Sleep(20 * time.Millisecond)
-	manager.cleanupIdlePublishers()
+
+	// Run cleanup in the background: the idle publisher's Close blocks until
+	// releaseClose. With close-under-lock this would stall every Publisher()/Stats().
+	done := make(chan struct{})
+	go func() {
+		manager.cleanupIdlePublishers()
+		close(done)
+	}()
+
+	// Bookkeeping is detached under the lock, so the publisher count drops to 0 even
+	// while its Close is still blocked.
+	assert.Eventually(t, func() bool {
+		manager.pubMu.RLock()
+		defer manager.pubMu.RUnlock()
+		return len(manager.publishers) == 0
+	}, time.Second, 5*time.Millisecond)
+
+	// Release the slow Close and let cleanup finish.
+	close(releaseClose)
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
 	assert.Equal(t, 1, closed)
 }
 
@@ -221,12 +262,19 @@ func TestMessagingManagerEvictsLRU(t *testing.T) {
 
 	var mu sync.Mutex
 	evicted := []string{}
+	// The LRU victim "a" (amqpURLA) uses a slow Close to assert eviction detaches
+	// bookkeeping under the lock and closes OUTSIDE it.
+	releaseClose := make(chan struct{})
 	factory := func(url string, _ logger.Logger) AMQPClient {
-		return &stubAMQPClient{closeCallback: func() {
+		client := &stubAMQPClient{closeCallback: func() {
 			mu.Lock()
 			defer mu.Unlock()
 			evicted = append(evicted, url)
 		}}
+		if url == amqpURLA {
+			client.closeHook = func() { <-releaseClose }
+		}
+		return client
 	}
 
 	source := &stubMessagingSource{urls: map[string]string{
@@ -240,12 +288,161 @@ func TestMessagingManagerEvictsLRU(t *testing.T) {
 	require.NoError(t, err)
 	_, err = manager.Publisher(ctx, "b")
 	require.NoError(t, err)
-	_, err = manager.Publisher(ctx, "c")
-	require.NoError(t, err)
+
+	// Publisher("c") evicts "a"; its Close blocks until releaseClose, so run it in the
+	// background. With close-under-lock this would hold m.pubMu and stall every Publisher.
+	done := make(chan struct{})
+	go func() {
+		_, gErr := manager.Publisher(ctx, "c")
+		assert.NoError(t, gErr)
+		close(done)
+	}()
+
+	// Bookkeeping is detached under the lock, so the publisher count stays at 2 even
+	// though the victim's Close is still blocked.
+	assert.Eventually(t, func() bool {
+		manager.pubMu.RLock()
+		defer manager.pubMu.RUnlock()
+		_, aStillCached := manager.publishers["a"]
+		return len(manager.publishers) == 2 && !aStillCached
+	}, time.Second, 5*time.Millisecond)
+
+	// Release the slow Close and let the eviction finish.
+	close(releaseClose)
+	<-done
 
 	mu.Lock()
 	defer mu.Unlock()
 	assert.Contains(t, evicted, amqpURLA)
+}
+
+// TestMessagingManagerEvictionWithSlowCloseDoesNotBlockConcurrentPublisher guards the
+// M3 audit finding: evictPublisherIfNeeded must NOT hold the publisher mutex while
+// closing the evicted client. A slow Close() on an evicted tenant's publisher must not
+// block a concurrent Publisher() that targets a different, still-cached tenant
+// (head-of-line blocking). Mirrors the collect-then-close pattern in cache/manager.go.
+func TestMessagingManagerEvictionWithSlowCloseDoesNotBlockConcurrentPublisher(t *testing.T) {
+	ctx := context.Background()
+	log := logger.New("error", false)
+
+	const slowClose = 200 * time.Millisecond
+	closeStarted := make(chan struct{})
+
+	factory := func(url string, _ logger.Logger) AMQPClient {
+		client := &stubAMQPClient{}
+		if url == amqpURLA {
+			// Tenant "a" is the LRU victim. Its Close blocks for slowClose to simulate
+			// a stuck connection teardown. Signal once so the test can race a Publisher.
+			var once sync.Once
+			client.closeHook = func() {
+				once.Do(func() { close(closeStarted) })
+				time.Sleep(slowClose)
+			}
+		}
+		return client
+	}
+
+	source := &stubMessagingSource{urls: map[string]string{
+		"a": amqpURLA,
+		"b": amqpURLB,
+		"c": amqpURLC,
+	}}
+
+	manager := NewMessagingManager(source, log, ManagerOptions{MaxPublishers: 2, IdleTTL: time.Minute}, factory)
+
+	_, err := manager.Publisher(ctx, "a")
+	require.NoError(t, err)
+	_, err = manager.Publisher(ctx, "b")
+	require.NoError(t, err)
+
+	// Creating "c" evicts the LRU victim "a", whose Close blocks for slowClose.
+	go func() {
+		_, _ = manager.Publisher(ctx, "c")
+	}()
+
+	// Wait until the slow Close has actually begun before measuring.
+	select {
+	case <-closeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("eviction Close never started")
+	}
+
+	// "b" is still cached: this Publisher only needs getExistingPublisher's lock. If
+	// eviction holds the publisher mutex across Close (the M3 bug), this blocks ~slowClose.
+	start := time.Now()
+	_, err = manager.Publisher(ctx, "b")
+	require.NoError(t, err)
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, slowClose/2,
+		"Publisher on a cached tenant must not block on another tenant's slow eviction Close (close-under-lock)")
+}
+
+// TestMessagingManagerCreatePublisherReturnsExistingOnDoubleCreate guards the
+// concurrent double-create branch in createPublisher: when another goroutine
+// populated the cache while this caller was building its client, createPublisher
+// must return the already-cached publisher and close the freshly-created client
+// outside the lock. Mirrors database's
+// TestCreateConnectionReturnsExistingInstanceWhenAlreadyCached.
+func TestMessagingManagerCreatePublisherReturnsExistingOnDoubleCreate(t *testing.T) {
+	ctx := context.Background()
+	log := logger.New("error", false)
+
+	// The freshly-created client that createPublisher builds; it must be closed
+	// once the cache is found already populated.
+	fresh := &stubAMQPClient{}
+	factory := func(string, logger.Logger) AMQPClient { return fresh }
+	manager := NewMessagingManager(&stubMessagingSource{urls: map[string]string{tenantID: amqpHost}}, log, ManagerOptions{MaxPublishers: 5, IdleTTL: time.Minute}, factory)
+
+	// Pre-seed the cache to simulate another goroutine winning the race.
+	existing := newTenantAwarePublisher(&stubAMQPClient{}, tenantID)
+	manager.pubMu.Lock()
+	element := manager.pubLru.PushFront(tenantID)
+	manager.publishers[tenantID] = &publisherEntry{client: existing, element: element, lastUsed: time.Now(), key: tenantID}
+	manager.pubMu.Unlock()
+
+	got, err := manager.createPublisher(ctx, tenantID)
+	require.NoError(t, err)
+	assert.Same(t, existing, got, "createPublisher must return the already-cached publisher")
+
+	fresh.closedMu.Lock()
+	closed := fresh.closed
+	fresh.closedMu.Unlock()
+	assert.True(t, closed, "the redundant freshly-created client must be closed on the double-create branch")
+}
+
+// TestMessagingManagerCleanupIdlePublishersLogsCloseError drives the close-error
+// branch of closeEvictedPublisher through the idle-cleanup path: the idle entry
+// is detached from bookkeeping and Close() is still attempted even when it returns
+// an error. Mirrors database's TestCleanupIdleConnectionsLogsCloseError.
+func TestMessagingManagerCleanupIdlePublishersLogsCloseError(t *testing.T) {
+	ctx := context.Background()
+	log := logger.New("error", false)
+
+	failing := &stubAMQPClient{closeErr: errors.New("broker fault on close")}
+	factory := func(string, logger.Logger) AMQPClient { return failing }
+	manager := NewMessagingManager(&stubMessagingSource{urls: map[string]string{"idle": amqpURLIdle}}, log, ManagerOptions{MaxPublishers: 5, IdleTTL: time.Hour}, factory)
+	defer func() { _ = manager.Close() }()
+
+	_, err := manager.Publisher(ctx, "idle")
+	require.NoError(t, err)
+
+	// Backdate lastUsed so the cleanup pass sees the entry as idle.
+	manager.pubMu.Lock()
+	manager.publishers["idle"].lastUsed = time.Now().Add(-2 * time.Hour)
+	manager.pubMu.Unlock()
+
+	manager.cleanupIdlePublishers()
+
+	manager.pubMu.RLock()
+	n := len(manager.publishers)
+	manager.pubMu.RUnlock()
+	assert.Equal(t, 0, n, "idle publisher removed from cache despite Close() error")
+
+	failing.closedMu.Lock()
+	closed := failing.closed
+	failing.closedMu.Unlock()
+	assert.True(t, closed, "Close was attempted even though it returned an error")
 }
 
 func TestMessagingManagerEnsureConsumersIdempotent(t *testing.T) {

--- a/wiki/cache.md
+++ b/wiki/cache.md
@@ -127,6 +127,14 @@ cache:
     cleanupinterval: 10m # Less frequent cleanup
 ```
 
+### Sizing `maxsize` for multi-tenant deployments
+
+`maxsize` is an LRU cap, not a per-tenant guarantee. When more tenants are active than `maxsize`, every request that targets a not-currently-cached tenant evicts the least-recently-used instance and recreates a fresh one — **eviction thrash** that silently degrades latency (each miss pays the full connect cost) without any error.
+
+Size the pool to hold every concurrently-active tenant: set `cache.manager.maxsize` (and `multitenant.limits.tenants`) to at least the number of tenants you expect to serve simultaneously. For **statically-configured** tenants (`multitenant.tenants`), the framework counts them at startup and emits a **WARN** when the pool's `maxsize` is below the configured tenant count, so under-provisioning is visible in logs. For **dynamic** tenant sources the count is unknown at startup, so no warning can be emitted — size `maxsize` against your expected fleet manually.
+
+> Eviction closes the evicted instance **outside** the manager lock, so a slow `Close()` on an evicted tenant never blocks concurrent `Get()` calls for other tenants. It does, however, still incur a recreate on the next request for the evicted tenant.
+
 ---
 
 For comprehensive code-snippet examples (cache operations, multi-tenant patterns, testing), see [llms.txt](../llms.txt).

--- a/wiki/database.md
+++ b/wiki/database.md
@@ -279,6 +279,14 @@ database:
       interval: 30s
 ```
 
+### Per-tenant connection manager sizing (multi-tenant)
+
+The `pool.*` settings above govern the connection pool **within a single database**. In multi-tenant mode there is a second, outer cap: the `DbManager` keeps at most one connection per tenant key in an LRU cache whose size is `multitenant.limits.tenants`. This is an LRU cap, not a per-tenant guarantee — when more tenants are active than the limit, every request for a not-currently-cached tenant evicts the least-recently-used connection and opens a fresh one. That **eviction thrash** silently degrades latency (each miss pays the full connect cost) without surfacing an error.
+
+Size `multitenant.limits.tenants` to at least the number of tenants you expect to serve concurrently. For **statically-configured** tenants (`multitenant.tenants`) the framework counts them at startup and emits a **WARN** when the manager's max size is below the configured tenant count. For **dynamic** tenant sources the count is unknown at startup, so no warning can be emitted — size the limit against your expected fleet manually.
+
+> Eviction (and idle cleanup) closes the evicted connection **outside** the manager lock, so a slow `Close()` on an evicted tenant never blocks concurrent `Get()` calls for other tenants.
+
 ## Repository Method Attribution
 
 The `db.client.operation.duration` metric carries `db.operation.name` (the SQL verb:

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -202,7 +202,7 @@ messaging:
 
 ### Sizing the publisher pool for multi-tenant deployments
 
-`publisher.maxcached` (and, in multi-tenant mode, `multitenant.limits.tenants`) is an LRU cap on cached publisher clients, not a per-tenant guarantee. When more tenants publish than the cap allows, every publish for a not-currently-cached tenant evicts the least-recently-used publisher and creates a fresh one — **eviction thrash** that silently degrades latency (each miss reopens a broker connection) without an error.
+`publisher.maxcached` is the LRU cap on cached publisher clients (in multi-tenant mode, it falls back to `multitenant.limits.tenants` when unset), not a per-tenant guarantee. When more tenants publish than the cap allows, every publish for a not-currently-cached tenant evicts the least-recently-used publisher and creates a fresh one — **eviction thrash** that silently degrades latency (each miss reopens a broker connection) without an error.
 
 Size the cap to hold every concurrently-publishing tenant. For **statically-configured** tenants (`multitenant.tenants`) the framework counts them at startup and emits a **WARN** when the publisher pool's max size is below the configured tenant count. For **dynamic** tenant sources the count is unknown at startup, so no warning can be emitted — size the cap against your expected fleet manually.
 

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -199,3 +199,11 @@ messaging:
     maxcached: 100       # More cached publishers for high-throughput
     idlettl: 30m         # Keep publishers longer
 ```
+
+### Sizing the publisher pool for multi-tenant deployments
+
+`publisher.maxcached` (and, in multi-tenant mode, `multitenant.limits.tenants`) is an LRU cap on cached publisher clients, not a per-tenant guarantee. When more tenants publish than the cap allows, every publish for a not-currently-cached tenant evicts the least-recently-used publisher and creates a fresh one — **eviction thrash** that silently degrades latency (each miss reopens a broker connection) without an error.
+
+Size the cap to hold every concurrently-publishing tenant. For **statically-configured** tenants (`multitenant.tenants`) the framework counts them at startup and emits a **WARN** when the publisher pool's max size is below the configured tenant count. For **dynamic** tenant sources the count is unknown at startup, so no warning can be emitted — size the cap against your expected fleet manually.
+
+> Eviction (and idle cleanup) closes the evicted publisher **outside** the manager lock, so a slow `Close()` on an evicted tenant never blocks concurrent `Publisher()` calls for other tenants.


### PR DESCRIPTION
## Summary

Fixes **M3** (`VULNERABILITIES.md`) — the final finding of the Medium-remediation effort (PR1 #600, PR2 #601, PR3 #603, PR4 #604 merged). **Non-breaking** (internal concurrency fix + advisory WARN).

> Carries the `breaking-approved` label only because the apidiff gate diffs against `v0.42.0` and inherits #601's merged-but-unreleased `*bool` break. This PR itself changes no exported API.

## The bug

`DbManager` and `messaging.Manager` closed evicted/idle tenant handles **while holding the manager mutex**:
- A slow `Close()` on one tenant's handle blocked `Get()`/`Publisher()` for **every** other tenant (cross-tenant head-of-line blocking).
- The close-under-lock directly contradicted the safe pattern `cache/manager.go` already uses ("Close evicted cache outside the lock").

## The fix (scoped, non-breaking)

**(A) Close outside the lock** — `evictIfNeeded`/`evictPublisherIfNeeded` now detach the entry from the map+LRU under the lock and **return** it; `createConnection`/`createPublisher` `Unlock()` and then close via `closeEvicted`/`closeEvictedPublisher`. Idle cleanup collects into a `toClose` slice and closes after unlocking. The double-create-race path also closes the redundant handle outside the lock. Mirrors `cache/manager.go` exactly. Purely internal — no public signature change.

**(B) Under-provisioning WARN** — a non-fatal WARN at startup when a per-tenant pool's `MaxSize` is below the statically-configured tenant count (so operators see eviction-thrash risk). Counted only when multitenant is enabled; dynamic sources and unbounded pools are skipped. Failure mode + dynamic-MT caveat documented in `wiki/{cache,database,messaging}.md`.

## Out of scope (recommended follow-up)

A full **lease/refcount** wrapper for `Get()`/`Publisher()` would eliminate the in-use-eviction race entirely (an evicted handle can still be `Close()`d while a holder uses it), but that changes the public return types across all three managers — a separate breaking redesign warranting its own ADR. Filed as a follow-up recommendation, not attempted here.

## Testing

TDD slow-close tests (`...EvictionWithSlowCloseDoesNotBlockConcurrentGet`/`...Publisher`) assert a concurrent cross-tenant call is **not** blocked by an in-progress eviction Close; the 4 prior masking tests were updated to a channel-gated slow Close and verified (via git-stash) to fail against the old code. `closeEvictedPublisher` 100% / `createPublisher` 95.2% covered. `make check` green — build, vet, `test -race ./...`, golangci-lint 0, govulncheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added startup WARNs when multi-tenant static tenant provisioning exceeds the configured LRU pool sizes (database connections, message publishers, and cache), without failing startup.

* **Bug Fixes**
  * Single-tenant deployments are no longer impacted by default/multi-tenant tenant entries.
  * Improved concurrency by ensuring eviction/cleanup closing happens outside internal locks, reducing head-of-line blocking.

* **Documentation**
  * Updated cache, database, and messaging guides with clearer multi-tenant sizing, LRU cap behavior, eviction “thrash” expectations, and WARN explanations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->