### PR TITLE
fix(scheduler): emit action-log summary on job panic path so 100% sampling holds

### DIFF
--- a/scheduler/module.go
+++ b/scheduler/module.go
@@ -659,6 +659,7 @@ func (m *Module) executeJob(entry *jobEntry, ctx JobContext) {
 
 		if r := recover(); r != nil {
 			executionStatus = "panic"
+			panicErr := fmt.Errorf("panic: %v", r)
 
 			// Log panic with stack trace
 			m.logger.Error().
@@ -669,7 +670,7 @@ func (m *Module) executeJob(entry *jobEntry, ctx JobContext) {
 
 			// Record panic in span (if span exists)
 			if span != nil {
-				span.RecordError(fmt.Errorf("panic: %v", r))
+				span.RecordError(panicErr)
 				span.SetStatus(codes.Error, "panic")
 				span.SetAttributes(attribute.String(jobStatusAttr, "panic"))
 			}
@@ -679,6 +680,11 @@ func (m *Module) executeJob(entry *jobEntry, ctx JobContext) {
 
 			// Record metrics
 			m.recordMetrics(entry.metadata.JobID, executionStatus, entry.metadata.ScheduleType, duration)
+
+			// Emit the structured action log so the panic path also gets the
+			// advertised 100% job-execution sampling (the normal-return call
+			// below never runs when Execute panics).
+			m.logJobResultSummary(ctx, entry.metadata.JobID, entry.metadata.ScheduleType, ctx.TriggerType(), duration, panicErr, span)
 		}
 	}()
 

--- a/scheduler/module_test.go
+++ b/scheduler/module_test.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -110,6 +111,39 @@ func TestJobExecutionPanicMetrics(t *testing.T) {
 
 	execMetric := obtest.FindMetric(rm, "job.execution.total")
 	require.NotNil(t, execMetric, "Execution counter metric should be recorded")
+}
+
+// TestJobExecutionPanicEmitsActionLogSummary verifies that a panicking job still emits
+// the structured action-log summary (log.type=action) exactly once, so the 100%
+// job-execution sampling logJobResultSummary advertises actually holds on the panic path.
+func TestJobExecutionPanicEmitsActionLogSummary(t *testing.T) {
+	job := &panicJob{}
+
+	out := captureStdout(t, func() {
+		_, registrar := newTestScheduler(t, 5*time.Second)
+
+		err := registrar.FixedRate("panic-job", job, 100*time.Millisecond)
+		require.NoError(t, err)
+
+		waitFor(t, job.wasExecuted)
+
+		// wasExecuted flips before the panic unwinds into the recovery defer;
+		// give the defer's log call a bounded settle window before returning
+		// (captureStdout reads the pipe only after this closure returns).
+		time.Sleep(50 * time.Millisecond)
+	})
+
+	// Pre-existing panic ERROR line must still fire, unregressed.
+	assert.Contains(t, out, "Job panicked - recovered and marked as failed")
+	assert.Contains(t, out, `"jobID":"panic-job"`)
+
+	// New action-log summary line must now fire on the panic path.
+	assert.Contains(t, out, `"log.type":"action"`)
+	assert.Contains(t, out, `"job.id":"panic-job"`)
+	assert.Contains(t, out, `"result_code":"ERROR"`)
+
+	// Exactly one summary line for this job's single execution — no double-emit.
+	assert.Equal(t, 1, strings.Count(out, `"job.id":"panic-job"`))
 }
 
 // TestJobSkippedDuringShutdown verifies jobs skip execution when shutdown is triggered

--- a/scheduler/module_test.go
+++ b/scheduler/module_test.go
@@ -120,17 +120,20 @@ func TestJobExecutionPanicEmitsActionLogSummary(t *testing.T) {
 	job := &panicJob{}
 
 	out := captureStdout(t, func() {
-		_, registrar := newTestScheduler(t, 5*time.Second)
+		module, _ := newTestScheduler(t, 5*time.Second)
 
-		err := registrar.FixedRate("panic-job", job, 100*time.Millisecond)
+		err := module.FixedRate("panic-job", job, 100*time.Millisecond)
 		require.NoError(t, err)
 
 		waitFor(t, job.wasExecuted)
 
-		// wasExecuted flips before the panic unwinds into the recovery defer;
-		// give the defer's log call a bounded settle window before returning
-		// (captureStdout reads the pipe only after this closure returns).
-		time.Sleep(50 * time.Millisecond)
+		// Stop the scheduler inside the capture window instead of sleeping:
+		// Shutdown's wg.Wait blocks until the in-flight job wrapper's defer
+		// completes — i.e. after the recovery defer's logJobResultSummary call —
+		// a real happens-before rather than a timing guess, and it prevents a
+		// second FixedRate tick from emitting a duplicate action line. Mirrors
+		// the stop-before-read pattern in TestJobExecutionWithTracer.
+		require.NoError(t, module.Shutdown())
 	})
 
 	// Pre-existing panic ERROR line must still fire, unregressed.


### PR DESCRIPTION
## What

Emit the structured action-log summary (`log.type=action`) on the job **panic** path, so the "100% sampling of job executions" that `logJobResultSummary`'s doc comment advertises actually holds.

## Why

`logJobResultSummary` carries the operational action-log record (`result_code`, `db_queries`, `db_elapsed`, `amqp_published`, `correlation_id`, `tenant`, …) and advertises **100% sampling**. But a job that **panics** never reached that call — the panic-recovery `defer` logged an ERROR line and recorded metrics, then returned. Dashboards/alerts built on the action-log stream therefore silently omitted exactly the worst-case executions. Metrics still fired (`job.panic.total`, `job.execution.total{status=panic}`), so this was an observability-*completeness* gap against an advertised guarantee, not a silent failure — but "100% sampling" was false for one whole execution-outcome class.

## Change

- In the panic-recovery `defer` (after `incrementFailed()` + `recordMetrics(...)`), call the **existing** `m.logJobResultSummary(...)` with `panicErr := fmt.Errorf("panic: %v", r)`. Reusing the one emission function (rather than re-formatting a log line inline) means the field set **cannot drift** between the normal and panic paths.
- `panicErr` is hoisted once and shared with the pre-existing `span.RecordError(...)` call (removes a duplicate `fmt.Errorf`).

**Exactly-once is preserved by construction:** the defer's call runs only under `recover() != nil`; the normal-path call runs only when `Execute` returned. These branches are mutually exclusive on every execution — pinned by a `count == 1` assertion in the new test.

## Tests

`TestJobExecutionPanicEmitsActionLogSummary` (`scheduler/module_test.go`) captures stdout around a panicking `FixedRate` job and asserts: the pre-existing ERROR line still fires; the new action-log line fires (`log.type=action`, `job.id=panic-job`, `result_code=ERROR`); and the summary appears **exactly once** (no double-emit).

The test stops the scheduler **inside** the capture window via `module.Shutdown()` rather than a fixed sleep — `Shutdown`'s `wg.Wait` blocks until the in-flight job wrapper's defer completes (a real happens-before, after `logJobResultSummary` runs) and prevents a second `FixedRate` tick from double-emitting under `-race` CI load. This mirrors the existing stop-before-read pattern in `TestJobExecutionWithTracer`. Verified 20× under `-race`.

## Verification

- `make check` exit 0 (fmt + golangci-lint + `-race` suite + alloc guard + govulncheck: 0 vulnerabilities).
- Mutation check: removing the new panic-branch call makes the test fail (no `log.type=action` line, count drops to 0); restored → green.
- Adversarial correctness review (control-flow + test-determinism): exactly-once invariant confirmed under Go defer/recover semantics; no nil-deref on the panic path (same nil-safe `span`/`ctx` as the normal path); test hardened against the `FixedRate` re-fire race.

Note on the action-log `job.status` field on the panic path: it reads `"failure"` (via `jobStatusFromError`, which is binary success/failure), while the metrics counter and span record `"panic"`. The panic remains fully distinguishable in the action log via `result_code:"ERROR"` + the attached `error:"panic: …"` field (and the separate `"Job panicked…"` ERROR line). This is a deliberate consequence of reusing `logJobResultSummary` unchanged so the field set can't drift between paths; enriching the binary status taxonomy is a separate, out-of-scope change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job execution panics now emit the expected structured action log with an error result.
  * Panic recovery continues to record the error details and correlation information consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->