### PR TITLE
feat(database): add database.manager.* config parity (maxsize/idlettl/cleanupinterval)

### DIFF
--- a/app/bootstrap.go
+++ b/app/bootstrap.go
@@ -46,6 +46,7 @@ func (b *appBootstrap) dependencies(startupCtx context.Context) *dependencyBundl
 	configBuilder.readyTimeout = b.cfg.Messaging.Reconnect.ReadyTimeout
 	configBuilder.publisherConfig = b.cfg.Messaging.Publisher
 	configBuilder.cacheConfig = b.cfg.Cache.Manager
+	configBuilder.dbConfig = b.cfg.Database.Manager
 	// Only count statically-configured tenants when multitenancy is enabled. Koanf
 	// populates Multitenant.Tenants from YAML regardless of the enabled flag, but
 	// those entries are meaningless in single-tenant mode (mirrors the guard in

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -23,8 +23,8 @@ func (a *App) startMaintenanceLoops() {
 		a.warnIfCleanupIntervalTooLate("database.manager",
 			a.cfg.Database.Manager.CleanupInterval, a.cfg.Database.Manager.IdleTTL)
 		a.logger.Info().Msg("Starting database manager cleanup loop")
-		// DbManager.StartCleanup self-defaults a non-positive interval to 5m, so a
-		// zero/unset database.manager.cleanupinterval preserves the prior behavior.
+		// cleanupinterval has no builder fallback (unlike maxsize/idlettl); on the
+		// Validate-bypassing NewWithConfig path, StartCleanup's <=0->5m self-default is the only guard.
 		a.dbManager.StartCleanup(a.cfg.Database.Manager.CleanupInterval)
 	}
 	if a.messagingManager != nil {
@@ -36,16 +36,9 @@ func (a *App) startMaintenanceLoops() {
 	}
 }
 
