### PR TITLE
feat(messaging): declarative dead-letter opt-in via DeclareQueueWithDLQ

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,7 +339,7 @@ func (m *Module) DeclareMessaging(decls *messaging.Declarations) {
 
 **Critical Rules:**
 - Each `queue + consumer_tag + event_type` triple must be registered exactly **once** — duplicates panic at startup.
-- Handler errors and panics → message nacked WITHOUT requeue (no infinite retry loops). Make handlers thread-safe and idempotent; declare `Args["x-dead-letter-exchange"]` on the queue to park failures instead of dropping them — the full DLX route (exchange + queue + binding) must be declared too, and `Args` must be set before `decls.RegisterQueue(q)`, which deep-copies at registration; see [wiki/messaging.md](wiki/messaging.md).
+- Handler errors and panics → message nacked WITHOUT requeue (no infinite retry loops). Make handlers thread-safe and idempotent; use `DeclareQueueWithDLQ` to park failures in a dead-letter queue instead of dropping them (raw `Args["x-dead-letter-exchange"]` remains the custom-topology escape hatch — set Args before registration; see [wiki/messaging.md](wiki/messaging.md)).
 - Default consumer concurrency is `runtime.NumCPU() * 4` workers (v0.17+ breaking change). Set `Workers: 1` explicitly when message ordering matters.
 
 For helper API, error handling deep dive, panic recovery, concurrency tuning, and reconnection defaults, see [wiki/messaging.md](wiki/messaging.md).

--- a/messaging/amqp_client_integration_test.go
+++ b/messaging/amqp_client_integration_test.go
@@ -4,11 +4,14 @@ package messaging
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
+	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gaborage/go-bricks/logger"
@@ -265,6 +268,78 @@ func TestAMQPClientDeclareQueueArgsDeadLetter(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Timeout waiting for dead-lettered message in DLQ — Args did not reach the broker or topology is wrong")
 	}
+}
+
+// TestDeclarativeDLQParksFailedDelivery is the declarative-helper sibling of
+// TestAMQPClientDeclareQueueArgsDeadLetter above: instead of hand-declaring
+// the DLX/DLQ/binding and setting Args manually, it exercises
+// DeclareQueueWithDLQ's lowered topology end-to-end through a real Registry
+// (ReplayToRegistry -> DeclareInfrastructure -> StartConsumers) against a
+// real broker. A consumer handler that always errors triggers the same
+// nack-without-requeue path the framework's registry sends on handler
+// failure; the message must be parked in the derived "<queue>.dlq" with an
+// x-death header, not dropped.
+func TestDeclarativeDLQParksFailedDelivery(t *testing.T) {
+	brokerURL := setupTestBroker(t)
+	log := logger.New("disabled", true)
+
+	client := NewAMQPClient(brokerURL, log)
+	defer client.Close()
+
+	require.Eventually(t, client.IsReady, 10*time.Second, 200*time.Millisecond, clientReadyMsg)
+
+	ctx := t.Context()
+
+	decls := NewDeclarations()
+	exchange := decls.DeclareTopicExchange(uniqueName(t, "dlqtest-exchange"))
+	workQueueName := uniqueName(t, "dlqtest-queue")
+	queue := decls.DeclareQueueWithDLQ(workQueueName, nil)
+	decls.DeclareBinding(queue.Name, exchange.Name, "dlqtest.route")
+
+	failingHandler := &mockHandler{}
+	failingHandler.On("Handle", mock.Anything, mock.Anything).Return(errors.New("simulated handler failure"))
+
+	decls.DeclareConsumer(&ConsumerOptions{
+		Queue:     queue.Name,
+		Consumer:  uniqueName(t, "dlqtest-consumer"),
+		EventType: "DLQTest",
+		Handler:   failingHandler,
+		Workers:   1,
+	}, nil)
+
+	require.NoError(t, decls.Validate())
+
+	reg := NewRegistry(client, log)
+	require.NoError(t, decls.ReplayToRegistry(reg))
+	require.NoError(t, reg.DeclareInfrastructure(ctx))
+	require.NoError(t, reg.StartConsumers(ctx))
+	defer reg.StopConsumers()
+
+	dlqName := workQueueName + ".dlq"
+	dlqDeliveries, err := client.Consume(ctx, dlqName)
+	require.NoError(t, err)
+
+	testMsg := []byte("declarative dead-letter")
+	require.NoError(t, client.PublishToExchange(ctx, PublishOptions{
+		Exchange:   exchange.Name,
+		RoutingKey: "dlqtest.route",
+	}, testMsg))
+
+	select {
+	case delivery := <-dlqDeliveries:
+		assert.Equal(t, testMsg, delivery.Body, "parked message must retain its original body")
+		xDeath, ok := delivery.Headers["x-death"].([]any)
+		require.True(t, ok, "x-death header must be present on the parked message")
+		require.NotEmpty(t, xDeath)
+		firstEntry, ok := xDeath[0].(amqp.Table)
+		require.True(t, ok, "x-death entry must decode to an amqp.Table")
+		assert.Equal(t, workQueueName, firstEntry["queue"], "x-death must record the primary queue")
+		require.NoError(t, delivery.Ack(false))
+	case <-time.After(10 * time.Second):
+		t.Fatal("Timeout waiting for parked message in DLQ — DeclareQueueWithDLQ topology did not park the failed delivery")
+	}
+
+	failingHandler.AssertExpectations(t)
 }
 
 // TestAMQPClientDeclareQueueArgsQuorum pins the "cannot attach to

