### PR TITLE
deps(renovate): track the CI Flyway pin via github-releases + single-source the version

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -230,6 +230,14 @@ jobs:
     # Gates on `code` so integration coverage is part of every merged report.
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
+    env:
+      # Pinned to match the JSON-output fixture captures in
+      # migration/testdata/flyway. Flyway 12.x ships only from Redgate's own
+      # distribution server (Maven Central stopped publishing the
+      # self-contained platform CLI tarballs mid-11.x; see the Install step).
+      # renovate: datasource=github-releases depName=flyway/flyway
+      FLYWAY_VERSION: 12.8.1
+      FLYWAY_SHA256: 706a8838f5bea158af3f738c428102aa9f895da0d8ba4ccd0c0c1cbf6141ad9f
 
     steps:
       - uses: actions/checkout@v7
@@ -256,22 +264,15 @@ jobs:
 
       - name: Cache Flyway CLI
         id: cache-flyway
-        # Pinned to 12.8.1 to match the JSON-output fixture captures in
-        # migration/testdata/flyway. The SHA256 is part of the cache key so
-        # a version/digest bump invalidates the cached tarball automatically.
-        # NOTE: Flyway stopped publishing the self-contained platform CLI tarballs
-        # to Maven Central mid-11.x; 12.x ships only from Redgate's own distribution
-        # server (see the Install step). The SHA256 pin keeps the new host integrity-checked.
+        # The SHA256 is part of the cache key so a version/digest bump
+        # invalidates the cached tarball automatically.
         uses: actions/cache@v6
         with:
-          path: /tmp/flyway-12.8.1
-          key: flyway-12.8.1-706a8838f5bea158af3f738c428102aa9f895da0d8ba4ccd0c0c1cbf6141ad9f
+          path: /tmp/flyway-${{ env.FLYWAY_VERSION }}
+          key: flyway-${{ env.FLYWAY_VERSION }}-${{ env.FLYWAY_SHA256 }}
 
       - name: Install Flyway CLI
         if: steps.cache-flyway.outputs.cache-hit != 'true'
-        env:
-          FLYWAY_VERSION: 12.8.1
-          FLYWAY_SHA256: 706a8838f5bea158af3f738c428102aa9f895da0d8ba4ccd0c0c1cbf6141ad9f
         run: |
           set -euo pipefail
           # Flyway 12.x is distributed only from Redgate's server — Maven Central
@@ -291,7 +292,7 @@ jobs:
 
       - name: Wire Flyway onto PATH
         run: |
-          sudo ln -sf /tmp/flyway-12.8.1/flyway /usr/local/bin/flyway
+          sudo ln -sf "/tmp/flyway-${FLYWAY_VERSION}/flyway" /usr/local/bin/flyway
           flyway --version | head -3
 
       - name: Run integration tests

--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,17 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\s+run: go install \\S+@(?<currentValue>\\S+)"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Track the CI-pinned Flyway CLI version. Flyway 12.x tarballs ship only from Redgate's server (Maven Central stopped at 11.8.2), but flyway/flyway still tags GitHub releases (flyway-X.Y.Z), so github-releases tracks the version number; the SHA256 gate + test fixtures make the resulting bump PR fail CI until a maintainer re-pins the checksum and fixtures — that failing PR is the intended alert.",
+      "managerFilePatterns": [
+        "/(^|/)\\.github/workflows/[^/]+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+FLYWAY_VERSION: (?<currentValue>\\S+)"
+      ],
+      "extractVersionTemplate": "^flyway-(?<version>.*)$"
     }
   ]
 }


### PR DESCRIPTION
## What

Gives **Renovate visibility** into the CI-pinned Flyway version, and **single-sources** the pin so a bump only touches one line.

## Why

Every other externally-pinned tool in this repo (govulncheck, gosec, golangci-lint, apidiff) gets an automatic Renovate PR when a new version ships — via two custom regex managers built precisely because "these literals drift silently." The one exception was **Flyway**, the tool that runs every tenant's schema migration (and that this repo spent three PRs hardening: #695/#704/#708). Its CI pin (`FLYWAY_VERSION: 12.8.1` + SHA256) was invisible to Renovate, so an upstream Flyway CVE fix would sit unnoticed. And the "Wire Flyway onto PATH" step hardcoded `/tmp/flyway-12.8.1/` separately from `FLYWAY_VERSION`, so even a manual bump broke unless both sites were edited.

## Change

- **Single-source**: `FLYWAY_VERSION`/`FLYWAY_SHA256` hoisted from the Install step to the `framework-integration-test` **job-level env**. The cache `path`/`key` and the wire-PATH symlink now derive from `${{ env.FLYWAY_VERSION }}` / `${FLYWAY_VERSION}` — only the pin line carries the literal (`grep 12.8.1` → 1). The resolved cache key is byte-identical, so no cache invalidation.
- **Renovate visibility**: `# renovate: datasource=github-releases depName=flyway/flyway` annotation above the pin + a third `customManagers` regex entry. Flyway 12.x tarballs ship only from Redgate (Maven Central stopped at 11.8.2), but `flyway/flyway` still tags GitHub releases (`flyway-X.Y.Z`), so `github-releases` tracks the version number; `extractVersionTemplate` strips the `flyway-` prefix.

## Intended fail-closed behavior

The SHA256 integrity gate in the Install step is **unchanged**. A Renovate bump PR will bump `FLYWAY_VERSION` but the SHA256 (and the `12.8.1` test fixtures) stay pinned, so **CI fails until a maintainer re-pins the checksum + fixtures** — that failing PR *is* the alert. No unverified tarball is ever auto-adopted.

## Verification

- `grep -cE "12\.8\.1" ci-v2.yml` → 1; `customType` count in renovate.json → 3; JSON + YAML sanity pass.
- Independent regex simulation: the new manager captures exactly one match (`datasource=github-releases`, `depName=flyway/flyway`, `currentValue=12.8.1`).
- `renovate-config-validator@latest` → "Config validated successfully".
- Confirmed `flyway/flyway` still tags 12.x GitHub releases (`flyway-13.0.0` … `flyway-12.8.1`).
- Reviewed by a 2-lens panel (CI-semantics + supply-chain): env-hoist preserves exact behavior; SHA256 gate remains load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI configuration to centralize Flyway CLI version and checksum settings.
  * Added automated detection and update support for Flyway CLI versions in workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->