### PR TITLE
test(migrate): pin validate/info Action wiring end-to-end

### DIFF
--- a/migration/source/http/source_test.go
+++ b/migration/source/http/source_test.go
@@ -182,7 +182,7 @@ func TestHTTPTenantSourceContractErrorWithoutEnvelope(t *testing.T) {
 
 func TestHTTPTenantSourceContextCancellation(t *testing.T) {
 	srv := httptest.NewServer(stdhttp.HandlerFunc(func(_ stdhttp.ResponseWriter, _ *stdhttp.Request) {
-		time.Sleep(2 * time.Second)
+		time.Sleep(200 * time.Millisecond)
 	}))
 	defer srv.Close()
 

--- a/tools/migration/internal/commands/info_test.go
+++ b/tools/migration/internal/commands/info_test.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInfoCommandInvokesFlywayInfo(t *testing.T) {
+	listSrv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+		writeEnvelope(w, map[string]any{
+			"tenants":     []map[string]string{{"id": "t1"}},
+			"next_cursor": "",
+		})
+	}))
+	defer listSrv.Close()
+
+	smSrv := fakeSecretsManager(t, map[string]string{
+		"gobricks/migrate/t1": `{"type":"postgresql","host":"h1","port":5432,"database":"d1","username":"u1","password":"pw-tenant-1"}`,
+	})
+	defer smSrv.Close()
+
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	stub, capture := stubFlywayCapturing(t, "info")
+	cmd := NewInfoCommand()
+	cmd.SetArgs([]string{
+		"--source-url", listSrv.URL, "--allow-insecure-scheme",
+		"--aws-endpoint", smSrv.URL, "--aws-region", "us-east-1",
+		"--flyway-path", stub, "--flyway-config", flywayConfPath(t),
+		"--migrations-dir", makeTempDir(t),
+	})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetContext(context.Background())
+	require.NoError(t, cmd.Execute())
+
+	argv, err := os.ReadFile(capture)
+	require.NoError(t, err)
+	assert.Contains(t, string(argv), "info")
+	assert.NotContains(t, string(argv), "migrate")
+	assert.Contains(t, stdout.String(), "t1")
+	assert.Contains(t, stdout.String(), "Info summary")
+}

--- a/tools/migration/internal/commands/info_test.go
+++ b/tools/migration/internal/commands/info_test.go
@@ -2,10 +2,10 @@ package commands
 
 import (
 	"bytes"
-	"context"
 	stdhttp "net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,13 +40,14 @@ func TestInfoCommandInvokesFlywayInfo(t *testing.T) {
 	})
 	var stdout bytes.Buffer
 	cmd.SetOut(&stdout)
-	cmd.SetContext(context.Background())
+	cmd.SetContext(t.Context())
 	require.NoError(t, cmd.Execute())
 
 	argv, err := os.ReadFile(capture)
 	require.NoError(t, err)
-	assert.Contains(t, string(argv), "info")
-	assert.NotContains(t, string(argv), "migrate")
+	args := strings.Split(strings.TrimSpace(string(argv)), "\n")
+	assert.Contains(t, args, "info")
+	assert.NotContains(t, args, "migrate")
 	assert.Contains(t, stdout.String(), "t1")
 	assert.Contains(t, stdout.String(), "Info summary")
 }

--- a/tools/migration/internal/commands/validate_test.go
+++ b/tools/migration/internal/commands/validate_test.go
@@ -2,12 +2,12 @@ package commands
 
 import (
 	"bytes"
-	"context"
 	stdhttp "net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,7 +24,7 @@ func stubFlywayCapturing(t *testing.T, operation string) (stubPath, capturePath 
 	dir := t.TempDir()
 	capturePath = filepath.Join(dir, "argv.txt")
 	envelope := `{"operation":"` + operation + `","success":true,"flywayVersion":"12.8.1"}`
-	script := "#!/bin/sh\necho \"$@\" >> \"" + capturePath + "\"\necho '" + envelope + "'\nexit 0\n"
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" >> \"" + capturePath + "\"\necho '" + envelope + "'\nexit 0\n"
 	stubPath = filepath.Join(dir, "flyway-capture.sh")
 	require.NoError(t, os.WriteFile(stubPath, []byte(script), 0o755))
 	return stubPath, capturePath
@@ -58,13 +58,14 @@ func TestValidateCommandInvokesFlywayValidate(t *testing.T) {
 	})
 	var stdout bytes.Buffer
 	cmd.SetOut(&stdout)
-	cmd.SetContext(context.Background())
+	cmd.SetContext(t.Context())
 	require.NoError(t, cmd.Execute())
 
 	argv, err := os.ReadFile(capture)
 	require.NoError(t, err)
-	assert.Contains(t, string(argv), "validate")
-	assert.NotContains(t, string(argv), "migrate")
+	args := strings.Split(strings.TrimSpace(string(argv)), "\n")
+	assert.Contains(t, args, "validate")
+	assert.NotContains(t, args, "migrate")
 	assert.Contains(t, stdout.String(), "t1")
 	assert.Contains(t, stdout.String(), "Validate summary")
 }

