### PR TITLE
fix(migration): enforce Flyway timeout with WaitDelay and process-group kill

### DIFF
--- a/migration/audit_test.go
+++ b/migration/audit_test.go
@@ -761,3 +761,49 @@ func TestEmitterSinkPanicIsRecoveredAndCounted(t *testing.T) {
 	rm := mp.Collect(t)
 	obtest.AssertMetricValue(t, rm, "migration.audit.sink_failures", int64(1))
 }
+
+func TestMigrateEmitsTimedOutAuditAttribute(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+	setupTestTracer(t)
+
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{
+			Type: "postgresql", Host: "h", Port: 15432,
+			Username: "user", Password: "longenough-pw", Database: "db",
+		},
+		App: config.AppConfig{Env: "test"},
+	}
+	sink := newRecordingSink()
+	fm := NewFlywayMigrator(cfg, logger.New("disabled", true)).WithAuditRecorder(sink)
+	t.Cleanup(func() { _ = fm.Close(context.Background()) })
+
+	mcfg := &Config{
+		FlywayPath:    createSlowFlywayStub(t, 5),
+		ConfigPath:    filepath.Join(t.TempDir(), "flyway.conf"),
+		MigrationPath: filepath.Join(t.TempDir(), "migrations"),
+		Timeout:       500 * time.Millisecond,
+		Environment:   cfg.App.Env,
+		Audit:         AuditContext{Principal: "deployer@example.com", Target: "tenant_acme"},
+	}
+	require.NoError(t, os.WriteFile(mcfg.ConfigPath, []byte(""), 0o644))
+	require.NoError(t, os.MkdirAll(mcfg.MigrationPath, 0o755))
+
+	_, err := fm.Migrate(context.Background(), mcfg)
+	require.ErrorIs(t, err, ErrFlywayTimeout)
+
+	sink.waitForFirst(t, 2*time.Second)
+	events := sink.snapshot()
+	require.Len(t, events, 1)
+
+	got := events[0]
+	assert.Equal(t, AuditOutcomeFailed, got.Outcome)
+	assert.Equal(t, "true", got.Attributes["migration.timed_out"],
+		"a killed run must be machine-identifiable as a timeout")
+	// Pins the documented limitation: classifyFlywayError matches on Flyway's
+	// stdout, which a SIGKILLed JVM never writes, so the class is the catch-all.
+	// migration.timed_out is what alerting keys on until an ErrorClassTimeout
+	// lands in the ADR-019 taxonomy.
+	assert.Equal(t, ErrorClassInternal, got.ErrorClass)
+}