-// cleanupIntervalTooLate reports whether a manager's cleanupinterval is configured
-// to sweep no more often than its idlettl. The invariant used to hold implicitly:
-// cleanup intervals were hardcoded sweeps, always well below any configured idlettl.
-// Now that both values are independently operator-configurable for
-// messaging.publisher.* and database.manager.* (see config/validation.go), this
-// misconfiguration doesn't break anything — idle-handle eviction just lags by up to
-// one extra sweep interval — so callers should WARN, not fail, when this is true.
-// idleTTL <= 0 is treated as "nothing meaningful to compare" and skipped;
-// config.Validate applies the IdleTTL defaults unconditionally, so this guard is
-// purely defensive for callers that bypass Validate.
+// cleanupIntervalTooLate reports whether cleanupInterval sweeps no more often than
+// idleTTL. idleTTL <= 0 returns false: config.Validate defaults IdleTTL
+// unconditionally, so this guard only covers Validate-bypassing callers.
 func cleanupIntervalTooLate(cleanupInterval, idleTTL time.Duration) bool {
 	if idleTTL <= 0 {
 		return false
@@ -53,13 +46,8 @@ func cleanupIntervalTooLate(cleanupInterval, idleTTL time.Duration) bool {
 	return cleanupInterval >= idleTTL
 }
 
-// warnIfCleanupIntervalTooLate emits a non-fatal structured WARN when a manager's
-// cleanup sweep is configured no more frequently than its idle TTL (see
-// cleanupIntervalTooLate). keyPrefix names the config section ("database.manager",
-// "messaging.publisher") so the message points at the actual knobs. Validation
-// (config/validation.go) has no logger, so this check runs here instead — the first
-// point in the startup sequence where both values are read together and a logger is
-// available.
+// warnIfCleanupIntervalTooLate WARNs (never fails) when cleanupIntervalTooLate holds.
+// Lives here, not config.Validate, because Validate has no logger.
 func (a *App) warnIfCleanupIntervalTooLate(keyPrefix string, cleanupInterval, idleTTL time.Duration) {
 	if !cleanupIntervalTooLate(cleanupInterval, idleTTL) {
 		return

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -20,51 +20,57 @@ import (
 func (a *App) startMaintenanceLoops() {
 	// Start cleanup for unified managers
 	if a.dbManager != nil {
+		a.warnIfCleanupIntervalTooLate("database.manager",
+			a.cfg.Database.Manager.CleanupInterval, a.cfg.Database.Manager.IdleTTL)
 		a.logger.Info().Msg("Starting database manager cleanup loop")
-		a.dbManager.StartCleanup(5 * time.Minute) // Database cleanup every 5 minutes
+		// DbManager.StartCleanup self-defaults a non-positive interval to 5m, so a
+		// zero/unset database.manager.cleanupinterval preserves the prior behavior.
+		a.dbManager.StartCleanup(a.cfg.Database.Manager.CleanupInterval)
 	}
 	if a.messagingManager != nil {
 		cleanupInterval := a.cfg.Messaging.Publisher.CleanupInterval
 		idleTTL := a.cfg.Messaging.Publisher.IdleTTL
-		a.warnIfCleanupIntervalTooLate(cleanupInterval, idleTTL)
+		a.warnIfCleanupIntervalTooLate("messaging.publisher", cleanupInterval, idleTTL)
 		a.logger.Info().Msg("Starting messaging manager cleanup loop")
 		a.messagingManager.StartCleanup(cleanupInterval)
 	}
 }
 
-// publisherCleanupIntervalTooLate reports whether messaging.publisher.cleanupinterval
-// is configured to sweep no more often than messaging.publisher.idlettl. The invariant
-// used to hold implicitly: cleanupinterval was a hardcoded 2m sweep, always well below
-// any configured idlettl. Now that both are independently operator-configurable (see
-// config/validation.go: applyMessagingDefaults), this misconfiguration doesn't break
-// anything — idle-publisher eviction just lags by up to one extra sweep interval — so
-// callers should WARN, not fail, when this is true (matches PublisherPoolConfig's
-// "should be less than IdleTTL" godoc). idleTTL <= 0 is treated as "nothing meaningful
-// to compare" and skipped; config.Validate applies the IdleTTL default unconditionally
-// (see config/validation.go: validateMessaging), so this guard is purely defensive for
-// callers that bypass Validate.
-func publisherCleanupIntervalTooLate(cleanupInterval, idleTTL time.Duration) bool {
+// cleanupIntervalTooLate reports whether a manager's cleanupinterval is configured
+// to sweep no more often than its idlettl. The invariant used to hold implicitly:
+// cleanup intervals were hardcoded sweeps, always well below any configured idlettl.
+// Now that both values are independently operator-configurable for
+// messaging.publisher.* and database.manager.* (see config/validation.go), this
+// misconfiguration doesn't break anything — idle-handle eviction just lags by up to
+// one extra sweep interval — so callers should WARN, not fail, when this is true.
+// idleTTL <= 0 is treated as "nothing meaningful to compare" and skipped;
+// config.Validate applies the IdleTTL defaults unconditionally, so this guard is
+// purely defensive for callers that bypass Validate.
+func cleanupIntervalTooLate(cleanupInterval, idleTTL time.Duration) bool {
 	if idleTTL <= 0 {
 		return false
 	}
 	return cleanupInterval >= idleTTL
 }
 
-// warnIfCleanupIntervalTooLate emits a non-fatal structured WARN when the publisher
-// pool's cleanup sweep is configured no more frequently than its idle TTL (see
-// publisherCleanupIntervalTooLate). Validation (config/validation.go) has no logger,
-// so this check runs here instead — the first point in the startup sequence where
-// both values are read together and a logger is available.
-func (a *App) warnIfCleanupIntervalTooLate(cleanupInterval, idleTTL time.Duration) {
-	if !publisherCleanupIntervalTooLate(cleanupInterval, idleTTL) {
+// warnIfCleanupIntervalTooLate emits a non-fatal structured WARN when a manager's
+// cleanup sweep is configured no more frequently than its idle TTL (see
+// cleanupIntervalTooLate). keyPrefix names the config section ("database.manager",
+// "messaging.publisher") so the message points at the actual knobs. Validation
+// (config/validation.go) has no logger, so this check runs here instead — the first
+// point in the startup sequence where both values are read together and a logger is
+// available.
+func (a *App) warnIfCleanupIntervalTooLate(keyPrefix string, cleanupInterval, idleTTL time.Duration) {
+	if !cleanupIntervalTooLate(cleanupInterval, idleTTL) {
 		return
 	}
 	a.logger.Warn().
+		Str("resource", keyPrefix).
 		Dur("cleanupinterval", cleanupInterval).
 		Dur("idlettl", idleTTL).
-		Msg("messaging.publisher.cleanupinterval is >= messaging.publisher.idlettl; " +
-			"idle publisher eviction will lag by up to one extra cleanup cycle " +
-			"(lower messaging.publisher.cleanupinterval or raise messaging.publisher.idlettl)")
+		Msg(keyPrefix + ".cleanupinterval is >= " + keyPrefix + ".idlettl; " +
+			"idle handle eviction will lag by up to one extra cleanup cycle " +
+			"(lower " + keyPrefix + ".cleanupinterval or raise " + keyPrefix + ".idlettl)")
 }
 
 // prepareRuntime prepares the application for runtime execution

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -389,13 +389,10 @@ func TestStartMaintenanceLoopsUsesConfiguredPublisherCleanupInterval(t *testing.
 	}, time.Second, 10*time.Millisecond)
 }
 
-// TestStartMaintenanceLoopsUsesConfiguredDatabaseCleanupInterval mirrors
-// TestStartMaintenanceLoopsUsesConfiguredPublisherCleanupInterval for the
-// database manager: it proves startMaintenanceLoops passes the operator-
-// configured database.manager.cleanupinterval through to DbManager.StartCleanup
-// instead of the old hardcoded 5m literal. A 5m default interval would never
-// fire within this test's window; observing the idle connection actually get
-// swept proves the short configured interval was used.
+// TestStartMaintenanceLoopsUsesConfiguredDatabaseCleanupInterval proves the
+// configured 20ms interval reached DbManager.StartCleanup: the 5m hardcoded
+// default would never fire in this test's 1s window, so a swept idle connection
+// is the proof.
 func TestStartMaintenanceLoopsUsesConfiguredDatabaseCleanupInterval(t *testing.T) {
 	log := logger.New("error", false)
 
@@ -423,13 +420,6 @@ func TestStartMaintenanceLoopsUsesConfiguredDatabaseCleanupInterval(t *testing.T
 	}, time.Second, 10*time.Millisecond)
 }
 
-// TestCleanupIntervalTooLate guards the shared predicate: the previously
-// implicit guarantee (hardcoded sweeps always well below any configured TTL) no
-// longer holds now that cleanupinterval and idlettl are independently
-// operator-configurable for both messaging.publisher.* and database.manager.*.
-// The predicate must flag "sweep frequency >= TTL" (eviction merely lags, so this
-// is advisory, not fatal — see startMaintenanceLoops) while treating idleTTL <= 0
-// as "nothing meaningful to compare" — as the zero/negative cases here exercise.
 func TestCleanupIntervalTooLate(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gaborage/go-bricks/config"
+	"github.com/gaborage/go-bricks/database"
+	dbtest "github.com/gaborage/go-bricks/database/testing"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
 	"github.com/gaborage/go-bricks/server"
@@ -387,16 +389,48 @@ func TestStartMaintenanceLoopsUsesConfiguredPublisherCleanupInterval(t *testing.
 	}, time.Second, 10*time.Millisecond)
 }
 
-// TestPublisherCleanupIntervalTooLate guards the Fix-3 predicate: the previously
-// implicit guarantee (a hardcoded 2m sweep always well below any configured TTL) no
-// longer holds now that both messaging.publisher.cleanupinterval and
-// messaging.publisher.idlettl are independently operator-configurable. The predicate
-// must flag "sweep frequency >= TTL" (eviction merely lags, so this is advisory, not
-// fatal — see startMaintenanceLoops) while treating idleTTL <= 0 as "nothing
-// meaningful to compare". config.Validate applies the IdleTTL default unconditionally
-// (see config/validation.go: validateMessaging), so that guard is purely defensive
-// for callers that bypass Validate — as the zero/negative cases here exercise.
-func TestPublisherCleanupIntervalTooLate(t *testing.T) {
+// TestStartMaintenanceLoopsUsesConfiguredDatabaseCleanupInterval mirrors
+// TestStartMaintenanceLoopsUsesConfiguredPublisherCleanupInterval for the
+// database manager: it proves startMaintenanceLoops passes the operator-
+// configured database.manager.cleanupinterval through to DbManager.StartCleanup
+// instead of the old hardcoded 5m literal. A 5m default interval would never
+// fire within this test's window; observing the idle connection actually get
+// swept proves the short configured interval was used.
+func TestStartMaintenanceLoopsUsesConfiguredDatabaseCleanupInterval(t *testing.T) {
+	log := logger.New("error", false)
+
+	connector := func(*config.DatabaseConfig, logger.Logger) (database.Interface, error) {
+		return dbtest.NewTestDB("postgresql"), nil
+	}
+	dbManager := database.NewDbManager(&stubTenantResource{}, log, database.DbManagerOptions{MaxSize: 5, IdleTTL: 10 * time.Millisecond}, connector)
+	defer func() { _ = dbManager.Close() }()
+
+	_, rel, err := dbManager.Get(context.Background(), testKey)
+	require.NoError(t, err)
+	rel()
+
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{
+			Manager: config.DatabaseManagerConfig{CleanupInterval: 20 * time.Millisecond},
+		},
+	}
+	a := &App{cfg: cfg, logger: log, dbManager: dbManager}
+	a.startMaintenanceLoops()
+	defer a.dbManager.StopCleanup()
+
+	assert.Eventually(t, func() bool {
+		return dbManager.Stats()["active_connections"] == 0
+	}, time.Second, 10*time.Millisecond)
+}
+
+// TestCleanupIntervalTooLate guards the shared predicate: the previously
+// implicit guarantee (hardcoded sweeps always well below any configured TTL) no
+// longer holds now that cleanupinterval and idlettl are independently
+// operator-configurable for both messaging.publisher.* and database.manager.*.
+// The predicate must flag "sweep frequency >= TTL" (eviction merely lags, so this
+// is advisory, not fatal — see startMaintenanceLoops) while treating idleTTL <= 0
+// as "nothing meaningful to compare" — as the zero/negative cases here exercise.
+func TestCleanupIntervalTooLate(t *testing.T) {
 	tests := []struct {
 		name            string
 		cleanupInterval time.Duration
@@ -413,7 +447,7 @@ func TestPublisherCleanupIntervalTooLate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, publisherCleanupIntervalTooLate(tc.cleanupInterval, tc.idleTTL))
+			assert.Equal(t, tc.want, cleanupIntervalTooLate(tc.cleanupInterval, tc.idleTTL))
 		})
 	}
 }

--- a/app/managers.go
+++ b/app/managers.go
@@ -29,6 +29,9 @@ const (
 	defaultCacheMaxSize                = 100
 	defaultCacheIdleTTL                = 15 * time.Minute
 	defaultCacheCleanupInterval        = 5 * time.Minute
+	defaultDatabaseMaxSize             = 10
+	defaultDatabaseIdleTTL             = 1 * time.Hour    // Single-tenant default; see config/validation.go
+	defaultDatabaseIdleTTLMultiTenant  = 30 * time.Minute // Multi-tenant default; see config/validation.go
 )
 
 // ManagerConfigBuilder creates configuration options for database and messaging managers
@@ -58,6 +61,10 @@ type ManagerConfigBuilder struct {
 	// (cache.manager.*), sourced from validated config by bootstrap.
 	// When unset, documented defaults are applied as fallbacks.
 	cacheConfig config.CacheManagerConfig
+	// dbConfig carries operator-configurable database manager settings
+	// (database.manager.*), sourced from validated config by bootstrap.
+	// When unset, documented defaults are applied as fallbacks.
+	dbConfig config.DatabaseManagerConfig
 }
 
 // NewManagerConfigBuilder creates a new manager configuration builder.
@@ -72,16 +79,38 @@ func NewManagerConfigBuilder(multiTenantEnabled bool, tenantLimit int) *ManagerC
 // Multi-tenant mode uses tenant limits and shorter TTL for dynamic scaling.
 // Single-tenant mode uses smaller fixed limits and longer TTL for stability.
 func (b *ManagerConfigBuilder) BuildDatabaseOptions() database.DbManagerOptions {
-	if b.multiTenantEnabled {
-		return database.DbManagerOptions{
-			MaxSize: b.tenantLimit,    // Use configured tenant limit
-			IdleTTL: 30 * time.Minute, // Shorter TTL for multi-tenant
+	// Operator config (database.manager.*) is the source of truth. Mode-specific
+	// values are fallbacks when the operator left the key unset. Non-positive is
+	// treated as unset: config.Validate rejects negatives, but paths that bypass it
+	// (app.NewWithConfig with an injected config) must not leak a negative through
+	// to NewDbManager, whose own coercion would silently cap the pool at 100
+	// instead of the documented mode default.
+	maxSize := b.dbConfig.MaxSize
+	if maxSize <= 0 {
+		if b.multiTenantEnabled {
+			maxSize = b.tenantLimit // Scale database handle pool with tenant limit
+		} else {
+			maxSize = defaultDatabaseMaxSize // Documented single-tenant default
+		}
+	}
+
+	// On the config.Load bootstrap path, config.Validate (applyDatabaseManagerDefaults)
+	// has already stamped this mode-aware IdleTTL default before dbConfig reaches the
+	// builder, so this branch is inert there. It is load-bearing for construction that
+	// bypasses Validate — app.NewWithConfig with an injected config, and direct builder
+	// use in unit tests — mirroring BuildMessagingOptions's IdleTTL fallback.
+	idleTTL := b.dbConfig.IdleTTL
+	if idleTTL <= 0 {
+		if b.multiTenantEnabled {
+			idleTTL = defaultDatabaseIdleTTLMultiTenant // Shorter TTL for multi-tenant
+		} else {
+			idleTTL = defaultDatabaseIdleTTL // Documented single-tenant default
 		}
 	}
 
 	return database.DbManagerOptions{
-		MaxSize: 10,            // Small fixed size for single-tenant
-		IdleTTL: 1 * time.Hour, // Longer TTL for single-tenant
+		MaxSize: maxSize,
+		IdleTTL: idleTTL,
 	}
 }
 
@@ -100,12 +129,11 @@ func (b *ManagerConfigBuilder) BuildMessagingOptions() messaging.ManagerOptions 
 		}
 	}
 
-	// This fallback only serves direct/unvalidated construction (e.g. NewManagerConfigBuilder
-	// called without going through bootstrap.go's config.Validate()-backed cfg): on the real
-	// production path, config.Validate() (config/validation.go: applyMessagingDefaults) has
-	// already applied this same mode-aware default before publisherConfig reaches the builder,
-	// so this branch is dead there — it exists only to keep the builder's documented behavior
-	// correct when invoked without a fully-validated config (e.g. unit tests).
+	// On the config.Load bootstrap path, config.Validate (applyMessagingDefaults) has
+	// already applied this same mode-aware default before publisherConfig reaches the
+	// builder, so this branch is inert there. It is load-bearing for construction that
+	// bypasses Validate — app.NewWithConfig with an injected config, and direct builder
+	// use in unit tests.
 	idleTTL := b.publisherConfig.IdleTTL
 	if idleTTL == 0 {
 		if b.multiTenantEnabled {
@@ -234,8 +262,9 @@ func (f *ResourceManagerFactory) warnIfPoolBelowTenantCount(resource string, max
 		Msg("Resource pool max size is below the number of configured tenants; " +
 			"the LRU manager will evict and recreate handles on requests for uncached tenants " +
 			"(eviction thrash). Raise the pool size for this resource " +
-			"(cache.manager.maxsize, messaging.publisher.maxcached, or multitenant.limits.tenants " +
-			"for the database) to at least the tenant count.")
+			"(cache.manager.maxsize, messaging.publisher.maxcached, or for the database: " +
+			"database.manager.maxsize when set, otherwise multitenant.limits.tenants) " +
+			"to at least the tenant count.")
 }
 
 // poolBelowTenantCount reports whether a per-tenant pool of the given maxSize is

--- a/app/managers.go
+++ b/app/managers.go
@@ -30,8 +30,8 @@ const (
 	defaultCacheIdleTTL                = 15 * time.Minute
 	defaultCacheCleanupInterval        = 5 * time.Minute
 	defaultDatabaseMaxSize             = 10
-	defaultDatabaseIdleTTL             = 1 * time.Hour    // Single-tenant default; see config/validation.go
-	defaultDatabaseIdleTTLMultiTenant  = 30 * time.Minute // Multi-tenant default; see config/validation.go
+	defaultDatabaseIdleTTL             = 1 * time.Hour    // mirrors config/validation.go
+	defaultDatabaseIdleTTLMultiTenant  = 30 * time.Minute // mirrors config/validation.go
 )
 
 // ManagerConfigBuilder creates configuration options for database and messaging managers
@@ -61,9 +61,7 @@ type ManagerConfigBuilder struct {
 	// (cache.manager.*), sourced from validated config by bootstrap.
 	// When unset, documented defaults are applied as fallbacks.
 	cacheConfig config.CacheManagerConfig
-	// dbConfig carries operator-configurable database manager settings
-	// (database.manager.*), sourced from validated config by bootstrap.
-	// When unset, documented defaults are applied as fallbacks.
+	// dbConfig holds database.manager.* settings, set by bootstrap from validated config.
 	dbConfig config.DatabaseManagerConfig
 }
 
@@ -75,11 +73,9 @@ func NewManagerConfigBuilder(multiTenantEnabled bool, tenantLimit int) *ManagerC
 	}
 }
 
