### PR TITLE
fix(ci): apidiff gate fails only on the break a PR introduces (delta vs origin/main)

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -875,16 +875,21 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   # ============================================================================
-  # Exported-API compatibility gate (apidiff vs latest release tag)
+  # Exported-API compatibility gate (apidiff — delta over origin/main)
   # ----------------------------------------------------------------------------
   # Diffs the PR head's exported API surface (root module only — internal/ is
   # auto-ignored by apidiff and GOWORK=off excludes the separately-versioned
-  # tools/migration submodule) against the latest release tag. FAILS on an
-  # INCOMPATIBLE change UNLESS the squash PR title carries a conventional-commit
-  # '!' marker (feat!:/fix(scope)!: …) or the PR has the 'breaking-approved'
-  # label. This catches ACCIDENTAL breaks that would otherwise ship as a
-  # patch/minor — release-please derives the bump from the squash PR title, so
-  # the same '!' that bypasses the gate also drives the version bump (no drift).
+  # tools/migration submodule) against the latest release tag, then SUBTRACTS
+  # the incompatible changes origin/main already carries. The gate fails only on
+  # the DELTA — breaks THIS PR introduces — not acknowledged-but-unreleased
+  # breaks already merged to main (those would otherwise false-fail every later
+  # PR until the next release). FAILS on a NEW INCOMPATIBLE change UNLESS the
+  # squash PR title carries a conventional-commit '!' marker (feat!:/fix(scope)!:
+  # …) or the PR has the 'breaking-approved' label. This catches ACCIDENTAL
+  # breaks that would otherwise ship as a patch/minor — release-please derives
+  # the bump from the squash PR title, so the same '!' that bypasses the gate
+  # also drives the version bump (no drift). The tag stays the baseline so the
+  # cumulative report still measures drift since the last GA release.
   #
   # Runs on pull_request ONLY: the escape hatch reads the PR title, which exists
   # only in PR context. On push to main (post-merge) the break is already
@@ -953,6 +958,20 @@ jobs:
           ( cd /tmp/apidiff-base \
             && GOWORK=off apidiff -m -w /tmp/apidiff-base.snapshot github.com/gaborage/go-bricks )
 
+      - name: Build origin/main API snapshot (unreleased baseline)
+        if: steps.baseline.outputs.skip != 'true'
+        env:
+          GOWORK: "off"
+        run: |
+          set -euo pipefail
+          # Defensive pre-clean, matching the base-snapshot step.
+          git worktree remove --force /tmp/apidiff-main 2>/dev/null || true
+          rm -rf /tmp/apidiff-main
+          git fetch --quiet origin main
+          git worktree add --detach /tmp/apidiff-main origin/main
+          ( cd /tmp/apidiff-main \
+            && GOWORK=off apidiff -m -w /tmp/apidiff-main.snapshot github.com/gaborage/go-bricks )
+
       - name: Build PR-head API snapshot
         if: steps.baseline.outputs.skip != 'true'
         env:
@@ -974,25 +993,40 @@ jobs:
           # apidiff writes the change list to STDOUT and "Ignoring internal
           # package …" notices to STDERR, so stdout alone is the signal. It
           # exits 0 whether or not changes exist, and non-zero ONLY on a real
-          # tool/build error. NO `|| true` on the load-bearing capture below:
+          # tool/build error. NO `|| true` on the load-bearing captures below:
           # under `set -e` a tool failure aborts the step, so the gate fails
           # CLOSED instead of silently reporting "no breaks".
           echo "::group::Full apidiff report (base=$BASE_TAG vs PR head)"
           GOWORK=off apidiff -m /tmp/apidiff-base.snapshot /tmp/apidiff-head.snapshot || true
           echo "::endgroup::"
 
-          # The gate keys ONLY on incompatible changes. Compatible/additive
-          # changes (new funcs, new packages, added struct fields) never fail.
-          incompat="$(GOWORK=off apidiff -incompatible -m \
+          # Incompatible changes the PR head has vs the release tag, and the set
+          # origin/main already has vs the same tag. NO `|| true`: under `set -e`
+          # a tool error aborts the step, so the gate fails CLOSED.
+          incompat_head="$(GOWORK=off apidiff -incompatible -m \
             /tmp/apidiff-base.snapshot /tmp/apidiff-head.snapshot)"
+          incompat_main="$(GOWORK=off apidiff -incompatible -m \
+            /tmp/apidiff-base.snapshot /tmp/apidiff-main.snapshot)"
 
