### PR TITLE
fix(migration): recover panics in the audit-sink consumer goroutine

### DIFF
--- a/migration/audit_emitter.go
+++ b/migration/audit_emitter.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"sync"
 
 	"go.opentelemetry.io/otel"
@@ -270,21 +271,44 @@ func (e *auditEmitter) enqueueForSink(ctx context.Context, ev *AuditEvent) {
 func (e *auditEmitter) consumeSink(ctx context.Context) {
 	defer e.consumerWG.Done()
 	for ev := range e.sinkQueue {
-		err := e.sink.Record(ctx, ev)
-		if err == nil {
-			continue
-		}
-		if e.sinkFailures != nil {
-			e.sinkFailures.Add(ctx, 1,
-				metric.WithAttributes(attribute.String(attrKeyType, string(ev.Type))),
-			)
-		}
-		e.logger.Warn().
-			Err(err).
-			Str("audit_type", string(ev.Type)).
-			Str("target", ev.Target).
-			Msg("audit sink delivery failed")
+		e.deliverToSink(ctx, ev)
 	}
+}
+
+// deliverToSink calls the consumer-supplied sink for a single event and recovers
+// any panic so a faulty AuditRecorder cannot crash a migration mid-run (ADR-019:
+// sink errors log but don't abort — panics must behave the same).
+func (e *auditEmitter) deliverToSink(ctx context.Context, ev *AuditEvent) {
+	defer func() {
+		if r := recover(); r != nil {
+			if e.sinkFailures != nil {
+				e.sinkFailures.Add(ctx, 1,
+					metric.WithAttributes(attribute.String(attrKeyType, string(ev.Type))),
+				)
+			}
+			e.logger.Error().
+				Interface("panic", r).
+				Str("stack", string(debug.Stack())).
+				Str("audit_type", string(ev.Type)).
+				Str("target", ev.Target).
+				Msg("audit sink panicked; event dropped")
+		}
+	}()
+
+	err := e.sink.Record(ctx, ev)
+	if err == nil {
+		return
+	}
+	if e.sinkFailures != nil {
+		e.sinkFailures.Add(ctx, 1,
+			metric.WithAttributes(attribute.String(attrKeyType, string(ev.Type))),
+		)
+	}
+	e.logger.Warn().
+		Err(err).
+		Str("audit_type", string(ev.Type)).
+		Str("target", ev.Target).
+		Msg("audit sink delivery failed")
 }
 
 // Close drains the AuditRecorder queue and tears down the consumer goroutine.

--- a/migration/audit_emitter.go
+++ b/migration/audit_emitter.go
@@ -275,17 +275,24 @@ func (e *auditEmitter) consumeSink(ctx context.Context) {
 	}
 }
 
+// recordSinkFailure increments the sink-failure counter for the given event,
+// tagged by event type. Shared by the panic-recovery and error branches of
+// deliverToSink.
+func (e *auditEmitter) recordSinkFailure(ctx context.Context, ev *AuditEvent) {
+	if e.sinkFailures != nil {
+		e.sinkFailures.Add(ctx, 1,
+			metric.WithAttributes(attribute.String(attrKeyType, string(ev.Type))),
+		)
+	}
+}
+
 // deliverToSink calls the consumer-supplied sink for a single event and recovers
 // any panic so a faulty AuditRecorder cannot crash a migration mid-run (ADR-019:
 // sink errors log but don't abort — panics must behave the same).
 func (e *auditEmitter) deliverToSink(ctx context.Context, ev *AuditEvent) {
 	defer func() {
 		if r := recover(); r != nil {
-			if e.sinkFailures != nil {
-				e.sinkFailures.Add(ctx, 1,
-					metric.WithAttributes(attribute.String(attrKeyType, string(ev.Type))),
-				)
-			}
+			e.recordSinkFailure(ctx, ev)
 			e.logger.Error().
 				Interface("panic", r).
 				Str("stack", string(debug.Stack())).
@@ -299,11 +306,7 @@ func (e *auditEmitter) deliverToSink(ctx context.Context, ev *AuditEvent) {
 	if err == nil {
 		return
 	}
-	if e.sinkFailures != nil {
-		e.sinkFailures.Add(ctx, 1,
-			metric.WithAttributes(attribute.String(attrKeyType, string(ev.Type))),
-		)
-	}
+	e.recordSinkFailure(ctx, ev)
 	e.logger.Warn().
 		Err(err).
 		Str("audit_type", string(ev.Type)).

--- a/migration/audit_test.go
+++ b/migration/audit_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gaborage/go-bricks/config"
 	"github.com/gaborage/go-bricks/logger"
+	obtest "github.com/gaborage/go-bricks/observability/testing"
 )
 
 // recordingSink is a test AuditRecorder that captures every Record call.
@@ -76,6 +77,24 @@ func (s *recordingSink) waitForFirst(t *testing.T, timeout time.Duration) {
 	}
 }
 
+// panickingSink panics on the first Record call and records normally afterwards.
+type panickingSink struct {
+	recordingSink
+	panicked bool // consumer goroutine calls Record sequentially; no lock needed
+}
+
+func newPanickingSink() *panickingSink {
+	return &panickingSink{recordingSink: recordingSink{hits: make(chan struct{}, 256)}}
+}
+
+func (s *panickingSink) Record(ctx context.Context, event *AuditEvent) error {
+	if !s.panicked {
+		s.panicked = true
+		panic("sink exploded")
+	}
+	return s.recordingSink.Record(ctx, event)
+}
+
 // setupTestTracer installs an in-memory tracer provider for the duration of
 // the test and returns the exporter so callers can inspect emitted spans.
 func setupTestTracer(t *testing.T) *tracetest.InMemoryExporter {
@@ -89,6 +108,20 @@ func setupTestTracer(t *testing.T) *tracetest.InMemoryExporter {
 		otel.SetTracerProvider(previous)
 	})
 	return exporter
+}
+
+// setupTestMeter installs an in-memory meter provider for the duration of the
+// test so counters created via the global otel.Meter can be asserted.
+func setupTestMeter(t *testing.T) *obtest.TestMeterProvider {
+	t.Helper()
+	mp := obtest.NewTestMeterProvider()
+	previous := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		_ = mp.Shutdown(context.Background())
+		otel.SetMeterProvider(previous)
+	})
+	return mp
 }
 
 // disabledLogger returns a no-op logger matching the convention used across