--- a/messaging/helpers.go
+++ b/messaging/helpers.go
@@ -192,7 +192,14 @@ func (d *Declarations) DeclareQueueWithDLQ(name string, dl *DeadLetterSpec) *Que
 		Args:    make(map[string]any),
 	})
 	d.RegisterQueue(NewQueue(parking))
-	d.RegisterBinding(NewBinding(parking, dlx, ""))
+	// Register the parking binding once per DLX. Exchange/queue registration is
+	// map-backed (idempotent by name), but Bindings is a slice: several primary
+	// queues sharing one DLX (via DeadLetterSpec.Exchange/ParkingQueue) would
+	// otherwise append duplicate parking->dlx bindings, making Hash() depend on
+	// the queue count and issuing redundant BindQueue calls.
+	if !d.hasParkingBinding(parking, dlx) {
+		d.RegisterBinding(NewBinding(parking, dlx, ""))
+	}
 
 	queue := NewQueue(name)
 	queue.Args["x-dead-letter-exchange"] = dlx
@@ -201,6 +208,18 @@ func (d *Declarations) DeclareQueueWithDLQ(name string, dl *DeadLetterSpec) *Que
 	}
 	d.RegisterQueue(queue)
 	return queue
+}
+
+// hasParkingBinding reports whether a parking->dlx binding (routing key "") is
+// already registered, so DeclareQueueWithDLQ does not append a duplicate when
+// several primary queues share one dead-letter exchange.
+func (d *Declarations) hasParkingBinding(parking, dlx string) bool {
+	for _, b := range d.Bindings {
+		if b.Queue == parking && b.Exchange == dlx && b.RoutingKey == "" {
+			return true
+		}
+	}
+	return false
 }
 
 // DeclarePublisher creates and registers a publisher in one step.

--- a/messaging/helpers.go
+++ b/messaging/helpers.go
@@ -2,7 +2,10 @@ package messaging
 
 import "runtime"
 
-const exchangeTypeTopic = "topic"
+const (
+	exchangeTypeTopic  = "topic"
+	exchangeTypeFanout = "fanout"
+)
 
 // NewTopicExchange creates a topic exchange with production-safe defaults.
 // Topic exchanges route messages based on routing key patterns (e.g., "order.*", "user.#").
