### PR TITLE
fix(database): log the DB error type, not the raw driver message (PII/PAN redaction)

### DIFF
--- a/database/internal/tracking/statement_test.go
+++ b/database/internal/tracking/statement_test.go
@@ -140,8 +140,8 @@ func TestStatementExecPropagatesErrors(t *testing.T) {
 	if events[0].Level != "error" {
 		t.Fatalf("expected error level, got %s", events[0].Level)
 	}
-	if events[0].Err == nil {
-		t.Fatalf("expected error to be recorded")
+	if events[0].Fields["error_type"] != dbErrorClass(underlying.execErr) {
+		t.Fatalf("expected error_type field to hold the driver error's Go type, got %v", events[0].Fields["error_type"])
 	}
 }
 

--- a/database/internal/tracking/utils.go
+++ b/database/internal/tracking/utils.go
@@ -140,13 +140,14 @@ func TrackDBOperation(ctx context.Context, tc *Context, query string, args []any
 	log := tc.Logger.WithContext(ctx)
 	var event logger.LogEvent
 	var message string
+	var driverErr error
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
 		event, message = log.Debug(), msgDBOperationNoRows
 	case errors.Is(err, sql.ErrTxDone):
 		event, message = log.Debug(), msgDBTxFinalized
 	case err != nil:
-		event, message = log.Error().Err(err), msgDBOperationError
+		event, message, driverErr = log.Error(), msgDBOperationError, err
 	case elapsed > tc.Settings.SlowQueryThreshold():
 		event, message = log.Warn(), fmt.Sprintf("Slow database operation detected (%s)", elapsed)
 	default:
@@ -185,6 +186,8 @@ func TrackDBOperation(ctx context.Context, tc *Context, query string, args []any
 	// path did (full "***"). That divergence is by design for the typed-setter path and unreachable
 	// for these two keys under the default config; do not add vendor/query to the sensitive list to
 	// avoid relying on full masking here.
+	event = appendDBErrorType(event, driverErr)
+
 	event = event.
 		Str("vendor", tc.Vendor).
 		Int64("duration_ms", elapsed.Milliseconds()).
@@ -343,6 +346,22 @@ func createDBSpan(ctx context.Context, tc *Context, query string, start time.Tim
 // so span error attribution never carries driver-embedded row data.
 func dbErrorClass(err error) string {
 	return fmt.Sprintf("%T", err)
+}
+
+// appendDBErrorType appends an "error_type" field to event when driverErr is non-nil,
+// recording the error's Go type without its message. Returns event unchanged when
+// driverErr is nil. Extracted from TrackDBOperation to keep it under the gocyclo limit.
+//
+// SECURITY: Do not use .Err(driverErr) here. Postgres/Oracle driver errors embed the
+// offending row data (a unique-constraint violation echoes the colliding value, which may
+// be a PAN or other sensitive field). The log-path SensitiveDataFilter masks by FIELD NAME
+// only and cannot scrub a message body, so record the error's Go type instead — same posture
+// as the span path (see dbErrorClass / createDBSpan).
+func appendDBErrorType(event logger.LogEvent, driverErr error) logger.LogEvent {
+	if driverErr == nil {
+		return event
+	}
+	return event.Str("error_type", dbErrorClass(driverErr))
 }
 
 // extractDBOperation determines the database operation name from the given SQL query.

--- a/database/internal/tracking/utils_test.go
+++ b/database/internal/tracking/utils_test.go
@@ -350,9 +350,10 @@ func TestTrackDBOperationDisabledWarnStillEscalates(t *testing.T) {
 }
 
 // TestTrackDBOperationDisabledErrorStillEscalates verifies the disabled-ERROR path:
-// when the error level is disabled, no fields are built but event.Msg is still called
-// with the error message and the error is attached — proving severity escalation is
-// preserved on a dropped ERROR line.
+// when the error level is disabled, no fields are built (including error_type, which is
+// only built on the enabled path) and event.Err stays nil (redaction), but event.Msg is
+// still called with the error message — proving severity escalation is preserved on a
+// dropped ERROR line.
 func TestTrackDBOperationDisabledErrorStillEscalates(t *testing.T) {
 	ctx := logger.WithDBCounter(context.Background())
 	recLogger := newRecordingLoggerWithDisabled(levelError)
@@ -374,16 +375,19 @@ func TestTrackDBOperationDisabledErrorStillEscalates(t *testing.T) {
 	if event.Level != levelError {
 		t.Fatalf("expected error level event, got %s", event.Level)
 	}
-	// The error is attached via .Err(err) before the Enabled() short-circuit; the
-	// fields map itself must remain empty (no vendor/duration/query built).
+	// error_type is only built on the ENABLED path (right before the vendor/duration/query
+	// chain); the fields map itself must remain empty on a disabled event (allocation win).
 	if len(event.Fields) != 0 {
 		t.Fatalf("expected no fields built when error level disabled, got %v", event.Fields)
 	}
-	if !errors.Is(event.Err, failure) {
-		t.Fatalf("expected error to be attached on disabled ERROR, got %v", event.Err)
+	if event.Err != nil {
+		t.Fatalf("expected the raw driver error to stay unattached (redacted), got %v", event.Err)
 	}
 	if event.Msg != msgDBOperationError {
 		t.Fatalf("expected error message on disabled ERROR, got %q", event.Msg)
+	}
+	if strings.Contains(event.Msg, failure.Error()) {
+		t.Fatalf("log message must not leak the raw driver error, got %q", event.Msg)
 	}
 }
 
@@ -566,12 +570,64 @@ func TestTrackDBOperationLogsErrors(t *testing.T) {
 	if event.Level != levelError {
 		t.Fatalf("expected error level, got %s", event.Level)
 	}
-	if !errors.Is(event.Err, failure) {
-		t.Fatalf("expected error to be recorded")
+	if event.Err != nil {
+		t.Fatalf("expected the raw driver error to stay unattached (redacted), got %v", event.Err)
+	}
+	if event.Fields["error_type"] != dbErrorClass(failure) {
+		t.Fatalf("expected error_type field to hold the driver error's Go type, got %v", event.Fields["error_type"])
+	}
+	assertNoFieldsLeak(t, event.Fields, failure.Error())
+	if event.Msg != msgDBOperationError {
+		t.Fatalf("unexpected message: %q", event.Msg)
+	}
+}
+
+// assertNoFieldsLeak fails if any field value stringifies to something containing one of
+// needles — used to prove the raw driver error / embedded row data never reaches a log field.
+func assertNoFieldsLeak(t *testing.T, fields map[string]any, needles ...string) {
+	t.Helper()
+	for key, value := range fields {
+		str := fmt.Sprintf("%v", value)
+		for _, needle := range needles {
+			assert.NotContainsf(t, str, needle, "field %s leaked %q: %q", key, needle, str)
+		}
+	}
+}
+
+// TestTrackDBOperationRedactsDriverErrorMessage guards against raw driver errors
+// (which can embed offending row data, e.g. a PAN in a unique-constraint
+// violation) leaking to log backends unfiltered via the ERROR branch's event.Err.
+func TestTrackDBOperationRedactsDriverErrorMessage(t *testing.T) {
+	ctx := logger.WithDBCounter(context.Background())
+	recLogger := newRecordingLogger()
+	settings := Settings{slowQueryThreshold: time.Second}
+
+	sensitiveValue := "4111" + strings.Repeat("1", 12) // built at runtime so no PAN-like literal sits in test source
+	rawMessage := "duplicate key value violates unique constraint: Key (pan)=(" + sensitiveValue + ") already exists"
+	driverErr := errors.New(rawMessage)
+
+	start := time.Now().Add(-10 * time.Millisecond)
+	TrackDBOperation(ctx, &Context{Logger: recLogger, Vendor: "postgresql", Settings: settings}, selectOne, nil, start, 0, driverErr)
+
+	events := recLogger.events()
+	if len(events) != 1 {
+		t.Fatalf(singleEventExpected, len(events))
+	}
+	event := events[0]
+	if event.Level != levelError {
+		t.Fatalf("expected error level, got %s", event.Level)
 	}
 	if event.Msg != msgDBOperationError {
 		t.Fatalf("unexpected message: %q", event.Msg)
 	}
+
+	assert.Nil(t, event.Err, "the raw driver error must not be attached via .Err()")
+	assert.NotContains(t, event.Msg, sensitiveValue, "log message must not leak the sensitive value")
+	assert.NotContains(t, event.Msg, rawMessage, "log message must not leak the raw driver error")
+
+	assertNoFieldsLeak(t, event.Fields, sensitiveValue, rawMessage)
+
+	assert.Equal(t, dbErrorClass(driverErr), event.Fields["error_type"], "error_type must hold the error's Go type")
 }
 
 func TestTrackDBOperationNoLoggerOrContext(t *testing.T) {


### PR DESCRIPTION
## What

The DB-operation ERROR log no longer attaches the **raw driver error message**. It now logs the error's Go **type** in an `error_type` field instead.

Closes the last member of the driver-error redaction trio (DB **span** path and HTTP **5xx** path are already redacted).

## Why (PII/PCI leak)

The ERROR branch of `TrackDBOperation` did `.Err(err)`, which sets the structured `error` field to `err.Error()` — the verbatim Postgres/Oracle driver message. Those drivers embed the **offending row data**: a unique-constraint violation echoes back the value that collided, which may be a **PAN or other PII/PCI field**. That field bypasses the log-path `SensitiveDataFilter` (which masks by field **name** only, and cannot scrub a substring out of a message body), so it reached log backends **unredacted**.

## Change

- The switch's error arm captures the driver error (`driverErr`) and attaches **no** field.
- On the **enabled** path only, `appendDBErrorType` adds `error_type = <Go type>` (via the existing `dbErrorClass` helper the span path already uses) — the type name never carries row data.
- The **disabled**-ERROR path attaches nothing (no field, no `.Err`), preserving the "no fields built when disabled" allocation win and the `Msg`→`trackSeverity` escalation.
- `appendDBErrorType` is a small same-file helper (keeps `TrackDBOperation` under the `gocyclo` limit) carrying the grep-discoverable `// SECURITY:` annotation.

## ⚠️ Operator note (log-field rename)

Dashboards/alerts keyed on the raw **`error`** field of DB-operation error logs must move to **`error_type`** (which now holds the Go type, e.g. `*pgconn.PgError`). This is an observability field change, not an API/config break — no `!`.

## Tests

- New `TestTrackDBOperationRedactsDriverErrorMessage`: drives the ERROR path with a **runtime-built PAN-shaped value** inside a realistic unique-constraint message; asserts the value/message appear in **neither** `event.Err`, `event.Msg`, **nor any field** (via a shared `assertNoFieldsLeak` helper), and that `error_type` holds the Go type.
- Updated `TestTrackDBOperationLogsErrors`, `TestTrackDBOperationDisabledErrorStillEscalates` (redacted contract), and `statement_test.go` `TestStatementExecPropagatesErrors` (log assertion moved from `.Err` to `error_type`; the error is still returned from `Exec`).

## Verification

- `make check` exit 0 (fmt + golangci-lint incl. `gocyclo` + `-race` suite + alloc guard + govulncheck: 0).
- gosec: 0 issues on `database/internal/tracking/`.
- Mutation check: restoring `.Err(err)` in the switch makes the redaction tests fail (the raw PAN-shaped value leaks); restored → green.
- Reviewed by a 4-lens adversarial panel — the security lens confirmed no *other* residual leak path (only remaining `%v`-of-error is an unrelated OTel-init warning; `%T` is message-free; `query`/`args` unchanged and already sanitized) and correctness confirmed `error_type` is never added for `sql.ErrNoRows`/`sql.ErrTxDone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database error logging to prevent sensitive driver error messages from appearing in logs.
  * Error logs now retain the error category while omitting raw error details.
  * Updated error handling for disabled error-level logging to avoid creating or exposing unnecessary fields.
  * Added coverage to verify sensitive error information is consistently redacted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->