### PR TITLE
ci(release): warn when the go-bricks-migrate CLI tag trails the framework release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -148,3 +149,30 @@ jobs:
               || echo "note: 'autorelease: tagged' label missing on PR #$pr (non-fatal)"
             echo "Cleared autorelease:pending on PR #$pr"
           done
+      - name: Check go-bricks-migrate CLI tag freshness (non-blocking)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # At vX publish time the CLI tag for vX legitimately doesn't exist yet
+          # (RELEASING.md §6 cuts it after the proxy serves vX). Healthy state:
+          # CLI tag == previous framework release. Drift: CLI < previous release.
+          git fetch --tags --force --quiet
+          prev="$(git tag --list 'v*' --sort=-v:refname | grep -vx "$TAG" | head -1 || true)"
+          latest_cli="$(git tag --list 'tools/migration/v*' --sort=-v:refname | head -1 || true)"
+          cli_ver="${latest_cli#tools/migration/}"
+          if [ -z "$prev" ]; then echo "first release — nothing to compare"; exit 0; fi
+          if [ -n "$cli_ver" ] && [ "$(printf '%s\n%s\n' "$prev" "$cli_ver" | sort -V | head -1)" = "$prev" ]; then
+            echo "CLI tag $latest_cli is fresh (>= previous framework release $prev)"; exit 0
+          fi
+          msg="go-bricks-migrate CLI tag is stale: latest is '${latest_cli:-<none>}' but the framework is now at $TAG (previous release $prev). Cut tools/migration/$TAG per RELEASING.md §6 once $TAG is on the module proxy."
+          echo "::warning::$msg"
+          echo "$msg" >> "$GITHUB_STEP_SUMMARY"
+          title="chore(migrate): cut the tools/migration CLI tag (stale since ${latest_cli:-<none>})"
+          existing="$(gh issue list --state open --search 'chore(migrate): cut the tools/migration CLI tag in:title' --json number --jq '.[0].number' || true)"
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            gh issue comment "$existing" --body "$msg" || echo "issue comment failed (non-fatal)"
+          else
+            gh issue create --title "$title" --body "$msg" || echo "issue create failed (non-fatal)"
+          fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -99,6 +99,8 @@ git tag -s tools/migration/v0.38.0 -m "go-bricks-migrate v0.38.0"
 git push origin tools/migration/v0.38.0
 ```
 
+The release workflow's `publish` job checks this obligation on every framework tag: if the newest `tools/migration/v*` tag trails the *previous* framework release, it emits a workflow warning and opens/updates a `chore(migrate): cut the tools/migration CLI tag` issue. The tag cut itself stays manual and signed — CI never creates tags.
+
 ## 7. Security properties NOT yet provided (Phase 2)
 
 This flow provides **tag-signature provenance only** — verified against a committed


### PR DESCRIPTION
## What

A **non-blocking** release-time detector in `release.yml`: on every framework tag, the `publish` job checks whether the `go-bricks-migrate` CLI tag (`tools/migration/v*`) has fallen behind, and if so emits a workflow warning + step-summary line and opens (or comments on an existing) `chore(migrate): cut the tools/migration CLI tag` issue. Plus one documenting sentence in `RELEASING.md §6`.

## Why

Cutting the CLI tag after each framework release is a **manual** step (RELEASING.md §6) that's been missed for **13+ consecutive releases** — the only CLI tag is `tools/migration/v0.38.0` while the framework is now at `v0.52.0`. Anyone using the documented `go install .../go-bricks-migrate@latest` gets a binary built against go-bricks v0.38.0, silently missing every migration-tooling fix since (the Flyway subprocess-timeout kill #704, the robust JSON-envelope parser #695, the parent-cancel schema-unknown signal #708). Nothing detected the drift. This adds the detector.

## Design

- **Timing-aware**: at `vX` publish time the CLI tag for `vX` legitimately doesn't exist yet (§6 cuts it *after* `vX` is on the module proxy). So the assertion is "the CLI tag for the **previous** framework release should exist by now" — lag of exactly one release is healthy; lag ≥ 2 is drift. `sort -V` handles the semver comparison.
- **Non-blocking**: every failure path is guarded (`|| echo … (non-fatal)`); the drift path has **no** `exit 1`, so a stale-tag warning can never interfere with release creation. Placed as the **last** step in `publish`.
- **Idempotent**: the `gh issue list --search '… in:title'` prefix-matches the created title, so repeated stale releases comment on the one issue instead of spamming duplicates.
- **No tags created by CI** — the tag cut stays a manual, SSH-signed operator action. This PR only adds detection + a runbook (the plan carries the operator's exact `git tag -s tools/migration/v0.52.0` procedure).

## Security

- New permission is the minimal `issues: write` (needed for `gh issue create/comment`); uses the job's existing `GITHUB_TOKEN`.
- `github.ref_name` is consumed **only** via an `env: TAG:` mapping (the file's established pattern), never inlined in a `run:` block — no template-injection surface. `gh --body "$msg"` passes the message as an argument, not shell-eval'd.

## Scope

2 files: `.github/workflows/release.yml` (+1 permission, +1 step) and `RELEASING.md` (+1 sentence). No Go code, no `ci-v2.yml`.

## Pre-push gates

- **`/simplify`**: direct review — the step is a self-contained linear shell check; nothing to simplify.
- **`/security-audit`**: actionlint clean; `github.ref_name` only via env (no injection); minimal permission; standard token; non-blocking. (gosec N/A — no Go.)
- **Logic verified**: a local simulation (throwaway repos) exercised all four branches — fresh / stale / no-CLI-tag(`<none>`) / first-release — all correct. CodeRabbit = this review.

Classified `ci(release):` — release-workflow + docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release automation now detects when the migration CLI release is behind the previous framework release.
  * Stale releases trigger a workflow warning and create or update a tracking issue automatically.
  * Initial releases and up-to-date CLI releases complete without additional action.

* **Documentation**
  * Updated release guidance to explain the new check and tracking workflow.
  * Clarified that CLI tags continue to be created manually and with signed releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->