### PR TITLE
fix(server): warn when CORS reflects any origin with credentials (unset APP_ENV)

### DIFF
--- a/server/cors.go
+++ b/server/cors.go
@@ -120,6 +120,7 @@ func corsEcho(exposeResponseTime bool, envOverride ...string) echo.MiddlewareFun
 		// Echo v5 forbids AllowOrigins=["*"] with AllowCredentials=true,
 		// so we keep credentials on for dev convenience and use the unsafe
 		// echo-back func to satisfy Echo's validation.
+		emitDevPermissiveWarn(appEnv)
 		cfg.AllowOrigins = []string{"*"}
 		cfg.UnsafeAllowOriginFunc = func(_ *echo.Context, origin string) (string, bool, error) {
 			return origin, true, nil
@@ -156,4 +157,23 @@ func emitFailClosedWarn(appEnv string) {
 			"to enable a strict allowlist.",
 		strconv.Quote(appEnv),
 	)
+}
+
+// emitDevPermissiveWarn surfaces the reflect-any-origin + AllowCredentials CORS
+// posture loudly. It checks the process environment directly: on the production
+// path CORS() receives cfg.App.Env, which koanf has already defaulted to
+// "development" when APP_ENV is unset — the argument alone cannot distinguish
+// "operator chose dev" from "operator forgot to set APP_ENV".
+func emitDevPermissiveWarn(appEnv string) {
+	source := "APP_ENV=" + strconv.Quote(appEnv)
+	if raw, ok := os.LookupEnv("APP_ENV"); !ok {
+		source = "APP_ENV is not set in the process environment (the development default, or a config-file app.env, is in effect)"
+	} else if raw != appEnv {
+		// envOverride (koanf-resolved) took precedence over a differing raw
+		// process value — surface both so operators aren't misled about the source.
+		source += " (process APP_ENV=" + strconv.Quote(raw) + ")"
+	}
+	log.Printf("WARN [server.cors] %s: CORS reflects ANY origin WITH credentials "+
+		"(the most permissive posture). If this is production, set APP_ENV=production "+
+		"and CORS_ORIGINS=https://your.app. Ignore only for local development.", source)
 }

--- a/server/cors_test.go
+++ b/server/cors_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -758,4 +760,74 @@ func TestCORSStrictBranchAllWildcardFailsClosed(t *testing.T) {
 		"CORS_ORIGINS=* in non-dev env must fail closed, not echo the origin")
 	assert.NotEqual(t, "true", rec.Header().Get(HeaderAccessControlAllowCredentials),
 		"fail-closed mode must explicitly drop AllowCredentials so the response cannot carry session cookies cross-origin")
+}
+
+// TestCORSDevPermissiveEmitsWarn verifies the dev-permissive branch (reflect
+// any origin + AllowCredentials=true) now logs a WARN instead of staying
+// silent, and names the explicitly-set APP_ENV value.
+func TestCORSDevPermissiveEmitsWarn(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	t.Setenv("APP_ENV", "development")
+	t.Setenv("CORS_ORIGINS", "")
+
+	_ = CORS(true, "development")
+
+	assert.Contains(t, buf.String(), "reflects ANY origin")
+	assert.Contains(t, buf.String(), `APP_ENV="development"`)
+}
+
+// TestCORSUnsetEnvWarnsAboutDefaulting verifies the WARN calls out that
+// APP_ENV was never set in the process environment (as opposed to being
+// explicitly set to a dev alias) — this is the "operator forgot APP_ENV"
+// scenario the koanf default silently papers over.
+func TestCORSUnsetEnvWarnsAboutDefaulting(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	t.Setenv("APP_ENV", "x") // registers restore-on-cleanup
+	os.Unsetenv("APP_ENV")   // truly unset — t.Setenv("APP_ENV", "") would leave it set-but-empty
+	t.Setenv("CORS_ORIGINS", "")
+
+	// The override mimics the production path, where koanf has already
+	// defaulted cfg.App.Env to "development" despite APP_ENV being unset.
+	_ = CORS(true, "development")
+
+	assert.Contains(t, buf.String(), "not set in the process environment")
+}
+
+// TestCORSDevPermissiveWarnNotesProcessOverride verifies that when the
+// effective (envOverride) value diverges from the raw process APP_ENV, the
+// WARN surfaces both rather than implying the override IS the process value.
+func TestCORSDevPermissiveWarnNotesProcessOverride(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	t.Setenv("APP_ENV", "local")
+	t.Setenv("CORS_ORIGINS", "")
+
+	// envOverride ("dev") differs from the raw process APP_ENV ("local").
+	_ = CORS(true, "dev")
+
+	assert.Contains(t, buf.String(), `APP_ENV="dev"`)
+	assert.Contains(t, buf.String(), `process APP_ENV="local"`)
+}
+
+// TestCORSStrictAllowlistNoDevWarn is a regression guard: when CORS_ORIGINS
+// is set, the strict-allowlist branch wins regardless of env, so the
+// dev-permissive WARN must not fire.
+func TestCORSStrictAllowlistNoDevWarn(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	t.Setenv("CORS_ORIGINS", "https://a.example")
+
+	_ = CORS(true, "development")
+
+	assert.NotContains(t, buf.String(), "reflects ANY origin")
 }


