### PR TITLE
refactor(migration): cut parseFlywayJSON cognitive complexity below the gate

### DIFF
--- a/migration/result.go
+++ b/migration/result.go
@@ -146,36 +146,62 @@ func parseFlywayJSON(output string) (Result, error) {
 		if start < skipBelow {
 			continue
 		}
-		dec := json.NewDecoder(strings.NewReader(trimmed[start:]))
-		var raw json.RawMessage
-		if err := dec.Decode(&raw); err != nil {
-			if firstDecodeErr == nil && !errors.Is(err, io.EOF) {
-				firstDecodeErr = fmt.Errorf("migration: parse Flyway JSON: %w", err)
-			}
-			continue
+		env, consumed, decErr := tryFlywayCandidate(trimmed, start)
+		if consumed > 0 {
+			// Advance past a successfully decoded value so its nested braces
+			// never become candidates. Left at 0 on a decode failure, since
+			// InputOffset is not meaningful then and those braces must stay
+			// candidates.
+			skipBelow = consumed
 		}
-		// Only after a successful decode — InputOffset is not meaningful after
-		// a failure, and braces inside malformed text must stay candidates.
-		skipBelow = start + int(dec.InputOffset())
-		if trimmed[start] != '{' {
-			continue // arrays are consumed to guard their contents, never promoted
-		}
-		var env flywayJSONEnvelope
-		if err := json.Unmarshal(raw, &env); err != nil {
+		if decErr != nil {
 			if firstDecodeErr == nil {
-				firstDecodeErr = fmt.Errorf("migration: parse Flyway JSON: %w", err)
+				firstDecodeErr = decErr
 			}
 			continue
 		}
-		if !env.looksLikeFlyway() {
-			continue
+		if env != nil {
+			return resultFromEnvelope(env), nil
 		}
-		return resultFromEnvelope(&env), nil
 	}
 	if firstDecodeErr != nil {
 		return Result{}, firstDecodeErr
 	}
 	return Result{}, errEmptyFlywayOutput
+}
+
+// tryFlywayCandidate decodes the single JSON value starting at trimmed[start] and
+// classifies it for parseFlywayJSON. Returns:
+//   - env != nil        when the value is a well-formed Flyway envelope (a match);
+//   - consumed > 0      the offset just past a SUCCESSFULLY decoded value (the caller
+//     advances skipBelow to it); 0 when the initial decode failed, so the braces
+//     inside malformed text stay candidates;
+//   - decErr != nil     a recordable decode/unmarshal failure. A trailing io.EOF from
+//     the streaming decoder is not an error worth recording, so it maps to (nil, 0, nil).
+//
+// Non-object values (arrays) and objects that decode but aren't a Flyway envelope
+// return (nil, consumed, nil): consumed to guard their nested contents, never promoted.
+func tryFlywayCandidate(trimmed string, start int) (env *flywayJSONEnvelope, consumed int, decErr error) {
+	dec := json.NewDecoder(strings.NewReader(trimmed[start:]))
+	var raw json.RawMessage
+	if err := dec.Decode(&raw); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, 0, nil
+		}
+		return nil, 0, fmt.Errorf("migration: parse Flyway JSON: %w", err)
+	}
+	consumed = start + int(dec.InputOffset())
+	if trimmed[start] != '{' {
+		return nil, consumed, nil // arrays are consumed to guard their contents, never promoted
+	}
+	var parsed flywayJSONEnvelope
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, consumed, fmt.Errorf("migration: parse Flyway JSON: %w", err)
+	}
+	if !parsed.looksLikeFlyway() {
+		return nil, consumed, nil
+	}
+	return &parsed, consumed, nil
 }
 
 // valueStarts returns the index of every '{' and '[' byte in s, in the order


### PR DESCRIPTION
## What

SonarCloud `go:S3776` flagged `parseFlywayJSON` (`migration/result.go`) at **cognitive complexity 20** (limit 15). Its candidate-scanning loop interleaved four concerns at nested depth: decode-or-skip, advance the consumed offset, record the first decode error (with an `io.EOF` filter on the streaming-decoder path but not the unmarshal path), and match the Flyway envelope.

[Issue AZ9ZoNmmOsIJlDz0Tn4m](https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=gaborage_go-bricks&open=AZ9ZoNmmOsIJlDz0Tn4m)

## How

Extract the per-candidate work into **`tryFlywayCandidate`**, which decodes one JSON value and classifies it through three return values:

| Return | Meaning |
|--------|---------|
| `env != nil` | a well-formed Flyway envelope match |
| `consumed > 0` | offset past a **successfully** decoded value (caller advances `skipBelow`); `0` on decode failure so braces in malformed text stay candidates |
| `decErr != nil` | a recordable decode/unmarshal error; a trailing `io.EOF` maps to `(nil, 0, nil)`, matching the old inline filter |

The loop body flattens to a single level, dropping `parseFlywayJSON` to ~14 and leaving the helper at ~6 — both under the gate.

## Behavior preservation

Byte-identical. All four load-bearing rules are preserved:
- `skipBelow` advances **only** on a successful decode (unchanged on decode failure);
- the **dual** error recording (`Decode` path filters `io.EOF`, `Unmarshal` path does not);
- arrays are consumed to guard their nested contents but **never promoted** to envelope candidates;
- the `"migration: parse Flyway JSON: %w"` error wrapping.

The full existing parse suite — 14 tests covering multi-candidate iteration, array consumption, EOF/malformed input, nested-object skipping, and envelope-lookalike noise — passes **unchanged** with `-race`. `parseFlywayJSON` coverage rises to **100%**; the helper is 86.7% (the one uncovered branch is the defensive `io.EOF` case, unreachable because the decoder input always starts with a brace — uncovered in the original too). `make check` green.

No API change, no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Flyway output containing mixed or invalid JSON.
  * Correctly distinguishes valid Flyway data from unrelated JSON values.
  * Preserves and reports the first meaningful parsing error when no valid Flyway result is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->