--- a/migration/flyway.go
+++ b/migration/flyway.go
@@ -377,9 +377,11 @@ func (fm *FlywayMigrator) runFlywayCommandFor(ctx context.Context, db *config.Da
 	if err != nil && errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
 		// Elapsed, not cfg.Timeout: timeoutCtx inherits an earlier parent deadline
 		// (e.g. a MigrateAll budget), so cfg.Timeout would overstate the wait.
-		err = fmt.Errorf("%w after %s and its process group was killed; schema state is "+
-			"unknown (a partially applied migration is possible): %w",
-			ErrFlywayTimeout, time.Since(startedAt).Round(time.Millisecond), err)
+		// killScopeDesc is build-tagged: the message must not promise a process-group
+		// teardown on Windows, where the JVM child tree survives.
+		err = fmt.Errorf("%w after %s and %s; schema state is unknown "+
+			"(a partially applied migration is possible): %w",
+			ErrFlywayTimeout, time.Since(startedAt).Round(time.Millisecond), killScopeDesc, err)
 	}
 	redacted := redactPassword(string(rawOutput), db)
 	if err != nil {

--- a/migration/flyway.go
+++ b/migration/flyway.go
@@ -47,6 +47,14 @@ const (
 	minRedactablePasswordLength = config.MinDatabasePasswordLength
 	outputSuppressedSentinel    = "[REDACTED -- output suppressed: password too short for safe substring redaction]"
 	redactionPlaceholder        = "[REDACTED]"
+
+	// flywayKillGraceDelay bounds how long Wait blocks on I/O AFTER the process
+	// group has been signaled — a liveness backstop against an orphan still holding
+	// the output pipe, not a migration policy. Deliberately independent of
+	// Config.Timeout: deriving it (e.g. Timeout/10) would shrink the backstop to 3s
+	// under a `--timeout 30s` run and stretch it to 6 minutes under a 1h Oracle
+	// timeout — reintroducing the very hang it exists to bound. Do not couple them.
+	flywayKillGraceDelay = 10 * time.Second
 )
 
 // FlywayMigrator handles database migrations using Flyway
@@ -351,10 +359,11 @@ func (fm *FlywayMigrator) runFlywayCommandFor(ctx context.Context, db *config.Da
 
 	// #nosec G204 -- FlywayPath is validated by validateFlywayPath function
 	cmd := exec.CommandContext(timeoutCtx, cfg.FlywayPath, args...)
-	// WaitDelay bounds how long Wait blocks on I/O after the process is signaled
-	// to stop. Without it, an orphaned JVM holding the output pipe makes
+	// Without WaitDelay, an orphaned JVM holding the output pipe makes
 	// CombinedOutput block indefinitely, turning the timeout into a hang.
-	cmd.WaitDelay = 10 * time.Second
+	cmd.WaitDelay = flywayKillGraceDelay
+	// POSIX only: on Windows the JVM is NOT killed (see proc_windows.go) and
+	// WaitDelay alone bounds the hang.
 	configureProcessGroup(cmd)
 
 	envVars, err := buildEnvironmentVariables(db)
@@ -363,11 +372,14 @@ func (fm *FlywayMigrator) runFlywayCommandFor(ctx context.Context, db *config.Da
 	}
 	cmd.Env = append(os.Environ(), envVars...)
 
+	startedAt := time.Now()
 	rawOutput, err := cmd.CombinedOutput()
 	if err != nil && errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
-		err = fmt.Errorf("flyway timed out after %s and its process group was killed; "+
-			"schema state is unknown (a partially applied migration is possible): %w",
-			cfg.Timeout, err)
+		// Elapsed, not cfg.Timeout: timeoutCtx inherits an earlier parent deadline
+		// (e.g. a MigrateAll budget), so cfg.Timeout would overstate the wait.
+		err = fmt.Errorf("%w after %s and its process group was killed; schema state is "+
+			"unknown (a partially applied migration is possible): %w",
+			ErrFlywayTimeout, time.Since(startedAt).Round(time.Millisecond), err)
 	}
 	redacted := redactPassword(string(rawOutput), db)
 	if err != nil {
@@ -408,6 +420,14 @@ func (fm *FlywayMigrator) emitMigrationApplied(ctx context.Context, db *config.D
 		// fires only for actual applications). The attribute is retained so every emitted
 		// event positively asserts "this was a real application, not a rehearsal".
 		"migration.dry_run": strconv.FormatBool(cfg.DryRun),
+	}
+	if errors.Is(run.Err, ErrFlywayTimeout) {
+		// classifyFlywayError only sees Flyway's stdout, which a SIGKILLed JVM never
+		// writes — so a timeout would otherwise audit as the internal_error catch-all,
+		// indistinguishable from a JVM crash. Attributes is ADR-019's free-form seam,
+		// so alerting can pin "schema state unknown, do not auto-retry" without a
+		// taxonomy change and without string-matching the error text.
+		attrs["migration.timed_out"] = "true"
 	}
 	if run.Result.FlywayVersion != "" {
 		attrs["migration.flyway_version"] = run.Result.FlywayVersion
@@ -461,6 +481,15 @@ var ErrEnvFieldHasControlChar = errors.New("migration: env field contains forbid
 // before running rather than suppressing the output and hiding the outcome.
 // Match with errors.Is. Empty passwords (trust/IAM auth) are exempt.
 var ErrDatabasePasswordTooShort = errors.New("migration: database password too short to safely redact Flyway output")
+
+// ErrFlywayTimeout marks a run the framework killed on its own deadline. The
+// schema state is UNKNOWN: Flyway may have applied part of a migration before
+// the process group died, so this is not a clean failure and an automatic retry
+// can race a partially applied change. Match with errors.Is — the audit
+// ErrorClass cannot carry this (classifyFlywayError matches on Flyway's stdout,
+// which a SIGKILLed JVM never gets to write), so the machine-readable signals
+// are this sentinel and the migration.timed_out audit attribute.
+var ErrFlywayTimeout = errors.New("migration: flyway timed out")
 
 // ensurePasswordRedactable rejects a non-empty database password that is too
 // short to substring-redact from Flyway output. The error never echoes the

--- a/migration/flyway.go
+++ b/migration/flyway.go
@@ -351,6 +351,11 @@ func (fm *FlywayMigrator) runFlywayCommandFor(ctx context.Context, db *config.Da
 
 	// #nosec G204 -- FlywayPath is validated by validateFlywayPath function
 	cmd := exec.CommandContext(timeoutCtx, cfg.FlywayPath, args...)
+	// WaitDelay bounds how long Wait blocks on I/O after the process is signaled
+	// to stop. Without it, an orphaned JVM holding the output pipe makes
+	// CombinedOutput block indefinitely, turning the timeout into a hang.
+	cmd.WaitDelay = 10 * time.Second
+	configureProcessGroup(cmd)
 
 	envVars, err := buildEnvironmentVariables(db)
 	if err != nil {
@@ -359,6 +364,11 @@ func (fm *FlywayMigrator) runFlywayCommandFor(ctx context.Context, db *config.Da
 	cmd.Env = append(os.Environ(), envVars...)
 
 	rawOutput, err := cmd.CombinedOutput()
+	if err != nil && errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
+		err = fmt.Errorf("flyway timed out after %s and its process group was killed; "+
+			"schema state is unknown (a partially applied migration is possible): %w",
+			cfg.Timeout, err)
+	}
 	redacted := redactPassword(string(rawOutput), db)
 	if err != nil {
 		fm.logger.Error().Err(err).Str("output", redacted).Msg("Error executing Flyway command")

--- a/migration/flyway_test.go
+++ b/migration/flyway_test.go
@@ -1375,6 +1375,9 @@ func TestRunFlywayCommandKillsChildProcessGroup(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrFlywayTimeout)
 		assert.Contains(t, err.Error(), "schema state is unknown")
+		// The kill scope is build-tagged: the message must report what this platform
+		// actually terminated, never a hardcoded process-group claim (false on Windows).
+		assert.Contains(t, err.Error(), killScopeDesc)
 	case <-time.After(mcfg.Timeout + flywayKillGraceDelay + 5*time.Second):
 		t.Fatal("Migrate did not return within the guard deadline — process-group kill regressed to a hang")
 	}

--- a/migration/flyway_test.go
+++ b/migration/flyway_test.go
@@ -1315,3 +1315,75 @@ func TestMigrateNoopStillSucceeds(t *testing.T) {
 	assert.True(t, res.Success)
 	assert.Equal(t, "2", res.EndingVersion)
 }
+
+// createOrphanSpawningFlywayStub models the orphaned-JVM shape: the stub
+// spawns a background grandchild that inherits its stdout (the output pipe),
+// sleeps past the caller's timeout, and then writes a marker file. The stub
+// itself also sleeps past the timeout before exiting.
+func createOrphanSpawningFlywayStub(t *testing.T, markerPath string, sleepSeconds int) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "flyway-orphan.sh")
+	content := fmt.Sprintf(`#!/bin/sh
+( sleep %d; touch '%s' ) &
+sleep %d
+exit 0
+`, sleepSeconds, markerPath, sleepSeconds)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+	return path
+}
+
+// TestRunFlywayCommandKillsChildProcessGroup guards against the orphaned-JVM
+// regression: without a process-group kill, a grandchild holding the output
+// pipe either blocks CombinedOutput indefinitely or keeps running (and keeps
+// mutating the schema) after the timeout fires. See createOrphanSpawningFlywayStub.
+func TestRunFlywayCommandKillsChildProcessGroup(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("process-group kill is unix-only")
+	}
+
+	// Must outlast cfg.Timeout below so a working group-kill catches the
+	// grandchild mid-sleep, before it writes its marker.
+	const grandchildSleepSeconds = 1
+	// Mirrors cmd.WaitDelay set in runFlywayCommandFor; used only to size this
+	// test's own hard deadline, not to configure the code under test.
+	const waitDelay = 10 * time.Second
+
+	markerPath := filepath.Join(t.TempDir(), "grandchild-survived.marker")
+	stub := createOrphanSpawningFlywayStub(t, markerPath, grandchildSleepSeconds)
+
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{Type: "postgresql"},
+		App:      config.AppConfig{Env: "test"},
+	}
+	fm := NewFlywayMigrator(cfg, logger.New("disabled", true))
+
+	mcfg := &Config{
+		FlywayPath:    stub,
+		ConfigPath:    filepath.Join(t.TempDir(), "flyway.conf"),
+		MigrationPath: filepath.Join(t.TempDir(), "migrations"),
+		Timeout:       500 * time.Millisecond,
+	}
+	require.NoError(t, os.WriteFile(mcfg.ConfigPath, []byte(""), 0o644))
+	require.NoError(t, os.MkdirAll(mcfg.MigrationPath, 0o755))
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := fm.Migrate(context.Background(), mcfg)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "flyway timed out")
+	case <-time.After(mcfg.Timeout + waitDelay + 5*time.Second):
+		t.Fatal("Migrate did not return within the guard deadline — process-group kill regressed to a hang")
+	}
+
+	// Give the grandchild's own sleep time to elapse in case it survived a
+	// (supposedly) working group kill, then confirm it never wrote its marker.
+	time.Sleep(grandchildSleepSeconds*time.Second + 500*time.Millisecond)
+	_, statErr := os.Stat(markerPath)
+	assert.True(t, os.IsNotExist(statErr), "grandchild marker file exists — orphaned grandchild survived the timeout kill")
+}

