### PR TITLE
fix(server): log tenant/IP-preguard rejections so denied requests are auditable

### DIFF
--- a/server/ip_preguard.go
+++ b/server/ip_preguard.go
@@ -1,11 +1,15 @@
 package server
 
 import (
+	"fmt"
+	"log"
 	"net/http"
 	"time"
 
 	"github.com/labstack/echo/v5"
 	"github.com/labstack/echo/v5/middleware"
+
+	"github.com/gaborage/go-bricks/logger"
 )
 
 const (
@@ -20,15 +24,20 @@ const (
 //
 // The returned MiddlewareFunc is the framework-neutral (echo-free) form; the
 // echo-native logic lives in ipPreGuardEcho, which SetupMiddlewares wires directly
-// on the default request path (ADR-026, no per-request baton).
+// on the default request path (ADR-026, no per-request baton). Constructed here
+// with a nil logger — see ipPreGuardEcho for the framework-logger form.
 func IPPreGuard(threshold int) MiddlewareFunc {
-	return fromEchoMiddleware(ipPreGuardEcho(threshold))
+	return fromEchoMiddleware(ipPreGuardEcho(threshold, nil))
 }
 
 // ipPreGuardEcho is the echo-native IP pre-guard middleware constructor. Public
-// callers use IPPreGuard (echo-free); SetupMiddlewares uses this form to keep the
-// default chain baton-free.
-func ipPreGuardEcho(threshold int) echo.MiddlewareFunc {
+// callers use IPPreGuard (echo-free, nil logger); SetupMiddlewares passes its
+// framework logger so rejected (429) requests leave a structured WARN trail —
+// this middleware is registered outer to the access logger (server/middleware.go),
+// so a short-circuited request never reaches it and would otherwise leave zero
+// server-side trail when observability is disabled. l may be nil, in which case
+// the warning falls back to the stdlib log package (mirrors corsWarnf).
+func ipPreGuardEcho(threshold int, l logger.Logger) echo.MiddlewareFunc {
 	if threshold <= 0 {
 		return func(next echo.HandlerFunc) echo.HandlerFunc {
 			return next
@@ -49,6 +58,7 @@ func ipPreGuardEcho(threshold int) echo.MiddlewareFunc {
 			return ctx.RealIP(), nil
 		},
 		ErrorHandler: func(context *echo.Context, _ error) error {
+			logIPPreGuardRejection(l, context)
 			return context.JSON(http.StatusTooManyRequests, map[string]any{
 				fieldError: map[string]any{
 					fieldMessage:   "IP rate limit exceeded",
@@ -58,6 +68,7 @@ func ipPreGuardEcho(threshold int) echo.MiddlewareFunc {
 			})
 		},
 		DenyHandler: func(context *echo.Context, _ string, _ error) error {
+			logIPPreGuardRejection(l, context)
 			return context.JSON(http.StatusTooManyRequests, map[string]any{
 				fieldError: map[string]any{
 					fieldMessage:   "Too many requests from this IP",
@@ -69,4 +80,22 @@ func ipPreGuardEcho(threshold int) echo.MiddlewareFunc {
 	}
 
 	return middleware.RateLimiterWithConfig(config)
+}
+
+// logIPPreGuardRejection emits one WARN per request rejected by the IP
+// pre-guard (429). This middleware is registered outer to the access logger
+// and never calls next() on reject, so without this the request leaves no
+// server-side trail when observability is disabled. With a framework logger
+// it routes through structured WARN-level logging (SensitiveDataFilter,
+// dual-mode routing); with nil (public IPPreGuard construction) it falls
+// back to the stdlib log package, mirroring corsWarnf in cors.go.
+func logIPPreGuardRejection(l logger.Logger, c *echo.Context) {
+	req := c.Request()
+	msg := fmt.Sprintf("[server.ip_preguard] request rejected by IP pre-guard method=%s path=%s client=%s status=%d",
+		req.Method, req.URL.Path, c.RealIP(), http.StatusTooManyRequests)
+	if l == nil {
+		log.Printf("WARN %s", msg)
+		return
+	}
+	l.Warn().Msg(msg)
 }

--- a/server/ip_preguard_test.go
+++ b/server/ip_preguard_test.go
@@ -73,7 +73,7 @@ func TestIPPreGuard(t *testing.T) {
 			t.Parallel()
 			// Create fresh Echo instance for each test to avoid interference
 			e := echo.New()
-			e.Use(ipPreGuardEcho(tt.requestsPerSec))
+			e.Use(ipPreGuardEcho(tt.requestsPerSec, nil))
 
 			e.GET("/test", func(c *echo.Context) error {
 				return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
@@ -111,7 +111,7 @@ func TestIPPreGuard(t *testing.T) {
 
 func TestIPPreGuardDifferentIPs(t *testing.T) {
 	e := echo.New()
-	e.Use(ipPreGuardEcho(2)) // Very low limit to trigger easily
+	e.Use(ipPreGuardEcho(2, nil)) // Very low limit to trigger easily
 
 	e.GET("/test", func(c *echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
@@ -151,7 +151,7 @@ func TestIPPreGuardDifferentIPs(t *testing.T) {
 
 func TestIPPreGuardErrorResponse(t *testing.T) {
 	e := echo.New()
-	e.Use(ipPreGuardEcho(1)) // Very restrictive limit
+	e.Use(ipPreGuardEcho(1, nil)) // Very restrictive limit
 
 	e.GET("/test", func(c *echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
@@ -201,7 +201,7 @@ func TestIPPreGuardIntegrationWithOtherMiddleware(t *testing.T) {
 			return next(c)
 		}
 	})
-	e.Use(ipPreGuardEcho(3))
+	e.Use(ipPreGuardEcho(3, nil))
 
 	e.GET("/test", func(c *echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
@@ -233,4 +233,73 @@ func TestIPPreGuardIntegrationWithOtherMiddleware(t *testing.T) {
 	}
 
 	t.Fatal("Expected to receive a rate limited response")
+}
+
+// TestIPPreGuardLogsRejection verifies a 429 rejection emits one WARN through
+// the provided framework logger, carrying the path and status. This is the
+// audit trail for the observability-off blind spot: ipPreGuardEcho is
+// registered outer to the access logger (server/middleware.go) and never
+// calls next() on reject, so without this WARN the request leaves zero
+// server-side trail. capturingLogger is defined in cors_test.go.
+func TestIPPreGuardLogsRejection(t *testing.T) {
+	capturer := &capturingLogger{}
+	e := echo.New()
+	e.Use(ipPreGuardEcho(1, capturer)) // threshold 1: burst of 2 allowed, then rejected
+
+	e.GET("/test", func(c *echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+	})
+
+	ip := "10.0.0.200"
+	rejected := false
+	for range 5 {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", http.NoBody)
+		req.Header.Set(HeaderXRealIP, ip)
+		req.RemoteAddr = ip + portSuffix
+		rec := httptest.NewRecorder()
+
+		e.ServeHTTP(rec, req)
+
+		if rec.Code == http.StatusTooManyRequests {
+			rejected = true
+			break
+		}
+	}
+	require.True(t, rejected, "expected a 429 rejection to trip the WARN log")
+
+	captured := strings.Join(capturer.warns, "\n")
+	assert.Contains(t, captured, "path=/test")
+	assert.Contains(t, captured, "status=429")
+}
+
+// TestIPPreGuardNilLoggerDoesNotPanic verifies the nil-logger path (public
+// IPPreGuard construction, which threads nil through to ipPreGuardEcho) still
+// rejects with 429 and does not panic — guards against a future refactor
+// reintroducing an unconditional l.Warn() call.
+func TestIPPreGuardNilLoggerDoesNotPanic(t *testing.T) {
+	e := echo.New()
+	e.Use(ipPreGuardEcho(1, nil))
+
+	e.GET("/test", func(c *echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+	})
+
+	ip := "10.0.0.201"
+	rejected := false
+	assert.NotPanics(t, func() {
+		for range 5 {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", http.NoBody)
+			req.Header.Set(HeaderXRealIP, ip)
+			req.RemoteAddr = ip + portSuffix
+			rec := httptest.NewRecorder()
+
+			e.ServeHTTP(rec, req)
+
+			if rec.Code == http.StatusTooManyRequests {
+				rejected = true
+				break
+			}
+		}
+	})
+	assert.True(t, rejected, "expected a 429 rejection even with a nil logger")
 }

--- a/server/ip_preguard_test.go
+++ b/server/ip_preguard_test.go
@@ -267,8 +267,11 @@ func TestIPPreGuardLogsRejection(t *testing.T) {
 	}
 	require.True(t, rejected, "expected a 429 rejection to trip the WARN log")
 
+	require.Len(t, capturer.warns, 1, "exactly one WARN per rejected request")
 	captured := strings.Join(capturer.warns, "\n")
+	assert.Contains(t, captured, "method=GET")
 	assert.Contains(t, captured, "path=/test")
+	assert.Contains(t, captured, "client=10.0.0.200")
 	assert.Contains(t, captured, "status=429")
 }
 

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -95,7 +95,7 @@ func SetupMiddlewares(e *echo.Echo, log logger.Logger, cfg *config.Config, obser
 
 	// IP pre-guard rate limiting (runs before tenant resolution for attack prevention)
 	if cfg.App.Rate.IPPreGuard.Enabled {
-		e.Use(ipPreGuardEcho(cfg.App.Rate.IPPreGuard.Threshold))
+		e.Use(ipPreGuardEcho(cfg.App.Rate.IPPreGuard.Threshold, log))
 	}
 
 	// Multi-tenant tenant resolver middleware (if enabled)
@@ -104,7 +104,7 @@ func SetupMiddlewares(e *echo.Echo, log logger.Logger, cfg *config.Config, obser
 		if resolver != nil {
 			// Use skipper-aware middleware to bypass tenant resolution for health probes
 			skipper := CreateProbeSkipper(healthPath, readyPath)
-			e.Use(tenantMiddlewareEcho(resolver, skipper))
+			e.Use(tenantMiddlewareEcho(resolver, skipper, log))
 		} else {
 			log.Warn().Msg("Tenant resolver could not be constructed; skipping tenant middleware")
 		}

--- a/server/tenant_middleware.go
+++ b/server/tenant_middleware.go
@@ -1,10 +1,13 @@
 package server
 
 import (
+	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/labstack/echo/v5"
 
+	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/multitenant"
 )
 
@@ -20,14 +23,21 @@ type SkipperFunc func(r *http.Request) bool
 // The returned MiddlewareFunc is the framework-neutral (echo-free) form; the
 // echo-native logic lives in tenantMiddlewareEcho, which SetupMiddlewares wires
 // directly on the default request path (ADR-026, no per-request baton).
+// Constructed here with a nil logger — see tenantMiddlewareEcho for the
+// framework-logger form.
 func TenantMiddleware(resolver multitenant.TenantResolver, skipper SkipperFunc) MiddlewareFunc {
-	return fromEchoMiddleware(tenantMiddlewareEcho(resolver, skipper))
+	return fromEchoMiddleware(tenantMiddlewareEcho(resolver, skipper, nil))
 }
 
 // tenantMiddlewareEcho is the echo-native tenant-resolution middleware constructor.
-// Public callers use TenantMiddleware (echo-free); SetupMiddlewares uses this form to
-// keep the default chain baton-free. The SkipperFunc is invoked with c.Request().
-func tenantMiddlewareEcho(resolver multitenant.TenantResolver, skipper SkipperFunc) echo.MiddlewareFunc {
+// Public callers use TenantMiddleware (echo-free, nil logger); SetupMiddlewares
+// passes its framework logger so rejected (400) requests leave a structured WARN
+// trail — this middleware is registered outer to the access logger
+// (server/middleware.go), so a short-circuited request never reaches it and would
+// otherwise leave zero server-side trail when observability is disabled. The
+// SkipperFunc is invoked with c.Request(). l may be nil, in which case the
+// warning falls back to the stdlib log package (mirrors corsWarnf).
+func tenantMiddlewareEcho(resolver multitenant.TenantResolver, skipper SkipperFunc, l logger.Logger) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
 			// Skip tenant resolution for specified routes
@@ -41,6 +51,7 @@ func tenantMiddlewareEcho(resolver multitenant.TenantResolver, skipper SkipperFu
 
 			tenantID, err := resolver.ResolveTenant(c.Request().Context(), c.Request())
 			if err != nil || tenantID == "" {
+				logTenantRejection(l, c, err)
 				return NewBadRequestError("Invalid tenant")
 			}
 
@@ -49,6 +60,31 @@ func tenantMiddlewareEcho(resolver multitenant.TenantResolver, skipper SkipperFu
 			return next(c)
 		}
 	}
+}
+
+// logTenantRejection emits one WARN per request rejected by tenant resolution
+// (400). This middleware is registered outer to the access logger and never
+// calls next() on reject, so without this the request leaves no server-side
+// trail when observability is disabled. The resolved tenant is never logged
+// here — there is none on this path; only the failure reason (empty tenant vs
+// resolver error) is included, never the resolver error's message (which may
+// carry caller-controlled request data). With a framework logger it routes
+// through structured WARN-level logging (SensitiveDataFilter, dual-mode
+// routing); with nil (public TenantMiddleware construction) it falls back to
+// the stdlib log package, mirroring corsWarnf in cors.go.
+func logTenantRejection(l logger.Logger, c *echo.Context, resolveErr error) {
+	reason := "empty tenant"
+	if resolveErr != nil {
+		reason = "resolver error"
+	}
+	req := c.Request()
+	msg := fmt.Sprintf("[server.tenant] request rejected: invalid tenant method=%s path=%s client=%s status=%d reason=%q",
+		req.Method, req.URL.Path, c.RealIP(), http.StatusBadRequest, reason)
+	if l == nil {
+		log.Printf("WARN %s", msg)
+		return
+	}
+	l.Warn().Msg(msg)
 }
 
 // CreateProbeSkipper creates a skipper function for health probe endpoints.

--- a/server/tenant_middleware_test.go
+++ b/server/tenant_middleware_test.go
@@ -51,9 +51,10 @@ func TestTenantMiddlewareLogsRejection(t *testing.T) {
 	tests := []struct {
 		name     string
 		resolver multitenant.TenantResolver
+		reason   string
 	}{
-		{name: "empty_tenant", resolver: &fixedTenantResolver{tenantID: "", err: nil}},
-		{name: "resolver_error", resolver: &fixedTenantResolver{tenantID: "tenant-canary", err: errors.New("boom")}},
+		{name: "empty_tenant", resolver: &fixedTenantResolver{tenantID: "", err: nil}, reason: `reason="empty tenant"`},
+		{name: "resolver_error", resolver: &fixedTenantResolver{tenantID: "tenant-canary", err: errors.New("boom")}, reason: `reason="resolver error"`},
 	}
 
 	for _, tc := range tests {
@@ -77,6 +78,7 @@ func TestTenantMiddlewareLogsRejection(t *testing.T) {
 			assert.Contains(t, captured, "path=/tenant-check")
 			assert.Contains(t, captured, "client=192.0.2.1")
 			assert.Contains(t, captured, "status=400")
+			assert.Contains(t, captured, tc.reason, "each resolver outcome logs its fixed reason")
 			assert.NotContains(t, captured, "tenant=", "no resolved tenant field on the reject path")
 			assert.NotContains(t, captured, "tenant-canary", "a resolver-provided tenant must never be logged on reject")
 		})

--- a/server/tenant_middleware_test.go
+++ b/server/tenant_middleware_test.go
@@ -53,7 +53,7 @@ func TestTenantMiddlewareLogsRejection(t *testing.T) {
 		resolver multitenant.TenantResolver
 	}{
 		{name: "empty_tenant", resolver: &fixedTenantResolver{tenantID: "", err: nil}},
-		{name: "resolver_error", resolver: &fixedTenantResolver{tenantID: "", err: errors.New("boom")}},
+		{name: "resolver_error", resolver: &fixedTenantResolver{tenantID: "tenant-canary", err: errors.New("boom")}},
 	}
 
 	for _, tc := range tests {
@@ -71,10 +71,14 @@ func TestTenantMiddlewareLogsRejection(t *testing.T) {
 
 			require.Equal(t, http.StatusBadRequest, rec.Code)
 
+			require.Len(t, capturer.warns, 1, "exactly one WARN per rejected request")
 			captured := strings.Join(capturer.warns, "\n")
+			assert.Contains(t, captured, "method=GET")
 			assert.Contains(t, captured, "path=/tenant-check")
+			assert.Contains(t, captured, "client=192.0.2.1")
 			assert.Contains(t, captured, "status=400")
-			assert.NotContains(t, captured, "tenant=", "no resolved tenant exists on the reject path")
+			assert.NotContains(t, captured, "tenant=", "no resolved tenant field on the reject path")
+			assert.NotContains(t, captured, "tenant-canary", "a resolver-provided tenant must never be logged on reject")
 		})
 	}
 }

--- a/server/tenant_middleware_test.go
+++ b/server/tenant_middleware_test.go
@@ -1,0 +1,101 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaborage/go-bricks/config"
+	"github.com/gaborage/go-bricks/multitenant"
+)
+
+// newTenantTestEcho builds an *echo.Echo wired with customErrorHandler so an
+// IAPIError returned by tenantMiddlewareEcho (e.g. *BadRequestError) renders
+// its real HTTP status instead of Echo's default 500 for non-*echo.HTTPError
+// errors. Mirrors the pattern in errors_test.go.
+func newTenantTestEcho() *echo.Echo {
+	e := echo.New()
+	cfg := &config.Config{App: config.AppConfig{Env: config.EnvDevelopment}}
+	e.HTTPErrorHandler = func(c *echo.Context, err error) {
+		customErrorHandler(c, err, cfg, &testLogger{})
+	}
+	return e
+}
+
+// fixedTenantResolver is a minimal multitenant.TenantResolver test double that
+// always returns the configured (tenantID, err) pair, regardless of the request.
+type fixedTenantResolver struct {
+	tenantID string
+	err      error
+}
+
+func (r *fixedTenantResolver) ResolveTenant(_ context.Context, _ *http.Request) (string, error) {
+	return r.tenantID, r.err
+}
+
+// TestTenantMiddlewareLogsRejection verifies a 400 tenant-resolution rejection
+// emits one WARN through the provided framework logger, carrying the path and
+// status. This is the audit trail for the observability-off blind spot:
+// tenantMiddlewareEcho is registered outer to the access logger
+// (server/middleware.go) and never calls next() on reject, so without this
+// WARN the request leaves zero server-side trail. capturingLogger is defined
+// in cors_test.go.
+func TestTenantMiddlewareLogsRejection(t *testing.T) {
+	tests := []struct {
+		name     string
+		resolver multitenant.TenantResolver
+	}{
+		{name: "empty_tenant", resolver: &fixedTenantResolver{tenantID: "", err: nil}},
+		{name: "resolver_error", resolver: &fixedTenantResolver{tenantID: "", err: errors.New("boom")}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			capturer := &capturingLogger{}
+			e := newTenantTestEcho()
+			e.Use(tenantMiddlewareEcho(tc.resolver, nil, capturer))
+			e.GET("/tenant-check", func(c *echo.Context) error {
+				return c.String(http.StatusOK, "ok")
+			})
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/tenant-check", http.NoBody)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+
+			captured := strings.Join(capturer.warns, "\n")
+			assert.Contains(t, captured, "path=/tenant-check")
+			assert.Contains(t, captured, "status=400")
+			assert.NotContains(t, captured, "tenant=", "no resolved tenant exists on the reject path")
+		})
+	}
+}
+
+// TestTenantMiddlewareNilLoggerDoesNotPanic verifies the nil-logger path
+// (public TenantMiddleware construction, which threads nil through to
+// tenantMiddlewareEcho) still rejects with 400 and does not panic — guards
+// against a future refactor reintroducing an unconditional l.Warn() call.
+func TestTenantMiddlewareNilLoggerDoesNotPanic(t *testing.T) {
+	resolver := &fixedTenantResolver{tenantID: "", err: nil}
+	e := newTenantTestEcho()
+	e.Use(tenantMiddlewareEcho(resolver, nil, nil))
+	e.GET("/tenant-check", func(c *echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/tenant-check", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	assert.NotPanics(t, func() {
+		e.ServeHTTP(rec, req)
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}


### PR DESCRIPTION
## What

The two pre-guards that short-circuit requests before the access logger — the **IP pre-guard** (429) and the **tenant resolver** (400, "Invalid tenant") — now emit one WARN per rejected request. Previously, with `observability.enabled=false`, a denied request left **zero** server-side trail: both guards are registered outer to the access logger and never call `next` (so it never runs), `customErrorHandler` logs only 5xx, and the 429 path returns no error at all.

## Why

A tenant-ID spray or an IP flood — exactly the adversarial traffic these guards exist to stop — was invisible server-side when observability was off (a supported no-op-provider mode), degrading attack detection and incident forensics. This is specifically the **observability-off blind spot**: when observability is on, the OTel middleware (registered further out) still records a span. The fix is additive — one WARN line from each reject path.

## How

- Threaded a `logger.Logger` into the **unexported** echo-native constructors (`ipPreGuardEcho`, `tenantMiddlewareEcho`), mirroring the existing `corsEchoWithLogger` seam. `SetupMiddlewares` passes its framework `log`.
- The **exported** wrappers `IPPreGuard(threshold int)` / `TenantMiddleware(resolver, skipper)` keep **byte-identical signatures** (they pass `nil`) — the apidiff gate stays green. `nil` logger falls back to the stdlib `log` package (mirrors `corsWarnf`) and is exercised by a no-panic test.
- Each WARN carries method, path, client (`ctx.RealIP()`), status. The 400 path adds a fixed `reason` (`"empty tenant"` / `"resolver error"`) — **never the raw resolver error** (may carry caller data) and **never a tenant value** (there is none on the reject path).

## Tests

- `TestTenantMiddlewareLogsRejection` (table: empty-tenant + resolver-error) — asserts a WARN with `path=` + `status=400`, and `NotContains "tenant="`.
- `TestIPPreGuardLogsRejection` — trips the limiter, asserts a WARN with `status=429`.
- `TestTenantMiddlewareNilLoggerDoesNotPanic` / `TestIPPreGuardNilLoggerDoesNotPanic` — the public-wrapper `nil`-logger path still rejects (400/429) and does not panic.

## Scope

`server/ip_preguard.go`, `server/tenant_middleware.go`, `server/middleware.go` (only the 2 `log` args — registration order untouched), + the two test files. Out of scope by design: middleware ordering, IP-extraction/XFF-trust (ADR-015 follow-up), `customErrorHandler`.

## Pre-push gates

- **`/simplify`**: 4-angle review. Findings skipped with rationale — the `corsWarnf` nil-fallback unification needs out-of-scope `cors.go`; emitting **structured** log fields (nicer for SIEM querying) needs a field-capturing change to the shared `cors_test.go` test double (out of scope) since the framework logger has no buffer-writer test seam — noted as a follow-up; the `RealIP` micro-opt and a test-loop dedup are marginal.
- **`/security-audit`**: 0 findings — gosec clean on `server/`; no secret/tenant/raw-error logged; log-injection mitigated (net/http rejects control chars in request targets; structured logger escapes).
- CodeRabbit = this review. `make check` green throughout.

Classified `fix(server):` — additive, no API change (apidiff-verified).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured WARN logging for IP rate-limit (HTTP 429) and tenant-resolution rejections.
  * Rejection logs now include request method, path, client address, and status code, with clear tenant-failure reasons.

* **Bug Fixes**
  * Ensured rejection logging is safe when a logger is unavailable (no panics).
  * Updated middleware setup to consistently inject logging when tenant resolution is enabled.

* **Tests**
  * Added tests verifying WARN log emission for IP and tenant middleware.
  * Added tests confirming nil-logger behavior for both middleware paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->