### PR TITLE
fix(messaging): wait for cold client readiness before publish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,6 +447,7 @@ For dual-mode log routing, runtime metrics, custom-metric patterns, vendor authe
 | HTTP server read / write / idle / shutdown | `server.timeout.{read,write,idle,shutdown}` | 15s / 30s / 60s / 10s |
 | Outbound HTTP client | `httpclient.NewBuilder(...).WithTimeout(d)` | 30s |
 | Cache (Redis) dial / read / write | `cache.redis.{dialtimeout,readtimeout,writetimeout}` | 5s / 3s / 3s |
+| AMQP publish readiness pre-flight (cold/reconnecting client) | `messaging.reconnect.readytimeout` | 5s |
 | AMQP publish confirmation | `messaging.reconnect.connectiontimeout` | 30s |
 | Scheduler slow-job WARN / shutdown | `scheduler.timeout.{slowjob,shutdown}` | 25s / 30s |
 | Observability export | `observability.trace.export.timeout` | 10s (dev) / 60s (prod) |

--- a/app/bootstrap.go
+++ b/app/bootstrap.go
@@ -43,6 +43,7 @@ func (b *appBootstrap) dependencies(startupCtx context.Context) *dependencyBundl
 	configBuilder := NewManagerConfigBuilder(b.cfg.Multitenant.Enabled, b.cfg.Multitenant.Limits.Tenants)
 	configBuilder.connectionTimeout = b.cfg.Messaging.Reconnect.ConnectionTimeout
 	configBuilder.maxPublishAttempts = b.cfg.Messaging.Reconnect.MaxPublishAttempts
+	configBuilder.readyTimeout = b.cfg.Messaging.Reconnect.ReadyTimeout
 	configBuilder.publisherConfig = b.cfg.Messaging.Publisher
 	configBuilder.cacheConfig = b.cfg.Cache.Manager
 	// Only count statically-configured tenants when multitenancy is enabled. Koanf

--- a/app/factory_resolver.go
+++ b/app/factory_resolver.go
@@ -35,12 +35,37 @@ func (f *FactoryResolver) DatabaseConnector() database.Connector {
 	return database.NewConnection
 }
 
+// MessagingClientFactoryOptions bundles the per-publish tuning knobs threaded
+// into the default messaging client factory. Introduced alongside the
+// existing MessagingClientFactory (kept byte-identical for apidiff
+// compatibility — see reference_apidiff_variadic_incompatible) so ReadyTimeout
+// could be added without breaking that method's exported signature.
+type MessagingClientFactoryOptions struct {
+	ConnectionTimeout  time.Duration
+	MaxPublishAttempts int
+	ReadyTimeout       time.Duration
+}
+
 // MessagingClientFactory returns the appropriate messaging client factory function.
 // The default factory creates AMQPClient instances configured with the supplied per-publish
 // connection timeout and bounded publish-retry attempts. If a custom
 // Options.MessagingClientFactory is set it owns construction and receives only (url, log) —
 // neither connectionTimeout nor maxPublishAttempts applies to it.