@@ -710,4 +743,21 @@ func TestNewEmitterEmitsStateTransitionedToSink(t *testing.T) {
 	assert.Equal(t, "pending", events[0].FromState)
 	assert.Equal(t, "schema_created", events[0].ToState)
 	assert.Equal(t, testPrincipal, events[0].AppliedByPrincipal)
+}
+
+func TestEmitterSinkPanicIsRecoveredAndCounted(t *testing.T) {
+	setupTestTracer(t)
+	mp := setupTestMeter(t) // BEFORE newAuditEmitter: counters bind at construction
+	sink := newPanickingSink()
+	emitter := newAuditEmitter(disabledLogger(), sink)
+	t.Cleanup(func() { _ = emitter.Close(context.Background()) })
+
+	emitter.Emit(context.Background(), baseEvent()) // sink panics on this event
+	emitter.Emit(context.Background(), baseEvent()) // consumer must survive to deliver this one
+
+	sink.waitForFirst(t, time.Second)
+	require.Len(t, sink.snapshot(), 1, "second event should be delivered after the panic")
+
+	rm := mp.Collect(t)
+	obtest.AssertMetricValue(t, rm, "migration.audit.sink_failures", int64(1))
 }


### PR DESCRIPTION
## What

The migration audit-sink consumer goroutine delivered events to a
consumer-supplied `AuditRecorder` with **no panic recovery**. A panic inside
`sink.Record` (nil-map write, nil producer, …) was an unrecovered goroutine
panic that terminated the whole process — killing an app's startup migration at
boot, or a `go-bricks-migrate` fleet rollout mid-fan-out (potentially between a
tenant's Flyway apply and its result reporting). ADR-019 promises the sink
"cannot stall migrations, and sink errors log but don't abort" — errors were
handled, but panics were not, and this path was the exception to the framework's
messaging/scheduler panic-recovery convention.

## Fix

Extract `deliverToSink(ctx, ev)` with a **per-event** recover (so one panicking
event doesn't kill the drain loop for the rest of the queue), mirroring the
messaging-consumer / scheduler-job convention: logs `panic` + `stack`, and bumps
the existing `sink_failures` counter so a panic is observable exactly like a
delivery failure. The error-return branch is unchanged.

## Verification

- `make check` green.
- `TestEmitterSinkPanicIsRecoveredAndCounted` (new) — proves the consumer
  goroutine survives a panicking sink (the second event is still delivered) and
  `migration.audit.sink_failures` increments exactly once. Fails without the fix.
- `TestEmitterSinkErrorIsNotPropagated` (existing) — regression guard for the
  error-return branch through the refactored `deliverToSink`.

Produced via `/improve execute 004` (self-contained plan in `plans/004-*`,
implemented by a dispatched executor, then reviewed and approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented audit sink failures from interrupting migration runs.
  * Audit delivery now recovers from sink panics, logs diagnostic details, and records a failure metric.
  * Subsequent audit events continue to be delivered after a sink panic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->