@@ -141,6 +144,63 @@ func (d *Declarations) DeclareBinding(queue, exchange, routingKey string) *Bindi
 	binding := NewBinding(queue, exchange, routingKey)
 	d.RegisterBinding(binding)
 	return binding
+}
+
+// DeadLetterSpec configures the declarative dead-letter opt-in for a queue.
+// Zero-value fields get derived defaults; see DeclareQueueWithDLQ.
+type DeadLetterSpec struct {
+	// Exchange is the dead-letter exchange name. Empty derives "<queue>.dlx".
+	// The exchange is declared as a durable fanout so the parking queue
+	// receives every dead-lettered message regardless of routing key.
+	Exchange string
+
+	// ParkingQueue is the queue that collects dead-lettered messages.
+	// Empty derives "<queue>.dlq". Declared with the production defaults of
+	// NewQueue (durable, non-exclusive).
+	ParkingQueue string
+
+	// RoutingKey, when non-empty, is set as x-dead-letter-routing-key so
+	// dead-lettered messages are re-published with it instead of their
+	// original routing key. Rarely needed with the fanout DLX default.
+	RoutingKey string
+}
+
+// DeclareQueueWithDLQ declares a queue whose failed deliveries are parked
+// instead of dropped: the framework's nack-without-requeue on handler error
+// (see wiki/messaging.md) dead-letters into the spec's exchange, and the
+// parking queue bound to it retains the message with the x-death header.
+// Lowers to ordinary exchange/queue/binding declarations plus queue Args, so
+// per-tenant replay, validation, and topology hashing behave as if declared
+// by hand. Returns the primary queue declaration.
+func (d *Declarations) DeclareQueueWithDLQ(name string, dl *DeadLetterSpec) *QueueDeclaration {
+	if dl == nil {
+		dl = &DeadLetterSpec{}
+	}
+	dlx := dl.Exchange
+	if dlx == "" {
+		dlx = name + ".dlx"
+	}
+	parking := dl.ParkingQueue
+	if parking == "" {
+		parking = name + ".dlq"
+	}
+
+	d.RegisterExchange(&ExchangeDeclaration{
+		Name:    dlx,
+		Type:    exchangeTypeFanout,
+		Durable: true,
+		Args:    make(map[string]any),
+	})
+	d.RegisterQueue(NewQueue(parking))
+	d.RegisterBinding(NewBinding(parking, dlx, ""))
+
+	queue := NewQueue(name)
+	queue.Args["x-dead-letter-exchange"] = dlx
+	if dl.RoutingKey != "" {
+		queue.Args["x-dead-letter-routing-key"] = dl.RoutingKey
+	}
+	d.RegisterQueue(queue)
+	return queue
 }
 
 // DeclarePublisher creates and registers a publisher in one step.

--- a/messaging/helpers_test.go
+++ b/messaging/helpers_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // Test constructor functions
@@ -549,6 +550,105 @@ func TestDeclarationsConsumer(t *testing.T) {
 		assert.NotNil(t, c2)
 		assert.Len(t, decls.Consumers(), 2)
 	})
