### PR TITLE
fix(migration): harden redactPassword against escaped-form leaks and JSON-token collisions

### DIFF
--- a/migration/flyway.go
+++ b/migration/flyway.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -41,6 +42,7 @@ const (
 	// so log pipelines without UTF-8 don't mangle it.
 	minRedactablePasswordLength = 8
 	outputSuppressedSentinel    = "[REDACTED -- output suppressed: password too short for safe substring redaction]"
+	redactionPlaceholder        = "[REDACTED]"
 )
 
 // FlywayMigrator handles database migrations using Flyway
@@ -528,9 +530,9 @@ func (fm *FlywayMigrator) validateFlywayPath(flywayPath string) error {
 // redactPassword scrubs the database password from Flyway's stdout/stderr so
 // connection-string echoes in error logs don't leak credentials. Flyway echoes
 // resolved JDBC URLs (jdbc:postgresql://user:password@host/db) on connection
-// failures, and JDBC drivers percent-encode reserved characters in the
-// userinfo segment per RFC 3986 — so we redact both the raw password and its
-// PathEscape / QueryEscape forms. Passwords shorter than
+// failures, and JDBC drivers percent-encode reserved characters in the userinfo
+// segment per RFC 3986 — so we redact the raw password plus its PathEscape,
+// QueryEscape, and JSON-string-escaped forms. Passwords shorter than
 // minRedactablePasswordLength are not substring-redacted (they collide with
 // unrelated bytes); we drop the output entirely instead.
 func redactPassword(output string, db *config.DatabaseConfig) string {
@@ -541,45 +543,74 @@ func redactPassword(output string, db *config.DatabaseConfig) string {
 		return outputSuppressedSentinel
 	}
 
-	const placeholder = "[REDACTED]"
-	redacted := strings.ReplaceAll(output, db.Password, placeholder)
-	// Redact the encoded forms the password can take in Flyway output distinct
-	// from the raw bytes: RFC 3986 userinfo (JDBC URLs), form-encoding, and JSON
-	// string escaping (an error envelope embedding a connection string).
-	for _, encoded := range passwordRedactionVariants(db.Password) {
-		redacted = strings.ReplaceAll(redacted, encoded, placeholder)
+	forms := passwordRedactionForms(db.Password)
+	// For valid-JSON output, redact only inside string literals. Flyway echoes the
+	// password only within strings (JDBC URLs in error messages), never as a bare
+	// token, so string-scoped redaction masks every real credential while leaving
+	// numbers and structure intact: a numeric password can't corrupt a number
+	// token (which would turn a real success into an unparsable-output failure,
+	// #673), and a genuine credential is never restored by an all-or-nothing
+	// revert. Non-JSON error text is redacted byte-for-byte.
+	if json.Valid([]byte(output)) {
+		return redactWithinJSONStrings(output, forms)
 	}
-
-	// A numeric/bareword password can collide with a JSON token (e.g. a match
-	// inside `"totalMigrationTime": 12345678`) and corrupt an otherwise-valid
-	// envelope, turning a real success into an unparsable-output failure (#673).
-	// Flyway never echoes the password in a success envelope, so if the input was
-	// valid JSON and redaction broke it, the match was a collision, not the
-	// credential — revert. Redaction inside a JSON string value never invalidates
-	// the JSON, so a genuine credential in an error envelope is still redacted;
-	// non-JSON error text (JDBC URLs) is redacted as-is.
-	if redacted != output && json.Valid([]byte(output)) && !json.Valid([]byte(redacted)) {
-		return output
-	}
-	return redacted
+	return replaceAllForms(output, forms)
 }
 
-// passwordRedactionVariants returns the encoded forms of pw that can appear in
-// Flyway output distinct from the raw form (percent-encoded userinfo,
-// form-encoded, JSON-string-escaped). Forms equal to the raw password are
-// omitted so callers don't run redundant replacements.
-func passwordRedactionVariants(pw string) []string {
-	variants := make([]string, 0, 3)
-	if enc := url.PathEscape(pw); enc != pw {
-		variants = append(variants, enc)
+// passwordRedactionForms returns the distinct byte-forms the password can take
+// in Flyway output: the raw bytes plus its percent-encoded userinfo (JDBC URLs),
+// form-encoded, and JSON-string-escaped variants.
+func passwordRedactionForms(pw string) []string {
+	forms := []string{pw}
+	for _, enc := range []string{url.PathEscape(pw), url.QueryEscape(pw), jsonStringEscape(pw)} {
+		if !slices.Contains(forms, enc) {
+			forms = append(forms, enc)
+		}
 	}
-	if enc := url.QueryEscape(pw); enc != pw {
-		variants = append(variants, enc)
+	return forms
+}
+
+// replaceAllForms replaces every form of the password with the placeholder.
+func replaceAllForms(s string, forms []string) string {
+	for _, f := range forms {
+		s = strings.ReplaceAll(s, f, redactionPlaceholder)
 	}
-	if enc := jsonStringEscape(pw); enc != pw {
-		variants = append(variants, enc)
+	return s
+}
+
+// redactWithinJSONStrings replaces password forms with the placeholder, but only
+// inside JSON string literals, so number/bareword tokens stay untouched and the
+// envelope remains valid JSON. Assumes s is valid JSON (the caller checks), so
+// string literals are well-formed and the escape scan cannot overrun.
+func redactWithinJSONStrings(s string, forms []string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if s[i] != '"' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		// Scan the string literal to its closing quote, skipping escaped bytes.
+		j := i + 1
+		for j < len(s) {
+			if s[j] == '\\' {
+				j += 2
+				continue
+			}
+			if s[j] == '"' {
+				j++
+				break
+			}
+			j++
+		}
+		if j > len(s) {
+			j = len(s)
+		}
+		b.WriteString(replaceAllForms(s[i:j], forms))
+		i = j
 	}
-	return variants
+	return b.String()
 }
 
 // jsonStringEscape returns s as it appears inside a JSON string value

--- a/migration/flyway.go
+++ b/migration/flyway.go
@@ -3,6 +3,7 @@ package migration
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -542,17 +543,54 @@ func redactPassword(output string, db *config.DatabaseConfig) string {
 
 	const placeholder = "[REDACTED]"
 	redacted := strings.ReplaceAll(output, db.Password, placeholder)
-
-	// JDBC URL userinfo uses RFC 3986 percent-encoding (PathEscape semantics).
-	if encoded := url.PathEscape(db.Password); encoded != db.Password {
+	// Redact the encoded forms the password can take in Flyway output distinct
+	// from the raw bytes: RFC 3986 userinfo (JDBC URLs), form-encoding, and JSON
+	// string escaping (an error envelope embedding a connection string).
+	for _, encoded := range passwordRedactionVariants(db.Password) {
 		redacted = strings.ReplaceAll(redacted, encoded, placeholder)
 	}
-	// Belt and suspenders: form-encoded variant (spaces as '+') in case any
-	// helper logs the password in application/x-www-form-urlencoded form.
-	if encoded := url.QueryEscape(db.Password); encoded != db.Password {
-		redacted = strings.ReplaceAll(redacted, encoded, placeholder)
+
+	// A numeric/bareword password can collide with a JSON token (e.g. a match
+	// inside `"totalMigrationTime": 12345678`) and corrupt an otherwise-valid
+	// envelope, turning a real success into an unparsable-output failure (#673).
+	// Flyway never echoes the password in a success envelope, so if the input was
+	// valid JSON and redaction broke it, the match was a collision, not the
+	// credential — revert. Redaction inside a JSON string value never invalidates
+	// the JSON, so a genuine credential in an error envelope is still redacted;
+	// non-JSON error text (JDBC URLs) is redacted as-is.
+	if redacted != output && json.Valid([]byte(output)) && !json.Valid([]byte(redacted)) {
+		return output
 	}
 	return redacted
+}
+
+// passwordRedactionVariants returns the encoded forms of pw that can appear in
+// Flyway output distinct from the raw form (percent-encoded userinfo,
+// form-encoded, JSON-string-escaped). Forms equal to the raw password are
+// omitted so callers don't run redundant replacements.
+func passwordRedactionVariants(pw string) []string {
+	variants := make([]string, 0, 3)
+	if enc := url.PathEscape(pw); enc != pw {
+		variants = append(variants, enc)
+	}
+	if enc := url.QueryEscape(pw); enc != pw {
+		variants = append(variants, enc)
+	}
+	if enc := jsonStringEscape(pw); enc != pw {
+		variants = append(variants, enc)
+	}
+	return variants
+}
+
+// jsonStringEscape returns s as it appears inside a JSON string value
+// (backslash-escaped), without the surrounding quotes. Returns s unchanged if
+// marshaling fails (it cannot for a Go string).
+func jsonStringEscape(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return s
+	}
+	return string(b[1 : len(b)-1])
 }
 
 // RunMigrationsAtStartup executes migrations automatically at application

--- a/migration/flyway_test.go
+++ b/migration/flyway_test.go
@@ -2,6 +2,7 @@ package migration
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -1049,6 +1050,61 @@ func TestRedactPasswordKeepsAlphanumericLongPasswordsRedactedRaw(t *testing.T) {
 	out := redactPassword("error: jdbc:postgresql://user:longalphanumeric1@host/db", db)
 	assert.Contains(t, out, "[REDACTED]")
 	assert.NotContains(t, out, "longalphanumeric1")
+}
+
+// jsonStringEscaped returns s as it would appear inside a JSON string value
+// (backslash-escaped), without the surrounding quotes.
+func jsonStringEscaped(t *testing.T, s string) string {
+	t.Helper()
+	b, err := json.Marshal(s)
+	require.NoError(t, err)
+	return string(b[1 : len(b)-1])
+}
+
+func TestRedactPasswordHandlesJSONEscapedForm(t *testing.T) {
+	// A password containing " or \ appears backslash-escaped when Flyway embeds a
+	// connection string inside a JSON error envelope. The raw and URL-encoded
+	// forms won't match that; the JSON-escaped form must.
+	db := &config.DatabaseConfig{Password: `pw"or\d123`}
+	esc := jsonStringEscaped(t, db.Password)
+	output := `{"error":{"message":"connect failed at ` + esc + ` now"}}`
+	out := redactPassword(output, db)
+	assert.NotContains(t, out, esc, "the JSON-escaped password form must be redacted")
+	assert.Contains(t, out, "[REDACTED]")
+}
+
+func TestRedactPasswordDoesNotCorruptValidJSONOnNumericCollision(t *testing.T) {
+	// An all-digit password that equals a JSON number token would, under a blind
+	// ReplaceAll, corrupt an otherwise-valid envelope and turn a real success into
+	// an unparsable-output failure (#673). Redaction must not break valid JSON.
+	db := &config.DatabaseConfig{Password: "12345678"}
+	output := `{"operation":"migrate","success":true,"totalMigrationTime":12345678}`
+	out := redactPassword(output, db)
+	assert.Equal(t, output, out,
+		"a numeric password matching a JSON number token must not corrupt a valid envelope")
+}
+
+func TestRedactPasswordRedactsWithinJSONStringValue(t *testing.T) {
+	// The credential legitimately appears inside a JSON string (an error envelope
+	// echoing a JDBC URL); redaction stays inside the string, so the envelope
+	// remains valid and the guard must NOT revert it.
+	db := &config.DatabaseConfig{Password: "longpassword1"}
+	output := `{"error":{"message":"jdbc:postgresql://u:longpassword1@h/db"}}`
+	out := redactPassword(output, db)
+	assert.NotContains(t, out, "longpassword1")
+	assert.Contains(t, out, "[REDACTED]")
+	assert.True(t, json.Valid([]byte(out)))
+}
+
+func TestRedactPasswordRedactsNumericPasswordInsideJSONString(t *testing.T) {
+	// Safety: a numeric password that is a real credential inside a string value
+	// must still be redacted (the collision guard only reverts when redaction
+	// breaks valid JSON, which never happens for an in-string match).
+	db := &config.DatabaseConfig{Password: "12345678"}
+	output := `{"error":{"message":"auth failed for 12345678"}}`
+	out := redactPassword(output, db)
+	assert.NotContains(t, out, "12345678", "a numeric credential inside a string must not leak")
+	assert.Contains(t, out, "[REDACTED]")
 }
 
 func TestMigrateRequestsJSONOutputAndParsesResult(t *testing.T) {

--- a/migration/flyway_test.go
+++ b/migration/flyway_test.go
@@ -1098,13 +1098,26 @@ func TestRedactPasswordRedactsWithinJSONStringValue(t *testing.T) {
 
 func TestRedactPasswordRedactsNumericPasswordInsideJSONString(t *testing.T) {
 	// Safety: a numeric password that is a real credential inside a string value
-	// must still be redacted (the collision guard only reverts when redaction
-	// breaks valid JSON, which never happens for an in-string match).
+	// must still be redacted.
 	db := &config.DatabaseConfig{Password: "12345678"}
 	output := `{"error":{"message":"auth failed for 12345678"}}`
 	out := redactPassword(output, db)
 	assert.NotContains(t, out, "12345678", "a numeric credential inside a string must not leak")
 	assert.Contains(t, out, "[REDACTED]")
+}
+
+func TestRedactPasswordRedactsStringCredentialDespiteNumericCollision(t *testing.T) {
+	// The dual-occurrence case: a numeric password appears BOTH as a real
+	// credential inside a string value AND as a bare number token. Redaction must
+	// mask the in-string credential while leaving the number token intact — no
+	// leak, no corruption. (A revert-on-broken-JSON strategy would re-expose the
+	// credential here; string-scoped redaction does not.)
+	db := &config.DatabaseConfig{Password: "12345678"}
+	output := `{"msg":"connect string user:12345678@host","totalMigrationTime":12345678}`
+	out := redactPassword(output, db)
+	assert.NotContains(t, out, "user:12345678@host", "the in-string credential must be redacted")
+	assert.Contains(t, out, `"totalMigrationTime":12345678`, "the number token must be left intact")
+	assert.True(t, json.Valid([]byte(out)))
 }
 
 func TestMigrateRequestsJSONOutputAndParsesResult(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #676. Follow-up to #674. Hardens `migration.redactPassword` for `≥8`-char passwords against two gaps:

1. **Under-redaction leak (JSON-escaped form)** — a password containing `"` or `\` appears backslash-escaped inside a JSON error envelope; the raw and URL-encoded forms don't match it, so it **leaked**. Fixed by adding a JSON-string-escaped redaction form.
2. **Over-redaction corruption (numeric-token collision)** — an all-digit password equal to a JSON number token (e.g. matching `"totalMigrationTime":12345678`) was blindly `ReplaceAll`'d, corrupting an otherwise-valid envelope and turning a **real success into an unparsable-output failure** post-#674.

## Approach: string-scoped redaction

For **valid-JSON** output, redaction runs **only inside JSON string literals** (a small scanner walks the bytes, redacting within `"..."` spans and leaving numbers/structure untouched). Flyway echoes the password only within strings (JDBC URLs in error messages), never as a bare token, so this:

- masks **every** real credential (in error-envelope message strings, and even keys), and
- can **never** corrupt a number/bareword token, so a numeric password no longer breaks a valid envelope.

For **non-JSON** error text, redaction is byte-for-byte across all password forms (raw + PathEscape + QueryEscape + JSON-escaped), as before.

This supersedes an earlier revert-on-broken-JSON guard, which CodeRabbit correctly flagged (a separate numeric collision could restore an in-string credential). String-scoped redaction removes that edge by construction — masked credentials are never restored, and number tokens are never touched.

## Sequencing

The `<8`-char whole-output suppression is **retained** here as a safe fallback — dropping it before short passwords are rejected would open an under-redaction window. #675 (reject `<8`-char passwords at config validation) makes short passwords unreachable and will remove the now-dead suppression. The migrations E50 note from #674 stays accurate after this PR.

## Tests

New (TDD, RED→GREEN): JSON-escaped-form redaction; no-corruption-on-numeric-collision; redaction-within-JSON-string-value; numeric-credential-inside-string still redacted; and the **dual-occurrence** case (numeric password present both as an in-string credential and a bare number token) — the credential is masked, the number token is left intact, JSON stays valid. All existing redaction tests unchanged and green.

`make check` green; `tools/migration` CLI verified against this change with the go.work workspace active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