+//
+// Deprecated: kept for backward compatibility (its signature cannot change without
+// breaking apidiff). Use MessagingClientFactoryWithOptions to also configure
+// ReadyTimeout.
 func (f *FactoryResolver) MessagingClientFactory(connectionTimeout time.Duration, maxPublishAttempts int) messaging.ClientFactory {
+	return f.MessagingClientFactoryWithOptions(MessagingClientFactoryOptions{
+		ConnectionTimeout:  connectionTimeout,
+		MaxPublishAttempts: maxPublishAttempts,
+	})
+}
+
+// MessagingClientFactoryWithOptions is the ReadyTimeout-aware successor to
+// MessagingClientFactory. Internal bootstrap wiring (CreateMessagingManager)
+// uses this method so messaging.reconnect.readytimeout reaches the client.
+func (f *FactoryResolver) MessagingClientFactoryWithOptions(opts MessagingClientFactoryOptions) messaging.ClientFactory {
 	if f.opts != nil && f.opts.MessagingClientFactory != nil {
 		return func(url string, log logger.Logger) messaging.AMQPClient {
 			return f.opts.MessagingClientFactory(url, log)
@@ -49,8 +74,9 @@ func (f *FactoryResolver) MessagingClientFactory(connectionTimeout time.Duration
 
 	return func(url string, log logger.Logger) messaging.AMQPClient {
 		return messaging.NewAMQPClient(url, log,
-			messaging.WithConnectionTimeout(connectionTimeout),
-			messaging.WithMaxPublishAttempts(maxPublishAttempts),
+			messaging.WithConnectionTimeout(opts.ConnectionTimeout),
+			messaging.WithMaxPublishAttempts(opts.MaxPublishAttempts),
+			messaging.WithReadyTimeout(opts.ReadyTimeout),
 		)
 	}
 }

--- a/app/factory_resolver.go
+++ b/app/factory_resolver.go
@@ -65,6 +65,11 @@ func (f *FactoryResolver) MessagingClientFactory(connectionTimeout time.Duration
 // MessagingClientFactoryWithOptions is the ReadyTimeout-aware successor to
 // MessagingClientFactory. Internal bootstrap wiring (CreateMessagingManager)
 // uses this method so messaging.reconnect.readytimeout reaches the client.
+//
+// Same custom-factory precedence as MessagingClientFactory: if
+// Options.MessagingClientFactory is set it owns construction and receives only
+// (url, log) — none of opts (ConnectionTimeout, MaxPublishAttempts, ReadyTimeout)
+// applies to it.
 func (f *FactoryResolver) MessagingClientFactoryWithOptions(opts MessagingClientFactoryOptions) messaging.ClientFactory {
 	if f.opts != nil && f.opts.MessagingClientFactory != nil {
 		return func(url string, log logger.Logger) messaging.AMQPClient {

--- a/app/factory_resolver_test.go
+++ b/app/factory_resolver_test.go
@@ -136,6 +136,26 @@ func TestFactoryResolverMessagingClientFactory(t *testing.T) {
 		assert.NotNil(t, client)
 		t.Cleanup(func() { _ = client.Close() })
 	})
+
+	t.Run("WithOptions variant carries ReadyTimeout, old method stays byte-identical", func(t *testing.T) {
+		resolver := NewFactoryResolver(nil)
+
+		// Old 2-arg method must still work unchanged.
+		oldFactory := resolver.MessagingClientFactory(7*time.Second, 5)
+		assert.NotNil(t, oldFactory)
+
+		// New WithOptions method carries ReadyTimeout through to the client.
+		newFactory := resolver.MessagingClientFactoryWithOptions(MessagingClientFactoryOptions{
+			ConnectionTimeout:  7 * time.Second,
+			MaxPublishAttempts: 5,
+			ReadyTimeout:       9 * time.Second,
+		})
+		assert.NotNil(t, newFactory)
+
+		client := newFactory("amqp://127.0.0.1:1", logger.New("error", true))
+		assert.NotNil(t, client)
+		t.Cleanup(func() { _ = client.Close() })
+	})
 }
 
 // mockCacheInstance is a minimal mock implementation of cache.Cache for testing

--- a/app/managers.go
+++ b/app/managers.go
@@ -38,6 +38,9 @@ type ManagerConfigBuilder struct {
 	// maxPublishAttempts bounds the per-publish retry loop, sourced from
 	// messaging.reconnect.maxpublishattempts and set by bootstrap.
 	maxPublishAttempts int
+	// readyTimeout bounds the pre-flight readiness wait, sourced from
+	// messaging.reconnect.readytimeout and set by bootstrap.
+	readyTimeout time.Duration
 	// publisherConfig carries operator-configurable messaging publisher pool
 	// settings (messaging.publisher.*), sourced from validated config by bootstrap.
 	// When unset, documented defaults are applied as fallbacks.
@@ -102,6 +105,7 @@ func (b *ManagerConfigBuilder) BuildMessagingOptions() messaging.ManagerOptions 
 		IdleTTL:            idleTTL,
 		ConnectionTimeout:  b.connectionTimeout,
 		MaxPublishAttempts: b.maxPublishAttempts,
+		ReadyTimeout:       b.readyTimeout,
 	}
 }
 
@@ -245,7 +249,11 @@ func (f *ResourceManagerFactory) CreateMessagingManager(
 	}
 
 	msgOptions := f.configBuilder.BuildMessagingOptions()
-	clientFactory := f.factoryResolver.MessagingClientFactory(msgOptions.ConnectionTimeout, msgOptions.MaxPublishAttempts)
+	clientFactory := f.factoryResolver.MessagingClientFactoryWithOptions(MessagingClientFactoryOptions{
+		ConnectionTimeout:  msgOptions.ConnectionTimeout,
+		MaxPublishAttempts: msgOptions.MaxPublishAttempts,
+		ReadyTimeout:       msgOptions.ReadyTimeout,
+	})
 
 	f.warnIfPoolBelowTenantCount("messaging", msgOptions.MaxPublishers)
 

--- a/app/managers_test.go
+++ b/app/managers_test.go
@@ -170,6 +170,15 @@ func TestManagerConfigBuilderBuildMessagingOptions(t *testing.T) {
 		zero := NewManagerConfigBuilder(false, 100)
 		assert.Equal(t, time.Duration(0), zero.BuildMessagingOptions().ConnectionTimeout)
 	})
+
+	t.Run("ready_timeout_propagated_to_options", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(false, 100)
+		builder.readyTimeout = 9 * time.Second
+		assert.Equal(t, 9*time.Second, builder.BuildMessagingOptions().ReadyTimeout)
+
+		zero := NewManagerConfigBuilder(false, 100)
+		assert.Equal(t, time.Duration(0), zero.BuildMessagingOptions().ReadyTimeout)
+	})
 }
 
 func TestManagerConfigBuilderHonorsConfigDefaults(t *testing.T) {

--- a/config/types.go
+++ b/config/types.go
@@ -368,6 +368,7 @@ type MessagingConfig struct {
 //   - ReinitDelay: 2s (delay before channel reinitialization)
 //   - ResendDelay: 5s (delay before retrying failed publishes)
 //   - ConnectionTimeout: 30s (per-publish broker ACK/NACK confirmation wait)
+//   - ReadyTimeout: 5s (pre-flight wait for a not-yet-ready client, before a publish begins)
 //   - MaxDelay: 60s (maximum delay for exponential backoff cap)
 type ReconnectConfig struct {
 	// Delay is the initial delay between reconnection attempts.
@@ -387,6 +388,12 @@ type ReconnectConfig struct {
 	// The TCP/AMQP connection dial itself is bounded by amqp091-go's amqp.Dial default,
 	// not by this value. Default: 30s. Set higher for high-latency networks.
 	ConnectionTimeout time.Duration `koanf:"connectiontimeout" json:"connectiontimeout" yaml:"connectiontimeout" toml:"connectiontimeout" mapstructure:"connectiontimeout"`
+
+	// ReadyTimeout bounds how long a publish will wait, before entering the
+	// bounded retry loop, for a not-yet-ready client (cold start or
+	// mid-reconnect) to become ready. The wait does not consume a
+	// MaxPublishAttempts slot. Default: 5s. Must be >= 0.
+	ReadyTimeout time.Duration `koanf:"readytimeout" json:"readytimeout" yaml:"readytimeout" toml:"readytimeout" mapstructure:"readytimeout"`
 
 	// MaxPublishAttempts bounds the per-publish retry loop: after this many failed
 	// attempts a publish returns an error instead of retrying forever. This is what

--- a/config/validation.go
+++ b/config/validation.go
@@ -44,6 +44,7 @@ const (
 	defaultReinitDelay        = 2 * time.Second  // Delay before channel reinitialization
 	defaultResendDelay        = 5 * time.Second  // Delay before retrying failed publishes
 	defaultConnectionTimeout  = 30 * time.Second // Per-publish broker confirmation (ACK/NACK) wait
+	defaultReadyTimeout       = 5 * time.Second  // Pre-flight wait for a not-yet-ready client before a publish begins
 	defaultMaxReconnectDelay  = 60 * time.Second // Maximum delay for exponential backoff cap
 	defaultMaxPublishers      = 50               // Maximum publisher clients in cache
 	defaultPublisherIdleTTL   = 10 * time.Minute // Time before idle publishers are evicted
@@ -632,6 +633,7 @@ func validateNamedDatabaseEntry(name string, dbCfg *DatabaseConfig, mt *Multiten
 // - Reconnect.ReinitDelay: if 0, sets to 2s; if negative, returns an error.
 // - Reconnect.ResendDelay: if 0, sets to 5s; if negative, returns an error.
 // - Reconnect.ConnectionTimeout: if 0, sets to 30s; if negative, returns an error.
+// - Reconnect.ReadyTimeout: if 0, sets to 5s; if negative, returns an error.
 // - Reconnect.MaxDelay: if 0, sets to 60s; if negative, returns an error.
 // - Publisher.MaxCached: if 0, sets to 50; if negative, returns an error.
 // - Publisher.IdleTTL: if 0, sets to 10m; if negative, returns an error.
@@ -649,6 +651,7 @@ func applyMessagingDefaults(cfg *MessagingConfig) error {
 		{&cfg.Reconnect.ReinitDelay, defaultReinitDelay, "messaging.reconnect.reinitdelay"},
 		{&cfg.Reconnect.ResendDelay, defaultResendDelay, "messaging.reconnect.resenddelay"},
 		{&cfg.Reconnect.ConnectionTimeout, defaultConnectionTimeout, "messaging.reconnect.connectiontimeout"},
+		{&cfg.Reconnect.ReadyTimeout, defaultReadyTimeout, "messaging.reconnect.readytimeout"},
 		{&cfg.Reconnect.MaxDelay, defaultMaxReconnectDelay, "messaging.reconnect.maxdelay"},
 		{&cfg.Publisher.IdleTTL, defaultPublisherIdleTTL, "messaging.publisher.idlettl"},
 	} {

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -2184,6 +2184,22 @@ func TestApplyMessagingDefaultsMaxPublishAttempts(t *testing.T) {
 	})
 }
 
+func TestApplyMessagingDefaultsReadyTimeout(t *testing.T) {
+	t.Run("zero_gets_default", func(t *testing.T) {
+		cfg := &MessagingConfig{Broker: BrokerConfig{URL: testAMQPHost}}
+		require.NoError(t, validateMessaging(cfg))
+		assert.Equal(t, defaultReadyTimeout, cfg.Reconnect.ReadyTimeout)
+	})
+	t.Run("explicit_value_preserved", func(t *testing.T) {
+		cfg := &MessagingConfig{
+			Broker:    BrokerConfig{URL: testAMQPHost},
+			Reconnect: ReconnectConfig{ReadyTimeout: 9 * time.Second},
+		}
+		require.NoError(t, validateMessaging(cfg))
+		assert.Equal(t, 9*time.Second, cfg.Reconnect.ReadyTimeout)
+	})
+}
+
 func TestApplyMessagingDefaultsNegativeValues(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -2245,6 +2261,14 @@ func TestApplyMessagingDefaultsNegativeValues(t *testing.T) {
 				Reconnect: ReconnectConfig{MaxPublishAttempts: -1},
 			},
 			errorContains: "messaging.reconnect.maxpublishattempts",
+		},
+		{
+			name: "negative_ready_timeout_rejected",
+			config: MessagingConfig{
+				Broker:    BrokerConfig{URL: testAMQPHost},
+				Reconnect: ReconnectConfig{ReadyTimeout: -1 * time.Second},
+			},
+			errorContains: "messaging.reconnect.readytimeout",
 		},
 		{
 			name: "negative_publisher_idle_ttl_rejected",

--- a/messaging/amqp_client.go
+++ b/messaging/amqp_client.go
@@ -85,6 +85,13 @@ type AMQPClientImpl struct {
 	reInitDelay       time.Duration
 	resendDelay       time.Duration
 	connectionTimeout time.Duration
+	// readyTimeout bounds PublishToExchange's pre-flight wait for a not-yet-ready
+	// client (cold start or mid-reconnect) to become ready before the publish
+	// attempt begins. Zero or negative disables the wait entirely, reproducing the
+	// pre-#655 instant fail-fast — this is the Go zero value, so struct-literal
+	// test clients that don't set the field keep their old behavior. See
+	// waitForReady.
+	readyTimeout time.Duration
 	// maxPublishAttempts bounds the per-publish retry loop so PublishToExchange
 	// always returns to its caller. A value <= 0 means unbounded (the historical
 	// behavior) — kept so struct-literal test clients that don't set the field
@@ -106,6 +113,11 @@ const (
 	// typical reconnect (reconnectDelay 5s + reInitDelay 2s) across a few resend
 	// cycles before giving up and returning a classifiable error to the caller.
 	defaultMaxPublishAttempts = 5
+	// defaultReadyTimeout bounds PublishToExchange's pre-flight wait for a cold or
+	// mid-reconnect client to become ready before the publish attempt begins. 5s
+	// covers the common case (broker handshake + channel init) without materially
+	// extending a caller's request budget. See issue #655.
+	defaultReadyTimeout = 5 * time.Second
 	// defaultNackBackoff is a small cancelable pause between NACK retries so a
 	// transiently-unroutable publish (e.g. a binding still being created) gets a
 	// few spaced attempts without busy-spinning, while staying well under a tight
@@ -181,6 +193,18 @@ func WithMaxPublishAttempts(n int) ClientOption {
 	}
 }
 
+// WithReadyTimeout bounds PublishToExchange's pre-flight wait for a not-yet-ready
+// client to become ready before the publish attempt begins (see waitForReady).
+// The wait does not consume a maxPublishAttempts slot. Non-positive values are
+// ignored, leaving the 5s default in place.
+func WithReadyTimeout(d time.Duration) ClientOption {
+	return func(c *AMQPClientImpl) {
+		if d > 0 {
+			c.readyTimeout = d
+		}
+	}
+}
+
 // NewAMQPClient creates a new AMQP client instance.
 // It automatically attempts to connect to the broker and handles reconnections.
 // Optional Option values (e.g. WithConnectionTimeout) override the defaults.
@@ -196,6 +220,7 @@ func NewAMQPClient(brokerURL string, log logger.Logger, opts ...ClientOption) *A
 		reInitDelay:        defaultReInitDelay,
 		resendDelay:        defaultResendDelay,
 		connectionTimeout:  defaultConnectionTimeout,
+		readyTimeout:       defaultReadyTimeout,
 		maxPublishAttempts: defaultMaxPublishAttempts,
 		nackBackoff:        defaultNackBackoff,
 	}
@@ -297,6 +322,16 @@ func (c *AMQPClientImpl) PublishToExchange(ctx context.Context, options PublishO
 	// Create OpenTelemetry span for publish operation
 	ctx, span := createPublishSpan(ctx, options, len(data), startTime)
 	defer span.End()
+
+	// Pre-flight: give a cold or mid-reconnect client a bounded, context-aware
+	// window to become ready BEFORE entering the retry loop below. This wait does
+	// NOT consume a maxPublishAttempts slot — a cold client failing fast on the
+	// very first publish (before handleReconnect's async connect finishes) was
+	// the root cause of issue #655. A zero/negative readyTimeout disables the
+	// wait entirely, reproducing the pre-#655 behavior byte-for-byte.
+	if err := c.publishPreflight(ctx, options, startTime, span); err != nil {
+		return err
+	}
 
 	retryCount := 0
 	// lastCause records why the most recent attempt failed (the raw publish error,
@@ -471,6 +506,71 @@ func (c *AMQPClientImpl) PublishToExchange(ctx context.Context, options PublishO
 				return termErr
 			}
 			continue
+		}
+	}
+}
+
+// publishPreflight runs waitForReady ahead of PublishToExchange's retry loop and
+// translates the outcome into the same terminal-error shape as every other exit
+// path: a readyTimeout expiry logs the same WARN production always emitted for a
+// not-ready client and returns the raw errNotConnected; a ctx cancel or shutdown
+// is routed through publishAbort like every other abort. Split out of
+// PublishToExchange to keep its cyclomatic complexity within budget (gocyclo).
+func (c *AMQPClientImpl) publishPreflight(ctx context.Context, options PublishOptions, startTime time.Time, span trace.Span) error {
+	err := c.waitForReady(ctx)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, errNotConnected) {
+		c.log.Warn().
+			Str("exchange", options.Exchange).
+			Str("routing_key", options.RoutingKey).
+			Dur("ready_timeout", c.readyTimeout).
+			Msg("AMQP client still not ready after waiting, message not published")
+		span.RecordError(errNotConnected)
+		span.SetStatus(codes.Error, errNotConnected.Error())
+		return errNotConnected
+	}
+	return c.publishAbort(ctx, options, startTime, span, err, nil)
+}
+
+// waitForReady blocks PublishToExchange's pre-flight check until the client
+// becomes ready, the bounded readyTimeout elapses, the context is canceled, or
+// the client is shut down — whichever comes first. A readyTimeout <= 0 disables
+// the wait entirely (returns nil immediately without even checking IsReady),
+// reproducing the pre-#655 instant fail-fast for callers that opt out or for
+// struct-literal test clients that never set the field.
+//
+// Reuses the same readinessCheckInterval poll cadence as
+// Registry.DeclareInfrastructure so both "wait for ready" call sites share one
+// mental model. Returns errNotConnected (unwrapped) on timeout expiry — the
+// caller re-raises it as-is; ctx.Err() or errShutdown on cancellation/shutdown
+// — the caller wraps those through publishAbort like every other exit path.
+func (c *AMQPClientImpl) waitForReady(ctx context.Context) error {
+	if c.readyTimeout <= 0 {
+		return nil
+	}
+	if c.IsReady() {
+		return nil
+	}
+
+	timeout := time.NewTimer(c.readyTimeout)
+	defer timeout.Stop()
+	ticker := time.NewTicker(readinessCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-c.done:
+			return errShutdown
+		case <-timeout.C:
+			return errNotConnected
+		case <-ticker.C:
+			if c.IsReady() {
+				return nil
+			}
 		}
 	}
 }

--- a/messaging/amqp_client.go
+++ b/messaging/amqp_client.go
@@ -333,6 +333,16 @@ func (c *AMQPClientImpl) PublishToExchange(ctx context.Context, options PublishO
 		return err
 	}
 
+	// publishStart marks the beginning of the actual broker attempt, AFTER the
+	// pre-flight readiness wait resolved. The retry loop below feeds this — not
+	// startTime — into publish-latency metrics/logging: startTime→publishStart can
+	// be several seconds on a cold-start or mid-reconnect wait (bounded by
+	// readyTimeout), and folding that into "broker latency" would make a single
+	// successful publish look like a multi-second broker hiccup. The span created
+	// above intentionally keeps startTime — its duration is meant to cover the
+	// full call, wait included.
+	publishStart := time.Now()
+
 	retryCount := 0
 	// lastCause records why the most recent attempt failed (the raw publish error,
 	// ErrPublishNacked, or ErrPublishConfirmTimeout). It is wrapped into the terminal error on
@@ -342,9 +352,9 @@ func (c *AMQPClientImpl) PublishToExchange(ctx context.Context, options PublishO
 	for {
 		select {
 		case <-ctx.Done():
-			return c.publishAbort(ctx, options, startTime, span, ctx.Err(), lastCause)
+			return c.publishAbort(ctx, options, publishStart, span, ctx.Err(), lastCause)
 		case <-c.done:
-			return c.publishAbort(ctx, options, startTime, span, errShutdown, lastCause)
+			return c.publishAbort(ctx, options, publishStart, span, errShutdown, lastCause)
 		default:
 		}
 
@@ -414,7 +424,7 @@ func (c *AMQPClientImpl) PublishToExchange(ctx context.Context, options PublishO
 				attribute.String("error", err.Error()),
 				attribute.Int("retry_count", retryCount),
 			))
-			if termErr := c.retryBackoff(ctx, options, startTime, span, retryCount, lastCause, c.resendDelay); termErr != nil {
+			if termErr := c.retryBackoff(ctx, options, publishStart, span, retryCount, lastCause, c.resendDelay); termErr != nil {
 				return termErr
 			}
 			continue
@@ -427,14 +437,16 @@ func (c *AMQPClientImpl) PublishToExchange(ctx context.Context, options PublishO
 		case <-ctx.Done():
 			// Cleanup so the dispatcher doesn't hold a stale chan reference.
 			c.pendingPublishes.Delete(key)
-			return c.publishAbort(ctx, options, startTime, span, ctx.Err(), lastCause)
+			return c.publishAbort(ctx, options, publishStart, span, ctx.Err(), lastCause)
 		case <-c.done:
 			c.pendingPublishes.Delete(key)
-			return c.publishAbort(ctx, options, startTime, span, errShutdown, lastCause)
+			return c.publishAbort(ctx, options, publishStart, span, errShutdown, lastCause)
 		case confirm := <-confirmCh:
 			if confirm.Ack {
-				// Track elapsed time and increment AMQP counter in context for request tracking
-				elapsed := time.Since(startTime)
+				// Track elapsed time and increment AMQP counter in context for request tracking.
+				// publishStart (not startTime) excludes the pre-flight readiness wait so a
+				// cold-start publish doesn't misreport that wait as broker latency.
+				elapsed := time.Since(publishStart)
 				logger.IncrementAMQPCounter(ctx)
 				logger.AddAMQPElapsed(ctx, elapsed.Nanoseconds())
 
@@ -475,7 +487,7 @@ func (c *AMQPClientImpl) PublishToExchange(ctx context.Context, options PublishO
 			// retryBackoff applies the attempt ceiling and a cancelable backoff between
 			// NACK retries — replacing the old zero-delay hot-spin so a transiently-
 			// unroutable publish gets a few spaced attempts without pinning a core.
-			if termErr := c.retryBackoff(ctx, options, startTime, span, retryCount, lastCause, c.nackBackoff); termErr != nil {
+			if termErr := c.retryBackoff(ctx, options, publishStart, span, retryCount, lastCause, c.nackBackoff); termErr != nil {
 				return termErr
 			}
 			continue
@@ -502,7 +514,7 @@ func (c *AMQPClientImpl) PublishToExchange(ctx context.Context, options PublishO
 			))
 			// No extra backoff — this path already waited connectionTimeout; just
 			// apply the attempt ceiling before retrying.
-			if termErr := c.retryBackoff(ctx, options, startTime, span, retryCount, lastCause, 0); termErr != nil {
+			if termErr := c.retryBackoff(ctx, options, publishStart, span, retryCount, lastCause, 0); termErr != nil {
 				return termErr
 			}
 			continue
@@ -534,6 +546,60 @@ func (c *AMQPClientImpl) publishPreflight(ctx context.Context, options PublishOp
 	return c.publishAbort(ctx, options, startTime, span, err, nil)
 }
 
+// readyWaitOutcome reports why pollUntilReady's bounded wait ended. Callers
+// translate it into their own error shape — pollUntilReady itself is
+// error-shape-agnostic so it can serve both waitForReady (which distinguishes
+// timeout/cancel/shutdown into three different errors) and
+// Registry.DeclareInfrastructure (which has no shutdown channel at all).
+type readyWaitOutcome int
+
+const (
+	readyWaitBecameReady readyWaitOutcome = iota
+	readyWaitTimedOut
+	readyWaitCanceled
+	readyWaitDone
+)
+
+// pollUntilReady runs the shared timer+ticker+select poll loop behind both
+// AMQPClientImpl.waitForReady and Registry.DeclareInfrastructure's readiness
+// wait. It does NOT perform an immediate pre-check of isReady() before
+// starting the ticker — callers that want to skip the wait entirely when
+// already ready must do that check themselves first (waitForReady does;
+// DeclareInfrastructure historically does not, so it always waits for at
+// least one interval tick before its first readiness check — preserved here
+// to keep that call site's observable behavior unchanged).
+//
+// done is optional: passing nil is safe because a nil channel is never
+// selectable (that case simply never fires), which is what
+// DeclareInfrastructure needs since it has no shutdown channel to watch.
+// onTick, also optional, runs once per failed poll (i.e. every interval tick
+// where isReady() is still false) — DeclareInfrastructure uses it to preserve
+// its per-tick Debug log; waitForReady passes nil since it never logged per-tick.
+func pollUntilReady(ctx context.Context, timeout, interval time.Duration, isReady func() bool, done <-chan bool, onTick func()) readyWaitOutcome {
+	t := time.NewTimer(timeout)
+	defer t.Stop()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return readyWaitCanceled
+		case <-done:
+			return readyWaitDone
+		case <-t.C:
+			return readyWaitTimedOut
+		case <-ticker.C:
+			if isReady() {
+				return readyWaitBecameReady
+			}
+			if onTick != nil {
+				onTick()
+			}
+		}
+	}
+}
+
 // waitForReady blocks PublishToExchange's pre-flight check until the client
 // becomes ready, the bounded readyTimeout elapses, the context is canceled, or
 // the client is shut down — whichever comes first. A readyTimeout <= 0 disables
@@ -541,7 +607,7 @@ func (c *AMQPClientImpl) publishPreflight(ctx context.Context, options PublishOp
 // reproducing the pre-#655 instant fail-fast for callers that opt out or for
 // struct-literal test clients that never set the field.
 //
-// Reuses the same readinessCheckInterval poll cadence as
+// Reuses the same readinessCheckInterval poll cadence (via pollUntilReady) as
 // Registry.DeclareInfrastructure so both "wait for ready" call sites share one
 // mental model. Returns errNotConnected (unwrapped) on timeout expiry — the
 // caller re-raises it as-is; ctx.Err() or errShutdown on cancellation/shutdown
@@ -554,24 +620,15 @@ func (c *AMQPClientImpl) waitForReady(ctx context.Context) error {
 		return nil
 	}
 
-	timeout := time.NewTimer(c.readyTimeout)
-	defer timeout.Stop()
-	ticker := time.NewTicker(readinessCheckInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-c.done:
-			return errShutdown
-		case <-timeout.C:
-			return errNotConnected
-		case <-ticker.C:
-			if c.IsReady() {
-				return nil
-			}
-		}
+	switch pollUntilReady(ctx, c.readyTimeout, readinessCheckInterval, c.IsReady, c.done, nil) {
+	case readyWaitBecameReady:
+		return nil
+	case readyWaitCanceled:
+		return ctx.Err()
+	case readyWaitDone:
+		return errShutdown
+	default: // readyWaitTimedOut
+		return errNotConnected
 	}
 }
 

--- a/messaging/amqp_client_integration_test.go
+++ b/messaging/amqp_client_integration_test.go
@@ -377,3 +377,52 @@ func TestAMQPClientClose(t *testing.T) {
 	err = client.Close()
 	assert.Error(t, err, "Second close should return error")
 }
+
+// TestAMQPClientPublishImmediatelyOnColdStart is the secondary (real-broker)
+// confirmation for issue #655: publish IMMEDIATELY on a freshly constructed
+// client, WITHOUT the require.Eventually(IsReady) wait every other test in
+// this file uses first. The default 5s messaging.reconnect.readytimeout
+// pre-flight inside PublishToExchange must absorb the connect+channel-init
+// window against a real broker — on unpatched code this regresses to an
+// instant ErrNotConnected.
+func TestAMQPClientPublishImmediatelyOnColdStart(t *testing.T) {
+	brokerURL := setupTestBroker(t)
+	log := logger.New("disabled", true)
+
+	// Topology declaration is unaffected by #655 (only PublishToExchange gets a
+	// pre-flight wait), so set it up with a client that has already reached
+	// readiness. The fix is exercised by a SEPARATE, freshly constructed client
+	// below.
+	setup := NewAMQPClient(brokerURL, log)
+	defer setup.Close()
+	require.Eventually(t, setup.IsReady, 10*time.Second, 200*time.Millisecond, clientReadyMsg)
+
+	ctx := context.Background()
+	exchangeName := uniqueName(t, "cold-start-exchange")
+	queueName := uniqueName(t, "cold-start-queue")
+	routingKey := "cold-start-route"
+
+	require.NoError(t, setup.DeclareExchange(exchangeName, "direct", false, true, false, false))
+	require.NoError(t, setup.DeclareQueue(queueName, false, true, false, false))
+	require.NoError(t, setup.BindQueue(queueName, exchangeName, routingKey, false))
+	deliveries, err := setup.Consume(ctx, queueName)
+	require.NoError(t, err)
+
+	cold := NewAMQPClient(brokerURL, log)
+	defer cold.Close()
+
+	testMsg := []byte("cold start message")
+	err = cold.PublishToExchange(ctx, PublishOptions{
+		Exchange:   exchangeName,
+		RoutingKey: routingKey,
+	}, testMsg)
+	require.NoError(t, err, "publish immediately after client construction must succeed via the readytimeout pre-flight wait")
+
+	select {
+	case delivery := <-deliveries:
+		assert.Equal(t, testMsg, delivery.Body)
+		_ = delivery.Ack(false)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for cold-start published message")
+	}
+}

--- a/messaging/amqp_client_test.go
+++ b/messaging/amqp_client_test.go
@@ -1283,6 +1283,134 @@ func TestWithMaxPublishAttemptsOption(t *testing.T) {
 	assert.Equal(t, 7, c.maxPublishAttempts)
 }
 
+// TestPublishToExchangeWaitsForReadyClient reproduces issue #655: a client that
+// is not yet ready (cold start, or mid-reconnect) must NOT fail the publish
+// instantly. It must wait, bounded by readyTimeout, and succeed once the client
+// becomes ready. ON CURRENT MAIN (no pre-flight wait) this returns
+// ErrNotConnected in microseconds and the assertion below fails — see this
+// task's pristine-main repro step for the captured behavioral failure.
+func TestPublishToExchangeWaitsForReadyClient(t *testing.T) {
+	c := &AMQPClientImpl{
+		m:                 &sync.RWMutex{},
+		log:               &stubLogger{},
+		connectionTimeout: 15 * time.Millisecond,
+		resendDelay:       5 * time.Millisecond,
+		reInitDelay:       5 * time.Millisecond,
+		reconnectDelay:    5 * time.Millisecond,
+		done:              make(chan bool),
+		isReady:           false, // cold: not ready yet
+		readyTimeout:      2 * time.Second,
+	}
+	t.Cleanup(func() {
+		select {
+		case <-c.done:
+			// already closed by the test itself
+		default:
+			_ = c.Close()
+		}
+	})
+
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- c.PublishToExchange(context.Background(), PublishOptions{Exchange: "ex", RoutingKey: "rk"}, []byte("msg"))
+	}()
+
+	// Outlast one 100ms readiness poll tick so the pre-flight wait is actually
+	// exercised (not a lucky first check).
+	time.Sleep(150 * time.Millisecond)
+
+	ch := &fakeChannel{}
+	c.m.Lock()
+	c.isReady = true
+	c.m.Unlock()
+	c.changeChannel(ch)
+	sendConfirmsAfterEachAttempt(t, c, ch, amqp.Confirmation{Ack: true, DeliveryTag: 1})
+
+	select {
+	case err := <-resultCh:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("PublishToExchange did not return after the client became ready")
+	}
+}
+
+// TestPublishToExchangeReadyTimeoutExpires proves that when the client never
+// becomes ready, the pre-flight wait gives up after readyTimeout and returns
+// the raw (unwrapped) ErrNotConnected — not wrapped by ErrPublishRetriesExhausted,
+// since the retry loop was never entered.
+func TestPublishToExchangeReadyTimeoutExpires(t *testing.T) {
+	c := &AMQPClientImpl{
+		m:            &sync.RWMutex{},
+		log:          &stubLogger{},
+		done:         make(chan bool),
+		isReady:      false,
+		readyTimeout: 200 * time.Millisecond,
+	}
+
+	start := time.Now()
+	err := c.PublishToExchange(context.Background(), PublishOptions{Exchange: "ex", RoutingKey: "rk"}, []byte("msg"))
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, ErrNotConnected)
+	assert.GreaterOrEqual(t, elapsed, 200*time.Millisecond)
+}
+
+// TestPublishToExchangeReadyWaitDisabled proves readyTimeout<=0 is a complete
+// no-op pre-flight, preserving the pre-#655 instant fail-fast byte-for-byte —
+// this is the Go zero value every existing struct-literal test client already
+// has, so it also guards against a regression in every not-ready test in this
+// file (e.g. TestPublishNotReadyReturnsErrNotConnected).
+func TestPublishToExchangeReadyWaitDisabled(t *testing.T) {
+	c := &AMQPClientImpl{
+		m:    &sync.RWMutex{},
+		log:  &stubLogger{},
+		done: make(chan bool),
+		// isReady and readyTimeout both left at their Go zero values.
+	}
+
+	start := time.Now()
+	err := c.PublishToExchange(context.Background(), PublishOptions{Exchange: "ex", RoutingKey: "rk"}, []byte("msg"))
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, ErrNotConnected)
+	assert.Less(t, elapsed, 50*time.Millisecond)
+}
+
+// TestPublishToExchangeReadyWaitRespectsContext proves a ctx deadline that
+// fires during the pre-flight wait aborts promptly (not waiting out the full
+// readyTimeout), and reports a context-related error.
+func TestPublishToExchangeReadyWaitRespectsContext(t *testing.T) {
+	c := &AMQPClientImpl{
+		m:            &sync.RWMutex{},
+		log:          &stubLogger{},
+		done:         make(chan bool),
+		isReady:      false,
+		readyTimeout: 5 * time.Second,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := c.PublishToExchange(ctx, PublishOptions{Exchange: "ex", RoutingKey: "rk"}, []byte("msg"))
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, elapsed, 200*time.Millisecond)
+}
+
+// TestWithReadyTimeoutOption mirrors TestWithMaxPublishAttemptsOption: the
+// constructor option sets the field and ignores non-positive values.
+func TestWithReadyTimeoutOption(t *testing.T) {
+	c := &AMQPClientImpl{}
+	WithReadyTimeout(3 * time.Second)(c)
+	assert.Equal(t, 3*time.Second, c.readyTimeout)
+	WithReadyTimeout(0)(c)
+	assert.Equal(t, 3*time.Second, c.readyTimeout)
+	WithReadyTimeout(-1 * time.Second)(c)
+	assert.Equal(t, 3*time.Second, c.readyTimeout)
+}
+
 // TestPublishToExchangeNackBackoffHonorsContextCancel proves the new backoff
 // between NACK retries is cancelable (not a blind sleep) — a 1h backoff returns
 // promptly when the context is canceled.

--- a/messaging/amqp_client_test.go
+++ b/messaging/amqp_client_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gaborage/go-bricks/logger"
 	gobrickstrace "github.com/gaborage/go-bricks/trace"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/assert"
@@ -1332,6 +1333,76 @@ func TestPublishToExchangeWaitsForReadyClient(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("PublishToExchange did not return after the client became ready")
 	}
+}
+
+// TestPublishToExchangeExcludesReadyWaitFromLatencyMetrics reproduces the follow-up
+// finding to issue #655: the readiness pre-flight wait must NOT be reported as
+// publish/broker latency. Reuses TestPublishToExchangeWaitsForReadyClient's exact
+// choreography (client becomes ready only after outlasting one 100ms poll tick) and
+// asserts, via the logger.GetAMQPElapsed seam, that the elapsed time PublishToExchange
+// records on its ACK success path excludes the ~150ms wait.
+//
+// This seam is used instead of asserting against the OTel metrics SDK directly:
+// tracking.RecordAMQPPublishMetrics is fed the exact same local `elapsed` variable as
+// logger.AddAMQPElapsed on the ACK branch (see amqp_client.go), and the metrics
+// package's own singleton meter is process-wide and reset only via an unexported
+// tracking-package test helper unreachable from this package — so this lower-level,
+// exported context seam gives a deterministic, package-local assertion of the exact
+// value both call sites share, without depending on OTel global-provider delegation
+// ordering across this whole test binary.
+//
+// ON PRE-FIX CODE (elapsed measured from before the pre-flight wait) this reports
+// >=150ms and the assertion below fails.
+func TestPublishToExchangeExcludesReadyWaitFromLatencyMetrics(t *testing.T) {
+	c := &AMQPClientImpl{
+		m:                 &sync.RWMutex{},
+		log:               &stubLogger{},
+		connectionTimeout: 15 * time.Millisecond,
+		resendDelay:       5 * time.Millisecond,
+		reInitDelay:       5 * time.Millisecond,
+		reconnectDelay:    5 * time.Millisecond,
+		done:              make(chan bool),
+		isReady:           false, // cold: not ready yet
+		readyTimeout:      2 * time.Second,
+	}
+	t.Cleanup(func() {
+		select {
+		case <-c.done:
+			// already closed by the test itself
+		default:
+			_ = c.Close()
+		}
+	})
+
+	ctx := logger.WithRequestCounters(context.Background())
+
+	resultCh := make(chan error, 1)
+	go func() {
+		resultCh <- c.PublishToExchange(ctx, PublishOptions{Exchange: "ex", RoutingKey: "rk"}, []byte("msg"))
+	}()
+
+	// Outlast one 100ms readiness poll tick so the pre-flight wait is actually
+	// exercised (not a lucky first check) — same choreography as
+	// TestPublishToExchangeWaitsForReadyClient.
+	time.Sleep(150 * time.Millisecond)
+
+	ch := &fakeChannel{}
+	c.m.Lock()
+	c.isReady = true
+	c.m.Unlock()
+	c.changeChannel(ch)
+	sendConfirmsAfterEachAttempt(t, c, ch, amqp.Confirmation{Ack: true, DeliveryTag: 1})
+
+	select {
+	case err := <-resultCh:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("PublishToExchange did not return after the client became ready")
+	}
+
+	elapsed := time.Duration(logger.GetAMQPElapsed(ctx))
+	assert.Less(t, elapsed, 100*time.Millisecond,
+		"publish-latency elapsed must exclude the ~150ms readiness wait, got %s", elapsed)
 }
 
 // TestPublishToExchangeReadyTimeoutExpires proves that when the client never

--- a/messaging/manager.go
+++ b/messaging/manager.go
@@ -103,6 +103,9 @@ type ManagerOptions struct {
 	// MaxPublishAttempts bounds the per-publish retry loop for clients created by the
 	// default factory. Zero (or negative) leaves the client default (5).
 	MaxPublishAttempts int
+	// ReadyTimeout bounds the pre-flight readiness wait for clients created by the
+	// default factory. Zero (or negative) leaves the client default (5s).
+	ReadyTimeout time.Duration
 }
 
 // NewMessagingManager creates a new messaging manager
@@ -120,6 +123,7 @@ func NewMessagingManager(resourceSource BrokerURLProvider, log logger.Logger, op
 			return NewAMQPClient(url, log,
 				WithConnectionTimeout(opts.ConnectionTimeout),
 				WithMaxPublishAttempts(opts.MaxPublishAttempts),
+				WithReadyTimeout(opts.ReadyTimeout),
 			)
 		}
 	}

--- a/messaging/manager_test.go
+++ b/messaging/manager_test.go
@@ -1068,3 +1068,49 @@ func TestMessagingManagerPublisherReleaseIsIdempotent(t *testing.T) {
 		releaseA() // double release must be a safe no-op
 	})
 }