--- a/migration/flyway_test.go
+++ b/migration/flyway_test.go
@@ -1345,9 +1345,6 @@ func TestRunFlywayCommandKillsChildProcessGroup(t *testing.T) {
 	// Must outlast cfg.Timeout below so a working group-kill catches the
 	// grandchild mid-sleep, before it writes its marker.
 	const grandchildSleepSeconds = 1
-	// Mirrors cmd.WaitDelay set in runFlywayCommandFor; used only to size this
-	// test's own hard deadline, not to configure the code under test.
-	const waitDelay = 10 * time.Second
 
 	markerPath := filepath.Join(t.TempDir(), "grandchild-survived.marker")
 	stub := createOrphanSpawningFlywayStub(t, markerPath, grandchildSleepSeconds)
@@ -1376,8 +1373,9 @@ func TestRunFlywayCommandKillsChildProcessGroup(t *testing.T) {
 	select {
 	case err := <-done:
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "flyway timed out")
-	case <-time.After(mcfg.Timeout + waitDelay + 5*time.Second):
+		require.ErrorIs(t, err, ErrFlywayTimeout)
+		assert.Contains(t, err.Error(), "schema state is unknown")
+	case <-time.After(mcfg.Timeout + flywayKillGraceDelay + 5*time.Second):
 		t.Fatal("Migrate did not return within the guard deadline — process-group kill regressed to a hang")
 	}
 

--- a/migration/proc_unix.go
+++ b/migration/proc_unix.go
@@ -15,6 +15,14 @@ import (
 func configureProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
+		// SECURITY: kill(2) with a non-positive negated PID is catastrophic — -0
+		// signals the caller's OWN process group (SIGKILLing this very service) and
+		// -1 signals every process we are permitted to signal. os/exec only invokes
+		// Cancel after a successful Start, so Pid is always > 0 today; this guard
+		// makes the blast radius independent of that stdlib invariant.
+		if cmd.Process == nil || cmd.Process.Pid <= 0 {
+			return os.ErrProcessDone
+		}
 		// Kill the whole group: -pgid. An already-empty group (ESRCH) means the
 		// process finished as the deadline fired; os.ErrProcessDone tells Wait to
 		// keep the command's real exit status instead of failing a successful run.

--- a/migration/proc_unix.go
+++ b/migration/proc_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package migration
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// configureProcessGroup makes cmd the leader of a new process group so a timeout
+// can kill the launcher AND the JVM it spawns (negative-PID signal), not just the
+// direct child.
+func configureProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		// Kill the whole group: -pgid. An already-empty group (ESRCH) means the
+		// process finished as the deadline fired; os.ErrProcessDone tells Wait to
+		// keep the command's real exit status instead of failing a successful run.
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return os.ErrProcessDone
+			}
+			return err
+		}
+		return nil
+	}
+}

