### PR TITLE
feat(server): emit RouteDescriptor for raw RouteRegistrar.Add routes

### DIFF
--- a/server/descriptor.go
+++ b/server/descriptor.go
@@ -8,23 +8,35 @@ import (
 	"github.com/gaborage/go-bricks/jose"
 )
 
-// RouteDescriptor captures metadata about a registered route
+// RouteDescriptor captures metadata about a registered route.
+//
+// Routes registered through the raw RouteRegistrar.Add path (as opposed to the typed
+// server.GET/POST helpers) carry only method/path/handler metadata: RequestType, ResponseType,
+// InboundJOSE, and OutboundJOSE are nil, and ModuleName is empty, because a raw handler exposes
+// no request/response models. Consumers iterating the registry must nil-check those fields.
 type RouteDescriptor struct {
 	Method       string       // HTTP method (GET, POST, etc.)
 	Path         string       // Route path pattern (/users/:id)
 	HandlerID    string       // Unique identifier for handler function
 	HandlerName  string       // Function name (e.g., "getUser")
-	ModuleName   string       // Module that registered this route
+	ModuleName   string       // Module that registered this route (empty for raw routes)
 	Package      string       // Go package path
-	RequestType  reflect.Type // Request type T from HandlerFunc[T, R]
-	ResponseType reflect.Type // Response type R from HandlerFunc[T, R]
+	RequestType  reflect.Type // Request type T from HandlerFunc[T, R]; nil for raw routes
+	ResponseType reflect.Type // Response type R from HandlerFunc[T, R]; nil for raw routes
 	Middleware   []string     // Applied middleware names
 	Tags         []string     // Optional grouping tags
 	Summary      string       // Optional summary from comments
 	Description  string       // Optional description from comments
 	RawResponse  bool         // If true, bypass APIResponse envelope (for Strangler Fig migration)
-	InboundJOSE  *jose.Policy // Resolved at registration time from request type's jose: tag
-	OutboundJOSE *jose.Policy // Resolved at registration time from response type's jose: tag
+	InboundJOSE  *jose.Policy // Resolved at registration time from request type's jose: tag; nil for raw routes
+	OutboundJOSE *jose.Policy // Resolved at registration time from response type's jose: tag; nil for raw routes
+}
+
+// formatHandlerID builds the canonical HandlerID for a route ("METHOD:/full/path"). Both the
+// typed registration path (RegisterHandler) and the raw path (RouteRegistrar.Add) use it so the
+// identifiers stay identical across paths — consumers keying inventories by HandlerID depend on it.
+func formatHandlerID(method, fullPath string) string {
+	return method + ":" + fullPath
 }
 
 // RouteRegistry maintains discovered routes for introspection

--- a/server/handler.go
+++ b/server/handler.go
@@ -1281,10 +1281,10 @@ func RegisterHandler[T any, R any](
 	descriptor := RouteDescriptor{
 		Method:       method,
 		Path:         fullPath,
-		HandlerID:    fmt.Sprintf("%s:%s", method, fullPath),
+		HandlerID:    formatHandlerID(method, fullPath),
 		RequestType:  reflect.TypeOf(reqType),
 		ResponseType: reflect.TypeOf(respType),
-		Package:      getCallerPackage(),
+		Package:      getCallerPackage(3), // getCallerPackage → RegisterHandler → GET/POST/etc → module
 		HandlerName:  extractHandlerName(handler),
 	}
 
@@ -1497,9 +1497,12 @@ func WithLogger(log logger.Logger) HandlerRegistryOption {
 	}
 }
 
