### PR TITLE
fix(logger): fully mask URL-valued sensitive fields

### DIFF
--- a/logger/filter.go
+++ b/logger/filter.go
@@ -3,7 +3,6 @@ package logger
 
 import (
 	"fmt"
-	"net/url"
 	"reflect"
 	"strings"
 	"unsafe"
@@ -230,73 +229,11 @@ func (f *SensitiveDataFilter) maskString(value string) string {
 		return value
 	}
 
-	// Special handling for URLs to preserve structure while masking sensitive parts
-	if f.isURL(value) {
-		return f.maskURL(value)
-	}
-
-	// For all other sensitive strings, completely mask the value
-	// No partial disclosure for security reasons
+	// SECURITY: A URL value on the sensitive path is masked in full, never structure-preserved.
+	// URL query strings and fragments routinely carry the secret itself (client_secret=, apikey=,
+	// token=); partial masking (e.g. only user-info password) would leave those verbatim.
+	// For all sensitive strings, completely mask the value — no partial disclosure.
 	return f.config.MaskValue
-}
-
-// isURL checks if a string appears to be a URL
-func (f *SensitiveDataFilter) isURL(value string) bool {
-	return strings.HasPrefix(value, "http://") ||
-		strings.HasPrefix(value, "https://") ||
-		strings.HasPrefix(value, "amqp://") ||
-		strings.HasPrefix(value, "amqps://")
-}
-
-// maskURL masks sensitive information in URLs (like passwords) while preserving structure
-func (f *SensitiveDataFilter) maskURL(urlStr string) string {
-	parsed, err := url.Parse(urlStr)
-	if err != nil {
-		// If parsing fails, fallback to generic masking
-		return f.config.MaskValue
-	}
-
-	// Mask password in user info
-	if parsed.User != nil {
-		if _, hasPassword := parsed.User.Password(); hasPassword {
-			username := parsed.User.Username()
-			return f.buildMaskedURL(parsed, username)
-		}
-	}
-
-	// No password to mask, return original URL
-	return urlStr
-}
-
-// buildMaskedURL constructs a URL with masked password while preserving structure
-func (f *SensitiveDataFilter) buildMaskedURL(parsed *url.URL, username string) string {
-	var b strings.Builder
-
-	// Scheme and authority
-	b.WriteString(parsed.Scheme)
-	b.WriteString("://")
-
-	// User info with masked password
-	b.WriteString(username)
-	b.WriteByte(':')
-	b.WriteString(f.config.MaskValue)
-	b.WriteByte('@')
-	b.WriteString(parsed.Host)
-
-	// Preserve encoded path, query and fragment parts
-	if p := parsed.EscapedPath(); p != "" {
-		b.WriteString(p)
-	}
-	if q := parsed.RawQuery; q != "" {
-		b.WriteByte('?')
-		b.WriteString(q)
-	}
-	if frag := parsed.Fragment; frag != "" {
-		b.WriteByte('#')
-		b.WriteString(frag)
-	}
-
-	return b.String()
 }
 
 // filterStructWithProtection filters sensitive fields with cycle detection and depth limiting

--- a/logger/filter_test.go
+++ b/logger/filter_test.go
@@ -76,10 +76,34 @@ func TestFilterString(t *testing.T) {
 		t.Errorf(unexpectedValueMsg, testUserDoe, result)
 	}
 
-	// Test URL masking (clean masking without URL encoding)
+	// Test URL-valued sensitive field: full masking, not structure-preserving
 	result = filter.FilterString("broker_url", "amqp://user:pass@host/vhost")
-	if result != "amqp://user:***@host/vhost" {
-		t.Errorf("Expected clean masked URL, got '%s'", result)
+	if result != DefaultMaskValue {
+		t.Errorf(unexpectedValueMsg, DefaultMaskValue, result)
+	}
+}
+
+func TestFilterMasksURLValuedSensitiveFieldWithQuerySecret(t *testing.T) {
+	filter := NewSensitiveDataFilter(&FilterConfig{
+		SensitiveFields: []string{"secret"},
+		MaskValue:       DefaultMaskValue,
+	})
+
+	result := filter.FilterString("client_secret", "https://idp.example.com/oauth?client_secret=abc123")
+	if result != DefaultMaskValue {
+		t.Errorf(unexpectedValueMsg, DefaultMaskValue, result)
+	}
+}
+
+func TestFilterMasksURLValuedSensitiveFieldWithoutUserinfo(t *testing.T) {
+	filter := NewSensitiveDataFilter(&FilterConfig{
+		SensitiveFields: []string{"apikey"},
+		MaskValue:       DefaultMaskValue,
+	})
+
+	result := filter.FilterString("apikey", "https://api.example.com/v1/keys?apikey=zzz")
+	if result != DefaultMaskValue {
+		t.Errorf(unexpectedValueMsg, DefaultMaskValue, result)
 	}
 }
 
@@ -144,29 +168,6 @@ func TestFilterFields(t *testing.T) {
 	}
 	if result["email"] != testEmail {
 		t.Errorf("Expected email to remain unchanged")
-	}
-}
-
-func TestMaskURL(t *testing.T) {
-	filter := NewSensitiveDataFilter(nil)
-
-	// Test AMQP URL with password (clean masking)
-	result := filter.maskURL("amqp://user:secret@rabbitmq.example.com/vhost")
-	expected := "amqp://user:" + DefaultMaskValue + "@rabbitmq.example.com/vhost"
-	if result != expected {
-		t.Errorf(unexpectedValueMsg, expected, result)
-	}
-
-	// Test URL without password
-	result = filter.maskURL("https://api.example.com/v1/users")
-	if result != "https://api.example.com/v1/users" {
-		t.Errorf("Expected URL without password to remain unchanged")
-	}
-
-	// Test simple string (not a URL) - should pass through unchanged since no password to mask
-	result = filter.maskURL("not-a-valid-url")
-	if result != "not-a-valid-url" {
-		t.Errorf("Expected simple string to pass through unchanged, got '%s'", result)
 	}
 }
 
