### PR TITLE
docs(multitenant): correct llms.txt composite resolver example for required order (ADR-039)

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -3447,10 +3447,10 @@ The httpclient JOSE wrapper for outbound calls (sign-then-encrypt the request bo
 
 ## Multi-Tenancy
 - Enable with `multitenant.enabled=true`.
-- Resolution strategies: `header` (default `X-Tenant-ID`), `subdomain` (`<tenant>.<domain>`), `path` (1-indexed segment with optional prefix gate), or `composite` (first-match chain over an explicit `resolver.order` — **required**, no implicit default; recommended `[subdomain, path, header]`, or header-first when a trusted gateway owns `X-Tenant-ID`).
+- Resolution strategies: `header` (default `X-Tenant-ID`), `subdomain` (`<tenant>.<domain>`), `path` (1-indexed segment with optional prefix gate), or `composite` (first-match chain over an explicit `resolver.order` — **required since v0.50.0 (ADR-039)**, no implicit default; recommended `[subdomain, path, header]`, or header-first when a trusted gateway owns `X-Tenant-ID`).
 - Each tenant gets isolated DB connections, messaging clients, and module lifecycle events.
 - Resolution runs as middleware before route matching, so `deps.DB(ctx)` / `deps.Cache(ctx)` etc. resolve to the tenant-specific instance on every request.
-- Resolved tenant IDs are validated against `^[a-z0-9-]{1,64}$` before landing in context. The composite resolver advances to the next sub-resolver on validation failure.
+- Resolved tenant IDs are validated against `^[a-z0-9-]{1,64}$` before landing in context. The composite resolver returns the first non-empty, valid tenant ID, advancing to the next sub-resolver when one yields nothing (empty result or error) or fails validation.
 
 **Header (default for internal APIs):**
 
@@ -3496,7 +3496,7 @@ multitenant:
       prefix: /itsp        # optional gate; only paths under here are eligible
 ```
 
-**Composite (first-match chain; `order` is required — ADR-039):**
+**Composite (first-match chain; `order` required since v0.50.0 — ADR-039):**
 
 ```yaml
 multitenant:

--- a/llms.txt
+++ b/llms.txt
@@ -3447,7 +3447,7 @@ The httpclient JOSE wrapper for outbound calls (sign-then-encrypt the request bo
 
 ## Multi-Tenancy
 - Enable with `multitenant.enabled=true`.
-- Resolution strategies: `header` (default `X-Tenant-ID`), `subdomain` (`<tenant>.<domain>`), `path` (1-indexed segment with optional prefix gate), or `composite` (header → subdomain → path fallback chain).
+- Resolution strategies: `header` (default `X-Tenant-ID`), `subdomain` (`<tenant>.<domain>`), `path` (1-indexed segment with optional prefix gate), or `composite` (first-match chain over an explicit `resolver.order` — **required**, no implicit default; recommended `[subdomain, path, header]`, or header-first when a trusted gateway owns `X-Tenant-ID`).
 - Each tenant gets isolated DB connections, messaging clients, and module lifecycle events.
 - Resolution runs as middleware before route matching, so `deps.DB(ctx)` / `deps.Cache(ctx)` etc. resolve to the tenant-specific instance on every request.
 - Resolved tenant IDs are validated against `^[a-z0-9-]{1,64}$` before landing in context. The composite resolver advances to the next sub-resolver on validation failure.
@@ -3496,13 +3496,14 @@ multitenant:
       prefix: /itsp        # optional gate; only paths under here are eligible
 ```
 
-**Composite (header → subdomain → path fallback chain):**
+**Composite (first-match chain; `order` is required — ADR-039):**
 
 ```yaml
 multitenant:
   enabled: true
   resolver:
     type: composite
+    order: [subdomain, path, header]
     header: X-Tenant-ID
     domain: api.example.com
     path:


### PR DESCRIPTION
## What

Corrects the `llms.txt` multi-tenancy section for the **ADR-039** breaking change
(`fix(multitenant)!:` — #702, shipped in v0.50.0): the `composite` resolver now
**requires** an explicit `resolver.order`, with no implicit default.

Three stale sites are fixed:
- The composite bullet described a fixed "header → subdomain → path fallback chain".
- The section heading repeated that stale order.
- The copy-paste YAML example omitted the now-required `order:` key — so an LLM or
  developer pasting it verbatim shipped a config that **fails validation at startup**
  (`config/validation.go` `validateResolverOrder` returns a fatal `MissingFieldError`).

The example now includes `order: [subdomain, path, header]` and matches
`config.example.yaml` and `wiki/multi_tenant_resolvers.md`.

## Why

`llms.txt` is the framework's LLM copy-paste reference (per CLAUDE.md, "Quick code
examples for LLMs"). This was the one place that hadn't caught up to ADR-039 — and it
crashed at boot when used verbatim.

## Scope

Docs-only, single file (`llms.txt`). No code, no tests, no API surface — CLAUDE.md
doc-only gate exception applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified composite tenant resolution configuration requirements.
  * Documented that failed validation proceeds to the next resolver.
  * Updated examples to show a configurable first-match resolution chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->