+}
+
+func TestDeclareQueueWithDLQDefaults(t *testing.T) {
+	decls := NewDeclarations()
+
+	queue := decls.DeclareQueueWithDLQ("orders.queue", nil)
+
+	assert.NotNil(t, queue)
+
+	dlx, ok := decls.Exchanges["orders.queue.dlx"]
+	assert.True(t, ok)
+	assert.Equal(t, exchangeTypeFanout, dlx.Type)
+	assert.True(t, dlx.Durable)
+
+	dlq, ok := decls.Queues["orders.queue.dlq"]
+	assert.True(t, ok)
+	assert.True(t, dlq.Durable)
+
+	require.Len(t, decls.Bindings, 1)
+	binding := decls.Bindings[0]
+	assert.Equal(t, "orders.queue.dlq", binding.Queue)
+	assert.Equal(t, "orders.queue.dlx", binding.Exchange)
+	assert.Equal(t, "", binding.RoutingKey)
+
+	primary, ok := decls.Queues["orders.queue"]
+	assert.True(t, ok)
+	assert.Equal(t, "orders.queue.dlx", primary.Args["x-dead-letter-exchange"])
+	_, hasRoutingKey := primary.Args["x-dead-letter-routing-key"]
+	assert.False(t, hasRoutingKey)
+}
+
+func TestDeclareQueueWithDLQExplicitNames(t *testing.T) {
+	decls := NewDeclarations()
+
+	decls.DeclareQueueWithDLQ("orders.queue", &DeadLetterSpec{
+		Exchange:     "custom.dlx",
+		ParkingQueue: "custom.parking",
+		RoutingKey:   "dead",
+	})
+
+	_, ok := decls.Exchanges["custom.dlx"]
+	assert.True(t, ok)
+	_, ok = decls.Queues["custom.parking"]
+	assert.True(t, ok)
+
+	require.Len(t, decls.Bindings, 1)
+	binding := decls.Bindings[0]
+	assert.Equal(t, "custom.parking", binding.Queue)
+	assert.Equal(t, "custom.dlx", binding.Exchange)
+
+	primary := decls.Queues["orders.queue"]
+	assert.Equal(t, "custom.dlx", primary.Args["x-dead-letter-exchange"])
+	assert.Equal(t, "dead", primary.Args["x-dead-letter-routing-key"])
+}
+
+func TestDeclareQueueWithDLQValidatesAndHashes(t *testing.T) {
+	build := func() *Declarations {
+		decls := NewDeclarations()
+		queue := decls.DeclareQueueWithDLQ("orders.queue", nil)
+		decls.DeclareConsumer(&ConsumerOptions{
+			Queue:    queue.Name,
+			Consumer: testConsumer,
+			Handler:  &mockHandler{},
+		}, nil)
+		return decls
+	}
+
+	decls1 := build()
+	decls2 := build()
+
+	assert.NoError(t, decls1.Validate())
+	assert.Equal(t, decls1.Hash(), decls2.Hash())
+
+	withoutDLQ := NewDeclarations()
+	withoutDLQ.DeclareConsumer(&ConsumerOptions{
+		Queue:    withoutDLQ.DeclareQueue("orders.queue").Name,
+		Consumer: testConsumer,
+		Handler:  &mockHandler{},
+	}, nil)
+	assert.NotEqual(t, decls1.Hash(), withoutDLQ.Hash())
+}
+
+func TestDeclareQueueWithDLQArgsSurviveRegistration(t *testing.T) {
+	decls := NewDeclarations()
+
+	returned := decls.DeclareQueueWithDLQ("orders.queue", nil)
+
+	// RegisterQueue deep-copies Args at registration, so mutating the returned
+	// declaration afterwards must NOT reach the registered copy. This is why the
+	// helper sets Args before RegisterQueue rather than on the returned pointer.
+	returned.Args["x-dead-letter-exchange"] = "tampered"
+	returned.Args["injected"] = "value"
+
+	registered := decls.Queues["orders.queue"]
+	require.NotNil(t, registered)
+	assert.Equal(t, "orders.queue.dlx", registered.Args["x-dead-letter-exchange"],
+		"registered copy must be isolated from post-registration mutation of the returned declaration")
+	_, injected := registered.Args["injected"]
+	assert.False(t, injected, "keys added to the returned declaration after registration must not leak into the registered copy")
 }
 
 // Integration tests

--- a/messaging/helpers_test.go
+++ b/messaging/helpers_test.go
@@ -651,6 +651,27 @@ func TestDeclareQueueWithDLQArgsSurviveRegistration(t *testing.T) {
 	assert.False(t, injected, "keys added to the returned declaration after registration must not leak into the registered copy")
 }
 
