### PR TITLE
feat(server): add GlobalMiddlewareRegisterer for module-contributed global middleware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,12 @@ type MessagingDeclarer interface {
     DeclareMessaging(decls *messaging.Declarations)
 }
 
+// Optional: contribute global middleware (e.g. auth) that runs once per request,
+// after tenant resolution, before handlers, and cannot be skipped per-route (ADR-036).
+type GlobalMiddlewareRegisterer interface {
+    GlobalMiddleware() []server.MiddlewareFunc
+}
+
 // Simplified — see app/module.go for the full struct (~12 fields including
 // Scheduler, Outbox, Tracer, MeterProvider, DBByName, etc.)
 type ModuleDeps struct {

--- a/app/interfaces.go
+++ b/app/interfaces.go
@@ -47,3 +47,9 @@ type TenantStore interface {
 type declarationSetter interface {
 	SetDeclarations(*messaging.Declarations)
 }
+
+// globalMiddlewareRegistrar is the optional server capability for registering global
+// middleware. Asserted at wiring time so the exported ServerRunner need not grow a method.
+type globalMiddlewareRegistrar interface {
+	RegisterGlobalMiddleware(mw ...server.MiddlewareFunc)
+}

--- a/app/interfaces.go
+++ b/app/interfaces.go
@@ -47,9 +47,3 @@ type TenantStore interface {
 type declarationSetter interface {
 	SetDeclarations(*messaging.Declarations)
 }
-
-// globalMiddlewareRegistrar is the optional server capability for registering global
-// middleware. Asserted at wiring time so the exported ServerRunner need not grow a method.
-type globalMiddlewareRegistrar interface {
-	RegisterGlobalMiddleware(mw ...server.MiddlewareFunc)
-}

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -79,7 +79,9 @@ func (a *App) applyGlobalMiddleware() error {
 	if len(mws) == 0 {
 		return nil
 	}
-	reg, ok := a.server.(globalMiddlewareRegistrar)
+	reg, ok := a.server.(interface {
+		RegisterGlobalMiddleware(mw ...server.MiddlewareFunc)
+	})
 	if !ok {
 		return fmt.Errorf("%d module(s) registered global middleware but the configured server does not support it", len(mws))
 	}

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -60,9 +60,31 @@ func (a *App) prepareRuntime() error {
 		return err
 	}
 
+	if err := a.applyGlobalMiddleware(); err != nil {
+		return err
+	}
+
 	a.registry.RegisterRoutes(a.server.ModuleGroup())
 	a.startMaintenanceLoops()
 
+	return nil
+}
+
+// applyGlobalMiddleware registers module-contributed global middleware on the server. It
+// fails closed: if any module registered middleware but the server cannot install it, the
+// gate (canonically auth) would be silently absent, so startup aborts rather than serving
+// unguarded traffic.
+func (a *App) applyGlobalMiddleware() error {
+	mws := a.registry.CollectGlobalMiddleware()
+	if len(mws) == 0 {
+		return nil
+	}
+	reg, ok := a.server.(globalMiddlewareRegistrar)
+	if !ok {
+		return fmt.Errorf("%d module(s) registered global middleware but the configured server does not support it", len(mws))
+	}
+	reg.RegisterGlobalMiddleware(mws...)
+	a.logger.Info().Int("count", len(mws)).Msg("Registered global middleware")
 	return nil
 }
 

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gaborage/go-bricks/config"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/server"
 )
 
 const (
@@ -179,13 +180,13 @@ func TestPrepareRuntimeWithScheduler(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create minimal app with mocked server
-	server := newMockServer()
+	mockSrv := newMockServer()
 
 	app := &App{
 		cfg:      cfg,
 		logger:   testLogger,
 		registry: registry,
-		server:   server,
+		server:   mockSrv,
 		closers:  []namedCloser{},
 	}
 
@@ -296,4 +297,58 @@ func TestPrepareRuntimeSucceedsWithDeclarationsAndConfiguredMessaging(t *testing
 	require.NoError(t, app.RegisterModule(publisherDeclaringModule{}))
 
 	require.NoError(t, app.prepareRuntime())
+}
+
+// globalMWCapturingServer implements ServerRunner (via embedded mockServer) plus the
+// optional RegisterGlobalMiddleware capability, capturing what it receives.
+type globalMWCapturingServer struct {
+	*mockServer
+	received []server.MiddlewareFunc
+}
+
+func (s *globalMWCapturingServer) RegisterGlobalMiddleware(mw ...server.MiddlewareFunc) {
+	s.received = append(s.received, mw...)
+}
+
+// TestApplyGlobalMiddlewareRegistersOnSupportingServer verifies collected middleware is
+// handed to a server that supports registration.
+func TestApplyGlobalMiddlewareRegistersOnSupportingServer(t *testing.T) {
+	log := logger.New("debug", true)
+	registry := NewModuleRegistry(&ModuleDeps{Logger: log, Config: &config.Config{}})
+	require.NoError(t, registry.Register(&globalMWModule{name: "auth", mws: []server.MiddlewareFunc{
+		func(_ server.HandlerContext, next func() error) error { return next() },
+	}}))
+
+	srv := &globalMWCapturingServer{mockServer: &mockServer{}}
+	app := &App{server: srv, registry: registry, logger: log}
+
+	require.NoError(t, app.applyGlobalMiddleware())
+	assert.Len(t, srv.received, 1, "supporting server must receive the collected middleware")
+}
+
+// TestApplyGlobalMiddlewareFailsClosedOnUnsupportingServer verifies startup aborts (rather
+// than silently dropping a security gate) when the server cannot install global middleware.
+func TestApplyGlobalMiddlewareFailsClosedOnUnsupportingServer(t *testing.T) {
+	log := logger.New("debug", true)
+	registry := NewModuleRegistry(&ModuleDeps{Logger: log, Config: &config.Config{}})
+	require.NoError(t, registry.Register(&globalMWModule{name: "auth", mws: []server.MiddlewareFunc{
+		func(_ server.HandlerContext, next func() error) error { return next() },
+	}}))
+
+	app := &App{server: &mockServer{}, registry: registry, logger: log}
+
+	err := app.applyGlobalMiddleware()
+	require.Error(t, err, "startup must fail closed when the server cannot install global middleware")
+	assert.Contains(t, err.Error(), "global middleware")
+}
+
+// TestApplyGlobalMiddlewareNoopWhenNoModulesContribute verifies an unsupporting server is
+// fine as long as no module actually contributes middleware.
+func TestApplyGlobalMiddlewareNoopWhenNoModulesContribute(t *testing.T) {
+	log := logger.New("debug", true)
+	registry := NewModuleRegistry(&ModuleDeps{Logger: log, Config: &config.Config{}})
+	require.NoError(t, registry.Register(&minimalModule{name: "minimal"}))
+
+	app := &App{server: &mockServer{}, registry: registry, logger: log}
+	require.NoError(t, app.applyGlobalMiddleware(), "no contributing modules → no error even on an unsupporting server")
 }

--- a/app/module.go
+++ b/app/module.go
@@ -41,6 +41,13 @@ type MessagingDeclarer interface {
 	DeclareMessaging(decls *messaging.Declarations)
 }
 
+// GlobalMiddlewareRegisterer is an optional interface that modules can implement to
+// contribute middleware to the root request chain. It runs once per request after tenant
+// resolution, before handlers, and cannot be skipped per-route.
+type GlobalMiddlewareRegisterer interface {
+	GlobalMiddleware() []server.MiddlewareFunc
+}
+
 // JobRegistrar defines the interface for scheduling jobs.
 // This interface is defined here to avoid circular imports between app and scheduler packages.
 // The scheduler package implements this interface via its Module type.

--- a/app/module_registry.go
+++ b/app/module_registry.go
@@ -149,6 +149,22 @@ func (r *ModuleRegistry) RegisterRoutes(registrar server.RouteRegistrar) {
 	}
 }
 
+// CollectGlobalMiddleware gathers middleware from modules that implement
+// GlobalMiddlewareRegisterer, in registration order. Modules without global middleware are
+// silently skipped.
+func (r *ModuleRegistry) CollectGlobalMiddleware() []server.MiddlewareFunc {
+	var mws []server.MiddlewareFunc
+	for _, module := range r.modules {
+		if gm, ok := module.(GlobalMiddlewareRegisterer); ok {
+			r.logger.Info().
+				Str("module", module.Name()).
+				Msg("Collecting module global middleware")
+			mws = append(mws, gm.GlobalMiddleware()...)
+		}
+	}
+	return mws
+}
+
 // DeclareMessaging calls DeclareMessaging on modules that implement MessagingDeclarer.
 // Modules without messaging declarations are silently skipped.
 func (r *ModuleRegistry) DeclareMessaging(decls *messaging.Declarations) error {

--- a/app/module_test.go
+++ b/app/module_test.go
@@ -623,6 +623,72 @@ func (m *routeModule) RegisterRoutes(_ *server.HandlerRegistry, _ server.RouteRe
 	m.routeCalls++
 }
 
+// globalMWModule implements Module + GlobalMiddlewareRegisterer.
+type globalMWModule struct {
+	name  string
+	mws   []server.MiddlewareFunc
+	calls int
+}
+
+func (m *globalMWModule) Name() string             { return m.name }
+func (m *globalMWModule) Init(_ *ModuleDeps) error { return nil }
+func (m *globalMWModule) Shutdown() error          { return nil }
+func (m *globalMWModule) GlobalMiddleware() []server.MiddlewareFunc {
+	m.calls++
+	return m.mws
+}
+
+// TestCollectGlobalMiddlewareGathersFromImplementers verifies middleware is collected from
+// modules implementing GlobalMiddlewareRegisterer, calling the method exactly once.
+func TestCollectGlobalMiddlewareGathersFromImplementers(t *testing.T) {
+	log := logger.New("debug", true)
+	registry := NewModuleRegistry(&ModuleDeps{Logger: log, Config: &config.Config{}})
+
+	require.NoError(t, registry.Register(&minimalModule{name: "minimal"}))
+	gm := &globalMWModule{name: "auth", mws: []server.MiddlewareFunc{
+		func(_ server.HandlerContext, next func() error) error { return next() },
+	}}
+	require.NoError(t, registry.Register(gm))
+
+	collected := registry.CollectGlobalMiddleware()
+	assert.Len(t, collected, 1, "one middleware collected from the sole implementer")
+	assert.Equal(t, 1, gm.calls, "GlobalMiddleware must be called exactly once")
+}
+
+// TestCollectGlobalMiddlewareSkipsModulesWithoutInterface verifies modules that do not
+// implement GlobalMiddlewareRegisterer are silently skipped.
+func TestCollectGlobalMiddlewareSkipsModulesWithoutInterface(t *testing.T) {
+	log := logger.New("debug", true)
+	registry := NewModuleRegistry(&ModuleDeps{Logger: log, Config: &config.Config{}})
+	require.NoError(t, registry.Register(&minimalModule{name: "minimal"}))
+
+	assert.Empty(t, registry.CollectGlobalMiddleware(), "no implementers → no middleware")
+}
+
+// TestCollectGlobalMiddlewarePreservesRegistrationOrder verifies middleware composes in
+// module-registration order.
+func TestCollectGlobalMiddlewarePreservesRegistrationOrder(t *testing.T) {
+	log := logger.New("debug", true)
+	registry := NewModuleRegistry(&ModuleDeps{Logger: log, Config: &config.Config{}})
+
+	var order []string
+	mark := func(name string) server.MiddlewareFunc {
+		return func(_ server.HandlerContext, next func() error) error {
+			order = append(order, name)
+			return next()
+		}
+	}
+	require.NoError(t, registry.Register(&globalMWModule{name: "first", mws: []server.MiddlewareFunc{mark("first")}}))
+	require.NoError(t, registry.Register(&globalMWModule{name: "second", mws: []server.MiddlewareFunc{mark("second")}}))
+
+	collected := registry.CollectGlobalMiddleware()
+	require.Len(t, collected, 2)
+	for _, mw := range collected {
+		require.NoError(t, mw(server.HandlerContext{}, func() error { return nil }))
+	}
+	assert.Equal(t, []string{"first", "second"}, order, "middleware collected in module-registration order")
+}
+
 // TestRegisterRoutesSkipsModulesWithoutRouteRegisterer verifies that modules
 // without RegisterRoutes are silently skipped during route registration.
 func TestRegisterRoutesSkipsModulesWithoutRouteRegisterer(t *testing.T) {

--- a/server/global_middleware.go
+++ b/server/global_middleware.go
@@ -1,0 +1,33 @@
+package server
+
+import "github.com/labstack/echo/v5"
+
+// RegisterGlobalMiddleware appends application middleware to the root engine chain. Each
+// runs once per request after every built-in middleware (tenant resolution, rate limiting,
+// recovery, ...) and before the route handler, and skips the health/ready probes. It must
+// be called during startup, before Start().
+func (s *Server) RegisterGlobalMiddleware(mw ...MiddlewareFunc) {
+	healthPath := s.buildFullPath(s.healthRoute)
+	readyPath := s.buildFullPath(s.readyRoute)
+	adapted := make([]echo.MiddlewareFunc, 0, len(mw))
+	for _, m := range mw {
+		if m == nil {
+			continue
+		}
+		adapted = append(adapted, adaptMiddleware(skipProbes(m, healthPath, readyPath), s.cfg))
+	}
+	if len(adapted) == 0 {
+		return
+	}
+	s.echo.Use(adapted...)
+}
+
+func skipProbes(mw MiddlewareFunc, healthPath, readyPath string) MiddlewareFunc {
+	skipper := CreateProbeSkipper(healthPath, readyPath)
+	return func(c HandlerContext, next func() error) error {
+		if skipper(c.Request()) {
+			return next()
+		}
+		return mw(c, next)
+	}
+}

--- a/server/global_middleware.go
+++ b/server/global_middleware.go
@@ -7,14 +7,13 @@ import "github.com/labstack/echo/v5"
 // recovery, ...) and before the route handler, and skips the health/ready probes. It must
 // be called during startup, before Start().
 func (s *Server) RegisterGlobalMiddleware(mw ...MiddlewareFunc) {
-	healthPath := s.buildFullPath(s.healthRoute)
-	readyPath := s.buildFullPath(s.readyRoute)
+	skipper := CreateProbeSkipper(s.buildFullPath(s.healthRoute), s.buildFullPath(s.readyRoute))
 	adapted := make([]echo.MiddlewareFunc, 0, len(mw))
 	for _, m := range mw {
 		if m == nil {
 			continue
 		}
-		adapted = append(adapted, adaptMiddleware(skipProbes(m, healthPath, readyPath), s.cfg))
+		adapted = append(adapted, adaptMiddleware(skipProbes(m, skipper), s.cfg))
 	}
 	if len(adapted) == 0 {
 		return
@@ -22,8 +21,7 @@ func (s *Server) RegisterGlobalMiddleware(mw ...MiddlewareFunc) {
 	s.echo.Use(adapted...)
 }
 
-func skipProbes(mw MiddlewareFunc, healthPath, readyPath string) MiddlewareFunc {
-	skipper := CreateProbeSkipper(healthPath, readyPath)
+func skipProbes(mw MiddlewareFunc, skipper SkipperFunc) MiddlewareFunc {
 	return func(c HandlerContext, next func() error) error {
 		if skipper(c.Request()) {
 			return next()

--- a/server/global_middleware_test.go
+++ b/server/global_middleware_test.go
@@ -1,0 +1,206 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaborage/go-bricks/config"
+	"github.com/gaborage/go-bricks/multitenant"
+)
+
+func okEchoHandler(c *echo.Context) error { return c.String(http.StatusOK, "ok") }
+
+func blockUnlessAuthorized(c HandlerContext, next func() error) error {
+	if c.Request().Header.Get("Authorization") == "" {
+		return NewUnauthorizedError("missing token")
+	}
+	return next()
+}
+
+// TestSkipProbesBypassesProbePathsOnly verifies the skipProbes wrapper runs the wrapped
+// middleware for normal paths and bypasses it for the health/ready probes.
+func TestSkipProbesBypassesProbePathsOnly(t *testing.T) {
+	cfg := &config.Config{App: config.AppConfig{Env: "development"}}
+	var mwCalls int
+	wrapped := skipProbes(func(_ HandlerContext, next func() error) error {
+		mwCalls++
+		return next()
+	}, "/health", "/ready")
+
+	cases := []struct {
+		path   string
+		wantMW bool
+	}{
+		{"/health", false},
+		{"/ready", false},
+		{"/api/x", true},
+	}
+	for _, tc := range cases {
+		mwCalls = 0
+		nextCalls := 0
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.path, http.NoBody)
+		ctx := NewHandlerContextForTest(httptest.NewRecorder(), req, cfg)
+		require.NoError(t, wrapped(ctx, func() error { nextCalls++; return nil }))
+		assert.Equal(t, 1, nextCalls, "next must always run for %s", tc.path)
+		if tc.wantMW {
+			assert.Equal(t, 1, mwCalls, "wrapped middleware must run for %s", tc.path)
+		} else {
+			assert.Equal(t, 0, mwCalls, "wrapped middleware must be skipped for %s", tc.path)
+		}
+	}
+}
+
+// TestRegisterGlobalMiddlewareRunsOnRequest verifies a registered global middleware runs
+// on a normal request and chains to the handler.
+func TestRegisterGlobalMiddlewareRunsOnRequest(t *testing.T) {
+	srv := newTestServer("", "", "")
+	srv.echo.GET("/api/thing", okEchoHandler)
+	srv.RegisterGlobalMiddleware(func(c HandlerContext, next func() error) error {
+		c.ResponseWriter().Header().Set("X-Global", "ran")
+		return next()
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/thing", http.NoBody)
+	srv.echo.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ran", rec.Header().Get("X-Global"))
+	assert.Equal(t, "ok", rec.Body.String())
+}
+
+// TestRegisterGlobalMiddlewareSkipsProbes verifies health/ready bypass the gate while a
+// normal route is gated.
+func TestRegisterGlobalMiddlewareSkipsProbes(t *testing.T) {
+	srv := newTestServer("", "", "")
+	srv.echo.GET("/api/thing", okEchoHandler)
+	srv.RegisterGlobalMiddleware(blockUnlessAuthorized)
+
+	assertHTTPGetResponse(t, srv, "/health", http.StatusOK)
+	assertHTTPGetResponse(t, srv, "/ready", http.StatusOK)
+	assertHTTPGetResponse(t, srv, "/api/thing", http.StatusUnauthorized)
+}
+
+// TestRegisterGlobalMiddlewareShortCircuits401 verifies a gate that returns an IAPIError
+// without calling next aborts the request with the standard envelope.
+func TestRegisterGlobalMiddlewareShortCircuits401(t *testing.T) {
+	srv := newTestServer("", "", "")
+	handlerRan := false
+	srv.echo.GET("/api/secure", func(c *echo.Context) error {
+		handlerRan = true
+		return c.String(http.StatusOK, "secret")
+	})
+	srv.RegisterGlobalMiddleware(blockUnlessAuthorized)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/secure", http.NoBody)
+	srv.echo.ServeHTTP(rec, req)
+
+	assert.False(t, handlerRan, "handler must not run when the gate aborts")
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, "UNAUTHORIZED", resp.Error.Code)
+}
+
+// TestRegisterGlobalMiddlewareRunsAfterTenantResolution verifies the gate runs after the
+// built-in tenant middleware, so it observes the resolved tenant.
+func TestRegisterGlobalMiddlewareRunsAfterTenantResolution(t *testing.T) {
+	cfg := newTestConfig("", "", "")
+	cfg.Multitenant.Enabled = true
+	cfg.Multitenant.Resolver.Type = config.ResolverTypeHeader
+	srv := New(cfg, &testLogger{})
+
+	var seen string
+	srv.echo.GET("/api/whoami", okEchoHandler)
+	srv.RegisterGlobalMiddleware(func(c HandlerContext, next func() error) error {
+		seen, _ = multitenant.GetTenant(c.RequestContext())
+		return next()
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/whoami", http.NoBody)
+	req.Header.Set(HeaderXTenantID, "acme")
+	srv.echo.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "acme", seen, "global middleware must observe the tenant resolved earlier in the chain")
+}
+
+// TestRegisterGlobalMiddlewareRunsOncePerRequest guards against double-wrapping.
+func TestRegisterGlobalMiddlewareRunsOncePerRequest(t *testing.T) {
+	srv := newTestServer("", "", "")
+	var calls int32
+	srv.echo.GET("/api/thing", okEchoHandler)
+	srv.RegisterGlobalMiddleware(func(_ HandlerContext, next func() error) error {
+		atomic.AddInt32(&calls, 1)
+		return next()
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/thing", http.NoBody)
+	srv.echo.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+// TestRegisterGlobalMiddlewareAppliesToLaterRoutes proves the root-chain registration is
+// order-independent: a route added AFTER the gate is still gated.
+func TestRegisterGlobalMiddlewareAppliesToLaterRoutes(t *testing.T) {
+	srv := newTestServer("", "", "")
+	srv.RegisterGlobalMiddleware(blockUnlessAuthorized)
+	srv.echo.GET("/api/late", okEchoHandler)
+
+	assertHTTPGetResponse(t, srv, "/api/late", http.StatusUnauthorized)
+}
+
+// TestRegisterGlobalMiddlewareGatesSystemRoutes verifies system/debug routes are gated
+// (they are not part of the health/ready probe exemption).
+func TestRegisterGlobalMiddlewareGatesSystemRoutes(t *testing.T) {
+	srv := newTestServer("", "", "")
+	srv.echo.GET("/_sys/job", okEchoHandler)
+	srv.echo.GET("/debug/info", okEchoHandler)
+	srv.RegisterGlobalMiddleware(blockUnlessAuthorized)
+
+	assertHTTPGetResponse(t, srv, "/_sys/job", http.StatusUnauthorized)
+	assertHTTPGetResponse(t, srv, "/debug/info", http.StatusUnauthorized)
+}
+
+// TestRegisterGlobalMiddlewareNoopWhenEmpty verifies passing no middleware is a safe no-op.
+func TestRegisterGlobalMiddlewareNoopWhenEmpty(t *testing.T) {
+	srv := newTestServer("", "", "")
+	srv.echo.GET("/api/thing", okEchoHandler)
+	srv.RegisterGlobalMiddleware()
+
+	assertHTTPGetResponse(t, srv, "/api/thing", http.StatusOK, "ok")
+}
+
+// TestRegisterGlobalMiddlewareSkipsNilEntries verifies nil middleware entries are skipped
+// rather than panicking the request.
+func TestRegisterGlobalMiddlewareSkipsNilEntries(t *testing.T) {
+	srv := newTestServer("", "", "")
+	ran := false
+	srv.echo.GET("/api/thing", okEchoHandler)
+	mws := []MiddlewareFunc{nil, func(_ HandlerContext, next func() error) error {
+		ran = true
+		return next()
+	}, nil}
+	srv.RegisterGlobalMiddleware(mws...)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/thing", http.NoBody)
+	srv.echo.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, ran, "non-nil middleware must run; nil entries are skipped without panicking")
+}

--- a/server/global_middleware_test.go
+++ b/server/global_middleware_test.go
@@ -33,7 +33,7 @@ func TestSkipProbesBypassesProbePathsOnly(t *testing.T) {
 	wrapped := skipProbes(func(_ HandlerContext, next func() error) error {
 		mwCalls++
 		return next()
-	}, "/health", "/ready")
+	}, CreateProbeSkipper("/health", "/ready"))
 
 	cases := []struct {
 		path   string

--- a/wiki/adr_036_global_middleware.md
+++ b/wiki/adr_036_global_middleware.md
@@ -1,0 +1,82 @@
+# ADR-036: Module-Contributed Global Middleware
+
+**Status:** Accepted
+**Date:** 2026-07-05
+
+## Context
+
+Applications need app-wide HTTP middleware — canonically an auth gate — that runs once
+per request, cannot be skipped per-route, runs after tenant resolution but before handlers,
+and skips the health/ready probes. The framework already runs exactly such a chain
+internally (`SetupMiddlewares`: tenant resolution, rate limiting, recovery, ...) via echo's
+root `e.Use`, but there was no consumer-facing seam into it.
+
+The reachable seams were all wrong for this. `RouteRegistrar.Use` delegates to
+`echo.Group.Use`, which is group-scoped and order-fragile: echo bakes group middleware into
+a route at `Add` time, so it only applies to routes added *after* the `Use` call, and
+multiple modules stack duplicate copies. `RootGroup()` / `ModuleGroup()` return sibling
+groups whose middleware never crosses. Per-route middleware is skippable by definition.
+
+## Decision
+
+Add an optional duck-typed module interface, detected at startup like `RouteRegisterer` and
+`MessagingDeclarer`:
+
+```go
+type GlobalMiddlewareRegisterer interface {
+    GlobalMiddleware() []server.MiddlewareFunc
+}
+```
+
+The framework collects implementers' middleware in `prepareRuntime` (after every module
+`Init()`, before route registration and `Start`), so the middleware may capture
+dependencies a module wired up in `Init()` (e.g. a keystore-backed token verifier). It is
+registered once on the root engine chain via a new `*server.Server` method,
+`RegisterGlobalMiddleware`, which wraps each with a health/ready probe skipper
+(`CreateProbeSkipper`) and appends via `s.echo.Use`.
+
+Registration goes on the **raw root chain** (`s.echo.Use`), not a group. Echo's root `Use`
+recompiles the whole global chain (`buildRouterChains`) and applies to every request after
+routing, independent of route-registration order — dissolving the group-scoping/order trap.
+Appended after the built-in chain, global middleware lands at the innermost slot: after
+tenant resolution, inside `Recover`, before the handler.
+
+The app invokes the server method through an optional type assertion
+(`globalMiddlewareRegistrar`) rather than adding a method to the exported `ServerRunner`
+interface — keeping `ServerRunner` byte-identical and the change apidiff-additive (`feat:`).
+If a module registers global middleware but the configured `ServerRunner` does not implement
+the assertion, startup **fails closed** with an error: silently dropping a security gate is
+unsafe, so the app refuses to start rather than serve unguarded traffic.
+
+## Consequences
+
+- Auth / API-key / audit gates install once, un-skippable, with the tenant already in context.
+- Runs after rate-limit / timeout / gzip / bodyLimit (innermost slot): an unauthenticated
+  request still consumes rate-limit budget. This is an auth-gate hook, not a general
+  "run early" hook.
+- Runs before per-route JOSE decryption (JOSE runs in the typed-handler leaf): a global gate
+  authenticates on headers / token / tenant, never the decrypted body. Body-dependent
+  authorization belongs at the handler.
+- On a raw-response (Strangler-Fig) route a global rejection emits the standard envelope,
+  not the legacy raw shape (the raw-mode marker is set in the leaf, after middleware) — the
+  same property tenant middleware already has.
+- Fires before 404/405, so unauthenticated requests to unknown paths get 401 (does not leak
+  route existence). Only health/ready are exempt; `/_sys` and `/debug` are gated (their own
+  CIDR/bearer checks still apply underneath).
+- Ordering across multiple implementers is deterministic (module-registration order).
+
+## Alternatives Considered
+
+- **`app.Options` field / `app.Use()` method** — both build the middleware at
+  app-construction time, before module `Init()`, so an auth verifier built from the
+  keystore/DB is unavailable. Rejected in favor of the post-`Init` module interface.
+- **A method on `ServerRunner`** — apidiff-incompatible for external implementers; the
+  optional type assertion achieves the same wiring additively.
+- **`RouteRegistrar.Use` / `RootGroup().Use`** — group-scoped and order-fragile; would
+  silently miss routes and stack duplicates.
+
+## Related
+
+- [ADR-034](adr_034_echo_boundary_types.md) — the echo-free `MiddlewareFunc` / `HandlerContext` this builds on
+- [ADR-026](adr_026_zero_overhead_request_path.md) — typed handlers register via `addEcho`; global middleware uses the raw root chain
+- Design spec: `docs/superpowers/specs/2026-07-05-global-middleware-registerer-design.md`

--- a/wiki/adr_036_global_middleware.md
+++ b/wiki/adr_036_global_middleware.md
@@ -41,9 +41,9 @@ routing, independent of route-registration order — dissolving the group-scopin
 Appended after the built-in chain, global middleware lands at the innermost slot: after
 tenant resolution, inside `Recover`, before the handler.
 
-The app invokes the server method through an optional type assertion
-(`globalMiddlewareRegistrar`) rather than adding a method to the exported `ServerRunner`
-interface — keeping `ServerRunner` byte-identical and the change apidiff-additive (`feat:`).
+The app invokes the server method through an optional (inline) type assertion rather than
+adding a method to the exported `ServerRunner` interface — keeping `ServerRunner`
+byte-identical and the change apidiff-additive (`feat:`).
 If a module registers global middleware but the configured `ServerRunner` does not implement
 the assertion, startup **fails closed** with an error: silently dropping a security gate is
 unsafe, so the app refuses to start rather than serve unguarded traffic.

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -495,6 +495,27 @@ v0.46.0, `feat(server):` not `feat!:`.
 
 ---
 
+### [ADR-036: Module-Contributed Global Middleware](adr_036_global_middleware.md)
+
+**Date:** 2026-07-05 | **Status:** Accepted
+
+Adds an optional duck-typed module interface `GlobalMiddlewareRegisterer` (mirroring
+`RouteRegisterer` / `MessagingDeclarer`) so a module can contribute app-wide middleware —
+canonically an auth gate — that runs once per request, after tenant resolution, before
+handlers, and cannot be skipped per-route. The framework collects implementers after
+`Init()` and registers them once on the **raw root echo chain** (`s.echo.Use`, not a group:
+root `Use` recompiles the global chain and applies to every request regardless of
+route-registration order, dissolving echo's group-scoping/order trap) via a new
+`*server.Server.RegisterGlobalMiddleware`, wrapping each with the health/ready probe skipper.
+The app invokes it through an optional type assertion, leaving the exported `ServerRunner`
+interface byte-identical — purely additive, apidiff green, `feat:` not `feat!:`. Documented
+limitations: runs after rate-limiting and before JOSE body decryption (header/token/tenant
+auth only), and emits the standard envelope on raw-response routes.
+
+**Key Benefits:** Un-skippable app-wide auth/audit gates with the tenant already resolved; single framework-controlled registration (no per-module duplication or order-fragility); no change to the `ServerRunner` contract
+
+---
+
 ## ADR Lifecycle
 
 - **Proposed**: Under discussion, not yet implemented
@@ -504,7 +525,7 @@ v0.46.0, `feat(server):` not `feat!:`.
 
 ### Numbering Policy
 
-ADR numbers (ADR-001 through ADR-035) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
+ADR numbers (ADR-001 through ADR-036) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
 
 ## Writing New ADRs
 


### PR DESCRIPTION
## What

Adds an optional duck-typed module interface — `GlobalMiddlewareRegisterer` — so a module can contribute **app-wide HTTP middleware** (canonically an auth gate) that:

- runs **once** per request,
- **cannot be skipped** per-route,
- runs **after tenant resolution**, before handlers,
- **skips** the health/ready probes.

```go
type GlobalMiddlewareRegisterer interface {
    GlobalMiddleware() []server.MiddlewareFunc
}
```

It mirrors the existing `RouteRegisterer` / `MessagingDeclarer` opt-in interfaces. Because middleware is built **after** module `Init()`, it can capture dependencies a module wires up there (e.g. a keystore-backed token verifier).

## How

- **Collection**: `ModuleRegistry.CollectGlobalMiddleware()` gathers implementers in registration order, in `prepareRuntime` before route registration.
- **Registration**: a new `*server.Server.RegisterGlobalMiddleware` appends each (wrapped with the health/ready probe skipper) to the **raw root echo chain** (`s.echo.Use`). Root `Use` recompiles the global chain and applies to every request regardless of route-registration order — this is why it must be the root chain, not a group (`group.Use` is order-fragile and group-scoped).
- **No `ServerRunner` change**: the app invokes the server method through an optional type assertion, keeping the exported `ServerRunner` interface byte-identical → **purely additive, apidiff-green, `feat:`**.
- **Fails closed**: if a module registers global middleware but the configured server can't install it, startup aborts rather than silently serving unguarded traffic (a mis-wired auth gate should refuse to start). Nil entries are skipped.

## Placement & documented limits (ADR-036)

- Lands at the **innermost slot**: after tenant resolution + `Recover` + rate-limiting, before the handler. An unauthenticated request still consumes rate-limit budget (intended — cheap flood rejection; this is an auth-gate hook, not a general "run early" hook).
- Runs **before** per-route JOSE decryption → authenticates on headers/token/tenant, not the decrypted body.
- `/_sys` and `/debug` are **gated** (their own CIDR/bearer checks still apply); only health/ready are exempt.

## Tests

- `server/global_middleware_test.go`: end-to-end run, probe-skip, 401 short-circuit envelope, **runs-after-tenant-resolution**, runs-once, **applies-to-routes-registered-after** (proves root-chain order-independence), gates `/_sys`+`/debug`, nil-skip.
- `app/`: collection (once, skip-non-implementers, registration order), and the `applyGlobalMiddleware` wiring incl. the **fail-closed** path.

`make check` green (fmt/lint/test-race/alloc/vuln); gosec 0 issues. Reviewed with `/code-review` (high) and `/security-audit` before push.

## Scope

PR **1 of 2**. This is the feature + ADR-036. A follow-up PR adds the `wiki/global_middleware.md` deep-dive + the design spec + `llms.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for app-wide middleware contributed by modules, applied once per request across the request chain.
  * Middleware now respects health and readiness probes, while still covering other routes consistently.
  * Updated architecture notes to document the new middleware behavior and ordering.

* **Bug Fixes**
  * Startup now stops with an error if middleware is provided but the server cannot install it.
  * Nil or missing middleware entries are safely ignored.

* **Tests**
  * Added coverage for middleware collection, registration order, probe handling, and request flow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->