-          if [ -z "$incompat" ]; then
-            echo "✅ No incompatible exported-API changes vs $BASE_TAG."
+          # Delta = breaks THIS PR introduces = lines in head-set NOT in main-set.
+          # `comm -23` requires sorted, de-duplicated, blank-free inputs; the
+          # `grep -v '^[[:space:]]*$'` drops blank lines so an empty apidiff
+          # capture cannot inject a spurious empty-line "difference". Bash process
+          # substitution `<()` — the ubuntu-latest runner's default shell is bash;
+          # a process substitution's own exit status is not propagated to `comm`,
+          # so `grep` returning 1 on all-blank input never fails the step.
+          delta="$(comm -23 \
+            <(printf '%s\n' "$incompat_head" | grep -v '^[[:space:]]*$' | sort -u) \
+            <(printf '%s\n' "$incompat_main" | grep -v '^[[:space:]]*$' | sort -u))"
+
+          if [ -z "$delta" ]; then
+            echo "✅ No NEW incompatible exported-API changes vs origin/main (delta over already-merged breaks)."
+            echo "   (Any breaks vs $BASE_TAG are already acknowledged on main and pending release.)"
             exit 0
           fi
 
-          echo "::warning::Incompatible exported-API changes detected vs $BASE_TAG:"
-          printf '%s\n' "$incompat"
+          echo "::warning::NEW incompatible exported-API changes introduced by this PR vs origin/main (delta over already-merged breaks):"
+          printf '%s\n' "$delta"
 
           # ---- Escape hatch (only evaluated when a break exists) ----
           # 1) Conventional-commit '!' marker anchored at the ':' position.
@@ -1008,15 +1042,17 @@ jobs:
             exit 0
           fi
 
-          echo "::error::Incompatible exported-API change shipped without acknowledgement."
+          echo "::error::Incompatible exported-API change shipped without acknowledgement (delta vs origin/main, over already-merged breaks)."
           echo "Retitle the squash PR with a '!' breaking marker (e.g. 'feat!: …' /"
           echo "'fix(scope)!: …') so release-please bumps correctly, or add the"
           echo "'breaking-approved' label if the break is intentional and reviewed."
           exit 1
 
-      - name: Clean up baseline worktree
+      - name: Clean up API-snapshot worktrees
         if: always() && steps.baseline.outputs.skip != 'true'
-        run: git worktree remove --force /tmp/apidiff-base || true
+        run: |
+          git worktree remove --force /tmp/apidiff-base || true
+          git worktree remove --force /tmp/apidiff-main || true
 
   # ============================================================================
   # CI gate (fan-in aggregator — the single required status check on main)


### PR DESCRIPTION
## What & why

The `apidiff` CI gate compares the PR head's exported API against the **latest GA release tag** and fails on any *incompatible* change unless the squash PR title carries a `!` marker or the PR has the `breaking-approved` label. That tag baseline is wrong the moment `main` carries an **acknowledged-but-unreleased** break: the break reappears in every later PR's `apidiff(tag → head)` output, so unrelated PRs — even ones that change zero exported API — false-fail the gate.

**Concrete failure (first hit on PR #704):** PR #702 added `Order []string` to `config.ResolverConfig`, making the struct non-comparable — a real, intentional break, acknowledged with `fix(multitenant)!:` and merged to `main` but not yet released. Every subsequent PR then had to either carry a **false** `!` title (which would mis-drive release-please's version bump) or take the `breaking-approved` label (whose meaning — "acknowledged intentional breaking API change" — misrepresents a PR that breaks nothing).

## The fix

Fail only on the **delta**: incompatible changes in `tag → head` that are **not already** present in `tag → main`. That set is exactly the breaks *this PR* introduces.

- A third snapshot of `origin/main` is built alongside the existing tag-baseline and PR-head snapshots.
- The gate computes `delta = incompatible(tag→head) \ incompatible(tag→main)` via `comm -23` on sorted, blank-stripped line sets.
- The tag baseline **stays** (so release-please's version bump remains correct); we only subtract what `main` already carries.

## Properties preserved

- **Can only remove false failures.** A break this PR introduces is, by construction, absent from `origin/main`, so it always survives the delta and still fails the gate.
- **Fail-closed discipline intact.** No `|| true` on either `-incompatible` capture — a tool/build error still aborts the step.
- **Both escape hatches unchanged** (`!` marker + `breaking-approved` label); they now gate the delta instead of the raw tag→head set.
- **Injection-safe** — PR title/labels are still read as `env:` data, never inlined into the script body.
- When `main == baseline tag` (no unreleased breaks), the delta collapses to the legacy tag-only behavior — no regression for the common case.

## Verification

- YAML parses clean; isolated 5-case delta-algebra simulation passes (both-have→empty, new-break→survives, subset→empty, empty-main→legacy, both-empty→empty).
- End-to-end behavior is exercised in CI on this PR (needs the `pull_request` event, tags, and built module snapshots — not reproducible locally).

This PR changes **zero exported API** — `fix(ci)`, no `!` marker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API compatibility checks to identify only breaking changes newly introduced by a pull request.
  * Prevented compatibility checks from silently passing when analysis tools encounter errors.
  * Improved cleanup of temporary compatibility-check resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->