### PR TITLE
fix(migration): pass -schemas/-defaultSchema when the target DatabaseConfig carries a PostgreSQL schema

### DIFF
--- a/migration/flyway.go
+++ b/migration/flyway.go
@@ -26,6 +26,8 @@ const (
 	flagConfigFiles    = "-configFiles="
 	flagLocationsFS    = "-locations=filesystem:"
 	flagOutputTypeJSON = "-outputType=json"
+	flagSchemas        = "-schemas="
+	flagDefaultSchema  = "-defaultSchema="
 
 	flywayExecutable  = "flyway"
 	flywayCmdMigrate  = "migrate"
@@ -291,6 +293,12 @@ func (fm *FlywayMigrator) runFor(ctx context.Context, db *config.DatabaseConfig,
 	}
 
 	vendor := dbVendor(db, fm.config.Database.Type)
+
+	schemaFlags, err := schemaArgs(db, vendor)
+	if err != nil {
+		return Result{}, err
+	}
+
 	fm.logger.Info().
 		Str("vendor", vendor).
 		Str("action", verb).
@@ -304,6 +312,7 @@ func (fm *FlywayMigrator) runFor(ctx context.Context, db *config.DatabaseConfig,
 		flagConfigFiles + cfg.ConfigPath,
 		flagLocationsFS + cfg.MigrationPath,
 	}
+	args = append(args, schemaFlags...)
 	if isMigrate {
 		args = append(args, flagOutputTypeJSON)
 	}
@@ -484,6 +493,27 @@ func dbVendor(db *config.DatabaseConfig, fallback string) string {
 		return db.Type
 	}
 	return fallback
+}
+
+// schemaArgs returns the explicit Flyway schema-targeting flags for the
+// supplied database, or nil when no schema is configured. Only PostgreSQL
+// participates: Oracle's schema is the connecting user, which is already
+// per-tenant. The schema name must pass the same conservative identifier
+// check as role provisioning (safePGIdentifier) — it is formatted into
+// subprocess argv, and -schemas is comma-separated, so an unvalidated value
+// could smuggle a second schema.
+func schemaArgs(db *config.DatabaseConfig, vendor string) ([]string, error) {
+	if db == nil || vendor != config.PostgreSQL {
+		return nil, nil
+	}
+	schema := db.PostgreSQL.Schema
+	if schema == "" {
+		return nil, nil
+	}
+	if !safePGIdentifier.MatchString(schema) {
+		return nil, fmt.Errorf("%w: database.postgresql.schema=%q", ErrInvalidPGIdentifier, schema)
+	}
+	return []string{flagSchemas + schema, flagDefaultSchema + schema}, nil
 }
 
 // ErrEnvFieldHasControlChar is returned when a DatabaseConfig field destined

