### PR TITLE
fix(app): warn when debug endpoints register with no allowlist and no token

### DIFF
--- a/app/debug_handlers.go
+++ b/app/debug_handlers.go
@@ -116,6 +116,14 @@ func (d *DebugHandlers) RegisterDebugEndpoints(r server.RouteRegistrar) {
 		g.Add(http.MethodGet, "/info", d.handleInfo)
 	}
 
+	if len(d.config.AllowedIPs) == 0 && d.config.BearerToken == "" {
+		d.logger.Warn().
+			Str("prefix", d.config.PathPrefix).
+			Msg("Debug endpoints registered with NO access control (empty allowedips, no bearertoken): " +
+				"goroutine dumps, forced GC, and build info are reachable by anyone who can reach this port. " +
+				"Set debug.allowedips and/or debug.bearertoken.")
+	}
+
 	d.logger.Info().
 		Str("prefix", d.config.PathPrefix).
 		Msgf("Debug endpoints registered (allowed_ips=%d, auth_enabled=%t)",

--- a/app/debug_handlers.go
+++ b/app/debug_handlers.go
@@ -121,7 +121,7 @@ func (d *DebugHandlers) RegisterDebugEndpoints(r server.RouteRegistrar) {
 		exposed = append(exposed, "goroutine dumps")
 	}
 	if d.config.Endpoints.GC {
-		exposed = append(exposed, "forced GC")
+		exposed = append(exposed, "GC endpoints")
 	}
 	if d.config.Endpoints.Health {
 		exposed = append(exposed, "enhanced health")

--- a/app/debug_handlers.go
+++ b/app/debug_handlers.go
@@ -116,7 +116,9 @@ func (d *DebugHandlers) RegisterDebugEndpoints(r server.RouteRegistrar) {
 		g.Add(http.MethodGet, "/info", d.handleInfo)
 	}
 
-	if len(d.config.AllowedIPs) == 0 && d.config.BearerToken == "" {
+	anyEndpoint := d.config.Endpoints.Goroutines || d.config.Endpoints.GC ||
+		d.config.Endpoints.Health || d.config.Endpoints.Info
+	if anyEndpoint && len(d.config.AllowedIPs) == 0 && d.config.BearerToken == "" {
 		d.logger.Warn().
 			Str("prefix", d.config.PathPrefix).
 			Msg("Debug endpoints registered with NO access control (empty allowedips, no bearertoken): " +

--- a/app/debug_handlers.go
+++ b/app/debug_handlers.go
@@ -116,13 +116,25 @@ func (d *DebugHandlers) RegisterDebugEndpoints(r server.RouteRegistrar) {
 		g.Add(http.MethodGet, "/info", d.handleInfo)
 	}
 
-	anyEndpoint := d.config.Endpoints.Goroutines || d.config.Endpoints.GC ||
-		d.config.Endpoints.Health || d.config.Endpoints.Info
-	if anyEndpoint && len(d.config.AllowedIPs) == 0 && d.config.BearerToken == "" {
+	var exposed []string
+	if d.config.Endpoints.Goroutines {
+		exposed = append(exposed, "goroutine dumps")
+	}
+	if d.config.Endpoints.GC {
+		exposed = append(exposed, "forced GC")
+	}
+	if d.config.Endpoints.Health {
+		exposed = append(exposed, "enhanced health")
+	}
+	if d.config.Endpoints.Info {
+		exposed = append(exposed, "build info")
+	}
+	if len(exposed) > 0 && len(d.config.AllowedIPs) == 0 && d.config.BearerToken == "" {
 		d.logger.Warn().
 			Str("prefix", d.config.PathPrefix).
+			Str("exposed", strings.Join(exposed, ", ")).
 			Msg("Debug endpoints registered with NO access control (empty allowedips, no bearertoken): " +
-				"goroutine dumps, forced GC, and build info are reachable by anyone who can reach this port. " +
+				"the listed endpoints are reachable by anyone who can reach this port. " +
 				"Set debug.allowedips and/or debug.bearertoken.")
 	}
 

--- a/app/debug_handlers_test.go
+++ b/app/debug_handlers_test.go
@@ -270,11 +270,13 @@ func TestRegisterDebugEndpointsAccessControlWarn(t *testing.T) {
 		name        string
 		allowedIPs  []string
 		bearerToken string
+		endpoints   config.DebugEndpointsConfig
 		wantWarn    bool
 	}{
-		{name: "no_access_control_warns", allowedIPs: nil, bearerToken: "", wantWarn: true},
-		{name: "allowlist_set_no_warn", allowedIPs: []string{"127.0.0.1"}, bearerToken: "", wantWarn: false},
-		{name: "token_set_no_warn", allowedIPs: nil, bearerToken: "x", wantWarn: false},
+		{name: "no_access_control_warns", allowedIPs: nil, bearerToken: "", endpoints: config.DebugEndpointsConfig{Info: true}, wantWarn: true},
+		{name: "allowlist_set_no_warn", allowedIPs: []string{"127.0.0.1"}, bearerToken: "", endpoints: config.DebugEndpointsConfig{Info: true}, wantWarn: false},
+		{name: "token_set_no_warn", allowedIPs: nil, bearerToken: "x", endpoints: config.DebugEndpointsConfig{Info: true}, wantWarn: false},
+		{name: "no_endpoints_no_warn", allowedIPs: nil, bearerToken: "", endpoints: config.DebugEndpointsConfig{}, wantWarn: false},
 	}
 
 	for _, tt := range tests {
@@ -284,6 +286,7 @@ func TestRegisterDebugEndpointsAccessControlWarn(t *testing.T) {
 				PathPrefix:  "/_debug",
 				AllowedIPs:  tt.allowedIPs,
 				BearerToken: tt.bearerToken,
+				Endpoints:   tt.endpoints,
 			}
 
 			rec := &recLogger{}

--- a/app/debug_handlers_test.go
+++ b/app/debug_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -243,6 +244,53 @@ func TestAuthMiddlewareConstantTimeComparison(t *testing.T) {
 				assert.False(t, nextCalled)
 				assertAPIErrorStatus(t, err, http.StatusUnauthorized)
 			}
+		})
+	}
+}
+
+// loggedMsgContains reports whether rec recorded any log line whose message
+// contains substr.
+func loggedMsgContains(rec *recLogger, substr string) bool {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	for _, e := range rec.events {
+		if strings.Contains(e.msg, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRegisterDebugEndpointsAccessControlWarn verifies the no-access-control WARN fires only
+// when debug endpoints register with neither an IP allowlist nor a bearer token (the endpoints
+// — goroutine dumps, forced GC, build info — are otherwise reachable by anyone who can reach
+// the port), and stays quiet as soon as either gate is configured.
+func TestRegisterDebugEndpointsAccessControlWarn(t *testing.T) {
+	tests := []struct {
+		name        string
+		allowedIPs  []string
+		bearerToken string
+		wantWarn    bool
+	}{
+		{name: "no_access_control_warns", allowedIPs: nil, bearerToken: "", wantWarn: true},
+		{name: "allowlist_set_no_warn", allowedIPs: []string{"127.0.0.1"}, bearerToken: "", wantWarn: false},
+		{name: "token_set_no_warn", allowedIPs: nil, bearerToken: "x", wantWarn: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			debugConfig := &config.DebugConfig{
+				Enabled:     true,
+				PathPrefix:  "/_debug",
+				AllowedIPs:  tt.allowedIPs,
+				BearerToken: tt.bearerToken,
+			}
+
+			rec := &recLogger{}
+			debugHandlers := NewDebugHandlers(&App{logger: rec}, debugConfig, rec)
+			debugHandlers.RegisterDebugEndpoints(newRecordingRegistrar())
+
+			assert.Equal(t, tt.wantWarn, loggedMsgContains(rec, "NO access control"))
 		})
 	}
 }

--- a/app/debug_handlers_test.go
+++ b/app/debug_handlers_test.go
@@ -261,10 +261,23 @@ func loggedMsgContains(rec *recLogger, substr string) bool {
 	return false
 }
 
+// loggedStr returns the value of the given Str field on the first recorded log
+// event whose message contains substr, or "" if none.
+func loggedStr(rec *recLogger, substr, field string) string {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	for _, e := range rec.events {
+		if strings.Contains(e.msg, substr) {
+			return e.str[field]
+		}
+	}
+	return ""
+}
+
 // TestRegisterDebugEndpointsAccessControlWarn verifies the no-access-control WARN fires only
-// when debug endpoints register with neither an IP allowlist nor a bearer token (the endpoints
-// — goroutine dumps, forced GC, build info — are otherwise reachable by anyone who can reach
-// the port), and stays quiet as soon as either gate is configured.
+// when at least one debug endpoint is registered AND neither an IP allowlist nor a bearer token
+// is configured, and that the warning's "exposed" field lists exactly the enabled endpoints so
+// it cannot over-state the exposure.
 func TestRegisterDebugEndpointsAccessControlWarn(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -272,8 +285,10 @@ func TestRegisterDebugEndpointsAccessControlWarn(t *testing.T) {
 		bearerToken string
 		endpoints   config.DebugEndpointsConfig
 		wantWarn    bool
+		wantExposed string
 	}{
-		{name: "no_access_control_warns", allowedIPs: nil, bearerToken: "", endpoints: config.DebugEndpointsConfig{Info: true}, wantWarn: true},
+		{name: "no_access_control_warns", allowedIPs: nil, bearerToken: "", endpoints: config.DebugEndpointsConfig{Info: true}, wantWarn: true, wantExposed: "build info"},
+		{name: "lists_only_enabled_endpoints", allowedIPs: nil, bearerToken: "", endpoints: config.DebugEndpointsConfig{Goroutines: true, Info: true}, wantWarn: true, wantExposed: "goroutine dumps, build info"},
 		{name: "allowlist_set_no_warn", allowedIPs: []string{"127.0.0.1"}, bearerToken: "", endpoints: config.DebugEndpointsConfig{Info: true}, wantWarn: false},
 		{name: "token_set_no_warn", allowedIPs: nil, bearerToken: "x", endpoints: config.DebugEndpointsConfig{Info: true}, wantWarn: false},
 		{name: "no_endpoints_no_warn", allowedIPs: nil, bearerToken: "", endpoints: config.DebugEndpointsConfig{}, wantWarn: false},
@@ -294,6 +309,9 @@ func TestRegisterDebugEndpointsAccessControlWarn(t *testing.T) {
 			debugHandlers.RegisterDebugEndpoints(newRecordingRegistrar())
 
 			assert.Equal(t, tt.wantWarn, loggedMsgContains(rec, "NO access control"))
+			if tt.wantWarn {
+				assert.Equal(t, tt.wantExposed, loggedStr(rec, "NO access control", "exposed"))
+			}
 		})
 	}
 }

--- a/app/debug_handlers_test.go
+++ b/app/debug_handlers_test.go
@@ -289,6 +289,14 @@ func TestRegisterDebugEndpointsAccessControlWarn(t *testing.T) {
 	}{
 		{name: "no_access_control_warns", allowedIPs: nil, bearerToken: "", endpoints: config.DebugEndpointsConfig{Info: true}, wantWarn: true, wantExposed: "build info"},
 		{name: "lists_only_enabled_endpoints", allowedIPs: nil, bearerToken: "", endpoints: config.DebugEndpointsConfig{Goroutines: true, Info: true}, wantWarn: true, wantExposed: "goroutine dumps, build info"},
+		{
+			name:        "all_endpoints_listed",
+			allowedIPs:  nil,
+			bearerToken: "",
+			endpoints:   config.DebugEndpointsConfig{Goroutines: true, GC: true, Health: true, Info: true},
+			wantWarn:    true,
+			wantExposed: "goroutine dumps, GC endpoints, enhanced health, build info",
+		},
 		{name: "allowlist_set_no_warn", allowedIPs: []string{"127.0.0.1"}, bearerToken: "", endpoints: config.DebugEndpointsConfig{Info: true}, wantWarn: false},
 		{name: "token_set_no_warn", allowedIPs: nil, bearerToken: "x", endpoints: config.DebugEndpointsConfig{Info: true}, wantWarn: false},
 		{name: "no_endpoints_no_warn", allowedIPs: nil, bearerToken: "", endpoints: config.DebugEndpointsConfig{}, wantWarn: false},


### PR DESCRIPTION
## What

Emit a **WARN** when debug endpoints register with **both** an empty `debug.allowedips` **and** an empty `debug.bearertoken` — i.e. with zero access control. Warn-only; **no behavior change** for any configuration.

## Why

When `debug.enabled=true` with empty `debug.allowedips` AND empty `debug.bearertoken`, the debug endpoints (`GET /goroutines`, `GET|POST /gc` — POST forces a GC, a resource-exhaustion lever — `/health-debug`, `/info`) register with **zero** access control, and the only signal was an Info-level line. The shipped defaults are fail-closed (`debug.enabled=false`, `debug.allowedips=["127.0.0.1","::1"]`), so reaching this state requires an operator to deliberately enable debug, clear the loopback allowlist, and leave the token empty — but when they do, it should be **loud**. This mirrors the repo's established fail-open-WARN precedent for CORS (plan 009). A hard fail-closed would be a behavior change needing an ADR — explicitly out of scope; the WARN text names the remediation keys (`debug.allowedips` / `debug.bearertoken`) so it's actionable in a log aggregator.

## Guard correctness

`len(d.config.AllowedIPs) == 0 && d.config.BearerToken == ""` precisely captures the both-gates-inactive state, verified against the two real access-control mechanisms: the IP allowlist middleware is a pass-through when `AllowedIPs` is empty, and bearer auth is only wired when `BearerToken != ""`. `TrustedProxies` is **not** a third gate (it only makes client-IP derivation spoof-resistant and is inert when the allowlist is empty). A non-empty-but-all-invalid `AllowedIPs` yields a deny-all whitelist (fail-closed), so it correctly does **not** warn. The WARN fires once at registration (after the `!Enabled` early return), never per-request, and logs only the non-sensitive `PathPrefix`.

## Tests

One table-driven test (`TestRegisterDebugEndpointsAccessControlWarn`) covering the warn case + both single-gate no-warn cases (`allowlist_set`, `token_set`). It uses the app package's existing `recLogger` (a recording `logger.Logger` fake already used for the "Route registered" assertion) — asserting on the recorded messages via the injected interface, rather than swapping `os.Stdout` — so the tests are parallel-safe and carry no global-state fragility.

## Verification

- `make check` exit 0 (fmt + golangci-lint + `-race` suite + alloc guard + govulncheck: 0 vulnerabilities).
- gosec: 0 issues on `app/`.
- Mutation check: removing the WARN block fails the `no_access_control_warns` case; restored → green.
- Reviewed by a 4-lens adversarial panel (reuse / simplification / security / correctness) — security and correctness lenses confirmed the guard is exactly right with no false positive/miss and no secret leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a registration-time warning when debug endpoints are enabled without any IP allowlisting or bearer-token protection.
  * The warning includes which debug endpoint categories are exposed to help identify potentially sensitive diagnostics reachable via the service port.
  * The warning is suppressed when access controls are configured or when no debug endpoints are enabled.

* **Tests**
  * Added coverage to verify the warning behavior and confirm the exact exposed-endpoints list formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->