### PR TITLE
fix(migration): serialize per-tenant provisioning and make CREATE ROLE idempotent under races

### DIFF
--- a/migration/provisioning/integration_test.go
+++ b/migration/provisioning/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -318,4 +319,50 @@ func TestProvisioningRerunSameJobIDIsNoOp(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, StateReady, got.State,
 		"Upsert on an existing job ID must preserve the persisted state")
+}
+
+// TestProvisioningPartialUniqueIndexBlocksConcurrentActiveJobs verifies the
+// per-tenant mutual exclusion enforced by idx_..._active (a partial unique
+// index on tenant_id WHERE state NOT IN ('ready','failed')): two concurrent
+// Upserts for the same tenant under different job IDs must have exactly one
+// winner, with the loser observing ErrTenantBusy — never both succeeding.
+func TestProvisioningPartialUniqueIndexBlocksConcurrentActiveJobs(t *testing.T) {
+	env := newPGEnv(t)
+	store := env.newStore(t, "active_index")
+
+	ctx, cancel := testCtx(t)
+	defer cancel()
+
+	const tenantID = "tenant-concurrent"
+	var (
+		wg           sync.WaitGroup
+		mu           sync.Mutex
+		successCount int
+		busyCount    int
+		otherErrs    []error
+	)
+
+	for i := range 2 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			job := &Job{ID: fmt.Sprintf("job-concurrent-%d", n), TenantID: tenantID}
+			_, err := store.Upsert(ctx, job)
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case err == nil:
+				successCount++
+			case errors.Is(err, ErrTenantBusy):
+				busyCount++
+			default:
+				otherErrs = append(otherErrs, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	require.Empty(t, otherErrs, "unexpected errors: %v", otherErrs)
+	assert.Equal(t, 1, successCount, "exactly one concurrent Upsert for the same tenant must succeed")
+	assert.Equal(t, 1, busyCount, "exactly one concurrent Upsert for the same tenant must observe ErrTenantBusy")
 }

--- a/migration/provisioning/store.go
+++ b/migration/provisioning/store.go
@@ -71,6 +71,11 @@ var (
 	// ErrInvalidJob is returned by Upsert when the supplied Job is nil
 	// or has an empty ID/TenantID. Wrapped with the failing field name.
 	ErrInvalidJob = errors.New("provisioning: invalid job")
+
+	// ErrTenantBusy means another provisioning job for the same tenant is
+	// still in a non-terminal state. Retryable and non-destructive — callers
+	// must NOT treat it as a provisioning failure or trigger cleanup.
+	ErrTenantBusy = errors.New("provisioning: tenant already has an active provisioning job")
 )
 
 // validateJobForUpsert rejects nil jobs and jobs missing ID or TenantID

--- a/migration/provisioning/store_memory.go
+++ b/migration/provisioning/store_memory.go
@@ -2,6 +2,7 @@ package provisioning
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 )
@@ -52,7 +53,9 @@ func (m *MemoryStore) Get(_ context.Context, jobID string) (*Job, error) {
 // Upsert inserts job at StatePending if no record exists, or returns the
 // existing record unchanged. The CreatedAt and UpdatedAt fields on the
 // returned record are populated by the store. Rejects nil jobs and jobs
-// missing ID or TenantID via ErrInvalidJob.
+// missing ID or TenantID via ErrInvalidJob. Returns ErrTenantBusy if another
+// non-terminal job already exists for job.TenantID (mirrors the partial
+// unique index enforced by PostgresStore).
 func (m *MemoryStore) Upsert(_ context.Context, job *Job) (*Job, error) {
 	if err := validateJobForUpsert(job); err != nil {
 		return nil, err
@@ -61,6 +64,11 @@ func (m *MemoryStore) Upsert(_ context.Context, job *Job) (*Job, error) {
 	defer m.mu.Unlock()
 	if existing, ok := m.jobs[job.ID]; ok {
 		return cloneJob(existing), nil
+	}
+	for _, existing := range m.jobs {
+		if existing.TenantID == job.TenantID && !existing.State.IsTerminal() {
+			return nil, fmt.Errorf("%w: tenant %s", ErrTenantBusy, job.TenantID)
+		}
 	}
 	now := m.timestamp()
 	stored := cloneJob(job)

--- a/migration/provisioning/store_memory_test.go
+++ b/migration/provisioning/store_memory_test.go
@@ -125,6 +125,58 @@ func TestMemoryStoreCreateTableIsNoOp(t *testing.T) {
 	assert.NoError(t, NewMemoryStore().CreateTable(context.Background()))
 }
 
+// TestMemoryStoreUpsertRejectsSecondActiveJobForTenant pins the per-tenant
+// mutual exclusion mirrored from PostgresStore's partial unique index: a
+// second (different job ID) Upsert for a tenant with an existing non-terminal
+// job must fail with ErrTenantBusy rather than silently succeed and race
+// against the in-flight job.
+func TestMemoryStoreUpsertRejectsSecondActiveJobForTenant(t *testing.T) {
+	s := NewMemoryStore()
+	ctx := context.Background()
+
+	_, err := s.Upsert(ctx, &Job{ID: "job-1", TenantID: "tenant-x"})
+	require.NoError(t, err)
+
+	_, err = s.Upsert(ctx, &Job{ID: "job-2", TenantID: "tenant-x"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrTenantBusy), "want wrapped ErrTenantBusy, got %v", err)
+}
+
+// TestMemoryStoreUpsertAllowsReprovisionAfterTerminal verifies the exclusion
+// only blocks concurrent NON-terminal jobs: once the first job reaches a
+// terminal state (ready or failed), re-provisioning the same tenant under a
+// new job ID must succeed.
+func TestMemoryStoreUpsertAllowsReprovisionAfterTerminal(t *testing.T) {
+	s := NewMemoryStore()
+	ctx := context.Background()
+
+	_, err := s.Upsert(ctx, &Job{ID: "job-1", TenantID: "tenant-x"})
+	require.NoError(t, err)
+	require.NoError(t, s.Transition(ctx, "job-1", StatePending, StateSchemaCreated, nil, ""))
+	require.NoError(t, s.Transition(ctx, "job-1", StateSchemaCreated, StateCleanup, nil, "boom"))
+	require.NoError(t, s.Transition(ctx, "job-1", StateCleanup, StateFailed, nil, "boom"))
+
+	got, err := s.Upsert(ctx, &Job{ID: "job-2", TenantID: "tenant-x"})
+	require.NoError(t, err)
+	assert.Equal(t, StatePending, got.State)
+}
+
+// TestMemoryStoreUpsertSameIDIsNotBusy verifies the existing "re-upsert same
+// ID returns unchanged" behavior takes priority over the busy check — it is
+// checked first, so idempotent retries of the same job never see ErrTenantBusy.
+func TestMemoryStoreUpsertSameIDIsNotBusy(t *testing.T) {
+	s := NewMemoryStore()
+	ctx := context.Background()
+
+	first, err := s.Upsert(ctx, &Job{ID: "job-1", TenantID: "tenant-x"})
+	require.NoError(t, err)
+
+	again, err := s.Upsert(ctx, &Job{ID: "job-1", TenantID: "tenant-x"})
+	require.NoError(t, err)
+	assert.Equal(t, first.State, again.State)
+	assert.False(t, errors.Is(err, ErrTenantBusy))
+}
+
 func TestMemoryStoreUpsertRejectsInvalidJob(t *testing.T) {
 	s := NewMemoryStore()
 	tests := []struct {

--- a/migration/provisioning/store_postgres.go
+++ b/migration/provisioning/store_postgres.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gaborage/go-bricks/database"
 	"github.com/gaborage/go-bricks/internal/sqlid"
 )
 
@@ -40,10 +41,22 @@ const PostgresStateTableDDL = `CREATE TABLE IF NOT EXISTS %s (
 // PostgresStateTableIndexes are the supporting indexes for tenant- and
 // state-scoped lookups. The dispatcher (out of scope for #379) will scan
 // rows by (state) to find work; ad-hoc operator queries usually filter by
-// tenant. Both are idempotent.
+// tenant. All are idempotent.
+//
+// The third index enforces per-tenant mutual exclusion: at most one
+// non-terminal job per tenant_id. Without it, a retry job for tenant X can
+// run concurrently with a still-in-flight cleanup job for X — the retry's
+// CREATE SCHEMA IF NOT EXISTS no-ops over the still-present schema and
+// advances to ready, then the cleanup's DROP SCHEMA ... CASCADE completes,
+// leaving a ready tenant with a dropped schema. Terminal states (ready,
+// failed) are excluded so re-provisioning after completion is allowed.
+// The ('ready','failed') predicate MUST stay in sync with State.IsTerminal()
+// (which MemoryStore.Upsert uses for the same exclusion); adding a terminal
+// state means updating both, or the two stores diverge.
 var PostgresStateTableIndexes = []string{
 	`CREATE INDEX IF NOT EXISTS idx_%[2]s_tenant ON %[1]s (tenant_id)`,
 	`CREATE INDEX IF NOT EXISTS idx_%[2]s_state  ON %[1]s (state)`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS idx_%[2]s_active ON %[1]s (tenant_id) WHERE state NOT IN ('ready','failed')`,
 }
 
 // maxPGTableSegment caps the per-segment length of a provisioning table
@@ -203,6 +216,9 @@ func (s *PostgresStore) Upsert(ctx context.Context, job *Job) (*Job, error) {
 	if _, err := s.db.ExecContext(ctx, insert, // NOSONAR S2077: insert built from validated-identifier template; all 7 values via $N
 		job.ID, job.TenantID, string(StatePending), 0, "", metadataJSON, now,
 	); err != nil {
+		if database.IsUniqueViolation(err) { // 23505 on idx_..._active — another active job exists for this tenant
+			return nil, fmt.Errorf("%w: tenant %s", ErrTenantBusy, job.TenantID)
+		}
 		return nil, fmt.Errorf("provisioning postgres: upsert insert: %w", err)
 	}
 	return s.Get(ctx, job.ID)

--- a/migration/roles.go
+++ b/migration/roles.go
@@ -173,17 +173,16 @@ func buildPGRoleStatements(spec *PGRoleSpec) []string {
 
 	roles := []struct {
 		quotedIdent string
-		rolname     string
 		password    string
 	}{
-		{migrator, spec.MigratorRole, spec.MigratorPassword},
-		{runtime, spec.RuntimeRole, spec.RuntimePassword},
+		{migrator, spec.MigratorPassword},
+		{runtime, spec.RuntimePassword},
 	}
 
 	// Pre-size for the worst case: 2 roles × (create + lockdown + password) + 8 schema/grant/search_path statements.
 	stmts := make([]string, 0, 2*3+8)
 	for _, r := range roles {
-		stmts = append(stmts, buildRoleCreateAndLockdown(r.rolname, r.quotedIdent)...)
+		stmts = append(stmts, buildRoleCreateAndLockdown(r.quotedIdent)...)
 		if r.password != "" {
 			stmts = append(stmts, fmt.Sprintf(
 				`ALTER ROLE %s PASSWORD %s`,
@@ -219,18 +218,26 @@ func buildPGRoleStatements(spec *PGRoleSpec) []string {
 // locked-down baseline. Used for both the migrator and runtime roles since
 // both share the same NO* attribute requirements.
 //
-// The CREATE wrapped in DO-block is the canonical idempotent pattern because
-// PostgreSQL has no CREATE ROLE IF NOT EXISTS syntax; the unconditional
-// ALTER on the next statement re-applies the attribute floor on every run
-// so manual drift (e.g. someone ran ALTER ROLE ... SUPERUSER) snaps back.
-func buildRoleCreateAndLockdown(rolname, quotedIdent string) []string {
+// The CREATE is wrapped in a nested BEGIN/EXCEPTION block that swallows both
+// duplicate_object (42710) and unique_violation (23505) rather than checking
+// pg_roles first: the check-then-create form races when two provisioners run
+// concurrently for the same role name. If the role is already committed the
+// CREATE raises duplicate_object; if two sessions both pass CREATE ROLE's
+// internal existence check and then collide on the pg_authid rolname unique
+// index, the loser raises unique_violation instead — so both must be swallowed
+// for the concurrent path to be safe. The unconditional ALTER on the next
+// statement re-applies the attribute floor on every run so manual drift
+// (e.g. someone ran ALTER ROLE ... SUPERUSER) snaps back.
+func buildRoleCreateAndLockdown(quotedIdent string) []string {
 	const lockdownAttrs = "NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS"
 	return []string{
 		fmt.Sprintf(`DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = %s) THEN
+  BEGIN
     CREATE ROLE %s LOGIN %s;
-  END IF;
-END $$`, quotePGStringLiteral(rolname), quotedIdent, lockdownAttrs),
+  EXCEPTION WHEN duplicate_object OR unique_violation THEN
+    NULL; -- another provisioner created it concurrently; not an error
+  END;
+END $$`, quotedIdent, lockdownAttrs),
 		fmt.Sprintf(`ALTER ROLE %s %s`, quotedIdent, lockdownAttrs),
 	}
 }

--- a/migration/roles_test.go
+++ b/migration/roles_test.go
@@ -119,11 +119,10 @@ func TestPGRoleProvisioningSQLContainsExpectedStatements(t *testing.T) {
 
 	all := strings.Join(stmts, "\n;\n")
 
-	// Role creation in a DO block (idempotent).
+	// Role creation in a DO block (idempotent, race-safe via EXCEPTION).
 	assert.Contains(t, all, `CREATE ROLE "migrator"`)
 	assert.Contains(t, all, `CREATE ROLE "tenant_a_app"`)
-	assert.Contains(t, all, `pg_catalog.pg_roles WHERE rolname = 'migrator'`)
-	assert.Contains(t, all, `pg_catalog.pg_roles WHERE rolname = 'tenant_a_app'`)
+	assert.Contains(t, all, "EXCEPTION WHEN duplicate_object")
 
 	// Attribute lockdown on both roles.
 	assert.Contains(t, all, `ALTER ROLE "migrator" NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS`)
@@ -180,6 +179,20 @@ func TestPGRoleProvisioningSQLOmitsEmptyPasswordALTERs(t *testing.T) {
 	all := strings.Join(stmts, "\n;\n")
 	assert.NotContains(t, all, "PASSWORD '",
 		"empty passwords must not emit ALTER ROLE ... PASSWORD statements")
+}
+
+// TestBuildRoleCreateAndLockdownSwallowsDuplicate pins the race-safe
+// CREATE ROLE form: an EXCEPTION handler that swallows both duplicate_object
+// (42710, role already committed) and unique_violation (23505, the loser of a
+// concurrent race colliding on pg_authid's rolname index) instead of a
+// check-then-create pg_roles lookup, which races when two provisioners create
+// the same role concurrently.
+func TestBuildRoleCreateAndLockdownSwallowsDuplicate(t *testing.T) {
+	stmts := buildRoleCreateAndLockdown(`"tenant_a_app"`)
+	all := strings.Join(stmts, "\n;\n")
+
+	assert.Contains(t, all, "EXCEPTION WHEN duplicate_object OR unique_violation")
+	assert.NotContains(t, all, "IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles")
 }
 
 func TestQuotePGIdent(t *testing.T) {


### PR DESCRIPTION
## What

Closes two independent races in dynamic tenant provisioning that could leave a tenant marked `ready` with a dropped schema.

**Race 1 — no per-tenant mutual exclusion.** A retry job for tenant X could run concurrently with a still-in-flight cleanup for X: the retry's `CREATE SCHEMA IF NOT EXISTS` no-ops over the still-present schema and advances to `ready`, then the cleanup's `DROP SCHEMA … CASCADE` completes, leaving a `ready` tenant pointing at a dropped schema.

**Race 2 — `CREATE ROLE` check-then-create.** The DO-block used an `IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles …)` lookup. Two concurrent provisioners could both pass that check, and the loser would fail — routing an otherwise-fine tenant into `StateCleanup`.

## How

- **`migration/roles.go`** — the DO-block now swallows **both** `duplicate_object` (SQLSTATE 42710, role already committed) **and** `unique_violation` (SQLSTATE 23505, the loser of a genuine concurrent `CREATE ROLE` race colliding on `pg_authid`'s `rolname` unique index) via a nested `BEGIN/EXCEPTION`, instead of the racy `pg_roles` lookup. The unconditional `ALTER ROLE` immediately after reapplies the attribute floor, so nothing is lost. *(Catching only 42710 is safe on a sequential re-run but still crashes on the actual concurrent race — hence both codes.)*
- **`migration/provisioning/store_postgres.go`** — adds a partial unique index `idx_<table>_active ON (tenant_id) WHERE state NOT IN ('ready','failed')`, permitting at most one non-terminal job per tenant. The resulting 23505 maps to the new `ErrTenantBusy` via `database.IsUniqueViolation`. The `('ready','failed')` predicate is documented as the single source of truth that must stay in sync with `State.IsTerminal()` (which the memory store uses for the same exclusion).
- **`migration/provisioning/store.go`** — declares `ErrTenantBusy` alongside `ErrJobNotFound` as the retryable, non-destructive contract for future dispatchers.
- **`migration/provisioning/store_memory.go`** — mirrors the same exclusion for the in-memory test store.

## Testing

- Unit: `TestBuildRoleCreateAndLockdownSwallowsDuplicate` pins the combined `EXCEPTION WHEN duplicate_object OR unique_violation` clause; memory-store tests pin same-id idempotency + `ErrTenantBusy` on a second active tenant job.
- Integration (Docker/testcontainers): `TestProvisioningPartialUniqueIndexBlocksConcurrentActiveJobs` fires two concurrent goroutines and asserts exactly one success + one `ErrTenantBusy`; the PG roles integration suite exercises the new DO-block SQL end-to-end.
- **Mutation-tested each half:** reverting the DO-block fix, the index, the Postgres error mapping, or the memory-store check each independently fails the corresponding pinned test.
- `make check` green (fmt + lint + race tests + alloc guards + vuln scan).

Additive only — new `ErrTenantBusy` sentinel, no changed signatures, no ADR/migration hop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tenant-level protection to prevent multiple active provisioning jobs from running simultaneously.
  - Provisioning requests that encounter an active job now receive a retryable “tenant busy” response.
  - Reusing the same job remains idempotent, and new provisioning is allowed after the previous job completes or fails.

- **Bug Fixes**
  - Improved concurrent role provisioning to avoid conflicts when creating the same database role.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->