--- a/migration/proc_unix.go
+++ b/migration/proc_unix.go
@@ -9,6 +9,11 @@ import (
 	"syscall"
 )
 
+// killScopeDesc states what a timeout kill actually terminates on this platform.
+// It is interpolated into the operator-facing timeout error, which must not
+// promise more than the platform delivers.
+const killScopeDesc = "its process group was killed"
+
 // configureProcessGroup makes cmd the leader of a new process group so a timeout
 // can kill the launcher AND the JVM it spawns (negative-PID signal), not just the
 // direct child.

--- a/migration/proc_unix_test.go
+++ b/migration/proc_unix_test.go
@@ -1,0 +1,53 @@
+//go:build !windows
+
+package migration
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigureProcessGroupSetsKillableGroup(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "true")
+	configureProcessGroup(cmd)
+
+	require.NotNil(t, cmd.SysProcAttr)
+	assert.True(t, cmd.SysProcAttr.Setpgid,
+		"Setpgid must be set, else Cancel's -pid signal targets the wrong group")
+	require.NotNil(t, cmd.Cancel)
+}
+
+// TestConfigureProcessGroupCancelRefusesNonPositivePID pins the guard against
+// kill(-0)/kill(-1): -0 would SIGKILL this process's own group, -1 every process
+// we may signal. An unstarted cmd has a nil Process, so Cancel must bail out.
+func TestConfigureProcessGroupCancelRefusesNonPositivePID(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "true") // never started => Process == nil
+	configureProcessGroup(cmd)
+
+	require.ErrorIs(t, cmd.Cancel(), os.ErrProcessDone,
+		"Cancel must not reach syscall.Kill when the PID is unknown")
+}
+
+// TestConfigureProcessGroupCancelKillsGroup exercises the real signal path and
+// the ESRCH mapping: a second Cancel on an already-reaped group must report
+// os.ErrProcessDone, not ESRCH, or exec.Cmd.Wait would discard a clean exit
+// status and turn a successful migration into a reported failure.
+func TestConfigureProcessGroupCancelKillsGroup(t *testing.T) {
+	// Must be CommandContext: exec.Cmd.Start rejects a non-nil Cancel otherwise.
+	cmd := exec.CommandContext(context.Background(), "sleep", "30")
+	configureProcessGroup(cmd)
+	require.NoError(t, cmd.Start())
+
+	pid := cmd.Process.Pid
+	require.NoError(t, cmd.Cancel(), "killing a live process group must succeed")
+
+	_ = cmd.Wait() // reap; the process was SIGKILLed
+	assert.ErrorIs(t, syscall.Kill(-pid, 0), syscall.ESRCH, "process group must be gone")
+	assert.ErrorIs(t, cmd.Cancel(), os.ErrProcessDone, "ESRCH must map to os.ErrProcessDone")
+}

