### PR TITLE
dx(make): gate golangci-lint cache clean behind LINT_CLEAN=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,10 @@ coverage-report: ## Generate HTML coverage report from coverage.out
 docker-check: ## Check if Docker is available
 	@docker info >/dev/null 2>&1 || (echo "Error: Docker is not running. Integration tests require Docker Desktop or Docker daemon." && echo "Install Docker: https://www.docker.com/products/docker-desktop" && exit 1)
 
-lint: ## Run golangci-lint (pinned v2.12.2 + GOWORK=off, mirroring CI lint-framework's mechanism)
-	GOWORK=off go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) cache clean
+lint: ## Run golangci-lint (pinned + GOWORK=off, mirroring CI; LINT_CLEAN=1 wipes the result cache first)
+	@if [ "$(LINT_CLEAN)" = "1" ]; then \
+		GOWORK=off go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) cache clean; \
+	fi
 	GOWORK=off go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run --timeout=5m
 
 fmt: ## Format Go code

--- a/wiki/troubleshooting.md
+++ b/wiki/troubleshooting.md
@@ -13,9 +13,8 @@ docker info
 # Race condition failures
 go test -race -run TestSpecificFailing ./package
 
-# Linting errors
-golangci-lint cache clean
-golangci-lint run
+# Linting errors (force a cold run if results look stale)
+LINT_CLEAN=1 make lint
 ```
 
 ### Faster local Oracle integration runs (`GO_BRICKS_ORACLE_CONTAINER`)


### PR DESCRIPTION
## What

Make `make lint`'s `golangci-lint cache clean` **opt-in** behind `LINT_CLEAN=1` instead of running it unconditionally on every invocation.

```make
lint: ## Run golangci-lint (pinned + GOWORK=off, mirroring CI; LINT_CLEAN=1 wipes the result cache first)
	@if [ "$(LINT_CLEAN)" = "1" ]; then \
		GOWORK=off go run .../golangci-lint@$(GOLANGCI_LINT_VERSION) cache clean; \
	fi
	GOWORK=off go run .../golangci-lint@$(GOLANGCI_LINT_VERSION) run --timeout=5m
```

## Why

`make check` (which calls `lint`) is the mandated pre-commit gate — the command developers run most. But it wiped the incremental result cache before **every** run, so each local `make check` re-lints the full ~54K-LOC repo even for a one-line diff. CI does **not** pay this cost (its `golangci-lint-action` persists the cache), which contradicts the target's own help text ("mirroring CI lint-framework's mechanism"). Gating the wipe restores incremental lint speed locally while keeping the cold-run remedy one env var away.

**Safety:** golangci-lint's result cache is keyed by file content, config, and linter version, so removing the forced clear cannot hide a real finding on changed code — changed code produces a different cache key and is re-linted regardless. The unconditional clean was belt-and-braces carried into #596; no rationale for it exists in that PR's description or the file's git history (re-verified during this change).

## Changes

- `Makefile` — `lint` target: wrap `cache clean` in a `LINT_CLEAN=1` gate (tabs preserved; only the clean line's conditionality changes — the version pin and `GOWORK=off go run` style from #596 are untouched).
- `wiki/troubleshooting.md` — the "Linting errors" remedy now points at `LINT_CLEAN=1 make lint` for a forced cold run.

CI lint jobs (`.github/workflows/ci-v2.yml`) are deliberately **not** touched — they already cache correctly. The speedup is local-only.

## Verification

- `make check` → exit 0 (fmt + lint + race tests + alloc guards + govulncheck: "No vulnerabilities found").
- `make lint` → exit 0, does **not** clean the cache.
- `LINT_CLEAN=1 make lint` → exit 0, cleans the cache first (verified by cache-dir mtime/entry-count change and gate-logic proof).
- `tools/migration/Makefile` has no `cache clean` — no change needed there.

## Reviewer note

Because the whole `@if … fi` block is one backslash-continued logical recipe line prefixed by a single `@`, GNU Make silences the entire block — so even when `LINT_CLEAN=1` runs the clean, there's no `cache clean` echo on stdout. That's expected; the gate was verified functionally (cache-dir mtime before/after + `make -n` dry-run), not by the echo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Linting now preserves its cache by default, with optional cache cleaning via `LINT_CLEAN=1`.
* **Documentation**
  * Updated troubleshooting guidance to use `LINT_CLEAN=1 make lint` for clean lint runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->