### PR TITLE
fix(migration): signal schema-state-unknown on parent-cancel kill (not only deadline)

### DIFF
--- a/migration/flyway.go
+++ b/migration/flyway.go
@@ -374,7 +374,8 @@ func (fm *FlywayMigrator) runFlywayCommandFor(ctx context.Context, db *config.Da
 
 	startedAt := time.Now()
 	rawOutput, err := cmd.CombinedOutput()
-	if err != nil && errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
+	switch {
+	case err != nil && errors.Is(timeoutCtx.Err(), context.DeadlineExceeded):
 		// Elapsed, not cfg.Timeout: timeoutCtx inherits an earlier parent deadline
 		// (e.g. a MigrateAll budget), so cfg.Timeout would overstate the wait.
 		// killScopeDesc is build-tagged: the message must not promise a process-group
@@ -382,6 +383,13 @@ func (fm *FlywayMigrator) runFlywayCommandFor(ctx context.Context, db *config.Da
 		err = fmt.Errorf("%w after %s and %s; schema state is unknown "+
 			"(a partially applied migration is possible): %w",
 			ErrFlywayTimeout, time.Since(startedAt).Round(time.Millisecond), killScopeDesc, err)
+	case err != nil && errors.Is(timeoutCtx.Err(), context.Canceled):
+		// Parent-context cancellation (a fail-fast sibling abort in a parallel
+		// MigrateAll, or operator Ctrl-C) kills the subprocess the same way a
+		// deadline does — the schema state is equally unknown.
+		err = fmt.Errorf("%w after %s and %s; schema state is unknown "+
+			"(a partially applied migration is possible): %w",
+			ErrFlywayCanceled, time.Since(startedAt).Round(time.Millisecond), killScopeDesc, err)
 	}
 	redacted := redactPassword(string(rawOutput), db)
 	if err != nil {
@@ -430,6 +438,12 @@ func (fm *FlywayMigrator) emitMigrationApplied(ctx context.Context, db *config.D
 		// so alerting can pin "schema state unknown, do not auto-retry" without a
 		// taxonomy change and without string-matching the error text.
 		attrs["migration.timed_out"] = "true"
+	}
+	if errors.Is(run.Err, ErrFlywayCanceled) {
+		// Same rationale as migration.timed_out above, for the parent-cancel
+		// kill class: alerting can pin "schema state unknown, do not
+		// auto-retry" without asserting a false "this timed out".
+		attrs["migration.canceled"] = "true"
 	}
 	if run.Result.FlywayVersion != "" {
 		attrs["migration.flyway_version"] = run.Result.FlywayVersion
@@ -492,6 +506,12 @@ var ErrDatabasePasswordTooShort = errors.New("migration: database password too s
 // which a SIGKILLed JVM never gets to write), so the machine-readable signals
 // are this sentinel and the migration.timed_out audit attribute.
 var ErrFlywayTimeout = errors.New("migration: flyway timed out")
+
+// ErrFlywayCanceled marks a run the framework killed via parent-context
+// cancellation (a fail-fast sibling abort in a parallel MigrateAll, or operator
+// Ctrl-C) rather than its own deadline. Like a timeout, the SIGKILL can leave the
+// schema partially applied — schema state is unknown; do not auto-retry blindly.
+var ErrFlywayCanceled = errors.New("migration: flyway canceled")
 
 // ensurePasswordRedactable rejects a non-empty database password that is too
 // short to substring-redact from Flyway output. The error never echoes the

--- a/migration/flyway.go
+++ b/migration/flyway.go
@@ -374,22 +374,25 @@ func (fm *FlywayMigrator) runFlywayCommandFor(ctx context.Context, db *config.Da
 
 	startedAt := time.Now()
 	rawOutput, err := cmd.CombinedOutput()
+	// A SIGKILL from the migration's own deadline OR a parent-context cancellation
+	// (a fail-fast sibling abort in a parallel MigrateAll, or operator Ctrl-C) leaves
+	// the schema state equally unknown — classify them distinctly so the audit stream
+	// never records a false "timed out" for a cancel.
+	ctxErr := timeoutCtx.Err()
+	// Elapsed, not cfg.Timeout: timeoutCtx inherits an earlier parent deadline
+	// (e.g. a MigrateAll budget), so cfg.Timeout would overstate the wait.
+	// killScopeDesc is build-tagged: the message must not promise a process-group
+	// teardown on Windows, where the JVM child tree survives.
+	wrapKilled := func(sentinel error) error {
+		return fmt.Errorf("%w after %s and %s; schema state is unknown "+
+			"(a partially applied migration is possible): %w",
+			sentinel, time.Since(startedAt).Round(time.Millisecond), killScopeDesc, err)
+	}
 	switch {
-	case err != nil && errors.Is(timeoutCtx.Err(), context.DeadlineExceeded):
-		// Elapsed, not cfg.Timeout: timeoutCtx inherits an earlier parent deadline
-		// (e.g. a MigrateAll budget), so cfg.Timeout would overstate the wait.
-		// killScopeDesc is build-tagged: the message must not promise a process-group
-		// teardown on Windows, where the JVM child tree survives.
-		err = fmt.Errorf("%w after %s and %s; schema state is unknown "+
-			"(a partially applied migration is possible): %w",
-			ErrFlywayTimeout, time.Since(startedAt).Round(time.Millisecond), killScopeDesc, err)
-	case err != nil && errors.Is(timeoutCtx.Err(), context.Canceled):
-		// Parent-context cancellation (a fail-fast sibling abort in a parallel
-		// MigrateAll, or operator Ctrl-C) kills the subprocess the same way a
-		// deadline does — the schema state is equally unknown.
-		err = fmt.Errorf("%w after %s and %s; schema state is unknown "+
-			"(a partially applied migration is possible): %w",
-			ErrFlywayCanceled, time.Since(startedAt).Round(time.Millisecond), killScopeDesc, err)
+	case err != nil && errors.Is(ctxErr, context.DeadlineExceeded):
+		err = wrapKilled(ErrFlywayTimeout)
+	case err != nil && errors.Is(ctxErr, context.Canceled):
+		err = wrapKilled(ErrFlywayCanceled)
 	}
 	redacted := redactPassword(string(rawOutput), db)
 	if err != nil {

--- a/migration/flyway_test.go
+++ b/migration/flyway_test.go
@@ -517,6 +517,22 @@ exit 0
 	return path
 }
 
+// createReadySignalingFlywayStub writes a stub that touches readyMarker the moment
+// it starts, then sleeps delaySeconds. Tests wait for that marker before acting so a
+// cancel/kill deterministically lands on an in-flight subprocess, not on test setup.
+func createReadySignalingFlywayStub(t *testing.T, readyMarker string, delaySeconds int) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "flyway-ready.sh")
+	content := fmt.Sprintf(`#!/bin/sh
+touch %q
+sleep %d
+exit 0
+`, readyMarker, delaySeconds)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+	return path
+}
+
 func TestRunFlywayCommandErrorHandling(t *testing.T) {
 	if runtime.GOOS == windowsOS {
 		t.Skip("shell script stub not supported on windows CI")
@@ -1402,7 +1418,8 @@ func TestRunFlywayCommandParentCancelSignalsUnknownState(t *testing.T) {
 		t.Skip("shell script stub not supported on windows CI")
 	}
 
-	stub := createSlowFlywayStub(t, 5) // 5 second delay, well past the parent cancel below
+	readyMarker := filepath.Join(t.TempDir(), "flyway-started.marker")
+	stub := createReadySignalingFlywayStub(t, readyMarker, 5) // sleeps 5s; signals readiness first
 	cfg := &config.Config{
 		Database: config.DatabaseConfig{Type: "postgresql"},
 		App:      config.AppConfig{Env: "test"},
@@ -1423,13 +1440,20 @@ func TestRunFlywayCommandParentCancelSignalsUnknownState(t *testing.T) {
 	require.NoError(t, os.MkdirAll(mcfg.MigrationPath, 0o755))
 
 	ctx, cancel := context.WithCancel(context.Background())
-	time.AfterFunc(300*time.Millisecond, cancel)
-
 	done := make(chan error, 1)
 	go func() {
 		_, err := fm.Migrate(ctx, mcfg)
 		done <- err
 	}()
+
+	// Cancel only once the Flyway subprocess is actually running (it touches
+	// readyMarker on start), so the cancel deterministically kills an in-flight
+	// process rather than racing test setup — no fixed sleep, no flake under load.
+	require.Eventually(t, func() bool {
+		_, statErr := os.Stat(readyMarker)
+		return statErr == nil
+	}, 5*time.Second, 10*time.Millisecond, "Flyway stub never signaled readiness")
+	cancel()
 
 	select {
 	case err := <-done:
@@ -1440,7 +1464,7 @@ func TestRunFlywayCommandParentCancelSignalsUnknownState(t *testing.T) {
 		// The kill scope is build-tagged: the message must report what this platform
 		// actually terminated, never a hardcoded process-group claim (false on Windows).
 		assert.Contains(t, err.Error(), killScopeDesc)
-	case <-time.After(300*time.Millisecond + flywayKillGraceDelay + 5*time.Second):
+	case <-time.After(flywayKillGraceDelay + 5*time.Second):
 		t.Fatal("Migrate did not return within the guard deadline — cancel-kill classification regressed to a hang")
 	}
 

--- a/migration/flyway_test.go
+++ b/migration/flyway_test.go
@@ -1388,3 +1388,70 @@ func TestRunFlywayCommandKillsChildProcessGroup(t *testing.T) {
 	_, statErr := os.Stat(markerPath)
 	assert.True(t, os.IsNotExist(statErr), "grandchild marker file exists — orphaned grandchild survived the timeout kill")
 }
+
+// TestRunFlywayCommandParentCancelSignalsUnknownState guards the cancel-kill
+// class: a fail-fast sibling abort in a parallel MigrateAll (or an operator
+// Ctrl-C) kills the subprocess via parent-context cancellation, not the
+// migration's own deadline. The SIGKILL leaves the schema state equally
+// unknown as a timeout does, so the cancel path must classify distinctly
+// (ErrFlywayCanceled) rather than collapsing into the generic
+// "flyway command failed" catch-all — and it must NOT also match
+// ErrFlywayTimeout, since nothing timed out.
+func TestRunFlywayCommandParentCancelSignalsUnknownState(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+
+	stub := createSlowFlywayStub(t, 5) // 5 second delay, well past the parent cancel below
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{Type: "postgresql"},
+		App:      config.AppConfig{Env: "test"},
+	}
+	sink := newRecordingSink()
+	fm := NewFlywayMigrator(cfg, logger.New("disabled", true)).WithAuditRecorder(sink)
+	t.Cleanup(func() { _ = fm.Close(context.Background()) })
+
+	mcfg := &Config{
+		FlywayPath:    stub,
+		ConfigPath:    filepath.Join(t.TempDir(), "flyway.conf"),
+		MigrationPath: filepath.Join(t.TempDir(), "migrations"),
+		Timeout:       10 * time.Second, // must not fire before the parent cancel below
+		Environment:   cfg.App.Env,
+		Audit:         AuditContext{Principal: "deployer@example.com", Target: "tenant_acme"},
+	}
+	require.NoError(t, os.WriteFile(mcfg.ConfigPath, []byte(""), 0o644))
+	require.NoError(t, os.MkdirAll(mcfg.MigrationPath, 0o755))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(300*time.Millisecond, cancel)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := fm.Migrate(ctx, mcfg)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrFlywayCanceled)
+		assert.NotErrorIs(t, err, ErrFlywayTimeout, "a parent-cancel kill must not also classify as a timeout")
+		assert.Contains(t, err.Error(), "schema state is unknown")
+		// The kill scope is build-tagged: the message must report what this platform
+		// actually terminated, never a hardcoded process-group claim (false on Windows).
+		assert.Contains(t, err.Error(), killScopeDesc)
+	case <-time.After(300*time.Millisecond + flywayKillGraceDelay + 5*time.Second):
+		t.Fatal("Migrate did not return within the guard deadline — cancel-kill classification regressed to a hang")
+	}
+
+	sink.waitForFirst(t, 2*time.Second)
+	events := sink.snapshot()
+	require.Len(t, events, 1)
+
+	got := events[0]
+	assert.Equal(t, AuditOutcomeFailed, got.Outcome)
+	assert.Equal(t, "true", got.Attributes["migration.canceled"],
+		"a parent-canceled run must be machine-identifiable as canceled")
+	_, hasTimedOut := got.Attributes["migration.timed_out"]
+	assert.False(t, hasTimedOut, "a cancel-kill must not also assert migration.timed_out")
+}


### PR DESCRIPTION
## What

When Flyway is killed by a **parent-context cancellation** — a fail-fast sibling
abort in a parallel `MigrateAll`, or an operator Ctrl-C — the subprocess is
SIGKILLed exactly as a deadline kill does, leaving the schema in an unknown,
possibly partially-applied state. The old code only wrapped `ErrFlywayTimeout` for
`context.DeadlineExceeded`; a `context.Canceled` fell through to the generic "flyway
command failed", so the audit stream lost the "schema state unknown, do not
auto-retry" signal for that kill class (it audited as `internal_error`).

This adds a distinct `ErrFlywayCanceled` sentinel + `migration.canceled` audit
attribute (mirroring `ErrFlywayTimeout` / `migration.timed_out`). Reusing the timeout
sentinel would be dishonest — a Ctrl-C is not a timeout, and the remediation differs
(timeout → raise `cfg.Timeout`; cancel → investigate the sibling failure /
interruption). Both share the "do not auto-retry, schema unknown" floor.

## Why distinct, not reused

`context.Context.Err()` returns exactly `DeadlineExceeded` or `Canceled` for a
non-nil result — two kill classes with different operator meaning.
`emitMigrationApplied` handles both symmetrically; a test asserts they never overlap
in either direction.

## Tests

- `TestRunFlywayCommandParentCancelSignalsUnknownState`: cancels the parent ctx once
  the Flyway stub signals it is running (readiness marker, no fixed sleep), asserts
  the error `ErrorIs(ErrFlywayCanceled)` AND `NotErrorIs(ErrFlywayTimeout)`, carries
  the "schema state is unknown" text and the build-tagged `killScopeDesc`, and that
  the audit event sets `migration.canceled=true` with `migration.timed_out` absent.

## API

Adds an exported `ErrFlywayCanceled` var — apidiff-**compatible** (addition), no `!`.

## Pre-push gates

- `/simplify`: applied — extracted a `wrapKilled(sentinel)` closure so the two kill
  cases don't duplicate the wrap format+args.
- `/security-audit`: clean (no SQL/secrets/new exec surface; gosec + govulncheck green).
- `/code-review` (CodeRabbit): found 1 minor (a fixed-sleep flake risk in the cancel
  test) → fixed with the suggested readiness-marker synchronization; the local
  re-confirm was rate-limited (free-OSS quota), so the cloud PR review is the final
  verdict here.

## Out of scope (noted for a future backlog item)

`multi_tenant.go`'s `MigrateAll` return can surface a raw `context.Canceled`
(unwrapped by either sentinel) when the outer ctx is canceled with no worker error
recorded — pre-existing, distinct from this per-run classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration error reporting by distinguishing canceled operations from timed-out operations.
  * Canceled migrations now clearly indicate that the database schema state may be unknown.
  * Audit records now identify migrations canceled during execution, without incorrectly marking them as timed out.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->