--- a/migration/proc_windows.go
+++ b/migration/proc_windows.go
@@ -4,8 +4,11 @@ package migration
 
 import "os/exec"
 
-// configureProcessGroup is a best-effort no-op on Windows; exec.CommandContext
-// already terminates the direct process on ctx cancel, and WaitDelay bounds the
-// pipe wait. The child TREE is not killed here (a Job Object would be needed) —
-// deferred follow-up, see Maintenance notes.
+// configureProcessGroup is a documented no-op on Windows. exec.CommandContext
+// already terminates the direct process on ctx cancel, and flywayKillGraceDelay
+// bounds the pipe wait — so the timeout is enforceable here, but NOT lethal: the
+// child TREE survives, meaning an orphaned JVM can keep applying the migration
+// after the run is recorded failed. Killing the tree needs a Job Object
+// (CreateJobObject + JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE); until then Windows
+// deployments carry that residual risk.
 func configureProcessGroup(_ *exec.Cmd) {}

--- a/migration/proc_windows.go
+++ b/migration/proc_windows.go
@@ -4,6 +4,11 @@ package migration
 
 import "os/exec"
 
+// killScopeDesc states what a timeout kill actually terminates on this platform.
+// Windows gets no process-group kill, so the operator-facing timeout error must
+// say the JVM may still be alive rather than promise a group teardown.
+const killScopeDesc = "the launcher process was killed, but its JVM child tree may have survived and may still be applying the migration"
+
 // configureProcessGroup is a documented no-op on Windows. exec.CommandContext
 // already terminates the direct process on ctx cancel, and flywayKillGraceDelay
 // bounds the pipe wait — so the timeout is enforceable here, but NOT lethal: the
