### PR TITLE
fix(database): apply pool defaults to dynamic-tenant DB configs

### DIFF
--- a/config/validation.go
+++ b/config/validation.go
@@ -457,6 +457,14 @@ func applyConnectionCountDefaults(cfg *DatabaseConfig) error {
 	return nil
 }
 
+// ApplyDatabasePoolDefaults normalizes zero-value Pool settings on cfg to the
+// documented defaults (25 max, idle tracks max, keepalive rules). Exported so
+// callers that bypass Validate — notably dynamic multi-tenant DBConfigProviders
+// resolved in DbManager — get the same safe pool sizing as static config.
+func ApplyDatabasePoolDefaults(cfg *DatabaseConfig) error {
+	return applyDatabasePoolDefaults(cfg)
+}
+
 // applyDatabasePoolDefaults sets production-safe defaults and validates database pool/query/session settings.
 //
 // It modifies cfg in-place:

--- a/config/validation.go
+++ b/config/validation.go
@@ -457,11 +457,15 @@ func applyConnectionCountDefaults(cfg *DatabaseConfig) error {
 	return nil
 }
 
-// ApplyDatabasePoolDefaults normalizes zero-value Pool settings on cfg to the
-// documented defaults (25 max, idle tracks max, keepalive rules). Exported so
+// ApplyDatabasePoolDefaults normalizes zero-value Pool, Timezone, and Query
+// (log/slow-threshold) settings on cfg to the documented defaults (25 max
+// connections, idle tracks max, keepalive rules, UTC timezone). Exported so
 // callers that bypass Validate — notably dynamic multi-tenant DBConfigProviders
-// resolved in DbManager — get the same safe pool sizing as static config.
+// resolved in DbManager — get the same normalization as static config.
 func ApplyDatabasePoolDefaults(cfg *DatabaseConfig) error {
+	if cfg == nil {
+		return NewValidationError("database", "configuration is nil")
+	}
 	return applyDatabasePoolDefaults(cfg)
 }
 

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -4843,3 +4843,12 @@ func TestValidateRejectsManagerBlockOnNamedDatabase(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "databases.legacy.manager")
 }
