### PR TITLE
fix(migration)!: reject database passwords shorter than 8 bytes

### DIFF
--- a/config/validation.go
+++ b/config/validation.go
@@ -103,6 +103,13 @@ const (
 	Oracle     = "oracle"
 )
 
+// MinDatabasePasswordLength is the minimum length for a non-empty database
+// password. Below this, the migration engine cannot safely substring-redact the
+// password from Flyway output and suppresses the whole output instead, which
+// hides a migration's outcome (see migration.redactPassword). Empty passwords
+// (trust/IAM auth) are exempt.
+const MinDatabasePasswordLength = 8
+
 // Environment constants
 const (
 	EnvDevelopment = "development"
@@ -117,24 +124,25 @@ const (
 
 // Validation error message constants
 const (
-	errMustBeNonNegative = "must be non-negative"
-	errMustBePositive    = "must be positive"
-	errNotSupportedFmt   = "'%s' is not supported"
-	portRange            = "1-65535"
-	fieldDatabase        = "database"
-	fieldDatabasePort    = "database.port"
-	fieldMessaging       = "messaging"
-	fieldCache           = "cache"
-	fieldDebug           = "debug"
-	fieldServerPort      = "server.port"
-	fieldLogLevel        = "log.level"
-	fieldAppEnv          = "app.env"
-	fieldAppRateLimit    = "app.rate.limit"
-	fieldCacheRedisDB    = "cache.redis.database"
-	fieldCacheRedisPool  = "cache.redis.poolsize"
-	errInvalidField      = "invalid value: %v"
-	databasesFieldPrefix = "databases.%s"
-	defaultHost          = "localhost"
+	errMustBeNonNegative  = "must be non-negative"
+	errMustBePositive     = "must be positive"
+	errNotSupportedFmt    = "'%s' is not supported"
+	portRange             = "1-65535"
+	fieldDatabase         = "database"
+	fieldDatabasePort     = "database.port"
+	fieldDatabasePassword = "database.password"
+	fieldMessaging        = "messaging"
+	fieldCache            = "cache"
+	fieldDebug            = "debug"
+	fieldServerPort       = "server.port"
+	fieldLogLevel         = "log.level"
+	fieldAppEnv           = "app.env"
+	fieldAppRateLimit     = "app.rate.limit"
+	fieldCacheRedisDB     = "cache.redis.database"
+	fieldCacheRedisPool   = "cache.redis.poolsize"
+	errInvalidField       = "invalid value: %v"
+	databasesFieldPrefix  = "databases.%s"
+	defaultHost           = "localhost"
 )
 
 func Validate(cfg *Config) error {
@@ -393,6 +401,18 @@ func validateDatabaseCoreFields(cfg *DatabaseConfig) error {
 
 	if cfg.Username == "" {
 		return NewMissingFieldError("database.username", "DATABASE_USERNAME", "database.username")
+	}
+
+	// A non-empty password below MinDatabasePasswordLength cannot be safely
+	// redacted from Flyway output at migration time, so the engine would suppress
+	// the whole output and hide the migration outcome. Reject it here (message
+	// never echoes the value). Empty passwords (trust/IAM auth) are exempt.
+	if cfg.Password != "" && len(cfg.Password) < MinDatabasePasswordLength {
+		return NewInvalidFieldError(
+			fieldDatabasePassword,
+			fmt.Sprintf("must be at least %d characters when set", MinDatabasePasswordLength),
+			[]string{fmt.Sprintf("%d+ characters", MinDatabasePasswordLength)},
+		)
 	}
 
 	return nil

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -2909,6 +2909,28 @@ func createValidServerConfig() ServerConfig {
 	}
 }
 
+func TestValidateRejectsShortDatabasePassword(t *testing.T) {
+	cfg := createValidFullConfig()
+	cfg.Database.Password = "short" // 5 bytes
+	err := Validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database.password")
+	assert.NotContains(t, err.Error(), "short", "the error must never echo the password")
+}
+
+func TestValidateAllowsEmptyDatabasePassword(t *testing.T) {
+	// Empty means trust/IAM auth; it never reaches the redaction-suppression path.
+	cfg := createValidFullConfig()
+	cfg.Database.Password = ""
+	require.NoError(t, Validate(cfg))
+}
+
+func TestValidateAllowsLongEnoughDatabasePassword(t *testing.T) {
+	cfg := createValidFullConfig()
+	cfg.Database.Password = "longenough-pw"
+	require.NoError(t, Validate(cfg))
+}
+
 // createValidDatabaseConfig returns a valid DatabaseConfig for testing
 func createValidDatabaseConfig() DatabaseConfig {
 	return DatabaseConfig{
@@ -4618,12 +4640,12 @@ func TestValidateAppliesDatabaseManagerDefaultsOnlyToPrimaryDatabase(t *testing.
 		Log: LogConfig{Level: "info"},
 		Database: DatabaseConfig{
 			Type: PostgreSQL, Host: "localhost", Port: 5432, Database: "app",
-			Username: "user", Password: "pass",
+			Username: "user", Password: "longenough-pw",
 		},
 		Databases: map[string]DatabaseConfig{
 			"legacy": {
 				Type: PostgreSQL, Host: "localhost", Port: 5432, Database: "legacy",
-				Username: "user", Password: "pass",
+				Username: "user", Password: "longenough-pw",
 			},
 		},
 	}
@@ -4757,7 +4779,7 @@ func TestValidateMultiTenantAppliesCacheManagerDefaultsEndToEnd(t *testing.T) {
 		} else {
 			cfg.Database = DatabaseConfig{
 				Type: PostgreSQL, Host: "localhost", Port: 5432, Database: "app",
-				Username: "user", Password: "pass",
+				Username: "user", Password: "longenough-pw",
 			}
 		}
 		return cfg
@@ -4806,12 +4828,12 @@ func TestValidateRejectsManagerBlockOnNamedDatabase(t *testing.T) {
 		Log: LogConfig{Level: "info"},
 		Database: DatabaseConfig{
 			Type: PostgreSQL, Host: "localhost", Port: 5432, Database: "app",
-			Username: "user", Password: "pass",
+			Username: "user", Password: "longenough-pw",
 		},
 		Databases: map[string]DatabaseConfig{
 			"legacy": {
 				Type: PostgreSQL, Host: "localhost", Port: 5432, Database: "legacy",
-				Username: "user", Password: "pass",
+				Username: "user", Password: "longenough-pw",
 				Manager: DatabaseManagerConfig{MaxSize: 5},
 			},
 		},

--- a/migration/flyway.go
+++ b/migration/flyway.go
@@ -34,13 +34,17 @@ const (
 
 	// minRedactablePasswordLength gates substring-style password redaction.
 	// Short needles (1-7 bytes) are statistically likely to appear inside
-	// unrelated Flyway output (timestamps, error codes, table names),
-	// causing false-positive over-redaction that obscures the real diagnostic
-	// AND failing to mask encoded variants whose alphabet differs from the
-	// raw password. 8 bytes matches the same minimum we expect at config
-	// validation; below that we drop the output entirely. ASCII-only sentinel
-	// so log pipelines without UTF-8 don't mangle it.
-	minRedactablePasswordLength = 8
+	// unrelated Flyway output (timestamps, error codes, table names), causing
+	// false-positive over-redaction that obscures the real diagnostic AND failing
+	// to mask encoded variants whose alphabet differs from the raw password. It is
+	// single-sourced from config.MinDatabasePasswordLength, which config.Validate
+	// now enforces for static configs; the migrate path additionally rejects a
+	// short password up front (see ErrDatabasePasswordTooShort), covering
+	// per-tenant configs. The whole-output suppression below therefore remains
+	// only as a fallback for the non-migrate (info/validate) verbs, whose output
+	// is not parsed. ASCII-only sentinel so log pipelines without UTF-8 don't
+	// mangle it.
+	minRedactablePasswordLength = config.MinDatabasePasswordLength
 	outputSuppressedSentinel    = "[REDACTED -- output suppressed: password too short for safe substring redaction]"
 	redactionPlaceholder        = "[REDACTED]"
 )
@@ -268,6 +272,16 @@ func (fm *FlywayMigrator) runFor(ctx context.Context, db *config.DatabaseConfig,
 	// as an application, and migration.dry_run stays accurate on real applications.
 	verb = effectiveVerb(cfg, verb)
 
+	// A migrate whose password is too short to redact safely is rejected up front
+	// rather than run-then-suppressed (which would hide the outcome and audit a
+	// real success as failed). This covers per-tenant configs that never pass
+	// through config.Validate (#675).
+	if verb == flywayCmdMigrate {
+		if err := ensurePasswordRedactable(db); err != nil {
+			return Result{}, err
+		}
+	}
+
 	vendor := dbVendor(db, fm.config.Database.Type)
 	fm.logger.Info().
 		Str("vendor", vendor).
@@ -430,6 +444,26 @@ func dbVendor(db *config.DatabaseConfig, fallback string) string {
 // rejecting at the boundary prevents a compromised secret writer from
 // propagating multi-line surprises into downstream logs or env-parsing tools.
 var ErrEnvFieldHasControlChar = errors.New("migration: env field contains forbidden control character (CR/LF/NUL)")
+
+// ErrDatabasePasswordTooShort is returned by the migrate path when a non-empty
+// database password is shorter than minRedactablePasswordLength. Such passwords
+// cannot be safely redacted from Flyway output, so the migration is rejected
+// before running rather than suppressing the output and hiding the outcome.
+// Match with errors.Is. Empty passwords (trust/IAM auth) are exempt.
+var ErrDatabasePasswordTooShort = errors.New("migration: database password too short to safely redact Flyway output")
+
+// ensurePasswordRedactable rejects a non-empty database password that is too
+// short to substring-redact from Flyway output. The error never echoes the
+// password.
+func ensurePasswordRedactable(db *config.DatabaseConfig) error {
+	if db == nil || db.Password == "" {
+		return nil
+	}
+	if len(db.Password) < minRedactablePasswordLength {
+		return ErrDatabasePasswordTooShort
+	}
+	return nil
+}
 
 // buildEnvironmentVariables builds Flyway environment variables for the supplied database.
 // Returns ErrEnvFieldHasControlChar wrapped with the offending field name when

--- a/migration/flyway_test.go
+++ b/migration/flyway_test.go
@@ -1272,18 +1272,34 @@ func TestMigrateReturnsErrorOnErrorEnvelopeExitZero(t *testing.T) {
 	assert.NotContains(t, err.Error(), "longenough-pw", "password must never appear in the error")
 }
 
-func TestMigrateShortPasswordSuppressedOutputFailsUniformly(t *testing.T) {
+func TestMigrateRejectsShortPassword(t *testing.T) {
 	if runtime.GOOS == windowsOS {
 		t.Skip("shell script stub not supported on windows CI")
 	}
-	// The stub emits valid JSON, but a <8-char password makes redactPassword
-	// replace the whole output with the no-'{' sentinel, so parsing fails. Per
-	// the #673 decision this is treated exactly like malformed output.
+	// A <8-char password can't be safely redacted from Flyway output, so the
+	// migrate path rejects it before running Flyway rather than suppressing the
+	// output and mis-reporting the outcome (#675).
 	stub, _ := createCommandCapturingStub(t, minimalMigrateSuccessJSON)
-	fm, mcfg := newMigrateFixture(t, stub, "short")
+	fm, mcfg := newMigrateFixture(t, stub, "pw12345") // 7 bytes, distinct from the error text
 	_, err := fm.Migrate(context.Background(), mcfg)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrFlywayOutputUnparsed)
+	assert.ErrorIs(t, err, ErrDatabasePasswordTooShort)
+	assert.NotErrorIs(t, err, ErrFlywayOutputUnparsed, "rejected before Flyway runs, not a parse failure")
+	assert.NotContains(t, err.Error(), "pw12345", "the error must not echo the password")
+}
+
+func TestMigrateForRejectsShortTenantPassword(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+	// Per-tenant coverage: a tenant DatabaseConfig (from a store / AWS secrets)
+	// never passes config.Validate(), so MigrateFor must reject a short password.
+	stub, _ := createCommandCapturingStub(t, minimalMigrateSuccessJSON)
+	fm, mcfg := newMigrateFixture(t, stub, "longenough-pw")
+	tenantDB := &config.DatabaseConfig{Type: "postgresql", Password: "tiny"}
+	_, err := fm.MigrateFor(context.Background(), tenantDB, mcfg)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDatabasePasswordTooShort)
 }
 
 func TestMigrateNoopStillSucceeds(t *testing.T) {

--- a/tools/migration/internal/commands/migrate_test.go
+++ b/tools/migration/internal/commands/migrate_test.go
@@ -159,9 +159,9 @@ func TestMigrateCommandFailFastStopsAfterFirstFailure(t *testing.T) {
 	defer listSrv.Close()
 
 	smSrv := fakeSecretsManager(t, map[string]string{
-		"gobricks/migrate/t1": `{"type":"postgresql","host":"h","port":5432,"database":"d","username":"u","password":"p"}`,
-		"gobricks/migrate/t2": `{"type":"postgresql","host":"h","port":5432,"database":"d","username":"u","password":"p"}`,
-		"gobricks/migrate/t3": `{"type":"postgresql","host":"h","port":5432,"database":"d","username":"u","password":"p"}`,
+		"gobricks/migrate/t1": `{"type":"postgresql","host":"h","port":5432,"database":"d","username":"u","password":"longenough-pw"}`,
+		"gobricks/migrate/t2": `{"type":"postgresql","host":"h","port":5432,"database":"d","username":"u","password":"longenough-pw"}`,
+		"gobricks/migrate/t3": `{"type":"postgresql","host":"h","port":5432,"database":"d","username":"u","password":"longenough-pw"}`,
 	})
 	defer smSrv.Close()
 
@@ -206,8 +206,8 @@ func TestMigrateCommandContinueOnErrorListsAllFailures(t *testing.T) {
 	defer listSrv.Close()
 
 	smSrv := fakeSecretsManager(t, map[string]string{
-		"gobricks/migrate/t1": `{"type":"postgresql","host":"h","port":5432,"database":"d","username":"u","password":"p"}`,
-		"gobricks/migrate/t2": `{"type":"postgresql","host":"h","port":5432,"database":"d","username":"u","password":"p"}`,
+		"gobricks/migrate/t1": `{"type":"postgresql","host":"h","port":5432,"database":"d","username":"u","password":"longenough-pw"}`,
+		"gobricks/migrate/t2": `{"type":"postgresql","host":"h","port":5432,"database":"d","username":"u","password":"longenough-pw"}`,
 	})
 	defer smSrv.Close()
 

--- a/wiki/adr_037_min_database_password_length.md
+++ b/wiki/adr_037_min_database_password_length.md
@@ -1,0 +1,57 @@
+# ADR-037: Minimum Database Password Length
+
+**Status:** Accepted
+**Date:** 2026-07-10
+
+## Context
+
+The migration engine's `redactPassword` (migration/flyway.go) scrubs the database
+password from Flyway's stdout/stderr so connection-string echoes in error logs don't
+leak credentials. A password shorter than 8 bytes cannot be safely substring-redacted —
+short needles collide with unrelated output bytes — so the engine suppresses the **whole**
+output instead of risking partial redaction.
+
+After ADR-less #674 made the migrate path fail on unparsable output, that suppression
+turned a **successful** migration with a short DB password into a hard failure, and
+`migration.applied` audited it as `Outcome=failed` with an empty version — an ADR-019
+audit false-negative. #676 hardened redaction for `≥8`-byte passwords but deliberately
+kept the `<8` suppression as a safe fallback.
+
+Nothing enforced a password-length floor: `config.Validate` checked host/port/database/
+username but never the password, and the stale `minRedactablePasswordLength` comment
+claimed a config-validation minimum that did not exist. Per-tenant configs (from a tenant
+store or AWS Secrets Manager) never pass through `config.Validate` at all.
+
+## Decision
+
+Reject a **non-empty** database password shorter than `config.MinDatabasePasswordLength`
+(8) at **both** boundaries:
+
+1. **`config.Validate`** — for static config (primary `database.*` and named
+   `databases.*`), failing fast at startup with a `database.password` field error that
+   never echoes the value.
+2. **The migrate path (`FlywayMigrator.runFor`)** — rejects before running Flyway with
+   `ErrDatabasePasswordTooShort`, covering per-tenant configs that never reach
+   `config.Validate`. `migration.redactPassword`'s `minRedactablePasswordLength` is
+   single-sourced from `config.MinDatabasePasswordLength`.
+
+**Empty passwords are exempt** (trust / IAM auth): they never reach the redaction-
+suppression path (`redactPassword` returns the output untouched for an empty password).
+
+## Consequences
+
+- **Breaking:** a static config with a 1–7 byte DB password that previously booted now
+  fails at startup; a per-tenant migration with such a password fails with a clear error
+  instead of a suppressed-output false-negative. Documented in migrations **E50 (C50.2)**.
+- The `<8` whole-output suppression in `redactPassword` remains only as a fallback for the
+  non-migrate (info/validate) verbs, whose output is not parsed.
+- The audit false-negative from #674 is closed for both single- and multi-tenant paths.
+
+## Alternatives considered
+
+- **Config validation only** — rejected: static-only, misses per-tenant runtime configs,
+  which are the primary source of the audit false-negative.
+- **Migration boundary only** — rejected: no startup fail-fast for a static config; the
+  operator would only learn of the problem at first migrate.
+- **Reject empty passwords too** — rejected: breaks legitimate trust/IAM-auth deployments,
+  and empty passwords never trigger the redaction-suppression path this ADR addresses.

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -516,6 +516,16 @@ auth only), and emits the standard envelope on raw-response routes.
 
 ---
 
+### [ADR-037: Minimum Database Password Length](adr_037_min_database_password_length.md)
+
+**Date:** 2026-07-10 | **Status:** Accepted
+
+Rejects a non-empty database password shorter than `config.MinDatabasePasswordLength` (8) at two boundaries: `config.Validate` (static config — fail-fast at startup) and the migrate path (`FlywayMigrator.runFor` → `ErrDatabasePasswordTooShort`, covering per-tenant configs that never pass through `config.Validate`). Closes the ADR-019 audit false-negative from #674, where a short-password migration's output was suppressed and audited as `Outcome=failed` even on success. Empty passwords (trust/IAM auth) are exempt. `migration.redactPassword`'s `minRedactablePasswordLength` is single-sourced from the new exported constant.
+
+**Key Benefits:** Closes the migration audit false-negative for single- and multi-tenant paths; a clear startup / pre-flight error (never echoing the password) instead of a suppressed-output false failure; a single-sourced password-length floor.
+
+---
+
 ## ADR Lifecycle
 
 - **Proposed**: Under discussion, not yet implemented
@@ -525,7 +535,7 @@ auth only), and emits the standard envelope on raw-response routes.
 
 ### Numbering Policy
 
-ADR numbers (ADR-001 through ADR-036) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
+ADR numbers (ADR-001 through ADR-037) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
 
 ## Writing New ADRs
 

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -32,7 +32,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E44  | v0.43.0 → v0.44.0 | noop | 2 | none | none |
 | E45  | v0.44.0 → v0.45.0 | compile-break | 9 | C45.1 C45.2 C45.3 C45.4 C45.5 C45.6 | outbox re-delivery count |
 | E49  | v0.45.0 → v0.49.0 | silent-config | 6 | none | multi-tenant outbox timeout guards / stale `messaging.*` + `database.manager.*` values / reconnect delay keys go live / mode-aware cache pool / unit-less duration guard |
-| E50  | v0.49.0 → v0.50.0 | silent-behavior | 2 | none | Flyway migrate surfaces unparseable/failure output as an error; DB passwords < 8 bytes fail migrate |
+| E50  | v0.49.0 → v0.50.0 | config-break | 2 | none | Flyway migrate surfaces unparseable/failure output as an error; non-empty DB passwords < 8 bytes rejected at config validation + migrate |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 - **`when: match`** → act only if `detect` returns ≥1 line (an API/arity/interface change, or a config key you set).
@@ -558,9 +558,9 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 
 ## E50 · v0.49.0 → v0.50.0 — Flyway migrate surfaces unparseable/failure output as an error
 
-- gist: `migration.Migrate`/`MigrateFor` (and everything on top of them — `RunMigrationsAtStartup`, multi-tenant `MigrateAll`, the `go-bricks-migrate` CLI) previously returned a **nil error with a zero-valued Result** when the Flyway subprocess exited 0 but its `-outputType=json` output could not be parsed — the parse error was only Debug-logged — so a migration whose outcome was unobservable was reported as success, and the `migration.applied` audit event recorded `Outcome=success` with an empty version. It now returns a non-nil error (`errors.Is` `migration.ErrFlywayOutputUnparsed` for empty/malformed/redaction-suppressed output, or `migration.ErrFlywayReportedFailure` for a `success:false` envelope even at exit 0) and the audit event records `Outcome=failed`. No exported signatures change; `parseFlywayJSON`'s own contract is unchanged.
+- gist: `migration.Migrate`/`MigrateFor` (and everything on top of them — `RunMigrationsAtStartup`, multi-tenant `MigrateAll`, the `go-bricks-migrate` CLI) previously returned a **nil error with a zero-valued Result** when the Flyway subprocess exited 0 but its `-outputType=json` output could not be parsed — the parse error was only Debug-logged — so a migration whose outcome was unobservable was reported as success, and the `migration.applied` audit event recorded `Outcome=success` with an empty version. It now returns a non-nil error (`errors.Is` `migration.ErrFlywayOutputUnparsed` for empty/malformed/redaction-suppressed output, or `migration.ErrFlywayReportedFailure` for a `success:false` envelope even at exit 0) and the audit event records `Outcome=failed`. No exported signatures change; `parseFlywayJSON`'s own contract is unchanged. Additionally, non-empty DB passwords shorter than 8 bytes are now rejected (config validation + migrate) rather than suppressed — see C50.2.
 - build-caught: none
-- preflight: none
+- preflight: run the C50.2 detect sweep BEFORE the bump — a non-empty DB password `< 8` bytes (static or per-tenant, including the ops/infra tenants file) now aborts startup or the migrate
 - exit: `go get github.com/gaborage/go-bricks@v0.50.0 && go mod tidy && go build ./... && go test ./...`
 
 ### [C50.1] migrate now errors on unparseable/failure Flyway output · silent-behavior · when: no-match
@@ -571,13 +571,13 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - verify: `go test ./...`
 - ref: #673 · migration/result.go: migrateOutcome · migration/flyway.go: runFor
 
-### [C50.2] DB passwords shorter than 8 bytes now fail migrate · silent-behavior · when: match
+### [C50.2] DB passwords shorter than 8 bytes are rejected (config validation + migrate) · config-break · when: match
 
-- detect: inspect every DB password reaching migration (single-tenant `database.password`, per-tenant configs from your tenant store / AWS secrets, and the `go-bricks-migrate --source-config` tenants file) for values shorter than 8 bytes
-- gate: match = any migrated database uses a password `len < 8`. Redaction suppresses the whole Flyway output below that length (short needles can't be safely substring-redacted), so the JSON can't be parsed — a **successful** migrate is now returned as an error AND audit-logged as `migration.applied` `Outcome=failed` / `ErrorClass=internal_error` with an empty version. Do NOT read that Failed event as proof no schema changed. `RunMigrationsAtStartup` under `APP_ENV=dev`/`local` will fail startup for a short password.
-- apply: use a DB password of at least 8 bytes for every migrated database.
-- verify: confirm each migrated database's password is `>= 8` bytes, then `make run` / `go-bricks-migrate migrate`
-- ref: #673 · migration/flyway.go: redactPassword (minRedactablePasswordLength)
+- detect: inspect every DB password for a **non-empty** value shorter than 8 bytes — static (`database.password`, named `databases.*`) and per-tenant (tenant store / AWS secrets, the `go-bricks-migrate --source-config` tenants file)
+- gate: match = any database config uses a non-empty password `len < 8`. Such passwords can't be safely redacted from Flyway output, so `config.Validate` now **rejects static configs at startup** (a `database.password` field error), and the migrate path **rejects per-tenant configs before running Flyway** (`errors.Is migration.ErrDatabasePasswordTooShort`). This replaces #674's suppress-then-fail behavior and closes the audit false-negative where a short-password migration was audited as `Outcome=failed` even on success. **Empty passwords (trust/IAM auth) are exempt.** `RunMigrationsAtStartup` under `APP_ENV=dev`/`local` fails startup for a short password.
+- apply: use a DB password of at least 8 bytes for every database (or leave it empty for trust/IAM auth).
+- verify: `make run` boots (or aborts with a `database.password` error naming the field); `go-bricks-migrate migrate` rejects a short-password tenant with `database password too short to safely redact Flyway output`
+- ref: #673 #675 · ADR-037 · config/validation.go: validateDatabaseCoreFields · migration/flyway.go: ensurePasswordRedactable
 
 
 ---


### PR DESCRIPTION
A non-empty database password below 8 bytes cannot be safely redacted from Flyway output, so the migration engine suppressed the whole output and hid the migration outcome -- auditing a real success as Outcome=failed (an ADR-019 audit false-negative surfaced by #674).

Reject such passwords at two boundaries (ADR-037):
- config.Validate for static config (primary + named databases), failing fast at startup with a database.password error that never echoes the value;
- the migrate path (runFor -> ensurePasswordRedactable), which rejects per-tenant configs (from a tenant store / AWS secrets) that never pass through config.Validate, before running Flyway.

minRedactablePasswordLength is single-sourced from the new exported config.MinDatabasePasswordLength. Empty passwords (trust/IAM auth) are exempt; the <8 whole-output suppression remains only as a fallback for the non-migrate info/validate verbs.

BREAKING CHANGE: a static config with a non-empty DB password shorter than 8 bytes now fails config validation at startup; a per-tenant migration with such a password fails with ErrDatabasePasswordTooShort. Use >=8-char passwords (or empty for trust/IAM auth). See migrations E50 (C50.2).

Closes #675

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation requiring non-empty database passwords to be at least 8 characters.
  * Migrations now reject passwords that are too short before execution, including tenant-specific migrations.
  * Empty passwords remain supported.

* **Bug Fixes**
  * Prevented unsafe password redaction and misleading migration failures.
  * Ensured short passwords are not exposed in validation or migration errors.

* **Documentation**
  * Updated architecture decisions and migration guidance to describe the new password requirement and upgrade precautions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->