@@ -11,4 +16,8 @@ import "os/exec"
 // after the run is recorded failed. Killing the tree needs a Job Object
 // (CreateJobObject + JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE); until then Windows
 // deployments carry that residual risk.
-func configureProcessGroup(_ *exec.Cmd) {}
+func configureProcessGroup(_ *exec.Cmd) {
+	// Intentionally empty: Windows has no POSIX process group to configure. The
+	// timeout is carried by exec.CommandContext (direct process) plus
+	// flywayKillGraceDelay (pipe wait); see the doc comment above.
+}

--- a/migration/proc_windows.go
+++ b/migration/proc_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package migration
+
+import "os/exec"
+
+// configureProcessGroup is a best-effort no-op on Windows; exec.CommandContext
+// already terminates the direct process on ctx cancel, and WaitDelay bounds the
+// pipe wait. The child TREE is not killed here (a Job Object would be needed) —
+// deferred follow-up, see Maintenance notes.
+func configureProcessGroup(_ *exec.Cmd) {}


### PR DESCRIPTION
## Problem

The per-tenant Flyway timeout was **unenforceable and non-lethal**.

`runFlywayCommandFor` used `context.WithTimeout` + `exec.CommandContext` + `cmd.CombinedOutput()` with no `WaitDelay`, no `Cancel`, and no process-group setup. `flyway` is a launcher that spawns a JVM, so:

1. **The timeout could become infinite.** On cancel, Go kills only the direct child. The orphaned JVM inherits the output pipe and — with `WaitDelay == 0` — `CombinedOutput` blocks *indefinitely* waiting for EOF. The 5-minute per-tenant timeout silently became unbounded, and a `MigrateAll` fan-out would stall permanently because the semaphore slot was never released.
2. **The orphan kept migrating.** Even when the call returned, the JVM went on applying the migration: the tenant was recorded failed while the schema change landed afterwards, and a pipeline retry could race the still-running first attempt.

## Fix

- `cmd.WaitDelay = flywayKillGraceDelay` (10s) bounds the post-signal pipe wait.
- Build-tagged `configureProcessGroup` puts the subprocess in its own process group (`Setpgid`) and installs a `Cancel` that `SIGKILL`s the whole group (`-pgid`), so the signal reaches the JVM and not just the launcher.
- Timeouts are now machine-identifiable: exported `ErrFlywayTimeout` sentinel (match with `errors.Is`) plus a `migration.timed_out=true` audit attribute.

**Windows is a deliberate half-fix**, stated plainly in `proc_windows.go`: the hang is bounded (`WaitDelay`) but the child *tree* is not killed — that needs a Job Object, and is a tracked follow-up. On POSIX the group kill is both necessary and sufficient.

## Notable findings from the pre-push gates