+
+func TestApplyDatabasePoolDefaultsNilConfig(t *testing.T) {
+	var err error
+	require.NotPanics(t, func() {
+		err = ApplyDatabasePoolDefaults(nil)
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "configuration is nil")
+}

--- a/database/manager.go
+++ b/database/manager.go
@@ -234,6 +234,9 @@ func (m *DbManager) createConnection(ctx context.Context, key string) (*dbEntry,
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database config for key %s: %w", key, err)
 	}
+	if err = config.ApplyDatabasePoolDefaults(dbConfig); err != nil {
+		return nil, fmt.Errorf("failed to apply pool defaults for key %s: %w", key, err)
+	}
 
 	conn, err := m.connector(dbConfig, m.logger)
 	if err != nil {

--- a/database/manager.go
+++ b/database/manager.go
@@ -234,11 +234,13 @@ func (m *DbManager) createConnection(ctx context.Context, key string) (*dbEntry,
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database config for key %s: %w", key, err)
 	}
-	if err = config.ApplyDatabasePoolDefaults(dbConfig); err != nil {
+	// Shallow-clone before defaulting: providers may return long-lived shared configs.
+	cfgCopy := *dbConfig
+	if err = config.ApplyDatabasePoolDefaults(&cfgCopy); err != nil {
 		return nil, fmt.Errorf("failed to apply pool defaults for key %s: %w", key, err)
 	}
 
-	conn, err := m.connector(dbConfig, m.logger)
+	conn, err := m.connector(&cfgCopy, m.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create database connection for key %s: %w", key, err)
 	}
@@ -286,7 +288,7 @@ func (m *DbManager) createConnection(ctx context.Context, key string) (*dbEntry,
 
 	m.logger.Info().
 		Str("key", key).
-		Str("db_type", dbConfig.Type).
+		Str("db_type", cfgCopy.Type).
 		Msg("Created new database connection")
 
 	return entry, nil

--- a/database/manager_test.go
+++ b/database/manager_test.go
@@ -740,6 +740,14 @@ func TestDbManagerDynamicConfigGetsPoolDefaults(t *testing.T) {
 	require.NotNil(t, captured.Pool.KeepAlive.Enabled)
 	assert.True(t, *captured.Pool.KeepAlive.Enabled, "keepalive defaults to enabled")
 	assert.Equal(t, 60*time.Second, captured.Pool.KeepAlive.Interval, "keepalive interval defaults to 60s")
+	assert.Equal(t, "UTC", captured.Timezone, "timezone defaults to UTC")
+	assert.Equal(t, 1000, captured.Query.Log.MaxLength, "query log max length defaults to 1000")
+	assert.Equal(t, 200*time.Millisecond, captured.Query.Slow.Threshold, "slow query threshold defaults to 200ms")
+
+	// The provider-owned config must stay pristine: defaults are applied to a clone.
+	assert.NotSame(t, resource.configs["tenant"], captured)
+	assert.Zero(t, resource.configs["tenant"].Pool.Max.Connections, "provider config pool untouched")
+	assert.Empty(t, resource.configs["tenant"].Timezone, "provider config timezone untouched")
 }
 
 // TestDbManagerDynamicConfigExplicitPoolPreserved proves that pool defaulting
@@ -800,4 +808,35 @@ func TestDbManagerDynamicConfigInvalidPoolRejected(t *testing.T) {
 	require.ErrorAs(t, err, &cfgErr, "wraps the underlying config validation error")
 	assert.ErrorContains(t, err, "database.pool.idle.time")
 	assert.False(t, connectorCalled, "connector must not run with an invalid pool config")
+}
+
+// TestDbManagerDynamicConfigConcurrentCreateSharedConfig guards the clone in
+// createConnection: concurrent creates against a shared provider config must
+// not race (make check runs -race).
+func TestDbManagerDynamicConfigConcurrentCreateSharedConfig(t *testing.T) {
+	ctx := context.Background()
+	resource := &stubResourceSource{configs: map[string]*config.DatabaseConfig{
+		"tenant": {Type: "postgresql", Host: "localhost"},
+	}}
+	connector := func(*config.DatabaseConfig, logger.Logger) (Interface, error) {
+		return &stubDB{}, nil
+	}
+	manager := NewDbManager(resource, newErrorTestLogger(), DbManagerOptions{MaxSize: 5, IdleTTL: time.Minute}, connector)
+
+	const goroutines = 8
+	errs := make(chan error, goroutines)
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := manager.createConnection(ctx, "tenant")
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
 }

--- a/database/manager_test.go
+++ b/database/manager_test.go
@@ -771,3 +771,33 @@ func TestDbManagerDynamicConfigExplicitPoolPreserved(t *testing.T) {
 	assert.Equal(t, int32(40), captured.Pool.Max.Connections, "explicit max connections preserved")
 	assert.Equal(t, int32(40), captured.Pool.Idle.Connections, "idle defaults to explicit max")
 }
+
+// TestDbManagerDynamicConfigInvalidPoolRejected proves an invalid dynamic pool
+// config fails createConnection before the connector is ever invoked.
+func TestDbManagerDynamicConfigInvalidPoolRejected(t *testing.T) {
+	ctx := context.Background()
+	resource := &stubResourceSource{configs: map[string]*config.DatabaseConfig{
+		"tenant": {
+			Type: "postgresql",
+			Host: "localhost",
+			Pool: config.PoolConfig{
+				Idle: config.PoolIdleConfig{Time: -1},
+			},
+		},
+	}}
+
+	connectorCalled := false
+	connector := func(*config.DatabaseConfig, logger.Logger) (Interface, error) {
+		connectorCalled = true
+		return &stubDB{}, nil
+	}
+	manager := NewDbManager(resource, newErrorTestLogger(), DbManagerOptions{}, connector)
+
+	_, err := manager.createConnection(ctx, "tenant")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to apply pool defaults for key")
+	var cfgErr *config.ConfigError
+	require.ErrorAs(t, err, &cfgErr, "wraps the underlying config validation error")
+	assert.ErrorContains(t, err, "database.pool.idle.time")
+	assert.False(t, connectorCalled, "connector must not run with an invalid pool config")
+}

--- a/database/manager_test.go
+++ b/database/manager_test.go
@@ -710,3 +710,64 @@ func TestDbManagerReleaseIsIdempotent(t *testing.T) {
 		releaseA() // double release must be a safe no-op (no double close, no negative refcount)
 	})
 }
+
+// TestDbManagerDynamicConfigGetsPoolDefaults proves a dynamic DBConfigProvider
+// (source.type=dynamic) that returns a zero-value Pool no longer reaches the
+// connector unnormalized: DbManager.createConnection must apply the same pool
+// defaults config.Validate applies to static config, so the PostgreSQL/Oracle
+// connectors never call SetMaxOpenConns(0) (unlimited connections).
+func TestDbManagerDynamicConfigGetsPoolDefaults(t *testing.T) {
+	ctx := context.Background()
+	resource := &stubResourceSource{configs: map[string]*config.DatabaseConfig{
+		"tenant": {Type: "postgresql", Host: "localhost"}, // zero-value Pool
+	}}
+
+	var captured *config.DatabaseConfig
+	connector := func(cfg *config.DatabaseConfig, _ logger.Logger) (Interface, error) {
+		captured = cfg
+		return &stubDB{}, nil
+	}
+	manager := NewDbManager(resource, newErrorTestLogger(), DbManagerOptions{}, connector)
+
+	_, err := manager.createConnection(ctx, "tenant")
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+
+	assert.Equal(t, int32(25), captured.Pool.Max.Connections, "max connections defaults to 25")
+	assert.Equal(t, captured.Pool.Max.Connections, captured.Pool.Idle.Connections, "idle tracks max")
+	assert.Equal(t, 5*time.Minute, captured.Pool.Idle.Time, "idle time defaults to 5m")
+	assert.Equal(t, 30*time.Minute, captured.Pool.Lifetime.Max, "lifetime max defaults to 30m")
+	require.NotNil(t, captured.Pool.KeepAlive.Enabled)
+	assert.True(t, *captured.Pool.KeepAlive.Enabled, "keepalive defaults to enabled")
+	assert.Equal(t, 60*time.Second, captured.Pool.KeepAlive.Interval, "keepalive interval defaults to 60s")
+}
+
+// TestDbManagerDynamicConfigExplicitPoolPreserved proves that pool defaulting
+// on the dynamic path only fills zero values — a dynamic config that already
+// sets an explicit pool size passes through unchanged.
+func TestDbManagerDynamicConfigExplicitPoolPreserved(t *testing.T) {
+	ctx := context.Background()
+	resource := &stubResourceSource{configs: map[string]*config.DatabaseConfig{
+		"tenant": {
+			Type: "postgresql",
+			Host: "localhost",
+			Pool: config.PoolConfig{
+				Max: config.PoolMaxConfig{Connections: 40},
+			},
+		},
+	}}
+
+	var captured *config.DatabaseConfig
+	connector := func(cfg *config.DatabaseConfig, _ logger.Logger) (Interface, error) {
+		captured = cfg
+		return &stubDB{}, nil
+	}
+	manager := NewDbManager(resource, newErrorTestLogger(), DbManagerOptions{}, connector)
+
+	_, err := manager.createConnection(ctx, "tenant")
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+
+	assert.Equal(t, int32(40), captured.Pool.Max.Connections, "explicit max connections preserved")
+	assert.Equal(t, int32(40), captured.Pool.Idle.Connections, "idle defaults to explicit max")
+}


### PR DESCRIPTION
## Summary

A dynamic/custom `DBConfigProvider` (`source.type=dynamic`) typically returns only host + credentials for a tenant. That config never passes through `applyDatabasePoolDefaults` (which only runs inside `config.Validate`), so the connector received a zero-value `Pool` and called:

- `db.SetMaxOpenConns(0)` → **unlimited** open connections
- `db.SetMaxIdleConns(0)` → no idle reuse (full TCP+TLS+auth per query)
- `db.SetConnMaxLifetime(0)` → connections never recycled
- keep-alive off

Under load this is fleet-wide DB connection exhaustion, one tenant at a time. The PostgreSQL connector already normalizes `Timezone` for exactly this "callers that bypass `config.Validate`" class — the pool settings were the remaining gap.

## Fix

Normalize at the single choke point where dynamic configs enter — `DbManager.createConnection` — before the config reaches any connector:

- `config/validation.go`: new exported thin wrapper `ApplyDatabasePoolDefaults` around the existing (unexported) defaulting logic. No logic changes; the default values (25 max, idle tracks max per ADR-025, keepalive rules per ADR-030) remain the single source of truth.
- `database/manager.go`: `createConnection` applies the defaults to the resolved `DBConfig` before invoking the connector. Re-application on already-validated (static) configs is a no-op — the function only fills zero/nil values.

Covers PostgreSQL and Oracle (and any future connector) uniformly.

## Tests

- `TestDbManagerDynamicConfigGetsPoolDefaults` — a dynamic config with a zero-value `Pool` reaches the connector with max=25, idle tracking max, idle time 5m, lifetime 30m, keepalive enabled at 60s.
- `TestDbManagerDynamicConfigExplicitPoolPreserved` — an explicit `Pool.Max.Connections = 40` passes through unchanged; defaults only fill zero values.

## Verification

- `make check` (fmt + lint + full `-race` suite + alloc guards + govulncheck) — exit 0
- Pre-push gates: CodeRabbit CLI review + security audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database connections now consistently apply connection pool defaults before connecting.
  * Invalid pool configurations are rejected before a connection attempt.
  * Explicit connection pool settings are preserved while missing values receive appropriate defaults.

* **Tests**
  * Added coverage for default pool settings, custom limits, and invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->