+
+// TestMessagingManagerColdRecreateAfterIdleEviction reproduces the issue #655
+// timeline: a once-daily publisher goes idle past IdleTTL, gets evicted, and
+// the NEXT Publisher() call must hand back a freshly created (cold) client
+// rather than reusing the evicted one. This is not a fail-on-main regression
+// test (stubAMQPClient has no not-ready state to model the readiness bug
+// itself — see Task 1.1's client-level tests for that); it documents and
+// locks in the eviction → cold-recreate sequence that triggers the bug.
+func TestMessagingManagerColdRecreateAfterIdleEviction(t *testing.T) {
+	ctx := context.Background()
+	log := logger.New("error", false)
+
+	var mu sync.Mutex
+	created := make([]*stubAMQPClient, 0, 2)
+	factory := func(string, logger.Logger) AMQPClient {
+		c := &stubAMQPClient{}
+		mu.Lock()
+		created = append(created, c)
+		mu.Unlock()
+		return c
+	}
+
+	manager := NewMessagingManager(&stubMessagingSource{urls: map[string]string{tenantID: amqpHost}}, log, ManagerOptions{MaxPublishers: 5, IdleTTL: time.Hour}, factory)
+	defer func() { _ = manager.Close() }()
+
+	first, relFirst, err := manager.Publisher(ctx, tenantID)
+	require.NoError(t, err)
+	relFirst()
+
+	// Backdate lastUsed so the cleanup pass sees the entry as idle, mirroring
+	// TestMessagingManagerCleanupIdlePublishersLogsCloseError's idiom.
+	manager.pubMu.Lock()
+	manager.publishers[tenantID].lastUsed = time.Now().Add(-2 * time.Hour)
+	manager.pubMu.Unlock()
+
+	manager.cleanupIdlePublishers()
+
+	second, relSecond, err := manager.Publisher(ctx, tenantID)
+	require.NoError(t, err)
+	defer relSecond()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, created, 2, "idle eviction must force a fresh client on the next Publisher() call")
+	assert.NotSame(t, first, second, "publisher after idle eviction must be a newly created (cold) client")
+}