**A timed-out run was auditing as the `internal_error` catch-all.** `classifyFlywayError(output, err)` accepts the error and then only nil-checks it — every rule matches against Flyway's *stdout*, which a SIGKILLed JVM never gets to write. So an error-string annotation is structurally incapable of reaching the classifier, and every timeout fell through to `internal_error`, indistinguishable from "JVM crashed" or "malformed JSON". Worse, it was non-deterministic: if the JDBC driver managed to print `connection timed out` first, the same timeout classified as `target_unreachable`.

This is fixed **without** a taxonomy change: `AuditEvent.Attributes` is ADR-019's documented free-form extension seam, so `migration.timed_out` gives alerting a stable key to pin *"schema state unknown — do not auto-retry"* today. A dedicated `ErrorClassTimeout` remains a clean additive follow-up. The `internal_error` fallback is now **pinned by a test** rather than left as folklore.

**An unguarded negative-PID kill.** `syscall.Kill(-cmd.Process.Pid, SIGKILL)` is safe only while `Pid > 0`: `kill(-0)` signals the caller's *own* process group — SIGKILLing the very service running the migration — and `kill(-1)` signals every process the user may signal. Not reachable today (`os/exec` only invokes `Cancel` after a successful `Start`), but that safety rested on a stdlib-internal invariant this code did not enforce, and the blast radius is unbounded. Guarded; mutation-verified (removing the guard makes `Cancel` nil-pointer panic).

**`flywayKillGraceDelay` is deliberately independent of `Config.Timeout`.** It is a liveness backstop, not a migration policy. Deriving it (e.g. `Timeout/10`) would shrink the backstop to 3s under a `--timeout 30s` run and stretch it to 6 minutes under a 1h Oracle timeout — reintroducing the very hang it exists to bound. The rationale lives on the const so the planned `--timeout` CLI flag doesn't "helpfully" couple them.

## Testing

- `TestRunFlywayCommandKillsChildProcessGroup` — a stub that spawns a pipe-holding grandchild (the orphan-JVM shape) and asserts the group kill reaches it. Guarded by a hard deadline so a regression fails instead of hanging CI. Passes `-count=5`.
- `proc_unix_test.go` (new 1:1 sibling) — pins that `Setpgid` is actually set (a `Cancel` signalling `-pid` *without* `Setpgid` would target the wrong group), that `Cancel` refuses a non-positive PID, and that `ESRCH` maps to `os.ErrProcessDone` (otherwise `Wait` discards a clean exit status and reports a *successful* migration as failed).
- `TestMigrateEmitsTimedOutAuditAttribute` — asserts the audit attribute *and* pins the documented `internal_error` fallback.
- The pre-existing `timeout_scenario` subtest passes unchanged.

**Mutation-verified**, not just green: removing `configureProcessGroup` fails the orphan test; removing the PID guard panics `Cancel`; removing the audit attribute fails the audit test.

## Known gap

`cmd.WaitDelay` is not pinned by any test. When the group kill works, the grandchild dies and the pipe closes, so `WaitDelay` never engages — it is redundant on POSIX and load-bearing only on Windows, where the test skips. Pinning it needs a non-portable `setsid` stub or an injectable delay; both are scope creep here. Named rather than papered over.

## Gates

`make check` green (fmt + lint + `-race` + alloc guards + govulncheck 0). Pre-push gates run in order per CLAUDE.md: `/simplify` → `/security-audit` (gosec 0, govulncheck 0 affecting, raw-SQL 5/5 annotated, no secrets) → `/code-review` (CodeRabbit CLI: **0 findings** on the final diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Flyway migrations now terminate more reliably on timeout and surface a dedicated timeout error.
  * Timeout failures are wrapped consistently for clearer deadline exceeded behavior.
  * Migration audit events now include a machine-readable `migration.timed_out` indicator when a run is stopped due to timeout.
  * Improved handling prevents lingering processes on supported platforms (with known residual risk on Windows).

* **Tests**
  * Added Unix-only coverage for process-group kill behavior and timeout/audit attributes.
  * Added regression coverage for timeout behavior and orphaned-child scenarios across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->