-// resolveMaxSize returns the operator-configured pool cap, falling back to the
-// tenant limit (multi-tenant) or the given single-tenant default when the key is
-// unset. Non-positive is treated as unset: config.Validate rejects negatives, but
-// paths that bypass it (app.NewWithConfig with an injected config) must not leak
-// a negative into a manager's own silent coercion.
+// resolveMaxSize treats non-positive as unset (not just zero) so a negative from a
+// Validate-bypassing path (app.NewWithConfig) can't skip the mode-aware fallback and
+// reach the managers' own <=0->default coercion (see database/manager.go, messaging/manager.go).
 func (b *ManagerConfigBuilder) resolveMaxSize(operatorValue, singleTenantDefault int) int {
 	if operatorValue > 0 {
 		return operatorValue
@@ -90,11 +86,7 @@ func (b *ManagerConfigBuilder) resolveMaxSize(operatorValue, singleTenantDefault
 	return singleTenantDefault
 }
 
-// resolveIdleTTL is resolveMaxSize's counterpart for mode-aware idle TTLs. On the
-// config.Load bootstrap path, config.Validate has already stamped these defaults,
-// so the fallback is inert there. It is load-bearing for construction that
-// bypasses Validate — app.NewWithConfig with an injected config, and direct
-// builder use in unit tests.
+// resolveIdleTTL mirrors resolveMaxSize: the fallback is inert once config.Validate stamps defaults, but load-bearing when Validate is bypassed (NewWithConfig, unit tests).
 func (b *ManagerConfigBuilder) resolveIdleTTL(operatorValue, multiTenantDefault, singleTenantDefault time.Duration) time.Duration {
 	if operatorValue > 0 {
 		return operatorValue
@@ -108,9 +100,6 @@ func (b *ManagerConfigBuilder) resolveIdleTTL(operatorValue, multiTenantDefault,
 // BuildDatabaseOptions creates database manager options based on deployment mode.
 // Multi-tenant mode uses tenant limits and shorter TTL for dynamic scaling.
 // Single-tenant mode uses smaller fixed limits and longer TTL for stability.
-// Operator config (database.manager.*) is the source of truth; mode-specific
-// values are fallbacks when the operator left the key unset (see resolveMaxSize
-// / resolveIdleTTL).
 func (b *ManagerConfigBuilder) BuildDatabaseOptions() database.DbManagerOptions {
 	return database.DbManagerOptions{
 		MaxSize: b.resolveMaxSize(b.dbConfig.MaxSize, defaultDatabaseMaxSize),
@@ -121,9 +110,6 @@ func (b *ManagerConfigBuilder) BuildDatabaseOptions() database.DbManagerOptions 
 // BuildMessagingOptions creates messaging manager options based on deployment mode.
 // Multi-tenant mode uses tenant limits and shorter TTL for dynamic scaling.
 // Single-tenant mode uses smaller fixed limits and a longer TTL (same 1h as the DB pool).
-// Operator config (messaging.publisher.*) is the source of truth; mode-specific
-// values are fallbacks when the operator left the key unset (see resolveMaxSize
-// / resolveIdleTTL).
 func (b *ManagerConfigBuilder) BuildMessagingOptions() messaging.ManagerOptions {
 	return messaging.ManagerOptions{
 		MaxPublishers:      b.resolveMaxSize(b.publisherConfig.MaxCached, defaultPublisherMaxCached),

--- a/app/managers.go
+++ b/app/managers.go
@@ -75,77 +75,59 @@ func NewManagerConfigBuilder(multiTenantEnabled bool, tenantLimit int) *ManagerC
 	}
 }
 
+// resolveMaxSize returns the operator-configured pool cap, falling back to the
+// tenant limit (multi-tenant) or the given single-tenant default when the key is
+// unset. Non-positive is treated as unset: config.Validate rejects negatives, but
+// paths that bypass it (app.NewWithConfig with an injected config) must not leak
+// a negative into a manager's own silent coercion.
+func (b *ManagerConfigBuilder) resolveMaxSize(operatorValue, singleTenantDefault int) int {
+	if operatorValue > 0 {
+		return operatorValue
+	}
+	if b.multiTenantEnabled {
+		return b.tenantLimit
+	}
+	return singleTenantDefault
+}
+
+// resolveIdleTTL is resolveMaxSize's counterpart for mode-aware idle TTLs. On the
+// config.Load bootstrap path, config.Validate has already stamped these defaults,
+// so the fallback is inert there. It is load-bearing for construction that
+// bypasses Validate — app.NewWithConfig with an injected config, and direct
+// builder use in unit tests.
+func (b *ManagerConfigBuilder) resolveIdleTTL(operatorValue, multiTenantDefault, singleTenantDefault time.Duration) time.Duration {
+	if operatorValue > 0 {
+		return operatorValue
+	}
+	if b.multiTenantEnabled {
+		return multiTenantDefault
+	}
+	return singleTenantDefault
+}
+
 // BuildDatabaseOptions creates database manager options based on deployment mode.
 // Multi-tenant mode uses tenant limits and shorter TTL for dynamic scaling.
 // Single-tenant mode uses smaller fixed limits and longer TTL for stability.
+// Operator config (database.manager.*) is the source of truth; mode-specific
+// values are fallbacks when the operator left the key unset (see resolveMaxSize
+// / resolveIdleTTL).
 func (b *ManagerConfigBuilder) BuildDatabaseOptions() database.DbManagerOptions {
-	// Operator config (database.manager.*) is the source of truth. Mode-specific
-	// values are fallbacks when the operator left the key unset. Non-positive is
-	// treated as unset: config.Validate rejects negatives, but paths that bypass it
-	// (app.NewWithConfig with an injected config) must not leak a negative through
-	// to NewDbManager, whose own coercion would silently cap the pool at 100
-	// instead of the documented mode default.
-	maxSize := b.dbConfig.MaxSize
-	if maxSize <= 0 {
-		if b.multiTenantEnabled {
-			maxSize = b.tenantLimit // Scale database handle pool with tenant limit
-		} else {
-			maxSize = defaultDatabaseMaxSize // Documented single-tenant default
-		}
-	}
-
-	// On the config.Load bootstrap path, config.Validate (applyDatabaseManagerDefaults)
-	// has already stamped this mode-aware IdleTTL default before dbConfig reaches the
-	// builder, so this branch is inert there. It is load-bearing for construction that
-	// bypasses Validate — app.NewWithConfig with an injected config, and direct builder
-	// use in unit tests — mirroring BuildMessagingOptions's IdleTTL fallback.
-	idleTTL := b.dbConfig.IdleTTL
-	if idleTTL <= 0 {
-		if b.multiTenantEnabled {
-			idleTTL = defaultDatabaseIdleTTLMultiTenant // Shorter TTL for multi-tenant
-		} else {
-			idleTTL = defaultDatabaseIdleTTL // Documented single-tenant default
-		}
-	}
-
 	return database.DbManagerOptions{
-		MaxSize: maxSize,
-		IdleTTL: idleTTL,
+		MaxSize: b.resolveMaxSize(b.dbConfig.MaxSize, defaultDatabaseMaxSize),
+		IdleTTL: b.resolveIdleTTL(b.dbConfig.IdleTTL, defaultDatabaseIdleTTLMultiTenant, defaultDatabaseIdleTTL),
 	}
 }
 
 // BuildMessagingOptions creates messaging manager options based on deployment mode.
 // Multi-tenant mode uses tenant limits and shorter TTL for dynamic scaling.
 // Single-tenant mode uses smaller fixed limits and a longer TTL (same 1h as the DB pool).
+// Operator config (messaging.publisher.*) is the source of truth; mode-specific
+// values are fallbacks when the operator left the key unset (see resolveMaxSize
+// / resolveIdleTTL).
 func (b *ManagerConfigBuilder) BuildMessagingOptions() messaging.ManagerOptions {
-	// Operator config (messaging.publisher.*) is the source of truth. Mode-specific
-	// values are only fallbacks when the operator left the key unset (zero).
-	maxPublishers := b.publisherConfig.MaxCached
-	if maxPublishers == 0 {
-		if b.multiTenantEnabled {
-			maxPublishers = b.tenantLimit // Scale publisher pool with tenant limit
-		} else {
-			maxPublishers = defaultPublisherMaxCached // Documented single-tenant default
-		}
-	}
-
-	// On the config.Load bootstrap path, config.Validate (applyMessagingDefaults) has
-	// already applied this same mode-aware default before publisherConfig reaches the
-	// builder, so this branch is inert there. It is load-bearing for construction that
-	// bypasses Validate — app.NewWithConfig with an injected config, and direct builder
-	// use in unit tests.
-	idleTTL := b.publisherConfig.IdleTTL
-	if idleTTL == 0 {
-		if b.multiTenantEnabled {
-			idleTTL = defaultPublisherIdleTTLMultiTenant // Documented multi-tenant default (10m)
-		} else {
-			idleTTL = defaultPublisherIdleTTL // Documented single-tenant default (1h)
-		}
-	}
-
 	return messaging.ManagerOptions{
-		MaxPublishers:      maxPublishers,
-		IdleTTL:            idleTTL,
+		MaxPublishers:      b.resolveMaxSize(b.publisherConfig.MaxCached, defaultPublisherMaxCached),
+		IdleTTL:            b.resolveIdleTTL(b.publisherConfig.IdleTTL, defaultPublisherIdleTTLMultiTenant, defaultPublisherIdleTTL),
 		ConnectionTimeout:  b.connectionTimeout,
 		MaxPublishAttempts: b.maxPublishAttempts,
 		ReadyTimeout:       b.readyTimeout,

--- a/app/managers_test.go
+++ b/app/managers_test.go
@@ -104,10 +104,7 @@ func TestManagerConfigBuilderBuildDatabaseOptions(t *testing.T) {
 		assert.Equal(t, 30*time.Minute, options.IdleTTL)
 	})
 
-	// Negative dbConfig values are rejected by config.Validate, but paths that
-	// bypass it (app.NewWithConfig with an injected config) must treat them as
-	// unset here — otherwise they'd leak to NewDbManager, whose <=0 coercion
-	// silently caps the pool at 100 instead of the documented mode default.
+	// Negatives can reach here via the app.NewWithConfig Validate-bypass; they must resolve to the mode default, not leak into NewDbManager's <=0 coercion (see resolveMaxSize).
 	t.Run("negative_operator_values_treated_as_unset_multi_tenant", func(t *testing.T) {
 		builder := NewManagerConfigBuilder(true, 42)
 		builder.dbConfig = config.DatabaseManagerConfig{MaxSize: -1, IdleTTL: -time.Second}
@@ -302,8 +299,7 @@ func TestManagerConfigBuilderHonorsConfigDefaults(t *testing.T) {
 	})
 
 	t.Run("multi-tenant database zero dbConfig scales to tenant limit and 30m", func(t *testing.T) {
-		// Zero-preservation pin (#661): an unset dbConfig must still let the
-		// builder scale MaxSize to the tenant limit and IdleTTL to 30m.
+		// Pins #661: unset dbConfig must fall through to multi-tenant defaults, not literal 0.
 		builder := NewManagerConfigBuilder(true, 250)
 		opts := builder.BuildDatabaseOptions()
 		assert.Equal(t, 250, opts.MaxSize, "unset database.manager.maxsize must scale to the tenant limit")

--- a/app/managers_test.go
+++ b/app/managers_test.go
@@ -103,6 +103,30 @@ func TestManagerConfigBuilderBuildDatabaseOptions(t *testing.T) {
 		assert.Equal(t, largeLimit, options.MaxSize)
 		assert.Equal(t, 30*time.Minute, options.IdleTTL)
 	})
+
+	// Negative dbConfig values are rejected by config.Validate, but paths that
+	// bypass it (app.NewWithConfig with an injected config) must treat them as
+	// unset here — otherwise they'd leak to NewDbManager, whose <=0 coercion
+	// silently caps the pool at 100 instead of the documented mode default.
+	t.Run("negative_operator_values_treated_as_unset_multi_tenant", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(true, 42)
+		builder.dbConfig = config.DatabaseManagerConfig{MaxSize: -1, IdleTTL: -time.Second}
+
+		options := builder.BuildDatabaseOptions()
+
+		assert.Equal(t, 42, options.MaxSize)
+		assert.Equal(t, 30*time.Minute, options.IdleTTL)
+	})
+
+	t.Run("negative_operator_values_treated_as_unset_single_tenant", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(false, 0)
+		builder.dbConfig = config.DatabaseManagerConfig{MaxSize: -1, IdleTTL: -time.Second}
+
+		options := builder.BuildDatabaseOptions()
+
+		assert.Equal(t, 10, options.MaxSize)
+		assert.Equal(t, 1*time.Hour, options.IdleTTL)
+	})
 }
 
 func TestManagerConfigBuilderBuildMessagingOptions(t *testing.T) {
@@ -248,6 +272,42 @@ func TestManagerConfigBuilderHonorsConfigDefaults(t *testing.T) {
 		builder.publisherConfig = config.PublisherPoolConfig{MaxCached: 888}
 		opts := builder.BuildMessagingOptions()
 		assert.Equal(t, 888, opts.MaxPublishers, "operator messaging.publisher.maxcached override must win over tenant limit")
+	})
+
+	t.Run("single-tenant BuildDatabaseOptions should honor config defaults not hardcoded 10", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(false, 100)
+		opts := builder.BuildDatabaseOptions()
+		assert.Equal(t, 10, opts.MaxSize, "should honor database.manager.maxsize config default of 10")
+	})
+
+	t.Run("single-tenant BuildDatabaseOptions IdleTTL should honor config default 1h", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(false, 100)
+		opts := builder.BuildDatabaseOptions()
+		assert.Equal(t, 1*time.Hour, opts.IdleTTL, "should honor database.manager.idlettl config default of 1h")
+	})
+
+	t.Run("operator override reaches database options", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(false, 100)
+		builder.dbConfig = config.DatabaseManagerConfig{MaxSize: 33, IdleTTL: 8 * time.Minute}
+		opts := builder.BuildDatabaseOptions()
+		assert.Equal(t, 33, opts.MaxSize, "operator database.manager.maxsize override must reach DbManagerOptions")
+		assert.Equal(t, 8*time.Minute, opts.IdleTTL, "operator database.manager.idlettl override must reach DbManagerOptions")
+	})
+
+	t.Run("multi-tenant database MaxSize honors operator override over tenant limit", func(t *testing.T) {
+		builder := NewManagerConfigBuilder(true, 250)
+		builder.dbConfig = config.DatabaseManagerConfig{MaxSize: 777}
+		opts := builder.BuildDatabaseOptions()
+		assert.Equal(t, 777, opts.MaxSize, "operator database.manager.maxsize override must win over tenant limit")
+	})
+
+	t.Run("multi-tenant database zero dbConfig scales to tenant limit and 30m", func(t *testing.T) {
+		// Zero-preservation pin (#661): an unset dbConfig must still let the
+		// builder scale MaxSize to the tenant limit and IdleTTL to 30m.
+		builder := NewManagerConfigBuilder(true, 250)
+		opts := builder.BuildDatabaseOptions()
+		assert.Equal(t, 250, opts.MaxSize, "unset database.manager.maxsize must scale to the tenant limit")
+		assert.Equal(t, 30*time.Minute, opts.IdleTTL, "unset database.manager.idlettl must fall back to multi-tenant 30m")
 	})
 }
 

--- a/config/types.go
+++ b/config/types.go
@@ -155,28 +155,13 @@ type DatabaseConfig struct {
 	PostgreSQL PostgreSQLConfig `koanf:"postgresql" json:"postgresql" yaml:"postgresql" toml:"postgresql" mapstructure:"postgresql"`
 	Oracle     OracleConfig     `koanf:"oracle" json:"oracle" yaml:"oracle" toml:"oracle" mapstructure:"oracle"`
 
-	// Manager holds database connection-manager (key-cached pool) lifecycle
-	// settings. It is honored only when this DatabaseConfig is Config.Database
-	// (the primary): that single database.DbManager also caches named
-	// databases.<name> handles (keyed "named:<name>") and per-tenant handles, so
-	// these keys govern all of them. A manager block on Config.Databases[name] or
-	// per-tenant database entries is rejected at startup (it would otherwise be
-	// silently ignored).
+	// Manager applies only to the primary Config.Database, whose single
+	// database.DbManager also caches named databases.<name> and per-tenant handles.
 	Manager DatabaseManagerConfig `koanf:"manager" json:"manager" yaml:"manager" toml:"manager" mapstructure:"manager"`
 }
 
 // DatabaseManagerConfig holds database manager (key-cached connection pool)
-// lifecycle settings. Production-safe defaults are applied automatically:
-//   - MaxSize: 10 (maximum active database handles, single-tenant)
-//   - IdleTTL: 1h (idle timeout per handle, single-tenant)
-//   - CleanupInterval: 5m (cleanup goroutine frequency)
-//
-// In multi-tenant mode, validation stamps IdleTTL to 30m when unset, while a
-// zero MaxSize is preserved so app.ManagerConfigBuilder.BuildDatabaseOptions
-// scales it to multitenant.limits.tenants at build time. An explicit positive
-// value always overrides the mode default, matching the messaging.publisher.* /
-// cache.manager.* precedent. Honored only on Config.Database; a manager block
-// on named or per-tenant database entries fails startup validation.
+// lifecycle settings. Per-mode defaults are documented on each field.
 type DatabaseManagerConfig struct {
 	// MaxSize is the maximum number of active database handles. 0 = use default
 	// (10 single-tenant / tenant limit multi-tenant); negative values are invalid.
@@ -190,9 +175,6 @@ type DatabaseManagerConfig struct {
 	CleanupInterval time.Duration `koanf:"cleanupinterval" json:"cleanupinterval" yaml:"cleanupinterval" toml:"cleanupinterval" mapstructure:"cleanupinterval"`
 }
 
-// isSet reports whether any DatabaseManagerConfig field has been explicitly
-// configured. Used by validation to reject manager blocks in locations where
-// they would be silently ignored (named and per-tenant database entries).
 func (c DatabaseManagerConfig) isSet() bool {
 	return c != (DatabaseManagerConfig{})
 }

--- a/config/types.go
+++ b/config/types.go
@@ -190,6 +190,13 @@ type DatabaseManagerConfig struct {
 	CleanupInterval time.Duration `koanf:"cleanupinterval" json:"cleanupinterval" yaml:"cleanupinterval" toml:"cleanupinterval" mapstructure:"cleanupinterval"`
 }
 
+// isSet reports whether any DatabaseManagerConfig field has been explicitly
+// configured. Used by validation to reject manager blocks in locations where
+// they would be silently ignored (named and per-tenant database entries).
+func (c DatabaseManagerConfig) isSet() bool {
+	return c != (DatabaseManagerConfig{})
+}
+
 // PoolConfig holds connection pool settings.
 // Production-safe defaults are applied automatically when database is configured:
 //   - Max.Connections: 25 (maximum open connections)

--- a/config/types.go
+++ b/config/types.go
@@ -154,6 +154,40 @@ type DatabaseConfig struct {
 
 	PostgreSQL PostgreSQLConfig `koanf:"postgresql" json:"postgresql" yaml:"postgresql" toml:"postgresql" mapstructure:"postgresql"`
 	Oracle     OracleConfig     `koanf:"oracle" json:"oracle" yaml:"oracle" toml:"oracle" mapstructure:"oracle"`
+
+	// Manager holds database connection-manager (key-cached pool) lifecycle
+	// settings. It is honored only when this DatabaseConfig is Config.Database
+	// (the primary): that single database.DbManager also caches named
+	// databases.<name> handles (keyed "named:<name>") and per-tenant handles, so
+	// these keys govern all of them. A manager block on Config.Databases[name] or
+	// per-tenant database entries is rejected at startup (it would otherwise be
+	// silently ignored).
+	Manager DatabaseManagerConfig `koanf:"manager" json:"manager" yaml:"manager" toml:"manager" mapstructure:"manager"`
+}
+
+// DatabaseManagerConfig holds database manager (key-cached connection pool)
+// lifecycle settings. Production-safe defaults are applied automatically:
+//   - MaxSize: 10 (maximum active database handles, single-tenant)
+//   - IdleTTL: 1h (idle timeout per handle, single-tenant)
+//   - CleanupInterval: 5m (cleanup goroutine frequency)
+//
+// In multi-tenant mode, validation stamps IdleTTL to 30m when unset, while a
+// zero MaxSize is preserved so app.ManagerConfigBuilder.BuildDatabaseOptions
+// scales it to multitenant.limits.tenants at build time. An explicit positive
+// value always overrides the mode default, matching the messaging.publisher.* /
+// cache.manager.* precedent. Honored only on Config.Database; a manager block
+// on named or per-tenant database entries fails startup validation.
+type DatabaseManagerConfig struct {
+	// MaxSize is the maximum number of active database handles. 0 = use default
+	// (10 single-tenant / tenant limit multi-tenant); negative values are invalid.
+	MaxSize int `koanf:"maxsize" json:"maxsize" yaml:"maxsize" toml:"maxsize" mapstructure:"maxsize"`
+
+	// IdleTTL is the idle timeout before a database handle is closed.
+	// Default: 1h single-tenant / 30m multi-tenant.
+	IdleTTL time.Duration `koanf:"idlettl" json:"idlettl" yaml:"idlettl" toml:"idlettl" mapstructure:"idlettl"`
+
+	// CleanupInterval is how often the cleanup goroutine runs. Default: 5m.
+	CleanupInterval time.Duration `koanf:"cleanupinterval" json:"cleanupinterval" yaml:"cleanupinterval" toml:"cleanupinterval" mapstructure:"cleanupinterval"`
 }
 
 // PoolConfig holds connection pool settings.

--- a/config/validation.go
+++ b/config/validation.go
@@ -663,7 +663,7 @@ func validateNamedDatabaseEntry(name string, dbCfg *DatabaseConfig, mt *Multiten
 	// Named databases share the primary DbManager (handles keyed "named:<name>")
 	// and have no manager of their own — a manager block here would be silently
 	// ignored, so reject it (Fail Fast, no silent config).
-	if dbCfg.Manager != (DatabaseManagerConfig{}) {
+	if dbCfg.Manager.isSet() {
 		return &ConfigError{
 			Category: errCategoryInvalid,
 			Field:    fmt.Sprintf(databasesFieldPrefix, name) + ".manager",
@@ -1325,7 +1325,7 @@ func validateMultitenantTenants(tenants map[string]TenantEntry) error {
 
 		// Per-tenant handles live in the single shared DbManager; a per-tenant
 		// manager block would be silently ignored, so reject it (Fail Fast).
-		if tenant.Database.Manager != (DatabaseManagerConfig{}) {
+		if tenant.Database.Manager.isSet() {
 			return NewMultiTenantError(tenantID, "database.manager",
 				"database.manager.* is only supported on the primary database",
 				fmt.Sprintf("remove the manager block from multitenant.tenants.%s.database; tune the shared pool via database.manager.*", tenantID))

--- a/config/validation.go
+++ b/config/validation.go
@@ -68,10 +68,10 @@ const (
 
 // Database manager defaults
 const (
-	defaultDatabaseManagerMaxSize            = 10               // Maximum active database handles (single-tenant)
-	defaultDatabaseManagerIdleTTL            = 1 * time.Hour    // Idle timeout per handle (single-tenant)
-	defaultDatabaseManagerIdleTTLMultiTenant = 30 * time.Minute // Idle timeout per handle (multi-tenant)
-	defaultDatabaseManagerCleanupInterval    = 5 * time.Minute  // Cleanup goroutine frequency
+	defaultDatabaseManagerMaxSize            = 10
+	defaultDatabaseManagerIdleTTL            = 1 * time.Hour
+	defaultDatabaseManagerIdleTTLMultiTenant = 30 * time.Minute
+	defaultDatabaseManagerCleanupInterval    = 5 * time.Minute
 )
 
 // Redis cache defaults. The top-level cache.* keys receive these via koanf
@@ -158,9 +158,7 @@ func Validate(cfg *Config) error {
 		return fmt.Errorf("database config: %w", err)
 	}
 
-	// Applied only to the primary Config.Database — named Config.Databases[name]
-	// entries have no DbManager of their own, so their Manager sub-struct stays
-	// unpopulated (validateNamedDatabases does not touch it).
+	// Named/tenant DBs share the primary DbManager (see validateNamedDatabaseEntry), so manager defaults apply only here.
 	if err := applyDatabaseManagerDefaults(&cfg.Database.Manager, cfg.Multitenant.Enabled); err != nil {
 		return fmt.Errorf("database config: %w", err)
 	}
@@ -660,9 +658,8 @@ func validateNamedDatabaseEntry(name string, dbCfg *DatabaseConfig, mt *Multiten
 		return fmt.Errorf("databases.%s: %w", name, err)
 	}
 
-	// Named databases share the primary DbManager (handles keyed "named:<name>")
-	// and have no manager of their own — a manager block here would be silently
-	// ignored, so reject it (Fail Fast, no silent config).
+	// Named databases share the single primary DbManager; a per-entry manager
+	// block would be silently ignored, so reject it (Fail Fast).
 	if dbCfg.Manager.isSet() {
 		return &ConfigError{
 			Category: errCategoryInvalid,
@@ -797,9 +794,6 @@ func applyCacheManagerDefaults(cfg *CacheConfig) error {
 //     zero is preserved so app.ManagerConfigBuilder.BuildDatabaseOptions scales
 //     the handle pool to the tenant limit; if negative, errors.
 //
-// The multitenant flag exists because MaxSize's multi-tenant default is dynamic —
-// see the inline comment on the MaxSize block below.
-//
 // Returns an error when any value is invalid; otherwise returns nil.
 func applyDatabaseManagerDefaults(cfg *DatabaseManagerConfig, multitenant bool) error {
 	idleTTLDefault := defaultDatabaseManagerIdleTTL
@@ -813,11 +807,7 @@ func applyDatabaseManagerDefaults(cfg *DatabaseManagerConfig, multitenant bool) 
 		return err
 	}
 
-	// MaxSize's multi-tenant default is dynamic — the builder scales the handle
-	// pool to the tenant limit when the key is unset — so zero is preserved in
-	// multi-tenant mode (negative is still rejected). Stamping the flat
-	// single-tenant default here would silently cap the pool below the tenant
-	// limit (the #661 MaxCached lesson).
+	// Multi-tenant: keep zero so the builder scales the pool — don't stamp the default (#661).
 	if multitenant {
 		if cfg.MaxSize < 0 {
 			return NewValidationError("database.manager.maxsize", errMustBeNonNegative)
@@ -1323,8 +1313,7 @@ func validateMultitenantTenants(tenants map[string]TenantEntry) error {
 			return fmt.Errorf("tenant %s database: %w", tenantID, err)
 		}
 
-		// Per-tenant handles live in the single shared DbManager; a per-tenant
-		// manager block would be silently ignored, so reject it (Fail Fast).
+		// A per-tenant manager block would be silently ignored — tenants share the primary DbManager — so reject it.
 		if tenant.Database.Manager.isSet() {
 			return NewMultiTenantError(tenantID, "database.manager",
 				"database.manager.* is only supported on the primary database",

--- a/config/validation.go
+++ b/config/validation.go
@@ -66,6 +66,14 @@ const (
 	defaultCacheCleanupInterval = 5 * time.Minute  // Cleanup goroutine frequency
 )
 
+// Database manager defaults
+const (
+	defaultDatabaseManagerMaxSize            = 10               // Maximum active database handles (single-tenant)
+	defaultDatabaseManagerIdleTTL            = 1 * time.Hour    // Idle timeout per handle (single-tenant)
+	defaultDatabaseManagerIdleTTLMultiTenant = 30 * time.Minute // Idle timeout per handle (multi-tenant)
+	defaultDatabaseManagerCleanupInterval    = 5 * time.Minute  // Cleanup goroutine frequency
+)
+
 // Redis cache defaults. The top-level cache.* keys receive these via koanf
 // (see config.go), but per-tenant multitenant.tenants.<id>.cache.* keys have no
 // koanf defaults, so validation must apply them itself (see applyRedisDefaults).
@@ -147,6 +155,13 @@ func Validate(cfg *Config) error {
 	}
 
 	if err := validateDatabase(&cfg.Database); err != nil {
+		return fmt.Errorf("database config: %w", err)
+	}
+
+	// Applied only to the primary Config.Database — named Config.Databases[name]
+	// entries have no DbManager of their own, so their Manager sub-struct stays
+	// unpopulated (validateNamedDatabases does not touch it).
+	if err := applyDatabaseManagerDefaults(&cfg.Database.Manager, cfg.Multitenant.Enabled); err != nil {
 		return fmt.Errorf("database config: %w", err)
 	}
 
@@ -645,6 +660,18 @@ func validateNamedDatabaseEntry(name string, dbCfg *DatabaseConfig, mt *Multiten
 		return fmt.Errorf("databases.%s: %w", name, err)
 	}
 
+	// Named databases share the primary DbManager (handles keyed "named:<name>")
+	// and have no manager of their own — a manager block here would be silently
+	// ignored, so reject it (Fail Fast, no silent config).
+	if dbCfg.Manager != (DatabaseManagerConfig{}) {
+		return &ConfigError{
+			Category: errCategoryInvalid,
+			Field:    fmt.Sprintf(databasesFieldPrefix, name) + ".manager",
+			Message:  "database.manager.* is only supported on the primary database",
+			Action:   fmt.Sprintf("remove the manager block from databases.%s; tune the shared pool via database.manager.*", name),
+		}
+	}
+
 	return nil
 }
 
@@ -758,6 +785,46 @@ func applyCacheManagerDefaults(cfg *CacheConfig) error {
 	}
 
 	return nil
+}
+
+// applyDatabaseManagerDefaults sets production-safe defaults for the database
+// connection-manager pool.
+//
+// It modifies cfg in-place:
+//   - IdleTTL: if 0, sets to 1h single-tenant / 30m multi-tenant; if negative, errors.
+//   - CleanupInterval: if 0, sets to 5m; if negative, errors.
+//   - MaxSize: if 0, sets to 10 when multitenant is false; in multi-tenant mode
+//     zero is preserved so app.ManagerConfigBuilder.BuildDatabaseOptions scales
+//     the handle pool to the tenant limit; if negative, errors.
+//
+// The multitenant flag exists because MaxSize's multi-tenant default is dynamic —
+// see the inline comment on the MaxSize block below.
+//
+// Returns an error when any value is invalid; otherwise returns nil.
+func applyDatabaseManagerDefaults(cfg *DatabaseManagerConfig, multitenant bool) error {
+	idleTTLDefault := defaultDatabaseManagerIdleTTL
+	if multitenant {
+		idleTTLDefault = defaultDatabaseManagerIdleTTLMultiTenant
+	}
+	if err := applyNonNegativeDefault(&cfg.IdleTTL, idleTTLDefault, "database.manager.idlettl"); err != nil {
+		return err
+	}
+	if err := applyNonNegativeDefault(&cfg.CleanupInterval, defaultDatabaseManagerCleanupInterval, "database.manager.cleanupinterval"); err != nil {
+		return err
+	}
+
+	// MaxSize's multi-tenant default is dynamic — the builder scales the handle
+	// pool to the tenant limit when the key is unset — so zero is preserved in
+	// multi-tenant mode (negative is still rejected). Stamping the flat
+	// single-tenant default here would silently cap the pool below the tenant
+	// limit (the #661 MaxCached lesson).
+	if multitenant {
+		if cfg.MaxSize < 0 {
+			return NewValidationError("database.manager.maxsize", errMustBeNonNegative)
+		}
+		return nil
+	}
+	return applyNonNegativeDefault(&cfg.MaxSize, defaultDatabaseManagerMaxSize, "database.manager.maxsize")
 }
 
 // applyTimeoutDefault validates and applies default to a component timeout.
@@ -1254,6 +1321,14 @@ func validateMultitenantTenants(tenants map[string]TenantEntry) error {
 		}
 		if err := validateDatabase(&tenant.Database); err != nil {
 			return fmt.Errorf("tenant %s database: %w", tenantID, err)
+		}
+
+		// Per-tenant handles live in the single shared DbManager; a per-tenant
+		// manager block would be silently ignored, so reject it (Fail Fast).
+		if tenant.Database.Manager != (DatabaseManagerConfig{}) {
+			return NewMultiTenantError(tenantID, "database.manager",
+				"database.manager.* is only supported on the primary database",
+				fmt.Sprintf("remove the manager block from multitenant.tenants.%s.database; tune the shared pool via database.manager.*", tenantID))
 		}
 
 		if err := validateTenantCache(tenantID, &tenant.Cache); err != nil {

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -4460,12 +4460,6 @@ func TestValidateMultiTenantStaticAppliesMessagingDefaultsEndToEnd(t *testing.T)
 	assert.Zero(t, cfg.Messaging.Publisher.MaxCached)
 }
 
-// TestApplyDatabaseManagerDefaults exercises the mode-aware defaulting for the
-// database connection-manager pool. MaxSize is preserved-zero in multi-tenant
-// mode so ManagerConfigBuilder.BuildDatabaseOptions can scale it to the tenant
-// limit — a flat validation-time default would silently cap the pool below the
-// tenant limit, the exact regression class fixed for messaging MaxCached in
-// commit 453d084 / PR #661.
 func TestApplyDatabaseManagerDefaults(t *testing.T) {
 	t.Run("single_tenant_zero_values_apply_all_defaults", func(t *testing.T) {
 		cfg := &DatabaseManagerConfig{}
@@ -4478,7 +4472,6 @@ func TestApplyDatabaseManagerDefaults(t *testing.T) {
 	t.Run("multi_tenant_zero_preserves_maxsize_uses_30m", func(t *testing.T) {
 		cfg := &DatabaseManagerConfig{}
 		require.NoError(t, applyDatabaseManagerDefaults(cfg, true))
-		// MaxSize preserved (the #661 pin): BuildDatabaseOptions scales it to the tenant limit.
 		assert.Zero(t, cfg.MaxSize)
 		assert.Equal(t, defaultDatabaseManagerIdleTTLMultiTenant, cfg.IdleTTL)
 		assert.Equal(t, defaultDatabaseManagerCleanupInterval, cfg.CleanupInterval)
@@ -4521,10 +4514,6 @@ func TestApplyDatabaseManagerDefaults(t *testing.T) {
 	})
 }
 
-// TestValidateAppliesDatabaseManagerDefaultsOnlyToPrimaryDatabase proves the
-// full top-level Validate stamps database.manager.* defaults on the primary
-// Config.Database only — named Config.Databases[name] entries have no DbManager
-// of their own, so their Manager sub-struct stays zero (no behavior change).
 func TestValidateAppliesDatabaseManagerDefaultsOnlyToPrimaryDatabase(t *testing.T) {
 	cfg := &Config{
 		App: AppConfig{
@@ -4560,15 +4549,12 @@ func TestValidateAppliesDatabaseManagerDefaultsOnlyToPrimaryDatabase(t *testing.
 	assert.Equal(t, defaultDatabaseManagerMaxSize, cfg.Database.Manager.MaxSize)
 	assert.Equal(t, defaultDatabaseManagerIdleTTL, cfg.Database.Manager.IdleTTL)
 	assert.Equal(t, defaultDatabaseManagerCleanupInterval, cfg.Database.Manager.CleanupInterval)
-	// Named DB entries are not manager-governed; their Manager sub-struct stays zero.
 	assert.Equal(t, DatabaseManagerConfig{}, cfg.Databases["legacy"].Manager)
 }
 
-// TestValidateMultiTenantAppliesDatabaseManagerDefaultsEndToEnd pins that the
-// multitenant flag is threaded into applyDatabaseManagerDefaults through the full
-// Validate() entry point: MaxSize must come out zero-preserved (so
-// BuildDatabaseOptions scales the handle pool to the tenant limit) and IdleTTL
-// mode-aware — the wiring-level guard against the #661 MaxCached regression class.
+// TestValidateMultiTenantAppliesDatabaseManagerDefaultsEndToEnd is the wiring-level
+// counterpart to the applyDatabaseManagerDefaults unit tests: it pins that Validate()
+// threads the multitenant flag through, guarding the #661 MaxCached regression class.
 func TestValidateMultiTenantAppliesDatabaseManagerDefaultsEndToEnd(t *testing.T) {
 	newCfg := func() *Config {
 		return &Config{
@@ -4607,7 +4593,6 @@ func TestValidateMultiTenantAppliesDatabaseManagerDefaultsEndToEnd(t *testing.T)
 				},
 			},
 			Source: SourceConfig{Type: SourceTypeStatic},
-			// No root Database section: tenants carry their own DB config.
 		}
 	}
 
@@ -4615,7 +4600,6 @@ func TestValidateMultiTenantAppliesDatabaseManagerDefaultsEndToEnd(t *testing.T)
 		cfg := newCfg()
 		require.NoError(t, Validate(cfg))
 
-		// Zero preserved: BuildDatabaseOptions scales the pool to the tenant limit.
 		assert.Zero(t, cfg.Database.Manager.MaxSize)
 		assert.Equal(t, defaultDatabaseManagerIdleTTLMultiTenant, cfg.Database.Manager.IdleTTL)
 		assert.Equal(t, defaultDatabaseManagerCleanupInterval, cfg.Database.Manager.CleanupInterval)
@@ -4641,9 +4625,6 @@ func TestValidateMultiTenantAppliesDatabaseManagerDefaultsEndToEnd(t *testing.T)
 	})
 }
 
-// TestValidateRejectsManagerBlockOnNamedDatabase pins the Fail-Fast rejection of a
-// manager block under databases.<name> — it is non-functional (named handles live in
-// the primary manager) and would otherwise be silently ignored.
 func TestValidateRejectsManagerBlockOnNamedDatabase(t *testing.T) {
 	cfg := &Config{
 		App: AppConfig{

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -4459,3 +4459,223 @@ func TestValidateMultiTenantStaticAppliesMessagingDefaultsEndToEnd(t *testing.T)
 	// Zero preserved: BuildMessagingOptions scales the pool to the tenant limit.
 	assert.Zero(t, cfg.Messaging.Publisher.MaxCached)
 }
+
+// TestApplyDatabaseManagerDefaults exercises the mode-aware defaulting for the
+// database connection-manager pool. MaxSize is preserved-zero in multi-tenant
+// mode so ManagerConfigBuilder.BuildDatabaseOptions can scale it to the tenant
+// limit — a flat validation-time default would silently cap the pool below the
+// tenant limit, the exact regression class fixed for messaging MaxCached in
+// commit 453d084 / PR #661.
+func TestApplyDatabaseManagerDefaults(t *testing.T) {
+	t.Run("single_tenant_zero_values_apply_all_defaults", func(t *testing.T) {
+		cfg := &DatabaseManagerConfig{}
+		require.NoError(t, applyDatabaseManagerDefaults(cfg, false))
+		assert.Equal(t, defaultDatabaseManagerMaxSize, cfg.MaxSize)
+		assert.Equal(t, defaultDatabaseManagerIdleTTL, cfg.IdleTTL)
+		assert.Equal(t, defaultDatabaseManagerCleanupInterval, cfg.CleanupInterval)
+	})
+
+	t.Run("multi_tenant_zero_preserves_maxsize_uses_30m", func(t *testing.T) {
+		cfg := &DatabaseManagerConfig{}
+		require.NoError(t, applyDatabaseManagerDefaults(cfg, true))
+		// MaxSize preserved (the #661 pin): BuildDatabaseOptions scales it to the tenant limit.
+		assert.Zero(t, cfg.MaxSize)
+		assert.Equal(t, defaultDatabaseManagerIdleTTLMultiTenant, cfg.IdleTTL)
+		assert.Equal(t, defaultDatabaseManagerCleanupInterval, cfg.CleanupInterval)
+	})
+
+	t.Run("explicit_values_preserved_single", func(t *testing.T) {
+		cfg := &DatabaseManagerConfig{MaxSize: 42, IdleTTL: 2 * time.Hour, CleanupInterval: 90 * time.Second}
+		require.NoError(t, applyDatabaseManagerDefaults(cfg, false))
+		assert.Equal(t, 42, cfg.MaxSize)
+		assert.Equal(t, 2*time.Hour, cfg.IdleTTL)
+		assert.Equal(t, 90*time.Second, cfg.CleanupInterval)
+	})
+
+	t.Run("explicit_values_preserved_multi", func(t *testing.T) {
+		cfg := &DatabaseManagerConfig{MaxSize: 42, IdleTTL: 2 * time.Hour, CleanupInterval: 90 * time.Second}
+		require.NoError(t, applyDatabaseManagerDefaults(cfg, true))
+		assert.Equal(t, 42, cfg.MaxSize)
+		assert.Equal(t, 2*time.Hour, cfg.IdleTTL)
+		assert.Equal(t, 90*time.Second, cfg.CleanupInterval)
+	})
+
+	t.Run("negative_maxsize_rejected_single", func(t *testing.T) {
+		cfg := &DatabaseManagerConfig{MaxSize: -1}
+		assertValidationError(t, applyDatabaseManagerDefaults(cfg, false), "database.manager.maxsize")
+	})
+
+	t.Run("negative_maxsize_rejected_multi", func(t *testing.T) {
+		cfg := &DatabaseManagerConfig{MaxSize: -1}
+		assertValidationError(t, applyDatabaseManagerDefaults(cfg, true), "database.manager.maxsize")
+	})
+
+	t.Run("negative_idlettl_rejected", func(t *testing.T) {
+		cfg := &DatabaseManagerConfig{IdleTTL: -1 * time.Second}
+		assertValidationError(t, applyDatabaseManagerDefaults(cfg, false), "database.manager.idlettl")
+	})
+
+	t.Run("negative_cleanupinterval_rejected", func(t *testing.T) {
+		cfg := &DatabaseManagerConfig{CleanupInterval: -1 * time.Second}
+		assertValidationError(t, applyDatabaseManagerDefaults(cfg, false), "database.manager.cleanupinterval")
+	})
+}
+
+// TestValidateAppliesDatabaseManagerDefaultsOnlyToPrimaryDatabase proves the
+// full top-level Validate stamps database.manager.* defaults on the primary
+// Config.Database only — named Config.Databases[name] entries have no DbManager
+// of their own, so their Manager sub-struct stays zero (no behavior change).
+func TestValidateAppliesDatabaseManagerDefaultsOnlyToPrimaryDatabase(t *testing.T) {
+	cfg := &Config{
+		App: AppConfig{
+			Name:    testAppName,
+			Version: testAppVersion,
+			Env:     EnvDevelopment,
+			Rate:    RateConfig{Limit: 100},
+		},
+		Server: ServerConfig{
+			Port: 8080,
+			Timeout: TimeoutConfig{
+				Read:       15 * time.Second,
+				Write:      30 * time.Second,
+				Middleware: 5 * time.Second,
+				Shutdown:   10 * time.Second,
+			},
+		},
+		Log: LogConfig{Level: "info"},
+		Database: DatabaseConfig{
+			Type: PostgreSQL, Host: "localhost", Port: 5432, Database: "app",
+			Username: "user", Password: "pass",
+		},
+		Databases: map[string]DatabaseConfig{
+			"legacy": {
+				Type: PostgreSQL, Host: "localhost", Port: 5432, Database: "legacy",
+				Username: "user", Password: "pass",
+			},
+		},
+	}
+
+	require.NoError(t, Validate(cfg))
+
+	assert.Equal(t, defaultDatabaseManagerMaxSize, cfg.Database.Manager.MaxSize)
+	assert.Equal(t, defaultDatabaseManagerIdleTTL, cfg.Database.Manager.IdleTTL)
+	assert.Equal(t, defaultDatabaseManagerCleanupInterval, cfg.Database.Manager.CleanupInterval)
+	// Named DB entries are not manager-governed; their Manager sub-struct stays zero.
+	assert.Equal(t, DatabaseManagerConfig{}, cfg.Databases["legacy"].Manager)
+}
+
+// TestValidateMultiTenantAppliesDatabaseManagerDefaultsEndToEnd pins that the
+// multitenant flag is threaded into applyDatabaseManagerDefaults through the full
+// Validate() entry point: MaxSize must come out zero-preserved (so
+// BuildDatabaseOptions scales the handle pool to the tenant limit) and IdleTTL
+// mode-aware — the wiring-level guard against the #661 MaxCached regression class.
+func TestValidateMultiTenantAppliesDatabaseManagerDefaultsEndToEnd(t *testing.T) {
+	newCfg := func() *Config {
+		return &Config{
+			App: AppConfig{
+				Name:    testAppName,
+				Version: testAppVersion,
+				Env:     EnvDevelopment,
+				Rate:    RateConfig{Limit: 100},
+			},
+			Server: ServerConfig{
+				Port: 8080,
+				Timeout: TimeoutConfig{
+					Read:       15 * time.Second,
+					Write:      30 * time.Second,
+					Middleware: 5 * time.Second,
+					Shutdown:   10 * time.Second,
+				},
+			},
+			Log: LogConfig{Level: "info"},
+			Multitenant: MultitenantConfig{
+				Enabled: true,
+				Resolver: ResolverConfig{
+					Type:   ResolverTypeHeader,
+					Header: testTenantHeader,
+				},
+				Tenants: map[string]TenantEntry{
+					"acme": {
+						Database: DatabaseConfig{
+							Type:     PostgreSQL,
+							Host:     "acme.db",
+							Port:     5432,
+							Database: "acme",
+							Username: "acme_user",
+						},
+					},
+				},
+			},
+			Source: SourceConfig{Type: SourceTypeStatic},
+			// No root Database section: tenants carry their own DB config.
+		}
+	}
+
+	t.Run("unset_manager_keys_get_mode_aware_defaults", func(t *testing.T) {
+		cfg := newCfg()
+		require.NoError(t, Validate(cfg))
+
+		// Zero preserved: BuildDatabaseOptions scales the pool to the tenant limit.
+		assert.Zero(t, cfg.Database.Manager.MaxSize)
+		assert.Equal(t, defaultDatabaseManagerIdleTTLMultiTenant, cfg.Database.Manager.IdleTTL)
+		assert.Equal(t, defaultDatabaseManagerCleanupInterval, cfg.Database.Manager.CleanupInterval)
+	})
+
+	t.Run("negative_maxsize_rejected_through_validate", func(t *testing.T) {
+		cfg := newCfg()
+		cfg.Database.Manager.MaxSize = -1
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "database.manager.maxsize")
+	})
+
+	t.Run("tenant_database_manager_block_rejected", func(t *testing.T) {
+		cfg := newCfg()
+		tenant := cfg.Multitenant.Tenants["acme"]
+		tenant.Database.Manager = DatabaseManagerConfig{IdleTTL: 5 * time.Minute}
+		cfg.Multitenant.Tenants["acme"] = tenant
+		err := Validate(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "acme")
+		assert.Contains(t, err.Error(), "manager")
+	})
+}
+
+// TestValidateRejectsManagerBlockOnNamedDatabase pins the Fail-Fast rejection of a
+// manager block under databases.<name> — it is non-functional (named handles live in
+// the primary manager) and would otherwise be silently ignored.
+func TestValidateRejectsManagerBlockOnNamedDatabase(t *testing.T) {
+	cfg := &Config{
+		App: AppConfig{
+			Name:    testAppName,
+			Version: testAppVersion,
+			Env:     EnvDevelopment,
+			Rate:    RateConfig{Limit: 100},
+		},
+		Server: ServerConfig{
+			Port: 8080,
+			Timeout: TimeoutConfig{
+				Read:       15 * time.Second,
+				Write:      30 * time.Second,
+				Middleware: 5 * time.Second,
+				Shutdown:   10 * time.Second,
+			},
+		},
+		Log: LogConfig{Level: "info"},
+		Database: DatabaseConfig{
+			Type: PostgreSQL, Host: "localhost", Port: 5432, Database: "app",
+			Username: "user", Password: "pass",
+		},
+		Databases: map[string]DatabaseConfig{
+			"legacy": {
+				Type: PostgreSQL, Host: "localhost", Port: 5432, Database: "legacy",
+				Username: "user", Password: "pass",
+				Manager: DatabaseManagerConfig{MaxSize: 5},
+			},
+		},
+	}
+
+	err := Validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "databases.legacy.manager")
+}

--- a/database/manager.go
+++ b/database/manager.go
@@ -87,8 +87,8 @@ type dbEntry struct {
 
 // DbManagerOptions configures the DbManager
 type DbManagerOptions struct {
-	MaxSize int           // Maximum number of connections to keep (<= 0: NewDbManager defaults to 100)
-	IdleTTL time.Duration // Time after which idle connections are cleaned up (<= 0: NewDbManager defaults to 30m)
+	MaxSize int           // Cached-connection cap; <=0 uses a default (not unlimited).
+	IdleTTL time.Duration // Idle-connection lifetime; <=0 uses a default (not disabled).
 }
 
 // NewDbManager creates a new database manager

--- a/database/manager.go
+++ b/database/manager.go
@@ -87,8 +87,8 @@ type dbEntry struct {
 
 // DbManagerOptions configures the DbManager
 type DbManagerOptions struct {
-	MaxSize int           // Maximum number of connections to keep (0 = no limit)
-	IdleTTL time.Duration // Time after which idle connections are cleaned up (0 = no cleanup)
+	MaxSize int           // Maximum number of connections to keep (<= 0: NewDbManager defaults to 100)
+	IdleTTL time.Duration // Time after which idle connections are cleaned up (<= 0: NewDbManager defaults to 30m)
 }
 
 // NewDbManager creates a new database manager

--- a/wiki/database.md
+++ b/wiki/database.md
@@ -289,6 +289,28 @@ Size `multitenant.limits.tenants` to at least the number of tenants you expect t
 >
 > A connection that is **still in use** when evicted (held by an in-flight request, message, or job) is detached from the cache immediately but its `Close()` is **deferred until the last borrower releases its lease** — so an in-use connection is never closed under an active caller ([ADR-032](adr_032_lease_refcount_tenant_handles.md), the M3 fix). The lease is reference-counted by `DbManager` and released by the framework at each request/message/job boundary; **application code is unchanged** (`deps.DB(ctx)` keeps its `(Interface, error)` signature). Direct callers of `DbManager.Get` see a new `ReleaseFunc` third return — see [migrations.md](migrations.md).
 
+### Connection-manager pool tunables (`database.manager.*`)
+
+The manager's own lifecycle is operator-tunable, matching the `messaging.publisher.*` and `cache.manager.*` surfaces. All three keys default to today's hardcoded behavior, so leaving them unset changes nothing.
+
+| Key | Default (single-tenant) | Default (multi-tenant) | Purpose |
+|-----|-------------------------|------------------------|---------|
+| `database.manager.maxsize` | `10` | `multitenant.limits.tenants` | Max cached database handles (LRU cap) |
+| `database.manager.idlettl` | `1h` | `30m` | Idle timeout before a cached handle is closed |
+| `database.manager.cleanupinterval` | `5m` | `5m` | How often the background cleanup sweep runs |
+
+```yaml
+database:
+  manager:
+    maxsize: 20       # raise the LRU cap above the default 10 single-tenant handles
+    idlettl: 2h
+    cleanupinterval: 10m
+```
+
+Each key also binds from the environment (`DATABASE_MANAGER_MAXSIZE`, `DATABASE_MANAGER_IDLETTL`, `DATABASE_MANAGER_CLEANUPINTERVAL`); negative values fail startup naming the key. In multi-tenant mode a zero/unset `maxsize` is **preserved** so the manager keeps scaling the cap to `multitenant.limits.tenants` — set an explicit positive value only to override that scaling.
+
+These keys are set under the primary `database:` section only, but they govern the **single process-wide manager**, which caches the primary handle, every named `databases.<name>` handle (keyed `named:<name>` via `deps.DBByName`), and per-tenant handles. **Count named databases when sizing `maxsize`**: a single-tenant app with the primary plus 12 named databases needs `maxsize >= 13` to avoid LRU eviction churn. A `manager` sub-block under `databases.<name>` or `multitenant.tenants.<id>.database` is rejected at startup — it would otherwise be silently ignored.
+
 ## Repository Method Attribution
 
 The `db.client.operation.duration` metric carries `db.operation.name` (the SQL verb:

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -31,7 +31,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E43  | v0.42.0 → v0.43.0 | compile-break | 6 | C43.2 C43.3 | bare section-named env vars |
 | E44  | v0.43.0 → v0.44.0 | noop | 2 | none | none |
 | E45  | v0.44.0 → v0.45.0 | compile-break | 9 | C45.1 C45.2 C45.3 C45.4 C45.5 C45.6 | outbox re-delivery count |
-| E49  | v0.45.0 → v0.49.0 (unreleased) | silent-config | 2 | none | multi-tenant outbox timeout guards / negative messaging.* values |
+| E49  | v0.45.0 → v0.49.0 (unreleased) | silent-config | 3 | none | multi-tenant outbox timeout guards / stale messaging.* + database.manager.* values |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 - **`when: match`** → act only if `detect` returns ≥1 line (an API/arity/interface change, or a config key you set).
@@ -506,9 +506,9 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - verify: `psql ... -c "SELECT count(*) FROM gobricks_outbox WHERE status='pending' AND retry_count >= <outbox.maxretries>;"`  # after the first relay cycle re-delivered volume matches the pre-upgrade count and consumers dedupe
 - ref: ADR-033 · #626 · wiki/adr_033_outbox_retry_count_status_parking.md
 
-## E49 · v0.45.0 → v0.49.0 (unreleased) — messaging defaults in all modes + publisher lifecycle hardening
+## E49 · v0.45.0 → v0.49.0 (unreleased) — messaging defaults in all modes + publisher lifecycle hardening + database.manager.* keys
 
-- gist: `config.Validate` now applies `messaging.*` reconnect/publisher defaults **unconditionally**, even when the root `messaging.broker.url` is empty — previously every no-root-broker config (all multi-tenant static deployments, since `validateNoSingleTenantConflict` rejects a root broker URL there; plus single-tenant apps without messaging) skipped both zero→default coercion and negative-value rejection. Consequences: the outbox `publishtimeout` guards (against `connectiontimeout` AND `readytimeout`, C45.8) now actually fire in multi-tenant mode, and negative `messaging.*` values now fail startup everywhere. Defaulting is publisher-mode-aware: `maxcached` 50 single-tenant / preserved-zero multi-tenant (pool scales to `multitenant.limits.tenants`). This release also raises the single-tenant publisher `IdleTTL` default 10m → 1h and adds a bounded readiness wait on cold publishes (#655/#656/#660).
+- gist: `config.Validate` now applies `messaging.*` reconnect/publisher defaults **unconditionally**, even when the root `messaging.broker.url` is empty — previously every no-root-broker config (all multi-tenant static deployments, since `validateNoSingleTenantConflict` rejects a root broker URL there; plus single-tenant apps without messaging) skipped both zero→default coercion and negative-value rejection. Consequences: the outbox `publishtimeout` guards (against `connectiontimeout` AND `readytimeout`, C45.8) now actually fire in multi-tenant mode, and negative `messaging.*` values now fail startup everywhere. Defaulting is publisher-mode-aware: `maxcached` 50 single-tenant / preserved-zero multi-tenant (pool scales to `multitenant.limits.tenants`). This release also raises the single-tenant publisher `IdleTTL` default 10m → 1h, adds a bounded readiness wait on cold publishes (#655/#656/#660), and introduces `database.manager.*` pool keys (C49.3) — previously-inert `database.manager.*` YAML/env values become live on upgrade.
 - build-caught: none
 - preflight: none
 - exit: `go get github.com/gaborage/go-bricks@v0.49.0 && go mod tidy && go build ./... && go test ./...`
@@ -526,6 +526,13 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - apply: none required; set `messaging.publisher.idlettl` explicitly if you relied on the 10m eviction cadence.
 - verify: start the app and let a publisher idle  # eviction now logs at Info at the new TTL; a publish right after eviction no longer fails with ErrNotConnected
 - ref: #655 #656 #657 #660 · app/managers.go · messaging/amqp_client.go
+
+### [C49.3] database.manager.* pool keys go live (maxsize/idlettl/cleanupinterval) · silent-config · when: match
+- detect: `git grep -nE '(^[[:space:]]*|\.)(maxsize|idlettl|cleanupinterval)[[:space:]]*:' -- '*.yaml' '*.yml'` then keep only hits under a `database:`/`databases:`/tenant `database:` block (leaf-anchored: matches nested and flat-dotted forms); also grep `DATABASE_MANAGER_` in deploy manifests
+- gate: match = you already carry `database.manager.*` keys or `DATABASE_MANAGER_*` env vars — inert (silently ignored) on v0.45–v0.48, they now bind: negative values abort startup naming the key, and a `manager` block under `databases.<name>` or `multitenant.tenants.<id>.database` is now rejected at startup (it was and remains non-functional — only the primary `database.manager.*` is honored). no-match = adopt-only: unset keys default to today's exact hardcoded behavior, byte-identical (single-tenant 10 / 1h / 5m; multi-tenant `maxsize` still scales to `multitenant.limits.tenants`, `idlettl` 30m, `cleanupinterval` 5m). The keys govern the single process-wide manager, which also caches named `databases.<name>` and per-tenant handles — count those when sizing `maxsize` (see wiki/database.md).
+- apply: delete stale/negative `database.manager.*` values and any `manager` block under named/tenant database entries; set the primary keys only to tune the pool.
+- verify: `make run`  # boots identically when unset; a negative value or misplaced manager block aborts with an error naming the key
+- ref: #658 · config/validation.go: applyDatabaseManagerDefaults · app/managers.go: BuildDatabaseOptions · wiki/database.md
 
 
 ---


### PR DESCRIPTION
## Summary

The database connection-manager pool was the only one of the three resource managers (database / messaging / cache) with **no operator config**: `MaxSize`/`IdleTTL` hardcoded in `BuildDatabaseOptions` (10/1h single-tenant, tenantLimit/30m multi-tenant), cleanup sweep a `5 * time.Minute` literal in `startMaintenanceLoops`. New `database.manager.{maxsize,idlettl,cleanupinterval}` keys close the parity gap with `cache.manager.*` / `messaging.publisher.*`. **Unset keys preserve today's behavior byte-identically in both modes.**

## Design: mode-aware defaulting (the #661 lesson)

`applyDatabaseManagerDefaults` takes the multitenant flag: `maxsize` defaults to 10 single-tenant but is **zero-preserved in multi-tenant** so `BuildDatabaseOptions` keeps scaling the pool to `multitenant.limits.tenants`; `idlettl` stamps 1h/30m. A flat validation-time default would have silently capped >tenantLimit fleets — the exact regression class the #661 review caught for messaging `MaxCached` (commit 453d084). Pinned by an end-to-end `Validate()` test asserting zero-preservation.

## Review-driven hardening (xhigh pass, 13 findings — 11 applied, 2 documented skips)

- **Misplaced `manager` blocks rejected at startup**: under `databases.<name>` or `multitenant.tenants.<id>.database` they were non-functional (all handles live in the single primary `DbManager`; named ones keyed `named:<name>`) and would have been silently ignored — Fail Fast instead.
- **`BuildDatabaseOptions` treats non-positive operator values as unset** so paths bypassing `config.Validate` (`app.NewWithConfig`) can't leak a negative into `NewDbManager`'s silent `<=0 → 100` coercion. Dead-fallback comments corrected on both builders: `NewWithConfig` never runs `Validate`, so the fallbacks are load-bearing there, not test-only.
- **`cleanupinterval >= idlettl` now WARNs for the database manager too** — generalized the messaging-only helper (`cleanupIntervalTooLate`); the WARN names the offending config section.
- **`warnIfPoolBelowTenantCount` remediation corrected** to name `database.manager.maxsize` (raising `multitenant.limits.tenants` is ineffective once maxsize is set).
- **`DbManagerOptions` godoc corrected**: the "0 = no limit / 0 = no cleanup" claims were never true (`NewDbManager` coerces `<=0` to 100/30m).
- **`wiki/database.md`**: `maxsize` sizing must count named databases — the keys govern the single process-wide manager that also caches `named:<name>` and per-tenant handles.
- **`wiki/migrations.md [C49.3]`** classified `silent-config · when: match`: previously-inert `database.manager.*` YAML/env values **go live on upgrade** (stale negative values newly abort startup) — with a leaf-anchored detect grep; E49 gist/heading/worst-risk updated.
- Test hygiene: deduped a redundant `DBConfigProvider` stub (reuse `stubTenantResource`); trimmed a duplicated rationale comment.

**Documented skips:** (1) unit-less numeric YAML durations decoding as nanoseconds is a framework-wide decode-layer class affecting every duration key → tracked in #665, not patched per-key here; (2) `idlettl: 0` meaning "default" not "disable eviction" follows the established zero-means-default convention across all three managers (the contradicting godoc was the bug — fixed).

## Verification

- `make check` green (fmt + lint + full race-enabled suite + govulncheck) after every wave.
- task-pipeline (4-lens adversarial review) → `/code-review` xhigh (24 agents, 26 verified candidates → 13 findings, all dispositioned) → `/security-audit` (gosec 0 issues, no raw-SQL, no secrets, no new HTTP surface).

Additive only — no exported-signature changes (apidiff-safe), no ADR needed; migrations note is the adopt-plus-inert-keys atom [C49.3].

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operator-configurable database connection-manager settings (`database.manager.maxsize`, `idlettl`, `cleanupinterval`), with automatic single-tenant vs multi-tenant defaults and “unset” handling.
* **Bug Fixes**
  * Database maintenance cleanup now uses the configured cleanup interval instead of a fixed schedule.
  * Negative/invalid manager values are rejected, and unsupported nested manager blocks in other database sections are no longer accepted.
* **Documentation**
  * Updated database and migration docs with the new `database.manager.*` keys, examples, and upgrade behavior.
* **Tests**
  * Added coverage for defaulting/validation and lifecycle cleanup interval wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->