### PR TITLE
feat(migration): optional NameFor hook for suffix-style secret-name grammars

### DIFF
--- a/migration/secrets.go
+++ b/migration/secrets.go
@@ -41,6 +41,16 @@ type SecretsProvider struct {
 	// Empty defaults to DefaultSecretsPrefix at lookup time.
 	Prefix string
 
+	// NameFor, when non-nil, composes the secret name for a tenant instead
+	// of the default Prefix + tenantID. The tenantID it receives has already
+	// been trimmed and allowlist-validated. Use it for grammars that place
+	// segments after the tenant ID (e.g. "/env/platform/<id>/db"). The
+	// returned name is used as-is apart from a blank-name check — the
+	// composer owns its correctness. When NameFor is set, Prefix is ignored
+	// for lookups but a non-empty Prefix is still checked by Validate (a
+	// malformed Prefix alongside NameFor fails fast rather than lingering).
+	NameFor func(tenantID string) (string, error)
+
 	// Fetch resolves a secret name to its payload. Required.
 	Fetch SecretFetcher
 
@@ -66,6 +76,10 @@ var ErrEmptyTenantID = errors.New("migration: tenantID is empty")
 // the 128-character length bound.
 var ErrInvalidTenantID = errors.New("migration: tenantID contains characters outside [A-Za-z0-9_-] or exceeds 128 characters")
 
+// ErrNameForFailed indicates the custom NameFor hook returned an error or
+// a blank (empty/whitespace-only) name for a validated tenant ID.
+var ErrNameForFailed = errors.New("migration: NameFor failed to compose a secret name")
+
 // Validate checks that the provider is wired correctly. Callers may invoke it
 // eagerly at startup; DBConfig also calls it lazily on first lookup so library
 // callers who skip the explicit check still get a clear error before any
@@ -84,13 +98,32 @@ func (p *SecretsProvider) Validate() error {
 }
 
 // SecretName composes the full secret name for the given tenant ID using the
-// provider's prefix (or DefaultSecretsPrefix when unset).
+// provider's prefix (or DefaultSecretsPrefix when unset). When NameFor is
+// set, DBConfig uses it instead and this method reflects only the default
+// Prefix + tenantID composition.
 func (p *SecretsProvider) SecretName(tenantID string) string {
 	prefix := p.Prefix
 	if prefix == "" {
 		prefix = DefaultSecretsPrefix
 	}
 	return prefix + tenantID
+}
+
+// secretNameFor resolves the effective secret name: NameFor when set,
+// otherwise the default Prefix + tenantID composition. tenantID must already
+// be validated by the caller.
+func (p *SecretsProvider) secretNameFor(tenantID string) (string, error) {
+	if p.NameFor == nil {
+		return p.SecretName(tenantID), nil
+	}
+	name, err := p.NameFor(tenantID)
+	if err != nil {
+		return "", fmt.Errorf("%w for tenant %q: %w", ErrNameForFailed, tenantID, err)
+	}
+	if strings.TrimSpace(name) == "" {
+		return "", fmt.Errorf("%w: blank name for tenant %q", ErrNameForFailed, tenantID)
+	}
+	return name, nil
 }
 
 // DBConfig satisfies database.DBConfigProvider. Looks up the tenant's secret,
@@ -108,7 +141,10 @@ func (p *SecretsProvider) DBConfig(ctx context.Context, tenantID string) (*confi
 		return nil, ErrInvalidTenantID
 	}
 
-	name := p.SecretName(tenantID)
+	name, err := p.secretNameFor(tenantID)
+	if err != nil {
+		return nil, err
+	}
 	raw, err := p.Fetch(ctx, name)
 	if err != nil {
 		return nil, fmt.Errorf("fetch secret %q for tenant %q: %w", name, tenantID, err)

--- a/migration/secrets_test.go
+++ b/migration/secrets_test.go
@@ -403,12 +403,10 @@ func TestSecretsProviderNameForNilIsUnchanged(t *testing.T) {
 }
 
 func TestSecretsProviderNameForRunsAfterValidation(t *testing.T) {
-	newRecordingProvider := func(t *testing.T) (*SecretsProvider, *bool) {
+	newRecordingProvider := func(t *testing.T) *SecretsProvider {
 		t.Helper()
-		called := false
-		p := &SecretsProvider{
+		return &SecretsProvider{
 			NameFor: func(id string) (string, error) {
-				called = true
 				t.Errorf("NameFor should not be called for an unvalidated tenantID, got %q", id)
 				return "", nil
 			},
@@ -417,21 +415,18 @@ func TestSecretsProviderNameForRunsAfterValidation(t *testing.T) {
 				return nil, nil
 			},
 		}
-		return p, &called
 	}
 
 	t.Run("invalid_characters", func(t *testing.T) {
-		p, called := newRecordingProvider(t)
+		p := newRecordingProvider(t)
 		_, err := p.DBConfig(context.Background(), "../../evil")
 		require.ErrorIs(t, err, ErrInvalidTenantID)
-		assert.False(t, *called)
 	})
 
 	t.Run("whitespace_only", func(t *testing.T) {
-		p, called := newRecordingProvider(t)
+		p := newRecordingProvider(t)
 		_, err := p.DBConfig(context.Background(), "  ")
 		require.ErrorIs(t, err, ErrEmptyTenantID)
-		assert.False(t, *called)
 	})
 }
 

--- a/migration/secrets_test.go
+++ b/migration/secrets_test.go
@@ -324,3 +324,153 @@ func TestSecretsProviderTenantIDAllowlist(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestSecretsProviderNameForComposesSuffixGrammar(t *testing.T) {
+	payload := []byte(`{
+		"type":     "postgresql",
+		"host":     "tenant-a.db.example.com",
+		"port":     5432,
+		"database": "tenant_a",
+		"username": "tenant_a_app",
+		"password": "s3cret"
+	}`)
+
+	var requestedName string
+	p := &SecretsProvider{
+		Prefix: "legacy/",
+		NameFor: func(id string) (string, error) {
+			return "/prod/platform/" + id + "/db", nil
+		},
+		Fetch: func(_ context.Context, name string) ([]byte, error) {
+			requestedName = name
+			return payload, nil
+		},
+	}
+
+	_, err := p.DBConfig(context.Background(), "tenant-a")
+	require.NoError(t, err)
+	assert.Equal(t, "/prod/platform/tenant-a/db", requestedName)
+	// SecretName reflects only the default Prefix + tenantID composition,
+	// regardless of NameFor.
+	assert.Equal(t, "legacy/tenant-a", p.SecretName("tenant-a"))
+}
+
+func TestSecretsProviderNameForErrorWrapsRealName(t *testing.T) {
+	boom := errors.New("secret not found")
+	p := &SecretsProvider{
+		NameFor: func(id string) (string, error) {
+			return "/prod/platform/" + id + "/db", nil
+		},
+		Fetch: func(context.Context, string) ([]byte, error) { return nil, boom },
+	}
+
+	_, err := p.DBConfig(context.Background(), "tenant-a")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
+	assert.Contains(t, err.Error(), "/prod/platform/tenant-a/db")
+	assert.NotContains(t, err.Error(), "gobricks/migrate/tenant-a")
+}
+
+func TestSecretsProviderNameForNilIsUnchanged(t *testing.T) {
+	validPayload := []byte(`{"type":"postgresql","host":"h","username":"u"}`)
+
+	t.Run("default_prefix", func(t *testing.T) {
+		var requestedName string
+		p := &SecretsProvider{
+			Fetch: func(_ context.Context, name string) ([]byte, error) {
+				requestedName = name
+				return validPayload, nil
+			},
+		}
+		_, err := p.DBConfig(context.Background(), "tenant-a")
+		require.NoError(t, err)
+		assert.Equal(t, "gobricks/migrate/tenant-a", requestedName)
+	})
+
+	t.Run("custom_prefix", func(t *testing.T) {
+		var requestedName string
+		p := &SecretsProvider{
+			Prefix: "custom/",
+			Fetch: func(_ context.Context, name string) ([]byte, error) {
+				requestedName = name
+				return validPayload, nil
+			},
+		}
+		_, err := p.DBConfig(context.Background(), "tenant-a")
+		require.NoError(t, err)
+		assert.Equal(t, "custom/tenant-a", requestedName)
+	})
+}
+
+func TestSecretsProviderNameForRunsAfterValidation(t *testing.T) {
+	newRecordingProvider := func(t *testing.T) (*SecretsProvider, *bool) {
+		t.Helper()
+		called := false
+		p := &SecretsProvider{
+			NameFor: func(id string) (string, error) {
+				called = true
+				t.Errorf("NameFor should not be called for an unvalidated tenantID, got %q", id)
+				return "", nil
+			},
+			Fetch: func(context.Context, string) ([]byte, error) {
+				t.Fatal("Fetch should not be called for an unvalidated tenantID")
+				return nil, nil
+			},
+		}
+		return p, &called
+	}
+
+	t.Run("invalid_characters", func(t *testing.T) {
+		p, called := newRecordingProvider(t)
+		_, err := p.DBConfig(context.Background(), "../../evil")
+		require.ErrorIs(t, err, ErrInvalidTenantID)
+		assert.False(t, *called)
+	})
+
+	t.Run("whitespace_only", func(t *testing.T) {
+		p, called := newRecordingProvider(t)
+		_, err := p.DBConfig(context.Background(), "  ")
+		require.ErrorIs(t, err, ErrEmptyTenantID)
+		assert.False(t, *called)
+	})
+}
+
+func TestSecretsProviderNameForBlankNameRejected(t *testing.T) {
+	cases := []struct {
+		name       string
+		blankValue string
+	}{
+		{name: "empty", blankValue: ""},
+		{name: "whitespace_only", blankValue: "   "},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &SecretsProvider{
+				NameFor: func(string) (string, error) { return tc.blankValue, nil },
+				Fetch: func(context.Context, string) ([]byte, error) {
+					t.Fatal("Fetch should not be called for a blank composed name")
+					return nil, nil
+				},
+			}
+			_, err := p.DBConfig(context.Background(), "tenant-a")
+			require.ErrorIs(t, err, ErrNameForFailed)
+		})
+	}
+}
+
+func TestSecretsProviderNameForErrorSurfacesBothSentinels(t *testing.T) {
+	errBoom := errors.New("boom")
+	p := &SecretsProvider{
+		NameFor: func(string) (string, error) { return "", errBoom },
+		Fetch: func(context.Context, string) ([]byte, error) {
+			t.Fatal("Fetch should not be called when NameFor errors")
+			return nil, nil
+		},
+	}
+
+	_, err := p.DBConfig(context.Background(), "tenant-a")
+	require.ErrorIs(t, err, ErrNameForFailed)
+	require.ErrorIs(t, err, errBoom)
+	assert.Contains(t, err.Error(), "tenant-a")
+}


### PR DESCRIPTION
## What

Adds an optional `NameFor func(tenantID string) (string, error)` hook to `migration.SecretsProvider`. When non-nil it composes the secret name for a tenant, replacing the default `Prefix + tenantID` composition. When nil, behavior is **byte-identical** to today.

## Why

`SecretsProvider` could only compose secret names as `Prefix + tenantID`. Any naming grammar that places path segments **after** the tenant ID — e.g. `/<env>/<platform>/<tenantID>/db`, the natural shape when IAM policies scope on `.../<tenantID>/*` — was inexpressible. Callers on such a grammar had to abandon the provider and reimplement its valuable parts (canonical + RDS-rotation payload parsing, tenant-ID allowlist validation). The known workaround — rewriting the name inside the `SecretFetcher` — made error messages **lie**: `DBConfig` wraps fetch/parse errors with the *composed* name, so an operator debugging a missing-secret incident got pointed at a path that was never fetched. `NameFor` closes that gap; the fetch/parse error wrapping now cites the real fetched name.

Closes #717

## Design

- **Additive / apidiff-compatible.** New struct field only; `SecretName`'s signature is unchanged. The struct already held a func-typed field (`Fetch`), so it was already non-comparable — adding another func field changes nothing apidiff cares about. No `!` / breaking release.
- **Validation still precedes composition.** `DBConfig` runs `TrimSpace` → empty check → `tenantIDPattern` allowlist **before** calling the hook, so a custom composer can never receive an unvalidated tenant ID (prevents hostile input like `../../evil` from being interpolated into a secret-manager path). Pinned by test `...RunsAfterValidation`.
- **Truthful, blank-guarded errors.** A hook error or a blank composed name yields `ErrNameForFailed` (wrapping the cause, carrying the tenant ID), matching the file's existing double-`%w` sentinel convention.
- `Validate()` intentionally still checks a non-empty malformed `Prefix` even when `NameFor` makes it unused — fail-fast on a misconfigured field. Documented on the field.

## Tests

Six new tests in `migration/secrets_test.go`: suffix-grammar composition + `NameFor`-beats-`Prefix` precedence + `SecretName` divergence, truthful error wrapping (real name, not default), nil-hook regression (default + custom prefix), validation-before-hook ordering, blank-name rejection, and the error-branch double-sentinel chain.

## Verification

- `make check` exit 0 (fmt + golangci-lint + `-race` suite + alloc guard + govulncheck: 0 vulnerabilities).
- gosec: 0 issues on `migration/`.
- Pre-push gates: `/simplify` (1 cleanup applied), `/security-audit` (clean), CodeRabbit CLI (0 findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional custom secret-name composition for tenant-specific database configurations.
  * Custom naming errors now provide clear failure details and preserve the underlying cause.

* **Bug Fixes**
  * Blank or whitespace-only secret names are rejected before attempting retrieval.
  * Invalid tenant identifiers are validated before custom naming callbacks or secret lookups run.
  * Existing default secret naming remains unchanged when custom naming is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->