--- a/tools/migration/internal/commands/validate_test.go
+++ b/tools/migration/internal/commands/validate_test.go
@@ -1,0 +1,70 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubFlywayCapturing writes a shell script that records its argv to capturePath
+// and emits a success envelope for the given operation. Skips on Windows.
+func stubFlywayCapturing(t *testing.T, operation string) (stubPath, capturePath string) {
+	t.Helper()
+	if runtime.GOOS == windowsOS {
+		t.Skip("shell script stub not supported on windows CI")
+	}
+	dir := t.TempDir()
+	capturePath = filepath.Join(dir, "argv.txt")
+	envelope := `{"operation":"` + operation + `","success":true,"flywayVersion":"12.8.1"}`
+	script := "#!/bin/sh\necho \"$@\" >> \"" + capturePath + "\"\necho '" + envelope + "'\nexit 0\n"
+	stubPath = filepath.Join(dir, "flyway-capture.sh")
+	require.NoError(t, os.WriteFile(stubPath, []byte(script), 0o755))
+	return stubPath, capturePath
+}
+
+func TestValidateCommandInvokesFlywayValidate(t *testing.T) {
+	listSrv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+		writeEnvelope(w, map[string]any{
+			"tenants":     []map[string]string{{"id": "t1"}},
+			"next_cursor": "",
+		})
+	}))
+	defer listSrv.Close()
+
+	smSrv := fakeSecretsManager(t, map[string]string{
+		"gobricks/migrate/t1": `{"type":"postgresql","host":"h1","port":5432,"database":"d1","username":"u1","password":"pw-tenant-1"}`,
+	})
+	defer smSrv.Close()
+
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	stub, capture := stubFlywayCapturing(t, "validate")
+	cmd := NewValidateCommand()
+	cmd.SetArgs([]string{
+		"--source-url", listSrv.URL, "--allow-insecure-scheme",
+		"--aws-endpoint", smSrv.URL, "--aws-region", "us-east-1",
+		"--flyway-path", stub, "--flyway-config", flywayConfPath(t),
+		"--migrations-dir", makeTempDir(t),
+	})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetContext(context.Background())
+	require.NoError(t, cmd.Execute())
+
+	argv, err := os.ReadFile(capture)
+	require.NoError(t, err)
+	assert.Contains(t, string(argv), "validate")
+	assert.NotContains(t, string(argv), "migrate")
+	assert.Contains(t, stdout.String(), "t1")
+	assert.Contains(t, stdout.String(), "Validate summary")
+}


### PR DESCRIPTION
## What

End-to-end tests that **pin** the `go-bricks-migrate validate` / `info` Action wiring, plus a fix for a 2s test-teardown stall. **Test-only — no production code changes.**

## Why

The only code distinguishing `validate` (dry-run, must never touch a schema) and `info` (read-only) from `migrate` (applies changes) is a single constant passed in a one-line `RunE` closure per file. **No test ever executed that closure for validate or info** — the existing `constructors_test.go` tests only check `cmd.Use`/`RunE != nil`/flags, and the extra-args test is rejected by cobra's `NoArgs` before `RunE` runs. So a copy-paste slip leaving `migration.ActionMigrate` in `validate.go` — turning a CI "dry-run" step into a **live migration** — would pass `make check`, the full CI matrix, and release gates undetected. The wiring is presently correct; this closes the test gap.

## How

- New `stubFlywayCapturing(t, operation)` helper writes a shell-script Flyway stub that records its **argv** and emits a valid success envelope.
- `TestValidateCommandInvokesFlywayValidate` / `TestInfoCommandInvokesFlywayInfo` drive `NewValidateCommand()` / `NewInfoCommand()` through a full `cmd.Execute()` (mirroring the existing `TestMigrateCommandSuccessAcrossPagesAndShapes`), then assert on the **captured argv**: `Contains "validate"`/`"info"` **and** `NotContains "migrate"`. The argv assertion is load-bearing — a cosmetic stdout check would still pass with the Action swapped.
- **Mutation check** (performed, not committed): swapping `validate.go`/`info.go` to `ActionMigrate` makes each test FAIL (capture contains `migrate`, stdout shows `Migrate summary`); reverting restores PASS. This proves the tests pin the wiring.

## Teardown-stall fix

`migration/source/http/source_test.go`'s `TestHTTPTenantSourceContextCancellation` slept 2s in its handler while the client cancels at 50ms; `httptest.Server.Close()` blocks on the outstanding request, so teardown wasted ~1.95s every run. Reduced to 200ms (still comfortably above the 50ms cancel, so the cancellation contract is unchanged) — the test now finishes in ~0.2s.

## Scope

3 test files only: `tools/migration/internal/commands/{validate,info}_test.go` (new) and `migration/source/http/source_test.go` (one sleep line). `validate.go`/`info.go`/`migrate_test.go`/`constructors_test.go` untouched.

## Pre-push gates

- **`/simplify`**: direct review of the 123-line test diff — the setup overlap between `validate_test.go` and `info_test.go` is intentional (source-to-test 1:1 convention); helpers reused appropriately; argv assertions at the right altitude. No change.
- **`/security-audit`**: gosec 0 issues on both changed packages; no production code; the only credential-shaped string is a test-fixture password.
- CodeRabbit = this review. `make check` green (CLI tests run against the local framework via the workspace, not `GOWORK=off`).

Classified `test(migrate):` — tests only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming the Info command invokes Flyway’s **info** operation and reports tenant details.
  * Added coverage confirming the Validate command invokes Flyway’s **validate** operation and reports tenant details.
  * Reduced the HTTP cancellation test delay, keeping cancellation/deadline coverage intact while speeding up the suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->