### PR TITLE
docs(multitenant): document required resolver.order for composite (ADR-039)

### DIFF
--- a/MULTI_TENANT.md
+++ b/MULTI_TENANT.md
@@ -24,6 +24,7 @@ multitenant:
     header: "X-Tenant-ID"   # header name for tenant resolution
     domain: "api.example.com" # root domain for subdomain resolution
     proxies: true           # trust X-Forwarded-Host headers
+    # order: [subdomain, path, header]  # resolver.order REQUIRED for type: composite — no default; startup fails without it (ADR-039)
   limits:
     tenants: 100           # maximum number of tenants
   tenants:
@@ -67,7 +68,7 @@ The framework provides multiple built-in tenant resolution strategies:
 - **HeaderResolver**: Extracts tenant ID from HTTP headers (e.g., `X-Tenant-ID`)
 - **SubdomainResolver**: Derives tenant ID from request host subdomains with proxy support
 - **PathResolver**: Extracts tenant ID from a 1-indexed URL path segment, with an optional prefix gate (e.g. `/itsp/{tenantID}/...`)
-- **CompositeResolver**: Tries multiple resolvers sequentially until one succeeds, with optional regex validation
+- **CompositeResolver**: Tries multiple resolvers sequentially until one succeeds, with optional regex validation. `resolver.order` is **required** — there is no default chain, and a composite resolver without it fails at startup (ADR-039; see [wiki/multi_tenant_resolvers.md](wiki/multi_tenant_resolvers.md)).
 - **ValidatingResolver**: Wraps any resolver with tenant ID format validation using regex patterns
 
 All resolvers support context propagation and integrate seamlessly with the middleware layer.


### PR DESCRIPTION
## What

`MULTI_TENANT.md` now documents that `multitenant.resolver.order` is **required** for `type: composite`:

- The `config.yaml` example gains a commented `order:` line mirroring `config.example.yaml`.
- The `CompositeResolver` strategy bullet now states there is no default chain and that a composite resolver without `order` fails fast at startup.

## Why

[ADR-039](wiki/adr_039_composite_resolver_order.md) (Accepted 2026-07-14, PR #702) made `resolver.order` required for composite resolution — a composite resolver without it now fails at startup with a config-validation error. PR #705 propagated that requirement to `CLAUDE.md`, `config.example.yaml`, `wiki/multi_tenant_resolvers.md`, and `llms.txt`, but **missed this file**.

`MULTI_TENANT.md` is the README-linked multi-tenant deep dive and it actively suggests switching to `composite`. A developer following that suggestion currently gets a startup crash with zero explanation in the doc they were reading. This closes that gap.

## Scope

Doc-only — one file, 2 lines added / 1 changed. No code or behavior change. A broader drift pass over the rest of `MULTI_TENANT.md` (e.g. its older `TenantStore` prose) is deliberately out of scope — that's `/doc-drift` territory.

## Verification

- `grep -c "resolver.order" MULTI_TENANT.md` → 2
- `grep -c "ADR-039" MULTI_TENANT.md` → 2
- `make check` → green (fmt / lint / test / alloc-guard / govulncheck all unaffected by a markdown change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `resolver.order` is required when configuring a composite resolver.
  * Documented that omitting this setting causes startup to fail, with a reference to ADR-039.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->