### PR TITLE
fix(inbox,outbox): initialize store/table per tenant in multi-tenant mode

### DIFF
--- a/inbox/coverage_test.go
+++ b/inbox/coverage_test.go
@@ -91,9 +91,83 @@ func TestEnsureStoreInitializedOracleWithAutoCreate(t *testing.T) {
 	db.ExpectExec(`CREATE INDEX idx_gobricks_inbox_processed`).WillReturnRowsAffected(0)
 	m := newCoverageModule(db, config.InboxConfig{Enabled: true, TableName: "gobricks_inbox", AutoCreateTable: true})
 
-	require.NoError(t, m.ensureStoreInitialized(t.Context()))
-	assert.True(t, m.tableCreated)
-	assert.NotNil(t, m.store)
+	store, err := m.ensureStoreInitialized(t.Context())
+	require.NoError(t, err)
+	assert.NotNil(t, store)
+}
+
+func TestEnsureStoreInitializedCreatesTablePerTenant(t *testing.T) {
+	tenants := dbtesting.NewTenantDBMap()
+	dbA := tenants.ForTenant("tenant-a")
+	dbA.ExpectExec(`CREATE TABLE IF NOT EXISTS gobricks_inbox`).WillReturnRowsAffected(0)
+	dbA.ExpectExec(`CREATE INDEX IF NOT EXISTS idx_gobricks_inbox_processed`).WillReturnRowsAffected(0)
+
+	dbB := tenants.ForTenant("tenant-b")
+	dbB.ExpectExec(`CREATE TABLE IF NOT EXISTS gobricks_inbox`).WillReturnRowsAffected(0)
+	dbB.ExpectExec(`CREATE INDEX IF NOT EXISTS idx_gobricks_inbox_processed`).WillReturnRowsAffected(0)
+
+	m := &Module{
+		logger: logger.New("info", false),
+		cfg:    config.InboxConfig{Enabled: true, TableName: "gobricks_inbox", AutoCreateTable: true},
+		getDB:  tenants.AsGetDBFunc(),
+	}
+
+	storeA, err := m.ensureStoreInitialized(multitenant.SetTenant(t.Context(), "tenant-a"))
+	require.NoError(t, err)
+	storeB, err := m.ensureStoreInitialized(multitenant.SetTenant(t.Context(), "tenant-b"))
+	require.NoError(t, err)
+	storeAAgain, err := m.ensureStoreInitialized(multitenant.SetTenant(t.Context(), "tenant-a"))
+	require.NoError(t, err)
+
+	assert.Same(t, storeA, storeAAgain, "a tenant reuses its cached store")
+	assert.NotSame(t, storeA, storeB, "different tenants receive isolated stores")
+
+	dbtesting.AssertExecExecuted(t, dbA, "CREATE TABLE")
+	dbtesting.AssertExecExecuted(t, dbB, "CREATE TABLE")
+}
+
+func TestEnsureStoreInitializedMixedVendorDialects(t *testing.T) {
+	tenants := dbtesting.NewTenantDBMap()
+	dbPG := tenants.ForTenantWithVendor("tenant-pg", dbtypes.PostgreSQL)
+	dbPG.ExpectExec(`CREATE TABLE IF NOT EXISTS gobricks_inbox`).WillReturnRowsAffected(0)
+	dbPG.ExpectExec(`CREATE INDEX IF NOT EXISTS idx_gobricks_inbox_processed`).WillReturnRowsAffected(0)
+
+	dbOra := tenants.ForTenantWithVendor("tenant-oracle", dbtypes.Oracle)
+	dbOra.ExpectExec(`CREATE TABLE gobricks_inbox`).WillReturnRowsAffected(0)
+	dbOra.ExpectExec(`CREATE INDEX idx_gobricks_inbox_processed`).WillReturnRowsAffected(0)
+
+	m := &Module{
+		logger: logger.New("info", false),
+		cfg:    config.InboxConfig{Enabled: true, TableName: "gobricks_inbox", AutoCreateTable: true},
+		getDB:  tenants.AsGetDBFunc(),
+	}
+
+	storePG, err := m.ensureStoreInitialized(multitenant.SetTenant(t.Context(), "tenant-pg"))
+	require.NoError(t, err)
+	storeOra, err := m.ensureStoreInitialized(multitenant.SetTenant(t.Context(), "tenant-oracle"))
+	require.NoError(t, err)
+
+	assert.IsType(t, &postgresStore{}, storePG, "postgres tenant gets the postgres dialect store")
+	assert.IsType(t, &oracleStore{}, storeOra, "oracle tenant gets the oracle dialect store")
+	dbtesting.AssertExecExecuted(t, dbPG, "CREATE TABLE")
+	dbtesting.AssertExecExecuted(t, dbOra, "CREATE TABLE")
+	assert.Len(t, dbPG.ExecLog(), 2, "postgres tenant's DB only sees its own DDL")
+	assert.Len(t, dbOra.ExecLog(), 2, "oracle tenant's DB only sees its own DDL")
+}
+
+func TestEnsureStoreInitializedSingleTenantIdempotent(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectExec(`CREATE TABLE IF NOT EXISTS gobricks_inbox`).WillReturnRowsAffected(0)
+	db.ExpectExec(`CREATE INDEX IF NOT EXISTS idx_gobricks_inbox_processed`).WillReturnRowsAffected(0)
+	m := newCoverageModule(db, config.InboxConfig{Enabled: true, TableName: "gobricks_inbox", AutoCreateTable: true})
+
+	first, err := m.ensureStoreInitialized(t.Context())
+	require.NoError(t, err)
+	second, err := m.ensureStoreInitialized(t.Context())
+	require.NoError(t, err)
+
+	assert.Same(t, first, second, "single-tenant store identity is preserved across calls")
+	assert.Len(t, db.ExecLog(), 2, "CreateTable runs exactly once for the empty-tenant key")
 }
 
 func TestLazyStoreDelegates(t *testing.T) {

--- a/inbox/inbox.go
+++ b/inbox/inbox.go
@@ -27,7 +27,8 @@ type Inbox struct {
 // id short-circuits (fn is not run) and returns nil. The tenant is resolved from
 // ctx; in single-tenant mode the tenant id is empty.
 func (i *Inbox) ProcessOnce(ctx context.Context, eventID string, fn func(ctx context.Context, tx dbtypes.Tx) error) error {
-	if err := i.module.ensureStoreInitialized(ctx); err != nil {
+	store, err := i.module.ensureStoreInitialized(ctx)
+	if err != nil {
 		return err
 	}
 	db, err := i.module.getDB(ctx)
@@ -39,7 +40,7 @@ func (i *Inbox) ProcessOnce(ctx context.Context, eventID string, fn func(ctx con
 	rec := Record{TenantID: tenantID, EventID: eventID, ProcessedAt: time.Now()}
 
 	return database.WithTx(ctx, db, func(ctx context.Context, tx dbtypes.Tx) error {
-		inserted, err := i.module.store.MarkProcessed(ctx, tx, rec)
+		inserted, err := store.MarkProcessed(ctx, tx, rec)
 		if err != nil {
 			return err
 		}

--- a/inbox/module.go
+++ b/inbox/module.go
@@ -93,26 +93,10 @@ func (m *Module) ensureStoreInitialized(ctx context.Context) (Store, error) {
 		AutoCreateTable: m.cfg.AutoCreateTable,
 		Logger:          m.logger,
 		GetDB:           m.getDB,
-		NewStore:        newStoreForVendor,
+		NewPostgres:     NewPostgresStore,
+		NewOracle:       NewOracleStore,
 		WarnMsg:         "Inbox table creation failed (may already exist)",
 	})
-}
-
-func newStoreForVendor(vendor, tableName string) (Store, error) {
-	var store Store
-	var err error
-	switch vendor {
-	case dbtypes.PostgreSQL:
-		store, err = NewPostgresStore(tableName)
-	case dbtypes.Oracle:
-		store, err = NewOracleStore(tableName)
-	default:
-		return nil, fmt.Errorf("inbox: unsupported database vendor: %s", vendor)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("inbox: failed to create store: %w", err)
-	}
-	return store, nil
 }
 
 // InboxProcessor implements app.InboxProvider — returns the processor for

--- a/inbox/module.go
+++ b/inbox/module.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gaborage/go-bricks/config"
 	dbtypes "github.com/gaborage/go-bricks/database/types"
 	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/multitenant"
 )
 
 // Module implements the GoBricks Module interface for the consumer-side inbox.
@@ -33,12 +34,11 @@ type Module struct {
 	config *config.Config
 	getDB  func(context.Context) (dbtypes.Interface, error)
 
-	store     Store
 	processor app.InboxProcessor
 	cfg       config.InboxConfig
 
-	initMu       sync.Mutex // Protects lazy store initialization
-	tableCreated bool
+	initMu sync.Mutex       // Protects stores
+	stores map[string]Store // key: tenant id ("" = single-tenant)
 }
 
 // NewModule creates a new inbox Module instance.
@@ -84,20 +84,24 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 	return nil
 }
 
-// ensureStoreInitialized creates the vendor-specific store on first use.
-// Lazy because the database vendor type is only known once a connection exists.
-// Uses mutex-guarded lazy initialization (not sync.Once) so a failed init can retry.
-func (m *Module) ensureStoreInitialized(ctx context.Context) error {
+// ensureStoreInitialized returns the store for the tenant in ctx, creating it
+// (and, if configured, its table) on first use for that tenant. Lazy because
+// the vendor is only known once a connection exists; per-tenant because each
+// tenant has its own DB (and possibly its own vendor). Mutex-guarded, not
+// sync.Once, so a failed init can retry.
+func (m *Module) ensureStoreInitialized(ctx context.Context) (Store, error) {
+	tenantID, _ := multitenant.GetTenant(ctx)
+
 	m.initMu.Lock()
 	defer m.initMu.Unlock()
 
-	if m.store != nil {
-		return nil
+	if store, ok := m.stores[tenantID]; ok {
+		return store, nil
 	}
 
 	db, err := m.getDB(ctx)
 	if err != nil {
-		return fmt.Errorf("inbox: database unavailable: %w", err)
+		return nil, fmt.Errorf("inbox: database unavailable: %w", err)
 	}
 
 	var store Store
@@ -107,25 +111,29 @@ func (m *Module) ensureStoreInitialized(ctx context.Context) error {
 	case dbtypes.Oracle:
 		store, err = NewOracleStore(m.cfg.TableName)
 	default:
-		return fmt.Errorf("inbox: unsupported database vendor: %s", db.DatabaseType())
+		return nil, fmt.Errorf("inbox: unsupported database vendor: %s", db.DatabaseType())
 	}
 	if err != nil {
-		return fmt.Errorf("inbox: failed to create store: %w", err)
+		return nil, fmt.Errorf("inbox: failed to create store: %w", err)
 	}
 
 	// Auto-create the table if configured. Warning-only on failure: PostgreSQL
 	// uses IF NOT EXISTS (idempotent), Oracle may return ORA-00955 if it exists.
-	if m.cfg.AutoCreateTable && !m.tableCreated {
+	// One attempt per tenant — map presence short-circuits subsequent calls.
+	if m.cfg.AutoCreateTable {
 		if createErr := store.CreateTable(ctx, db); createErr != nil {
 			m.logger.Warn().Err(createErr).
 				Str("table", m.cfg.TableName).
+				Str("tenant", tenantID).
 				Msg("Inbox table creation failed (may already exist)")
 		}
-		m.tableCreated = true
 	}
 
-	m.store = store
-	return nil
+	if m.stores == nil {
+		m.stores = make(map[string]Store) // lazy: tests build Module via struct literals
+	}
+	m.stores[tenantID] = store
+	return store, nil
 }
 
 // InboxProcessor implements app.InboxProvider — returns the processor for
@@ -192,24 +200,27 @@ type lazyStore struct {
 }
 
 func (s *lazyStore) MarkProcessed(ctx context.Context, tx dbtypes.Tx, rec Record) (bool, error) {
-	if err := s.module.ensureStoreInitialized(ctx); err != nil {
+	store, err := s.module.ensureStoreInitialized(ctx)
+	if err != nil {
 		return false, err
 	}
-	return s.module.store.MarkProcessed(ctx, tx, rec)
+	return store.MarkProcessed(ctx, tx, rec)
 }
 
 func (s *lazyStore) DeleteProcessed(ctx context.Context, db dbtypes.Interface, before time.Time) (int64, error) {
-	if err := s.module.ensureStoreInitialized(ctx); err != nil {
+	store, err := s.module.ensureStoreInitialized(ctx)
+	if err != nil {
 		return 0, err
 	}
-	return s.module.store.DeleteProcessed(ctx, db, before)
+	return store.DeleteProcessed(ctx, db, before)
 }
 
 func (s *lazyStore) CreateTable(ctx context.Context, db dbtypes.Interface) error {
-	if err := s.module.ensureStoreInitialized(ctx); err != nil {
+	store, err := s.module.ensureStoreInitialized(ctx)
+	if err != nil {
 		return err
 	}
-	return s.module.store.CreateTable(ctx, db)
+	return store.CreateTable(ctx, db)
 }
 
 // Compile-time guards.

--- a/inbox/module.go
+++ b/inbox/module.go
@@ -3,14 +3,13 @@ package inbox
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/gaborage/go-bricks/app"
 	"github.com/gaborage/go-bricks/config"
 	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/internal/tenantstore"
 	"github.com/gaborage/go-bricks/logger"
-	"github.com/gaborage/go-bricks/multitenant"
 )
 
 // Module implements the GoBricks Module interface for the consumer-side inbox.
@@ -37,8 +36,7 @@ type Module struct {
 	processor app.InboxProcessor
 	cfg       config.InboxConfig
 
-	initMu sync.Mutex       // Protects stores
-	stores map[string]Store // key: tenant id ("" = single-tenant)
+	stores tenantstore.Cache[Store] // one store per tenant ("" = single-tenant)
 }
 
 // NewModule creates a new inbox Module instance.
@@ -87,52 +85,33 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 // ensureStoreInitialized returns the store for the tenant in ctx, creating it
 // (and, if configured, its table) on first use for that tenant. Lazy because
 // the vendor is only known once a connection exists; per-tenant because each
-// tenant has its own DB (and possibly its own vendor). Mutex-guarded, not
-// sync.Once, so a failed init can retry.
+// tenant has its own DB (and possibly its own vendor).
 func (m *Module) ensureStoreInitialized(ctx context.Context) (Store, error) {
-	tenantID, _ := multitenant.GetTenant(ctx)
+	return m.stores.Get(ctx, &tenantstore.Deps[Store]{
+		Name:            "inbox",
+		TableName:       m.cfg.TableName,
+		AutoCreateTable: m.cfg.AutoCreateTable,
+		Logger:          m.logger,
+		GetDB:           m.getDB,
+		NewStore:        newStoreForVendor,
+		WarnMsg:         "Inbox table creation failed (may already exist)",
+	})
+}
 
-	m.initMu.Lock()
-	defer m.initMu.Unlock()
-
-	if store, ok := m.stores[tenantID]; ok {
-		return store, nil
-	}
-
-	db, err := m.getDB(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("inbox: database unavailable: %w", err)
-	}
-
+func newStoreForVendor(vendor, tableName string) (Store, error) {
 	var store Store
-	switch db.DatabaseType() {
+	var err error
+	switch vendor {
 	case dbtypes.PostgreSQL:
-		store, err = NewPostgresStore(m.cfg.TableName)
+		store, err = NewPostgresStore(tableName)
 	case dbtypes.Oracle:
-		store, err = NewOracleStore(m.cfg.TableName)
+		store, err = NewOracleStore(tableName)
 	default:
-		return nil, fmt.Errorf("inbox: unsupported database vendor: %s", db.DatabaseType())
+		return nil, fmt.Errorf("inbox: unsupported database vendor: %s", vendor)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("inbox: failed to create store: %w", err)
 	}
-
-	// Auto-create the table if configured. Warning-only on failure: PostgreSQL
-	// uses IF NOT EXISTS (idempotent), Oracle may return ORA-00955 if it exists.
-	// One attempt per tenant — map presence short-circuits subsequent calls.
-	if m.cfg.AutoCreateTable {
-		if createErr := store.CreateTable(ctx, db); createErr != nil {
-			m.logger.Warn().Err(createErr).
-				Str("table", m.cfg.TableName).
-				Str("tenant", tenantID).
-				Msg("Inbox table creation failed (may already exist)")
-		}
-	}
-
-	if m.stores == nil {
-		m.stores = make(map[string]Store) // lazy: tests build Module via struct literals
-	}
-	m.stores[tenantID] = store
 	return store, nil
 }
 

--- a/internal/tenantstore/tenantstore.go
+++ b/internal/tenantstore/tenantstore.go
@@ -24,7 +24,8 @@ type Deps[S TableCreator] struct {
 	AutoCreateTable bool
 	Logger          logger.Logger
 	GetDB           func(context.Context) (dbtypes.Interface, error)
-	NewStore        func(vendor, tableName string) (S, error)
+	NewPostgres     func(tableName string) (S, error)
+	NewOracle       func(tableName string) (S, error)
 	WarnMsg         string // e.g. "Inbox table creation failed (may already exist)"
 }
 
@@ -54,9 +55,17 @@ func (c *Cache[S]) Get(ctx context.Context, d *Deps[S]) (S, error) {
 		return zero, fmt.Errorf("%s: database unavailable: %w", d.Name, err)
 	}
 
-	store, err := d.NewStore(db.DatabaseType(), d.TableName)
+	var store S
+	switch db.DatabaseType() {
+	case dbtypes.PostgreSQL:
+		store, err = d.NewPostgres(d.TableName)
+	case dbtypes.Oracle:
+		store, err = d.NewOracle(d.TableName)
+	default:
+		return zero, fmt.Errorf("%s: unsupported database vendor: %s", d.Name, db.DatabaseType())
+	}
 	if err != nil {
-		return zero, err
+		return zero, fmt.Errorf("%s: failed to create store: %w", d.Name, err)
 	}
 
 	if d.AutoCreateTable {

--- a/internal/tenantstore/tenantstore.go
+++ b/internal/tenantstore/tenantstore.go
@@ -30,10 +30,12 @@ type Deps[S TableCreator] struct {
 }
 
 // Cache lazily builds and caches one store per tenant ("" = single-tenant).
-// Mutex-guarded so a failed init can retry.
+// Failed inits cache nothing, so they can retry. Both internal maps grow with
+// the tenant set — an accepted tradeoff, the values are small and stateless.
 type Cache[S TableCreator] struct {
-	mu     sync.Mutex
-	stores map[string]S
+	mu       sync.RWMutex
+	stores   map[string]S
+	tenantMu sync.Map // map[string]*sync.Mutex — per-tenant init locks
 }
 
 // Get returns the store for the tenant in ctx, creating it (and, if
@@ -43,10 +45,18 @@ func (c *Cache[S]) Get(ctx context.Context, d *Deps[S]) (S, error) {
 	var zero S
 	tenantID, _ := multitenant.GetTenant(ctx)
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	if store, ok := c.Cached(tenantID); ok {
+		return store, nil
+	}
 
-	if store, ok := c.stores[tenantID]; ok {
+	// Serialize initialization per tenant only — unrelated tenants must not
+	// block on each other's (possibly slow) DB connection or table creation.
+	lockAny, _ := c.tenantMu.LoadOrStore(tenantID, &sync.Mutex{})
+	tenantLock := lockAny.(*sync.Mutex)
+	tenantLock.Lock()
+	defer tenantLock.Unlock()
+
+	if store, ok := c.Cached(tenantID); ok {
 		return store, nil
 	}
 
@@ -77,17 +87,19 @@ func (c *Cache[S]) Get(ctx context.Context, d *Deps[S]) (S, error) {
 		}
 	}
 
+	c.mu.Lock()
 	if c.stores == nil {
 		c.stores = make(map[string]S)
 	}
 	c.stores[tenantID] = store
+	c.mu.Unlock()
 	return store, nil
 }
 
 // Cached reports the store already initialized for tenantID, if any.
 func (c *Cache[S]) Cached(tenantID string) (S, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	store, ok := c.stores[tenantID]
 	return store, ok
 }

--- a/internal/tenantstore/tenantstore.go
+++ b/internal/tenantstore/tenantstore.go
@@ -1,0 +1,84 @@
+// Package tenantstore provides the lazy, tenant-keyed store cache shared by
+// the inbox and outbox modules.
+package tenantstore
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/multitenant"
+)
+
+// TableCreator is the store capability Cache needs for table auto-creation.
+type TableCreator interface {
+	CreateTable(ctx context.Context, db dbtypes.Interface) error
+}
+
+// Deps carries the module-specific pieces of store initialization.
+type Deps[S TableCreator] struct {
+	Name            string // error prefix, e.g. "inbox"
+	TableName       string
+	AutoCreateTable bool
+	Logger          logger.Logger
+	GetDB           func(context.Context) (dbtypes.Interface, error)
+	NewStore        func(vendor, tableName string) (S, error)
+	WarnMsg         string // e.g. "Inbox table creation failed (may already exist)"
+}
+
+// Cache lazily builds and caches one store per tenant ("" = single-tenant).
+// Mutex-guarded so a failed init can retry.
+type Cache[S TableCreator] struct {
+	mu     sync.Mutex
+	stores map[string]S
+}
+
+// Get returns the store for the tenant in ctx, creating it (and, if
+// configured, its table) on first use for that tenant. Table auto-creation is
+// warn-only, one attempt per tenant — map presence short-circuits later calls.
+func (c *Cache[S]) Get(ctx context.Context, d *Deps[S]) (S, error) {
+	var zero S
+	tenantID, _ := multitenant.GetTenant(ctx)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if store, ok := c.stores[tenantID]; ok {
+		return store, nil
+	}
+
+	db, err := d.GetDB(ctx)
+	if err != nil {
+		return zero, fmt.Errorf("%s: database unavailable: %w", d.Name, err)
+	}
+
+	store, err := d.NewStore(db.DatabaseType(), d.TableName)
+	if err != nil {
+		return zero, err
+	}
+
+	if d.AutoCreateTable {
+		if createErr := store.CreateTable(ctx, db); createErr != nil {
+			d.Logger.Warn().Err(createErr).
+				Str("table", d.TableName).
+				Str("tenant", tenantID).
+				Msg(d.WarnMsg)
+		}
+	}
+
+	if c.stores == nil {
+		c.stores = make(map[string]S)
+	}
+	c.stores[tenantID] = store
+	return store, nil
+}
+
+// Cached reports the store already initialized for tenantID, if any.
+func (c *Cache[S]) Cached(tenantID string) (S, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	store, ok := c.stores[tenantID]
+	return store, ok
+}

--- a/internal/tenantstore/tenantstore_test.go
+++ b/internal/tenantstore/tenantstore_test.go
@@ -3,6 +3,8 @@ package tenantstore
 import (
 	"context"
 	"errors"
+	"runtime"
+	"strings"
 	"testing"
 
 	dbtesting "github.com/gaborage/go-bricks/database/testing"
@@ -180,4 +182,91 @@ func TestCacheCached(t *testing.T) {
 
 	_, ok = c.Cached("other-tenant")
 	assert.False(t, ok, "miss for a tenant never initialized")
+}
+
+func TestCacheGetTenantsInitializeIndependently(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	getDB := func(ctx context.Context) (dbtypes.Interface, error) {
+		if tid, _ := multitenant.GetTenant(ctx); tid == "tenant-slow" {
+			started <- struct{}{}
+			<-release
+		}
+		return dbtesting.NewTestDB(dbtypes.PostgreSQL), nil
+	}
+	d, _ := newTestDeps(getDB, false, nil)
+	c := &Cache[*fakeStore]{}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := c.Get(multitenant.SetTenant(context.Background(), "tenant-slow"), d)
+		done <- err
+	}()
+
+	<-started // tenant-slow is now blocked inside its init
+
+	// With a cache-wide init lock this Get would deadlock behind tenant-slow;
+	// per-tenant locking must let an unrelated tenant proceed immediately.
+	_, err := c.Get(multitenant.SetTenant(context.Background(), "tenant-fast"), d)
+	require.NoError(t, err, "an unrelated tenant must not block on another tenant's slow init")
+
+	close(release)
+	require.NoError(t, <-done, "the slow tenant's init completes once its DB responds")
+
+	_, ok := c.Cached("tenant-slow")
+	assert.True(t, ok)
+	_, ok = c.Cached("tenant-fast")
+	assert.True(t, ok)
+}
+
+func TestCacheGetSameTenantSerializesInit(t *testing.T) {
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	getDB := func(context.Context) (dbtypes.Interface, error) {
+		entered <- struct{}{}
+		<-release
+		return dbtesting.NewTestDB(dbtypes.PostgreSQL), nil
+	}
+	d, vendors := newTestDeps(getDB, false, nil)
+	c := &Cache[*fakeStore]{}
+
+	stores := make(chan *fakeStore, 2)
+	errs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			s, err := c.Get(context.Background(), d)
+			stores <- s
+			errs <- err
+		}()
+	}
+
+	// Exactly one goroutine wins the tenant init lock and enters GetDB; hold it
+	// there until the other is observably blocked on that lock, so the loser
+	// deterministically takes the double-checked cache hit after the handoff.
+	<-entered
+	waitForGoroutineBlockedOnTenantLock()
+	close(release)
+
+	s1, s2 := <-stores, <-stores
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+	assert.Same(t, s1, s2, "both concurrent callers receive the same store")
+	assert.Len(t, *vendors, 1, "the constructor runs exactly once for a contended tenant")
+}
+
+// waitForGoroutineBlockedOnTenantLock spins until some goroutine's stack shows
+// it waiting on the per-tenant init mutex inside Cache.Get. Stack-based because
+// sync.Mutex exposes no waiter count; converges once the loser reaches the lock
+// (the winner is parked pre-store, so the loser's fast-path check always misses).
+func waitForGoroutineBlockedOnTenantLock() {
+	buf := make([]byte, 1<<20)
+	for {
+		stacks := string(buf[:runtime.Stack(buf, true)])
+		for _, g := range strings.Split(stacks, "\n\n") {
+			if strings.Contains(g, "sync.(*Mutex).Lock") && strings.Contains(g, "tenantstore.go") {
+				return
+			}
+		}
+		runtime.Gosched()
+	}
 }

--- a/internal/tenantstore/tenantstore_test.go
+++ b/internal/tenantstore/tenantstore_test.go
@@ -1,0 +1,151 @@
+package tenantstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	dbtesting "github.com/gaborage/go-bricks/database/testing"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/multitenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeStore implements TableCreator with a controllable CreateTable outcome.
+type fakeStore struct {
+	tableName string
+	createErr error
+	creates   int
+}
+
+func (s *fakeStore) CreateTable(context.Context, dbtypes.Interface) error {
+	s.creates++
+	return s.createErr
+}
+
+// newTestDeps builds Deps backed by the given GetDB; newStore tracks calls.
+func newTestDeps(getDB func(context.Context) (dbtypes.Interface, error), autoCreate bool, createErr error) (deps *Deps[*fakeStore], storeVendors *[]string) {
+	vendors := []string{}
+	d := &Deps[*fakeStore]{
+		Name:            "testmod",
+		TableName:       "test_table",
+		AutoCreateTable: autoCreate,
+		Logger:          logger.New("info", false),
+		GetDB:           getDB,
+		NewStore: func(vendor, tableName string) (*fakeStore, error) {
+			vendors = append(vendors, vendor)
+			return &fakeStore{tableName: tableName, createErr: createErr}, nil
+		},
+		WarnMsg: "test table creation failed",
+	}
+	return d, &vendors
+}
+
+func singleDB(db dbtypes.Interface) func(context.Context) (dbtypes.Interface, error) {
+	return func(context.Context) (dbtypes.Interface, error) { return db, nil }
+}
+
+func TestCacheGetCreatesStorePerTenant(t *testing.T) {
+	tenants := dbtesting.NewTenantDBMap()
+	tenants.ForTenantWithVendor("tenant-a", dbtypes.PostgreSQL)
+	tenants.ForTenantWithVendor("tenant-b", dbtypes.Oracle)
+	d, vendors := newTestDeps(tenants.AsGetDBFunc(), false, nil)
+	c := &Cache[*fakeStore]{}
+
+	storeA, err := c.Get(multitenant.SetTenant(t.Context(), "tenant-a"), d)
+	require.NoError(t, err)
+	storeB, err := c.Get(multitenant.SetTenant(t.Context(), "tenant-b"), d)
+	require.NoError(t, err)
+
+	assert.NotSame(t, storeA, storeB, "different tenants receive isolated stores")
+	assert.Equal(t, []string{dbtypes.PostgreSQL, dbtypes.Oracle}, *vendors, "each tenant's store is built for its own vendor")
+	assert.Equal(t, "test_table", storeA.tableName, "table name passes through to the store factory")
+}
+
+func TestCacheGetReturnsCachedStoreOnHit(t *testing.T) {
+	d, vendors := newTestDeps(singleDB(dbtesting.NewTestDB(dbtypes.PostgreSQL)), false, nil)
+	c := &Cache[*fakeStore]{}
+
+	first, err := c.Get(t.Context(), d)
+	require.NoError(t, err)
+	second, err := c.Get(t.Context(), d)
+	require.NoError(t, err)
+
+	assert.Same(t, first, second, "the empty-tenant store is reused across calls")
+	assert.Len(t, *vendors, 1, "NewStore runs once per tenant")
+}
+
+func TestCacheGetReturnsGetDBError(t *testing.T) {
+	cause := errors.New("connection refused")
+	d, _ := newTestDeps(func(context.Context) (dbtypes.Interface, error) { return nil, cause }, false, nil)
+	c := &Cache[*fakeStore]{}
+
+	store, err := c.Get(t.Context(), d)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, cause)
+	assert.Contains(t, err.Error(), "testmod: database unavailable")
+	assert.Nil(t, store)
+	_, ok := c.Cached("")
+	assert.False(t, ok, "a failed init caches nothing, so it can retry")
+}
+
+func TestCacheGetReturnsNewStoreError(t *testing.T) {
+	cause := errors.New("bad table name")
+	d, _ := newTestDeps(singleDB(dbtesting.NewTestDB(dbtypes.PostgreSQL)), false, nil)
+	calls := 0
+	d.NewStore = func(_, _ string) (*fakeStore, error) {
+		calls++
+		return nil, cause
+	}
+	c := &Cache[*fakeStore]{}
+
+	_, err := c.Get(t.Context(), d)
+	require.ErrorIs(t, err, cause, "factory errors propagate unwrapped (the factory owns its prefix)")
+
+	_, err = c.Get(t.Context(), d)
+	require.ErrorIs(t, err, cause)
+	assert.Equal(t, 2, calls, "a failed init retries instead of caching the failure")
+}
+
+func TestCacheGetAutoCreateTableWarnOnly(t *testing.T) {
+	d, _ := newTestDeps(singleDB(dbtesting.NewTestDB(dbtypes.PostgreSQL)), true, errors.New("ORA-00955"))
+	c := &Cache[*fakeStore]{}
+
+	store, err := c.Get(t.Context(), d)
+	require.NoError(t, err, "a CreateTable failure is warn-only; Get still succeeds")
+	assert.Equal(t, 1, store.creates)
+
+	again, err := c.Get(t.Context(), d)
+	require.NoError(t, err)
+	assert.Same(t, store, again, "the store is cached despite the CreateTable failure")
+	assert.Equal(t, 1, store.creates, "one CreateTable attempt per tenant")
+}
+
+func TestCacheGetSkipsCreateTableWhenDisabled(t *testing.T) {
+	d, _ := newTestDeps(singleDB(dbtesting.NewTestDB(dbtypes.PostgreSQL)), false, nil)
+	c := &Cache[*fakeStore]{}
+
+	store, err := c.Get(t.Context(), d)
+	require.NoError(t, err)
+	assert.Zero(t, store.creates, "CreateTable is not attempted when AutoCreateTable is false")
+}
+
+func TestCacheCached(t *testing.T) {
+	d, _ := newTestDeps(singleDB(dbtesting.NewTestDB(dbtypes.PostgreSQL)), false, nil)
+	c := &Cache[*fakeStore]{}
+
+	_, ok := c.Cached("")
+	assert.False(t, ok, "miss before first Get")
+
+	store, err := c.Get(t.Context(), d)
+	require.NoError(t, err)
+
+	cached, ok := c.Cached("")
+	assert.True(t, ok, "hit after Get")
+	assert.Same(t, store, cached)
+
+	_, ok = c.Cached("other-tenant")
+	assert.False(t, ok, "miss for a tenant never initialized")
+}

--- a/internal/tenantstore/tenantstore_test.go
+++ b/internal/tenantstore/tenantstore_test.go
@@ -15,6 +15,7 @@ import (
 
 // fakeStore implements TableCreator with a controllable CreateTable outcome.
 type fakeStore struct {
+	vendor    string
 	tableName string
 	createErr error
 	creates   int
@@ -25,20 +26,25 @@ func (s *fakeStore) CreateTable(context.Context, dbtypes.Interface) error {
 	return s.createErr
 }
 
-// newTestDeps builds Deps backed by the given GetDB; newStore tracks calls.
-func newTestDeps(getDB func(context.Context) (dbtypes.Interface, error), autoCreate bool, createErr error) (deps *Deps[*fakeStore], storeVendors *[]string) {
+// newTestDeps builds Deps backed by the given GetDB; the per-vendor
+// constructors record which vendor was invoked into the returned slice.
+func newTestDeps(getDB func(context.Context) (dbtypes.Interface, error), autoCreate bool, createErr error) (deps *Deps[*fakeStore], constructorVendors *[]string) {
 	vendors := []string{}
+	newFor := func(vendor string) func(string) (*fakeStore, error) {
+		return func(tableName string) (*fakeStore, error) {
+			vendors = append(vendors, vendor)
+			return &fakeStore{vendor: vendor, tableName: tableName, createErr: createErr}, nil
+		}
+	}
 	d := &Deps[*fakeStore]{
 		Name:            "testmod",
 		TableName:       "test_table",
 		AutoCreateTable: autoCreate,
 		Logger:          logger.New("info", false),
 		GetDB:           getDB,
-		NewStore: func(vendor, tableName string) (*fakeStore, error) {
-			vendors = append(vendors, vendor)
-			return &fakeStore{tableName: tableName, createErr: createErr}, nil
-		},
-		WarnMsg: "test table creation failed",
+		NewPostgres:     newFor(dbtypes.PostgreSQL),
+		NewOracle:       newFor(dbtypes.Oracle),
+		WarnMsg:         "test table creation failed",
 	}
 	return d, &vendors
 }
@@ -60,8 +66,10 @@ func TestCacheGetCreatesStorePerTenant(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotSame(t, storeA, storeB, "different tenants receive isolated stores")
-	assert.Equal(t, []string{dbtypes.PostgreSQL, dbtypes.Oracle}, *vendors, "each tenant's store is built for its own vendor")
-	assert.Equal(t, "test_table", storeA.tableName, "table name passes through to the store factory")
+	assert.Equal(t, dbtypes.PostgreSQL, storeA.vendor, "postgres tenant's store comes from NewPostgres")
+	assert.Equal(t, dbtypes.Oracle, storeB.vendor, "oracle tenant's store comes from NewOracle")
+	assert.Equal(t, []string{dbtypes.PostgreSQL, dbtypes.Oracle}, *vendors, "each tenant invokes only its own vendor's constructor")
+	assert.Equal(t, "test_table", storeA.tableName, "table name passes through to the constructor")
 }
 
 func TestCacheGetReturnsCachedStoreOnHit(t *testing.T) {
@@ -74,7 +82,30 @@ func TestCacheGetReturnsCachedStoreOnHit(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Same(t, first, second, "the empty-tenant store is reused across calls")
-	assert.Len(t, *vendors, 1, "NewStore runs once per tenant")
+	assert.Len(t, *vendors, 1, "the constructor runs once per tenant")
+}
+
+func TestCacheGetOraclePath(t *testing.T) {
+	d, vendors := newTestDeps(singleDB(dbtesting.NewTestDB(dbtypes.Oracle)), false, nil)
+	c := &Cache[*fakeStore]{}
+
+	store, err := c.Get(t.Context(), d)
+	require.NoError(t, err)
+	assert.Equal(t, dbtypes.Oracle, store.vendor)
+	assert.Equal(t, []string{dbtypes.Oracle}, *vendors, "only NewOracle is invoked for an Oracle DB")
+}
+
+func TestCacheGetUnknownVendorError(t *testing.T) {
+	d, vendors := newTestDeps(singleDB(dbtesting.NewTestDB("mysql")), false, nil)
+	c := &Cache[*fakeStore]{}
+
+	store, err := c.Get(t.Context(), d)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "testmod: unsupported database vendor: mysql")
+	assert.Nil(t, store)
+	assert.Empty(t, *vendors, "no constructor runs for an unknown vendor")
+	_, ok := c.Cached("")
+	assert.False(t, ok)
 }
 
 func TestCacheGetReturnsGetDBError(t *testing.T) {
@@ -91,18 +122,19 @@ func TestCacheGetReturnsGetDBError(t *testing.T) {
 	assert.False(t, ok, "a failed init caches nothing, so it can retry")
 }
 
-func TestCacheGetReturnsNewStoreError(t *testing.T) {
+func TestCacheGetReturnsConstructorError(t *testing.T) {
 	cause := errors.New("bad table name")
 	d, _ := newTestDeps(singleDB(dbtesting.NewTestDB(dbtypes.PostgreSQL)), false, nil)
 	calls := 0
-	d.NewStore = func(_, _ string) (*fakeStore, error) {
+	d.NewPostgres = func(string) (*fakeStore, error) {
 		calls++
 		return nil, cause
 	}
 	c := &Cache[*fakeStore]{}
 
 	_, err := c.Get(t.Context(), d)
-	require.ErrorIs(t, err, cause, "factory errors propagate unwrapped (the factory owns its prefix)")
+	require.ErrorIs(t, err, cause)
+	assert.Contains(t, err.Error(), "testmod: failed to create store")
 
 	_, err = c.Get(t.Context(), d)
 	require.ErrorIs(t, err, cause)

--- a/outbox/module.go
+++ b/outbox/module.go
@@ -186,26 +186,10 @@ func (m *Module) ensureStoreInitialized(ctx context.Context) (Store, error) {
 		AutoCreateTable: m.cfg.AutoCreateTable,
 		Logger:          m.logger,
 		GetDB:           m.getDB,
-		NewStore:        newStoreForVendor,
+		NewPostgres:     NewPostgresStore,
+		NewOracle:       NewOracleStore,
 		WarnMsg:         "Outbox table creation failed (may already exist)",
 	})
-}
-
-func newStoreForVendor(vendor, tableName string) (Store, error) {
-	var store Store
-	var err error
-	switch vendor {
-	case dbtypes.PostgreSQL:
-		store, err = NewPostgresStore(tableName)
-	case dbtypes.Oracle:
-		store, err = NewOracleStore(tableName)
-	default:
-		return nil, fmt.Errorf("outbox: unsupported database vendor: %s", vendor)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("outbox: failed to create store: %w", err)
-	}
-	return store, nil
 }
 
 // OutboxPublisher implements app.OutboxProvider — returns the Publisher for ModuleDeps wiring.

--- a/outbox/module.go
+++ b/outbox/module.go
@@ -11,6 +11,7 @@ import (
 	dbtypes "github.com/gaborage/go-bricks/database/types"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/multitenant"
 )
 
 // Module implements the GoBricks Module interface for transactional outbox.
@@ -35,12 +36,11 @@ type Module struct {
 	getDB  func(context.Context) (dbtypes.Interface, error)
 	getMsg func(context.Context) (messaging.AMQPClient, error)
 
-	store     Store
 	publisher app.OutboxPublisher
 	cfg       config.OutboxConfig
 
-	initMu       sync.Mutex // Protects store initialization (lazy init from concurrent goroutines)
-	tableCreated bool
+	initMu sync.Mutex       // Protects stores
+	stores map[string]Store // key: tenant id ("" = single-tenant)
 }
 
 // NewModule creates a new Module instance.
@@ -177,24 +177,26 @@ func (m *Module) validatePublishTimeout() error {
 	return nil
 }
 
-// ensureStoreInitialized creates the vendor-specific store on first use.
-// This is lazy because the database vendor type is only known at runtime.
-// Uses a mutex (not sync.Once) because initialization can fail and should
-// be retried — matching the scheduler module pattern.
-func (m *Module) ensureStoreInitialized(ctx context.Context) error {
+// ensureStoreInitialized returns the store for the tenant in ctx, creating it
+// (and, if configured, its table) on first use for that tenant. Lazy because
+// the vendor is only known once a connection exists; per-tenant because each
+// tenant has its own DB (and possibly its own vendor). Mutex-guarded so a
+// failed init can retry — matching the scheduler module pattern.
+func (m *Module) ensureStoreInitialized(ctx context.Context) (Store, error) {
+	tenantID, _ := multitenant.GetTenant(ctx)
+
 	m.initMu.Lock()
 	defer m.initMu.Unlock()
 
-	if m.store != nil {
-		return nil
+	if store, ok := m.stores[tenantID]; ok {
+		return store, nil
 	}
 
 	db, err := m.getDB(ctx)
 	if err != nil {
-		return fmt.Errorf("outbox: database unavailable: %w", err)
+		return nil, fmt.Errorf("outbox: database unavailable: %w", err)
 	}
 
-	// Create vendor-specific store into local variable — only assign to m.store on success
 	var store Store
 	switch db.DatabaseType() {
 	case dbtypes.PostgreSQL:
@@ -202,31 +204,31 @@ func (m *Module) ensureStoreInitialized(ctx context.Context) error {
 	case dbtypes.Oracle:
 		store, err = NewOracleStore(m.cfg.TableName)
 	default:
-		return fmt.Errorf("outbox: unsupported database vendor: %s", db.DatabaseType())
+		return nil, fmt.Errorf("outbox: unsupported database vendor: %s", db.DatabaseType())
 	}
 	if err != nil {
-		return fmt.Errorf("outbox: failed to create store: %w", err)
+		return nil, fmt.Errorf("outbox: failed to create store: %w", err)
 	}
 
 	// Auto-create table if configured.
 	// Warning-only on failure: PostgreSQL uses IF NOT EXISTS (idempotent),
 	// Oracle may return ORA-00955 if the table/index already exists.
 	// Both cases are benign — the table is usable either way.
-	//
-	// m.tableCreated is set unconditionally to prevent repeated warnings on
-	// every subsequent call. If the failure was transient (e.g., network),
-	// the store operations themselves will fail with a clear error.
-	if m.cfg.AutoCreateTable && !m.tableCreated {
+	// One attempt per tenant — map presence short-circuits subsequent calls.
+	if m.cfg.AutoCreateTable {
 		if createErr := store.CreateTable(ctx, db); createErr != nil {
 			m.logger.Warn().Err(createErr).
 				Str("table", m.cfg.TableName).
+				Str("tenant", tenantID).
 				Msg("Outbox table creation failed (may already exist)")
 		}
-		m.tableCreated = true
 	}
 
-	m.store = store
-	return nil
+	if m.stores == nil {
+		m.stores = make(map[string]Store) // lazy: tests build Module via struct literals
+	}
+	m.stores[tenantID] = store
+	return store, nil
 }
 
 // OutboxPublisher implements app.OutboxProvider — returns the Publisher for ModuleDeps wiring.
@@ -286,23 +288,19 @@ func (m *Module) Shutdown() error {
 	return nil
 }
 
-// lazyPublisher wraps app.OutboxPublisher to lazily initialize the store on first use.
-// Caches the publisher instance after first successful initialization via sync.Once.
+// lazyPublisher wraps app.OutboxPublisher to resolve the tenant's store on
+// every call. No caching: a cached publisher would pin the first caller's
+// tenant store (and dialect) for the life of the process.
 type lazyPublisher struct {
-	module    *Module
-	once      sync.Once
-	cachedPub app.OutboxPublisher
+	module *Module
 }
 
 func (p *lazyPublisher) Publish(ctx context.Context, tx dbtypes.Tx, event *app.OutboxEvent) (string, error) {
-	if err := p.module.ensureStoreInitialized(ctx); err != nil {
+	store, err := p.module.ensureStoreInitialized(ctx)
+	if err != nil {
 		return "", err
 	}
-
-	p.once.Do(func() {
-		p.cachedPub = newPublisher(p.module.store, p.module.cfg.DefaultExchange)
-	})
-	return p.cachedPub.Publish(ctx, tx, event)
+	return newPublisher(store, p.module.cfg.DefaultExchange).Publish(ctx, tx, event)
 }
 
 // lazyStore wraps Store to lazily initialize via the module.
@@ -312,50 +310,57 @@ type lazyStore struct {
 }
 
 func (s *lazyStore) Insert(ctx context.Context, tx dbtypes.Tx, record *Record) error {
-	if err := s.module.ensureStoreInitialized(ctx); err != nil {
+	store, err := s.module.ensureStoreInitialized(ctx)
+	if err != nil {
 		return err
 	}
-	return s.module.store.Insert(ctx, tx, record)
+	return store.Insert(ctx, tx, record)
 }
 
 func (s *lazyStore) FetchPending(ctx context.Context, db dbtypes.Interface, batchSize int) ([]Record, error) {
-	if err := s.module.ensureStoreInitialized(ctx); err != nil {
+	store, err := s.module.ensureStoreInitialized(ctx)
+	if err != nil {
 		return nil, err
 	}
-	return s.module.store.FetchPending(ctx, db, batchSize)
+	return store.FetchPending(ctx, db, batchSize)
 }
 
 func (s *lazyStore) MarkPublished(ctx context.Context, db dbtypes.Interface, eventID string) error {
-	if err := s.module.ensureStoreInitialized(ctx); err != nil {
+	store, err := s.module.ensureStoreInitialized(ctx)
+	if err != nil {
 		return err
 	}
-	return s.module.store.MarkPublished(ctx, db, eventID)
+	return store.MarkPublished(ctx, db, eventID)
 }
 
 func (s *lazyStore) MarkFailed(ctx context.Context, db dbtypes.Interface, eventID, errMsg string) error {
-	if err := s.module.ensureStoreInitialized(ctx); err != nil {
+	store, err := s.module.ensureStoreInitialized(ctx)
+	if err != nil {
 		return err
 	}
-	return s.module.store.MarkFailed(ctx, db, eventID, errMsg)
+	return store.MarkFailed(ctx, db, eventID, errMsg)
 }
 
 func (s *lazyStore) MarkDeadLettered(ctx context.Context, db dbtypes.Interface, eventID, errMsg string) error {
-	if err := s.module.ensureStoreInitialized(ctx); err != nil {
+	store, err := s.module.ensureStoreInitialized(ctx)
+	if err != nil {
 		return err
 	}
-	return s.module.store.MarkDeadLettered(ctx, db, eventID, errMsg)
+	return store.MarkDeadLettered(ctx, db, eventID, errMsg)
 }
 
 func (s *lazyStore) DeletePublished(ctx context.Context, db dbtypes.Interface, before time.Time) (int64, error) {
-	if err := s.module.ensureStoreInitialized(ctx); err != nil {
+	store, err := s.module.ensureStoreInitialized(ctx)
+	if err != nil {
 		return 0, err
 	}
-	return s.module.store.DeletePublished(ctx, db, before)
+	return store.DeletePublished(ctx, db, before)
 }
 
 func (s *lazyStore) CreateTable(ctx context.Context, db dbtypes.Interface) error {
-	if err := s.module.ensureStoreInitialized(ctx); err != nil {
+	store, err := s.module.ensureStoreInitialized(ctx)
+	if err != nil {
 		return err
 	}
-	return s.module.store.CreateTable(ctx, db)
+	return store.CreateTable(ctx, db)
 }

--- a/outbox/module.go
+++ b/outbox/module.go
@@ -3,15 +3,14 @@ package outbox
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/gaborage/go-bricks/app"
 	"github.com/gaborage/go-bricks/config"
 	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/internal/tenantstore"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
-	"github.com/gaborage/go-bricks/multitenant"
 )
 
 // Module implements the GoBricks Module interface for transactional outbox.
@@ -39,8 +38,7 @@ type Module struct {
 	publisher app.OutboxPublisher
 	cfg       config.OutboxConfig
 
-	initMu sync.Mutex       // Protects stores
-	stores map[string]Store // key: tenant id ("" = single-tenant)
+	stores tenantstore.Cache[Store] // one store per tenant ("" = single-tenant)
 }
 
 // NewModule creates a new Module instance.
@@ -180,54 +178,33 @@ func (m *Module) validatePublishTimeout() error {
 // ensureStoreInitialized returns the store for the tenant in ctx, creating it
 // (and, if configured, its table) on first use for that tenant. Lazy because
 // the vendor is only known once a connection exists; per-tenant because each
-// tenant has its own DB (and possibly its own vendor). Mutex-guarded so a
-// failed init can retry — matching the scheduler module pattern.
+// tenant has its own DB (and possibly its own vendor).
 func (m *Module) ensureStoreInitialized(ctx context.Context) (Store, error) {
-	tenantID, _ := multitenant.GetTenant(ctx)
+	return m.stores.Get(ctx, &tenantstore.Deps[Store]{
+		Name:            "outbox",
+		TableName:       m.cfg.TableName,
+		AutoCreateTable: m.cfg.AutoCreateTable,
+		Logger:          m.logger,
+		GetDB:           m.getDB,
+		NewStore:        newStoreForVendor,
+		WarnMsg:         "Outbox table creation failed (may already exist)",
+	})
+}
 
-	m.initMu.Lock()
-	defer m.initMu.Unlock()
-
-	if store, ok := m.stores[tenantID]; ok {
-		return store, nil
-	}
-
-	db, err := m.getDB(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("outbox: database unavailable: %w", err)
-	}
-
+func newStoreForVendor(vendor, tableName string) (Store, error) {
 	var store Store
-	switch db.DatabaseType() {
+	var err error
+	switch vendor {
 	case dbtypes.PostgreSQL:
-		store, err = NewPostgresStore(m.cfg.TableName)
+		store, err = NewPostgresStore(tableName)
 	case dbtypes.Oracle:
-		store, err = NewOracleStore(m.cfg.TableName)
+		store, err = NewOracleStore(tableName)
 	default:
-		return nil, fmt.Errorf("outbox: unsupported database vendor: %s", db.DatabaseType())
+		return nil, fmt.Errorf("outbox: unsupported database vendor: %s", vendor)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("outbox: failed to create store: %w", err)
 	}
-
-	// Auto-create table if configured.
-	// Warning-only on failure: PostgreSQL uses IF NOT EXISTS (idempotent),
-	// Oracle may return ORA-00955 if the table/index already exists.
-	// Both cases are benign — the table is usable either way.
-	// One attempt per tenant — map presence short-circuits subsequent calls.
-	if m.cfg.AutoCreateTable {
-		if createErr := store.CreateTable(ctx, db); createErr != nil {
-			m.logger.Warn().Err(createErr).
-				Str("table", m.cfg.TableName).
-				Str("tenant", tenantID).
-				Msg("Outbox table creation failed (may already exist)")
-		}
-	}
-
-	if m.stores == nil {
-		m.stores = make(map[string]Store) // lazy: tests build Module via struct literals
-	}
-	m.stores[tenantID] = store
 	return store, nil
 }
 

--- a/outbox/module_test.go
+++ b/outbox/module_test.go
@@ -12,6 +12,7 @@ import (
 	dbtypes "github.com/gaborage/go-bricks/database/types"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/multitenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -449,22 +450,24 @@ func initEnabledModule(t *testing.T, dbVendor string, retention time.Duration) (
 
 func TestModuleEnsureStoreInitializedPostgres(t *testing.T) {
 	m, _ := initEnabledModule(t, "postgresql", 0)
-	require.NoError(t, m.ensureStoreInitialized(context.Background()))
-	assert.NotNil(t, m.store, "store created for postgres vendor")
+	store, err := m.ensureStoreInitialized(context.Background())
+	require.NoError(t, err)
+	assert.NotNil(t, store, "store created for postgres vendor")
 }
 
 func TestModuleEnsureStoreInitializedOracle(t *testing.T) {
 	m, _ := initEnabledModule(t, "oracle", 0)
-	require.NoError(t, m.ensureStoreInitialized(context.Background()))
-	assert.NotNil(t, m.store, "store created for oracle vendor")
+	store, err := m.ensureStoreInitialized(context.Background())
+	require.NoError(t, err)
+	assert.NotNil(t, store, "store created for oracle vendor")
 }
 
 func TestModuleEnsureStoreInitializedUnknownVendor(t *testing.T) {
 	m, _ := initEnabledModule(t, "mysql", 0)
-	err := m.ensureStoreInitialized(context.Background())
+	store, err := m.ensureStoreInitialized(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported database vendor")
-	assert.Nil(t, m.store, "store must remain nil on unsupported vendor")
+	assert.Nil(t, store, "store must remain nil on unsupported vendor")
 }
 
 func TestModuleEnsureStoreInitializedDBResolverError(t *testing.T) {
@@ -482,21 +485,23 @@ func TestModuleEnsureStoreInitializedDBResolverError(t *testing.T) {
 	}
 	require.NoError(t, m.Init(deps))
 
-	err := m.ensureStoreInitialized(context.Background())
+	store, err := m.ensureStoreInitialized(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "database unavailable")
 	assert.Contains(t, err.Error(), "connection refused")
+	assert.Nil(t, store)
 }
 
 func TestModuleEnsureStoreInitializedIdempotent(t *testing.T) {
 	m, _ := initEnabledModule(t, "postgresql", 0)
-	require.NoError(t, m.ensureStoreInitialized(context.Background()))
-	first := m.store
+	first, err := m.ensureStoreInitialized(context.Background())
+	require.NoError(t, err)
 
 	// Second call must not re-create the store — assert via identity since
 	// TestDB.DatabaseType() doesn't log call counts.
-	require.NoError(t, m.ensureStoreInitialized(context.Background()))
-	assert.Same(t, first, m.store, "store identity must be preserved on subsequent calls")
+	second, err := m.ensureStoreInitialized(context.Background())
+	require.NoError(t, err)
+	assert.Same(t, first, second, "store identity must be preserved on subsequent calls")
 }
 
 func TestModuleOutboxPublisherReturnsLazyPublisher(t *testing.T) {
@@ -563,7 +568,7 @@ func TestModuleRegisterJobsPropagatesCleanupError(t *testing.T) {
 
 func TestLazyPublisherPublishLazilyInitializesStore(t *testing.T) {
 	m, db := initEnabledModule(t, "postgresql", 0)
-	require.Nil(t, m.store, "store is nil before first Publish")
+	require.Nil(t, m.stores[""], "store is nil before first Publish")
 
 	// Wire the tx's INSERT expectation matching postgresStore.Insert.
 	db.ExpectTransaction().
@@ -582,7 +587,7 @@ func TestLazyPublisherPublishLazilyInitializesStore(t *testing.T) {
 	id, err := m.OutboxPublisher().Publish(context.Background(), tx, event)
 	require.NoError(t, err)
 	assert.NotEmpty(t, id, "Publish returns a generated event ID")
-	assert.NotNil(t, m.store, "store initialized lazily on first Publish")
+	assert.NotNil(t, m.stores[""], "store initialized lazily on first Publish")
 }
 
 func TestLazyStoreDelegatesAllMethodsAfterInit(t *testing.T) {
@@ -597,7 +602,7 @@ func TestLazyStoreDelegatesAllMethodsAfterInit(t *testing.T) {
 
 	_, err := ls.DeletePublished(context.Background(), db, time.Now())
 	require.NoError(t, err)
-	assert.NotNil(t, m.store, "lazyStore.DeletePublished triggered lazy init")
+	assert.NotNil(t, m.stores[""], "lazyStore.DeletePublished triggered lazy init")
 }
 
 func TestLazyStoreInsertDelegatesAfterInit(t *testing.T) {
@@ -612,7 +617,7 @@ func TestLazyStoreInsertDelegatesAfterInit(t *testing.T) {
 
 	rec := &Record{ID: "evt", EventType: "x", Payload: []byte("{}"), Exchange: "ex", RoutingKey: "rk"}
 	require.NoError(t, ls.Insert(context.Background(), tx, rec))
-	assert.NotNil(t, m.store)
+	assert.NotNil(t, m.stores[""])
 }
 
 func TestLazyStoreMarkPublishedDelegatesAfterInit(t *testing.T) {
@@ -621,7 +626,7 @@ func TestLazyStoreMarkPublishedDelegatesAfterInit(t *testing.T) {
 
 	db.ExpectExec(`UPDATE gobricks_outbox SET status`).WillReturnRowsAffected(1)
 	require.NoError(t, ls.MarkPublished(context.Background(), db, "evt-id"))
-	assert.NotNil(t, m.store)
+	assert.NotNil(t, m.stores[""])
 }
 
 func TestLazyStoreMarkFailedDelegatesAfterInit(t *testing.T) {
@@ -630,7 +635,7 @@ func TestLazyStoreMarkFailedDelegatesAfterInit(t *testing.T) {
 
 	db.ExpectExec(`UPDATE gobricks_outbox SET retry_count`).WillReturnRowsAffected(1)
 	require.NoError(t, ls.MarkFailed(context.Background(), db, "evt-id", "boom"))
-	assert.NotNil(t, m.store)
+	assert.NotNil(t, m.stores[""])
 }
 
 func TestLazyStoreFetchPendingDelegatesAfterInit(t *testing.T) {
@@ -646,7 +651,7 @@ func TestLazyStoreFetchPendingDelegatesAfterInit(t *testing.T) {
 
 	_, err := ls.FetchPending(context.Background(), db, 10)
 	require.NoError(t, err)
-	assert.NotNil(t, m.store, "lazyStore.FetchPending triggered lazy init")
+	assert.NotNil(t, m.stores[""], "lazyStore.FetchPending triggered lazy init")
 }
 
 func TestLazyStoreCreateTableDelegatesAfterInit(t *testing.T) {
@@ -661,5 +666,69 @@ func TestLazyStoreCreateTableDelegatesAfterInit(t *testing.T) {
 	db.ExpectExec(`CREATE INDEX IF NOT EXISTS idx_gobricks_outbox_published`).WillReturnRowsAffected(0)
 
 	require.NoError(t, ls.CreateTable(context.Background(), db))
-	assert.NotNil(t, m.store, "lazyStore.CreateTable triggered lazy init")
+	assert.NotNil(t, m.stores[""], "lazyStore.CreateTable triggered lazy init")
+}
+
+func TestOutboxStorePerTenant(t *testing.T) {
+	tenants := dbtesting.NewTenantDBMap()
+	dbA := tenants.ForTenant("tenant-a")
+	dbA.ExpectExec(`CREATE TABLE IF NOT EXISTS gobricks_outbox`).WillReturnRowsAffected(0)
+	dbA.ExpectExec(`CREATE INDEX IF NOT EXISTS idx_gobricks_outbox_pending`).WillReturnRowsAffected(0)
+	dbA.ExpectExec(`CREATE INDEX IF NOT EXISTS idx_gobricks_outbox_published`).WillReturnRowsAffected(0)
+
+	dbB := tenants.ForTenant("tenant-b")
+	dbB.ExpectExec(`CREATE TABLE IF NOT EXISTS gobricks_outbox`).WillReturnRowsAffected(0)
+	dbB.ExpectExec(`CREATE INDEX IF NOT EXISTS idx_gobricks_outbox_pending`).WillReturnRowsAffected(0)
+	dbB.ExpectExec(`CREATE INDEX IF NOT EXISTS idx_gobricks_outbox_published`).WillReturnRowsAffected(0)
+
+	m := &Module{
+		logger: logger.New("info", false),
+		cfg:    config.OutboxConfig{Enabled: true, TableName: "gobricks_outbox", AutoCreateTable: true},
+		getDB:  tenants.AsGetDBFunc(),
+	}
+
+	storeA, err := m.ensureStoreInitialized(multitenant.SetTenant(context.Background(), "tenant-a"))
+	require.NoError(t, err)
+	storeB, err := m.ensureStoreInitialized(multitenant.SetTenant(context.Background(), "tenant-b"))
+	require.NoError(t, err)
+	storeAAgain, err := m.ensureStoreInitialized(multitenant.SetTenant(context.Background(), "tenant-a"))
+	require.NoError(t, err)
+
+	assert.Same(t, storeA, storeAAgain, "a tenant reuses its cached store")
+	assert.NotSame(t, storeA, storeB, "different tenants receive isolated stores")
+
+	dbtesting.AssertExecExecuted(t, dbA, "CREATE TABLE")
+	dbtesting.AssertExecExecuted(t, dbB, "CREATE TABLE")
+}
+
+func TestLazyPublisherUsesCallersTenantStore(t *testing.T) {
+	tenants := dbtesting.NewTenantDBMap()
+	dbA := tenants.ForTenantWithVendor("tenant-a", dbtypes.PostgreSQL)
+	dbA.ExpectTransaction().ExpectExec(`VALUES ($1, $2`).WillReturnRowsAffected(1)
+
+	dbB := tenants.ForTenantWithVendor("tenant-b", dbtypes.Oracle)
+	dbB.ExpectTransaction().ExpectExec(`VALUES (:1, :2`).WillReturnRowsAffected(1)
+
+	m := &Module{
+		logger: logger.New("info", false),
+		cfg:    config.OutboxConfig{Enabled: true, TableName: "gobricks_outbox", DefaultExchange: "ex"},
+		getDB:  tenants.AsGetDBFunc(),
+	}
+	pub := &lazyPublisher{module: m}
+	event := &app.OutboxEvent{EventType: "test.event", AggregateID: "agg-1", Payload: []byte(`{}`), Exchange: "ex"}
+
+	ctxA := multitenant.SetTenant(context.Background(), "tenant-a")
+	txA, err := dbA.Begin(ctxA)
+	require.NoError(t, err)
+	_, err = pub.Publish(ctxA, txA, event)
+	require.NoError(t, err)
+
+	ctxB := multitenant.SetTenant(context.Background(), "tenant-b")
+	txB, err := dbB.Begin(ctxB)
+	require.NoError(t, err)
+	// Tenant B is Oracle (:N placeholders). Before the fix, lazyPublisher cached
+	// the first Publish's store behind a sync.Once — this second call would still
+	// emit tenant A's Postgres $N-placeholder SQL and fail txB's :N-only expectation.
+	_, err = pub.Publish(ctxB, txB, event)
+	require.NoError(t, err, "tenant B's publish must use tenant B's (Oracle) store, not a cached tenant-A store")
 }

--- a/outbox/module_test.go
+++ b/outbox/module_test.go
@@ -568,7 +568,8 @@ func TestModuleRegisterJobsPropagatesCleanupError(t *testing.T) {
 
 func TestLazyPublisherPublishLazilyInitializesStore(t *testing.T) {
 	m, db := initEnabledModule(t, "postgresql", 0)
-	require.Nil(t, m.stores[""], "store is nil before first Publish")
+	_, ok := m.stores.Cached("")
+	require.False(t, ok, "store is nil before first Publish")
 
 	// Wire the tx's INSERT expectation matching postgresStore.Insert.
 	db.ExpectTransaction().
@@ -587,7 +588,8 @@ func TestLazyPublisherPublishLazilyInitializesStore(t *testing.T) {
 	id, err := m.OutboxPublisher().Publish(context.Background(), tx, event)
 	require.NoError(t, err)
 	assert.NotEmpty(t, id, "Publish returns a generated event ID")
-	assert.NotNil(t, m.stores[""], "store initialized lazily on first Publish")
+	_, ok = m.stores.Cached("")
+	assert.True(t, ok, "store initialized lazily on first Publish")
 }
 
 func TestLazyStoreDelegatesAllMethodsAfterInit(t *testing.T) {
@@ -602,7 +604,8 @@ func TestLazyStoreDelegatesAllMethodsAfterInit(t *testing.T) {
 
 	_, err := ls.DeletePublished(context.Background(), db, time.Now())
 	require.NoError(t, err)
-	assert.NotNil(t, m.stores[""], "lazyStore.DeletePublished triggered lazy init")
+	_, ok := m.stores.Cached("")
+	assert.True(t, ok, "lazyStore.DeletePublished triggered lazy init")
 }
 
 func TestLazyStoreInsertDelegatesAfterInit(t *testing.T) {
@@ -617,7 +620,8 @@ func TestLazyStoreInsertDelegatesAfterInit(t *testing.T) {
 
 	rec := &Record{ID: "evt", EventType: "x", Payload: []byte("{}"), Exchange: "ex", RoutingKey: "rk"}
 	require.NoError(t, ls.Insert(context.Background(), tx, rec))
-	assert.NotNil(t, m.stores[""])
+	_, ok := m.stores.Cached("")
+	assert.True(t, ok)
 }
 
 func TestLazyStoreMarkPublishedDelegatesAfterInit(t *testing.T) {
@@ -626,7 +630,8 @@ func TestLazyStoreMarkPublishedDelegatesAfterInit(t *testing.T) {
 
 	db.ExpectExec(`UPDATE gobricks_outbox SET status`).WillReturnRowsAffected(1)
 	require.NoError(t, ls.MarkPublished(context.Background(), db, "evt-id"))
-	assert.NotNil(t, m.stores[""])
+	_, ok := m.stores.Cached("")
+	assert.True(t, ok)
 }
 
 func TestLazyStoreMarkFailedDelegatesAfterInit(t *testing.T) {
@@ -635,7 +640,8 @@ func TestLazyStoreMarkFailedDelegatesAfterInit(t *testing.T) {
 
 	db.ExpectExec(`UPDATE gobricks_outbox SET retry_count`).WillReturnRowsAffected(1)
 	require.NoError(t, ls.MarkFailed(context.Background(), db, "evt-id", "boom"))
-	assert.NotNil(t, m.stores[""])
+	_, ok := m.stores.Cached("")
+	assert.True(t, ok)
 }
 
 func TestLazyStoreFetchPendingDelegatesAfterInit(t *testing.T) {
@@ -651,7 +657,8 @@ func TestLazyStoreFetchPendingDelegatesAfterInit(t *testing.T) {
 
 	_, err := ls.FetchPending(context.Background(), db, 10)
 	require.NoError(t, err)
-	assert.NotNil(t, m.stores[""], "lazyStore.FetchPending triggered lazy init")
+	_, ok := m.stores.Cached("")
+	assert.True(t, ok, "lazyStore.FetchPending triggered lazy init")
 }
 
 func TestLazyStoreCreateTableDelegatesAfterInit(t *testing.T) {
@@ -666,7 +673,8 @@ func TestLazyStoreCreateTableDelegatesAfterInit(t *testing.T) {
 	db.ExpectExec(`CREATE INDEX IF NOT EXISTS idx_gobricks_outbox_published`).WillReturnRowsAffected(0)
 
 	require.NoError(t, ls.CreateTable(context.Background(), db))
-	assert.NotNil(t, m.stores[""], "lazyStore.CreateTable triggered lazy init")
+	_, ok := m.stores.Cached("")
+	assert.True(t, ok, "lazyStore.CreateTable triggered lazy init")
 }
 
 func TestOutboxStorePerTenant(t *testing.T) {


### PR DESCRIPTION
## Problem

Inbox and outbox lazy store initialization was keyed on a single process-global flag (`m.tableCreated`) and a single `m.store` whose SQL dialect was fixed by the **first** tenant to trigger it:

- In multi-tenant mode with `autocreatetable: true`, only the first tenant's database ever got the ledger table. Every other tenant's inbox `MarkProcessed` hit a missing table → handler error → nack **without requeue** → the message was silently dropped. The outbox side surfaced as HTTP 500s on `Publish`.
- Mixed PostgreSQL/Oracle fleets ran the first tenant's SQL dialect against every tenant.
- `outbox.lazyPublisher` had a second, independent first-tenant cache (`sync.Once` + `cachedPub`) that froze the first caller's store into the publisher for the life of the process.

## Fix

`ensureStoreInitialized` in both packages now returns the tenant's store — `(Store, error)` instead of `error` — backed by a tenant-keyed map (`stores map[string]Store`, `""` = single-tenant) guarded by the existing `initMu`. Table auto-creation runs once per tenant (same warn-only semantics as before). Returning the store made every stale call site a compile error, which mechanically enumerated all consumers:

- `inbox.ProcessOnce` and both packages' `lazyStore` wrappers now use the returned per-tenant store.
- `outbox.lazyPublisher` lost its `sync.Once`/`cachedPub` cache entirely and resolves the caller's tenant store on every publish (one thin-struct allocation per publish, noise next to the DB transaction it wraps).

Single-tenant behavior is unchanged: the `""` key yields one store, one CreateTable attempt, identical identity across calls.

## Tests

- `TestEnsureStoreInitializedCreatesTablePerTenant` (inbox) / `TestOutboxStorePerTenant` (outbox): tenants A and B on distinct mock DBs both receive `CREATE TABLE`, with per-tenant store identity (`assert.Same` on repeat, `assert.NotSame` across tenants).
- `TestEnsureStoreInitializedMixedVendorDialects`: PG tenant gets the PG store, Oracle tenant the Oracle store, and each DB sees only its own dialect's DDL.
- `TestEnsureStoreInitializedSingleTenantIdempotent`: empty-tenant key preserves store identity and runs CreateTable exactly once.
- `TestLazyPublisherUsesCallersTenantStore`: tenant A publishes via PostgreSQL (`$N` placeholders), tenant B via Oracle (`:N`); the old cached publisher structurally cannot pass this test (verified by mutation: reintroducing the `sync.Once` cache makes it fail).
- All pinned tests converted to the returned-store form; assertions converted, none deleted.

## Verification

- `make check` green (fmt, lint incl. gosec, full `-race` suite, alloc guards, govulncheck).
- CodeRabbit CLI review of the final diff: 0 findings.
- Security delta audit clean: no new raw-SQL escape hatches, secrets, or input boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tenant-aware database store handling for inbox and outbox processing.
  - Stores are reused for repeated operations within a tenant while remaining isolated across tenants.
  - Added vendor-specific database initialization and table creation support.

- **Bug Fixes**
  - Ensured inbox and outbox operations use the correct tenant’s database store.
  - Prevented repeated table creation during store reuse.
  - Improved handling of initialization failures and unsupported database vendors.

- **Tests**
  - Expanded coverage for tenant isolation, caching, database vendors, retries, and idempotent initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->