@@ -386,52 +387,6 @@ func TestFilterValueNonStructType(t *testing.T) {
 	mapResultTyped, ok := mapResult.(map[string]any)
 	if !ok || mapResultTyped["username"] != "alice" {
 		t.Errorf("Expected non-sensitive string map field to pass through unchanged")
-	}
-}
-
-func TestMaskURLErrorHandling(t *testing.T) {
-	filter := NewSensitiveDataFilter(nil)
-
-	// Test with malformed URL that causes parsing error
-	malformedURL := "ht!@#$%tp://invalid-url-format"
-	result := filter.maskURL(malformedURL)
-
-	// Should fallback to generic masking when URL parsing fails
-	expected := DefaultMaskValue
-	if result != expected {
-		t.Errorf("Expected fallback to generic masking for malformed URL, got '%s'", result)
-	}
-}
-
-func TestMaskURLNoUserInfo(t *testing.T) {
-	filter := NewSensitiveDataFilter(nil)
-
-	// Test URLs without user info
-	testCases := []string{
-		"https://example.com/path",
-		"http://localhost:8080",
-		"amqp://host/vhost",
-		"amqps://secure.example.com",
-	}
-
-	for _, url := range testCases {
-		result := filter.maskURL(url)
-		if result != url {
-			t.Errorf("Expected URL without user info to remain unchanged: %s, got: %s", url, result)
-		}
-	}
-}
-
-func TestMaskURLUserWithoutPassword(t *testing.T) {
-	filter := NewSensitiveDataFilter(nil)
-
-	// Test URL with username but no password
-	url := "amqp://username@host/vhost"
-	result := filter.maskURL(url)
-
-	// Should remain unchanged since there's no password to mask
-	if result != url {
-		t.Errorf("Expected URL with username but no password to remain unchanged: %s, got: %s", url, result)
 	}
 }
 

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -678,46 +678,6 @@ func TestFilterSliceNoChangesPath(t *testing.T) {
 	})
 }
 
-func TestBuildMaskedURLCoverage(t *testing.T) {
-	filter := NewSensitiveDataFilter(DefaultFilterConfig())
-
-	// Test URL without path/query/fragment to cover lines 232-242
-	t.Run("url_without_path_query_fragment", func(t *testing.T) {
-		testURL := "https://user:password@example.com"
-		result := filter.FilterString("password", testURL)
-
-		expected := "https://user:***@example.com"
-		assert.Equal(t, expected, result)
-	})
-
-	// Test URL with empty path
-	t.Run("url_with_empty_path", func(t *testing.T) {
-		testURL := "https://user:password@example.com/"
-		result := filter.FilterString("token", testURL)
-
-		expected := "https://user:***@example.com/"
-		assert.Equal(t, expected, result)
-	})
-
-	// Test URL with query but no fragment
-	t.Run("url_with_query_no_fragment", func(t *testing.T) {
-		testURL := "https://user:password@example.com/path?key=value"
-		result := filter.FilterString("secret", testURL)
-
-		expected := "https://user:***@example.com/path?key=value"
-		assert.Equal(t, expected, result)
-	})
-
-	// Test URL with fragment but no query
-	t.Run("url_with_fragment_no_query", func(t *testing.T) {
-		testURL := "https://user:password@example.com/path#section"
-		result := filter.FilterString("key", testURL)
-
-		expected := "https://user:***@example.com/path#section"
-		assert.Equal(t, expected, result)
-	})
-}
-
 func TestFilterStructEarlyReturns(t *testing.T) {
 	filter := NewSensitiveDataFilter(DefaultFilterConfig())
 


### PR DESCRIPTION
## What

When a field is classified sensitive (via `log.sensitivefields` or a matching
default token such as `token_endpoint` / `auth_url`), `maskString` delegated URL
values to `maskURL`, which:

1. returned the URL **verbatim** when it had no userinfo password
   (`return urlStr`), and
2. re-appended the raw query string even when it masked a userinfo password
   (`buildMaskedURL`).

So a sensitive field holding `https://idp/oauth?client_secret=…` was logged in
full — correct operator configuration could not actually mask URL-valued
secrets.

## Fix

A field marked sensitive is now masked **in full** (`f.config.MaskValue`). URL
query strings and fragments routinely carry the secret itself (`client_secret=`,
`apikey=`, `token=`), so structure-preserving masking is unsafe on the sensitive
path. The now-dead `isURL` / `maskURL` / `buildMaskedURL` helpers and the
`net/url` import are removed.

## Verification

- `make check` green.
- TDD: `TestFilterMasksURLValuedSensitiveFieldWithQuerySecret` and
  `TestFilterMasksURLValuedSensitiveFieldWithoutUserinfo` (written first, failed
  proving the secret survived masking).
- Removed the now-obsolete `TestBuildMaskedURLCoverage` (it covered the deleted
  code path; the same single path is covered by the two new tests plus
  `TestFilterString`'s `broker_url` case).

## Follow-up (out of scope here)

- `messaging/url_redaction.go` `buildRedactedURL` has the **same** leak class
  (re-appends `RawQuery` after masking only the userinfo password) — surfaced by
  the review, needs its own change.
- `database/internal/tracking/utils.go:180` carries a now-stale comment
  describing `maskString` as "URL-aware"; needs a doc fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive values are now fully masked when their field is configured as sensitive, including values formatted as URLs.
  * URL query parameters and credentials no longer expose portions of sensitive values.
  * Consistent masking is applied to URL values with or without embedded user information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->