### PR TITLE
fix(config): apply messaging defaults in all deployment modes

### DIFF
--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -39,9 +39,10 @@ func (a *App) startMaintenanceLoops() {
 // config/validation.go: applyMessagingDefaults), this misconfiguration doesn't break
 // anything — idle-publisher eviction just lags by up to one extra sweep interval — so
 // callers should WARN, not fail, when this is true (matches PublisherPoolConfig's
-// "should be less than IdleTTL" godoc). idleTTL <= 0 means the raw config value was
-// never defaulted (messaging not configured at the root level; see
-// config.IsMessagingConfigured) and is skipped: there is nothing meaningful to compare.
+// "should be less than IdleTTL" godoc). idleTTL <= 0 is treated as "nothing meaningful
+// to compare" and skipped; config.Validate applies the IdleTTL default unconditionally
+// (see config/validation.go: validateMessaging), so this guard is purely defensive for
+// callers that bypass Validate.
 func publisherCleanupIntervalTooLate(cleanupInterval, idleTTL time.Duration) bool {
 	if idleTTL <= 0 {
 		return false

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -392,10 +392,10 @@ func TestStartMaintenanceLoopsUsesConfiguredPublisherCleanupInterval(t *testing.
 // longer holds now that both messaging.publisher.cleanupinterval and
 // messaging.publisher.idlettl are independently operator-configurable. The predicate
 // must flag "sweep frequency >= TTL" (eviction merely lags, so this is advisory, not
-// fatal — see startMaintenanceLoops) while never flagging an idleTTL of zero, since
-// that means the raw config value was never defaulted (messaging not configured at
-// the root level; see config.IsMessagingConfigured) and there is nothing meaningful
-// to compare yet.
+// fatal — see startMaintenanceLoops) while treating idleTTL <= 0 as "nothing
+// meaningful to compare". config.Validate applies the IdleTTL default unconditionally
+// (see config/validation.go: validateMessaging), so that guard is purely defensive
+// for callers that bypass Validate — as the zero/negative cases here exercise.
 func TestPublisherCleanupIntervalTooLate(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/config/types.go
+++ b/config/types.go
@@ -353,7 +353,8 @@ type OutputConfig struct {
 }
 
 // MessagingConfig holds messaging/broker settings.
-// Production-safe defaults are applied automatically when messaging is configured.
+// Production-safe defaults are applied unconditionally at startup — even when
+// messaging.broker.url is unset (see config/validation.go: validateMessaging).
 type MessagingConfig struct {
 	Broker    BrokerConfig        `koanf:"broker" json:"broker" yaml:"broker" toml:"broker" mapstructure:"broker"`
 	Routing   RoutingConfig       `koanf:"routing" json:"routing" yaml:"routing" toml:"routing" mapstructure:"routing"`

--- a/config/validation.go
+++ b/config/validation.go
@@ -187,14 +187,26 @@ func validateDebug(cfg *DebugConfig) error {
 }
 
 // validateMessaging validates messaging configuration and applies defaults.
-// multitenant selects the deployment-mode-dependent Publisher.IdleTTL default
-// (see applyMessagingDefaults); it has no effect on any other field.
-// Returns nil if messaging is not configured or if all settings are valid.
+// multitenant selects the deployment-mode-dependent Publisher.IdleTTL and
+// Publisher.MaxCached defaults (see applyMessagingDefaults); it has no effect
+// on any other field.
+//
+// Defaults are applied unconditionally, even when the root broker URL is empty
+// (IsMessagingConfigured is false). Multi-tenant deployments carry broker URLs
+// per-tenant — a root broker URL is rejected there by
+// validateNoSingleTenantConflict, though other root messaging.* keys remain
+// legal and are the tuning seam for per-tenant clients — yet per-tenant AMQP
+// clients and the outbox relay still run with the client-side
+// reconnect/publisher defaults. Leaving cfg.Messaging.* at zero would silently
+// defeat cross-field validators that read the effective values (e.g. outbox's
+// publishtimeout >= connectiontimeout and >= readytimeout Fail-Fast checks), so
+// defaults are materialized in every deployment mode. (The reconnect
+// delay/backoff keys — delay, reinitdelay, resenddelay, maxdelay — are
+// validated here but not yet wired into the AMQP client, which uses its own
+// hardcoded values; see messaging/amqp_client.go.)
+//
+// Returns an error if any setting is invalid; otherwise nil.
 func validateMessaging(cfg *MessagingConfig, multitenant bool) error {
-	if !IsMessagingConfigured(cfg) {
-		return nil
-	}
-
 	// Apply messaging defaults (reconnection, publisher pool)
 	return applyMessagingDefaults(cfg, multitenant)
 }
@@ -645,7 +657,9 @@ func validateNamedDatabaseEntry(name string, dbCfg *DatabaseConfig, mt *Multiten
 //   - Reconnect.ConnectionTimeout: if 0, sets to 30s; if negative, returns an error.
 //   - Reconnect.ReadyTimeout: if 0, sets to 5s; if negative, returns an error.
 //   - Reconnect.MaxDelay: if 0, sets to 60s; if negative, returns an error.
-//   - Publisher.MaxCached: if 0, sets to 50; if negative, returns an error.
+//   - Publisher.MaxCached: if 0, sets to 50 when multitenant is false; in
+//     multi-tenant mode zero is preserved so app.ManagerConfigBuilder scales the
+//     publisher pool to the tenant limit; if negative, returns an error.
 //   - Publisher.IdleTTL: if 0, sets to 1h when multitenant is false, 10m when true
 //     (mode-dependent — a shorter multi-tenant default bounds per-tenant publisher
 //     churn); if negative, returns an error.
@@ -682,20 +696,22 @@ func applyMessagingDefaults(cfg *MessagingConfig, multitenant bool) error {
 		return err
 	}
 
-	for _, n := range []struct {
-		field *int
-		def   int
-		name  string
-	}{
-		{&cfg.Reconnect.MaxPublishAttempts, defaultMaxPublishAttempts, "messaging.reconnect.maxpublishattempts"},
-		{&cfg.Publisher.MaxCached, defaultMaxPublishers, "messaging.publisher.maxcached"},
-	} {
-		if err := applyNonNegativeDefault(n.field, n.def, n.name); err != nil {
-			return err
-		}
+	if err := applyNonNegativeDefault(&cfg.Reconnect.MaxPublishAttempts, defaultMaxPublishAttempts, "messaging.reconnect.maxpublishattempts"); err != nil {
+		return err
 	}
 
-	return nil
+	// Publisher.MaxCached's multi-tenant default is dynamic — app.ManagerConfigBuilder.
+	// BuildMessagingOptions scales the publisher pool to the tenant limit when the key
+	// is unset — so zero is preserved in multi-tenant mode (negative is still rejected).
+	// Stamping the flat single-tenant default here would silently cap the pool below
+	// the tenant limit.
+	if multitenant {
+		if cfg.Publisher.MaxCached < 0 {
+			return NewValidationError("messaging.publisher.maxcached", errMustBeNonNegative)
+		}
+		return nil
+	}
+	return applyNonNegativeDefault(&cfg.Publisher.MaxCached, defaultMaxPublishers, "messaging.publisher.maxcached")
 }
 
 // applyNonNegativeDefault sets *field to def when it is zero, or returns a validation

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -4380,3 +4380,82 @@ func TestLoadFailsOnAllInvalidCIDRAllowlistEnv(t *testing.T) {
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "scheduler.security.cidrallowlist")
 }
+
+// TestValidateMessagingAppliesDefaultsWhenBrokerURLEmpty pins the #659 fix: defaults
+// and negative-value rejection apply even when the root broker URL is empty (see
+// validateMessaging's doc comment for why). Field-by-field defaulting is covered by
+// TestApplyMessagingDefaults; these subtests pin the no-gate behavior and the
+// mode-aware Publisher defaults.
+func TestValidateMessagingAppliesDefaultsWhenBrokerURLEmpty(t *testing.T) {
+	t.Run("single_tenant_empty_broker_applies_defaults", func(t *testing.T) {
+		cfg := &MessagingConfig{} // empty Broker.URL
+		require.NoError(t, validateMessaging(cfg, false))
+
+		assert.Equal(t, defaultConnectionTimeout, cfg.Reconnect.ConnectionTimeout)
+		assert.Equal(t, defaultPublisherIdleTTL, cfg.Publisher.IdleTTL)
+		assert.Equal(t, defaultMaxPublishers, cfg.Publisher.MaxCached)
+	})
+
+	t.Run("multi_tenant_empty_broker_applies_mode_aware_publisher_defaults", func(t *testing.T) {
+		cfg := &MessagingConfig{}
+		require.NoError(t, validateMessaging(cfg, true))
+
+		assert.Equal(t, defaultConnectionTimeout, cfg.Reconnect.ConnectionTimeout)
+		assert.Equal(t, defaultPublisherIdleTTLMultiTenant, cfg.Publisher.IdleTTL)
+		// MaxCached stays zero in multi-tenant mode so BuildMessagingOptions scales
+		// the publisher pool to the tenant limit (app/managers.go).
+		assert.Zero(t, cfg.Publisher.MaxCached)
+	})
+
+	t.Run("empty_broker_negative_value_rejected", func(t *testing.T) {
+		cfg := &MessagingConfig{Reconnect: ReconnectConfig{Delay: -1}}
+		require.Error(t, validateMessaging(cfg, false))
+	})
+
+	t.Run("multi_tenant_negative_maxcached_rejected", func(t *testing.T) {
+		cfg := &MessagingConfig{Publisher: PublisherPoolConfig{MaxCached: -1}}
+		require.Error(t, validateMessaging(cfg, true))
+	})
+}
+
+// TestValidateMultiTenantStaticAppliesMessagingDefaultsEndToEnd proves a multi-tenant
+// static config — where the root broker URL is necessarily empty — yields effective
+// messaging defaults through the full Validate() entry point, so the outbox
+// publishtimeout Fail-Fast guards have real values to compare against (see
+// validateMessaging's doc comment).
+func TestValidateMultiTenantStaticAppliesMessagingDefaultsEndToEnd(t *testing.T) {
+	cfg := &Config{
+		App:    createValidAppConfig(),
+		Server: createValidServerConfig(),
+		Log:    createValidLogConfig(),
+		Multitenant: MultitenantConfig{
+			Enabled: true,
+			Resolver: ResolverConfig{
+				Type:   ResolverTypeHeader,
+				Header: testTenantHeader,
+			},
+			Tenants: map[string]TenantEntry{
+				"acme": {
+					Database: DatabaseConfig{
+						Type:     PostgreSQL,
+						Host:     "acme.db",
+						Port:     5432,
+						Database: "acme",
+						Username: "acme_user",
+					},
+					Messaging: TenantMessagingConfig{URL: testAMQPHost},
+				},
+			},
+		},
+		Source: SourceConfig{Type: SourceTypeStatic},
+		// No root broker URL: validateNoSingleTenantConflict rejects one in
+		// static multi-tenant mode (other root messaging.* keys stay legal).
+	}
+
+	require.NoError(t, Validate(cfg))
+
+	assert.Equal(t, 30*time.Second, cfg.Messaging.Reconnect.ConnectionTimeout)
+	assert.Equal(t, 10*time.Minute, cfg.Messaging.Publisher.IdleTTL)
+	// Zero preserved: BuildMessagingOptions scales the pool to the tenant limit.
+	assert.Zero(t, cfg.Messaging.Publisher.MaxCached)
+}

--- a/outbox/module.go
+++ b/outbox/module.go
@@ -72,10 +72,6 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 		return nil
 	}
 
-	if err := m.validatePublishTimeout(); err != nil {
-		return err
-	}
-
 	// Fail fast: when outbox is enabled, DB and Messaging resolvers are required.
 	// Without them, the relay job would panic on first poll instead of failing at startup.
 	if m.getDB == nil {
@@ -109,6 +105,14 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 			return fmt.Errorf("outbox: multi-tenant is enabled but no static multitenant.tenants are configured; " +
 				"the relay would never deliver any events. Configure multitenant.tenants, or set outbox.enabled=false")
 		}
+	}
+
+	// Timeout-tuning validation runs AFTER the root-cause checks above: when messaging
+	// isn't configured at all (or the relay can't fan out), that actionable error must
+	// surface first — not a derived publishtimeout complaint against defaulted values
+	// (config.Validate now defaults connectiontimeout/readytimeout in every mode).
+	if err := m.validatePublishTimeout(); err != nil {
+		return err
 	}
 
 	// Store creation is deferred until first use (lazy init like scheduler)

--- a/outbox/module_test.go
+++ b/outbox/module_test.go
@@ -222,6 +222,87 @@ func TestModuleInitRejectsPublishTimeoutBelowReadyTimeout(t *testing.T) {
 	assert.Contains(t, err.Error(), "readytimeout")
 }
 
+// TestModuleInitMessagingUnconfiguredErrorPrecedesTimeoutGuard pins Init's error
+// ordering: with no broker URL AND a publishtimeout below connectiontimeout, the
+// actionable root cause ("messaging is not configured") must surface, not the derived
+// timeout complaint (see the validatePublishTimeout call order in Init).
+func TestModuleInitMessagingUnconfiguredErrorPrecedesTimeoutGuard(t *testing.T) {
+	m := NewModule()
+	deps := &app.ModuleDeps{
+		Logger: logger.New("info", false),
+		Config: &config.Config{
+			Outbox: config.OutboxConfig{Enabled: true, PublishTimeout: 10 * time.Second},
+			Messaging: config.MessagingConfig{
+				// Broker.URL intentionally empty; connectiontimeout mirrors the value
+				// config.Validate now defaults in every deployment mode.
+				Reconnect: config.ReconnectConfig{ConnectionTimeout: 30 * time.Second},
+			},
+		},
+		DB:        func(_ context.Context) (dbtypes.Interface, error) { return nil, nil },
+		Messaging: func(_ context.Context) (messaging.AMQPClient, error) { return nil, nil },
+	}
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "messaging is not configured")
+	assert.NotContains(t, err.Error(), "publishtimeout")
+}
+
+// TestModuleInitMultiTenantGuardFiresOnValidatedDefaults composes the #659 fix with
+// the outbox guard end-to-end: a multi-tenant static config (root broker URL empty)
+// run through config.Validate() picks up the defaulted 30s connectiontimeout, so an
+// explicit outbox.publishtimeout below it must fail Init — pinning that the guard can
+// no longer be silently bypassed by an un-defaulted zero.
+func TestModuleInitMultiTenantGuardFiresOnValidatedDefaults(t *testing.T) {
+	cfg := &config.Config{
+		App: config.AppConfig{Name: "outbox-test", Version: "1.0.0", Env: "development"},
+		Server: config.ServerConfig{
+			Port: 8080,
+			Timeout: config.TimeoutConfig{
+				Read:       15 * time.Second,
+				Write:      30 * time.Second,
+				Middleware: 5 * time.Second,
+				Shutdown:   10 * time.Second,
+			},
+		},
+		Log: config.LogConfig{Level: "info"},
+		Multitenant: config.MultitenantConfig{
+			Enabled:  true,
+			Resolver: config.ResolverConfig{Type: config.ResolverTypeHeader, Header: "X-Tenant-ID"},
+			Tenants: map[string]config.TenantEntry{
+				"acme": {
+					Database: config.DatabaseConfig{
+						Type:     config.PostgreSQL,
+						Host:     "acme.db",
+						Port:     5432,
+						Database: "acme",
+						Username: "acme_user",
+					},
+					Messaging: config.TenantMessagingConfig{URL: "amqp://localhost:5672/"},
+				},
+			},
+		},
+		Source: config.SourceConfig{Type: config.SourceTypeStatic},
+		Outbox: config.OutboxConfig{Enabled: true, PublishTimeout: 10 * time.Second},
+		// Root broker URL intentionally empty — Validate() must still default
+		// messaging.reconnect.connectiontimeout to 30s (#659).
+	}
+	require.NoError(t, config.Validate(cfg))
+
+	m := NewModule()
+	deps := &app.ModuleDeps{
+		Logger:    logger.New("info", false),
+		Config:    cfg,
+		DB:        func(_ context.Context) (dbtypes.Interface, error) { return nil, nil },
+		Messaging: func(_ context.Context) (messaging.AMQPClient, error) { return nil, nil },
+	}
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "publishtimeout")
+	assert.Contains(t, err.Error(), "connectiontimeout")
+}
+
 // TestModuleInitEnabledMessagingUnconfiguredMultiTenant verifies the static
 // check is skipped when multitenant.enabled=true — each tenant supplies its
 // own broker URL via the resource source, so a global check would be wrong.

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -176,7 +176,9 @@ decls.DeclareConsumer(&messaging.ConsumerOptions{
 
 ## Messaging Reconnection Defaults
 
-GoBricks applies production-safe AMQP reconnection defaults when messaging is configured:
+GoBricks applies production-safe AMQP reconnection defaults unconditionally at startup — even when
+`messaging.broker.url` is unset (multi-tenant deployments rely on this: per-tenant clients and
+cross-field validators like the outbox `publishtimeout` guards read these effective values):
 
 | Setting | Default | Purpose |
 |---------|---------|---------|
@@ -187,7 +189,7 @@ GoBricks applies production-safe AMQP reconnection defaults when messaging is co
 | `reconnect.readytimeout` | 5s | Bounded pre-flight wait for a not-yet-ready client before a publish begins (see below) |
 | `reconnect.maxpublishattempts` | 5 | Max publish attempts before returning `ErrPublishRetriesExhausted` (see below) |
 | `reconnect.maxdelay` | 60s | Maximum backoff cap for exponential retry |
-| `publisher.maxcached` | 50 | Maximum cached publisher channels |
+| `publisher.maxcached` | 50 single-tenant / unset multi-tenant (pool scales to `multitenant.limits.tenants`) | Maximum cached publisher channels |
 | `publisher.idlettl` | 1h single-tenant / 10m multi-tenant | TTL for idle publisher channels |
 | `publisher.cleanupinterval` | 2m | How often the idle-publisher cleanup goroutine runs |
 

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -17,8 +17,10 @@ A plain `vX.Y.Z` is your current node. `=>` a local path (dev `replace`) means t
 **3 — Select the hop chain** on the Ladder: every edge strictly to the right of CURRENT, up to and including TARGET. Never apply an edge at/left of CURRENT.
 
 ```
-v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0 ─E43─ v0.43.0 ─E44─ v0.44.0 ─E45─ v0.45.0
+v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0 ─E43─ v0.43.0 ─E44─ v0.44.0 ─E45─ v0.45.0 ─E49─ v0.49.0
 ```
+
+> v0.46.0–v0.48.0 shipped additive-only changes (route template/path-param accessors, raw-route descriptors, module-contributed global middleware — adopt-only, no migration atoms), so E49 is the next hop after v0.45.0 and applies when crossing from any of v0.45.0–v0.48.0 to v0.49.0.
 
 | edge | hop | worst risk | atoms | compiler-caught | preflight (run BEFORE the bump) |
 |------|-----|-----------|-------|-----------------|---------------------------------|
@@ -29,6 +31,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E43  | v0.42.0 → v0.43.0 | compile-break | 6 | C43.2 C43.3 | bare section-named env vars |
 | E44  | v0.43.0 → v0.44.0 | noop | 2 | none | none |
 | E45  | v0.44.0 → v0.45.0 | compile-break | 9 | C45.1 C45.2 C45.3 C45.4 C45.5 C45.6 | outbox re-delivery count |
+| E49  | v0.45.0 → v0.49.0 (unreleased) | silent-config | 2 | none | multi-tenant outbox timeout guards / negative messaging.* values |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 - **`when: match`** → act only if `detect` returns ≥1 line (an API/arity/interface change, or a config key you set).
@@ -502,6 +505,27 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - apply: Run the count query before upgrading, then either let idempotent consumers absorb the re-delivery OR delete the rows you intend to abandon; note `'failed'` rows now accumulate (`DeletePublished` purges only `'published'`) — monitor and prune.
 - verify: `psql ... -c "SELECT count(*) FROM gobricks_outbox WHERE status='pending' AND retry_count >= <outbox.maxretries>;"`  # after the first relay cycle re-delivered volume matches the pre-upgrade count and consumers dedupe
 - ref: ADR-033 · #626 · wiki/adr_033_outbox_retry_count_status_parking.md
+
+## E49 · v0.45.0 → v0.49.0 (unreleased) — messaging defaults in all modes + publisher lifecycle hardening
+
+- gist: `config.Validate` now applies `messaging.*` reconnect/publisher defaults **unconditionally**, even when the root `messaging.broker.url` is empty — previously every no-root-broker config (all multi-tenant static deployments, since `validateNoSingleTenantConflict` rejects a root broker URL there; plus single-tenant apps without messaging) skipped both zero→default coercion and negative-value rejection. Consequences: the outbox `publishtimeout` guards (against `connectiontimeout` AND `readytimeout`, C45.8) now actually fire in multi-tenant mode, and negative `messaging.*` values now fail startup everywhere. Defaulting is publisher-mode-aware: `maxcached` 50 single-tenant / preserved-zero multi-tenant (pool scales to `multitenant.limits.tenants`). This release also raises the single-tenant publisher `IdleTTL` default 10m → 1h and adds a bounded readiness wait on cold publishes (#655/#656/#660).
+- build-caught: none
+- preflight: none
+- exit: `go get github.com/gaborage/go-bricks@v0.49.0 && go mod tidy && go build ./... && go test ./...`
+
+### [C49.1] messaging.* defaults/validation now run without a root broker URL — outbox timeout guards armed in multi-tenant · silent-config · when: match
+- detect: `git grep -nE '(^[[:space:]]*|\.)(publishtimeout|connectiontimeout|readytimeout)[[:space:]]*:' -- '*.yaml' '*.yml'` (leaf-anchored so it matches BOTH the nested `outbox:`→`publishtimeout:` form and flat-dotted keys; also grep the env forms `OUTBOX_PUBLISHTIMEOUT`, `MESSAGING_RECONNECT_CONNECTIONTIMEOUT`, `MESSAGING_RECONNECT_READYTIMEOUT` in deploy manifests) — and check `messaging.*` keys for negative values (`git grep -nE ':[[:space:]]*-[0-9]' -- '*.yaml' '*.yml'`)
+- gate: match = (a) you run multi-tenant with the outbox module and set `outbox.publishtimeout` below the effective `messaging.reconnect.connectiontimeout` (default 30s) **or** `messaging.reconnect.readytimeout` (default 5s) — both guards were silently skipped in multi-tenant mode because those timeouts stayed 0 without a root broker URL, so the config booted and then risked the unbounded duplicate-delivery loop the checks exist to prevent; startup now rejects it by design (`outbox.publishtimeout` defaults to 60s, so leaving it unset = unaffected); or (b) any deployment mode without a root `messaging.broker.url` carries a negative `messaging.*` value — previously silently ignored, now a startup validation error naming the key.
+- apply: (a) raise `outbox.publishtimeout` to `>= max(messaging.reconnect.connectiontimeout, messaging.reconnect.readytimeout)` (with defaults: `>= 30s`); (b) delete or correct negative `messaging.*` values. Single-tenant deployments WITH a broker URL already had defaults and guards applied — nothing changes for them.
+- verify: `make run`  # a previously-booting config either boots identically or aborts with a `messaging config: ...` / `outbox: publishtimeout ...` error naming the offending key
+- ref: #659 · config/validation.go: validateMessaging · wiki/outbox.md
+
+### [C49.2] Single-tenant publisher IdleTTL default 10m → 1h; cold publishes wait for readiness · silent-behavior · when: no-match
+- detect: `git grep -nE '(^[[:space:]]*|\.)idlettl[[:space:]]*:' -- '*.yaml' '*.yml'` (also `MESSAGING_PUBLISHER_IDLETTL` in deploy manifests)
+- gate: no-match = you left `messaging.publisher.idlettl` unset in a single-tenant deployment, so the effective idle-eviction TTL rises from 10m to 1h (#660) — publishers for low-frequency publish cadences stay warm longer (the fix for the once-daily cold-publish failure class, #655). Multi-tenant default stays 10m; explicitly-set values are untouched. Independently, the first publish on a cold publisher now waits up to `messaging.reconnect.readytimeout` (default 5s) for client readiness instead of failing fast with `ErrNotConnected` (#656), and evictions/idle-cleanups now log at Info with `Stats()` counters (#657).
+- apply: none required; set `messaging.publisher.idlettl` explicitly if you relied on the 10m eviction cadence.
+- verify: start the app and let a publisher idle  # eviction now logs at Info at the new TTL; a publish right after eviction no longer fails with ErrNotConnected
+- ref: #655 #656 #657 #660 · app/managers.go · messaging/amqp_client.go
 
 
 ---


### PR DESCRIPTION
## Summary

`validateMessaging` short-circuited on `!IsMessagingConfigured(cfg)` — keyed solely on `messaging.broker.url` being non-empty — so `applyMessagingDefaults` never ran for any no-root-broker config. That is **every multi-tenant static deployment** (a root broker URL is rejected there by `validateNoSingleTenantConflict`), plus single-tenant apps without messaging. Consequences:

- `messaging.reconnect.connectiontimeout`/`readytimeout` stayed `0`, silently disarming the outbox `publishtimeout >= connectiontimeout` and `>= readytimeout` Fail-Fast guards (ADR-033) in multi-tenant mode.
- Negative `messaging.*` values booted unvalidated (runtime fallbacks masked them), contrary to the documented "negative → startup validation error" contract. Empirical repro: `MessagingConfig{Publisher:{CleanupInterval:-5s}}` with an empty broker URL passed `Validate()` and reached `StartCleanup(-5s)`.

## What changed

- **`config/validation.go`** — defaults + negative-value rejection now run unconditionally; only broker-connectivity concerns remain gated on `IsMessagingConfigured`. **`Publisher.MaxCached` defaulting is mode-aware**: 50 single-tenant, zero preserved in multi-tenant so `BuildMessagingOptions` keeps scaling the publisher pool to the tenant limit — a flat 50 would have silently capped >50-tenant fleets and caused LRU eviction/reconnect churn (caught by the xhigh review pass).
- **`outbox/module.go`** — `validatePublishTimeout` moved after the root-cause checks, so a no-broker single-tenant config fails with the actionable `messaging is not configured` error instead of a derived timeout complaint against now-defaulted values.
- **Tests** — pinned: empty-broker defaulting (both modes), multi-tenant `MaxCached` zero-preservation, negative rejection on the no-broker path, Init error ordering, and a composed end-to-end test proving a `config.Validate()`-produced multi-tenant config actually arms the outbox guard.
- **Docs de-drifted** — `config/types.go` + `wiki/messaging.md` gated-defaulting claims corrected; over-broad "root messaging section is forbidden" comments narrowed to the broker URL; noted that `reconnect.delay/reinitdelay/resenddelay/maxdelay` are validated but not yet wired into the AMQP client (follow-up issue candidate).
- **`wiki/migrations.md`** — the change ships as a proper runbook edge **E49** (ladder node + edge-table row + exit line, replacing a protocol-unreachable free-floating row): `[C49.1]` covers both armed guards **and** newly-rejected negative values, with a leaf-anchored detect grep that matches nested YAML; `[C49.2]` documents the v0.49 publisher-lifecycle default flips (#655/#656/#657/#660) that previously had no atom.

## Upgrade note (adopt-only, documented in E49)

A multi-tenant config that sets `outbox.publishtimeout` below 30s (or below a configured `connectiontimeout`/`readytimeout`), or any no-broker config carrying a negative `messaging.*` value, previously booted and now fails startup by design. `outbox.publishtimeout` defaults to 60s, so unset configs are unaffected. Not a breaking API change — no exported signature changes, enforces an already-documented contract.

## Verification

- `make check` green (fmt + lint + full race-enabled suite + govulncheck).
- Multi-lens review (task-pipeline: correctness/precedent/security/test-adequacy, adversarially verified) + `/code-review` xhigh (25 agents, 12 confirmed findings — all applied) + `/security-audit` (gosec 0 issues, no raw-SQL sites, no secrets, no new HTTP surface).

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Messaging defaults now apply consistently at startup, even when the broker URL is not set.
  * Negative messaging settings are rejected more reliably, and timeout checks now surface the most relevant error first.
  * Outbox startup validation now uses the expected configured/defaulted values in multi-tenant setups.

* **Documentation**
  * Clarified messaging default behavior and updated migration guidance for the new upgrade path.

* **New Features**
  * Improved publisher handling for single-tenant and multi-tenant deployments, including updated caching and readiness behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->