--- a/migration/flyway_integration_test.go
+++ b/migration/flyway_integration_test.go
@@ -3,6 +3,7 @@
 package migration
 
 import (
+	"database/sql"
 	"os"
 	"testing"
 
@@ -83,4 +84,46 @@ func TestFlywayMigrateChecksumMismatchFailsFast(t *testing.T) {
 	// pending migrations.
 	entries := env.schemaHistoryEntries(t, env.defaultDB)
 	assert.Len(t, entries, 1, "checksum failure must not produce a new flyway_schema_history row")
+}
+
+// TestMigrateForTargetsSchemaDespiteConfPin proves the CLI-passed -schemas /
+// -defaultSchema flags override a shared conf that pins flyway.schemas=public,
+// so a per-tenant schema on the DatabaseConfig wins and nothing lands in public.
+func TestMigrateForTargetsSchemaDespiteConfPin(t *testing.T) {
+	env := newIntegrationEnv(t)
+	env.writeMigration(t, 1, "create_widgets", "CREATE TABLE widgets (id INT);")
+
+	// Pin the WRONG schema in the conf — CLI args must win over it.
+	confBytes, err := os.ReadFile(env.configPath)
+	require.NoError(t, err)
+	confBytes = append(confBytes, []byte("flyway.schemas=public\nflyway.defaultSchema=public\n")...)
+	require.NoError(t, os.WriteFile(env.configPath, confBytes, 0o600))
+
+	dbCfg := env.dbConfigFor(env.defaultDB)
+	dbCfg.PostgreSQL.Schema = "tenant_a"
+
+	admin := env.adminDB(t)
+	ctx, cancel := testCtx(t)
+	defer cancel()
+	_, err = admin.ExecContext(ctx, "CREATE SCHEMA tenant_a")
+	require.NoError(t, err, "pre-create target schema")
+
+	_, err = env.migrator().MigrateFor(ctx, dbCfg, env.flywayConfig(t))
+	require.NoError(t, err)
+
+	regclass := func(qualified string) bool {
+		qctx, qcancel := testCtx(t)
+		defer qcancel()
+		var rel sql.NullString
+		require.NoError(t, admin.QueryRowContext(qctx, "SELECT to_regclass($1)", qualified).Scan(&rel))
+		return rel.Valid
+	}
+
+	assert.True(t, regclass("tenant_a.widgets"), "migration must land in the targeted schema")
+	assert.True(t, regclass("tenant_a.flyway_schema_history"),
+		"schema history must live in the targeted schema, not public")
+	assert.False(t, regclass("public.widgets"),
+		"conf's flyway.schemas=public must be overridden — nothing may land in public")
+	assert.False(t, regclass("public.flyway_schema_history"),
+		"schema history must not appear in public")
 }

--- a/migration/flyway_test.go
+++ b/migration/flyway_test.go
@@ -1479,3 +1479,67 @@ func TestRunFlywayCommandParentCancelSignalsUnknownState(t *testing.T) {
 	_, hasTimedOut := got.Attributes["migration.timed_out"]
 	assert.False(t, hasTimedOut, "a cancel-kill must not also assert migration.timed_out")
 }
+
+func TestMigrateForPassesSchemaFlags(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+	// A per-tenant DatabaseConfig carrying postgresql.schema must target that
+	// schema explicitly so schema-per-tenant topologies don't collapse into one.
+	stub, capturePath := createCommandCapturingStub(t, minimalMigrateSuccessJSON)
+	fm, mcfg := newMigrateFixture(t, stub, "longenough-pw")
+	tenantDB := &config.DatabaseConfig{
+		Type:       "postgresql",
+		Password:   "longenough-pw",
+		PostgreSQL: config.PostgreSQLConfig{Schema: "tenant_a"},
+	}
+	_, err := fm.MigrateFor(context.Background(), tenantDB, mcfg)
+	require.NoError(t, err)
+
+	captured, readErr := os.ReadFile(capturePath)
+	require.NoError(t, readErr)
+	args := string(captured)
+	assert.Contains(t, args, "-schemas=tenant_a", "a configured schema must be passed to Flyway")
+	assert.Contains(t, args, "-defaultSchema=tenant_a", "-defaultSchema pins where flyway_schema_history lives")
+}
+
+func TestMigrateOmitsSchemaFlagsWhenUnset(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+	// Regression: an empty schema keeps legacy behavior — the conf / search_path
+	// decides — so no schema flags are appended.
+	stub, capturePath := createCommandCapturingStub(t, minimalMigrateSuccessJSON)
+	fm, mcfg := newMigrateFixture(t, stub, "longenough-pw")
+	tenantDB := &config.DatabaseConfig{Type: "postgresql", Password: "longenough-pw"}
+	_, err := fm.MigrateFor(context.Background(), tenantDB, mcfg)
+	require.NoError(t, err)
+
+	captured, readErr := os.ReadFile(capturePath)
+	require.NoError(t, readErr)
+	args := string(captured)
+	assert.NotContains(t, args, "-schemas", "no schema configured must not emit -schemas")
+	assert.NotContains(t, args, "-defaultSchema", "no schema configured must not emit -defaultSchema")
+}
+
+func TestMigrateForRejectsInvalidSchemaName(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+	// A schema name that could smuggle a second comma-separated schema into the
+	// -schemas argv is rejected before Flyway runs, so the stub never executes.
+	stub, capturePath := createCommandCapturingStub(t, minimalMigrateSuccessJSON)
+	fm, mcfg := newMigrateFixture(t, stub, "longenough-pw")
+	tenantDB := &config.DatabaseConfig{
+		Type:       "postgresql",
+		Password:   "longenough-pw",
+		PostgreSQL: config.PostgreSQLConfig{Schema: "a,b"},
+	}
+	_, err := fm.MigrateFor(context.Background(), tenantDB, mcfg)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidPGIdentifier)
+
+	_, statErr := os.Stat(capturePath)
+	assert.True(t, os.IsNotExist(statErr),
+		"schema rejected up front — the Flyway stub must never have executed")
+}

