### PR TITLE
fix(messaging): mask AMQP URL query string in redacted log output

### DIFF
--- a/messaging/url_redaction.go
+++ b/messaging/url_redaction.go
@@ -74,7 +74,8 @@ func buildRedactedURL(u *url.URL, username string) string {
 
 	if u.RawQuery != "" {
 		// SECURITY: never echo the query verbatim — AMQP URL query params can carry
-		// tokens/secrets (same class as PR #683 on the logger path). Mask in full.
+		// tokens/secrets. Mask the whole query, not per-key (same posture as
+		// httpclient's redactURLForLog and the logger URL masking, #683).
 		result.WriteString("?<redacted>")
 	}
 

--- a/messaging/url_redaction.go
+++ b/messaging/url_redaction.go
@@ -73,8 +73,9 @@ func buildRedactedURL(u *url.URL, username string) string {
 	}
 
 	if u.RawQuery != "" {
-		result.WriteString("?")
-		result.WriteString(u.RawQuery)
+		// SECURITY: never echo the query verbatim — AMQP URL query params can carry
+		// tokens/secrets (same class as PR #683 on the logger path). Mask in full.
+		result.WriteString("?<redacted>")
 	}
 
 	return result.String()

--- a/messaging/url_redaction_test.go
+++ b/messaging/url_redaction_test.go
@@ -50,7 +50,12 @@ func TestRedactAMQPURL(t *testing.T) {
 		{
 			name:     "url_with_query_parameters",
 			input:    "amqp://user:pass@localhost:5672/?heartbeat=30&connection_timeout=10",
-			expected: "amqp://user:****@localhost:5672/?heartbeat=30&connection_timeout=10",
+			expected: "amqp://user:****@localhost:5672/?<redacted>",
+		},
+		{
+			name:     "query_string_is_masked_not_leaked",
+			input:    "amqp://user:secret@host:5672/vhost?token=leakme&heartbeat=60",
+			expected: "amqp://user:****@host:5672/vhost?<redacted>",
 		},
 		{
 			name:     "malformed_url_returns_placeholder",
@@ -129,4 +134,12 @@ func TestRedactAMQPURLPreservesDebuggingInfo(t *testing.T) {
 	// Should mask password
 	assert.Contains(t, result, "****")
 	assert.NotContains(t, result, "secret")
+}
+
+func TestRedactAMQPURLMasksQueryString(t *testing.T) {
+	result := redactAMQPURL("amqp://user:secret@host:5672/vhost?token=leakme&heartbeat=60")
+	assert.NotContains(t, result, "leakme")
+	assert.NotContains(t, result, "token=")
+	assert.NotContains(t, result, "heartbeat")
+	assert.Contains(t, result, "?<redacted>")
 }

--- a/messaging/url_redaction_test.go
+++ b/messaging/url_redaction_test.go
@@ -135,11 +135,3 @@ func TestRedactAMQPURLPreservesDebuggingInfo(t *testing.T) {
 	assert.Contains(t, result, "****")
 	assert.NotContains(t, result, "secret")
 }
-
-func TestRedactAMQPURLMasksQueryString(t *testing.T) {
-	result := redactAMQPURL("amqp://user:secret@host:5672/vhost?token=leakme&heartbeat=60")
-	assert.NotContains(t, result, "leakme")
-	assert.NotContains(t, result, "token=")
-	assert.NotContains(t, result, "heartbeat")
-	assert.Contains(t, result, "?<redacted>")
-}


### PR DESCRIPTION
## What

`redactAMQPURL` masks broker connection strings for safe logging, but
`buildRedactedURL` re-appended the URL **query string verbatim** — the same leak
class PR #683 closed on the logger path. AMQP query params are usually connection
tuning (`heartbeat`, `connection_timeout`), but a redaction helper must not bet on
that: any token or signed-URL parameter a caller puts there was logged in the clear.

The query is now masked as `?<redacted>` (whole-query mask, not per-key
allow-listing), matching httpclient's `redactURLForLog` and the logger #683 posture.
Both broker-URL log sites (`amqp_client.go`, `manager.go`) route through this single
choke point, so the mask applies everywhere.

## Tests

- Updated the `url_with_query_parameters` table case to expect `?<redacted>`.
- Added `query_string_is_masked_not_leaked` (exact-match) asserting the token and
  param names are absent.

## Scope

`messaging/url_redaction.go` + its 1:1 test. No exported-API change.

## Pre-push gates

- `/simplify`: applied — dropped a redundant test that duplicated the table case's
  exact-match, and sharpened the precedent comment (the "strip whole query" policy
  now exists in httpclient too).
- `/security-audit`: clean — no raw-SQL escape hatches, no secrets; gosec +
  govulncheck green.
- `/code-review` (CodeRabbit): **0 findings** on the final diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AMQP URL redaction by masking entire query strings in logs.
  * Sensitive query parameters, including tokens and secrets, are now replaced with `<redacted>`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->