### PR TITLE
feat(migrate): add --timeout to go-bricks-migrate to override per-tenant Flyway timeout

### DIFF
--- a/tools/migration/internal/commands/common.go
+++ b/tools/migration/internal/commands/common.go
@@ -293,14 +293,15 @@ func validateConfigPath(path string) error {
 }
 
 // buildBaseConfig translates flag values into a *migration.Config with only
-// user-supplied fields filled. Vendor-specific defaults (including Timeout)
-// are applied per tenant inside MigrateAll, so leaving Timeout zero here lets
-// each vendor's recommended timeout win unless the user overrides it.
+// user-supplied fields filled. Vendor-specific defaults are applied per
+// tenant inside MigrateAll, so leaving Timeout zero here lets each vendor's
+// recommended timeout win; a non-zero --timeout overrides it via mergeConfigs.
 func buildBaseConfig(flags *CommonFlags) *migration.Config {
 	return &migration.Config{
 		FlywayPath:    flags.FlywayPath,
 		ConfigPath:    flags.FlywayConfig,
 		MigrationPath: flags.MigrationsDir,
+		Timeout:       flags.Timeout, // 0 -> vendor default wins in mergeConfigs
 		Audit: migration.AuditContext{
 			Principal:     flags.AppliedBy,
 			GitCommitSHA:  flags.GitSHA,

--- a/tools/migration/internal/commands/common.go
+++ b/tools/migration/internal/commands/common.go
@@ -295,13 +295,13 @@ func validateConfigPath(path string) error {
 // buildBaseConfig translates flag values into a *migration.Config with only
 // user-supplied fields filled. Vendor-specific defaults are applied per
 // tenant inside MigrateAll, so leaving Timeout zero here lets each vendor's
-// recommended timeout win; a non-zero --timeout overrides it via mergeConfigs.
+// recommended timeout win; a positive --timeout overrides it via mergeConfigs.
 func buildBaseConfig(flags *CommonFlags) *migration.Config {
 	return &migration.Config{
 		FlywayPath:    flags.FlywayPath,
 		ConfigPath:    flags.FlywayConfig,
 		MigrationPath: flags.MigrationsDir,
-		Timeout:       flags.Timeout, // 0 -> vendor default wins in mergeConfigs
+		Timeout:       flags.Timeout, // 0 or negative -> vendor default wins in mergeConfigs
 		Audit: migration.AuditContext{
 			Principal:     flags.AppliedBy,
 			GitCommitSHA:  flags.GitSHA,

--- a/tools/migration/internal/commands/constructors_test.go
+++ b/tools/migration/internal/commands/constructors_test.go
@@ -305,8 +305,14 @@ func TestBuildBaseConfig(t *testing.T) {
 	assert.Equal(t, "flyway", cfg.FlywayPath)
 	assert.Equal(t, "x.conf", cfg.ConfigPath)
 	assert.Equal(t, "m", cfg.MigrationPath)
-	// Timeout left zero so per-vendor default wins inside MigrateAll.
+	// A zero (unset) --timeout flag still yields a zero Timeout, so mergeConfigs
+	// keeps the per-vendor default inside MigrateAll.
 	assert.Zero(t, cfg.Timeout)
+}
+
+func TestBuildBaseConfigTimeoutFlagSetsOverride(t *testing.T) {
+	cfg := buildBaseConfig(&CommonFlags{Timeout: 30 * time.Minute})
+	assert.Equal(t, 30*time.Minute, cfg.Timeout)
 }
 
 func TestBuildBaseConfigPopulatesAudit(t *testing.T) {

--- a/tools/migration/internal/commands/root.go
+++ b/tools/migration/internal/commands/root.go
@@ -2,6 +2,8 @@
 package commands
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 
 	"github.com/gaborage/go-bricks/migration"
@@ -39,6 +41,7 @@ type CommonFlags struct {
 	Tenant          string
 	JSON            bool
 	Verbose         bool
+	Timeout         time.Duration
 }
 
 // NewRootCommand constructs the cobra root with shared flags wired up.
@@ -99,6 +102,8 @@ func addCommonFlags(cmd *cobra.Command) *CommonFlags {
 	cmd.Flags().StringVar(&flags.Tenant, "tenant", "", "Run for a single tenant ID instead of listing all")
 	cmd.Flags().BoolVar(&flags.JSON, "json", false, "Emit NDJSON progress records (for CI/CD parsing)")
 	cmd.Flags().BoolVarP(&flags.Verbose, "verbose", "v", false, "Verbose logging")
+	cmd.Flags().DurationVar(&flags.Timeout, "timeout", 0,
+		"Per-tenant Flyway timeout (e.g. 30m); 0 uses the vendor default (5m). Raise for large index builds/backfills.")
 
 	return flags
 }

--- a/tools/migration/internal/commands/root.go
+++ b/tools/migration/internal/commands/root.go
@@ -103,7 +103,7 @@ func addCommonFlags(cmd *cobra.Command) *CommonFlags {
 	cmd.Flags().BoolVar(&flags.JSON, "json", false, "Emit NDJSON progress records (for CI/CD parsing)")
 	cmd.Flags().BoolVarP(&flags.Verbose, "verbose", "v", false, "Verbose logging")
 	cmd.Flags().DurationVar(&flags.Timeout, "timeout", 0,
-		"Per-tenant Flyway timeout (e.g. 30m); 0 uses the vendor default (5m). Raise for large index builds/backfills.")
+		"Per-tenant Flyway timeout (e.g. 30m); 0 or a negative value uses the vendor default (5m). Raise for large index builds/backfills.")
 
 	return flags
 }


### PR DESCRIPTION
## What

Adds a `--timeout` flag to `go-bricks-migrate` to override the per-tenant Flyway timeout.

## Why

The CLI hardcoded the 5-minute per-tenant Flyway timeout (the vendor default) with **no** override. A migration that legitimately exceeds 5 minutes (a large index build, a data backfill) was context-killed on every tenant of a fleet rollout — deterministically failing the exact operation the CLI exists for, with no workaround short of recompiling. The merge machinery already honored a non-zero override (`migration/multi_tenant.go` `mergeConfigs`), so this is a small, self-contained gap: register the flag and thread it into the base config.

## Change

- `--timeout` (`time.Duration`) on the shared `CommonFlags`, registered via `DurationVar` (mirroring the `--ttl` precedent), threaded into `buildBaseConfig`'s `*migration.Config`.
- **`0` (unset) = vendor default (5m)** — the pre-existing behavior is preserved (`mergeConfigs` only applies `Timeout` when `> 0`). A non-zero value overrides per-tenant, uniformly for single-tenant and fan-out runs.

## Note on negative values

A negative `--timeout` (e.g. `-5m`) parses but is treated as "use the vendor default" — `mergeConfigs`'s existing `override.Timeout > 0` guard filters it out, so a negative/zero duration never reaches `context.WithTimeout`. This is intentionally **not** rejected with an error, to stay consistent with the CLI's existing silent-normalization of out-of-range numerics (`--parallel < 1` is clamped to `1`). Adding a hard rejection for `--timeout` alone would make numeric-flag handling inconsistent.

## Tests

`TestBuildBaseConfigTimeoutFlagSetsOverride` pins that a non-zero flag flows into `cfg.Timeout`; the pre-existing `TestBuildBaseConfig`'s `assert.Zero(cfg.Timeout)` is the (unchanged) zero-case guard. The `mergeConfigs` override path itself is already covered in `migration/multi_tenant_test.go`.

## Verification

- `make -C tools/migration check` exit 0 — the CLI module's **own** gate (fmt + lint incl. gosec + `-race` tests + CLI-validation + govulncheck: 0). Root `make check` excludes `tools/migration`, so this is the authoritative gate.
- Root `make check` exit 0 (proves nothing spilled into the framework).
- End-to-end: `--timeout` appears in `migrate --help` with the documented default.
- Reviewed by a 4-lens adversarial panel (reuse / simplification / security / correctness) — all clean; the negative-value handling was assessed and deemed safe + precedent-consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--timeout` option to configure a per-tenant Flyway migration timeout.
  * Default behavior (`0`) keeps the vendor-provided timeout; negative values also fall back to the vendor default.
  * Enables longer timeouts for larger builds and backfills.
* **Bug Fixes / Behavior**
  * Ensures the configured timeout flag is correctly applied during migration configuration merging.
* **Tests**
  * Added/updated coverage to verify `--timeout` default and override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->