### PR DESCRIPTION
## Problem

`app.env` defaults to `development` in koanf, so an **unset** `APP_ENV` silently selects the CORS dev-permissive branch: `AllowOrigins=["*"]` plus an `UnsafeAllowOriginFunc` that reflects **any** origin, with `AllowCredentials=true` — the most dangerous CORS posture (any website can make credentialed cross-origin requests and read the responses). An operator who deploys to production but forgets `APP_ENV=production` gets this posture with **no signal**: `emitFailClosedWarn` fires only on the safe fail-closed branches, while the dangerous branch stays silent.

## Fix

Warn-only (no behavior change): add `emitDevPermissiveWarn`, called on the dev-permissive branch, mirroring the existing `emitFailClosedWarn` pre-bootstrap convention (stdlib `log.Printf`, `strconv.Quote` on env-derived strings for gosec G706).

The helper checks the process environment directly via `os.LookupEnv("APP_ENV")` — by the time `CORS()` runs, koanf has already defaulted an unset `APP_ENV` to `"development"`, so the argument alone cannot distinguish "operator chose dev" from "operator forgot to set APP_ENV". The WARN therefore names its source precisely:

- explicitly set: `APP_ENV="development": CORS reflects ANY origin WITH credentials …`
- unset: `APP_ENV is not set in the process environment (the development default, or a config-file app.env, is in effect): …`
- override diverging from the raw process value: both are surfaced, e.g. `APP_ENV="dev" (process APP_ENV="local")`

## Tests

Four new tests in `server/cors_test.go` (log-capture via buffer swap, no `t.Parallel()`):

- `TestCORSDevPermissiveEmitsWarn` — explicit dev env → WARN names the value
- `TestCORSUnsetEnvWarnsAboutDefaulting` — truly-unset `APP_ENV` → WARN calls out the defaulting
- `TestCORSDevPermissiveWarnNotesProcessOverride` — override vs process divergence surfaced
- `TestCORSStrictAllowlistNoDevWarn` — regression guard: strict-allowlist branch stays silent

Mutation-verified: with the `cors.go` change reverted, the new tests fail.

## Gates

- `make check` green (fmt, lint, race suite, alloc guards, govulncheck)
- CodeRabbit CLI review: 0 findings
- Security audit (gosec, raw-SQL annotation sweep, secrets scan, govulncheck): clean

## Notes

Follow-up (deferred, operator-authorized): requiring explicit opt-in for the reflect+credentials posture (`CORS_DEV_WILDCARD`) is planned as a separate breaking change with its own ADR (ADR-038).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear warning when development mode uses permissive CORS settings that allow requests from any origin.
  * Warnings now clarify how the active environment was determined, including defaulting and environment overrides.
  * No warning is shown when a strict CORS allowlist is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->