### PR TITLE
fix(migration): surface unparseable Flyway output and failure envelopes as errors

### DIFF
--- a/migration/audit_test.go
+++ b/migration/audit_test.go
@@ -416,6 +416,93 @@ func TestMigrateForEmitsClassifiedErrorOnFailure(t *testing.T) {
 	assert.Equal(t, ErrorClassChecksumMismatch, events[0].ErrorClass)
 }
 
+func TestMigrateForRecordsFailedOutcomeOnErrorEnvelope(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+	setupTestTracer(t)
+
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{
+			Type: "postgresql", Host: "h", Port: 15432,
+			Username: "user", Password: "longenough-pw", Database: "db",
+		},
+		App: config.AppConfig{Env: "test"},
+	}
+	sink := newRecordingSink()
+	fm := NewFlywayMigrator(cfg, logger.New("disabled", true)).WithAuditRecorder(sink)
+	t.Cleanup(func() { _ = fm.Close(context.Background()) })
+
+	// Stub emits a Flyway error envelope (success:false) but exits 0 — facet 3:
+	// the process succeeds yet the migration failed. The audit event must record
+	// Outcome=Failed, not a silent Success.
+	stub, _ := createCommandCapturingStub(t, readFixture(t, "migrate_checksum_fail.json"))
+	mcfg := &Config{
+		FlywayPath:    stub,
+		ConfigPath:    filepath.Join(t.TempDir(), "flyway.conf"),
+		MigrationPath: filepath.Join(t.TempDir(), "migrations"),
+		Timeout:       10 * time.Second,
+		Environment:   cfg.App.Env,
+		Audit:         AuditContext{Principal: "deployer@example.com"},
+	}
+	require.NoError(t, os.WriteFile(mcfg.ConfigPath, []byte(""), 0o644))
+	require.NoError(t, os.MkdirAll(mcfg.MigrationPath, 0o755))
+
+	_, err := fm.Migrate(context.Background(), mcfg)
+	require.Error(t, err, "a success:false envelope at exit 0 must be reported as a failure")
+	assert.ErrorIs(t, err, ErrFlywayReportedFailure)
+
+	sink.waitForFirst(t, 2*time.Second)
+	events := sink.snapshot()
+	require.Len(t, events, 1)
+	assert.Equal(t, AuditOutcomeFailed, events[0].Outcome)
+	assert.Equal(t, ErrorClassChecksumMismatch, events[0].ErrorClass)
+	assert.Equal(t, "deployer@example.com", events[0].AppliedByPrincipal)
+}
+
+func TestMigrateForRecordsFailedOutcomeOnUnparseableOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+	setupTestTracer(t)
+
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{
+			Type: "postgresql", Host: "h", Port: 15432,
+			Username: "user", Password: "longenough-pw", Database: "db",
+		},
+		App: config.AppConfig{Env: "test"},
+	}
+	sink := newRecordingSink()
+	fm := NewFlywayMigrator(cfg, logger.New("disabled", true)).WithAuditRecorder(sink)
+	t.Cleanup(func() { _ = fm.Close(context.Background()) })
+
+	// Subprocess exits 0 but emits no parseable JSON — the #673 headline case:
+	// a run whose outcome is unobservable must be audited as Failed, never a
+	// silent Success.
+	stub, _ := createCommandCapturingStub(t, "SLF4J: warning\nno json here\n")
+	mcfg := &Config{
+		FlywayPath:    stub,
+		ConfigPath:    filepath.Join(t.TempDir(), "flyway.conf"),
+		MigrationPath: filepath.Join(t.TempDir(), "migrations"),
+		Timeout:       10 * time.Second,
+		Environment:   cfg.App.Env,
+		Audit:         AuditContext{Principal: "deployer@example.com"},
+	}
+	require.NoError(t, os.WriteFile(mcfg.ConfigPath, []byte(""), 0o644))
+	require.NoError(t, os.MkdirAll(mcfg.MigrationPath, 0o755))
+
+	_, err := fm.Migrate(context.Background(), mcfg)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFlywayOutputUnparsed)
+
+	sink.waitForFirst(t, 2*time.Second)
+	events := sink.snapshot()
+	require.Len(t, events, 1)
+	assert.Equal(t, AuditOutcomeFailed, events[0].Outcome)
+	assert.Equal(t, ErrorClassInternal, events[0].ErrorClass)
+}
+
 func TestInfoAndValidateDoNotEmitMigrationApplied(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell script stub not supported on windows CI")

--- a/migration/flyway.go
+++ b/migration/flyway.go
@@ -196,10 +196,11 @@ func (fm *FlywayMigrator) defaultMigrationConfig() *Config {
 }
 
 // Migrate executes pending migrations against the migrator's configured
-// database. The Result carries the parsed per-target outcome; if Flyway's
-// JSON output fails to parse, Result is zero-valued even though the returned
-// error may be nil when the underlying flyway process itself succeeded (the
-// parse failure is only Debug-logged, see runFor).
+// database. It returns a non-nil error when the Flyway process fails, when its
+// JSON output is empty/malformed/redaction-suppressed (errors.Is
+// ErrFlywayOutputUnparsed), or when Flyway reports a failed migration via a
+// success=false envelope even on a zero exit (errors.Is ErrFlywayReportedFailure).
+// The Result is returned best-effort alongside any error.
 func (fm *FlywayMigrator) Migrate(ctx context.Context, cfg *Config) (Result, error) {
 	if cfg == nil {
 		cfg = fm.DefaultMigrationConfig()
@@ -209,7 +210,7 @@ func (fm *FlywayMigrator) Migrate(ctx context.Context, cfg *Config) (Result, err
 
 // MigrateFor executes pending migrations against the supplied database.
 // Used by multi-tenant migrations to target a tenant-specific DatabaseConfig.
-// See Migrate for the Result contract.
+// See Migrate for the Result and error contract.
 func (fm *FlywayMigrator) MigrateFor(ctx context.Context, db *config.DatabaseConfig, cfg *Config) (Result, error) {
 	return fm.runFor(ctx, db, cfg, flywayCmdMigrate)
 }
@@ -290,21 +291,22 @@ func (fm *FlywayMigrator) runFor(ctx context.Context, db *config.DatabaseConfig,
 	}
 
 	result, parseErr := parseFlywayJSON(output)
-	if parseErr != nil {
-		fm.logger.Debug().Err(parseErr).Msg("Failed to parse Flyway JSON output")
-	}
+	outErr := migrateOutcome(runErr, parseErr, &result)
 
-	// ADR-019: migration.applied fires only for actual applications.
+	// ADR-019: migration.applied fires only for actual applications. Feeding the
+	// classified error (not just runErr) records an unparsable output or a
+	// success=false envelope as AuditOutcomeFailed instead of a silent
+	// AuditOutcomeSuccess (#673).
 	fm.emitMigrationApplied(ctx, db, cfg, &flywayRunOutcome{
 		Vendor:      vendor,
 		StartedAt:   startedAt,
 		CompletedAt: time.Now(),
 		Output:      output,
 		Result:      result,
-		Err:         runErr,
+		Err:         outErr,
 	})
 
-	return result, runErr
+	return result, outErr
 }
 
 // flywayRunOutcome bundles the result of a single Flyway subprocess

--- a/migration/flyway_test.go
+++ b/migration/flyway_test.go
@@ -27,14 +27,17 @@ func createFlywayStub(t *testing.T, vendor string) string {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "flyway-stub.sh")
+	// Emit a parseable success envelope so migrate callers get a valid Result;
+	// info/validate callers take the !isMigrate early return and discard stdout.
+	emit := "echo '" + minimalMigrateSuccessJSON + "'\n"
 	var content string
 	switch vendor {
 	case "postgresql":
-		content = "#!/bin/sh\n: \"${DB_HOST:?}\"\n: \"${DB_PORT:?}\"\n: \"${DB_USER:?}\"\n: \"${DB_PASSWORD:?}\"\n: \"${DB_NAME:?}\"\nexit 0\n"
+		content = "#!/bin/sh\n: \"${DB_HOST:?}\"\n: \"${DB_PORT:?}\"\n: \"${DB_USER:?}\"\n: \"${DB_PASSWORD:?}\"\n: \"${DB_NAME:?}\"\n" + emit + "exit 0\n"
 	case "oracle":
-		content = "#!/bin/sh\n: \"${ORACLE_HOST:?}\"\n: \"${ORACLE_PORT:?}\"\n: \"${ORACLE_USER:?}\"\n: \"${ORACLE_PASSWORD:?}\"\n: \"${ORACLE_PDB:?}\"\nexit 0\n"
+		content = "#!/bin/sh\n: \"${ORACLE_HOST:?}\"\n: \"${ORACLE_PORT:?}\"\n: \"${ORACLE_USER:?}\"\n: \"${ORACLE_PASSWORD:?}\"\n: \"${ORACLE_PDB:?}\"\n" + emit + "exit 0\n"
 	default:
-		content = "#!/bin/sh\nexit 0\n"
+		content = "#!/bin/sh\n" + emit + "exit 0\n"
 	}
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
 	return path
@@ -45,7 +48,7 @@ func createSimpleFlywayStub(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "flyway-simple.sh")
-	content := "#!/bin/sh\nexit 0\n"
+	content := "#!/bin/sh\necho '" + minimalMigrateSuccessJSON + "'\nexit 0\n"
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
 	return path
 }
@@ -133,7 +136,7 @@ func TestRunFlywayCommandSuccessWithEnv(t *testing.T) {
 		Host:     "h",
 		Port:     15432,
 		Username: "user",
-		Password: "pass",
+		Password: "longenough-pw",
 		Database: "db",
 	}, App: config.AppConfig{Env: "test"}}
 
@@ -375,7 +378,8 @@ func TestRunMigrationsAtStartup(t *testing.T) {
 
 			fm := NewFlywayMigrator(cfg, logger.New("disabled", true))
 
-			stub, capturePath := createCommandCapturingStub(t, "")
+			// dev env runs migrate (needs parseable JSON); other envs validate (stdout discarded).
+			stub, capturePath := createCommandCapturingStub(t, minimalMigrateSuccessJSON)
 			tempDir := t.TempDir()
 			configPath := filepath.Join(tempDir, "flyway.conf")
 			migrationPath := filepath.Join(tempDir, "migrations")
@@ -428,13 +432,14 @@ func TestFlywayMigratorDryRunRunsValidate(t *testing.T) {
 			cfg := &config.Config{
 				Database: config.DatabaseConfig{
 					Type: "postgresql", Host: "h", Port: 5432,
-					Username: "u", Password: "p", Database: "d",
+					Username: "u", Password: "longenough-pw", Database: "d",
 				},
 				App: config.AppConfig{Env: "test"},
 			}
 			fm := NewFlywayMigrator(cfg, logger.New("disabled", true))
 
-			stub, capturePath := createCommandCapturingStub(t, "")
+			// migrate emits parseable JSON; the dry-run (validate) case discards stdout.
+			stub, capturePath := createCommandCapturingStub(t, minimalMigrateSuccessJSON)
 			tempDir := t.TempDir()
 			configPath := filepath.Join(tempDir, "flyway.conf")
 			migrationPath := filepath.Join(tempDir, "migrations")
@@ -837,7 +842,7 @@ func TestMigrateEdgeCases(t *testing.T) {
 	fm := NewFlywayMigrator(cfg, logger.New("disabled", true))
 
 	t.Run("migrate_with_nil_config_uses_default", func(t *testing.T) {
-		stub, capturePath := createCommandCapturingStub(t, "")
+		stub, capturePath := createCommandCapturingStub(t, minimalMigrateSuccessJSON)
 		tempDir := t.TempDir()
 		configPath := filepath.Join(tempDir, "flyway.conf")
 		migrationPath := filepath.Join(tempDir, "migrations")
@@ -1128,4 +1133,100 @@ func TestInfoAndValidateDoNotRequestJSONOutput(t *testing.T) {
 				"info/validate keep default pretty-printed output for operator-facing sessions")
 		})
 	}
+}
+
+// minimalMigrateSuccessJSON is the smallest Flyway envelope that parses to a
+// successful Result — enough for stubs that only need "migrate reported success".
+const minimalMigrateSuccessJSON = `{"operation":"migrate","success":true,"targetSchemaVersion":"2","flywayVersion":"12.8.1"}`
+
+// newMigrateFixture builds a FlywayMigrator plus a ready-to-run migrate Config
+// pointed at stub. password sets the migrator's DB password, which drives
+// redactPassword: pass a >=8-char value to keep output un-suppressed, or a
+// shorter one to exercise the redaction-suppression path (#673).
+func newMigrateFixture(t *testing.T, stub, password string) (*FlywayMigrator, *Config) {
+	t.Helper()
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{Type: "postgresql", Password: password},
+		App:      config.AppConfig{Env: "test"},
+	}
+	fm := NewFlywayMigrator(cfg, logger.New("disabled", true))
+	dir := t.TempDir()
+	mcfg := &Config{
+		FlywayPath:    stub,
+		ConfigPath:    filepath.Join(dir, "flyway.conf"),
+		MigrationPath: filepath.Join(dir, "migrations"),
+		Timeout:       10 * time.Second,
+		Environment:   cfg.App.Env,
+	}
+	require.NoError(t, os.WriteFile(mcfg.ConfigPath, []byte(""), 0o644))
+	require.NoError(t, os.MkdirAll(mcfg.MigrationPath, 0o755))
+	return fm, mcfg
+}
+
+func TestMigrateReturnsErrorOnUnparseableOutput(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+	stub, _ := createCommandCapturingStub(t, "SLF4J: warning\nboom, not json\n")
+	fm, mcfg := newMigrateFixture(t, stub, "longenough-pw")
+	_, err := fm.Migrate(context.Background(), mcfg)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFlywayOutputUnparsed)
+	assert.ErrorIs(t, err, errEmptyFlywayOutput, "no-'{' output maps to the empty sentinel underneath")
+}
+
+func TestMigrateReturnsErrorOnMalformedJSON(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+	stub, _ := createCommandCapturingStub(t, `{"success": notabool}`)
+	fm, mcfg := newMigrateFixture(t, stub, "longenough-pw")
+	_, err := fm.Migrate(context.Background(), mcfg)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFlywayOutputUnparsed)
+	assert.NotErrorIs(t, err, errEmptyFlywayOutput, "malformed JSON is distinct from empty output")
+	assert.NotErrorIs(t, err, ErrFlywayReportedFailure)
+}
+
+func TestMigrateReturnsErrorOnErrorEnvelopeExitZero(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+	stub, _ := createCommandCapturingStub(t, readFixture(t, "migrate_checksum_fail.json"))
+	fm, mcfg := newMigrateFixture(t, stub, "longenough-pw")
+	res, err := fm.Migrate(context.Background(), mcfg)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFlywayReportedFailure, "a success:false envelope must surface even at exit 0")
+	assert.False(t, res.Success)
+	assert.Equal(t, "VALIDATE_ERROR", res.ErrorCode)
+	assert.NotContains(t, err.Error(), "checksum mismatch", "free-text ErrorMessage must not leak into the error")
+	assert.NotContains(t, err.Error(), "longenough-pw", "password must never appear in the error")
+}
+
+func TestMigrateShortPasswordSuppressedOutputFailsUniformly(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+	// The stub emits valid JSON, but a <8-char password makes redactPassword
+	// replace the whole output with the no-'{' sentinel, so parsing fails. Per
+	// the #673 decision this is treated exactly like malformed output.
+	stub, _ := createCommandCapturingStub(t, minimalMigrateSuccessJSON)
+	fm, mcfg := newMigrateFixture(t, stub, "short")
+	_, err := fm.Migrate(context.Background(), mcfg)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFlywayOutputUnparsed)
+}
+
+func TestMigrateNoopStillSucceeds(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+	// Non-breakage guard: a genuine no-op emits valid JSON, so strict parsing
+	// must NOT turn "nothing to migrate" into a failure.
+	stub, _ := createCommandCapturingStub(t, readFixture(t, "migrate_noop.json"))
+	fm, mcfg := newMigrateFixture(t, stub, "longenough-pw")
+	res, err := fm.Migrate(context.Background(), mcfg)
+	require.NoError(t, err)
+	assert.True(t, res.Success)
+	assert.Equal(t, "2", res.EndingVersion)
 }