+func TestDeclareQueueWithDLQSharedDLXSingleBinding(t *testing.T) {
+	decls := NewDeclarations()
+	spec := &DeadLetterSpec{Exchange: "shared.dlx", ParkingQueue: "shared.dlq"}
+
+	decls.DeclareQueueWithDLQ("orders.queue", spec)
+	decls.DeclareQueueWithDLQ("payments.queue", spec)
+
+	// Two primary queues share one DLX/parking queue: the parking binding must
+	// be registered exactly once, not once per primary queue.
+	parkingBindings := 0
+	for _, b := range decls.Bindings {
+		if b.Queue == "shared.dlq" && b.Exchange == "shared.dlx" {
+			parkingBindings++
+		}
+	}
+	assert.Equal(t, 1, parkingBindings, "sharing a DLX across queues must not append duplicate parking bindings")
+
+	assert.Equal(t, "shared.dlx", decls.Queues["orders.queue"].Args["x-dead-letter-exchange"])
+	assert.Equal(t, "shared.dlx", decls.Queues["payments.queue"].Args["x-dead-letter-exchange"])
+}
+
 // Integration tests
 
 func TestHelpersIntegrationWorkflow(t *testing.T) {

--- a/messaging/registry.go
+++ b/messaging/registry.go
@@ -714,6 +714,7 @@ func (r *Registry) processMessage(ctx context.Context, consumer *ConsumerDeclara
 		// Queues declared with x-dead-letter-exchange route the message to that
 		// exchange (retained only if a binding delivers it to a queue); queues
 		// without one drop it (logged above).
+		// DeclareQueueWithDLQ declares that full route in one call.
 		r.nackMessage(delivery, consumer.AutoAck, tlog)
 		return
 	}

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -109,14 +109,37 @@ func (h *Handler) Handle(ctx context.Context, delivery *amqp.Delivery) error {
 
 **Breaking Change (v2.X):** Previous behavior auto-requeued errors (infinite retry risk). New behavior drops failed messages with rich logging. Review handler error handling and set up monitoring.
 
-### User-Managed Dead-Lettering
+### Dead-Lettering
 
 Handler errors and panics nack without requeue. Without a dead-letter exchange
 configured on the queue, that message is dropped (logged, but gone). Setting
-`Args["x-dead-letter-exchange"]` on the queue tells RabbitMQ to park the
-message on that exchange instead — the framework does not auto-provision any
-DLX/DLQ infrastructure; you declare and bind it yourself, same as any other
-exchange/queue.
+`x-dead-letter-exchange` on the queue tells RabbitMQ to park the message on
+that exchange instead of dropping it.
+
+**`DeclareQueueWithDLQ` — the one-call form:**
+
+```go
+queue := decls.DeclareQueueWithDLQ("orders.queue", nil)
+```
+
+This declares a durable fanout exchange (`orders.queue.dlx`), a parking queue
+(`orders.queue.dlq`) bound to it, and sets `x-dead-letter-exchange` on
+`orders.queue` — the full route in one call. A fanout DLX is used
+deliberately: a dead-lettered message keeps its original routing key, and a
+direct/topic DLX whose binding key doesn't happen to match that routing key
+silently drops the message on the floor instead of parking it. Fanout ignores
+routing keys entirely, so the parking queue always receives it. Override the
+derived names or set `x-dead-letter-routing-key` via `&messaging.DeadLetterSpec{
+Exchange: "...", ParkingQueue: "...", RoutingKey: "..."}` as the second
+argument. Inspect a parked message's `x-death` header (queue, exchange,
+reason, count) for triage.
+
+**Custom topology — the raw `Args` escape hatch:**
+
+For DLX topology `DeclareQueueWithDLQ` doesn't fit (shared DLX across queues,
+non-fanout exchange with a deliberately matching binding key, ...), set
+`Args["x-dead-letter-exchange"]` directly and declare/bind the DLX and parking
+queue yourself:
 
 `Declarations.RegisterQueue` deep-copies `Args` at registration — and
 `decls.DeclareQueue(name)` registers immediately — so `Args` must be set on the