-// getCallerPackage extracts the package path of the calling function
-func getCallerPackage() string {
-	pc, _, _, ok := runtime.Caller(3) // Skip this func + RegisterHandler + GET/POST/etc
+// getCallerPackage extracts the package path of the calling function. skip is the number of
+// stack frames above getCallerPackage to inspect: the typed registration path passes 3
+// (getCallerPackage → RegisterHandler → GET/POST/etc → module), the raw RouteRegistrar.Add
+// path passes 2 (getCallerPackage → Add → module).
+func getCallerPackage(skip int) string {
+	pc, _, _, ok := runtime.Caller(skip)
 	if !ok {
 		return ""
 	}

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -819,7 +819,9 @@ func (packageCaller) callPackage() string {
 }
 
 func packageCallerNested() string {
-	return getCallerPackage()
+	// skip 3: getCallerPackage → packageCallerNested → callPackage → TestGetCallerPackage,
+	// mirroring the typed path's getCallerPackage → RegisterHandler → GET/POST → module depth.
+	return getCallerPackage(3)
 }
 
 func TestExtractHandlerName(t *testing.T) {

--- a/server/route_registrar.go
+++ b/server/route_registrar.go
@@ -31,8 +31,25 @@ func (rg *routeGroup) addEcho(method, path string, h echo.HandlerFunc) {
 // Add registers an echo-free Handler with optional flat middleware. The go-bricks→echo
 // adapters are built once here at registration time; the route handle (echo.RouteInfo)
 // is intentionally discarded.
+//
+// It also records a RouteDescriptor in DefaultRouteRegistry so raw routes are discoverable
+// alongside typed ones (issue #634). The framework's routeGroup implements the addEcho seam, so
+// typed handlers register through addEcho (which emits its own descriptor and never traverses
+// Add) — framework-registered routes are never double-counted. Only the fields derivable at this
+// seam are populated (method, full path, handler ID/name, caller package); type- and JOSE-related
+// fields stay zero-valued because raw handlers carry no request/response models.
 func (rg *routeGroup) Add(method, path string, handler Handler, middleware ...MiddlewareFunc) {
-	rg.group.Add(method, rg.relativePath(path), adaptHandler(handler, rg.cfg), rg.adaptAll(middleware)...)
+	relative := rg.relativePath(path)
+	rg.group.Add(method, relative, adaptHandler(handler, rg.cfg), rg.adaptAll(middleware)...)
+
+	fullPath := rg.fullPathFromRelative(relative)
+	DefaultRouteRegistry.Register(&RouteDescriptor{
+		Method:      method,
+		Path:        fullPath,
+		HandlerID:   formatHandlerID(method, fullPath),
+		HandlerName: extractHandlerName(handler),
+		Package:     getCallerPackage(2), // getCallerPackage → Add → module (best-effort, as typed routes)
+	})
 }
 
 func (rg *routeGroup) Group(prefix string, middleware ...MiddlewareFunc) RouteRegistrar {
@@ -63,7 +80,12 @@ func (rg *routeGroup) adaptAll(mw []MiddlewareFunc) []echo.MiddlewareFunc {
 }
 
 func (rg *routeGroup) FullPath(path string) string {
-	relative := rg.relativePath(path)
+	return rg.fullPathFromRelative(rg.relativePath(path))
+}
+
+// fullPathFromRelative joins the group prefix with an already-resolved relative path. Add uses it
+// to avoid recomputing relativePath (which FullPath would otherwise do a second time per route).
+func (rg *routeGroup) fullPathFromRelative(relative string) string {
 	if relative == "" {
 		if rg.prefix == "" {
 			return "/"

--- a/server/route_registrar_test.go
+++ b/server/route_registrar_test.go
@@ -167,6 +167,64 @@ func TestTypedHandlerThroughRouteGroupSeam(t *testing.T) {
 	assert.NotEmpty(t, resp.Meta["timestamp"])
 }
 
+// TestRouteGroupAddEmitsRouteDescriptor verifies that a raw route registered through
+// RouteRegistrar.Add is recorded in DefaultRouteRegistry (issue #634), mirroring the typed
+// GET/POST path so startup inventories keyed by route template see the full surface. Fields
+// that only make sense for typed routes stay zero-valued.
+func TestRouteGroupAddEmitsRouteDescriptor(t *testing.T) {
+	DefaultRouteRegistry.Clear()
+	defer DefaultRouteRegistry.Clear()
+
+	e := echo.New()
+	base := newRouteGroup(e.Group("/api"), "/api", nil)
+
+	base.Add(http.MethodGet, "/raw-widgets", func(c HandlerContext) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	routes := DefaultRouteRegistry.ByPath("/api/raw-widgets")
+	require.Len(t, routes, 1, "raw Add must emit exactly one descriptor")
+
+	d := routes[0]
+	assert.Equal(t, http.MethodGet, d.Method)
+	assert.Equal(t, "/api/raw-widgets", d.Path)
+	assert.Equal(t, "GET:/api/raw-widgets", d.HandlerID)
+	assert.NotEmpty(t, d.HandlerName, "HandlerName falls back to the reflected function name")
+	// getCallerPackage(2) walks getCallerPackage → Add → this test function. Because the test is
+	// itself in package server, the attributed package is the server package. This pins the value
+	// but cannot, by construction, catch an under-shot skip that lands on Add's own frame (also
+	// package server) — validating that requires a caller in a different package.
+	assert.Equal(t, "github.com/gaborage/go-bricks/server", d.Package,
+		"Package is derived from the registering caller's frame, same mechanism as typed routes")
+
+	// Typed-only metadata stays zero-valued for raw routes.
+	assert.Nil(t, d.RequestType)
+	assert.Nil(t, d.ResponseType)
+	assert.Nil(t, d.InboundJOSE)
+	assert.Nil(t, d.OutboundJOSE)
+	assert.False(t, d.RawResponse)
+	assert.Empty(t, d.ModuleName)
+}
+
+// TestRouteGroupAddDescriptorUsesFullPath verifies the emitted descriptor records the fully
+// resolved path (group prefix + route), matching what typed routes store via FullPath.
+func TestRouteGroupAddDescriptorUsesFullPath(t *testing.T) {
+	DefaultRouteRegistry.Clear()
+	defer DefaultRouteRegistry.Clear()
+
+	e := echo.New()
+	base := newRouteGroup(e.Group("/api"), "/api", nil)
+	child := base.Group("/v1")
+
+	child.Add(http.MethodPost, "/widgets", func(c HandlerContext) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	routes := DefaultRouteRegistry.ByPath("/api/v1/widgets")
+	require.Len(t, routes, 1)
+	assert.Equal(t, "POST:/api/v1/widgets", routes[0].HandlerID)
+}
+
 // TestRouteGroupGroupAppliesFlatMiddleware verifies Group(prefix, ...MiddlewareFunc) wires
 // flat middleware onto the nested registrar and a raw Handler registered via Add runs.
 func TestRouteGroupGroupAppliesFlatMiddleware(t *testing.T) {


### PR DESCRIPTION
## Problem

`server.DefaultRouteRegistry` recorded a `RouteDescriptor` for every **typed** route (registered through `server.GET/POST/...`), but routes registered through the raw `RouteRegistrar.Add(method, path, Handler)` path never produced a descriptor. Consumers building startup inventories keyed by route template (metrics pre-registration, authz matrices, route documentation) silently missed every raw route.

Root cause: `DefaultRouteRegistry.Register()` was called from exactly one seam — the generic `RegisterHandler[T,R]` behind the typed helpers. The raw path (`routeGroup.Add`) registered with Echo but never touched the registry.

## Fix

`routeGroup.Add` now records a `RouteDescriptor` alongside the Echo registration. Only the fields derivable at the raw seam are populated (method, full path, handler ID/name, caller package); `RequestType`/`ResponseType`/`InboundJOSE`/`OutboundJOSE` stay `nil` and `ModuleName` stays empty, because a raw handler carries no request/response models (tight scope, per the issue).

Key design points:

- **No double-registration.** The framework's `routeGroup` implements the unexported `addEcho` seam, so typed handlers register through `addEcho` (which emits its own descriptor) and never traverse `Add`. Framework-registered routes are counted exactly once.
- **Single source of truth for `HandlerID`.** Extracted `formatHandlerID(method, fullPath)`, used by both paths, so the `"METHOD:/path"` identifier can't drift — consumers keying inventories by `HandlerID` depend on it.
- **Shared caller attribution.** `getCallerPackage()` → `getCallerPackage(skip int)` so both paths attribute the registering caller's package at their respective stack depths (typed = 3, raw = 2), best-effort, matching existing typed behavior.
- **Nil-field documentation.** `RouteDescriptor` now documents which fields are `nil`/empty for raw routes, so registry consumers nil-check.

## Review handling

`/code-review` (xhigh) + `/security-audit` were run on the diff. Security gates clean (gosec 0 issues, no raw-SQL, no secrets). Of 9 code-review findings:

- **Applied (4):** de-duplicated the `relativePath` recomputation in `Add`; removed a dead `*routeGroup` cast in the new test; documented the nil-for-raw descriptor fields; strengthened the skip-depth assertion.
- **Pushed back (5), with reasoning:** the `getCallerPackage` skip fragility and unbounded-global-accumulation are pre-existing and identical to the typed path; debug endpoints appearing in the registry is the intended feature (raw routes *should* appear); double-registration via a non-`addEcho` wrapper cannot be reached by the framework's own registrar; middleware isn't auto-recorded for typed routes either. No runtime code reads `DefaultRouteRegistry`, so the consumer-gated findings are defensive-only.

The skip-depth test is pinned as far as an in-package test allows; fully validating `skip=2` would require a `package server_test` black-box file, deliberately not added to preserve the repo's 1:1 source-to-test file convention (the limitation is documented in the test).

## Test plan

- New `TestRouteGroupAddEmitsRouteDescriptor` / `TestRouteGroupAddDescriptorUsesFullPath` (RED → GREEN).
- `make check` green: fmt, lint (incl. gosec), race tests across all packages, the ADR-026 alloc-stability guard, and govulncheck.

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Raw route registrations now appear in the route registry with readable method/path details, making routes easier to discover.
  * Handler identifiers are now generated in a consistent `METHOD:/path` format.

* **Bug Fixes**
  * Improved path handling so nested routes are recorded using their full resolved path.
  * Clarified behavior for raw routes so metadata is handled more reliably when some fields are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->