--- a/migration/flyway_test.go
+++ b/migration/flyway_test.go
@@ -1493,7 +1493,7 @@ func TestMigrateForPassesSchemaFlags(t *testing.T) {
 		Password:   "longenough-pw",
 		PostgreSQL: config.PostgreSQLConfig{Schema: "tenant_a"},
 	}
-	_, err := fm.MigrateFor(context.Background(), tenantDB, mcfg)
+	_, err := fm.MigrateFor(t.Context(), tenantDB, mcfg)
 	require.NoError(t, err)
 
 	captured, readErr := os.ReadFile(capturePath)
@@ -1512,7 +1512,7 @@ func TestMigrateOmitsSchemaFlagsWhenUnset(t *testing.T) {
 	stub, capturePath := createCommandCapturingStub(t, minimalMigrateSuccessJSON)
 	fm, mcfg := newMigrateFixture(t, stub, "longenough-pw")
 	tenantDB := &config.DatabaseConfig{Type: "postgresql", Password: "longenough-pw"}
-	_, err := fm.MigrateFor(context.Background(), tenantDB, mcfg)
+	_, err := fm.MigrateFor(t.Context(), tenantDB, mcfg)
 	require.NoError(t, err)
 
 	captured, readErr := os.ReadFile(capturePath)
@@ -1535,7 +1535,7 @@ func TestMigrateForRejectsInvalidSchemaName(t *testing.T) {
 		Password:   "longenough-pw",
 		PostgreSQL: config.PostgreSQLConfig{Schema: "a,b"},
 	}
-	_, err := fm.MigrateFor(context.Background(), tenantDB, mcfg)
+	_, err := fm.MigrateFor(t.Context(), tenantDB, mcfg)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrInvalidPGIdentifier)
 

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -34,7 +34,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E49  | v0.45.0 → v0.49.0 | silent-config | 6 | none | multi-tenant outbox timeout guards / stale `messaging.*` + `database.manager.*` values / reconnect delay keys go live / mode-aware cache pool / unit-less duration guard |
 | E50  | v0.49.0 → v0.50.0 | config-break | 4 | none | Flyway migrate surfaces unparseable/failure output as an error; non-empty DB passwords < 8 bytes rejected at config validation + migrate; dev CORS wildcard opt-in; `multitenant.resolver.order` now REQUIRED for `type: composite` (no default — composite deployments fail to start until they declare one) |
 | E51  | v0.50.0 → v0.51.0 | silent-behavior (adopt-only) | 3 | none | none |