--- a/migration/multi_tenant_test.go
+++ b/migration/multi_tenant_test.go
@@ -95,9 +95,9 @@ func TestMigrateAllSequentialSuccess(t *testing.T) {
 	base := makeBaseConfig(t, stub)
 
 	provider := newFakeConfigProvider(map[string]*config.DatabaseConfig{
-		"t1": {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "p1"},
-		"t2": {Type: "postgresql", Host: "h2", Port: 5432, Database: "d2", Username: "u2", Password: "p2"},
-		"t3": {Type: "postgresql", Host: "h3", Port: 5432, Database: "d3", Username: "u3", Password: "p3"},
+		"t1": {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "pw-tenant-1"},
+		"t2": {Type: "postgresql", Host: "h2", Port: 5432, Database: "d2", Username: "u2", Password: "pw-tenant-2"},
+		"t3": {Type: "postgresql", Host: "h3", Port: 5432, Database: "d3", Username: "u3", Password: "pw-tenant-3"},
 	})
 
 	var hookCalls int
@@ -134,9 +134,9 @@ func TestMigrateAllSequentialFailFast(t *testing.T) {
 	base := makeBaseConfig(t, stub)
 
 	provider := newFakeConfigProvider(map[string]*config.DatabaseConfig{
-		"t1": {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "p1"},
+		"t1": {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "pw-tenant-1"},
 		// t2 missing → DBConfig returns error → fail-fast
-		"t3": {Type: "postgresql", Host: "h3", Port: 5432, Database: "d3", Username: "u3", Password: "p3"},
+		"t3": {Type: "postgresql", Host: "h3", Port: 5432, Database: "d3", Username: "u3", Password: "pw-tenant-3"},
 	})
 
 	var hookCalls int32
@@ -172,8 +172,8 @@ func TestMigrateAllContinueOnError(t *testing.T) {
 	base := makeBaseConfig(t, stub)
 
 	provider := newFakeConfigProvider(map[string]*config.DatabaseConfig{
-		"t1": {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "p1"},
-		"t3": {Type: "postgresql", Host: "h3", Port: 5432, Database: "d3", Username: "u3", Password: "p3"},
+		"t1": {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "pw-tenant-1"},
+		"t3": {Type: "postgresql", Host: "h3", Port: 5432, Database: "d3", Username: "u3", Password: "pw-tenant-3"},
 	})
 
 	res, err := MigrateAll(
@@ -209,7 +209,7 @@ func TestMigrateAllParallel(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		id := "tenant-" + string(rune('a'+i))
 		ids = append(ids, id)
-		cfgs[id] = &config.DatabaseConfig{Type: "postgresql", Host: "h", Port: 5432, Database: "d", Username: "u", Password: "p"}
+		cfgs[id] = &config.DatabaseConfig{Type: "postgresql", Host: "h", Port: 5432, Database: "d", Username: "u", Password: "pw-tenant-x"}
 	}
 	provider := newFakeConfigProvider(cfgs)
 
@@ -252,8 +252,8 @@ func TestMigrateAllMixedVendors(t *testing.T) {
 	oracleStub := createFlywayStub(t, "oracle")
 
 	provider := newFakeConfigProvider(map[string]*config.DatabaseConfig{
-		"pg":  {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "p1"},
-		"ora": {Type: "oracle", Host: "h2", Port: 1521, Database: "PDB1", Username: "u2", Password: "p2"},
+		"pg":  {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "pw-tenant-1"},
+		"ora": {Type: "oracle", Host: "h2", Port: 1521, Database: "PDB1", Username: "u2", Password: "pw-tenant-2"},
 	})
 
 	cases := []struct {
@@ -392,8 +392,8 @@ func TestMigrateAllStopsWhenQuiesced(t *testing.T) {
 	fm := newFlywayMigratorForTest(t)
 	base := makeBaseConfig(t, stub)
 	provider := newFakeConfigProvider(map[string]*config.DatabaseConfig{
-		"t1": {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "p1"},
-		"t2": {Type: "postgresql", Host: "h2", Port: 5432, Database: "d2", Username: "u2", Password: "p2"},
+		"t1": {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "pw-tenant-1"},
+		"t2": {Type: "postgresql", Host: "h2", Port: 5432, Database: "d2", Username: "u2", Password: "pw-tenant-2"},
 	})
 	gate := NewMemoryQuiesceController()
 	_, err := gate.Set(context.Background(), QuiesceSetOptions{By: "deployer", TTL: time.Hour})
@@ -415,8 +415,8 @@ func TestMigrateAllProceedsWhenNotQuiesced(t *testing.T) {
 	fm := newFlywayMigratorForTest(t)
 	base := makeBaseConfig(t, stub)
 	provider := newFakeConfigProvider(map[string]*config.DatabaseConfig{
-		"t1": {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "p1"},
-		"t2": {Type: "postgresql", Host: "h2", Port: 5432, Database: "d2", Username: "u2", Password: "p2"},
+		"t1": {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "pw-tenant-1"},
+		"t2": {Type: "postgresql", Host: "h2", Port: 5432, Database: "d2", Username: "u2", Password: "pw-tenant-2"},
 	})
 	gate := NewMemoryQuiesceController() // never set
 
@@ -436,10 +436,10 @@ func TestMigrateAllParallelStopsWhenQuiesced(t *testing.T) {
 	fm := newFlywayMigratorForTest(t)
 	base := makeBaseConfig(t, stub)
 	provider := newFakeConfigProvider(map[string]*config.DatabaseConfig{
-		"t1": {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "p1"},
-		"t2": {Type: "postgresql", Host: "h2", Port: 5432, Database: "d2", Username: "u2", Password: "p2"},
-		"t3": {Type: "postgresql", Host: "h3", Port: 5432, Database: "d3", Username: "u3", Password: "p3"},
-		"t4": {Type: "postgresql", Host: "h4", Port: 5432, Database: "d4", Username: "u4", Password: "p4"},
+		"t1": {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "pw-tenant-1"},
+		"t2": {Type: "postgresql", Host: "h2", Port: 5432, Database: "d2", Username: "u2", Password: "pw-tenant-2"},
+		"t3": {Type: "postgresql", Host: "h3", Port: 5432, Database: "d3", Username: "u3", Password: "pw-tenant-3"},
+		"t4": {Type: "postgresql", Host: "h4", Port: 5432, Database: "d4", Username: "u4", Password: "pw-tenant-4"},
 	})
 	gate := NewMemoryQuiesceController()
 	_, err := gate.Set(context.Background(), QuiesceSetOptions{By: "deployer", TTL: time.Hour})
@@ -480,10 +480,10 @@ func TestMigrateAllParallelStopsDispatchWhenQuiesceFlipsMidRun(t *testing.T) {
 	fm := newFlywayMigratorForTest(t)
 	base := makeBaseConfig(t, stub)
 	provider := newFakeConfigProvider(map[string]*config.DatabaseConfig{
-		"t1": {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "p1"},
-		"t2": {Type: "postgresql", Host: "h2", Port: 5432, Database: "d2", Username: "u2", Password: "p2"},
-		"t3": {Type: "postgresql", Host: "h3", Port: 5432, Database: "d3", Username: "u3", Password: "p3"},
-		"t4": {Type: "postgresql", Host: "h4", Port: 5432, Database: "d4", Username: "u4", Password: "p4"},
+		"t1": {Type: "postgresql", Host: "h1", Port: 5432, Database: "d1", Username: "u1", Password: "pw-tenant-1"},
+		"t2": {Type: "postgresql", Host: "h2", Port: 5432, Database: "d2", Username: "u2", Password: "pw-tenant-2"},
+		"t3": {Type: "postgresql", Host: "h3", Port: 5432, Database: "d3", Username: "u3", Password: "pw-tenant-3"},
+		"t4": {Type: "postgresql", Host: "h4", Port: 5432, Database: "d4", Username: "u4", Password: "pw-tenant-4"},
 	})
 	// First dispatch iteration sees not-quiesced; the flag flips before the
 	// second, so dispatch stops after exactly one tenant.

--- a/migration/result.go
+++ b/migration/result.go
@@ -83,6 +83,39 @@ type flywayErrorPayload struct {
 // before Flyway could write its JSON envelope.
 var errEmptyFlywayOutput = errors.New("migration: empty Flyway JSON output")
 
+// ErrFlywayOutputUnparsed wraps the underlying parse failure (errEmptyFlywayOutput
+// or a JSON decode error) so a zero-exit run whose output is empty, malformed, or
+// redaction-suppressed surfaces as a non-nil error instead of a silent success.
+// Match with errors.Is.
+var ErrFlywayOutputUnparsed = errors.New("flyway output could not be parsed")
+
+// ErrFlywayReportedFailure is returned when Flyway emitted a well-formed JSON
+// envelope that itself reports failure (Result.Success == false), including when
+// the subprocess exited 0. Match with errors.Is.
+var ErrFlywayReportedFailure = errors.New("flyway reported a failed migration")
+
+// migrateOutcome collapses the three failure signals of a migrate invocation into
+// a single error with fixed precedence: subprocess error > unparsable output >
+// envelope-reported failure. A nil return means the Result is authoritative. Pure
+// (no receiver, no I/O) so it is unit-testable without a subprocess stub. The
+// sentinel messages omit a "migration:" prefix because the wrapped parseErr
+// already carries one, keeping the rendered chain free of a doubled prefix.
+func migrateOutcome(runErr, parseErr error, result *Result) error {
+	switch {
+	case runErr != nil:
+		return runErr
+	case parseErr != nil:
+		return fmt.Errorf("%w: %w", ErrFlywayOutputUnparsed, parseErr)
+	case !result.Success:
+		// Only the Flyway errorCode enum (e.g. VALIDATE_ERROR) is interpolated;
+		// result.ErrorMessage is deliberately omitted so no free-text field that
+		// could echo connection details enters a propagated/logged error string.
+		return fmt.Errorf("%w: code=%q", ErrFlywayReportedFailure, result.ErrorCode)
+	default:
+		return nil
+	}
+}
+
 // parseFlywayJSON parses Flyway's -outputType=json output into a Result.
 // The first JSON object embedded in output is consumed; any leading non-JSON
 // noise (e.g. JVM warnings printed before the envelope) is skipped over

--- a/migration/result_test.go
+++ b/migration/result_test.go
@@ -100,3 +100,29 @@ func TestParseFlywayJSONStopsAtFirstObject(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, got.Success)
 }
+
+func TestMigrateOutcomeRunErrorWins(t *testing.T) {
+	runErr := errors.New("flyway command failed: exit status 1")
+	err := migrateOutcome(runErr, errEmptyFlywayOutput, &Result{})
+	assert.ErrorIs(t, err, runErr, "subprocess error takes precedence")
+	assert.False(t, errors.Is(err, ErrFlywayOutputUnparsed), "parse error must not shadow the subprocess error")
+}
+
+func TestMigrateOutcomeParseErrorWrapped(t *testing.T) {
+	err := migrateOutcome(nil, errEmptyFlywayOutput, &Result{})
+	assert.ErrorIs(t, err, ErrFlywayOutputUnparsed, "unparsable output surfaces as an error")
+	assert.ErrorIs(t, err, errEmptyFlywayOutput, "the underlying parse cause stays inspectable via the %w:%w chain")
+}
+
+func TestMigrateOutcomeEnvelopeFailure(t *testing.T) {
+	res := Result{Success: false, ErrorCode: "VALIDATE_ERROR", ErrorMessage: "checksum mismatch on V1 -> host secret leak"}
+	err := migrateOutcome(nil, nil, &res)
+	assert.ErrorIs(t, err, ErrFlywayReportedFailure, "a success:false envelope surfaces even at exit 0")
+	assert.Contains(t, err.Error(), "VALIDATE_ERROR", "the errorCode enum is safe to surface")
+	assert.NotContains(t, err.Error(), "host secret leak",
+		"result.ErrorMessage is free-text and must never enter the propagated error string")
+}
+
+func TestMigrateOutcomeSuccessIsNil(t *testing.T) {
+	assert.NoError(t, migrateOutcome(nil, nil, &Result{Success: true}))
+}

--- a/tools/migration/internal/commands/migrate_test.go
+++ b/tools/migration/internal/commands/migrate_test.go
@@ -37,7 +37,11 @@ func stubFlyway(t *testing.T) string {
 	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "flyway-stub.sh")
-	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	// Emit a parseable migrate success envelope: the migration engine now treats
+	// empty/unparseable output from a zero-exit run as a failure (#673), so a
+	// bare `exit 0` no longer represents a successful migration.
+	const migrateJSON = `{"operation":"migrate","success":true,"targetSchemaVersion":"2","flywayVersion":"12.8.1"}`
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\necho '"+migrateJSON+"'\nexit 0\n"), 0o755))
 	return path
 }
 
@@ -109,10 +113,10 @@ func TestMigrateCommandSuccessAcrossPagesAndShapes(t *testing.T) {
 
 	smSrv := fakeSecretsManager(t, map[string]string{
 		// Canonical shape
-		"gobricks/migrate/t1": `{"type":"postgresql","host":"h1","port":5432,"database":"d1","username":"u1","password":"p1"}`,
-		"gobricks/migrate/t2": `{"type":"postgresql","host":"h2","port":5432,"database":"d2","username":"u2","password":"p2"}`,
+		"gobricks/migrate/t1": `{"type":"postgresql","host":"h1","port":5432,"database":"d1","username":"u1","password":"pw-tenant-1"}`,
+		"gobricks/migrate/t2": `{"type":"postgresql","host":"h2","port":5432,"database":"d2","username":"u2","password":"pw-tenant-2"}`,
 		// RDS rotation fallback
-		"gobricks/migrate/t3": `{"engine":"postgres","host":"h3","port":5432,"dbname":"d3","username":"u3","password":"p3"}`,
+		"gobricks/migrate/t3": `{"engine":"postgres","host":"h3","port":5432,"dbname":"d3","username":"u3","password":"pw-tenant-3"}`,
 	})
 	defer smSrv.Close()
 

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -564,6 +564,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - exit: `go get github.com/gaborage/go-bricks@v0.50.0 && go mod tidy && go build ./... && go test ./...`
 
 ### [C50.1] migrate now errors on unparseable/failure Flyway output · silent-behavior · when: no-match
+
 - detect: `git grep -nE '\.(Migrate|MigrateFor)\(' -- '*.go'` then keep call sites that ignore the returned error, plus any custom `provisioning.Steps.Migrate` that wires `MigrateFor` and drops its error
 - gate: no-match = well-behaved callers already consult the returned error and now correctly surface a previously-silent failure (a genuinely broken/unobservable migration that used to pass). Multi-tenant `MigrateAll` now lists such tenants in `Failed()`; under the default `ContinueOnError=false` the first one aborts the fan-out. Callers that discarded the error may newly observe failures — this is the fix, not a regression.
 - apply: handle the returned error (`errors.Is` the two sentinels above); never read a zero-valued `Result` as proof of success.
@@ -571,6 +572,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: #673 · migration/result.go: migrateOutcome · migration/flyway.go: runFor
 
 ### [C50.2] DB passwords shorter than 8 bytes now fail migrate · silent-behavior · when: match
+
 - detect: inspect every DB password reaching migration (single-tenant `database.password`, per-tenant configs from your tenant store / AWS secrets, and the `go-bricks-migrate --source-config` tenants file) for values shorter than 8 bytes
 - gate: match = any migrated database uses a password `len < 8`. Redaction suppresses the whole Flyway output below that length (short needles can't be safely substring-redacted), so the JSON can't be parsed — a **successful** migrate is now returned as an error AND audit-logged as `migration.applied` `Outcome=failed` / `ErrorClass=internal_error` with an empty version. Do NOT read that Failed event as proof no schema changed. `RunMigrationsAtStartup` under `APP_ENV=dev`/`local` will fail startup for a short password.
 - apply: use a DB password of at least 8 bytes for every migrated database.

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -17,7 +17,7 @@ A plain `vX.Y.Z` is your current node. `=>` a local path (dev `replace`) means t
 **3 — Select the hop chain** on the Ladder: every edge strictly to the right of CURRENT, up to and including TARGET. Never apply an edge at/left of CURRENT.
 
 ```
-v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0 ─E43─ v0.43.0 ─E44─ v0.44.0 ─E45─ v0.45.0 ─E49─ v0.49.0
+v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0 ─E43─ v0.43.0 ─E44─ v0.44.0 ─E45─ v0.45.0 ─E49─ v0.49.0 ─E50─ v0.50.0
 ```
 
 > v0.46.0–v0.48.0 shipped additive-only changes (route template/path-param accessors, raw-route descriptors, module-contributed global middleware — adopt-only, no migration atoms), so E49 is the next hop after v0.45.0 and applies when crossing from any of v0.45.0–v0.48.0 to v0.49.0.
@@ -32,6 +32,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E44  | v0.43.0 → v0.44.0 | noop | 2 | none | none |
 | E45  | v0.44.0 → v0.45.0 | compile-break | 9 | C45.1 C45.2 C45.3 C45.4 C45.5 C45.6 | outbox re-delivery count |
 | E49  | v0.45.0 → v0.49.0 | silent-config | 6 | none | multi-tenant outbox timeout guards / stale `messaging.*` + `database.manager.*` values / reconnect delay keys go live / mode-aware cache pool / unit-less duration guard |
+| E50  | v0.49.0 → v0.50.0 | silent-behavior | 2 | none | Flyway migrate surfaces unparseable/failure output as an error; DB passwords < 8 bytes fail migrate |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 - **`when: match`** → act only if `detect` returns ≥1 line (an API/arity/interface change, or a config key you set).
@@ -554,6 +555,27 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - apply: add the unit suffix — `300` → `300s` (or `5m`, `1h30m`).
 - verify: `make run`  # a config with a bare numeric duration now aborts with `unit-less numeric duration <value> — use a duration string with an explicit unit (e.g. "300s", "5m", "1h30m")` naming the key path; a properly-suffixed value boots identically
 - ref: #665 · internal/configdecode/configdecode.go: NumericToDurationGuardHookFunc · migration/secrets.go: decodeSecretConfig · tools/migration/internal/commands/common.go: numericToDurationGuardHookFunc
+
+## E50 · v0.49.0 → v0.50.0 — Flyway migrate surfaces unparseable/failure output as an error
+
+- gist: `migration.Migrate`/`MigrateFor` (and everything on top of them — `RunMigrationsAtStartup`, multi-tenant `MigrateAll`, the `go-bricks-migrate` CLI) previously returned a **nil error with a zero-valued Result** when the Flyway subprocess exited 0 but its `-outputType=json` output could not be parsed — the parse error was only Debug-logged — so a migration whose outcome was unobservable was reported as success, and the `migration.applied` audit event recorded `Outcome=success` with an empty version. It now returns a non-nil error (`errors.Is` `migration.ErrFlywayOutputUnparsed` for empty/malformed/redaction-suppressed output, or `migration.ErrFlywayReportedFailure` for a `success:false` envelope even at exit 0) and the audit event records `Outcome=failed`. No exported signatures change; `parseFlywayJSON`'s own contract is unchanged.
+- build-caught: none
+- preflight: none
+- exit: `go get github.com/gaborage/go-bricks@v0.50.0 && go mod tidy && go build ./... && go test ./...`
+
+### [C50.1] migrate now errors on unparseable/failure Flyway output · silent-behavior · when: no-match
+- detect: `git grep -nE '\.(Migrate|MigrateFor)\(' -- '*.go'` then keep call sites that ignore the returned error, plus any custom `provisioning.Steps.Migrate` that wires `MigrateFor` and drops its error
+- gate: no-match = well-behaved callers already consult the returned error and now correctly surface a previously-silent failure (a genuinely broken/unobservable migration that used to pass). Multi-tenant `MigrateAll` now lists such tenants in `Failed()`; under the default `ContinueOnError=false` the first one aborts the fan-out. Callers that discarded the error may newly observe failures — this is the fix, not a regression.
+- apply: handle the returned error (`errors.Is` the two sentinels above); never read a zero-valued `Result` as proof of success.
+- verify: `go test ./...`
+- ref: #673 · migration/result.go: migrateOutcome · migration/flyway.go: runFor
+
+### [C50.2] DB passwords shorter than 8 bytes now fail migrate · silent-behavior · when: match
+- detect: inspect every DB password reaching migration (single-tenant `database.password`, per-tenant configs from your tenant store / AWS secrets, and the `go-bricks-migrate --source-config` tenants file) for values shorter than 8 bytes
+- gate: match = any migrated database uses a password `len < 8`. Redaction suppresses the whole Flyway output below that length (short needles can't be safely substring-redacted), so the JSON can't be parsed — a **successful** migrate is now returned as an error AND audit-logged as `migration.applied` `Outcome=failed` / `ErrorClass=internal_error` with an empty version. Do NOT read that Failed event as proof no schema changed. `RunMigrationsAtStartup` under `APP_ENV=dev`/`local` will fail startup for a short password.
+- apply: use a DB password of at least 8 bytes for every migrated database.
+- verify: confirm each migrated database's password is `>= 8` bytes, then `make run` / `go-bricks-migrate migrate`
+- ref: #673 · migration/flyway.go: redactPassword (minRedactablePasswordLength)
 
 
 ---


### PR DESCRIPTION
## Summary

Fixes #673. `migration.runFor` swallowed a Flyway JSON parse error: when the Flyway subprocess exited 0 but its `-outputType=json` output could not be parsed, it returned `(Result{}, nil)` and the `migration.applied` audit event recorded `Outcome=success` with an empty version — a silent failure that violated Fail Fast.

## What changed

Comprehensive fix — all three sibling silent-failure facets:

1. **Swallowed parse error** — a new pure `migrateOutcome` classifier (`result.go`) collapses the three failure signals with fixed precedence: subprocess error > unparsable output (`ErrFlywayOutputUnparsed`) > `success=false` envelope even at a zero exit (`ErrFlywayReportedFailure`).
2. **Audit lie** — `runFor` feeds the classified error to `emitMigrationApplied`, so `migration.applied` records `Outcome=Failed` (not a spurious Success) on those paths. `classifyFlywayError` still keys off the redacted output, so the `ErrorClass` stays correct.
3. **Error-envelope path** — a valid Flyway `success:false` envelope returned at exit 0 now surfaces as an error (defensive; real Flyway exits non-zero on failure).

No exported signatures change (`Migrate`/`MigrateFor` keep `(Result, error)`), so apidiff stays clean; `parseFlywayJSON`'s own contract is unchanged.

## Behavior change (migrations E50)

- `Migrate` / `MigrateFor` / `RunMigrationsAtStartup` / multi-tenant `MigrateAll` now return a non-nil error where they previously returned nil for empty/malformed/suppressed output. Well-behaved callers (all of them, per a repo-wide consumer census) already key off the error and now correctly surface previously-silent failures. Legitimate no-ops still succeed (they emit valid JSON).
- A DB password `< 8` bytes makes redaction suppress the whole output, so a **successful** migrate now **fails uniformly** rather than silently succeeding — use ≥8-char passwords. Documented in `wiki/migrations.md` E50 (C50.2).

## Security

- The envelope error interpolates only the Flyway `errorCode` enum, never the free-text `ErrorMessage`.
- `parseErr` is wrapped over already-redacted output (`redactPassword` runs before parse), so no secret reaches the propagated error. Locked by tests.

## Tests

- `migrateOutcome` unit tests: precedence, `%w:%w` inspectability, ErrorMessage-leak lock.
- Facet integration tests: unparseable / malformed / error-envelope-at-exit-0 / short-password-suppressed / no-op-still-succeeds.
- Audit-outcome tests: `Outcome=Failed` on **both** the parse-failure and error-envelope paths.
- Rewired 7 fossil tests that were green only because the parse error was swallowed (empty-output stubs → real JSON fixtures; `<8`-char test passwords bumped to ≥8).

`make check` green (fmt + lint + `-race` tests + alloc guards + govulncheck clean); `tools/migration` CLI builds/tests clean.

## Follow-ups (filed)

- #675 — reject `<8`-char DB passwords at config validation (makes the suppression path unreachable, closes the audit false-negative).
- #676 — harden `redactPassword` to redact within JSON-safe spans instead of whole-output suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migrations now fail and report errors when Flyway output is unparseable or when Flyway reports `success=false`, even if the Flyway process exits with code 0.
  * Migration audit events now consistently record `failed` outcomes with the correctly classified error details.
  * Successful no-op migrations still complete normally.
  * Database credential validation now rejects passwords shorter than 8 bytes, failing migrations and potentially startup in dev environments.
* **Documentation**
  * Updated the migration ladder with E50 (v0.49.0 → v0.50.0) and added runbook guidance for the new Flyway error-handling and credential validation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->