### PR TITLE
fix(app): propagate module Shutdown errors so Run reports an unclean shutdown

### DIFF
--- a/app/module_registry.go
+++ b/app/module_registry.go
@@ -306,7 +306,8 @@ func (r *ModuleRegistry) RegisterJobs() error {
 }
 
 // Shutdown gracefully shuts down all registered modules.
-// It calls each module's Shutdown method and logs any errors.
+// It calls each module's Shutdown method (continuing past failures), logs each
+// error, and returns them joined via errors.Join (nil if all shut down cleanly).
 // Messaging shutdown is handled by the messaging manager.
 func (r *ModuleRegistry) Shutdown() error {
 	var errs []error

--- a/app/module_registry.go
+++ b/app/module_registry.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/gaborage/go-bricks/jose"
@@ -308,6 +309,7 @@ func (r *ModuleRegistry) RegisterJobs() error {
 // It calls each module's Shutdown method and logs any errors.
 // Messaging shutdown is handled by the messaging manager.
 func (r *ModuleRegistry) Shutdown() error {
+	var errs []error
 	for _, module := range r.modules {
 		r.logger.Info().
 			Str("module", module.Name()).
@@ -318,7 +320,8 @@ func (r *ModuleRegistry) Shutdown() error {
 				Err(err).
 				Str("module", module.Name()).
 				Msg("Failed to shutdown module")
+			errs = append(errs, fmt.Errorf("shutdown module %s: %w", module.Name(), err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }

--- a/app/module_test.go
+++ b/app/module_test.go
@@ -320,6 +320,8 @@ func TestModuleRegistryShutdownMixedSuccessAndFailure(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, failErr)
 	assert.Contains(t, err.Error(), "failing-module")
+	// A cleanly-shut-down module must not appear in the joined error.
+	assert.NotContains(t, err.Error(), "ok-module")
 
 	okModule.AssertExpectations(t)
 	failModule.AssertExpectations(t)

--- a/app/module_test.go
+++ b/app/module_test.go
@@ -280,15 +280,49 @@ func TestModuleRegistryShutdownWithErrors(t *testing.T) {
 	require.NoError(t, registry.Register(module2))
 
 	// Setup shutdown expectations - modules fail to shutdown
-	module1.On("Shutdown").Return(errors.New("shutdown failed 1"))
-	module2.On("Shutdown").Return(errors.New("shutdown failed 2"))
+	err1 := errors.New("shutdown failed 1")
+	err2 := errors.New("shutdown failed 2")
+	module1.On("Shutdown").Return(err1)
+	module2.On("Shutdown").Return(err2)
 
-	// Should not return error even if modules fail to shutdown
+	// Both modules still shut down; the joined error surfaces both failures.
 	err := registry.Shutdown()
-	assert.NoError(t, err)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, err1)
+	assert.ErrorIs(t, err, err2)
+	assert.Contains(t, err.Error(), "failing-module1")
+	assert.Contains(t, err.Error(), "failing-module2")
 
 	module1.AssertExpectations(t)
 	module2.AssertExpectations(t)
+}
+
+func TestModuleRegistryShutdownMixedSuccessAndFailure(t *testing.T) {
+	log := logger.New("debug", true)
+	deps := &ModuleDeps{
+		Logger: log,
+		Config: &config.Config{},
+	}
+	registry := NewModuleRegistry(deps)
+
+	okModule := &MockModule{name: "ok-module"}
+	failModule := &MockModule{name: "failing-module"}
+	okModule.On("Init", deps).Return(nil)
+	failModule.On("Init", deps).Return(nil)
+	require.NoError(t, registry.Register(okModule))
+	require.NoError(t, registry.Register(failModule))
+
+	failErr := errors.New("shutdown failed")
+	okModule.On("Shutdown").Return(nil)
+	failModule.On("Shutdown").Return(failErr)
+
+	err := registry.Shutdown()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, failErr)
+	assert.Contains(t, err.Error(), "failing-module")
+
+	okModule.AssertExpectations(t)
+	failModule.AssertExpectations(t)
 }
 
 func TestModuleRegistryShutdownSingleModule(t *testing.T) {


### PR DESCRIPTION
## What

`ModuleRegistry.Shutdown()` logged each module's `Shutdown()` error but then
`return nil` unconditionally — so the "modules" phase of `App.Shutdown()` could
never contribute to its `errors.Join` aggregate. A module that failed to shut down
cleanly (a scheduler that didn't drain in time, an outbox/inbox teardown error) was
logged, but `app.Run()` still returned nil and the process exited 0. A supervisor
keying on the exit code or `Run()`'s error got a false all-clear.

The "HTTP server" shutdown phase already propagates its error into the same
aggregate — this was a hardened-here-not-there asymmetry. The fix accumulates a
`[]error` across the loop (still logging each, still shutting down every module) and
returns `errors.Join(errs...)` (nil when all succeed), so the modules phase now flows
through the existing `shutdownPhase → errs → errors.Join` machinery, matching the
server / observability / closers phases.

## Behavioral change (non-breaking)

`app.Run()` / `app.Shutdown()` now return a non-nil error when a module fails to shut
down cleanly (previously swallowed). The `Shutdown() error` signature is unchanged —
no exported-API break, so **no `!` marker**. Integrators that key off `Run()`'s return
can now alert on an unclean shutdown; those that ignored it are unaffected. Reviewers:
please confirm no consumer relied on the old always-nil behavior.

## Tests

- `TestModuleRegistryShutdownWithErrors` rewritten: asserts the joined error surfaces
  BOTH module failures (`ErrorIs` + name `Contains`) and that every module still shut
  down (`AssertExpectations` — continue-through preserved).
- Added `TestModuleRegistryShutdownMixedSuccessAndFailure`: 1 ok + 1 failing module →
  the error wraps the failure and does **not** contain the ok module's name.
- The three all-succeed shutdown tests pass unchanged (clean shutdown → nil).

## Pre-push gates

- `/simplify`: applied — the `Shutdown()` godoc now documents the aggregate-and-return
  behavior; the mixed test gained a no-leak assertion.
- `/security-audit`: clean — no raw-SQL, no secrets; gosec + govulncheck green.
- `/code-review` (CodeRabbit): **0 findings** on the final diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Module shutdown failures are now reported instead of being silently ignored.
  * Multiple shutdown errors are combined into a single error with module context.
  * Successful shutdowns are excluded from the reported error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->