### PR TITLE
fix(scheduler): register manual job in-flight before tryLock and re-check shutdown

### DIFF
--- a/scheduler/api_handlers.go
+++ b/scheduler/api_handlers.go
@@ -1,12 +1,8 @@
 package scheduler
 
 import (
-	"context"
 	"net/http"
 
-	"github.com/gaborage/go-bricks/database/types"
-	"github.com/gaborage/go-bricks/internal/leasescope"
-	"github.com/gaborage/go-bricks/messaging"
 	"github.com/gaborage/go-bricks/server"
 )
 
@@ -106,70 +102,10 @@ func (m *Module) triggerJobHandler(req JobIDParam, _ server.HandlerContext) (ser
 	return server.NewResult(http.StatusAccepted, response), nil
 }
 
-// executeManualJob executes a job triggered manually (not by scheduler)
+// executeManualJob executes a job triggered manually (not by scheduler). It
+// shares the full execution body — in-flight registration, shutdown re-check,
+// overlap prevention, lease scope, and the panic-recovered run — with the
+// scheduled path via runJobWithSlot, passing the "manual" trigger type.
 func (m *Module) executeManualJob(entry *jobEntry) {
-	// Register as in-flight BEFORE any shutdown check or tryLock — see
-	// createJobWrapper: Add after either races Shutdown's wg.Wait().
-	m.wg.Add(1)
-	defer m.wg.Done()
-
-	// Re-check shutdown now that the in-flight registration is visible.
-	select {
-	case <-m.shutdownCtx.Done():
-		m.logger.Warn().
-			Str("jobID", entry.metadata.JobID).
-			Str("triggerType", "manual").
-			Msg("Job trigger skipped - scheduler is shutting down")
-		return
-	default:
-	}
-
-	// Overlapping prevention (same as scheduled execution)
-	if !entry.tryLock() {
-		m.logger.Warn().
-			Str("jobID", entry.metadata.JobID).
-			Str("triggerType", "manual").
-			Msg("Job trigger skipped - job is already running")
-		entry.metadata.incrementSkipped()
-		return
-	}
-	defer entry.unlock()
-
-	ctx, cancel := context.WithCancel(m.shutdownCtx)
-	defer cancel()
-
-	// Install the per-job lease scope (ADR-032), same as the scheduled path: a manually
-	// triggered job (POST /_sys/job/:jobId) borrows per-tenant handles via JobContext.DB()/
-	// Messaging() and runs concurrently with other tenants' work, so its leases must be held
-	// until the run completes — otherwise an evicted handle could be closed mid-job.
-	ctx, scope := leasescope.Install(ctx)
-	defer scope.ReleaseAll()
-
-	// Create JobContext with manual trigger type
-	jobCtx := newJobContext(
-		ctx,
-		entry.metadata.JobID,
-		"manual", // Trigger type is manual, not scheduled
-		m.logger,
-		func() types.Interface {
-			db, err := m.getDB(ctx)
-			if err != nil {
-				m.logger.Error().Err(err).Msg("Failed to get database connection")
-				return nil
-			}
-			return db
-		},
-		func() messaging.Client {
-			msg, err := m.getMessaging(ctx)
-			if err != nil {
-				m.logger.Error().Err(err).Msg("Failed to get messaging client")
-				return nil
-			}
-			return msg
-		},
-		m.config,
-	)
-
-	// Execute with same panic recovery as scheduled jobs
-	m.executeJob(entry, jobCtx)
+	m.runJobWithSlot(entry, "manual")
 }

