### PR TITLE
fix(migration): set provisioned roles' default search_path to the tenant schema

### DIFF
--- a/migration/roles.go
+++ b/migration/roles.go
@@ -180,8 +180,8 @@ func buildPGRoleStatements(spec *PGRoleSpec) []string {
 		{runtime, spec.RuntimeRole, spec.RuntimePassword},
 	}
 
-	// Pre-size for the worst case: 2 roles × (create + lockdown + password) + 6 schema/grant statements.
-	stmts := make([]string, 0, 2*3+6)
+	// Pre-size for the worst case: 2 roles × (create + lockdown + password) + 8 schema/grant/search_path statements.
+	stmts := make([]string, 0, 2*3+8)
 	for _, r := range roles {
 		stmts = append(stmts, buildRoleCreateAndLockdown(r.rolname, r.quotedIdent)...)
 		if r.password != "" {
@@ -204,6 +204,12 @@ func buildPGRoleStatements(spec *PGRoleSpec) []string {
 		// by future Flyway migrations auto-grant to the runtime role.
 		fmt.Sprintf(`ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %s`, migrator, schema, runtime),
 		fmt.Sprintf(`ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO %s`, migrator, schema, runtime),
+		// Default search_path for both roles: without it, every unqualified
+		// statement from either role resolves to public — migrations from the
+		// migrator role land in the wrong schema (pre-#716 fallback), and
+		// unqualified runtime queries silently miss tenant tables.
+		fmt.Sprintf(`ALTER ROLE %s SET search_path = %s`, migrator, schema),
+		fmt.Sprintf(`ALTER ROLE %s SET search_path = %s`, runtime, schema),
 	)
 	return stmts
 }

--- a/migration/roles_integration_test.go
+++ b/migration/roles_integration_test.go
@@ -194,6 +194,120 @@ func TestPGRolesProvisioningIsIdempotent(t *testing.T) {
 	require.NoError(t, rotated.PingContext(ctx))
 }
 
+// TestPGRolesSearchPathSetOnBothRoles verifies that provisioning sets a
+// default search_path on both roles, pointing at the tenant schema, and that
+// the setting converges (idempotent) on rerun.
+//
+// Stored-form trap: search_path is a GUC_LIST_QUOTE parameter — PostgreSQL
+// re-normalizes the value through quote_identifier at SET time, stripping
+// quotes from any name that is legal unquoted. The test uses a lowercase
+// snake_case schema, so even though the emitted SQL says
+// SET search_path = "tenant_sp", the stored rolconfig entry is unquoted:
+// search_path=tenant_sp. Assert on that unquoted form.
+func TestPGRolesSearchPathSetOnBothRoles(t *testing.T) {
+	env := newIntegrationEnv(t)
+	spec := &PGRoleSpec{
+		Schema:           "tenant_sp",
+		MigratorRole:     "mig_sp",
+		MigratorPassword: "mig-sp-pw-1234",
+		RuntimeRole:      "rt_sp",
+		RuntimePassword:  "rt-sp-pw-1234",
+	}
+
+	ctx, cancel := testCtx(t)
+	defer cancel()
+
+	admin := env.adminDB(t)
+	require.NoError(t, ProvisionPGRoles(ctx, admin, spec))
+
+	rolconfigs := func() map[string]string {
+		// array_to_string avoids scanning rolconfig (a PG text[]) directly —
+		// lib/pq isn't a dependency and pgx v5 stdlib doesn't scan text[]
+		// into []string natively.
+		rows, err := admin.QueryContext(ctx,
+			`SELECT rolname, array_to_string(rolconfig, ',') FROM pg_roles WHERE rolname IN ($1, $2) ORDER BY rolname`,
+			spec.MigratorRole, spec.RuntimeRole)
+		require.NoError(t, err)
+		defer func() { _ = rows.Close() }()
+
+		out := make(map[string]string)
+		for rows.Next() {
+			var rolname, cfg string
+			require.NoError(t, rows.Scan(&rolname, &cfg))
+			out[rolname] = cfg
+		}
+		require.NoError(t, rows.Err())
+		return out
+	}
+
+	cfgs := rolconfigs()
+	require.Len(t, cfgs, 2)
+	assert.Contains(t, cfgs[spec.MigratorRole], "search_path="+spec.Schema,
+		"migrator rolconfig: %q", cfgs[spec.MigratorRole])
+	assert.Contains(t, cfgs[spec.RuntimeRole], "search_path="+spec.Schema,
+		"runtime rolconfig: %q", cfgs[spec.RuntimeRole])
+
+	// Convergence: rerunning with the same spec must not error, and the
+	// stored rolconfig must be unchanged (issue AC #3).
+	require.NoError(t, ProvisionPGRoles(ctx, admin, spec), "second run must be idempotent")
+	assert.Equal(t, cfgs, rolconfigs(), "rolconfig must be unchanged after a convergent rerun")
+}
+
+// TestPGRolesUnqualifiedResolutionUsesTenantSchema verifies the runtime-
+// ergonomics half of the search_path change: unqualified DDL from the
+// migrator role and unqualified DML from the runtime role both resolve
+// against the tenant schema instead of falling through to public.
+func TestPGRolesUnqualifiedResolutionUsesTenantSchema(t *testing.T) {
+	env := newIntegrationEnv(t)
+	spec := &PGRoleSpec{
+		Schema:           "tenant_unq",
+		MigratorRole:     "mig_unq",
+		MigratorPassword: "mig-unq-pw-1234",
+		RuntimeRole:      "rt_unq",
+		RuntimePassword:  "rt-unq-pw-1234",
+	}
+
+	ctx, cancel := testCtx(t)
+	defer cancel()
+
+	admin := env.adminDB(t)
+	require.NoError(t, ProvisionPGRoles(ctx, admin, spec))
+
+	// Migrator role: the openAsRole DSN does not pin search_path, so the role
+	// default under test actually takes effect for this connection.
+	migratorDB := env.openAsRole(t, spec.MigratorRole, spec.MigratorPassword)
+	_, err := migratorDB.ExecContext(ctx, `CREATE TABLE sp_probe (id INT)`)
+	require.NoError(t, err, "migrator must be able to CREATE TABLE unqualified")
+
+	var tenantRegclass, publicRegclass *string
+	require.NoError(t, admin.QueryRowContext(ctx,
+		`SELECT to_regclass($1)`, spec.Schema+".sp_probe").Scan(&tenantRegclass))
+	assert.NotNil(t, tenantRegclass, "sp_probe must exist in the tenant schema")
+
+	require.NoError(t, admin.QueryRowContext(ctx,
+		`SELECT to_regclass('public.sp_probe')`).Scan(&publicRegclass))
+	assert.Nil(t, publicRegclass, "sp_probe must NOT exist in public")
+
+	runtimeDB := env.openAsRole(t, spec.RuntimeRole, spec.RuntimePassword)
+
+	// 1. Schema-qualified SELECT succeeds — isolates the grants chain
+	// (schema USAGE + the ALTER DEFAULT PRIVILEGES auto-grant, already
+	// pinned by TestPGRolesAlterDefaultPrivilegesAutoGrants). This is a
+	// dependency of assertion 2 below, not what this plan changes.
+	var count int
+	qualified := quotePGIdent(spec.Schema) + ".sp_probe"
+	require.NoError(t, runtimeDB.QueryRowContext(ctx,
+		fmt.Sprintf(`SELECT COUNT(*) FROM %s`, qualified)).Scan(&count),
+		"qualified SELECT must succeed via the existing grants chain")
+
+	// 2. Unqualified SELECT succeeds — isolates the new search_path default.
+	// If only this assertion fails (with #1 passing), search_path is the
+	// culprit; if #1 fails, the grants model regressed instead.
+	require.NoError(t, runtimeDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sp_probe`).Scan(&count),
+		"unqualified SELECT must succeed via the new search_path default")
+}
+
 // isPermissionDenied reports whether err looks like a PostgreSQL privilege-
 // rejection error (SQLSTATE 42501). We match on the message because the test
 // uses database/sql + pgx stdlib, which surfaces the SQLSTATE inside the

--- a/migration/roles_test.go
+++ b/migration/roles_test.go
@@ -140,6 +140,31 @@ func TestPGRoleProvisioningSQLContainsExpectedStatements(t *testing.T) {
 
 	// The AC-critical ALTER DEFAULT PRIVILEGES line.
 	assert.Contains(t, all, `ALTER DEFAULT PRIVILEGES FOR ROLE "migrator" IN SCHEMA "tenant_a" GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "tenant_a_app"`)
+
+	// Default search_path on both roles: migrator-side keeps Flyway's
+	// no-explicit-schema fallback pointed at the tenant schema; runtime-side
+	// keeps unqualified DML off public.
+	assert.Contains(t, all, `ALTER ROLE "migrator" SET search_path = "tenant_a"`)
+	assert.Contains(t, all, `ALTER ROLE "tenant_a_app" SET search_path = "tenant_a"`)
+}
+
+// TestPGRoleProvisioningSQLSearchPathUsesQuotedIdents pins the exact quoted
+// ALTER ROLE ... SET search_path statements for a mixed-case schema — mixed
+// case is where quoting is semantically load-bearing: unquoted, PostgreSQL
+// would fold the identifier to lowercase and the search_path would miss the
+// actual (mixed-case) schema.
+func TestPGRoleProvisioningSQLSearchPathUsesQuotedIdents(t *testing.T) {
+	spec := &PGRoleSpec{
+		Schema:       "TenantX",
+		MigratorRole: "MigX",
+		RuntimeRole:  "AppX",
+	}
+	stmts, err := PGRoleProvisioningSQL(spec)
+	require.NoError(t, err)
+
+	all := strings.Join(stmts, "\n;\n")
+	assert.Contains(t, all, `ALTER ROLE "MigX" SET search_path = "TenantX"`)
+	assert.Contains(t, all, `ALTER ROLE "AppX" SET search_path = "TenantX"`)
 }
 
 func TestPGRoleProvisioningSQLOmitsEmptyPasswordALTERs(t *testing.T) {

--- a/wiki/migration_roles.md
+++ b/wiki/migration_roles.md
@@ -49,6 +49,44 @@ Result: a Flyway migration adding `CREATE TABLE tenant_a.gadgets (...)` does
 not need a follow-up `GRANT` statement — the table is automatically
 DML-accessible to the runtime role.
 
+## Default search_path
+
+Every provisioning run also sets a default `search_path` on both roles:
+
+```sql
+ALTER ROLE "migrator" SET search_path = "tenant_a";
+ALTER ROLE "tenant_a_app" SET search_path = "tenant_a";
+```
+
+Like the attribute lockdown, this is idempotent and unconditional — no
+opt-out flag. Re-running the same spec converges the setting; manual drift
+(e.g. someone runs `ALTER ROLE migrator SET search_path = public`) snaps
+back on the next provisioning call.
+
+**Why it matters on both sides:**
+- **Migrator side.** Flyway's fallback when no schema is explicitly targeted
+  resolves against the *connection's* current schema, which in turn is
+  driven by the role's default `search_path`. Without this `ALTER ROLE`, a
+  freshly provisioned tenant whose migration runner omits explicit schema
+  args would silently land migrations in `public` and still report success.
+  See [Schema targeting (PostgreSQL)](multi_tenant_migration.md#schema-targeting-postgresql)
+  for how the runner passes `-schemas`/`-defaultSchema` explicitly — this
+  role-level default is the belt to that suspenders, covering any caller
+  that provisions roles without going through the runner's explicit args.
+- **Runtime side.** Without a role default, unqualified `INSERT`/`SELECT`
+  statements from the running service resolve against `public`. The grants
+  boundary still prevents cross-tenant reads (this is not a leak), but an
+  unqualified query from application code or an operator's `psql` session
+  is a silent wrong-schema bug rather than a hard failure.
+
+**Scoping decision:** the statements use plain `ALTER ROLE ... SET`
+(cluster-global default for the role), not `ALTER ROLE ... IN DATABASE ...
+SET`. These roles are provisioned per-tenant and per-purpose — a single role
+is never shared across schemas or databases — so a cluster-global default is
+equivalent to a database-scoped one in practice, and DB-scoping was deferred
+as unnecessary complexity for v1. Shared-cluster deployments that reuse role
+names across databases would need to revisit this.
+
 ## Using the helper
 
 ```go


### PR DESCRIPTION
## What

`ProvisionPGRoles` / `PGRoleProvisioningSQL` now emit two additional idempotent statements per provisioning run:

```sql
ALTER ROLE "<migrator>" SET search_path = "<schema>";
ALTER ROLE "<runtime>"  SET search_path = "<schema>";
```

Closes #718

## Why

The provisioned role-pair (migrator owns the schema, runtime gets DML-only grants) never had a default `search_path`, and nothing else in the framework sets one. Two failure modes followed:

- **Migration side (load-bearing).** Flyway's fallback when no schema is explicitly targeted resolves against the connection's current schema — the migrator role's default `search_path`, i.e. `public`. A freshly provisioned tenant whose runner omits explicit schema args would land migrations in `public` and still report success. (Plan/PR #730 fixes the runner side with explicit `-schemas`/`-defaultSchema`; this is the belt to that suspenders — the role-level default is right even without explicit args.)
- **Runtime side.** Unqualified `INSERT`/`SELECT` from the runtime role resolved against `public`. The grants boundary still prevents cross-tenant reads (not a leak), but an unqualified query from app code or an operator `psql` session was a silent wrong-schema bug.

## Design note — why role-level `ALTER ROLE`, not per-connection

The framework's role model (see `wiki/migration_roles.md` and `PGRoleSpec`) provisions **one role-pair per tenant, per purpose** — `PGRoleSpec.Validate()` enforces `MigratorRole != RuntimeRole`, and each tenant is provisioned with its own spec (its own migrator/runtime role names + schema). Under that model, `ALTER ROLE "<tenant_a_migrator>" SET search_path = "<tenant_a>"` and the tenant-B equivalent operate on **distinct** roles, so there is no cross-tenant clobbering.

This is why the change uses plain `ALTER ROLE ... SET` (cluster-global for the role) rather than `ALTER ROLE ... IN DATABASE ... SET` or a per-connection setting — a deliberate, recorded decision. Shared-cluster deployments that reuse one role name across tenants/databases are the explicitly-deferred case documented in the new `wiki/migration_roles.md` "Default search_path" subsection.

## Tests

- **Unit:** extended `TestPGRoleProvisioningSQLContainsExpectedStatements` with the two exact statements; added `TestPGRoleProvisioningSQLSearchPathUsesQuotedIdents` (mixed-case `TenantX`/`MigX`/`AppX` — pins that quoting is load-bearing, since unquoted PG folds to lowercase).
- **Integration (real PG container):** `TestPGRolesSearchPathSetOnBothRoles` (asserts both roles' `rolconfig` via `array_to_string`, handling the `GUC_LIST_QUOTE` unquoted-stored-form trap, plus a convergent-rerun idempotency check) and `TestPGRolesUnqualifiedResolutionUsesTenantSchema` (migrator unqualified `CREATE TABLE` → `to_regclass` in tenant schema not `public`; runtime qualified-then-unqualified `SELECT`, ordered for mechanism isolation between the grants chain and the new `search_path`).

## Verification

- `make check` exit 0 (fmt + golangci-lint + `-race` suite + alloc guard + govulncheck: 0 vulnerabilities).
- Integration tests run locally against a real PostgreSQL container: both new tests + all 4 pre-existing role tests PASS.
- Mutation check (both `ALTER ROLE` lines removed) fails all four tests with distinct signals — unit "statement not found", integration `NULL`-scan and `permission denied for schema public` (42501, migrator's unqualified CREATE falling through to `public`).
- Pre-push gates: `/simplify` (no changes — already clean), `/security-audit` (clean — identifiers are `safePGIdentifier`-validated + `quotePGIdent`-quoted; no injection surface), CodeRabbit CLI (see design note above re: the role-level scoping decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