--- a/messaging/registry.go
+++ b/messaging/registry.go
@@ -266,29 +266,22 @@ func (r *Registry) DeclareInfrastructure(ctx context.Context) error {
 		return fmt.Errorf("AMQP client is not available")
 	}
 
-	// Wait for AMQP client to be ready with timeout
-	timeout := time.NewTimer(readyTimeoutDuration)
-	defer timeout.Stop()
-
-	ticker := time.NewTicker(readinessCheckInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("context canceled while waiting for AMQP client: %w", ctx.Err())
-		case <-timeout.C:
-			return fmt.Errorf("timeout waiting for AMQP client to be ready")
-		case <-ticker.C:
-			if r.client.IsReady() {
-				r.logger.Info().Msg("AMQP client is ready, proceeding with infrastructure declaration")
-				goto ready
-			}
-			r.logger.Debug().Msg("Waiting for AMQP client to be ready...")
-		}
+	// Wait for AMQP client to be ready with timeout. Shares its poll loop with
+	// AMQPClientImpl.waitForReady via pollUntilReady (see amqp_client.go); this
+	// call site has no shutdown channel (done is nil, so readyWaitDone never
+	// fires) and — unlike waitForReady — does not pre-check IsReady() before the
+	// first tick, preserving this method's historical behavior of always waiting
+	// at least one readinessCheckInterval before its first readiness check.
+	switch pollUntilReady(ctx, readyTimeoutDuration, readinessCheckInterval, r.client.IsReady, nil, func() {
+		r.logger.Debug().Msg("Waiting for AMQP client to be ready...")
+	}) {
+	case readyWaitBecameReady:
+		r.logger.Info().Msg("AMQP client is ready, proceeding with infrastructure declaration")
+	case readyWaitCanceled:
+		return fmt.Errorf("context canceled while waiting for AMQP client: %w", ctx.Err())
+	default: // readyWaitTimedOut (readyWaitDone is unreachable: done is nil)
+		return fmt.Errorf("timeout waiting for AMQP client to be ready")
 	}