-| E52  | v0.51.0 → v0.52.0 | compile-break | 2 | C52.1 | if you set `.Args` on any declaration in ≤v0.51.0, verify current broker state before upgrading |
+| E52  | v0.51.0 → v0.52.0 | compile-break | 3 | C52.1 | if you set `.Args` on any declaration in ≤v0.51.0, verify current broker state before upgrading |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 - **`when: match`** → act only if `detect` returns ≥1 line (an API/arity/interface change, or a config key you set).
@@ -663,6 +663,14 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - apply: before upgrading, verify the broker's current arguments match what your `Args` maps now declare — queues/exchanges via the management UI or `rabbitmqctl list_queues name arguments` / `rabbitmqctl list_exchanges name arguments`, bindings via `rabbitmqctl list_bindings source_name destination_name routing_key arguments`; reconcile queues/exchanges by updating your `Args` to match the broker or deleting/recreating the broker object (data-loss risk on delete — plan accordingly for durable queues with messages in flight); for bindings, delete the stale argless binding (unbind requires the SAME args the binding was created with) so only the args-bearing one remains.
 - verify: `make run` (or equivalent staging deploy) against the real broker — startup succeeds with no `406 PRECONDITION_FAILED`; for a queue carrying `x-dead-letter-exchange`, provision the complete dead-letter route first (DLX exchange + DLQ queue + binding), then confirm a nacked-without-requeue message is parked in the DLQ instead of dropped; for bindings that carry args, `rabbitmqctl list_bindings` shows exactly one binding per intended route (no stale argless duplicate)
 - ref: ADR-040 · `messaging/amqp_client.go` (`toTable`) · `messaging/registry.go` (`DeclareInfrastructure`)
+
+### [C52.3] `database.postgresql.schema` now targets migrations · silent-config · when: match
+
+- detect: your config sets `database.postgresql.schema` (YAML `postgresql: { schema: ... }`, env `DATABASE_POSTGRESQL_SCHEMA`, or a tenant secret's `"postgresql": {"schema": ...}`)
+- gate: none — the key previously fed only observability namespaces; it now also appends `-schemas=<schema> -defaultSchema=<schema>` to every Flyway invocation
+- apply: if you set the key expecting schema-targeted migrations, nothing to do — it now works. If you set it for observability labeling while migrations deliberately land in `public`, unset it (or move the label elsewhere) before upgrading
+- verify: run `migrate info` against a staging target and confirm `flyway_schema_history` resolves in the intended schema
+- ref: #716
 
 ---
 

--- a/wiki/multi_tenant_migration.md
+++ b/wiki/multi_tenant_migration.md
@@ -136,6 +136,44 @@ Minimum IAM for the runner role:
 }
 ```
 
+## Schema targeting (PostgreSQL)
+
+When the target `DatabaseConfig` carries a non-empty `postgresql.schema`, the
+runner passes `-schemas=<schema> -defaultSchema=<schema>` to every Flyway
+invocation (migrate, info, validate). Flyway CLI args override any
+`flyway.schemas` in a shared conf file, so one conf cannot misroute a tenant —
+the schema on the tenant's `DatabaseConfig` always wins, and
+`flyway_schema_history` is created inside that same target schema. This is what
+makes schema-per-tenant topologies safe: without it, every tenant's tables land
+wherever the connection's `search_path` resolves (typically `public`) and report
+success regardless.
+
+The per-tenant secret already carries the canonical `DatabaseConfig` shape, so
+targeting a schema is the whole wiring — add a `postgresql` block to the secret:
+
+```json
+{
+  "type":     "postgresql",
+  "host":     "tenant-a.db.example.com",
+  "port":     5432,
+  "database": "tenant_a",
+  "username": "tenant_a_app",
+  "password": "...",
+  "postgresql": { "schema": "tenant_a" }
+}
+```
+
+An empty schema keeps legacy behavior unchanged — the conf file or the
+connection's `search_path` decides where migrations land. Note this koanf key
+(`database.postgresql.schema`) now has two consumers: the observability
+namespace and this migration-targeting path.
+
+Schema names must match `^[A-Za-z_][A-Za-z0-9_]{0,62}$`; an invalid name fails
+fast with `ErrInvalidPGIdentifier` before Flyway runs (the value is formatted
+into subprocess argv, and `-schemas` is comma-separated, so an unvalidated name
+could smuggle a second schema). Oracle is not applicable — its schema is the
+connecting user, which is already per-tenant.
+
 ## Installing the CLI
 
 ```bash