@@ -134,9 +157,11 @@ For a queue already registered elsewhere, mutate the stored copy instead:
 Args participate in RabbitMQ's declare-equivalence check: redeclaring an
 existing queue with different args fails the channel with 406
 PRECONDITION_FAILED. Values must be amqp091-supported types (string,
-int/int64, bool, float64, nested `amqp.Table`, ...). Framework-managed DLQ
-provisioning (auto-declaring DLX/parking queues, retry policies) remains
-future work — this is the enabling primitive only.
+int/int64, bool, float64, nested `amqp.Table`, ...).
+
+Both forms only shape topology (Tier 1). Bounded redelivery — capping retries
+via `x-death` count before parking permanently — remains future work; see
+[#721](https://github.com/gaborage/go-bricks/issues/721).
 
 ## Consumer Concurrency (v0.17+)
 

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -34,7 +34,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E49  | v0.45.0 → v0.49.0 | silent-config | 6 | none | multi-tenant outbox timeout guards / stale `messaging.*` + `database.manager.*` values / reconnect delay keys go live / mode-aware cache pool / unit-less duration guard |
 | E50  | v0.49.0 → v0.50.0 | config-break | 4 | none | Flyway migrate surfaces unparseable/failure output as an error; non-empty DB passwords < 8 bytes rejected at config validation + migrate; dev CORS wildcard opt-in; `multitenant.resolver.order` now REQUIRED for `type: composite` (no default — composite deployments fail to start until they declare one) |
 | E51  | v0.50.0 → v0.51.0 | silent-behavior (adopt-only) | 3 | none | none |
-| E52  | v0.51.0 → v0.52.0 | compile-break | 3 | C52.1 | if you set `.Args` on any declaration in ≤v0.51.0, verify current broker state before upgrading |
+| E52  | v0.51.0 → v0.52.0 | compile-break | 4 | C52.1 | if you set `.Args` on any declaration in ≤v0.51.0, verify current broker state before upgrading |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 - **`when: match`** → act only if `detect` returns ≥1 line (an API/arity/interface change, or a config key you set).
@@ -671,6 +671,10 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - apply: if you set the key expecting schema-targeted migrations, nothing to do — it now works. If you set it for observability labeling while migrations deliberately land in `public`, unset it (or move the label elsewhere) before upgrading
 - verify: run `migrate info` against a staging target and confirm `flyway_schema_history` resolves in the intended schema
 - ref: #716
+
+### [C52.4] DeclareQueueWithDLQ declarative dead-letter opt-in · additive-optional
+- note: `decls.DeclareQueueWithDLQ(name, spec)` declares the fanout DLX + parking queue + binding and sets `x-dead-letter-exchange` (and optionally `x-dead-letter-routing-key`) on the primary queue in one call — failed deliveries park in `<queue>.dlq` instead of dropping. Raw `Args["x-dead-letter-exchange"]` (see "Dead-Lettering" in wiki/messaging.md) remains valid for custom topologies. Purely additive; existing hand-rolled DLX declarations are untouched.
+- ref: #721 · messaging/helpers.go
 
 ---
 

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -673,7 +673,8 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: #716
 
 ### [C52.4] DeclareQueueWithDLQ declarative dead-letter opt-in · additive-optional
-- note: `decls.DeclareQueueWithDLQ(name, spec)` declares the fanout DLX + parking queue + binding and sets `x-dead-letter-exchange` (and optionally `x-dead-letter-routing-key`) on the primary queue in one call — failed deliveries park in `<queue>.dlq` instead of dropping. Raw `Args["x-dead-letter-exchange"]` (see "Dead-Lettering" in wiki/messaging.md) remains valid for custom topologies. Purely additive; existing hand-rolled DLX declarations are untouched.
+
+- note: `decls.DeclareQueueWithDLQ(name, spec)` declares the fanout DLX + parking queue + binding and sets `x-dead-letter-exchange` (and optionally `x-dead-letter-routing-key`) on the primary queue in one call — failed deliveries park in the default `<queue>.dlq` (or the configured parking queue) instead of dropping. Raw `Args["x-dead-letter-exchange"]` (see "Dead-Lettering" in wiki/messaging.md) remains valid for custom topologies. Purely additive; existing hand-rolled DLX declarations are untouched.
 - ref: #721 · messaging/helpers.go
 
 ---


### PR DESCRIPTION
## What

`DeclareQueueWithDLQ` — a one-call declarative **dead-letter opt-in** for consumer queues.

Closes the Tier 1 gap in #721 (PR #714 shipped the raw-`Args` enabling primitive; this is the sugar on top).

## Why

A consumer handler returning an error nacks the delivery **without requeue** — and on a queue with no dead-letter exchange, the message is **dropped permanently**. No-requeue is the right default (poison loops are worse), but drop-forever forces every consumer that can't afford message loss to guarantee its handler never errors. This makes the safe path one call.

## Change

```go
queue := decls.DeclareQueueWithDLQ("orders.queue", nil)
```

Declares a durable **fanout** DLX (`orders.queue.dlx`), a parking queue (`orders.queue.dlq`) bound to it, and sets `x-dead-letter-exchange` on the primary queue. Failed deliveries park in `<queue>.dlq` with the `x-death` header instead of dropping. `&DeadLetterSpec{Exchange, ParkingQueue, RoutingKey}` overrides the derived names / sets `x-dead-letter-routing-key`.

**Two load-bearing design choices:**
- **Fanout DLX** — a dead-lettered message keeps its *original* routing key; a direct/topic DLX whose binding key doesn't happen to match would silently drop it on the floor. Fanout ignores routing keys, so the parking queue always receives it.
- **Args before `RegisterQueue`** — `RegisterQueue` deep-copies `Args` at registration, so setting them on the returned pointer afterward is a silent no-op. The helper sets them before registering (regression-pinned by a test that mutates the returned declaration and asserts the registered copy is isolated).

Everything lowers onto ordinary exchange/queue/binding registrations, so `Validate`, `Hash`, `Clone`, and per-tenant replay work with **zero new code**. No ack/nack runtime change — the `registry.go` edit is a one-line comment. **Additive-only** (no exported signature change; apidiff-safe). Tier 2 (bounded redelivery via `x-death` counting) is an explicit non-goal.

## Tests

4 unit tests (defaults, explicit names, Validate+deterministic-Hash-differs-without-DLQ, deep-copy-isolation regression pin) + a real-broker integration test (`TestDeclarativeDLQParksFailedDelivery`): builds the topology via the helper, drives it end-to-end through a real `Registry` with an always-failing handler, and asserts the message is parked in `<queue>.dlq` with an `x-death` header naming the primary queue.

## Verification

- `make check` exit 0; gosec 0 on `messaging/`.
- Integration test **PASSES against a real RabbitMQ testcontainer** (not skipped).
- Mutation check: removing the `x-dead-letter-exchange` arg fails the unit tests + integration test (message dropped, not parked); restored → green.
- Reviewed by a 4-lens adversarial panel — correctness lens verified the topology lowering (fanout, args-before-register, Validate/Hash, overwrite-by-name), api-docs lens confirmed the docs match behavior and the `C52.4` migrations atom is correctly classed.

## Docs

`wiki/messaging.md` dead-letter section rewritten to lead with the one-call form (raw `Args` demoted to the custom-topology escape hatch); `CLAUDE.md` Critical Rules bullet updated; `wiki/migrations.md` E52 `C52.4` additive-optional atom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in dead-letter queue support for failed message delivery.
  * Added options to customize dead-letter exchange, parking queue, and routing key names.
  * Failed messages can now be preserved in a parking queue with delivery metadata.

* **Documentation**
  * Updated messaging and migration guidance for dead-letter queue configuration and custom topologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->