-
-ready:
 
 	r.logger.Info().
 		Int("exchanges", len(r.exchanges)).

--- a/outbox/module.go
+++ b/outbox/module.go
@@ -131,6 +131,12 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 // routes the message, but the relay never marks it published and re-publishes it on every
 // cycle — an unbounded duplicate-delivery loop. That is severe enough to reject at startup
 // (Fail Fast) rather than emit a warning an operator might miss.
+//
+// It also requires publishtimeout >= messaging.reconnect.readytimeout: a shorter value makes
+// the per-record deadline expire INSIDE the client's readiness pre-flight, so a not-ready
+// broker surfaces as context.DeadlineExceeded instead of ErrNotConnected — which silently
+// defeats the relay's mid-batch broker-drop detection (outcomeBrokerDown never fires) and
+// reintroduces the serial per-record stall it exists to cap.
 func (m *Module) validatePublishTimeout() error {
 	if m.config == nil {
 		return nil
@@ -140,6 +146,12 @@ func (m *Module) validatePublishTimeout() error {
 		return fmt.Errorf("outbox: publishtimeout (%s) must be >= messaging.reconnect.connectiontimeout (%s); "+
 			"a shorter value truncates every publish confirmation into a false failure (duplicate-delivery loop)",
 			m.cfg.PublishTimeout, ct)
+	}
+	rt := m.config.Messaging.Reconnect.ReadyTimeout
+	if rt > 0 && m.cfg.PublishTimeout < rt {
+		return fmt.Errorf("outbox: publishtimeout (%s) must be >= messaging.reconnect.readytimeout (%s); "+
+			"a shorter value expires inside the readiness pre-flight and defeats the relay's mid-batch broker-drop detection",
+			m.cfg.PublishTimeout, rt)
 	}
 	return nil
 }

--- a/outbox/module_test.go
+++ b/outbox/module_test.go
@@ -197,6 +197,31 @@ func TestModuleInitRejectsPublishTimeoutBelowConnectionTimeout(t *testing.T) {
 	assert.Contains(t, err.Error(), "connectiontimeout")
 }
 
+// TestModuleInitRejectsPublishTimeoutBelowReadyTimeout guards the companion fail-fast: a
+// publishtimeout shorter than the client's readiness pre-flight wait expires INSIDE that
+// wait, so a not-ready broker surfaces as context.DeadlineExceeded instead of
+// ErrNotConnected — silently defeating the relay's mid-batch broker-drop detection.
+func TestModuleInitRejectsPublishTimeoutBelowReadyTimeout(t *testing.T) {
+	m := NewModule()
+	deps := &app.ModuleDeps{
+		Logger: logger.New("info", false),
+		Config: &config.Config{
+			Outbox: config.OutboxConfig{Enabled: true, PublishTimeout: 3 * time.Second},
+			Messaging: config.MessagingConfig{
+				Broker:    config.BrokerConfig{URL: "amqp://localhost"},
+				Reconnect: config.ReconnectConfig{ReadyTimeout: 5 * time.Second},
+			},
+		},
+		DB:        func(_ context.Context) (dbtypes.Interface, error) { return nil, nil },
+		Messaging: func(_ context.Context) (messaging.AMQPClient, error) { return nil, nil },
+	}
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "publishtimeout")
+	assert.Contains(t, err.Error(), "readytimeout")
+}
+
 // TestModuleInitEnabledMessagingUnconfiguredMultiTenant verifies the static
 // check is skipped when multitenant.enabled=true — each tenant supplies its
 // own broker URL via the resource source, so a global check would be wrong.

--- a/outbox/relay.go
+++ b/outbox/relay.go
@@ -65,6 +65,14 @@ const (
 	outcomeFailed                                    // failed; retry_count advanced, record stays pending
 	outcomeDeadLettered                              // poison exhausted MaxRetries; parked as status=failed
 	outcomeAborted                                   // interrupted by shutdown/cancel; do NOT count, stop the batch
+	// outcomeBrokerDown signals that THIS record's publish failed with a connectivity
+	// error (messaging.ErrNotConnected) AND the client is still not ready right now —
+	// i.e. the broker dropped mid-batch rather than being down at cycle start. This
+	// record keeps normal failed accounting (markRecordFailed already ran); the
+	// caller stops the loop and routes the UNATTEMPTED remainder through the same
+	// outage semantics markOutage applies at cycle start, instead of letting every
+	// remaining record pay its own serial readiness pre-flight wait.
+	outcomeBrokerDown
 )
 
 // relayTenant runs a single relay cycle for the given (tenant-scoped) context.
@@ -111,31 +119,61 @@ func (r *Relay) relayTenant(ctx context.Context, log logger.Logger, tenantID str
 		return brokerUnavailableErr(msgErr)
 	}
 