--- a/scheduler/api_handlers.go
+++ b/scheduler/api_handlers.go
@@ -108,6 +108,22 @@ func (m *Module) triggerJobHandler(req JobIDParam, _ server.HandlerContext) (ser
 
 // executeManualJob executes a job triggered manually (not by scheduler)
 func (m *Module) executeManualJob(entry *jobEntry) {
+	// Register as in-flight BEFORE any shutdown check or tryLock — see
+	// createJobWrapper: Add after either races Shutdown's wg.Wait().
+	m.wg.Add(1)
+	defer m.wg.Done()
+
+	// Re-check shutdown now that the in-flight registration is visible.
+	select {
+	case <-m.shutdownCtx.Done():
+		m.logger.Warn().
+			Str("jobID", entry.metadata.JobID).
+			Str("triggerType", "manual").
+			Msg("Job trigger skipped - scheduler is shutting down")
+		return
+	default:
+	}
+
 	// Overlapping prevention (same as scheduled execution)
 	if !entry.tryLock() {
 		m.logger.Warn().
@@ -117,14 +133,7 @@ func (m *Module) executeManualJob(entry *jobEntry) {
 		entry.metadata.incrementSkipped()
 		return
 	}
-
-	// Track in-flight execution
-	m.wg.Add(1)
-
-	defer func() {
-		entry.unlock()
-		m.wg.Done()
-	}()
+	defer entry.unlock()
 
 	ctx, cancel := context.WithCancel(m.shutdownCtx)
 	defer cancel()

--- a/scheduler/api_handlers_test.go
+++ b/scheduler/api_handlers_test.go
@@ -182,13 +182,7 @@ func TestExecuteManualJobSkippedAfterShutdown(t *testing.T) {
 
 	// Add/Done must balance — a hang here means wg.Add(1) was not matched by a
 	// deferred wg.Done() on the shutdown-bail path.
-	done := make(chan struct{})
-	go func() { module.wg.Wait(); close(done) }()
-	select {
-	case <-done:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("wg.Wait() blocked after executeManualJob returned via shutdown-bail path")
-	}
+	assertWaitGroupDrains(t, module, "executeManualJob returned via shutdown-bail path")
 }
 
 // TestExecuteManualJobBalancesAddDoneOnTryLockFailPath mirrors
@@ -211,11 +205,5 @@ func TestExecuteManualJobBalancesAddDoneOnTryLockFailPath(t *testing.T) {
 	assert.Equal(t, int64(0), job.Count(), "job Execute should not run when tryLock fails")
 	assert.Equal(t, int64(1), entry.metadata.snapshot().SkippedCount, "expected skip counter increment")
 
-	done := make(chan struct{})
-	go func() { module.wg.Wait(); close(done) }()
-	select {
-	case <-done:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("wg.Wait() blocked after executeManualJob returned via tryLock-fail path")
-	}
+	assertWaitGroupDrains(t, module, "executeManualJob returned via tryLock-fail path")
 }

--- a/scheduler/api_handlers_test.go
+++ b/scheduler/api_handlers_test.go
@@ -159,3 +159,63 @@ func TestListJobsHandlerExposesTimezone(t *testing.T) {
 	require.Nil(t, apiErr)
 	assert.Equal(t, "America/New_York", result.Data.Meta["timezone"])
 }
+
+// TestExecuteManualJobSkippedAfterShutdown is the distinguishing regression test
+// for the Add-after-Wait race: the pre-fix executeManualJob had no shutdown
+// re-check at all (tryLock ran first, wg.Add ran after), so a manual trigger
+// racing Shutdown would run Execute even after wg.Wait() had already returned.
+// Post-fix, wg.Add(1) runs first and the shutdown re-check bails before
+// tryLock/Execute, so the job never runs.
+func TestExecuteManualJobSkippedAfterShutdown(t *testing.T) {
+	module, _ := newTestScheduler(t, 5*time.Second)
+
+	job := &counterJob{}
+	entry := &jobEntry{job: job, metadata: &JobMetadata{JobID: "manual-shutdown-test"}}
+
+	// Initiate shutdown BEFORE invoking the manual path.
+	module.shutdownCancel()
+
+	module.executeManualJob(entry)
+
+	// Execute must never have run.
+	assert.Equal(t, int64(0), job.Count(), "job Execute should not run after shutdown")
+
+	// Add/Done must balance — a hang here means wg.Add(1) was not matched by a
+	// deferred wg.Done() on the shutdown-bail path.
+	done := make(chan struct{})
+	go func() { module.wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("wg.Wait() blocked after executeManualJob returned via shutdown-bail path")
+	}
+}
+
+// TestExecuteManualJobBalancesAddDoneOnTryLockFailPath mirrors
+// TestCreateJobWrapperBalancesAddDoneOnTryLockFailPath (module_test.go) for the
+// manual-trigger path: pre-acquire the entry lock so executeManualJob's tryLock
+// fails, and verify the skip is counted (this skip path DOES increment
+// SkippedCount, unlike the shutdown-bail path) and Add/Done stays balanced.
+func TestExecuteManualJobBalancesAddDoneOnTryLockFailPath(t *testing.T) {
+	module, _ := newTestScheduler(t, 5*time.Second)
+
+	job := &counterJob{}
+	entry := &jobEntry{job: job, metadata: &JobMetadata{JobID: "manual-trylock-test"}}
+
+	// Pre-acquire the lock so executeManualJob's tryLock fails.
+	require.True(t, entry.tryLock(), "test setup: first tryLock must succeed")
+	defer entry.unlock()
+
+	module.executeManualJob(entry)
+
+	assert.Equal(t, int64(0), job.Count(), "job Execute should not run when tryLock fails")
+	assert.Equal(t, int64(1), entry.metadata.snapshot().SkippedCount, "expected skip counter increment")
+
+	done := make(chan struct{})
+	go func() { module.wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("wg.Wait() blocked after executeManualJob returned via tryLock-fail path")
+	}
+}

--- a/scheduler/module.go
+++ b/scheduler/module.go
@@ -528,76 +528,84 @@ func (m *Module) scheduleWithGocron(entry *jobEntry) (gocron.Job, error) {
 // - Graceful shutdown handling per FR-024
 func (m *Module) createJobWrapper(entry *jobEntry) func() {
 	return func() {
-		// Register as in-flight BEFORE any shutdown check or tryLock. If Add(1)
-		// happens after either, a shutdown firing concurrently with this closure
-		// can race: Shutdown's wg.Wait() observes counter==0 and returns before
-		// this wrapper increments it, then the job runs after Shutdown returned.
-		// Defer Done() immediately so every return path balances the Add.
-		m.wg.Add(1)
-		defer m.wg.Done()
-
-		// Check for shutdown
-		select {
-		case <-m.shutdownCtx.Done():
-			m.logger.Warn().
-				Str("jobID", entry.metadata.JobID).
-				Msg("Job trigger skipped - scheduler is shutting down")
-			return
-		default:
-		}
-
-		// Overlapping execution prevention per FR-026
-		if !entry.tryLock() {
-			m.logger.Warn().
-				Str("jobID", entry.metadata.JobID).
-				Str("triggerType", "scheduled").
-				Msg("Job trigger skipped - job is already running")
-			entry.metadata.incrementSkipped()
-			return
-		}
-		// Defer unlock AFTER Done() so LIFO ordering releases the lock first,
-		// matching the prior coupled-defer ordering (unlock then Done).
-		defer entry.unlock()
-
-		// Create execution context with cancellation for graceful shutdown
-		ctx, cancel := context.WithCancel(m.shutdownCtx)
-		defer cancel()
-
-		// Install the per-job lease scope (ADR-032): per-tenant handles the job borrows via
-		// JobContext.DB()/Messaging() — including the per-tenant fan-out in outbox relay and
-		// inbox cleanup, whose SetTenant children inherit this scope — are released when the
-		// job run completes, so a handle evicted mid-job is not closed under it.
-		ctx, scope := leasescope.Install(ctx)
-		defer scope.ReleaseAll()
-
-		// Create JobContext with multi-tenant resolvers
-		jobCtx := newJobContext(
-			ctx,
-			entry.metadata.JobID,
-			"scheduled",
-			m.logger,
-			func() types.Interface {
-				db, err := m.getDB(ctx)
-				if err != nil {
-					m.logger.Error().Err(err).Msg("Failed to get DB for job execution")
-					return nil
-				}
-				return db
-			},
-			func() messaging.Client {
-				msg, err := m.getMessaging(ctx)
-				if err != nil {
-					m.logger.Error().Err(err).Msg("Failed to get Messaging for job execution")
-					return nil
-				}
-				return msg
-			},
-			m.config,
-		)
-
-		// Execute job with panic recovery per FR-021
-		m.executeJob(entry, jobCtx)
+		m.runJobWithSlot(entry, "scheduled")
 	}
+}
+
+// runJobWithSlot is the shared job-execution body for both the scheduled wrapper
+// (createJobWrapper) and the manual trigger (executeManualJob). triggerType
+// ("scheduled" or "manual") distinguishes the two in logs and the JobContext.
+//
+// wg.Add(1) is the FIRST statement so every bail path (shutdown, tryLock-fail)
+// balances Shutdown's wg.Wait(): an Add placed after either would let Shutdown
+// return before this goroutine registered, then run the job afterward. The LIFO
+// defers release the per-job lock before wg.Done().
+func (m *Module) runJobWithSlot(entry *jobEntry, triggerType string) {
+	// Register as in-flight BEFORE any shutdown check or tryLock.
+	m.wg.Add(1)
+	defer m.wg.Done()
+
+	// Check for shutdown.
+	select {
+	case <-m.shutdownCtx.Done():
+		m.logger.Warn().
+			Str("jobID", entry.metadata.JobID).
+			Str("triggerType", triggerType).
+			Msg("Job trigger skipped - scheduler is shutting down")
+		return
+	default:
+	}
+
+	// Overlapping execution prevention per FR-026.
+	if !entry.tryLock() {
+		m.logger.Warn().
+			Str("jobID", entry.metadata.JobID).
+			Str("triggerType", triggerType).
+			Msg("Job trigger skipped - job is already running")
+		entry.metadata.incrementSkipped()
+		return
+	}
+	// Defer unlock AFTER Done() so LIFO ordering releases the lock first.
+	defer entry.unlock()
+
+	// Create execution context with cancellation for graceful shutdown.
+	ctx, cancel := context.WithCancel(m.shutdownCtx)
+	defer cancel()
+
+	// Install the per-job lease scope (ADR-032): per-tenant handles the job borrows via
+	// JobContext.DB()/Messaging() — including the per-tenant fan-out in outbox relay and
+	// inbox cleanup, whose SetTenant children inherit this scope — are released when the
+	// job run completes, so a handle evicted mid-job is not closed under it.
+	ctx, scope := leasescope.Install(ctx)
+	defer scope.ReleaseAll()
+
+	// Create JobContext with multi-tenant resolvers.
+	jobCtx := newJobContext(
+		ctx,
+		entry.metadata.JobID,
+		triggerType,
+		m.logger,
+		func() types.Interface {
+			db, err := m.getDB(ctx)
+			if err != nil {
+				m.logger.Error().Err(err).Msg("Failed to get DB for job execution")
+				return nil
+			}
+			return db
+		},
+		func() messaging.Client {
+			msg, err := m.getMessaging(ctx)
+			if err != nil {
+				m.logger.Error().Err(err).Msg("Failed to get Messaging for job execution")
+				return nil
+			}
+			return msg
+		},
+		m.config,
+	)
+
+	// Execute job with panic recovery per FR-021.
+	m.executeJob(entry, jobCtx)
 }
 
 // executeJob executes the job with panic recovery, metadata updates, and observability instrumentation.

--- a/scheduler/module_test.go
+++ b/scheduler/module_test.go
@@ -154,15 +154,7 @@ func TestCreateJobWrapperBalancesAddDoneOnShutdownPath(t *testing.T) {
 
 	wrapper() // synchronous invoke; defer wg.Done() must fire on return
 
-	// After the wrapper returns, wg counter must be back to 0 (Add balanced by Done).
-	// Use a goroutine + timeout so a leak surfaces as a test failure, not a hang.
-	done := make(chan struct{})
-	go func() { module.wg.Wait(); close(done) }()
-	select {
-	case <-done:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("wg.Wait() blocked after wrapper returned — Add(1) was not balanced by Done()")
-	}
+	assertWaitGroupDrains(t, module, "wrapper returned on shutdown-bail path")
 }
 
 // TestCreateJobWrapperBalancesAddDoneOnTryLockFailPath asserts the same Add/Done
@@ -185,13 +177,7 @@ func TestCreateJobWrapperBalancesAddDoneOnTryLockFailPath(t *testing.T) {
 	wrapper := module.createJobWrapper(entry)
 	wrapper() // closure bails at tryLock-fail; defer Done() must still fire
 
-	done := make(chan struct{})
-	go func() { module.wg.Wait(); close(done) }()
-	select {
-	case <-done:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("wg.Wait() blocked after wrapper returned via tryLock-fail path")
-	}
+	assertWaitGroupDrains(t, module, "wrapper returned via tryLock-fail path")
 
 	// Sanity: the skip counter should have incremented (proves we actually hit
 	// the tryLock-fail branch rather than some other path).

--- a/scheduler/test_helpers_test.go
+++ b/scheduler/test_helpers_test.go
@@ -15,6 +15,21 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// assertWaitGroupDrains fails if module m's in-flight WaitGroup does not reach
+// zero within 100ms after the code path under test returned. A hang means a
+// wg.Add(1) was not matched by a deferred wg.Done() on that path — surfaced as a
+// failure, not a hung test.
+func assertWaitGroupDrains(t *testing.T, m *Module, afterContext string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() { m.wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("wg.Wait() blocked after %s — Add(1) was not balanced by Done()", afterContext)
+	}
+}
+
 type testSchedulerOption func(*app.ModuleDeps)
 
 func withTracer(tr trace.Tracer) testSchedulerOption {


### PR DESCRIPTION
## What

The manual-job-trigger path (`POST /_sys/job/:jobId`) had a `sync.WaitGroup`
Add-after-Wait race: `executeManualJob` called `entry.tryLock()` **before**
`m.wg.Add(1)`, and never re-checked the shutdown context after acquiring the
lock. If `Module.Shutdown` ran in that window, `wg.Wait()` observed counter 0 and
returned, and the manual job then executed **after** Shutdown had returned —
running `Execute` against DB/messaging managers the app was in the process of
closing. This is the exact misuse the scheduled-job wrapper (`createJobWrapper`)
was specifically written to avoid, and the trigger is reachable because HTTP is
still serving during module shutdown.

## Fix

Reorder `executeManualJob`'s prologue to mirror `createJobWrapper`:

1. `m.wg.Add(1)` + `defer m.wg.Done()` **first** (register in-flight before
   anything can race `wg.Wait()`),
2. a **post-Add** shutdown re-check (warn-only — it must not increment
   `SkippedCount`, which per FR-026 counts only overlapping-prevention skips),
3. then `entry.tryLock()` + `defer entry.unlock()`.

LIFO defer ordering keeps `unlock` running before `Done`, matching the scheduled
wrapper. The lease-scope / context-cancel body after the prologue is unchanged.

## Verification

- `make check` green; `go test -race ./scheduler/` passes.
- `TestExecuteManualJobSkippedAfterShutdown` — the distinguishing regression:
  pre-fix (no shutdown re-check) the job **runs** in this scenario; post-fix it's
  skipped (`job.Count() == 0`) and the `WaitGroup` Add/Done stays balanced (no
  Shutdown hang).
- `TestExecuteManualJobBalancesAddDoneOnTryLockFailPath` — the tryLock-fail skip
  path stays Add/Done-balanced (`SkippedCount == 1`, counted).

Produced via `/improve execute plan 005` (self-contained plan in `plans/005-*`,
implemented by a dispatched executor, then reviewed and approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved manual job execution during shutdown so canceled jobs are skipped safely.
  - Prevented overlapping manual runs from executing concurrently.
  - Corrected in-flight job tracking when execution is skipped.

- **Refactor**
  - Standardized manual and scheduled jobs on a shared execution path for more consistent behavior.

- **Tests**
  - Added regression coverage for shutdown handling, locking conflicts, and synchronization cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->