### PR TITLE
feat(server): add WithRouteTemplate test option for HandlerContext

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -106,18 +106,47 @@ func newHandlerContext(c *echo.Context, cfg *config.Config) HandlerContext {
 	return HandlerContext{Config: cfg, ectx: c}
 }
 
+// TestContextOption customizes a HandlerContext built by NewHandlerContextForTest. It
+// seeds pre-routing state the engine would otherwise populate during matching, so unit
+// tests can exercise code that reads that state without standing up a router. Test-support
+// only: options are applied at test construction, never on a live request context.
+type TestContextOption func(*HandlerContext)
+
+// WithRouteTemplate stamps the matched route template so RouteTemplate() reports it on an
+// otherwise-unrouted test context (which never routes and would report ""). On a live
+// request the router owns this value; the option is reachable only through the test
+// constructor, so it cannot mutate a routed context's identity. See issue #639.
+func WithRouteTemplate(template string) TestContextOption {
+	return func(c *HandlerContext) { c.ectx.SetPath(template) }
+}
+
 // NewHandlerContextForTest builds a HandlerContext backed by a real Echo context for use
 // in external-package tests (e.g. app/, scheduler/) that exercise Handler / MiddlewareFunc
 // code but cannot name the unexported escape hatch. It keeps the echo dependency confined
-// to package server. Test-support only — not for production wiring.
+// to package server. Test-support only — not for production wiring. To seed routing state
+// the synthetic context would otherwise leave empty, use NewHandlerContextForTestWithOptions.
 func NewHandlerContextForTest(w http.ResponseWriter, r *http.Request, cfg *config.Config) HandlerContext {
+	return NewHandlerContextForTestWithOptions(w, r, cfg)
+}
+
+// NewHandlerContextForTestWithOptions is NewHandlerContextForTest plus TestContextOption
+// values (e.g. WithRouteTemplate) that seed pre-routing state the engine would otherwise
+// populate during matching. It exists as a separate constructor rather than a variadic on
+// NewHandlerContextForTest so the already-released signature stays API-compatible (adding a
+// variadic changes a function's type identity — apidiff classifies it as incompatible).
+// Test-support only — not for production wiring.
+func NewHandlerContextForTestWithOptions(w http.ResponseWriter, r *http.Request, cfg *config.Config, opts ...TestContextOption) HandlerContext {
 	e := echo.New()
 	// Register the framework validator so contexts built here drive the typed pipeline
 	// (which calls c.Validate) exactly as a live request would.
 	if v := NewValidator(); v != nil {
 		e.Validator = v
 	}
-	return newHandlerContext(e.NewContext(r, w), cfg)
+	c := newHandlerContext(e.NewContext(r, w), cfg)
+	for _, opt := range opts {
+		opt(&c)
+	}
+	return c
 }
 
 // Request returns the underlying *http.Request.

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -2144,6 +2144,34 @@ func TestHandlerContextRouteTemplate(t *testing.T) {
 	})
 }
 
+// TestNewHandlerContextForTestWithOptionsWithRouteTemplate verifies the WithRouteTemplate
+// test option seeds RouteTemplate() on an otherwise-unrouted synthetic context (the gap
+// from issue #639), that it reads back through the real public getter, and that it composes
+// with SetPathParams on one context. It exercises only exported symbols — the exact surface
+// an external consumer reaches. (The zero-option / unrouted-empty case is covered by
+// TestHandlerContextRouteTemplate's empty_on_unrouted_context subtest.)
+func TestNewHandlerContextForTestWithOptionsWithRouteTemplate(t *testing.T) {
+	cfg := &config.Config{App: config.AppConfig{Env: "development"}}
+
+	t.Run("option_seeds_route_template", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orders/42", http.NoBody)
+		c := NewHandlerContextForTestWithOptions(httptest.NewRecorder(), req, cfg, WithRouteTemplate("/api/orders/:id"))
+		// Observable through the existing getter — no new read path, no ectx access.
+		assert.Equal(t, "/api/orders/:id", c.RouteTemplate())
+		// The template is the registered pattern, NOT the concrete URL.
+		assert.Equal(t, "/api/orders/42", c.Request().URL.Path)
+	})
+
+	t.Run("composes_with_set_path_params", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orders/42", http.NoBody)
+		c := NewHandlerContextForTestWithOptions(httptest.NewRecorder(), req, cfg, WithRouteTemplate("/api/orders/:id"))
+		c.SetPathParams([]PathParam{{Name: "id", Value: "42"}})
+		// Both seams settable independently on a single test context (issue #639 AC).
+		assert.Equal(t, "/api/orders/:id", c.RouteTemplate())
+		assert.Equal(t, "42", c.Param("id"))
+	})
+}
+
 // TestHandlerContextPathParams verifies PathParams returns the matched parameters in
 // route-template declaration order, covers catch-all routes, and returns a defensive
 // copy decoupled from the pooled engine state.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -228,6 +228,55 @@ assert.Error(t, err)
 
 See [outbox/testing](../outbox/testing/) package for full API documentation.
 
