### PR TITLE
fix(messaging): run lazy infra setup on a bounded budget detached from the request deadline

### DIFF
--- a/messaging/amqp_client.go
+++ b/messaging/amqp_client.go
@@ -745,13 +745,10 @@ func (c *AMQPClientImpl) Consume(ctx context.Context, destination string) (<-cha
 
 // ConsumeFromQueue consumes messages from a queue with specific options.
 func (c *AMQPClientImpl) ConsumeFromQueue(_ context.Context, options ConsumeOptions) (<-chan amqp.Delivery, error) {
-	c.m.RLock()
-	if !c.isReady {
-		c.m.RUnlock()
-		return nil, errNotConnected
+	channel, err := c.readyChannel()
+	if err != nil {
+		return nil, err
 	}
-	channel := c.channel
-	c.m.RUnlock()
 
 	// Set QoS for fair dispatch with configurable prefetch (v0.17+)
 	prefetchCount := options.PrefetchCount
@@ -781,6 +778,18 @@ func toTable(args map[string]any) amqp.Table {
 	return amqp.Table(args)
 }
 
+// readyChannel returns the current channel under RLock, or errNotConnected
+// when the client is not ready. Callers must not retain the channel across
+// reconnects.
+func (c *AMQPClientImpl) readyChannel() (amqpChannel, error) {
+	c.m.RLock()
+	defer c.m.RUnlock()
+	if !c.isReady {
+		return nil, errNotConnected
+	}
+	return c.channel, nil
+}
+
 // DeclareQueue declares a queue from the given declaration.
 // ctx is honored as a pre-flight check: amqp091 declare/bind operations are not
 // context-aware on the wire, so a canceled context fails fast before the call.
@@ -791,15 +800,12 @@ func (c *AMQPClientImpl) DeclareQueue(ctx context.Context, queue *QueueDeclarati
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	c.m.RLock()
-	if !c.isReady {
-		c.m.RUnlock()
-		return errNotConnected
+	channel, err := c.readyChannel()
+	if err != nil {
+		return err
 	}
-	channel := c.channel
-	c.m.RUnlock()
 
-	_, err := channel.QueueDeclare(queue.Name, queue.Durable, queue.AutoDelete, queue.Exclusive, queue.NoWait, toTable(queue.Args))
+	_, err = channel.QueueDeclare(queue.Name, queue.Durable, queue.AutoDelete, queue.Exclusive, queue.NoWait, toTable(queue.Args))
 	return err
 }
 
@@ -811,13 +817,10 @@ func (c *AMQPClientImpl) DeclareExchange(ctx context.Context, exchange *Exchange
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	c.m.RLock()
-	if !c.isReady {
-		c.m.RUnlock()
-		return errNotConnected
+	channel, err := c.readyChannel()
+	if err != nil {
+		return err
 	}
-	channel := c.channel
-	c.m.RUnlock()
 
 	return channel.ExchangeDeclare(exchange.Name, exchange.Type, exchange.Durable, exchange.AutoDelete, exchange.Internal, exchange.NoWait, toTable(exchange.Args))
 }
@@ -830,13 +833,10 @@ func (c *AMQPClientImpl) BindQueue(ctx context.Context, binding *BindingDeclarat
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	c.m.RLock()
-	if !c.isReady {
-		c.m.RUnlock()
-		return errNotConnected
+	channel, err := c.readyChannel()
+	if err != nil {
+		return err
 	}
-	channel := c.channel
-	c.m.RUnlock()
 
 	return channel.QueueBind(binding.Queue, binding.RoutingKey, binding.Exchange, binding.NoWait, toTable(binding.Args))
 }
@@ -1257,13 +1257,10 @@ func StartConsumeSpan(ctx context.Context, delivery *amqp.Delivery, queueName st
 
 // unsafePublish publishes a message without confirmation handling.
 func (c *AMQPClientImpl) unsafePublish(ctx context.Context, options PublishOptions, data []byte) error {
-	c.m.RLock()
-	if !c.isReady {
-		c.m.RUnlock()
-		return errNotConnected
+	channel, err := c.readyChannel()
+	if err != nil {
+		return err
 	}
-	channel := c.channel
-	c.m.RUnlock()
 
 	publishing := preparePublishing(ctx, options, data)
 

--- a/messaging/constants.go
+++ b/messaging/constants.go
@@ -51,11 +51,14 @@ const (
 	// enough not to spin the CPU.
 	readinessCheckInterval = 100 * time.Millisecond
 
-	// infraSetupTimeout bounds one consumer-infrastructure setup pass
-	// (client create + readiness wait + declare loop). Independent of any
-	// caller deadline: lazy setup triggered by a ~5s HTTP request must not
-	// abort mid-declare-loop and roll back otherwise-successful setup.
-	// Must exceed readyTimeoutDuration (the wait phase) with headroom for
-	// the declares themselves.
+	// infraSetupTimeout is the best-effort budget for one consumer-infrastructure
+	// setup pass (client create + readiness wait + declare loop), independent of
+	// any caller deadline so lazy setup triggered by a ~5s HTTP request can't
+	// abort mid-declare-loop and roll back otherwise-successful setup. It is a
+	// SOFT bound, not a hard wall-clock cap: it cancels the readiness wait and
+	// fail-fasts between declares, but amqp091 declare RPCs are not context-aware
+	// on the wire, so a single already-issued declare that blocks can outlast it
+	// (and hold consMu past expiry — the F17 lock-hold tradeoff). Must exceed
+	// readyTimeoutDuration (the wait phase) with headroom for the declares.
 	infraSetupTimeout = 45 * time.Second
 )

--- a/messaging/constants.go
+++ b/messaging/constants.go
@@ -50,4 +50,12 @@ const (
 	// wait loop. Tight enough to react quickly to broker connect; loose
 	// enough not to spin the CPU.
 	readinessCheckInterval = 100 * time.Millisecond
+
+	// infraSetupTimeout bounds one consumer-infrastructure setup pass
+	// (client create + readiness wait + declare loop). Independent of any
+	// caller deadline: lazy setup triggered by a ~5s HTTP request must not
+	// abort mid-declare-loop and roll back otherwise-successful setup.
+	// Must exceed readyTimeoutDuration (the wait phase) with headroom for
+	// the declares themselves.
+	infraSetupTimeout = 45 * time.Second
 )

--- a/messaging/manager.go
+++ b/messaging/manager.go
@@ -209,8 +209,15 @@ func (m *Manager) ensureConsumersInternal(ctx context.Context, key string, decls
 		}
 	}
 
+	// Setup runs on its own bounded budget, detached from the caller's
+	// deadline: a lazy-start request's ~5s deadline expiring mid-declare
+	// would abort and roll back an otherwise-successful setup (values —
+	// trace/tenant — are preserved by WithoutCancel).
+	setupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), infraSetupTimeout)
+	defer cancel()
+
 	// Create AMQP client for consumers (error is already well-formatted from createAMQPClient)
-	client, err := m.createAMQPClient(ctx, key)
+	client, err := m.createAMQPClient(setupCtx, key)
 	if err != nil {
 		return err
 	}
@@ -222,7 +229,7 @@ func (m *Manager) ensureConsumersInternal(ctx context.Context, key string, decls
 		return fmt.Errorf("failed to replay messaging declarations: %w", err)
 	}
 
-	if err := registry.DeclareInfrastructure(ctx); err != nil {
+	if err := registry.DeclareInfrastructure(setupCtx); err != nil {
 		m.closeClientOnRollback(client, key, "declare_infrastructure")
 		return fmt.Errorf("failed to declare messaging infrastructure: %w", err)
 	}
@@ -233,7 +240,7 @@ func (m *Manager) ensureConsumersInternal(ctx context.Context, key string, decls
 	// supervisor goroutines would stop every consumer when the first request ends, and
 	// they would never restart. context.WithoutCancel severs the request's cancellation
 	// and deadline while preserving values (trace/tenant), so consumer lifetime is
-	// governed solely by StopConsumers/Close. (Setup calls above keep the caller deadline.)
+	// governed solely by StopConsumers/Close.
 	consumerCtx := multitenant.SetTenant(context.WithoutCancel(ctx), key)
 	if err := registry.StartConsumers(consumerCtx); err != nil {
 		m.closeClientOnRollback(client, key, "start_consumers")

--- a/messaging/manager.go
+++ b/messaging/manager.go
@@ -209,10 +209,11 @@ func (m *Manager) ensureConsumersInternal(ctx context.Context, key string, decls
 		}
 	}
 
-	// Setup runs on its own bounded budget, detached from the caller's
+	// Setup runs on its own best-effort budget, detached from the caller's
 	// deadline: a lazy-start request's ~5s deadline expiring mid-declare
 	// would abort and roll back an otherwise-successful setup (values —
-	// trace/tenant — are preserved by WithoutCancel).
+	// trace/tenant — are preserved by WithoutCancel). The budget is soft —
+	// see infraSetupTimeout: amqp091 declares aren't ctx-cancelable on the wire.
 	setupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), infraSetupTimeout)
 	defer cancel()
 

--- a/messaging/manager_test.go
+++ b/messaging/manager_test.go
@@ -26,14 +26,15 @@ func (s *stubMessagingSource) BrokerURL(_ context.Context, key string) (string, 
 }
 
 type stubAMQPClient struct {
-	closed        bool
-	closedMu      sync.Mutex
-	lastPublish   PublishOptions
-	consumers     int
-	consumeCtx    context.Context //nolint:containedctx // test-only: captures the ctx the supervisor subscribes with, to assert its lifecycle
-	closeCallback func()
-	closeHook     func() // optional: invoked at the start of Close (e.g. to simulate a slow close)
-	closeErr      error
+	closed         bool
+	closedMu       sync.Mutex
+	lastPublish    PublishOptions
+	consumers      int
+	consumeCtx     context.Context //nolint:containedctx // test-only: captures the ctx the supervisor subscribes with, to assert its lifecycle
+	closeCallback  func()
+	closeHook      func() // optional: invoked at the start of Close (e.g. to simulate a slow close)
+	closeErr       error
+	declaredQueues []string
 }
 
 func (s *stubAMQPClient) Publish(ctx context.Context, destination string, data []byte) error {
@@ -81,9 +82,23 @@ func (s *stubAMQPClient) lastConsumeCtx() context.Context {
 	return s.consumeCtx
 }
 
-func (s *stubAMQPClient) DeclareQueue(context.Context, *QueueDeclaration) error       { return nil }
+func (s *stubAMQPClient) DeclareQueue(_ context.Context, queue *QueueDeclaration) error {
+	s.closedMu.Lock()
+	defer s.closedMu.Unlock()
+	s.declaredQueues = append(s.declaredQueues, queue.Name)
+	return nil
+}
+
 func (s *stubAMQPClient) DeclareExchange(context.Context, *ExchangeDeclaration) error { return nil }
 func (s *stubAMQPClient) BindQueue(context.Context, *BindingDeclaration) error        { return nil }
+
+// declaredQueueNames returns the queue names DeclareQueue was called with,
+// read under the same lock they were written with.
+func (s *stubAMQPClient) declaredQueueNames() []string {
+	s.closedMu.Lock()
+	defer s.closedMu.Unlock()
+	return append([]string(nil), s.declaredQueues...)
+}
 
 func (s *stubAMQPClient) Close() error {
 	s.closedMu.Lock()
@@ -1186,4 +1201,32 @@ func TestNewMessagingManagerDefaultFactoryForwardsReconnectOptions(t *testing.T)
 	assert.Equal(t, 90*time.Second, client.reconnectMaxDelay)
 	assert.Equal(t, 3*time.Second, client.reInitDelay)
 	assert.Equal(t, 11*time.Second, client.resendDelay)
+}
+
+// TestEnsureConsumersSucceedsWithExpiredCallerContext pins that lazy consumer
+// setup runs on its own bounded budget, detached from the caller's deadline:
+// an already-expired caller context (e.g. an HTTP request whose ~5s deadline
+// passed before the first tenant touch) must not abort the declare loop.
+func TestEnsureConsumersSucceedsWithExpiredCallerContext(t *testing.T) {
+	log := logger.New("error", false)
+	client := &stubAMQPClient{}
+	factory := func(string, logger.Logger) AMQPClient { return client }
+	manager := NewMessagingManager(&stubMessagingSource{urls: map[string]string{testTenantID: amqpHost}}, log, ManagerOptions{MaxPublishers: 5, IdleTTL: time.Minute}, factory)
+	defer func() { _ = manager.Close() }()
+
+	decls := NewDeclarations()
+	decls.RegisterExchange(&ExchangeDeclaration{Name: testExchange, Type: exchangeTypeTopic})
+	decls.RegisterQueue(&QueueDeclaration{Name: testQueue})
+	decls.RegisterBinding(&BindingDeclaration{Queue: testQueue, Exchange: testExchange, RoutingKey: testQueue})
+	decls.RegisterConsumer(&ConsumerDeclaration{Queue: testQueue, Consumer: testConsumer, Handler: &mockMessageHandler{}})
+
+	// Caller context is already expired BEFORE EnsureConsumers is even called —
+	// simulates a lazy-start request whose ~5s deadline passed mid-setup.
+	callerCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, manager.EnsureConsumers(callerCtx, testTenantID, decls))
+
+	assert.Contains(t, client.declaredQueueNames(), testQueue)
+	assert.Equal(t, 1, client.consumerCount())
 }


### PR DESCRIPTION
## What

Runs lazy consumer-infrastructure setup on its own **bounded budget detached from the caller's request deadline**, and folds a copy-pasted readiness guard into one helper.

## Why (the bug)

In multi-tenant lazy start, the first request touching a tenant's messaging drives the full setup — client create + readiness wait + exchange/queue/binding declare loop — under that request's **~5s middleware deadline**. PR #714 added a `ctx.Err()` pre-flight to every declare, so a deadline expiring *between declares* now aborts the loop mid-way and rolls the whole setup back (`closeClientOnRollback`). Result under a slow broker: the triggering request fails, consumers never start, and the next request pays the entire setup again.

## Change

- **Detach setup** in `ensureConsumersInternal`: `setupCtx = context.WithTimeout(context.WithoutCancel(ctx), infraSetupTimeout=45s)`, used for `createAMQPClient` + `registry.DeclareInfrastructure`. `WithoutCancel` preserves trace/tenant values. Setup now completes (or fails on its own terms) **exactly once**, for all four call sites (MT lazy, single-tenant lazy, startup prewarm, startup setup).
- **`consumerCtx` unchanged** — it derives from the *original* ctx (`WithoutCancel(ctx)` + `SetTenant`), **not** `setupCtx`, so consumer lifetime is still governed only by `StopConsumers`/`Close`, never the 45s budget.
- **`readyChannel()` helper**: the six-line `RLock; if !isReady { return errNotConnected }; snapshot channel; RUnlock` guard was copy-pasted to five sites (`ConsumeFromQueue`, `DeclareQueue`, `DeclareExchange`, `BindQueue`, `unsafePublish`) — extracted into one behavior-preserving helper. The publish path keeps its inline snapshot (it must read `generation` atomically with the channel under the same lock).

**Why the latency contract is unchanged:** `server.timeout.middleware` (timeoutEcho) already responds to the HTTP client at its deadline while the handler goroutine continues in the background. This trades "goroutine returns early + setup wasted" for "goroutine bounded a bit longer + setup completes."

## Known tradeoff (F17, tracked separately)

The detached budget lengthens the worst-case `consMu` hold on the lazy path (from ~5s to ≤45s) since `ensureConsumersInternal` holds it across the readiness wait. This is the pre-existing F17 backlog item (consMu held across broker I/O); unifying I/O out of the lock is future work, and the setup-budget constant is documented to move with it.

## Tests

`TestEnsureConsumersSucceedsWithExpiredCallerContext` passes an **already-expired** caller context into `EnsureConsumers` (simulating a lazy-start request whose ~5s deadline passed) and asserts no error + the queue was declared + the consumer started. Mutation-verified: reverting to the caller ctx (`setupCtx := ctx`) fails the test with `context canceled while waiting for AMQP client`. The five converted guard sites are covered by the existing `-race` suite (unchanged, `errNotConnected` sentinel unchanged).

## Verification

- `make check` exit 0 (fmt + lint + `-race` suite + alloc guard + govulncheck: 0). gosec 0 on `messaging/`.
- Reviewed by a 4-lens adversarial panel — logic-equivalence lens proved the readyChannel extraction behavior-preserving at all 5 sites; concurrency lens confirmed context lifetime/leak-safety, `consumerCtx` non-inheritance, the readyChannel lock semantics, and the 45s>30s budget ordering are all sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Consumer infrastructure setup now completes reliably even if the initiating request context expires or is canceled.
  - Added a bounded setup window to avoid long/hanging initialization during consumer startup.
  - Improved robustness around disconnected messaging clients while keeping the same not-ready behavior.

- **Tests**
  - Extended AMQP client test coverage to verify which queues are declared during consumer setup.
  - Added a test confirming consumers start and expected queues are declared even after the caller’s context is already canceled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->