### PR TITLE
fix(httpclient): shallow-copy caller-provided client before setting Transport

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -177,7 +177,9 @@ func (b *Builder) WithPeerName(name string) *Builder {
 // Build shallow-copies the provided client and never mutates it: the caller's
 // client keeps its own Transport and Timeout. If the provided client's Timeout
 // is zero, the copy gets the builder's configured Timeout.
-// The copy's Transport is preserved unless explicitly overridden via WithTransport.
+// The copy's Transport is preserved unless explicitly overridden via
+// WithTransport or WithJOSE. The copy is shallow: reference fields such as the
+// cookie Jar remain shared with the caller's client.
 func (b *Builder) WithHTTPClient(client *nethttp.Client) *Builder {
 	b.httpClient = client
 	return b
@@ -211,8 +213,9 @@ type JOSEConfig struct {
 // Composition: WithJOSE wraps whatever transport was set via an earlier WithTransport
 // call — so that transport customization remains in the chain below the JOSE layer.
 // A Transport configured directly on the *http.Client passed to WithHTTPClient is NOT
-// threaded through: Build() overwrites httpClient.Transport whenever WithTransport or
-// WithJOSE set b.transport, so use WithTransport if a custom RoundTripper needs to
+// threaded through: Build() sets the transport on the built client's copied *http.Client
+// whenever WithTransport or WithJOSE set b.transport (the client passed to WithHTTPClient
+// is never modified), so use WithTransport if a custom RoundTripper needs to
 // survive beneath WithJOSE. Calling WithTransport AFTER WithJOSE replaces the JOSE
 // transport entirely.
 //

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -174,8 +174,10 @@ func (b *Builder) WithPeerName(name string) *Builder {
 }
 
 // WithHTTPClient allows providing a custom *http.Client instance.
-// If the provided client's Timeout is zero, the builder applies its configured Timeout; otherwise it is used as-is.
-// The client's Transport is preserved unless explicitly overridden via WithTransport.
+// Build shallow-copies the provided client and never mutates it: the caller's
+// client keeps its own Transport and Timeout. If the provided client's Timeout
+// is zero, the copy gets the builder's configured Timeout.
+// The copy's Transport is preserved unless explicitly overridden via WithTransport.
 func (b *Builder) WithHTTPClient(client *nethttp.Client) *Builder {
 	b.httpClient = client
 	return b
@@ -247,14 +249,16 @@ func (b *Builder) Build() Client {
 	var httpClient *nethttp.Client
 	if b.httpClient == nil {
 		httpClient = &nethttp.Client{Timeout: cfg.Timeout}
-	} else if b.httpClient.Timeout == 0 {
-		// Shallow-copy to avoid mutating provided client
-		c := *b.httpClient
-		c.Timeout = cfg.Timeout
-		httpClient = &c
 	} else {
-		// Use provided client as-is
-		httpClient = b.httpClient
+		// Always shallow-copy the caller-provided client: Build must never mutate
+		// a client the caller may reuse (e.g. across builders with different JOSE
+		// policies), which would let Transport be overwritten with another
+		// counterparty's JOSETransport.
+		c := *b.httpClient
+		if c.Timeout == 0 {
+			c.Timeout = cfg.Timeout
+		}
+		httpClient = &c
 	}
 
 	if b.transport != nil {

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -63,12 +63,6 @@ func newIPv4TestServer(t *testing.T, handler nethttp.Handler) *httptest.Server {
 	return server
 }
 
-type roundTripperFunc func(*nethttp.Request) (*nethttp.Response, error)
-
-func (f roundTripperFunc) RoundTrip(req *nethttp.Request) (*nethttp.Response, error) {
-	return f(req)
-}
-
 type stubRoundTripper struct {
 	name string
 }
@@ -141,9 +135,7 @@ func TestBuilder(t *testing.T) {
 	})
 
 	t.Run("with custom http client", func(t *testing.T) {
-		customTransport := roundTripperFunc(func(req *nethttp.Request) (*nethttp.Response, error) {
-			return nil, fmt.Errorf("not implemented: %s", req.URL)
-		})
+		customTransport := &stubRoundTripper{name: "custom"}
 		custom := &nethttp.Client{Timeout: 123 * time.Millisecond, Transport: customTransport}
 		built := NewBuilder(log).
 			WithHTTPClient(custom).
@@ -154,8 +146,7 @@ func TestBuilder(t *testing.T) {
 		require.True(t, ok)
 		assert.NotSame(t, custom, clientImpl.httpClient, "Build must copy, not alias, the provided client")
 		assert.Equal(t, 123*time.Millisecond, clientImpl.httpClient.Timeout)
-		// The copy keeps the caller's transport (no WithTransport/WithJOSE here).
-		assert.NotNil(t, clientImpl.httpClient.Transport)
+		assert.Same(t, customTransport, clientImpl.httpClient.Transport, "copy must keep the caller's transport when no override is set")
 	})
 
 	t.Run("with custom http client zero timeout uses builder timeout", func(t *testing.T) {
@@ -165,7 +156,8 @@ func TestBuilder(t *testing.T) {
 			WithTimeout(2 * time.Second).
 			Build()
 
-		clientImpl := built.(*client)
+		clientImpl, ok := built.(*client)
+		require.True(t, ok)
 		assert.Equal(t, 2*time.Second, clientImpl.httpClient.Timeout)
 		assert.Equal(t, time.Duration(0), custom.Timeout, "original client must not be mutated")
 	})
@@ -204,6 +196,24 @@ func TestBuilder(t *testing.T) {
 		assert.Same(t, transportA, clientImplA.httpClient.Transport)
 		assert.Same(t, transportB, clientImplB.httpClient.Transport)
 		assert.Same(t, sentinel, tuned.Transport, "shared client transport must remain the original sentinel")
+	})
+
+	t.Run("with JOSE does not mutate provided client", func(t *testing.T) {
+		sentinel := &stubRoundTripper{name: "sentinel"}
+		tuned := &nethttp.Client{Timeout: 5 * time.Second, Transport: sentinel}
+
+		built := NewBuilder(log).
+			WithHTTPClient(tuned).
+			WithJOSE(JOSEConfig{}).
+			Build()
+
+		assert.Same(t, sentinel, tuned.Transport, "caller's client must be untouched by WithJOSE+Build")
+
+		clientImpl, ok := built.(*client)
+		require.True(t, ok)
+		joseTransport, ok := clientImpl.httpClient.Transport.(*JOSETransport)
+		require.True(t, ok, "built client must carry the JOSE transport")
+		assert.Nil(t, joseTransport.Inner)
 	})
 
 	t.Run("with custom transport", func(t *testing.T) {

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -152,8 +152,10 @@ func TestBuilder(t *testing.T) {
 
 		clientImpl, ok := built.(*client)
 		require.True(t, ok)
-		assert.Equal(t, custom, clientImpl.httpClient)
+		assert.NotSame(t, custom, clientImpl.httpClient, "Build must copy, not alias, the provided client")
 		assert.Equal(t, 123*time.Millisecond, clientImpl.httpClient.Timeout)
+		// The copy keeps the caller's transport (no WithTransport/WithJOSE here).
+		assert.NotNil(t, clientImpl.httpClient.Transport)
 	})
 
 	t.Run("with custom http client zero timeout uses builder timeout", func(t *testing.T) {
@@ -165,6 +167,43 @@ func TestBuilder(t *testing.T) {
 
 		clientImpl := built.(*client)
 		assert.Equal(t, 2*time.Second, clientImpl.httpClient.Timeout)
+		assert.Equal(t, time.Duration(0), custom.Timeout, "original client must not be mutated")
+	})
+
+	t.Run("build does not mutate provided client transport", func(t *testing.T) {
+		sentinel := &stubRoundTripper{name: "sentinel"}
+		tuned := &nethttp.Client{Timeout: 5 * time.Second, Transport: sentinel}
+		override := &stubRoundTripper{name: "override"}
+
+		built := NewBuilder(log).
+			WithHTTPClient(tuned).
+			WithTransport(override).
+			Build()
+
+		assert.Same(t, sentinel, tuned.Transport, "caller's client transport must be untouched by Build")
+
+		clientImpl, ok := built.(*client)
+		require.True(t, ok)
+		assert.Same(t, override, clientImpl.httpClient.Transport)
+	})
+
+	t.Run("two builders sharing one client keep independent transports", func(t *testing.T) {
+		sentinel := &stubRoundTripper{name: "sentinel"}
+		tuned := &nethttp.Client{Timeout: 5 * time.Second, Transport: sentinel}
+		transportA := &stubRoundTripper{name: "a"}
+		transportB := &stubRoundTripper{name: "b"}
+
+		builtA := NewBuilder(log).WithHTTPClient(tuned).WithTransport(transportA).Build()
+		builtB := NewBuilder(log).WithHTTPClient(tuned).WithTransport(transportB).Build()
+
+		clientImplA, ok := builtA.(*client)
+		require.True(t, ok)
+		clientImplB, ok := builtB.(*client)
+		require.True(t, ok)
+
+		assert.Same(t, transportA, clientImplA.httpClient.Transport)
+		assert.Same(t, transportB, clientImplB.httpClient.Transport)
+		assert.Same(t, sentinel, tuned.Transport, "shared client transport must remain the original sentinel")
 	})
 
 	t.Run("with custom transport", func(t *testing.T) {


### PR DESCRIPTION
## Problem

`Builder.Build` treated a caller-provided `*http.Client` asymmetrically: a client with `Timeout == 0` was shallow-copied (safe), but a client with a non-zero `Timeout` was used **as-is** — and Build then assigned `httpClient.Transport = b.transport` directly onto the caller-owned object.

Because `WithJOSE` populates `b.transport` with a `JOSETransport`, reusing one tuned client across two builders with different JOSE policies (counterparty A vs B) left the shared client — and both built clients — with whichever `JOSETransport` was assigned last. Request bodies could be sealed with the **wrong counterparty's keys**, and a plain client used directly elsewhere silently gained a JOSE/interceptor transport.

## Fix

`Build()` now **always shallow-copies** a caller-provided client before touching `Transport`, collapsing the two non-nil branches into one. The builder-timeout defaulting for `Timeout == 0` is preserved inside the copy.

The old code also performed an unsynchronized *write* to the shared client; the new code only reads it, strictly shrinking the race surface for shared clients.

## Behavioral note (intentional contract change)

The `WithHTTPClient` doc previously stated a non-zero-Timeout client is "used as-is". Code that relied on **post-`Build` mutation** of the provided client propagating into built clients (e.g. swapping `Transport` for credential rotation) no longer observes that propagation — it never worked for `Timeout == 0` clients anyway. The doc comments now state the copy semantics explicitly, including that the copy is shallow (reference fields such as the cookie `Jar` remain shared).

## Tests

- `with custom http client` — rewritten to pin the new contract: `assert.NotSame` (copy, not alias) + `assert.Same` on the preserved caller transport (fixture switched to the identity-comparable `*stubRoundTripper`; the now-unused `roundTripperFunc` helper removed).
- `with custom http client zero timeout uses builder timeout` — extended: original client's `Timeout` stays 0; checked type assertion.
- `build does not mutate provided client transport` — new: caller's sentinel transport survives `Build()` with a `WithTransport` override.
- `two builders sharing one client keep independent transports` — new: two builds from one shared client each keep their own transport; shared client untouched.
- `with JOSE does not mutate provided client` — new: pins the motivating hazard through `WithJOSE` itself (zero-value `JOSEConfig`, wiring-level, no key fixtures).

## Verification

- `make check` green (fmt + lint + race tests + alloc guards + govulncheck).
- Pre-push review gates run per CLAUDE.md: code review (xhigh, workflow-backed) — all accepted findings applied in the second commit; security audit (gosec lint 0 issues, no raw-SQL/secrets/validation surface in diff, govulncheck 0 affecting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP client construction to prevent caller-provided clients from being modified.
  * Preserved custom transports and timeout settings when building clients.
  * Ensured transport overrides apply independently to each built client.
  * Improved JOSE client handling without altering the original HTTP client.

* **Documentation**
  * Clarified how HTTP clients, timeouts, transports, and shared references are handled during construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->