### PR TITLE
fix(scheduler): register manual trigger under m.mu before spawn to close Add-after-Wait race

### DIFF
--- a/scheduler/api_handlers.go
+++ b/scheduler/api_handlers.go
@@ -80,13 +80,13 @@ func (m *Module) triggerJobHandler(req JobIDParam, _ server.HandlerContext) (ser
 		return server.Result[JobTriggerResponse]{}, server.NewNotFoundError("job").WithDetails("job_id", jobID)
 	}
 
-	// Check for shutdown
-	select {
-	case <-m.shutdownCtx.Done():
+	// Atomically check shutdown + register the in-flight slot under m.mu (Shutdown
+	// cancels under the same lock), so wg.Add happens-before Shutdown's wg.Wait and
+	// can never land after Wait returned. Nothing may return/panic between here and
+	// the spawn, or the Add leaks and hangs Shutdown.
+	if !m.registerManualTrigger() {
 		return server.Result[JobTriggerResponse]{}, server.NewServiceUnavailableError("scheduler is shutting down")
-	default:
 	}
-
 	go m.executeManualJob(entry)
 
 	// Return with standard GoBricks envelope
@@ -102,10 +102,11 @@ func (m *Module) triggerJobHandler(req JobIDParam, _ server.HandlerContext) (ser
 	return server.NewResult(http.StatusAccepted, response), nil
 }
 
-// executeManualJob executes a job triggered manually (not by scheduler). It
-// shares the full execution body — in-flight registration, shutdown re-check,
-// overlap prevention, lease scope, and the panic-recovered run — with the
-// scheduled path via runJobWithSlot, passing the "manual" trigger type.
+// executeManualJob runs a manually-triggered job in its own goroutine. Its caller
+// (triggerJobHandler) MUST have registered the in-flight slot via
+// registerManualTrigger (which did the wg.Add); this method owns the matching
+// wg.Done. Shares the execution body with the scheduled path via runJobBody.
 func (m *Module) executeManualJob(entry *jobEntry) {
-	m.runJobWithSlot(entry, "manual")
+	defer m.wg.Done()
+	m.runJobBody(entry, "manual")
 }

--- a/scheduler/api_handlers_test.go
+++ b/scheduler/api_handlers_test.go
@@ -160,43 +160,48 @@ func TestListJobsHandlerExposesTimezone(t *testing.T) {
 	assert.Equal(t, "America/New_York", result.Data.Meta["timezone"])
 }
 
-// TestExecuteManualJobSkippedAfterShutdown is the distinguishing regression test
-// for the Add-after-Wait race: the pre-fix executeManualJob had no shutdown
-// re-check at all (tryLock ran first, wg.Add ran after), so a manual trigger
-// racing Shutdown would run Execute even after wg.Wait() had already returned.
-// Post-fix, wg.Add(1) runs first and the shutdown re-check bails before
-// tryLock/Execute, so the job never runs.
-func TestExecuteManualJobSkippedAfterShutdown(t *testing.T) {
-	module, _ := newTestScheduler(t, 5*time.Second)
+// TestRegisterManualTrigger is the deterministic invariant that closes the
+// Add-after-Wait race: registration is refused (no wg.Add) once shutdown is
+// signaled, and accepted (one wg.Add) while live.
+func TestRegisterManualTrigger(t *testing.T) {
+	t.Run("rejects_after_shutdown", func(t *testing.T) {
+		module, _ := newTestScheduler(t, 5*time.Second)
+		module.shutdownCancel()
+		assert.False(t, module.registerManualTrigger(), "must reject after shutdown")
+		assertWaitGroupDrains(t, module, "registerManualTrigger rejected after shutdown")
+	})
+	t.Run("accepts_when_live", func(t *testing.T) {
+		module, _ := newTestScheduler(t, 5*time.Second)
+		require.True(t, module.registerManualTrigger(), "must accept when live")
+		module.executeManualJob(&jobEntry{job: &counterJob{}, metadata: &JobMetadata{JobID: "live"}})
+		assertWaitGroupDrains(t, module, "executeManualJob balanced a live registration")
+	})
+}
 
+// TestExecuteManualJobBailsWhenShutdownAfterRegister covers the case the internal
+// re-check guards: registration succeeds, THEN shutdown fires, so runJobBody bails
+// before running the job — and the Add/Done still balances.
+func TestExecuteManualJobBailsWhenShutdownAfterRegister(t *testing.T) {
+	module, _ := newTestScheduler(t, 5*time.Second)
 	job := &counterJob{}
 	entry := &jobEntry{job: job, metadata: &JobMetadata{JobID: "manual-shutdown-test"}}
 
-	// Initiate shutdown BEFORE invoking the manual path.
-	module.shutdownCancel()
+	require.True(t, module.registerManualTrigger()) // Add(1)
+	module.shutdownCancel()                         // shutdown after registering
+	module.executeManualJob(entry)                  // defers Done; runJobBody bails at re-check
 
-	module.executeManualJob(entry)
-
-	// Execute must never have run.
-	assert.Equal(t, int64(0), job.Count(), "job Execute should not run after shutdown")
-
-	// Add/Done must balance — a hang here means wg.Add(1) was not matched by a
-	// deferred wg.Done() on the shutdown-bail path.
-	assertWaitGroupDrains(t, module, "executeManualJob returned via shutdown-bail path")
+	assert.Equal(t, int64(0), job.Count(), "job must not run when shutdown fires after registration")
+	assertWaitGroupDrains(t, module, "executeManualJob bailed via shutdown re-check")
 }
 
-// TestExecuteManualJobBalancesAddDoneOnTryLockFailPath mirrors
-// TestCreateJobWrapperBalancesAddDoneOnTryLockFailPath (module_test.go) for the
-// manual-trigger path: pre-acquire the entry lock so executeManualJob's tryLock
-// fails, and verify the skip is counted (this skip path DOES increment
-// SkippedCount, unlike the shutdown-bail path) and Add/Done stays balanced.
+// TestExecuteManualJobBalancesAddDoneOnTryLockFailPath: with the slot registered,
+// a tryLock failure still balances and counts the skip.
 func TestExecuteManualJobBalancesAddDoneOnTryLockFailPath(t *testing.T) {
 	module, _ := newTestScheduler(t, 5*time.Second)
-
 	job := &counterJob{}
 	entry := &jobEntry{job: job, metadata: &JobMetadata{JobID: "manual-trylock-test"}}
 
-	// Pre-acquire the lock so executeManualJob's tryLock fails.
+	require.True(t, module.registerManualTrigger()) // Add(1) — pairs with executeManualJob's Done
 	require.True(t, entry.tryLock(), "test setup: first tryLock must succeed")
 	defer entry.unlock()
 
@@ -204,6 +209,5 @@ func TestExecuteManualJobBalancesAddDoneOnTryLockFailPath(t *testing.T) {
 
 	assert.Equal(t, int64(0), job.Count(), "job Execute should not run when tryLock fails")
 	assert.Equal(t, int64(1), entry.metadata.snapshot().SkippedCount, "expected skip counter increment")
-
 	assertWaitGroupDrains(t, module, "executeManualJob returned via tryLock-fail path")
 }

--- a/scheduler/module.go
+++ b/scheduler/module.go
@@ -519,6 +519,28 @@ func (m *Module) scheduleWithGocron(entry *jobEntry) (gocron.Job, error) {
 	return gocronJob, err
 }
 
+// registerManualTrigger atomically checks for shutdown and registers one in-flight
+// manual job under m.mu. Returns false (WITHOUT calling wg.Add) when the scheduler
+// is shutting down. Because Shutdown() also cancels under m.mu, the wg.Add(1) here
+// provably happens-before Shutdown's wg.Wait(): either Wait observes the Add and
+// waits for the job's Done, or the check sees the cancellation and no Add occurs.
+//
+// CONTRACT: a true return MUST be paired with exactly one wg.Done() — supplied by
+// the spawned executeManualJob — and the caller MUST NOT return or panic between
+// this call and `go m.executeManualJob(entry)`, or the Add would leak and hang
+// Shutdown's Wait.
+func (m *Module) registerManualTrigger() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	select {
+	case <-m.shutdownCtx.Done():
+		return false
+	default:
+	}
+	m.wg.Add(1)
+	return true
+}
+
 // createJobWrapper creates the execution wrapper for a job.
 // This wrapper handles:
 // - JobContext creation with multi-tenant resource resolution
@@ -528,23 +550,21 @@ func (m *Module) scheduleWithGocron(entry *jobEntry) (gocron.Job, error) {
 // - Graceful shutdown handling per FR-024
 func (m *Module) createJobWrapper(entry *jobEntry) func() {
 	return func() {
-		m.runJobWithSlot(entry, "scheduled")
+		m.wg.Add(1)
+		defer m.wg.Done()
+		m.runJobBody(entry, "scheduled")
 	}
 }
 
-// runJobWithSlot is the shared job-execution body for both the scheduled wrapper
-// (createJobWrapper) and the manual trigger (executeManualJob). triggerType
-// ("scheduled" or "manual") distinguishes the two in logs and the JobContext.
-//
-// wg.Add(1) is the FIRST statement so every bail path (shutdown, tryLock-fail)
-// balances Shutdown's wg.Wait(): an Add placed after either would let Shutdown
-// return before this goroutine registered, then run the job afterward. The LIFO
-// defers release the per-job lock before wg.Done().
-func (m *Module) runJobWithSlot(entry *jobEntry, triggerType string) {
-	// Register as in-flight BEFORE any shutdown check or tryLock.
-	m.wg.Add(1)
-	defer m.wg.Done()
-
+// runJobBody is the shared execution body for both the scheduled wrapper
+// (createJobWrapper) and the manual trigger (executeManualJob). The CALLER owns
+// the in-flight WaitGroup registration — scheduled: the gocron-invoked closure;
+// manual: registerManualTrigger + executeManualJob's deferred Done — so runJobBody
+// itself does NOT touch m.wg and is safe to call directly (e.g. from tests).
+// triggerType ("scheduled"/"manual") distinguishes them in logs and the JobContext.
+// The post-entry shutdown re-check still bails before tryLock/execute so a job
+// registered just before shutdown never runs against tearing-down managers.
+func (m *Module) runJobBody(entry *jobEntry, triggerType string) {
 	// Check for shutdown.
 	select {
 	case <-m.shutdownCtx.Done():
@@ -565,7 +585,7 @@ func (m *Module) runJobWithSlot(entry *jobEntry, triggerType string) {
 		entry.metadata.incrementSkipped()
 		return
 	}
-	// Defer unlock AFTER Done() so LIFO ordering releases the lock first.
+	// Release the per-job lock when the job body returns.
 	defer entry.unlock()
 
 	// Create execution context with cancellation for graceful shutdown.


### PR DESCRIPTION
## What

Closes the residual **manual-trigger spawn-window WaitGroup race** (F40, surfaced by CodeRabbit on #687). `triggerJobHandler` launches `go m.executeManualJob(entry)` with no synchronization coupling that spawn to `Shutdown()`'s `wg.Wait()`, so the goroutine's `wg.Add(1)` can execute **after** `Shutdown()`'s `wg.Wait()` has already returned observing counter 0 — a `sync.WaitGroup` contract violation.

Two things scope it:
- **The dangerous outcome was already fixed by #687** — the post-`Add` shutdown re-check means the job never runs after teardown.
- **The residual is a *silent* misuse** — for this exact interleaving `go test -race` reports nothing (Shutdown's counter-0 `Wait` fast path never `race.Write`s the sema; the late `Add` is a lone `race.Read`) and the runtime panic doesn't fire (no registered waiter). So it can't be caught by CI's `-race` gate, which is exactly why it's worth fixing proactively — and why the test that guards it is a **deterministic invariant**, not a race reproduction.

## Fix

Register the in-flight slot **atomically with the shutdown check, under `m.mu`** — the same lock `Shutdown()` holds while it cancels — *before* the `go` spawn:

- `registerManualTrigger()` — `m.mu.Lock()` → check `shutdownCtx.Done()` → `wg.Add(1)` (or return false, no Add). Because `Shutdown` cancels under `m.mu` too, the `Add` provably happens-before `Shutdown`'s `wg.Wait()`.
- `runJobWithSlot` → **`runJobBody`, now wg-free** (safe to call directly). The caller owns registration: the manual path via `registerManualTrigger` + `executeManualJob`'s deferred `Done`; the scheduled path keeps `Add`/`Done` inside the gocron closure (safe — `scheduler.Shutdown()` blocks on gocron's own WaitGroup before go-bricks calls `wg.Wait()`).

## Provenance

This is a shutdown-coordination change, so the design was **adversarially verified by a 5-lens Opus panel** (race-validity, fix-soundness, deadlock/hang, spawn-site inventory, refactor-mechanics) and the plan was **cold-reviewed** by a fresh-context reviewer before implementation. The panel confirmed the approach is sound (no deadlock — `m.mu` is a leaf vs. the WaitGroup; single spawn site; scheduled path safe against gocron v2.22.0 internals) and caught the naive "split Add/Done across methods" version as a blocker (it panics the direct-call tests) — hence the wg-free `runJobBody`.

## Verification

- `make check` green; `go test -race ./scheduler/` passes.
- `TestRegisterManualTrigger` (the invariant guard) — registration is refused with no `Add` after shutdown, accepted with one `Add` while live.
- `TestExecuteManualJobBailsWhenShutdownAfterRegister` — job never runs if shutdown fires after registration; Add/Done still balances.
- `TestExecuteManualJobBalancesAddDoneOnTryLockFailPath` (rewritten) — skip path balances and counts.
- `TestCreateJobWrapperBalancesAddDone*` pass **unchanged** — the scheduled path is unaffected.

## Follow-up (out of scope)

The Opus panel also surfaced **F41**: if a scheduled job outruns gocron's stop-timeout, `scheduler.Shutdown()` returns `ErrStopJobsTimedOut` and `Module.Shutdown()` returns early, *skipping* `m.wg.Wait()` — so in-flight manual jobs aren't drained in that error path. Separate change; tracked.

Produced via `/improve execute 015` (self-contained, Opus-verified & cold-reviewed plan; implemented by a dispatched executor, then reviewed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling for manually triggered jobs.
  * Manual triggers now return a service-unavailable response when shutdown is already in progress.
  * Prevented jobs from starting during shutdown races and ensured in-progress execution tracking remains balanced.
  * Preserved correct skip behavior when a manual job cannot acquire its execution lock.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->