### PR TITLE
docs: expand llms.txt global-middleware guide + fix spec drift

### DIFF
--- a/docs/superpowers/specs/2026-07-05-global-middleware-registerer-design.md
+++ b/docs/superpowers/specs/2026-07-05-global-middleware-registerer-design.md
@@ -68,19 +68,24 @@ type GlobalMiddlewareRegisterer interface {
 // Must be called during startup, before Start(). Safe to call once with all
 // collected middleware, or repeatedly; ordering follows call order.
 func (s *Server) RegisterGlobalMiddleware(mw ...MiddlewareFunc) {
-    healthPath := s.buildFullPath(s.healthRoute)
-    readyPath  := s.buildFullPath(s.readyRoute)
+    skipper := CreateProbeSkipper(s.buildFullPath(s.healthRoute), s.buildFullPath(s.readyRoute))
+    adapted := make([]echo.MiddlewareFunc, 0, len(mw))
     for _, m := range mw {
-        wrapped := skipProbes(m, healthPath, readyPath)
-        s.echo.Use(adaptMiddleware(wrapped, s.cfg)) // RAW ROOT CHAIN — see §5
+        if m == nil {
+            continue
+        }
+        adapted = append(adapted, adaptMiddleware(skipProbes(m, skipper), s.cfg)) // RAW ROOT CHAIN — see §5
     }
+    if len(adapted) == 0 {
+        return
+    }
+    s.echo.Use(adapted...)
 }
 
-// skipProbes wraps a MiddlewareFunc so it is bypassed for the health/ready
-// endpoints, reusing CreateProbeSkipper for byte-identical semantics with the
-// tenant middleware (server/tenant_middleware.go:57).
-func skipProbes(mw MiddlewareFunc, healthPath, readyPath string) MiddlewareFunc {
-    skipper := CreateProbeSkipper(healthPath, readyPath) // exact-path match on r.URL.Path
+// skipProbes wraps a MiddlewareFunc so it is bypassed for the health/ready endpoints. The
+// skipper is built once by the caller (CreateProbeSkipper) for byte-identical semantics with
+// the tenant middleware (server/tenant_middleware.go:57).
+func skipProbes(mw MiddlewareFunc, skipper SkipperFunc) MiddlewareFunc {
     return func(c HandlerContext, next func() error) error {
         if skipper(c.Request()) {
             return next()
@@ -114,7 +119,7 @@ This method **must** live in package `server`: `adaptMiddleware` is unexported (
 
 ## 4. Lifecycle & wiring
 
-**Collection point:** `app/lifecycle.go`, in `prepareRuntime()`, immediately before `RegisterRoutes` (`lifecycle.go:63`). By then all module `Init()` has run synchronously inside `ModuleRegistry.Register` (`app/module_registry.go:55`), and the serve loop has not started — the same window `RegisterJobs` (`lifecycle.go:59`) and `RegisterRoutes` (`lifecycle.go:63`) already use.
+**Collection point:** `app/lifecycle.go`, in `prepareRuntime()`: `applyGlobalMiddleware()` runs at `lifecycle.go:63`, immediately before `RegisterRoutes` (`lifecycle.go:67`). By then all module `Init()` has run synchronously inside `ModuleRegistry.Register` (`app/module_registry.go:55`), and the serve loop has not started — the same window `RegisterJobs` (`lifecycle.go:59`) and `RegisterRoutes` (`lifecycle.go:67`) already use.
 
 **New collector on `*ModuleRegistry`** — a drop-in analogue of the `RegisterRoutes` loop (`module_registry.go:141-149`):
 

--- a/llms.txt
+++ b/llms.txt
@@ -932,7 +932,8 @@ func LoggingMiddleware(log logger.Logger) server.MiddlewareFunc {
 // === Register Middleware in Module ===
 
 func (m *Module) RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar) {
-	// Global middleware for all routes in this module
+	// Group-scoped middleware — applies to routes registered on this registrar
+	// (NOT app-wide; for that see GlobalMiddlewareRegisterer below)
 	r.Use(LoggingMiddleware(m.logger))
 
 	// Group with auth middleware - all routes inherit it
@@ -994,6 +995,67 @@ func (h *Handler) GetUser(req GetUserReq, ctx server.HandlerContext) (server.Res
 | `r.Group("/path", middleware)` | Apply to route subtree | Auth for /admin/* |
 | Skipper function | Conditionally skip | Skip rate limit for /health |
 | Context propagation | Pass data downstream | User ID, tenant ID |
+| `GlobalMiddleware()` (module interface) | App-wide, once, un-skippable | Auth gate on every route |
+
+### App-Wide Global Middleware (`GlobalMiddlewareRegisterer`, v0.48.0+)
+
+`r.Use` / `r.Group` above are **group-scoped** — they wrap only routes registered on that
+registrar. For middleware that must run on **every** request across the whole app (auth
+gates, API-key checks, global audit) — once per request, **after tenant resolution**, before
+handlers, with **no per-route opt-out** — a module implements `GlobalMiddlewareRegisterer`.
+The framework collects it after `Init()` and registers it once on the root chain, skipping
+only the health/ready probes.
+
+```go
+// Unlike r.Use / r.Group (group-scoped), GlobalMiddlewareRegisterer contributes middleware
+// that runs once per request on EVERY route. Built after Init(), so it can capture
+// dependencies the module wired up there (e.g. a keystore-backed verifier).
+type AuthModule struct {
+	verifier *TokenVerifier
+}
+
+func (m *AuthModule) Name() string { return "auth" }
+
+func (m *AuthModule) Init(deps *app.ModuleDeps) error {
+	m.verifier = NewTokenVerifier(deps.KeyStore) // captured by the closure below
+	return nil
+}
+
+func (m *AuthModule) Shutdown() error { return nil }
+
+// GlobalMiddleware satisfies app.GlobalMiddlewareRegisterer.
+func (m *AuthModule) GlobalMiddleware() []server.MiddlewareFunc {
+	return []server.MiddlewareFunc{
+		func(c server.HandlerContext, next func() error) error {
+			// No route can opt out, so public-path exemptions live HERE, in the gate body.
+			if isPublicPath(c.Request().URL.Path) {
+				return next()
+			}
+			if !m.verifier.Valid(c.RequestHeader("Authorization")) {
+				return server.NewUnauthorizedError("invalid token") // → 401, standard envelope
+			}
+			// Tenant is already resolved: multitenant.GetTenant(c.RequestContext()).
+			return next()
+		},
+	}
+}
+
+// Register like any module; no r.Use needed.
+//   fw.RegisterModules(keystore.NewModule(), &AuthModule{}, ...)
+```
+
+Behavior and limits (see [wiki/global_middleware.md](wiki/global_middleware.md) / ADR-036):
+- **Innermost slot**: runs after the built-in chain (tenant resolution, `Recover`,
+  rate-limiting), before the handler. An unauthenticated request still consumes rate-limit
+  budget — this is an auth-gate hook, not a general "run early" hook.
+- **Before JOSE decryption**: authenticates on headers/token/tenant, never a decrypted body
+  (JOSE runs in the typed-handler leaf, after middleware).
+- **Fires before 404/405**: an unauthenticated request to an unknown path gets 401, not 404.
+- **Gated**: `/_sys` and `/debug` are subject to the gate (their own CIDR/bearer checks still
+  apply); only `/health` and `/ready` are exempt.
+- **Fail-closed**: if the configured server cannot install it (a custom `ServerRunner`),
+  startup aborts rather than serving unguarded traffic.
+- **Ordering**: across modules, middleware composes in module-registration order.
 
 ### Route Template & Path Parameters (v0.46.0+)
 

--- a/llms.txt
+++ b/llms.txt
@@ -995,7 +995,7 @@ func (h *Handler) GetUser(req GetUserReq, ctx server.HandlerContext) (server.Res
 | `r.Group("/path", middleware)` | Apply to route subtree | Auth for /admin/* |
 | Skipper function | Conditionally skip | Skip rate limit for /health |
 | Context propagation | Pass data downstream | User ID, tenant ID |
-| `GlobalMiddleware()` (module interface) | App-wide, once, un-skippable | Auth gate on every route |
+| `GlobalMiddleware()` (module interface) | App-wide, once; no route opt-out (probes exempt) | Auth gate on every route |
 
 ### App-Wide Global Middleware (`GlobalMiddlewareRegisterer`, v0.48.0+)
 


### PR DESCRIPTION
## What

Documentation polish for `GlobalMiddlewareRegisterer` (shipped in #643/#644):

1. **`llms.txt`** — proper treatment under `## HTTP Middleware`: a new **"App-Wide Global Middleware (`GlobalMiddlewareRegisterer`)"** subsection with a full auth-gate example (module `Init()` capturing a verifier → `GlobalMiddleware()` returning the gate) and a behavior/limits list (innermost slot, before-JOSE-decrypt, before-404, `/_sys`+`/debug` gated, fail-closed, ordering). Also adds a middleware-pattern table row and clarifies that `r.Use`/`r.Group` are **group-scoped**, not app-wide (the old comment misleadingly called `r.Use` "global").

2. **Design spec** — an adversarial docs-review panel (6 reviewers + independent verifiers) checked every global-middleware doc against the merged code. It confirmed the **consumer docs (ADR-036, wiki deep-dive, llms.txt, CLAUDE.md, ADR index) are accurate — zero findings** — and caught two stale references in the internal design spec, both fixed here:
   - §3.2 `skipProbes` sketch showed the pre-hoist signature (`skipProbes(mw, healthPath, readyPath)`); shipped code is `skipProbes(mw, skipper SkipperFunc)` with the skipper built once in `RegisterGlobalMiddleware`.
   - A `RegisterRoutes` line reference was `:63`; it shifted to `:67` after `applyGlobalMiddleware` was inserted at `:63`.

## Notes

Docs-only. `make check` green. CI's CodeRabbit + SonarCloud review the prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `Use`/`Group` middleware is route-group scoped, not module/global.
  * Added guidance for app-wide GlobalMiddleware, including execution timing (after tenant resolution, before handlers), scope (covers all routes), and probe skipping rules.
  * Refined the middleware registration lifecycle to better explain when global middleware is collected and registered.
  * Expanded examples and ordering/behavior notes for protected routes and unknown-route handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->