### PR DESCRIPTION
## What

`FlywayMigrator.MigrateFor` now passes `-schemas=<schema> -defaultSchema=<schema>` to Flyway whenever the target `DatabaseConfig` carries a non-empty `postgresql.schema`. Since CLI args override conf files, this makes the migration target deterministic regardless of what a shared `flyway.conf` pins.

## Why (closes #716)

Per-tenant migrations had **no schema-targeting mechanism end to end**. `MigrateFor` never told Flyway which schema to migrate into — so tenant migrations landed wherever the connection's `search_path` resolved (typically `public`), or wherever a shared conf pinned `flyway.schemas` — and reported SUCCESS either way. In a schema-per-tenant topology this silently collapses every tenant's tables into one schema. The `database.postgresql.schema` koanf key already existed but only fed observability namespaces; the migration path dropped it.

## How

- New `schemaArgs(db, vendor)` helper (PostgreSQL-only — Oracle's schema is the connecting user) validates the name with the existing `safePGIdentifier` (`^[A-Za-z_][A-Za-z0-9_]{0,62}$`) and returns the two flags, or `ErrInvalidPGIdentifier`.
- Wired into `runFor` **before** the "Starting Flyway command" log, so a rejected schema returns early with **no** subprocess spawn and **no** `migration.applied` audit event (mirrors the sibling `ensurePasswordRedactable` guard).
- Flags apply to `migrate`/`info`/`validate` alike (info/validate must inspect the same schema they'd migrate).

## Security

The schema is formatted into subprocess argv and `-schemas` is comma-separated, so an unvalidated value could smuggle a second schema. `safePGIdentifier` blocks commas, a leading `-` (flag injection), and any metacharacter; the value is passed as a separate `exec.Cmd` arg (no shell). `TestMigrateForRejectsInvalidSchemaName` proves `"a,b"` is rejected **and** the subprocess never runs.

## Tests

- Unit: flags present (`-schemas=tenant_a` + `-defaultSchema=tenant_a`); flags absent when unset (regression); invalid-name rejection with the stub never executed.
- Integration (`TestMigrateForTargetsSchemaDespiteConfPin`): pins `flyway.schemas=public` in the conf, sets `tenant_a` on the config, then proves via `to_regclass` that widgets + `flyway_schema_history` land in `tenant_a` and **nothing** in `public`. Ran for real locally (Flyway + Docker).
- Mutation check performed (revert → the two positive tests + integration fail; restore → green).

## Docs

- `wiki/multi_tenant_migration.md` — "Schema targeting (PostgreSQL)" section (mechanism, per-tenant-secret wiring, the two-consumer note, identifier rule).
- `wiki/migrations.md` — atom `[C52.3] … silent-config · when: match` + E52 summary count bump.

## Pre-push gates

`/simplify` (applied one cleanup: integration-test `regclass` helper returns `bool` instead of `*string`) → `/security-audit` (0 findings; gosec clean) → CodeRabbit (this review). `make check` green throughout.

Classified `fix(migration):` without `!` — no API change; the behavior change is confined to configs that set a previously-inert key, covered by the C52.3 migrations atom.

Closes #716


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - PostgreSQL migrations can now target a tenant-specific schema.
  - Migration history is stored within the selected schema.
  - Empty schema settings preserve existing migration behavior.

- **Bug Fixes**
  - Invalid PostgreSQL schema names are rejected before migrations run.
  - Tenant schema settings now take precedence over conflicting Flyway configuration.

- **Documentation**
  - Added guidance for schema targeting, validation, and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->