-	var published, unrecorded, failed, deadlettered int
-relayLoop:
+	res := r.runRelayLoop(ctx, log, db, msgClient, records)
+
+	r.logCycle(log, tenantID, res.published, res.unrecorded, res.failed, res.deadlettered, len(records))
+	if res.outageErr != nil {
+		return brokerUnavailableErr(res.outageErr)
+	}
+	return nil
+}
+
+// relayBatchResult holds the per-record bookkeeping counts from one relay cycle's
+// publish loop, plus (if the batch stopped early on a mid-batch broker drop) the
+// outage error the caller surfaces at the job level.
+type relayBatchResult struct {
+	published, unrecorded, failed, deadlettered int
+	outageErr                                   error
+}
+
+// runRelayLoop publishes each pending record in order, stopping early on
+// shutdown/cancel, a shutdown-aborted publish, or a mid-batch broker drop
+// (outcomeBrokerDown — see publishRecord). Split out of relayTenant to keep
+// that function's cyclomatic complexity within budget (gocyclo).
+func (r *Relay) runRelayLoop(ctx context.Context, log logger.Logger, db dbtypes.Interface, msgClient messaging.AMQPClient, records []Record) relayBatchResult {
+	var res relayBatchResult
 	for i := range records {
 		// Stop cleanly on shutdown/cancel: leave the rest pending for the next startup
 		// rather than bumping their retry_count on the way down.
 		if ctx.Err() != nil {
 			break
 		}
-		switch r.publishRecord(ctx, log, db, msgClient, &records[i]) {
+		outcome, pubErr := r.publishRecord(ctx, log, db, msgClient, &records[i])
+		switch outcome {
 		case outcomePublished:
-			published++
+			res.published++
 		case outcomePublishedUnrecorded:
-			unrecorded++
+			res.unrecorded++
 		case outcomeFailed:
-			failed++
+			res.failed++
 		case outcomeDeadLettered:
-			deadlettered++
+			res.deadlettered++
+		case outcomeBrokerDown:
+			// The broker dropped mid-batch: this record's own failed accounting
+			// already ran inside publishRecord. Route the UNATTEMPTED remainder
+			// through the same outage path markOutage applies at cycle start —
+			// advance retry_count without paying each record's own serial
+			// readiness pre-flight wait — and stop the loop.
+			res.failed++
+			res.outageErr = pubErr
+			r.markOutage(ctx, log, db, records[i+1:])
+			return res
 		case outcomeAborted:
 			// Shutting down mid-publish — stop without counting this record.
-			break relayLoop
+			return res
 		}
 	}
-
-	r.logCycle(log, tenantID, published, unrecorded, failed, deadlettered, len(records))
-	return nil
+	return res
 }
 
 // markOutage advances retry_count for every pending record without attempting a publish,
@@ -179,13 +217,15 @@ func brokerUnavailableErr(msgErr error) error {
 // publishRecord attempts to publish a single outbox record and returns the bookkeeping
 // outcome. All Mark* calls run on the parent ctx; the per-record publish deadline applies
 // only to the publish itself, so an expired deadline never fails the bookkeeping UPDATE.
-func (r *Relay) publishRecord(ctx context.Context, log logger.Logger, db dbtypes.Interface, msgClient messaging.AMQPClient, record *Record) publishOutcome {
+// The second return is non-nil only for outcomeBrokerDown, carrying the connectivity
+// error the caller surfaces as the job-level outage error (see relayTenant).
+func (r *Relay) publishRecord(ctx context.Context, log logger.Logger, db dbtypes.Interface, msgClient messaging.AMQPClient, record *Record) (publishOutcome, error) {
 	// Decode headers — corrupt headers are deterministic, broker-independent corruption
 	// (poison), so they dead-letter at MaxRetries rather than retrying forever. This is the
 	// ONLY poison case; every broker-side publish failure below is connectivity.
 	headers, decodeErr := decodeHeaders(record.Headers)
 	if decodeErr != nil {
-		return r.deadLetterPoison(ctx, log, db, record, decodeErr.Error())
+		return r.deadLetterPoison(ctx, log, db, record, decodeErr.Error()), nil
 	}
 
 	// Inject outbox metadata headers for consumer idempotency
@@ -217,7 +257,7 @@ func (r *Relay) publishRecord(ctx context.Context, log logger.Logger, db dbtypes
 	if err != nil {
 		// Shutdown/cancel is not a delivery failure — do not advance retry_count.
 		if errors.Is(err, context.Canceled) || errors.Is(err, messaging.ErrShutdown) {
-			return outcomeAborted
+			return outcomeAborted, nil
 		}
 		// Every broker-side publish failure — NOT-connected, confirmation timeout, deadline,
 		// and even a broker NACK — is CONNECTIVITY: the broker either could not be reached or
@@ -226,7 +266,16 @@ func (r *Relay) publishRecord(ctx context.Context, log logger.Logger, db dbtypes
 		// synthesized NACK too — neither means the message is bad, so neither parks. We advance
 		// retry_count and retry (at-least-once); only undecodable headers (above) are poison.
 		r.markRecordFailed(ctx, log, db, record.ID, err.Error())
-		return outcomeFailed
+		// A not-connected error AND a still-not-ready client (checked fresh, not
+		// inferred from the error alone) means the broker dropped mid-batch — the
+		// caller stops attempting the rest rather than letting each remaining
+		// record pay its own serial readiness pre-flight wait. If IsReady() has
+		// already flipped back to true (a brief flap), fall through to the normal
+		// per-record failed outcome and keep the batch going.
+		if errors.Is(err, messaging.ErrNotConnected) && !msgClient.IsReady() {
+			return outcomeBrokerDown, err
+		}
+		return outcomeFailed, nil
 	}
 
 	if err := r.store.MarkPublished(ctx, db, record.ID); err != nil {
@@ -236,10 +285,10 @@ func (r *Relay) publishRecord(ctx context.Context, log logger.Logger, db dbtypes
 			Msg("Failed to mark outbox event as published")
 		// The message WAS delivered; do not bump retry_count. It re-delivers next
 		// cycle and the consumer dedups via the x-outbox-event-id header.
-		return outcomePublishedUnrecorded
+		return outcomePublishedUnrecorded, nil
 	}
 
-	return outcomePublished
+	return outcomePublished, nil
 }
 
 // deadLetterPoison handles a poison record (undecodable headers): it advances retry_count and,

--- a/outbox/relay.go
+++ b/outbox/relay.go
@@ -163,10 +163,12 @@ func (r *Relay) runRelayLoop(ctx context.Context, log logger.Logger, db dbtypes.
 			// already ran inside publishRecord. Route the UNATTEMPTED remainder
 			// through the same outage path markOutage applies at cycle start —
 			// advance retry_count without paying each record's own serial
-			// readiness pre-flight wait — and stop the loop.
+			// readiness pre-flight wait — and stop the loop. The remainder counts
+			// as failed too (markOutage marked it in the DB), so logCycle's counts
+			// still sum to the batch total.
 			res.failed++
 			res.outageErr = pubErr
-			r.markOutage(ctx, log, db, records[i+1:])
+			res.failed += r.markOutage(ctx, log, db, records[i+1:])
 			return res
 		case outcomeAborted:
 			// Shutting down mid-publish — stop without counting this record.
@@ -178,14 +180,17 @@ func (r *Relay) runRelayLoop(ctx context.Context, log logger.Logger, db dbtypes.
 
 // markOutage advances retry_count for every pending record without attempting a publish,
 // used when the broker is unreachable/not-ready. Stops early on shutdown/cancel so a
-// shutdown does not inflate retry_count for records it never got to.
-func (r *Relay) markOutage(ctx context.Context, log logger.Logger, db dbtypes.Interface, records []Record) {
+// shutdown does not inflate retry_count for records it never got to. Returns how many
+// records it actually marked (fewer than len(records) on early stop) so callers can
+// fold the outage remainder into their cycle accounting.
+func (r *Relay) markOutage(ctx context.Context, log logger.Logger, db dbtypes.Interface, records []Record) int {
 	for i := range records {
 		if ctx.Err() != nil {
-			return
+			return i
 		}
 		r.markRecordFailed(ctx, log, db, records[i].ID, "messaging unavailable")
 	}
+	return len(records)
 }
 
 // logCycle emits the per-cycle delivery summary. "unrecorded" counts events delivered to the

--- a/outbox/relay_test.go
+++ b/outbox/relay_test.go
@@ -502,6 +502,45 @@ func TestRelayStopsBatchWhenBrokerDropsMidBatch(t *testing.T) {
 	assert.Equal(t, 0, store.MarkDeadLetteredCalls)
 }
 
+// TestRelayMidBatchDropAccountingSumsToTotal guards the cycle-accounting invariant for
+// the mid-batch broker-drop path: the outage remainder routed through markOutage is
+// marked failed in the DB, so it must be reflected in the batch result too — otherwise
+// logCycle reports published+unrecorded+failed+deadlettered < total whenever the drop
+// isn't on the last record. Tests runRelayLoop directly since relayBatchResult is the
+// seam that feeds logCycle's arguments (Execute discards it and the test logger is
+// disabled, so there is no log-capture seam in this file).
+func TestRelayMidBatchDropAccountingSumsToTotal(t *testing.T) {
+	records := []Record{
+		{ID: "evt-1", Exchange: "ex", RoutingKey: "rk1"},
+		{ID: "evt-2", Exchange: "ex", RoutingKey: "rk2"},
+		{ID: "evt-3", Exchange: "ex", RoutingKey: "rk3"},
+	}
+	store := &fakeStore{}
+	amqp := newFakeAMQP()
+	amqp.PublishErrFor = map[string]error{
+		"ex:rk2": messaging.ErrNotConnected,
+	}
+	amqp.PublishHook = func(f *fakeAMQP) {
+		if f.PublishCalls == 2 {
+			f.Ready = false
+		}
+	}
+	r := newRelayWithFakes(store, amqp)
+	db := dbtesting.NewTestDB("postgresql")
+	ctx := newFakeJobCtx(db, amqp)
+
+	res := r.runRelayLoop(ctx, ctx.Logger(), db, amqp, records)
+
+	assert.Equal(t, 1, res.published, "record 1 published before the drop")
+	assert.Equal(t, 0, res.unrecorded)
+	assert.Equal(t, 0, res.deadlettered)
+	assert.Equal(t, 2, res.failed, "record 2 (failed attempt) AND record 3 (outage remainder) both count as failed")
+	assert.ErrorIs(t, res.outageErr, messaging.ErrNotConnected)
+	sum := res.published + res.unrecorded + res.failed + res.deadlettered
+	assert.Equal(t, len(records), sum, "cycle accounting must sum to the batch total")
+	assert.Equal(t, res.failed, store.MarkFailedCalls, "result count matches what was actually marked failed in the DB")
+}
+
 // TestRelayContinuesBatchWhenNotConnectedButStillReady locks in the "AND IsReady()"
 // half of the mid-batch-drop detection: an ErrNotConnected on its own (e.g. a stray
 // error classification, or a flap that already recovered) must NOT stop the batch

--- a/outbox/relay_test.go
+++ b/outbox/relay_test.go
@@ -192,9 +192,10 @@ func TestPublishRecordMarksFailedOnInvalidHeaders(t *testing.T) {
 	ctx := newFakeJobCtx(db, amqp)
 
 	rec := &Record{ID: "evt-bad-hdr", Headers: []byte(`{not valid json}`)}
-	out := r.publishRecord(ctx, ctx.Logger(), db, amqp, rec)
+	out, outErr := r.publishRecord(ctx, ctx.Logger(), db, amqp, rec)
 
 	assert.Equal(t, outcomeFailed, out, "corrupt headers are a (poison) failure")
+	assert.NoError(t, outErr)
 	assert.Equal(t, 0, amqp.PublishCalls, "publish never attempted with bad headers")
 	assert.Equal(t, 1, store.MarkFailedCalls)
 	assert.Equal(t, "evt-bad-hdr", store.MarkFailedLastID)
@@ -215,8 +216,9 @@ func TestPublishRecordInjectsOutboxMetadataHeaders(t *testing.T) {
 		RoutingKey: "created",
 		Headers:    []byte(`{"x-correlation-id":"abc"}`),
 	}
-	out := r.publishRecord(ctx, ctx.Logger(), db, amqp, rec)
+	out, outErr := r.publishRecord(ctx, ctx.Logger(), db, amqp, rec)
 	require.Equal(t, outcomePublished, out)
+	require.NoError(t, outErr)
 
 	require.NotNil(t, amqp.LastPublishHdrs)
 	assert.Equal(t, "evt-42", amqp.LastPublishHdrs[HeaderEventID])
@@ -234,7 +236,9 @@ func TestPublishRecordInjectsHeadersWhenRecordHasNone(t *testing.T) {
 	ctx := newFakeJobCtx(db, amqp)
 
 	rec := &Record{ID: "evt-7", EventType: "x.y", Exchange: "ex", RoutingKey: "rk"}
-	require.Equal(t, outcomePublished, r.publishRecord(ctx, ctx.Logger(), db, amqp, rec))
+	out, outErr := r.publishRecord(ctx, ctx.Logger(), db, amqp, rec)
+	require.Equal(t, outcomePublished, out)
+	require.NoError(t, outErr)
 	require.NotNil(t, amqp.LastPublishHdrs)
 	assert.Equal(t, "evt-7", amqp.LastPublishHdrs[HeaderEventID])
 }
@@ -247,9 +251,10 @@ func TestPublishRecordReturnsFalseWhenMarkPublishedFails(t *testing.T) {
 	ctx := newFakeJobCtx(db, amqp)
 
 	rec := &Record{ID: "evt-mp-fail", Exchange: "ex", RoutingKey: "rk"}
-	out := r.publishRecord(ctx, ctx.Logger(), db, amqp, rec)
+	out, outErr := r.publishRecord(ctx, ctx.Logger(), db, amqp, rec)
 
 	assert.Equal(t, outcomePublishedUnrecorded, out, "the message WAS delivered; a MarkPublished failure must not bump retry_count")
+	assert.NoError(t, outErr)
 	assert.Equal(t, 1, amqp.PublishCalls)
 	assert.Equal(t, 1, store.MarkPublishedCalls)
 	assert.Equal(t, 0, store.MarkFailedCalls, "MarkFailed not called when only MarkPublished failed")
@@ -276,7 +281,9 @@ func TestPublishRecordRehydratesTraceContextForPublish(t *testing.T) {
 		RoutingKey: "created",
 		Headers:    []byte(`{"traceparent":"` + inboundTraceparent + `","X-Request-ID":"` + inboundTraceID + `"}`),
 	}
-	require.Equal(t, outcomePublished, r.publishRecord(ctx, ctx.Logger(), db, amqp, rec))
+	out, outErr := r.publishRecord(ctx, ctx.Logger(), db, amqp, rec)
+	require.Equal(t, outcomePublished, out)
+	require.NoError(t, outErr)
 
 	require.NotNil(t, amqp.LastPublishCtx, "publish context must be captured")
 	tp, ok := gobrickstrace.ParentFromContext(amqp.LastPublishCtx)
@@ -454,4 +461,69 @@ func TestRelayPerRecordPublishTimeoutDoesNotStarveBatch(t *testing.T) {
 	assert.Equal(t, "healthy", store.MarkPublishedLastID)
 	assert.Equal(t, 1, store.MarkFailedCalls, "the stuck record times out and advances retry_count (connectivity)")
 	assert.Equal(t, "stuck", store.MarkFailedLastID)
+}
+
+// TestRelayStopsBatchWhenBrokerDropsMidBatch guards the fix for a mid-batch broker drop:
+// before this fix, once the broker dropped after the cycle-start IsReady() gate had
+// already passed, every REMAINING record in the batch paid its own serial readiness
+// pre-flight wait inside PublishToExchange (BatchSize x readyTimeout stall). Now the
+// relay detects the drop on the record whose publish fails with ErrNotConnected AND
+// IsReady() still false, and routes the unattempted remainder through the same
+// no-publish outage path the cycle-start gate uses — stopping the loop immediately.
+func TestRelayStopsBatchWhenBrokerDropsMidBatch(t *testing.T) {
+	store := &fakeStore{FetchPendingResult: []Record{
+		{ID: "evt-1", Exchange: "ex", RoutingKey: "rk1"},
+		{ID: "evt-2", Exchange: "ex", RoutingKey: "rk2"},
+		{ID: "evt-3", Exchange: "ex", RoutingKey: "rk3"},
+	}}
+	amqp := newFakeAMQP()
+	amqp.PublishErrFor = map[string]error{
+		"ex:rk2": messaging.ErrNotConnected,
+	}
+	amqp.PublishHook = func(f *fakeAMQP) {
+		if f.PublishCalls == 2 {
+			// Simulate the broker dropping connectivity exactly as record 2's
+			// publish is about to fail with ErrNotConnected.
+			f.Ready = false
+		}
+	}
+	r := newRelayWithFakes(store, amqp)
+	db := dbtesting.NewTestDB("postgresql")
+	ctx := newFakeJobCtx(db, amqp)
+
+	err := r.Execute(ctx)
+	require.Error(t, err, "the mid-batch outage surfaces as a job-level error, like the cycle-start path")
+	assert.Contains(t, err.Error(), "messaging not available")
+
+	assert.Equal(t, 2, amqp.PublishCalls, "the loop stops after record 2's connectivity failure — record 3 is never attempted")
+	assert.Equal(t, 1, store.MarkPublishedCalls, "record 1 published normally before the drop")
+	assert.Equal(t, "evt-1", store.MarkPublishedLastID)
+	assert.Equal(t, 2, store.MarkFailedCalls, "record 2 (the failed attempt) and record 3 (the outage remainder) both advance retry_count")
+	assert.Equal(t, 0, store.MarkDeadLetteredCalls)
+}
+
+// TestRelayContinuesBatchWhenNotConnectedButStillReady locks in the "AND IsReady()"
+// half of the mid-batch-drop detection: an ErrNotConnected on its own (e.g. a stray
+// error classification, or a flap that already recovered) must NOT stop the batch
+// when the client reports ready again by the time the check runs — that is an
+// ordinary per-record failure, not a broker-down condition.
+func TestRelayContinuesBatchWhenNotConnectedButStillReady(t *testing.T) {
+	store := &fakeStore{FetchPendingResult: []Record{
+		{ID: "evt-1", Exchange: "ex", RoutingKey: "rk1"},
+		{ID: "evt-2", Exchange: "ex", RoutingKey: "rk2"},
+	}}
+	amqp := newFakeAMQP()
+	amqp.PublishErrFor = map[string]error{
+		"ex:rk1": messaging.ErrNotConnected,
+	}
+	r := newRelayWithFakes(store, amqp)
+	db := dbtesting.NewTestDB("postgresql")
+	ctx := newFakeJobCtx(db, amqp)
+
+	require.NoError(t, r.Execute(ctx), "IsReady() stayed true, so this is an ordinary failure — no job-level outage error")
+	assert.Equal(t, 2, amqp.PublishCalls, "record 2 is still attempted despite record 1's ErrNotConnected")
+	assert.Equal(t, 1, store.MarkPublishedCalls)
+	assert.Equal(t, "evt-2", store.MarkPublishedLastID)
+	assert.Equal(t, 1, store.MarkFailedCalls)
+	assert.Equal(t, "evt-1", store.MarkFailedLastID)
 }

--- a/outbox/test_helpers_test.go
+++ b/outbox/test_helpers_test.go
@@ -164,6 +164,12 @@ type fakeAMQP struct {
 	// until ctx is done and then return ctx.Err() — simulating a stuck broker that
 	// the relay's per-record PublishTimeout must interrupt without starving siblings.
 	PublishBlock map[string]bool
+	// PublishHook, if set, runs synchronously inside PublishToExchange (while
+	// still holding the internal lock) right after PublishCalls is incremented
+	// and before the configured error is resolved. Lets a test flip Ready
+	// exactly on a specific call number to simulate the broker dropping
+	// connectivity mid-batch (rather than being down for the whole cycle).
+	PublishHook func(f *fakeAMQP)
 
 	// Captured calls.
 	PublishCalls    int
@@ -188,6 +194,9 @@ func (f *fakeAMQP) PublishToExchange(ctx context.Context, opts messaging.Publish
 	f.LastPublishData = data
 	f.LastPublishHdrs = opts.Headers
 	f.LastPublishCtx = ctx
+	if f.PublishHook != nil {
+		f.PublishHook(f)
+	}
 	key := opts.Exchange + ":" + opts.RoutingKey
 	block := f.PublishBlock[key]
 	err := f.PublishErr

--- a/wiki/context_deadlines.md
+++ b/wiki/context_deadlines.md
@@ -15,6 +15,7 @@ Every operation that crosses an external boundary already has a configured timeo
 | HTTP server graceful shutdown | `server.timeout.shutdown` | 10s | Drain inflight requests on SIGTERM |
 | Outbound HTTP client | `httpclient.NewBuilder(...).WithTimeout(d)` | 30s | Per-request timeout on the underlying `http.Client` |
 | Cache (Redis) dial / read / write | `cache.redis.{dialtimeout,readtimeout,writetimeout}` | 5s / 3s / 3s | Per-operation socket timeouts |
+| AMQP publish readiness pre-flight | `messaging.reconnect.readytimeout` | 5s | Context-aware wait for a cold/reconnecting client to become ready; runs once per publish call, before the first attempt (and its confirmation wait) begins — see [messaging.md](messaging.md#cold-client-readiness-pre-flight-reconnectreadytimeout) |
 | AMQP publish confirmation | `messaging.reconnect.connectiontimeout` | 30s | Per-publish wait for broker ACK/NACK. Connection dial uses `amqp091-go`'s `amqp.Dial` (its own ~30s TCP+handshake timeout), not this key |
 | Scheduler — slow job warning | `scheduler.timeout.slowjob` | 25s | Logs WARN if a job exceeds this; does not cancel |
 | Scheduler — graceful shutdown | `scheduler.timeout.shutdown` | 30s | Wait for in-flight jobs on shutdown |

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -264,7 +264,9 @@ retry loop described above. The wait polls every 100ms (the same cadence
 
 There is no circuit breaker or single-flight coalescing at the client level: during a sustained
 broker outage, every publish independently waits up to `min(readytimeout, ctx deadline)` before
-returning `messaging.ErrNotConnected` — prefer short ctx deadlines on latency-sensitive paths.
+failing — with `messaging.ErrNotConnected` when `readytimeout` expires first, or the ctx's own
+error (`context.DeadlineExceeded` / `context.Canceled`) when the ctx deadline binds — so match
+both when classifying. Prefer short ctx deadlines on latency-sensitive paths.
 
 **Need fail-fast anyway?** Two working options:
 

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -224,11 +224,16 @@ failure:
 > backoff).
 
 Cancel / shutdown / deadline returns are also wrapped with the last cause, so a deadline that
-fires after a NACK still reports `ErrPublishNacked` — **match with `errors.Is`, not `==`**.
+fires after a NACK still reports `ErrPublishNacked` — **match with `errors.Is`, not `==`**
+(use `errors.Is` for the raw `ErrNotConnected` sentinel too: it works on unwrapped errors, and
+it keeps working if a future version ever wraps it).
 Between NACK retries the client waits a small cancelable `nackBackoff` (100ms) rather than
 busy-spinning. These causes are informational for logging/observability; the outbox relay treats
-**every** publish failure (NACK included) as a recoverable *connectivity* failure that retries and
-never parks — only undecodable message bodies are poison — see
+**every** publish failure as a recoverable *connectivity* failure that retries and never parks —
+NACK included, and likewise a raw `ErrNotConnected`, though the relay rarely sees one: it checks
+`IsReady()` itself at the start of each cycle and routes a cold broker to its outage path
+(advancing `retry_count` without calling `PublishToExchange` at all). Only undecodable message
+headers are poison — see
 [outbox.md](outbox.md#retry--dead-lettering) and [ADR-033](adr_033_outbox_retry_count_status_parking.md).
 
 > **Breaking change:** before this, a persistently-failing publish looped **forever** (returning
@@ -250,23 +255,36 @@ retry loop described above. The wait polls every 100ms (the same cadence
 
 - If the client becomes ready within the window, the publish proceeds normally into the retry loop.
 - If `reconnect.readytimeout` elapses first, `PublishToExchange` returns the raw
-  `messaging.ErrNotConnected` — unwrapped, matching the pre-#655 behavior exactly — and **not**
-  counted against `reconnect.maxpublishattempts`.
+  `messaging.ErrNotConnected` — the same unwrapped error **shape** pre-#655 callers received
+  (only the timing changed: up to `readytimeout` instead of instant) — without consuming a
+  `reconnect.maxpublishattempts` slot, since the wait happens entirely before the retry loop
+  starts.
 - If the context is canceled/deadlined, or the client is shutting down, while waiting, the
-  pre-flight returns that error instead.
+  pre-flight returns that error (`ctx.Err()` / `messaging.ErrShutdown`) instead.
 
-This wait does not consume a `maxpublishattempts` slot — it happens entirely before the retry loop
-starts.
+**Need fail-fast anyway?** Two working options:
+
+- **Context deadline (preferred):** pass a `ctx` with a short deadline — the pre-flight is
+  context-aware (third bullet above), so the effective wait is the *smaller* of the ctx deadline
+  and `readytimeout`. This is the framework's context-first idiom, and the same deadline also
+  bounds the publish attempts that follow.
+- **Config:** set `reconnect.readytimeout` to a small positive value (e.g. `1ms`) for
+  near-instant failure on a not-ready client.
 
 > **Disabling the wait:** `reconnect.readytimeout: 0` in `config.yaml` is treated the same as
-> leaving the key unset — like every other `reconnect.*` duration — and defaults to 5s. There is no
+> leaving the key unset — like every other `reconnect.*` duration — and defaults to 5s. A
+> **negative** value does not fall back to the default either: it fails startup with a validation
+> error (`messaging.reconnect.readytimeout: must be non-negative`). There is no
 > way to reach a `readyTimeout <= 0` (the pre-#655 instant fail-fast) through the public API:
 > `NewAMQPClient` always initializes it to the 5s default before applying `ClientOption`s, and
 > `WithReadyTimeout` itself ignores non-positive values — the same guard `WithMaxPublishAttempts`
 > applies to `reconnect.maxpublishattempts`' `<= 0` "unbounded retries" mode. Both zero-value
-> sentinels are reachable only via a struct-literal `AMQPClientImpl{}`, which — since the fields are
-> unexported — is possible only from code inside the `messaging` package itself (its own test
-> suite), never from an external caller. A custom `app.Options.MessagingClientFactory` supplying a
+> sentinels are reachable only by building an `AMQPClientImpl` struct literal that bypasses
+> `NewAMQPClient` — a dead end outside the `messaging` package: the fields are unexported, so only
+> the package's own test suite can set them, and while a bare `&messaging.AMQPClientImpl{}` does
+> compile externally, it is non-functional (nil unexported mutex and channels — the first method
+> call panics). No *working* client with `readyTimeout <= 0` is constructible outside the
+> `messaging` package. A custom `app.Options.MessagingClientFactory` supplying a
 > different `AMQPClient` implementation sidesteps the concept entirely: it receives only
 > `(url, log)`, so `reconnect.readytimeout` never reaches it.
 

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -184,6 +184,7 @@ GoBricks applies production-safe AMQP reconnection defaults when messaging is co
 | `reconnect.reinitdelay` | 2s | Delay between channel re-initialization |
 | `reconnect.resenddelay` | 5s | Delay before resending failed messages |
 | `reconnect.connectiontimeout` | 30s | Per-publish broker confirmation (ACK/NACK) timeout |
+| `reconnect.readytimeout` | 5s | Bounded pre-flight wait for a not-yet-ready client before a publish begins (see below) |
 | `reconnect.maxpublishattempts` | 5 | Max publish attempts before returning `ErrPublishRetriesExhausted` (see below) |
 | `reconnect.maxdelay` | 60s | Maximum backoff cap for exponential retry |
 | `publisher.maxcached` | 50 | Maximum cached publisher channels |
@@ -213,7 +214,14 @@ failure:
 |----------------|---------|
 | `messaging.ErrPublishNacked` | the broker received the message and returned `basic.nack` (a transient broker condition — disk alarm, mirror resync, failover; also how a missing exchange surfaces) |
 | `messaging.ErrPublishConfirmTimeout` | no ACK/NACK arrived within `connectiontimeout` |
-| `messaging.ErrNotConnected` | the client was not connected when the publish was attempted |
+
+> `messaging.ErrNotConnected` is **not** one of the wrapped causes above — it is returned directly
+> (unwrapped), most commonly by the readiness pre-flight described below, timing out after waiting
+> up to `reconnect.readytimeout`. That case means "still not ready after the bounded wait," not
+> "not connected right now." The retry loop's own per-attempt readiness check — which pre-dates the
+> pre-flight and still runs on every iteration — can also raise it immediately, with no wait, if the
+> client drops connectivity again between two retry attempts (e.g. a broker blip during a NACK
+> backoff).
 
 Cancel / shutdown / deadline returns are also wrapped with the last cause, so a deadline that
 fires after a NACK still reports `ErrPublishNacked` — **match with `errors.Is`, not `==`**.
@@ -227,6 +235,40 @@ never parks — only undecodable message bodies are poison — see
 > only on cancel/shutdown/ACK). It now returns an error after `maxpublishattempts`. Direct
 > publishers that relied on infinite blocking should handle the error; durable delivery should go
 > through the outbox, which retries on its next cycle. See [migrations.md](migrations.md).
+
+### Cold-client readiness pre-flight (`reconnect.readytimeout`)
+
+`NewAMQPClient` starts connecting asynchronously and returns immediately — `IsReady()` only flips
+true once the broker handshake and channel init finish. Before this pre-flight existed, the very
+first publish against a freshly created (or mid-reconnect) client failed instantly with
+`messaging.ErrNotConnected`, even though the client would have become ready a moment later (issue
+#655).
+
+`PublishToExchange` now runs a bounded, context-aware wait for readiness **before** entering the
+retry loop described above. The wait polls every 100ms (the same cadence
+`Registry.DeclareInfrastructure` uses) up to `reconnect.readytimeout` (default 5s):
+
+- If the client becomes ready within the window, the publish proceeds normally into the retry loop.
+- If `reconnect.readytimeout` elapses first, `PublishToExchange` returns the raw
+  `messaging.ErrNotConnected` — unwrapped, matching the pre-#655 behavior exactly — and **not**
+  counted against `reconnect.maxpublishattempts`.
+- If the context is canceled/deadlined, or the client is shutting down, while waiting, the
+  pre-flight returns that error instead.
+
+This wait does not consume a `maxpublishattempts` slot — it happens entirely before the retry loop
+starts.
+
+> **Disabling the wait:** `reconnect.readytimeout: 0` in `config.yaml` is treated the same as
+> leaving the key unset — like every other `reconnect.*` duration — and defaults to 5s. There is no
+> way to reach a `readyTimeout <= 0` (the pre-#655 instant fail-fast) through the public API:
+> `NewAMQPClient` always initializes it to the 5s default before applying `ClientOption`s, and
+> `WithReadyTimeout` itself ignores non-positive values — the same guard `WithMaxPublishAttempts`
+> applies to `reconnect.maxpublishattempts`' `<= 0` "unbounded retries" mode. Both zero-value
+> sentinels are reachable only via a struct-literal `AMQPClientImpl{}`, which — since the fields are
+> unexported — is possible only from code inside the `messaging` package itself (its own test
+> suite), never from an external caller. A custom `app.Options.MessagingClientFactory` supplying a
+> different `AMQPClient` implementation sidesteps the concept entirely: it receives only
+> `(url, log)`, so `reconnect.readytimeout` never reaches it.
 
 ### Sizing the publisher pool for multi-tenant deployments
 

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -262,6 +262,10 @@ retry loop described above. The wait polls every 100ms (the same cadence
 - If the context is canceled/deadlined, or the client is shutting down, while waiting, the
   pre-flight returns that error (`ctx.Err()` / `messaging.ErrShutdown`) instead.
 
+There is no circuit breaker or single-flight coalescing at the client level: during a sustained
+broker outage, every publish independently waits up to `min(readytimeout, ctx deadline)` before
+returning `messaging.ErrNotConnected` — prefer short ctx deadlines on latency-sensitive paths.
+
 **Need fail-fast anyway?** Two working options:
 
 - **Context deadline (preferred):** pass a `ctx` with a short deadline — the pre-flight is
@@ -274,7 +278,7 @@ retry loop described above. The wait polls every 100ms (the same cadence
 > **Disabling the wait:** `reconnect.readytimeout: 0` in `config.yaml` is treated the same as
 > leaving the key unset — like every other `reconnect.*` duration — and defaults to 5s. A
 > **negative** value does not fall back to the default either: it fails startup with a validation
-> error (`messaging.reconnect.readytimeout: must be non-negative`). There is no
+> error (`config_invalid: messaging.reconnect.readytimeout must be non-negative`). There is no
 > way to reach a `readyTimeout <= 0` (the pre-#655 instant fail-fast) through the public API:
 > `NewAMQPClient` always initializes it to the 5s default before applying `ClientOption`s, and
 > `WithReadyTimeout` itself ignores non-positive values — the same guard `WithMaxPublishAttempts`


### PR DESCRIPTION
## Summary

First publish on a cold AMQP publisher client always failed fast with `ErrNotConnected`: `NewAMQPClient` starts its connection asynchronously (`handleReconnect` goroutine) and returns with `isReady == false`, while `PublishToExchange` returned instantly on a not-ready client — no bounded wait, no retry. Combined with publisher idle eviction (single-tenant TTL 10m), any service publishing less often than the TTL hit a cold client on **every** publish and failed deterministically — confirmed in production for a once-daily scheduled job.

This PR gives `PublishToExchange` a bounded, context-aware readiness pre-flight, modeled on the readiness poll `Registry.DeclareInfrastructure` already uses for consumers (the publish side simply never got the same wait).

## What changed

- **`messaging/amqp_client.go`** — `publishPreflight` → `waitForReady`: before entering the retry loop, a not-ready client gets up to `readytimeout` (default **5s**, capped by the caller's ctx deadline) to become ready, polling at the shared 100ms `readinessCheckInterval`. The wait does **not** consume a `maxpublishattempts` slot. On expiry the raw `ErrNotConnected` is returned as before; ctx expiry surfaces the ctx's own error. `readyTimeout <= 0` (programmatic only) preserves the old instant fail-fast.
- **`messaging.reconnect.readytimeout` config key** — wired end-to-end (`config/types.go` → `applyMessagingDefaults` (zero→5s, negative→startup validation error) → `app/managers.go` → `app/factory_resolver.go` → `messaging/manager.go`). The exported `FactoryResolver.MessagingClientFactory` signature is unchanged (apidiff-safe); new options travel via `MessagingClientFactoryWithOptions`.
- **Publish-latency metrics stay honest** — the elapsed fed to `logger.AddAMQPElapsed` / publish-latency histograms is measured from after the pre-flight (`publishStart`), so a reconnect wait doesn't masquerade as broker latency. The tracing span still covers the full call, wait included.
- **Outbox relay: mid-batch broker drop is capped** — the relay's cycle-start `IsReady()` gate only protected cold starts; with the new wait, a mid-batch drop would have cost up to `BatchSize × readytimeout` in serial pre-flights. Now, when a publish fails `ErrNotConnected` and the client is still not ready, the unattempted remainder takes the existing outage path (retry_count advance, no publish attempts, connectivity never dead-letters) and cycle stats still sum to the batch total. Startup validation newly enforces `outbox.publishtimeout >= messaging.reconnect.readytimeout` (mirroring the existing `connectiontimeout` gate) so the `ErrNotConnected` classification can't be silently starved by a shorter relay deadline.
- **Shared readiness poll** — `pollUntilReady` now backs both `waitForReady` and `Registry.DeclareInfrastructure` (behavioral lock: all pre-existing tests for both call sites pass unchanged).
- **Docs** — `wiki/messaging.md` `ErrNotConnected` contract corrected (it never participated in `ErrPublishRetriesExhausted` wrapping), `readytimeout` documented with fail-fast guidance and the sustained-outage trade-off; boundary-timeout tables in `CLAUDE.md` / `wiki/context_deadlines.md` updated; pre-existing "undecodable message bodies" → "headers" poison-classification drift fixed.

## Reproduction (pristine main)

```
go test -run TestPublishToExchangeWaitsForReadyClient ./messaging/
```

```
--- FAIL: TestPublishToExchangeWaitsForReadyClient (0.15s)
    amqp_client_test.go:1336:
        	Error Trace:	.../messaging/amqp_client_test.go:1336
        	Error:      	Received unexpected error:
        	            	not connected to AMQP broker
        	Test:       	TestPublishToExchangeWaitsForReadyClient
FAIL
FAIL	github.com/gaborage/go-bricks/messaging	0.561s
```

The publish returned `ErrNotConnected` microseconds after the call while the test only flipped readiness at 150ms — the exact production failure signature from #655, captured before any fix was written. The same test (now with `readyTimeout: 2s`) passes with the fix and is the regression guard.

## Test plan

- [x] Behavioral repro captured on pristine main before implementation (above)
- [x] Client-level: waits-for-ready, timeout-expiry, wait-disabled opt-out, ctx-deadline, option-setter, metrics-exclusion (`< 100ms` vs 150ms wait)
- [x] Manager-level: idle-eviction → cold-recreate sequence (production timeline from #655)
- [x] Outbox: mid-batch drop stops the batch (attempt count asserted), still-ready continues, accounting sums to total, publishtimeout-below-readytimeout rejected at Init
- [x] Integration (real RabbitMQ container): publish immediately after `NewAMQPClient` with no readiness wait — passes; adversarial reflection probe confirmed the same scenario fails 8/8 in µs with the wait zeroed (non-vacuous)
- [x] `make check` (fmt + lint + full race suite + govulncheck) green at every commit; local apidiff vs v0.48.0 clean

## Notes for reviewers

- **Behavior change (documented, intentional):** during a sustained broker outage a publish now waits up to `min(readytimeout, ctx deadline)` instead of failing instantly; latency-sensitive callers should bound via ctx (context-first) or a small positive `readytimeout`.
- **New startup-rejection class (intentional fail-fast):** configs with `outbox.publishtimeout < messaging.reconnect.readytimeout` (previously bootable) now fail Init with a descriptive error. Defaults (60s / 5s) unaffected.
- Mid-flight reconnect flaps inside the retry loop intentionally keep the existing instant `ErrNotConnected` semantics — this fix targets the cold-start class only.

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable readiness wait for AMQP publishing, helping clients publish more reliably on cold start or after reconnects.
  * Added support for a new reconnect timeout setting with a default of 5s.

* **Bug Fixes**
  * Improved publish behavior so readiness waiting happens before retries, with better handling of timeouts, cancellations, and broker disconnects.
  * Updated outbox behavior to fail fast when publish timeouts are too short for readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->