+## Server / HandlerContext Testing
+
+Unit-test a `Handler` or `MiddlewareFunc` without standing up a router by building a
+`HandlerContext` directly. Use `server.NewHandlerContextForTest` when no routing state is
+needed, or `server.NewHandlerContextForTestWithOptions` to seed it. The synthetic context is
+never routed, so routing-derived state is empty by default — seed only what the code under
+test reads:
+
+| State | How to seed | Read back via |
+|---|---|---|
+| Route template (`RouteTemplate()`) | `server.WithRouteTemplate("/api/orders/:id")` construction option | `ctx.RouteTemplate()` |
+| Path params (`Param`, `param:"…"` binding) | `ctx.SetPathParams([]server.PathParam{…})` | `ctx.Param("id")` / `PathParams()` |
+| Query params | already read from the request URL | `ctx.Query("limit")` |
+| Request headers | already read from the request | `ctx.RequestHeader("X-…")` |
+
+The two routing seams are deliberately different shapes: `RouteTemplate` is set once by the
+router and has no runtime mutation path, so it is seeded by a **test-only construction
+option** (it cannot corrupt a live routed context); path params have a legitimate runtime
+setter (`SetPathParams`), reused as-is in tests.
+
+Seed the context, then **drive the middleware/handler under test** and assert on its
+observable effect — don't just assert on the seeded context:
+
+```go
+// Production middleware under test: record the matched route template.
+func RouteTemplateRecorder(sink *string) server.MiddlewareFunc {
+    return func(c server.HandlerContext, next func() error) error {
+        *sink = c.RouteTemplate()
+        return next()
+    }
+}
+
+func TestRouteTemplateRecorder(t *testing.T) {
+    req := httptest.NewRequest(http.MethodGet, "/api/orders/42", http.NoBody)
+    c := server.NewHandlerContextForTestWithOptions(httptest.NewRecorder(), req, cfg,
+        server.WithRouteTemplate("/api/orders/:id"),
+    )
+
+    var recorded string
+    err := RouteTemplateRecorder(&recorded)(c, func() error { return nil }) // exercise the middleware
+
+    require.NoError(t, err)
+    assert.Equal(t, "/api/orders/:id", recorded) // asserts the middleware's behavior, not the seed
+}
+```
+
+For end-to-end fidelity (real router populating template *and* params), register the route on
+a `server.Server` and drive it with `httptest` / `ServeHTTP` instead.
+
 ## Integration Testing with Testcontainers
 
 **Prerequisites:** Docker Desktop or Docker Engine running


### PR DESCRIPTION
## Summary

`HandlerContext.RouteTemplate()` (restored in v0.46.0, ADR-035 / #635) was **readable but not seedable in unit tests**. The only public test constructor, `server.NewHandlerContextForTest`, builds a context that was never routed, so `RouteTemplate()` always returned `""` and there was no public way to set it. This is the sibling gap to `PathParams()`, which is already seedable via `SetPathParams`. Consumers who unit-test handlers/middleware that branch on the matched route template (template-keyed lookups, template-derived paths, observability labels) couldn't pin that behavior without standing up a real router.

Closes #639.

## What changed

- **`server.WithRouteTemplate(template)` + `server.TestContextOption`** — a test-only construction option that stamps the matched route template, applied by a new **`server.NewHandlerContextForTestWithOptions`** constructor. The template reads back through the existing public `RouteTemplate()` getter and composes with `SetPathParams` on one context.
- **`NewHandlerContextForTest` is unchanged** — byte-identical signature; it now delegates. Adding a variadic to the already-released v0.46.0 signature would be an apidiff-**incompatible** change (a function's type identity changes), so a separate constructor keeps the API additive and avoids a spurious `feat!` / breaking release for a test-only helper.
- **`wiki/testing.md`** — documents the blessed `HandlerContext` unit-testing pattern (the discoverability ask in the issue), including driving the middleware-under-test rather than only asserting on the seeded context.

## Design notes

- **Why an option, not a `SetRouteTemplate` method.** The route template is set once by the router and has no runtime mutation path. A public method would be callable on a live routed context and could corrupt downstream observability or template-keyed authorization. The construction-option shape makes that unrepresentable — the seam is reachable only at test construction, never mid-request.
- **No `WithPathParams`.** The framework's functional-option precedent is one option per state that has no other setter. Path params already have the `SetPathParams` method; #639's acceptance criteria ask the template to *compose with* it, not replace it.

## Testing

- New `TestNewHandlerContextForTestWithOptionsWithRouteTemplate` — seeds the template, composes with `SetPathParams`; exercises only exported symbols (the exact external-consumer surface).
- `make check` green: fmt, lint (gosec 0 issues), race tests, test-alloc guards, govulncheck.
- apidiff vs `v0.46.0`: **no incompatible changes**; `NewHandlerContextForTestWithOptions`, `TestContextOption`, `WithRouteTemplate` reported as compatible additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible testing helpers for constructing handler contexts with optional routing state.
  * Added support for seeding route templates in synthetic handler tests.
* **Documentation**
  * Expanded testing guidance with examples for unit-testing handlers and middleware without a router.
  * Clarified how to set up route templates, path params, query params, and headers in tests.
* **Tests**
  * Added coverage for route-template seeding and parameter handling in the new testing helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->