### PR TITLE
refactor(cache): extract generic internal/resourcepool and rewire CacheManager onto it

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -1,15 +1,13 @@
 package cache
 
 import (
-	"container/list"
 	"context"
+	"errors"
 	"fmt"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/gaborage/go-bricks/config"
-	"golang.org/x/sync/singleflight"
+	"github.com/gaborage/go-bricks/internal/resourcepool"
 )
 
 // ConfigProvider provides per-key cache configurations.
@@ -42,60 +40,14 @@ type Connector func(ctx context.Context, key string) (Cache, error)
 // See ADR-032.
 type ReleaseFunc func()
 
-// maxGetAttempts bounds the rare retry where a freshly resolved entry is evicted before
-// the caller can take a lease (only under extreme pool churn). A new entry is inserted at
-// the LRU front, so in practice the first attempt always succeeds.
-const maxGetAttempts = 4
-
-// cacheEntry represents a cache instance in the manager's LRU.
-// refs, detached, and closed are guarded by CacheManager.mu.
-type cacheEntry struct {
-	cache    Cache
-	key      string
-	lastUsed time.Time
-	element  *list.Element // Position in LRU list
-
-	// refs counts outstanding leases (current borrowers); a cache with refs > 0 is in use.
-	refs int
-	// seedHeld is true when one of refs is an unclaimed "seed" lease taken at creation. The
-	// seed keeps a brand-new entry alive (refs >= 1) through the window before its first Get
-	// caller claims it, so a concurrent evict/Remove can only detach (never close) it. The
-	// first claimOrAcquire takes the seed; later callers increment refs normally.
-	seedHeld bool
-	// detached marks an entry removed from the map+LRU whose Close() was deferred because
-	// a lease was still outstanding.
-	detached bool
-	// closed guards against a double Close() once the deferred close has run.
-	closed bool
-}
-
-// CacheManager implements the Manager interface for multi-tenant cache instances.
+// CacheManager implements the Manager interface for multi-tenant cache instances. It is a thin
+// adapter over internal/resourcepool.Pool, which owns the ADR-032 lease/evict/close protocol
+// (seed leases, LRU eviction, idle cleanup, and the closed-pool guard).
 //
 //nolint:revive // CacheManager is intentional - Manager is the interface name
 type CacheManager struct {
-	mu     sync.RWMutex
-	caches map[string]*cacheEntry
-	lru    *list.List
-	sfg    singleflight.Group
-
-	maxSize   int
-	idleTTL   time.Duration
+	pool      *resourcepool.Pool[Cache]
 	connector Connector
-
-	// Statistics
-	totalCreated int
-	evictions    int
-	idleCleanups int
-	errors       int
-
-	// Lifecycle
-	closeCh   chan struct{}
-	closeOnce sync.Once
-	// closed flips to true the moment Close() begins. Read on the hot path of
-	// Get/Remove so callers immediately see ErrManagerClosed instead of getting
-	// a handle to a cache instance that is about to be torn down. Atomic so we
-	// don't need to take m.mu on every operation just to consult shutdown state.
-	closed atomic.Bool
 }
 
 // ManagerConfig configures the cache manager's behavior.
@@ -133,18 +85,18 @@ func NewCacheManager(cfg ManagerConfig, connector Connector) (*CacheManager, err
 		cfg.CleanupInterval = 5 * time.Minute
 	}
 
+	pool := resourcepool.New[Cache](cfg.MaxSize, cfg.IdleTTL, func(c Cache) error {
+		return c.Close()
+	})
+
 	m := &CacheManager{
-		caches:    make(map[string]*cacheEntry),
-		lru:       list.New(),
-		maxSize:   cfg.MaxSize,
-		idleTTL:   cfg.IdleTTL,
+		pool:      pool,
 		connector: connector,
-		closeCh:   make(chan struct{}),
 	}
 
-	// Start background cleanup goroutine if idle TTL is configured
+	// Start the background cleanup goroutine if an idle TTL is configured.
 	if cfg.IdleTTL > 0 {
-		go m.cleanupLoop(cfg.CleanupInterval)
+		pool.StartCleanup(cfg.CleanupInterval)
 	}
 
 	return m, nil
@@ -156,351 +108,59 @@ func NewCacheManager(cfg ManagerConfig, connector Connector) (*CacheManager, err
 // cache instance evicted while in use from being closed under an active caller (the #606
 // race). On error the returned ReleaseFunc is nil — check err first.
 func (m *CacheManager) Get(ctx context.Context, key string) (Cache, ReleaseFunc, error) {
-	for attempt := 0; attempt < maxGetAttempts; attempt++ {
-		// Re-check on every iteration (not just once up front): a concurrent Close() must not
-		// be raced into recreating an instance on a shut-down manager. createCache also
-		// re-checks under the lock to close the window fully.
-		if m.closed.Load() {
+	value, release, err := m.pool.GetOrCreate(ctx, key, func(ctx context.Context) (Cache, error) {
+		inst, cerr := m.connector(ctx, key)
+		if cerr != nil {
+			return nil, fmt.Errorf("failed to create cache for key %q: %w", key, cerr)
+		}
+		return inst, nil
+	})
+	if err != nil {
+		if errors.Is(err, resourcepool.ErrPoolClosed) {
 			return nil, nil, ErrManagerClosed
 		}
-
-		// Fast path: getExisting increments the refcount atomically with the lookup, so the
-		// cache cannot be evicted-and-closed before the lease is taken.
-		if entry := m.getExisting(key); entry != nil {
-			return entry.cache, m.makeRelease(entry), nil
-		}
-
-		// Slow path: singleflight collapses concurrent creates for the same key into one. It
-		// returns the shared entry (freshly created with a seed lease, or an existing one);
-		// every caller then takes its own lease on that pointer via claimOrAcquire — the first
-		// claims the seed, the rest increment — so each concurrent borrower is counted.
-		v, err, _ := m.sfg.Do(key, func() (any, error) {
-			if e := m.peek(key); e != nil {
-				return e, nil
-			}
-			return m.createCache(ctx, key)
-		})
-		if err != nil {
-			m.mu.Lock()
-			m.errors++
-			m.mu.Unlock()
-			return nil, nil, err
-		}
-
-		entry := v.(*cacheEntry)
-		if m.claimOrAcquire(entry) {
-			return entry.cache, m.makeRelease(entry), nil
-		}
-		// The reused entry was closed in the window between lookup and claim (a concurrent
-		// evict/Remove of an unleased entry); loop to create a fresh one. The create path
-		// always succeeds because a new entry carries a seed lease, so this converges.
+		return nil, nil, err
 	}
-
-	return nil, nil, fmt.Errorf("failed to acquire cache for key %q after %d attempts (pool churn)", key, maxGetAttempts)
-}
-
-// claimOrAcquire takes one lease on entry, operating on the shared pointer so it can never
-// "miss" via a map lookup. It returns false only when the entry has already been fully closed
-// (a reused entry that lost a race), signaling the caller to retry with a fresh entry.
-func (m *CacheManager) claimOrAcquire(entry *cacheEntry) bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if entry.closed {
-		return false
-	}
-	if entry.seedHeld {
-		entry.seedHeld = false // claim the seed: that ref becomes this caller's lease
-	} else {
-		entry.refs++
-	}
-	return true
-}
-
-// getExisting retrieves an existing entry with a lease acquired (refcount incremented) and
-// updates LRU position, or nil if not found. The refcount increment happens under the same
-// lock as the lookup so the entry cannot be evicted-and-closed before the lease is taken.
-func (m *CacheManager) getExisting(key string) *cacheEntry {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	entry, exists := m.caches[key]
-	if !exists {
-		return nil
-	}
-
-	// Update LRU position (move to front)
-	m.lru.MoveToFront(entry.element)
-	entry.lastUsed = time.Now()
-	entry.refs++
-
-	return entry
-}
-
-// peek reports whether an entry exists for the key without taking a lease or touching LRU.
-func (m *CacheManager) peek(key string) *cacheEntry {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.caches[key]
-}
-
-// makeRelease returns an idempotent ReleaseFunc bound to a single lease on entry.
-func (m *CacheManager) makeRelease(entry *cacheEntry) ReleaseFunc {
-	var once sync.Once
-	return func() {
-		once.Do(func() { m.releaseEntry(entry) })
-	}
-}
-
-// releaseEntry drops one lease. If the entry was detached (evicted/idle-cleaned) while
-// leased and this was the final lease, it closes the cache now — outside the lock.
-func (m *CacheManager) releaseEntry(entry *cacheEntry) {
-	m.mu.Lock()
-	entry.refs--
-	shouldClose := entry.detached && entry.refs <= 0 && !entry.closed
-	if shouldClose {
-		entry.closed = true
-	}
-	m.mu.Unlock()
-
-	if shouldClose {
-		if err := entry.cache.Close(); err != nil {
-			m.mu.Lock()
-			m.errors++
-			m.mu.Unlock()
-		}
-	}
-}
-
-// createCache creates a new cache instance and adds it to the manager with a single seed
-// lease (refs == 1, seedHeld). The seed keeps the entry alive through the window before the
-// caller claims it via claimOrAcquire, so a concurrent evict/Remove can only detach it.
-func (m *CacheManager) createCache(ctx context.Context, key string) (*cacheEntry, error) {
-	// Create cache using connector function
-	cache, err := m.connector(ctx, key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create cache for key %q: %w", key, err)
-	}
-
-	m.mu.Lock()
-	// If Close() ran between the caller's m.closed check and here, do not resurrect the
-	// (cleared) map with a new instance that nothing would ever close. Close the just-created
-	// instance and report the manager as closed.
-	if m.closed.Load() {
-		m.mu.Unlock()
-		_ = cache.Close()
-		return nil, ErrManagerClosed
-	}
-
-	// Evict LRU cache if at capacity (returns entry to close outside lock)
-	evicted := m.evictIfNeeded()
-
-	// Add to LRU front (most recently used) with a seed lease.
-	entry := &cacheEntry{
-		cache:    cache,
-		key:      key,
-		lastUsed: time.Now(),
-		refs:     1,
-		seedHeld: true,
-	}
-	entry.element = m.lru.PushFront(entry)
-	m.caches[key] = entry
-	m.totalCreated++
-	m.mu.Unlock()
-
-	// Close evicted cache outside the lock (ignore errors during eviction)
-	if evicted != nil {
-		_ = evicted.cache.Close()
-	}
-
-	return entry, nil
-}
-
-// evictIfNeeded removes the least recently used cache if at capacity. Must be called with
-// mu held. It detaches the entry and returns it for the caller to close OUTSIDE the lock —
-// but ONLY when the entry has no outstanding leases. If the LRU victim is still leased, its
-// Close() is deferred to the final lease release (the #606 race). Returns nil when nothing
-// should be closed now.
-func (m *CacheManager) evictIfNeeded() *cacheEntry {
-	if m.maxSize <= 0 || len(m.caches) < m.maxSize {
-		return nil
-	}
-
-	// Remove oldest entry (back of LRU list)
-	oldest := m.lru.Back()
-	if oldest == nil {
-		return nil
-	}
-
-	entry := oldest.Value.(*cacheEntry)
-	m.removeEntryLocked(entry.key)
-	m.evictions++
-
-	if entry.refs > 0 {
-		return nil // still leased — defer the close to the final lease release
-	}
-	entry.closed = true
-	return entry
+	return value, ReleaseFunc(release), nil
 }
 
 // Remove explicitly removes a cache instance from the manager.
 // Returns ErrManagerClosed if Close() has been called.
 func (m *CacheManager) Remove(key string) error {
-	if m.closed.Load() {
+	if m.pool.Closed() {
 		return ErrManagerClosed
 	}
-	m.mu.Lock()
-	entry := m.removeEntryLocked(key)
-	shouldClose := entry != nil && entry.refs <= 0 && !entry.closed
-	if shouldClose {
-		entry.closed = true
-	}
-	m.mu.Unlock()
 
-	if entry == nil {
-		return nil // Already removed
-	}
-
-	// A still-leased entry is detached now but its Close() is deferred to the final lease
-	// release, so an in-use cache is never closed (the #606 race).
+	// A still-leased instance is detached now but its Close() is deferred to the final lease
+	// release, so an in-use cache is never closed (the #606 race); the pool reports shouldClose
+	// false in that case.
+	inst, shouldClose := m.pool.Remove(key)
 	if !shouldClose {
 		return nil
 	}
 
-	// Close the cache instance outside the lock
-	if err := entry.cache.Close(); err != nil {
+	if err := inst.Close(); err != nil {
 		return fmt.Errorf("failed to close cache %q: %w", key, err)
 	}
-
 	return nil
-}
-
-// removeEntryLocked removes bookkeeping for a cache (must be called with mu lock held).
-// Returns the removed entry or nil if not found.
-// The caller is responsible for closing the returned entry's cache.
-func (m *CacheManager) removeEntryLocked(key string) *cacheEntry {
-	entry, exists := m.caches[key]
-	if !exists {
-		return nil
-	}
-
-	// Remove from tracking structures (always cleanup, even if close fails later)
-	m.lru.Remove(entry.element)
-	delete(m.caches, key)
-	entry.detached = true
-
-	return entry
-}
-
-// cleanupLoop periodically removes idle cache instances.
-func (m *CacheManager) cleanupLoop(interval time.Duration) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			m.cleanupIdleCaches()
-		case <-m.closeCh:
-			return
-		}
-	}
-}
-
-// cleanupIdleCaches removes cache instances that have been idle beyond the TTL.
-func (m *CacheManager) cleanupIdleCaches() {
-	if m.idleTTL <= 0 {
-		return
-	}
-
-	// Collect idle entries under lock
-	m.mu.Lock()
-	now := time.Now()
-	var toClose []*cacheEntry
-
-	for key, entry := range m.caches {
-		if now.Sub(entry.lastUsed) > m.idleTTL {
-			if removed := m.removeEntryLocked(key); removed != nil {
-				m.idleCleanups++
-				if removed.refs > 0 {
-					continue // still leased — defer close to the final lease release
-				}
-				removed.closed = true
-				toClose = append(toClose, removed)
-			}
-		}
-	}
-	m.mu.Unlock()
-
-	// Close collected caches outside the lock
-	for _, entry := range toClose {
-		if err := entry.cache.Close(); err != nil {
-			// Increment error counter on close failures
-			m.mu.Lock()
-			m.errors++
-			m.mu.Unlock()
-		}
-	}
 }
 
 // Close shuts down all managed cache instances and stops the cleanup goroutine.
 // After Close() returns, subsequent calls to Get() and Remove() return ErrManagerClosed.
 func (m *CacheManager) Close() error {
-	var closeErr error
-
-	m.closeOnce.Do(func() {
-		// Flip closed BEFORE doing any teardown work so concurrent Get/Remove
-		// callers immediately see ErrManagerClosed rather than racing against
-		// half-torn-down state (e.g. getting a cache instance that's already
-		// in the toClose slice below). atomic.Bool is the right primitive here:
-		// it's lock-free on the hot path of every Get, and the memory ordering
-		// guarantees that any subsequent Load reads the final true value.
-		m.closed.Store(true)
-
-		// Signal cleanup goroutine to stop
-		close(m.closeCh)
-
-		// Collect all cache entries under lock. Mark each closed under the lock so a
-		// concurrent lease release cannot also close it (avoids a double Close()).
-		m.mu.Lock()
-		var toClose []*cacheEntry
-		for key := range m.caches {
-			if entry := m.removeEntryLocked(key); entry != nil {
-				entry.closed = true
-				toClose = append(toClose, entry)
-			}
-		}
-		m.mu.Unlock()
-
-		// Close all caches outside the lock
-		for _, entry := range toClose {
-			if err := entry.cache.Close(); err != nil {
-				// Track errors and return first error encountered
-				m.mu.Lock()
-				m.errors++
-				m.mu.Unlock()
-
-				if closeErr == nil {
-					closeErr = err
-				}
-			}
-		}
-	})
-
-	return closeErr
+	return m.pool.Close()
 }
 
 // Stats returns current manager statistics.
 func (m *CacheManager) Stats() ManagerStats {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
+	ps := m.pool.Stats()
 	return ManagerStats{
-		ActiveCaches: len(m.caches),
-		TotalCreated: m.totalCreated,
-		Evictions:    m.evictions,
-		IdleCleanups: m.idleCleanups,
-		Errors:       m.errors,
-		MaxSize:      m.maxSize,
-		IdleTTL:      int64(m.idleTTL.Seconds()),
+		ActiveCaches: ps.Size,
+		TotalCreated: ps.TotalCreated,
+		Evictions:    ps.Evictions,
+		IdleCleanups: ps.IdleCleanups,
+		Errors:       ps.Errors,
+		MaxSize:      ps.MaxSize,
+		IdleTTL:      int64(ps.IdleTTL.Seconds()),
 	}
 }

--- a/internal/resourcepool/resourcepool.go
+++ b/internal/resourcepool/resourcepool.go
@@ -155,10 +155,17 @@ func (p *Pool[V]) GetOrCreate(ctx context.Context, key string, create func(conte
 			if e := p.peek(key); e != nil {
 				return e, nil
 			}
-			return p.createEntry(ctx, key, create)
+			e, cerr := p.createEntry(ctx, key, create)
+			if cerr != nil {
+				// Count the failure once, HERE in the singleflight leader. sf.Do hands the same
+				// error to every collapsed waiter, so incrementing after Do would over-count a
+				// single create failure by the number of blocked callers.
+				p.incErrors()
+				return nil, cerr
+			}
+			return e, nil
 		})
 		if err != nil {
-			p.incErrors()
 			return zero, nil, err
 		}
 

--- a/internal/resourcepool/resourcepool.go
+++ b/internal/resourcepool/resourcepool.go
@@ -1,6 +1,6 @@
 // Package resourcepool implements the ADR-032 keyed pool of leasable,
-// refcounted, LRU-capped, idle-evicted resources shared by the cache,
-// database, and messaging managers.
+// refcounted, LRU-capped, idle-evicted resources. CacheManager is the first
+// consumer; the database and messaging managers adopt it in follow-up PRs.
 //
 // A pool hands each borrower a lease (via GetOrCreate) plus an idempotent
 // ReleaseFunc. A resource evicted (LRU, idle, or explicit Remove) while a
@@ -357,6 +357,13 @@ func (p *Pool[V]) StartCleanup(interval time.Duration) {
 
 	p.cleanupMu.Lock()
 	defer p.cleanupMu.Unlock()
+	// Re-check closed under cleanupMu. A concurrent Close may have flipped closed and run its
+	// (no-op, because cleanupStop was still nil) StopCleanup between the lock-free guard above
+	// and our acquiring cleanupMu. Without this re-check we would start a cleanupLoop that Close
+	// will never stop — a goroutine leaked forever on a closed pool.
+	if p.closed.Load() {
+		return
+	}
 	if p.cleanupStop != nil {
 		return // already running
 	}

--- a/internal/resourcepool/resourcepool.go
+++ b/internal/resourcepool/resourcepool.go
@@ -1,0 +1,497 @@
+// Package resourcepool implements the ADR-032 keyed pool of leasable,
+// refcounted, LRU-capped, idle-evicted resources shared by the cache,
+// database, and messaging managers.
+//
+// A pool hands each borrower a lease (via GetOrCreate) plus an idempotent
+// ReleaseFunc. A resource evicted (LRU, idle, or explicit Remove) while a
+// lease is outstanding is detached immediately but its Closer runs only once
+// the final lease is released, so an in-use resource is never closed under an
+// active caller (the #606 race). The Closer is ALWAYS invoked outside the pool
+// lock.
+package resourcepool
+
+import (
+	"container/list"
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// ErrPoolClosed is returned by GetOrCreate after Close has been called.
+// Callers can errors.Is(err, ErrPoolClosed) to distinguish "pool is gone" from
+// a per-resource creation failure.
+var ErrPoolClosed = errors.New("resourcepool: pool closed")
+
+// Closer releases the underlying resource. It is always invoked OUTSIDE the
+// pool lock and exactly once per resource. A non-nil return increments the
+// pool's error counter on the lifecycle paths that track close failures (final
+// lease release, idle cleanup, and Close); the create-time eviction and
+// closed-pool cleanup paths discard it.
+type Closer[V any] func(v V) error
+
+// ReleaseFunc releases a lease obtained from GetOrCreate. Callers must invoke it
+// (typically deferred) when finished with the resource for the current unit of
+// work. It is idempotent and does NOT close the shared resource; it signals this
+// borrower is done, so a resource evicted while leased is closed only once its
+// last lease is released. See ADR-032.
+type ReleaseFunc func()
+
+// maxAcquireAttempts bounds the rare retry where a freshly resolved entry is
+// evicted before the caller can take a lease (only under extreme pool churn). A
+// new entry is inserted at the LRU front with a seed lease, so in practice the
+// first attempt always succeeds.
+const maxAcquireAttempts = 4
+
+// PoolStats is a point-in-time snapshot of the pool's counters. Consumers adapt
+// it into their own stat shape (cache's typed ManagerStats, database/messaging's
+// map[string]any).
+type PoolStats struct {
+	Size         int           // Current number of active entries
+	MaxSize      int           // Maximum allowed active entries (0 = unlimited)
+	TotalCreated int           // Total entries created since the pool started
+	Evictions    int           // Total evictions due to LRU policy
+	IdleCleanups int           // Total removals due to idle timeout
+	Errors       int           // Total create failures and tracked close failures
+	IdleTTL      time.Duration // Idle timeout duration
+}
+
+// entry represents a pooled resource in the LRU.
+// refs, seedHeld, detached, and closed are guarded by Pool.mu.
+type entry[V any] struct {
+	value    V
+	key      string
+	lastUsed time.Time
+	element  *list.Element // Position in the LRU list
+
+	// refs counts outstanding leases (current borrowers); an entry with refs > 0 is in use.
+	refs int
+	// seedHeld is true when one of refs is an unclaimed "seed" lease taken at creation. The
+	// seed keeps a brand-new entry alive (refs >= 1) through the window before its first
+	// GetOrCreate caller claims it, so a concurrent evict/Remove can only detach (never close)
+	// it. The first claimOrAcquire takes the seed; later callers increment refs normally.
+	seedHeld bool
+	// detached marks an entry removed from the map+LRU whose Closer was deferred because a
+	// lease was still outstanding.
+	detached bool
+	// closed guards against a double Closer call once the deferred close has run.
+	closed bool
+}
+
+// Pool is a keyed pool of leasable, refcounted, LRU-capped, idle-evicted
+// resources. The zero value is not usable; construct with New.
+type Pool[V any] struct {
+	mu      sync.Mutex
+	entries map[string]*entry[V]
+	lru     *list.List
+	sf      singleflight.Group
+
+	maxSize int
+	idleTTL time.Duration
+	closer  Closer[V]
+
+	// Statistics (guarded by mu).
+	totalCreated int
+	evictions    int
+	idleCleanups int
+	errors       int
+
+	// closed flips to true the moment Close begins. Read on the hot path of
+	// GetOrCreate so callers immediately see ErrPoolClosed instead of receiving a
+	// handle to a resource that is about to be torn down. Atomic so the hot path
+	// does not need to take mu just to consult shutdown state.
+	closed atomic.Bool
+
+	// Cleanup-goroutine lifecycle (guarded by cleanupMu, independent of mu).
+	cleanupMu   sync.Mutex
+	cleanupStop chan struct{} // non-nil while a cleanup loop is running
+	closeOnce   sync.Once
+}
+
+// New creates a pool with the given capacity, idle timeout, and Closer. The
+// Closer is required; a nil Closer panics on the first close. maxSize <= 0 means
+// unlimited; idleTTL <= 0 disables idle cleanup.
+func New[V any](maxSize int, idleTTL time.Duration, closer Closer[V]) *Pool[V] {
+	return &Pool[V]{
+		entries: make(map[string]*entry[V]),
+		lru:     list.New(),
+		maxSize: maxSize,
+		idleTTL: idleTTL,
+		closer:  closer,
+	}
+}
+
+// GetOrCreate returns the resource for key plus a ReleaseFunc the caller must
+// invoke when finished with it for the current unit of work (typically
+// deferred). It creates the resource via create on first use, collapsing
+// concurrent creates for the same key through singleflight. Returns
+// ErrPoolClosed if Close has been called. On error the returned ReleaseFunc is
+// nil — check err first.
+func (p *Pool[V]) GetOrCreate(ctx context.Context, key string, create func(context.Context) (V, error)) (V, ReleaseFunc, error) {
+	var zero V
+	for attempt := 0; attempt < maxAcquireAttempts; attempt++ {
+		// Re-check on every iteration (not just once up front): a concurrent Close must not be
+		// raced into recreating an entry on a shut-down pool. createEntry also re-checks under
+		// the lock to close the window fully.
+		if p.closed.Load() {
+			return zero, nil, ErrPoolClosed
+		}
+
+		// Fast path: getExisting increments the refcount atomically with the lookup, so the
+		// entry cannot be evicted-and-closed before the lease is taken.
+		if e := p.getExisting(key); e != nil {
+			return e.value, p.makeRelease(e), nil
+		}
+
+		// Slow path: singleflight collapses concurrent creates for the same key into one. It
+		// returns the shared entry (freshly created with a seed lease, or an existing one);
+		// every caller then takes its own lease on that pointer via claimOrAcquire — the first
+		// claims the seed, the rest increment — so each concurrent borrower is counted.
+		v, err, _ := p.sf.Do(key, func() (any, error) {
+			if e := p.peek(key); e != nil {
+				return e, nil
+			}
+			return p.createEntry(ctx, key, create)
+		})
+		if err != nil {
+			p.incErrors()
+			return zero, nil, err
+		}
+
+		e := v.(*entry[V])
+		if p.claimOrAcquire(e) {
+			return e.value, p.makeRelease(e), nil
+		}
+		// The reused entry was closed in the window between lookup and claim (a concurrent
+		// evict/Remove of an unleased entry); loop to create a fresh one. The create path
+		// always succeeds because a new entry carries a seed lease, so this converges.
+	}
+
+	return zero, nil, fmt.Errorf("resourcepool: failed to acquire %q after %d attempts (pool churn)", key, maxAcquireAttempts)
+}
+
+// claimOrAcquire takes one lease on e, operating on the shared pointer so it can never "miss"
+// via a map lookup. It returns false only when the entry has already been fully closed (a
+// reused entry that lost a race), signaling the caller to retry with a fresh entry.
+func (p *Pool[V]) claimOrAcquire(e *entry[V]) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if e.closed {
+		return false
+	}
+	if e.seedHeld {
+		e.seedHeld = false // claim the seed: that ref becomes this caller's lease
+	} else {
+		e.refs++
+	}
+	return true
+}
+
+// getExisting retrieves an existing entry with a lease acquired (refcount incremented) and
+// updates LRU position, or nil if not found. The refcount increment happens under the same
+// lock as the lookup so the entry cannot be evicted-and-closed before the lease is taken.
+func (p *Pool[V]) getExisting(key string) *entry[V] {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	e, exists := p.entries[key]
+	if !exists {
+		return nil
+	}
+
+	p.lru.MoveToFront(e.element)
+	e.lastUsed = time.Now()
+	e.refs++
+
+	return e
+}
+
+// peek reports whether an entry exists for the key without taking a lease or touching LRU.
+func (p *Pool[V]) peek(key string) *entry[V] {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.entries[key]
+}
+
+// makeRelease returns an idempotent ReleaseFunc bound to a single lease on e.
+func (p *Pool[V]) makeRelease(e *entry[V]) ReleaseFunc {
+	var once sync.Once
+	return func() {
+		once.Do(func() { p.releaseEntry(e) })
+	}
+}
+
+// releaseEntry drops one lease. If the entry was detached (evicted/removed/idle-cleaned) while
+// leased and this was the final lease, it closes the resource now — outside the lock — and
+// counts a close failure.
+func (p *Pool[V]) releaseEntry(e *entry[V]) {
+	p.mu.Lock()
+	e.refs--
+	shouldClose := e.detached && e.refs <= 0 && !e.closed
+	if shouldClose {
+		e.closed = true
+	}
+	p.mu.Unlock()
+
+	if shouldClose {
+		if err := p.closer(e.value); err != nil {
+			p.incErrors()
+		}
+	}
+}
+
+// createEntry creates a new resource and adds it to the pool with a single seed lease
+// (refs == 1, seedHeld). The seed keeps the entry alive through the window before the caller
+// claims it via claimOrAcquire, so a concurrent evict/Remove can only detach it. If Close ran
+// between the caller's closed check and here, the just-created resource is closed and
+// ErrPoolClosed is returned rather than resurrecting the cleared map.
+func (p *Pool[V]) createEntry(ctx context.Context, key string, create func(context.Context) (V, error)) (*entry[V], error) {
+	value, err := create(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	p.mu.Lock()
+	if p.closed.Load() {
+		p.mu.Unlock()
+		_ = p.closer(value) // orphaned instance — close is best-effort, not counted
+		return nil, ErrPoolClosed
+	}
+
+	evicted := p.evictIfNeeded()
+
+	e := &entry[V]{
+		value:    value,
+		key:      key,
+		lastUsed: time.Now(),
+		refs:     1,
+		seedHeld: true,
+	}
+	e.element = p.lru.PushFront(e)
+	p.entries[key] = e
+	p.totalCreated++
+	p.mu.Unlock()
+
+	// Close the evicted resource outside the lock (eviction close failures are not counted).
+	if evicted != nil {
+		_ = p.closer(evicted.value)
+	}
+
+	return e, nil
+}
+
+// evictIfNeeded removes the least recently used entry if at capacity. Must be called with mu
+// held. It detaches the entry and returns it for the caller to close OUTSIDE the lock — but
+// ONLY when the entry has no outstanding leases. If the LRU victim is still leased, its close
+// is deferred to the final lease release (the #606 race). Returns nil when nothing should be
+// closed now.
+func (p *Pool[V]) evictIfNeeded() *entry[V] {
+	if p.maxSize <= 0 || len(p.entries) < p.maxSize {
+		return nil
+	}
+
+	oldest := p.lru.Back()
+	if oldest == nil {
+		return nil
+	}
+
+	e := oldest.Value.(*entry[V])
+	p.removeEntryLocked(e.key)
+	p.evictions++
+
+	if e.refs > 0 {
+		return nil // still leased — defer the close to the final lease release
+	}
+	e.closed = true
+	return e
+}
+
+// Remove detaches the entry for key from the pool. If it exists and is unleased, it marks the
+// entry closed and returns (value, true) for the caller to close OUTSIDE the pool. If it is
+// still leased, the close is deferred to the final lease release and Remove returns
+// (zero, false). A missing key returns (zero, false).
+func (p *Pool[V]) Remove(key string) (v V, shouldClose bool) {
+	var zero V
+	p.mu.Lock()
+	e := p.removeEntryLocked(key)
+	shouldClose = e != nil && e.refs <= 0 && !e.closed
+	if shouldClose {
+		e.closed = true
+	}
+	p.mu.Unlock()
+
+	if !shouldClose {
+		return zero, false
+	}
+	return e.value, true
+}
+
+// removeEntryLocked removes bookkeeping for an entry (must be called with mu held). Returns
+// the removed entry or nil if not found. The caller is responsible for closing the returned
+// entry's resource. A removed entry is marked detached so a concurrent final lease release
+// runs its deferred close.
+func (p *Pool[V]) removeEntryLocked(key string) *entry[V] {
+	e, exists := p.entries[key]
+	if !exists {
+		return nil
+	}
+
+	p.lru.Remove(e.element)
+	delete(p.entries, key)
+	e.detached = true
+
+	return e
+}
+
+// StartCleanup starts the idle-cleanup loop at the given interval. It is a no-op when the
+// pool has no idle timeout, the interval is non-positive, the pool is closed, or a loop is
+// already running (idempotent).
+func (p *Pool[V]) StartCleanup(interval time.Duration) {
+	if p.idleTTL <= 0 || interval <= 0 || p.closed.Load() {
+		return
+	}
+
+	p.cleanupMu.Lock()
+	defer p.cleanupMu.Unlock()
+	if p.cleanupStop != nil {
+		return // already running
+	}
+	stop := make(chan struct{})
+	p.cleanupStop = stop
+	go p.cleanupLoop(interval, stop)
+}
+
+// StopCleanup stops a running idle-cleanup loop. It is idempotent: calling it when no loop is
+// running is a no-op.
+func (p *Pool[V]) StopCleanup() {
+	p.cleanupMu.Lock()
+	defer p.cleanupMu.Unlock()
+	if p.cleanupStop == nil {
+		return
+	}
+	close(p.cleanupStop)
+	p.cleanupStop = nil
+}
+
+// cleanupLoop periodically removes idle entries until stopped.
+func (p *Pool[V]) cleanupLoop(interval time.Duration, stop <-chan struct{}) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			p.cleanupIdle()
+		case <-stop:
+			return
+		}
+	}
+}
+
+// cleanupIdle removes entries idle beyond the TTL. A leased idle entry is detached (and
+// counted as a cleanup) but its close is deferred to the final lease release. Close failures
+// are counted.
+func (p *Pool[V]) cleanupIdle() {
+	if p.idleTTL <= 0 {
+		return
+	}
+
+	p.mu.Lock()
+	now := time.Now()
+	var toClose []*entry[V]
+
+	for key, e := range p.entries {
+		if now.Sub(e.lastUsed) > p.idleTTL {
+			if removed := p.removeEntryLocked(key); removed != nil {
+				p.idleCleanups++
+				if removed.refs > 0 {
+					continue // still leased — defer close to the final lease release
+				}
+				removed.closed = true
+				toClose = append(toClose, removed)
+			}
+		}
+	}
+	p.mu.Unlock()
+
+	for _, e := range toClose {
+		if err := p.closer(e.value); err != nil {
+			p.incErrors()
+		}
+	}
+}
+
+// Close shuts down all pooled resources and stops the cleanup loop. After Close returns,
+// GetOrCreate returns ErrPoolClosed. It is idempotent and returns the first close error
+// encountered (if any); all close errors are counted.
+func (p *Pool[V]) Close() error {
+	var first error
+
+	p.closeOnce.Do(func() {
+		// Flip closed BEFORE any teardown so concurrent GetOrCreate callers immediately see
+		// ErrPoolClosed rather than racing against half-torn-down state.
+		p.closed.Store(true)
+		p.StopCleanup()
+
+		// Collect all entries under the lock, marking each closed so a concurrent lease release
+		// cannot also close it (avoids a double Closer call).
+		p.mu.Lock()
+		var toClose []*entry[V]
+		for key := range p.entries {
+			if e := p.removeEntryLocked(key); e != nil {
+				e.closed = true
+				toClose = append(toClose, e)
+			}
+		}
+		p.mu.Unlock()
+
+		for _, e := range toClose {
+			if err := p.closer(e.value); err != nil {
+				p.incErrors()
+				if first == nil {
+					first = err
+				}
+			}
+		}
+	})
+
+	return first
+}
+
+// Closed reports whether Close has been called.
+func (p *Pool[V]) Closed() bool {
+	return p.closed.Load()
+}
+
+// Size returns the current number of active entries.
+func (p *Pool[V]) Size() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.entries)
+}
+
+// Stats returns a point-in-time snapshot of the pool's counters.
+func (p *Pool[V]) Stats() PoolStats {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return PoolStats{
+		Size:         len(p.entries),
+		MaxSize:      p.maxSize,
+		TotalCreated: p.totalCreated,
+		Evictions:    p.evictions,
+		IdleCleanups: p.idleCleanups,
+		Errors:       p.errors,
+		IdleTTL:      p.idleTTL,
+	}
+}
+
+// incErrors bumps the error counter. Must be called without mu held.
+func (p *Pool[V]) incErrors() {
+	p.mu.Lock()
+	p.errors++
+	p.mu.Unlock()
+}

--- a/internal/resourcepool/resourcepool_test.go
+++ b/internal/resourcepool/resourcepool_test.go
@@ -93,6 +93,17 @@ func uniqueConnector(created *atomic.Int32) func(context.Context) (*fakeResource
 	}
 }
 
+// failingConnector returns a create function that always fails with err after a delay, tallying
+// call count. The delay widens the singleflight window so concurrent callers collapse onto one
+// failing create.
+func failingConnector(calls *atomic.Int32, err error, delay time.Duration) func(context.Context) (*fakeResource, error) {
+	return func(context.Context) (*fakeResource, error) {
+		calls.Add(1)
+		time.Sleep(delay)
+		return nil, err
+	}
+}
+
 // TestPoolGetOrCreateCreatesOnceAndReuses pins lazy creation and reuse of a single entry.
 func TestPoolGetOrCreateCreatesOnceAndReuses(t *testing.T) {
 	tr := newCloseTracker()
@@ -323,6 +334,37 @@ func TestPoolCreateErrorPropagatesAndCounts(t *testing.T) {
 	assert.Equal(t, 0, st.Size)
 	assert.Equal(t, 1, st.Errors)
 	assert.Equal(t, 0, st.TotalCreated)
+}
+
+// TestPoolConcurrentCreateFailureCountsErrorOnce pins that a create failure collapsed across N
+// concurrent GetOrCreate callers (singleflight hands the same error to every waiter) increments
+// Errors exactly ONCE — in the leader — not once per blocked caller. Every caller still receives
+// the shared error.
+func TestPoolConcurrentCreateFailureCountsErrorOnce(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(0, 0, tr.closer)
+	defer p.Close()
+
+	wantErr := errors.New("boom")
+	var calls atomic.Int32
+	create := failingConnector(&calls, wantErr, 20*time.Millisecond)
+
+	const workers = 8
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			v, rel, err := p.GetOrCreate(context.Background(), keyOne, create)
+			assert.ErrorIs(t, err, wantErr)
+			assert.Nil(t, v)
+			assert.Nil(t, rel)
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), calls.Load(), "singleflight must collapse the failing create to one call")
+	assert.Equal(t, 1, p.Stats().Errors, "a single collapsed create failure counts once, not once per waiter")
 }
 
 // TestPoolRemoveClosesUnleased verifies Remove hands back an unleased resource for the caller

--- a/internal/resourcepool/resourcepool_test.go
+++ b/internal/resourcepool/resourcepool_test.go
@@ -73,6 +73,26 @@ func keyedConnector() func(context.Context, string) (*fakeResource, error) {
 	}
 }
 
+// slowConnector returns a create function that sleeps before producing a fixed-id resource,
+// widening the singleflight window so concurrent followers reliably pile up on one create.
+func slowConnector(created *atomic.Int32, id string, delay time.Duration) func(context.Context) (*fakeResource, error) {
+	return func(context.Context) (*fakeResource, error) {
+		created.Add(1)
+		time.Sleep(delay)
+		return newFakeResource(id), nil
+	}
+}
+
+// uniqueConnector returns a create function giving every resource a unique id (via the atomic
+// counter's return value, which is race-free unlike a separate Load), so a close tracker can
+// detect any double-close under concurrency.
+func uniqueConnector(created *atomic.Int32) func(context.Context) (*fakeResource, error) {
+	return func(context.Context) (*fakeResource, error) {
+		id := created.Add(1)
+		return newFakeResource(fmt.Sprintf("res-%d", id)), nil
+	}
+}
+
 // TestPoolGetOrCreateCreatesOnceAndReuses pins lazy creation and reuse of a single entry.
 func TestPoolGetOrCreateCreatesOnceAndReuses(t *testing.T) {
 	tr := newCloseTracker()
@@ -789,4 +809,125 @@ func TestPoolConcurrentGetRacesRemove(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// TestPoolStartCleanupAfterCloseIsNoOp pins the contract behind the StartCleanup/Close leak fix:
+// once the pool is closed, StartCleanup must not launch a cleanup goroutine (Close would never
+// stop it). Both the lock-free top guard and the under-lock re-check enforce this; removing both
+// fails this test. idleTTL and interval are positive so `closed` is the only thing that can
+// prevent the loop from starting.
+func TestPoolStartCleanupAfterCloseIsNoOp(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 50*time.Millisecond, tr.closer)
+	require.NoError(t, p.Close())
+
+	p.StartCleanup(10 * time.Millisecond)
+
+	p.cleanupMu.Lock()
+	defer p.cleanupMu.Unlock()
+	assert.Nil(t, p.cleanupStop, "StartCleanup on a closed pool must not start a cleanup loop")
+}
+
+// TestPoolConcurrentLeasesAllCountedBeforeClose pins that EVERY concurrent follower's lease is
+// counted (claimOrAcquire's non-seed refs++), not just the seed claim. N callers race on one key
+// (singleflight -> one create, N leases); Remove then detaches the entry while all N are held, so
+// the deferred close must wait for the FINAL release. If the follower refs++ were dropped, refs
+// would sit at 1 and the first release would close the resource while N-1 leases still hold it.
+func TestPoolConcurrentLeasesAllCountedBeforeClose(t *testing.T) {
+	tr := newCloseTracker()
+	var creations atomic.Int32
+	p := New(0, 0, tr.closer)
+	defer p.Close()
+
+	create := slowConnector(&creations, "shared", 20*time.Millisecond) // widen the singleflight window
+
+	const workers = 8
+	rels := make(chan ReleaseFunc, workers)
+	var v0 *fakeResource
+	var v0mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			v, rel, err := p.GetOrCreate(context.Background(), keyOne, create)
+			if err != nil {
+				t.Errorf("GetOrCreate failed: %v", err)
+				return
+			}
+			v0mu.Lock()
+			v0 = v
+			v0mu.Unlock()
+			rels <- rel
+		}()
+	}
+	wg.Wait()
+	close(rels)
+	require.Equal(t, int32(1), creations.Load(), "singleflight must collapse to one create")
+
+	// Detach the entry while all N leases are outstanding: Remove must defer the close.
+	if _, shouldClose := p.Remove(keyOne); shouldClose {
+		t.Fatal("Remove must defer close while leases are held")
+	}
+
+	got := make([]ReleaseFunc, 0, workers)
+	for r := range rels {
+		got = append(got, r)
+	}
+	require.Len(t, got, workers)
+
+	// Release all but the last; the resource must stay open the entire time — which only holds if
+	// every follower lease was counted, not just the seed.
+	for i := 0; i < len(got)-1; i++ {
+		got[i]()
+		assert.Falsef(t, tr.wasClosed(v0.id),
+			"resource closed after %d of %d releases — a follower lease was uncounted", i+1, workers)
+	}
+	got[len(got)-1]()
+	assert.True(t, tr.wasClosed(v0.id), "final release must close the detached resource")
+	assert.Equal(t, 1, tr.count(v0.id), "the deferred close must run exactly once")
+}
+
+// TestPoolConcurrentEvictWhileLeasedRace drives eviction and lease-release on the same entries
+// from different goroutines with maxSize>0, exercising the #606 deferred-close path under -race
+// (the single-threaded TestPoolEvictWhileLeasedDefersClose cannot surface a data race between a
+// concurrent evict marking detached/closed and a concurrent releaseEntry reading them). Unique
+// per-resource ids let the tracker catch any double-close.
+func TestPoolConcurrentEvictWhileLeasedRace(t *testing.T) {
+	tr := newCloseTracker()
+	var creations atomic.Int32
+	p := New(2, 0, tr.closer) // small capacity forces constant eviction across 8 keys
+	ctx := context.Background()
+
+	create := uniqueConnector(&creations)
+
+	const workers = 16
+	const ops = 60
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			for j := 0; j < ops; j++ {
+				key := fmt.Sprintf("key-%d", (w+j)%8)
+				_, rel, err := p.GetOrCreate(ctx, key, create)
+				if err != nil {
+					assert.Contains(t, err.Error(), "pool churn", "unexpected GetOrCreate error")
+					continue
+				}
+				time.Sleep(time.Millisecond) // hold the lease across other goroutines' evictions
+				rel()
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// No resource may have been closed more than once during the concurrent eviction phase.
+	tr.mu.Lock()
+	for id, n := range tr.closed {
+		assert.LessOrEqualf(t, n, 1, "resource %s closed %d times (double-close under eviction race)", id, n)
+	}
+	tr.mu.Unlock()
+
+	require.NoError(t, p.Close())
 }

--- a/internal/resourcepool/resourcepool_test.go
+++ b/internal/resourcepool/resourcepool_test.go
@@ -1,0 +1,792 @@
+package resourcepool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	keyOne   = "key-1"
+	keyTwo   = "key-2"
+	keyThree = "key-3"
+)
+
+// fakeResource is a trivial pooled value with a controllable close outcome.
+type fakeResource struct {
+	id       string
+	closed   atomic.Bool
+	closeErr error
+}
+
+func newFakeResource(id string) *fakeResource {
+	return &fakeResource{id: id}
+}
+
+// closeTracker records which resources have been closed and how many times.
+type closeTracker struct {
+	mu     sync.Mutex
+	closed map[string]int
+}
+
+func newCloseTracker() *closeTracker {
+	return &closeTracker{closed: make(map[string]int)}
+}
+
+func (t *closeTracker) closer(r *fakeResource) error {
+	r.closed.Store(true)
+	t.mu.Lock()
+	t.closed[r.id]++
+	t.mu.Unlock()
+	return r.closeErr
+}
+
+func (t *closeTracker) count(id string) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.closed[id]
+}
+
+func (t *closeTracker) wasClosed(id string) bool {
+	return t.count(id) > 0
+}
+
+// countingConnector returns a create function that produces a fresh fakeResource per key and
+// tallies creations.
+func countingConnector(created *atomic.Int32) func(context.Context) (*fakeResource, error) {
+	return func(context.Context) (*fakeResource, error) {
+		created.Add(1)
+		return newFakeResource(fmt.Sprintf("res-%d", created.Load())), nil
+	}
+}
+
+func keyedConnector() func(context.Context, string) (*fakeResource, error) {
+	return func(_ context.Context, key string) (*fakeResource, error) {
+		return newFakeResource(key), nil
+	}
+}
+
+// TestPoolGetOrCreateCreatesOnceAndReuses pins lazy creation and reuse of a single entry.
+func TestPoolGetOrCreateCreatesOnceAndReuses(t *testing.T) {
+	tr := newCloseTracker()
+	conn := keyedConnector()
+	var creations atomic.Int32
+	p := New(5, 0, tr.closer)
+	defer p.Close()
+
+	create := func(ctx context.Context) (*fakeResource, error) {
+		creations.Add(1)
+		return conn(ctx, keyOne)
+	}
+
+	v1, rel1, err := p.GetOrCreate(context.Background(), keyOne, create)
+	require.NoError(t, err)
+	require.NotNil(t, v1)
+	require.NotNil(t, rel1)
+	assert.Equal(t, int32(1), creations.Load())
+
+	v2, rel2, err := p.GetOrCreate(context.Background(), keyOne, create)
+	require.NoError(t, err)
+	assert.Same(t, v1, v2, "second GetOrCreate must reuse the cached resource")
+	assert.Equal(t, int32(1), creations.Load(), "no new creation on reuse")
+
+	rel1()
+	rel2()
+
+	st := p.Stats()
+	assert.Equal(t, 1, st.Size)
+	assert.Equal(t, 1, st.TotalCreated)
+}
+
+// TestPoolGetOrCreateReturnsNonNilRelease verifies releasing a live cached entry does not
+// close it.
+func TestPoolGetOrCreateReturnsNonNilRelease(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 0, tr.closer)
+	defer p.Close()
+
+	v, rel, err := p.GetOrCreate(context.Background(), keyOne, func(ctx context.Context) (*fakeResource, error) {
+		return keyedConnector()(ctx, keyOne)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, rel)
+
+	rel()
+	assert.False(t, tr.wasClosed(v.id), "releasing a lease on a live cached resource must not close it")
+	assert.Equal(t, 1, p.Size())
+}
+
+// TestPoolConcurrentGetOrCreateSingleflight pins invariant 1: concurrent first-GetOrCreate for
+// one key yields one created resource, N usable leases, no double-create.
+func TestPoolConcurrentGetOrCreateSingleflight(t *testing.T) {
+	tr := newCloseTracker()
+	var creations atomic.Int32
+	var inProgress atomic.Bool
+	p := New(0, 0, tr.closer)
+	defer p.Close()
+
+	create := func(context.Context) (*fakeResource, error) {
+		if !inProgress.CompareAndSwap(false, true) {
+			t.Error("concurrent creation detected — singleflight failed")
+		}
+		defer inProgress.Store(false)
+		creations.Add(1)
+		time.Sleep(30 * time.Millisecond)
+		return newFakeResource(keyOne), nil
+	}
+
+	const workers = 12
+	type res struct {
+		v   *fakeResource
+		rel ReleaseFunc
+	}
+	results := make(chan res, workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			v, rel, err := p.GetOrCreate(context.Background(), keyOne, create)
+			if err != nil {
+				t.Errorf("GetOrCreate failed: %v", err)
+			}
+			results <- res{v, rel}
+		}()
+	}
+
+	var got []res
+	for i := 0; i < workers; i++ {
+		got = append(got, <-results)
+	}
+	for i := 1; i < len(got); i++ {
+		assert.Same(t, got[0].v, got[i].v, "all concurrent callers must receive the same resource")
+	}
+	assert.Equal(t, int32(1), creations.Load(), "singleflight must collapse concurrent creates")
+
+	// All N leases are independent: releasing all of them, then evicting, closes exactly once.
+	for _, r := range got {
+		r.rel()
+	}
+	assert.Equal(t, int32(1), creations.Load())
+}
+
+// TestPoolEvictWhileLeasedDefersClose pins invariant 2 and is the mutation-check target for the
+// defer-close-if-leased branch in evictIfNeeded.
+func TestPoolEvictWhileLeasedDefersClose(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(1, 0, tr.closer) // capacity 1: creating key-2 evicts key-1
+	defer p.Close()
+	ctx := context.Background()
+
+	a, relA, err := p.GetOrCreate(ctx, keyOne, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyOne)
+	})
+	require.NoError(t, err)
+
+	_, relB, err := p.GetOrCreate(ctx, keyTwo, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyTwo)
+	})
+	require.NoError(t, err)
+	defer relB()
+
+	assert.False(t, tr.wasClosed(a.id), "an evicted-but-leased resource must not be closed while a lease is held (#606)")
+
+	relA()
+	assert.True(t, tr.wasClosed(a.id), "an evicted resource must close once its last lease is released")
+	assert.Equal(t, 1, tr.count(a.id), "the deferred close must run exactly once")
+}
+
+// TestPoolTwoLeasesKeepAliveUntilBothReleased verifies refcounting across two borrowers.
+func TestPoolTwoLeasesKeepAliveUntilBothReleased(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(1, 0, tr.closer)
+	defer p.Close()
+	ctx := context.Background()
+
+	a, rel1, err := p.GetOrCreate(ctx, keyOne, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyOne)
+	})
+	require.NoError(t, err)
+	_, rel2, err := p.GetOrCreate(ctx, keyOne, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyOne)
+	})
+	require.NoError(t, err)
+
+	_, relB, err := p.GetOrCreate(ctx, keyTwo, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyTwo)
+	})
+	require.NoError(t, err)
+	defer relB()
+
+	rel1()
+	assert.False(t, tr.wasClosed(a.id), "resource must stay open while a second lease is outstanding")
+
+	rel2()
+	assert.True(t, tr.wasClosed(a.id), "resource must close when the final lease is released")
+}
+
+// TestPoolReleaseIsIdempotent pins invariant 3: a double release decrements once.
+func TestPoolReleaseIsIdempotent(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(1, 0, tr.closer)
+	defer p.Close()
+	ctx := context.Background()
+
+	a, relA, err := p.GetOrCreate(ctx, keyOne, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyOne)
+	})
+	require.NoError(t, err)
+	_, relB, err := p.GetOrCreate(ctx, keyTwo, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyTwo)
+	})
+	require.NoError(t, err)
+	defer relB()
+
+	assert.NotPanics(t, func() {
+		relA()
+		relA() // double release must be a safe no-op
+	})
+	assert.Equal(t, 1, tr.count(a.id), "double release must not double-close")
+}
+
+// TestPoolGetOrCreateAfterCloseReturnsErrPoolClosed pins invariant 4 (the F22 closed guard).
+func TestPoolGetOrCreateAfterCloseReturnsErrPoolClosed(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 0, tr.closer)
+	require.NoError(t, p.Close())
+
+	_, rel, err := p.GetOrCreate(context.Background(), keyOne, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyOne)
+	})
+	assert.ErrorIs(t, err, ErrPoolClosed)
+	assert.Nil(t, rel)
+}
+
+// TestPoolCreateRacingCloseDoesNotResurrect drives Close into the window between the top closed
+// check and createEntry taking the lock: the create callback closes the pool before returning.
+// createEntry must re-check under the lock, close the just-created resource, and report
+// ErrPoolClosed rather than resurrecting the cleared map.
+func TestPoolCreateRacingCloseDoesNotResurrect(t *testing.T) {
+	tr := newCloseTracker()
+	var p *Pool[*fakeResource]
+	var once sync.Once
+	p = New(5, 0, tr.closer)
+
+	_, _, err := p.GetOrCreate(context.Background(), keyOne, func(context.Context) (*fakeResource, error) {
+		once.Do(func() { _ = p.Close() }) // Close lands before createEntry takes the lock
+		return newFakeResource(keyOne), nil
+	})
+	assert.ErrorIs(t, err, ErrPoolClosed, "GetOrCreate must report closed, not resurrect the map")
+	assert.True(t, tr.wasClosed(keyOne), "the just-created resource must be closed, not leaked")
+	assert.Equal(t, 0, p.Size(), "the map must not be resurrected with a new entry")
+}
+
+// TestPoolCreateErrorPropagatesAndCounts verifies a create failure is returned and counted.
+func TestPoolCreateErrorPropagatesAndCounts(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 0, tr.closer)
+	defer p.Close()
+
+	wantErr := errors.New("boom")
+	v, rel, err := p.GetOrCreate(context.Background(), keyOne, func(context.Context) (*fakeResource, error) {
+		return nil, wantErr
+	})
+	assert.ErrorIs(t, err, wantErr)
+	assert.Nil(t, v)
+	assert.Nil(t, rel)
+
+	st := p.Stats()
+	assert.Equal(t, 0, st.Size)
+	assert.Equal(t, 1, st.Errors)
+	assert.Equal(t, 0, st.TotalCreated)
+}
+
+// TestPoolRemoveClosesUnleased verifies Remove hands back an unleased resource for the caller
+// to close and detaches it from the pool.
+func TestPoolRemoveClosesUnleased(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 0, tr.closer)
+	defer p.Close()
+	ctx := context.Background()
+
+	v, rel, err := p.GetOrCreate(ctx, keyOne, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyOne)
+	})
+	require.NoError(t, err)
+	rel() // drop the lease so Remove reports shouldClose
+
+	got, shouldClose := p.Remove(keyOne)
+	require.True(t, shouldClose)
+	assert.Same(t, v, got)
+	assert.Equal(t, 0, p.Size())
+
+	// A subsequent GetOrCreate makes a fresh instance.
+	v2, rel2, err := p.GetOrCreate(ctx, keyOne, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyOne)
+	})
+	require.NoError(t, err)
+	defer rel2()
+	assert.NotSame(t, v, v2)
+}
+
+// TestPoolRemoveWhileLeasedDefersClose verifies Remove on a leased entry defers the close.
+func TestPoolRemoveWhileLeasedDefersClose(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 0, tr.closer)
+	defer p.Close()
+
+	v, rel, err := p.GetOrCreate(context.Background(), keyOne, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyOne)
+	})
+	require.NoError(t, err)
+
+	got, shouldClose := p.Remove(keyOne)
+	assert.False(t, shouldClose, "Remove on a leased entry must defer the close")
+	assert.Nil(t, got)
+	assert.False(t, tr.wasClosed(v.id))
+
+	rel()
+	assert.True(t, tr.wasClosed(v.id), "removed resource closes when its last lease is released")
+}
+
+// TestPoolRemoveNonexistent verifies removing a missing key is a no-op.
+func TestPoolRemoveNonexistent(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 0, tr.closer)
+	defer p.Close()
+
+	got, shouldClose := p.Remove("missing")
+	assert.False(t, shouldClose)
+	assert.Nil(t, got)
+}
+
+// TestPoolLRUEvictionClosesOldest verifies LRU ordering and eviction of an unleased victim.
+func TestPoolLRUEvictionClosesOldest(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(3, 0, tr.closer)
+	defer p.Close()
+	ctx := context.Background()
+
+	get := func(key string) {
+		_, rel, err := p.GetOrCreate(ctx, key, func(c context.Context) (*fakeResource, error) {
+			return keyedConnector()(c, key)
+		})
+		require.NoError(t, err)
+		rel() // release so victims are closable
+	}
+
+	get(keyOne)
+	get(keyTwo)
+	get(keyThree)
+	assert.Equal(t, 0, p.Stats().Evictions)
+
+	// Refresh key-1 and key-2 so key-3 is the LRU victim.
+	get(keyOne)
+	get(keyTwo)
+
+	get("key-4") // evicts key-3
+	st := p.Stats()
+	assert.Equal(t, 3, st.Size)
+	assert.Equal(t, 1, st.Evictions)
+	assert.True(t, tr.wasClosed(keyThree), "the LRU victim must be closed")
+	assert.False(t, tr.wasClosed(keyOne))
+	assert.False(t, tr.wasClosed(keyTwo))
+}
+
+// TestPoolUnlimitedMaxSizeNeverEvicts verifies maxSize <= 0 disables eviction.
+func TestPoolUnlimitedMaxSizeNeverEvicts(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(0, 0, tr.closer)
+	defer p.Close()
+	ctx := context.Background()
+
+	for i := 0; i < 20; i++ {
+		key := fmt.Sprintf("key-%d", i)
+		_, rel, err := p.GetOrCreate(ctx, key, func(c context.Context) (*fakeResource, error) {
+			return keyedConnector()(c, key)
+		})
+		require.NoError(t, err)
+		rel()
+	}
+	st := p.Stats()
+	assert.Equal(t, 20, st.Size)
+	assert.Equal(t, 0, st.Evictions)
+}
+
+// TestPoolCleanupIdleEvictsUnleased verifies the idle-cleanup loop removes and closes an idle
+// unleased entry.
+func TestPoolCleanupIdleEvictsUnleased(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 40*time.Millisecond, tr.closer)
+	defer p.Close()
+	p.StartCleanup(20 * time.Millisecond)
+	ctx := context.Background()
+
+	v, rel, err := p.GetOrCreate(ctx, keyOne, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyOne)
+	})
+	require.NoError(t, err)
+	rel() // unleased → idle cleanup may close it
+
+	// The close runs after the IdleCleanups counter bumps and the pool lock is released, so wait
+	// on the close itself (the downstream effect), not the counter.
+	require.Eventually(t, func() bool { return tr.wasClosed(v.id) }, time.Second, 10*time.Millisecond,
+		"idle unleased resource must be closed")
+	assert.GreaterOrEqual(t, p.Stats().IdleCleanups, 1)
+	assert.Equal(t, 0, p.Size())
+}
+
+// TestPoolCleanupIdleHonorsLease verifies an idle but leased entry is detached (counted) yet
+// closed only after its lease is released.
+func TestPoolCleanupIdleHonorsLease(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 40*time.Millisecond, tr.closer)
+	defer p.Close()
+	p.StartCleanup(20 * time.Millisecond)
+
+	v, rel, err := p.GetOrCreate(context.Background(), keyOne, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyOne)
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool { return p.Stats().IdleCleanups >= 1 }, time.Second, 10*time.Millisecond)
+	assert.False(t, tr.wasClosed(v.id), "idle cleanup must not close a leased resource")
+
+	rel()
+	require.Eventually(t, func() bool { return tr.wasClosed(v.id) }, time.Second, 10*time.Millisecond,
+		"idle-cleaned resource closes when its last lease is released")
+}
+
+// TestPoolCleanupIdleCloseErrorCounted verifies a failing close during idle cleanup is counted.
+func TestPoolCleanupIdleCloseErrorCounted(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 40*time.Millisecond, tr.closer)
+	defer p.Close()
+	p.StartCleanup(20 * time.Millisecond)
+
+	_, rel, err := p.GetOrCreate(context.Background(), keyOne, func(context.Context) (*fakeResource, error) {
+		r := newFakeResource(keyOne)
+		r.closeErr = errors.New("close failed")
+		return r, nil
+	})
+	require.NoError(t, err)
+	rel()
+
+	// The error counter bumps after the close runs (outside the pool lock), so wait on Errors
+	// directly rather than on the IdleCleanups counter.
+	require.Eventually(t, func() bool { return p.Stats().Errors == 1 }, time.Second, 10*time.Millisecond,
+		"a failing close during idle cleanup must be counted")
+}
+
+// TestPoolCleanupIdleNoOpWithoutTTL verifies the defensive guard: cleanupIdle is inert when the
+// pool has no idle timeout, even if invoked directly.
+func TestPoolCleanupIdleNoOpWithoutTTL(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 0, tr.closer) // idleTTL == 0
+	defer p.Close()
+
+	_, rel, err := p.GetOrCreate(context.Background(), keyOne, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyOne)
+	})
+	require.NoError(t, err)
+	rel()
+
+	p.cleanupIdle() // direct call — must be a no-op with no idle TTL
+	assert.Equal(t, 1, p.Size())
+	assert.Equal(t, 0, p.Stats().IdleCleanups)
+}
+
+// TestPoolReleaseCloseErrorCounted verifies a failing deferred close (on final release of an
+// evicted-while-leased entry) is counted.
+func TestPoolReleaseCloseErrorCounted(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(1, 0, tr.closer)
+	defer p.Close()
+	ctx := context.Background()
+
+	_, relA, err := p.GetOrCreate(ctx, keyOne, func(context.Context) (*fakeResource, error) {
+		r := newFakeResource(keyOne)
+		r.closeErr = errors.New("close failed")
+		return r, nil
+	})
+	require.NoError(t, err)
+
+	_, relB, err := p.GetOrCreate(ctx, keyTwo, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyTwo)
+	}) // evicts key-1 (leased) → deferred close
+	require.NoError(t, err)
+	defer relB()
+
+	relA() // triggers the deferred (failing) close
+	assert.Equal(t, 1, p.Stats().Errors, "a failing deferred close must be counted")
+}
+
+// TestPoolCloseClosesAllAndReturnsFirstError verifies Close closes every entry, counts close
+// failures, and returns the first error.
+func TestPoolCloseClosesAllAndReturnsFirstError(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 0, tr.closer)
+	ctx := context.Background()
+
+	closeErr := errors.New("close failed")
+	// key-2 fails to close; the others succeed.
+	makeCreate := func(key string, fail bool) func(context.Context) (*fakeResource, error) {
+		return func(context.Context) (*fakeResource, error) {
+			r := newFakeResource(key)
+			if fail {
+				r.closeErr = closeErr
+			}
+			return r, nil
+		}
+	}
+	for _, kv := range []struct {
+		key  string
+		fail bool
+	}{{keyOne, false}, {keyTwo, true}, {keyThree, false}} {
+		_, rel, err := p.GetOrCreate(ctx, kv.key, makeCreate(kv.key, kv.fail))
+		require.NoError(t, err)
+		rel()
+	}
+
+	err := p.Close()
+	assert.ErrorIs(t, err, closeErr, "Close returns the first close error")
+	assert.True(t, tr.wasClosed(keyOne))
+	assert.True(t, tr.wasClosed(keyTwo))
+	assert.True(t, tr.wasClosed(keyThree))
+	assert.Equal(t, 0, p.Size())
+	assert.Equal(t, 1, p.Stats().Errors)
+}
+
+// TestPoolCloseIsIdempotent verifies Close can be called repeatedly.
+func TestPoolCloseIsIdempotent(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 0, tr.closer)
+
+	_, rel, err := p.GetOrCreate(context.Background(), keyOne, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyOne)
+	})
+	require.NoError(t, err)
+	rel()
+
+	require.NoError(t, p.Close())
+	assert.NoError(t, p.Close(), "Close must be idempotent")
+	assert.True(t, p.Closed())
+	assert.Equal(t, 1, tr.count(keyOne), "each resource closes exactly once across repeated Close")
+}
+
+// TestPoolCloseClosesLeasedEntriesWithoutDoubleClose verifies Close closes even leased entries,
+// and a later release of that lease does not double-close.
+func TestPoolCloseClosesLeasedEntriesWithoutDoubleClose(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 0, tr.closer)
+
+	v, rel, err := p.GetOrCreate(context.Background(), keyOne, func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, keyOne)
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, p.Close())
+	assert.True(t, tr.wasClosed(v.id), "Close closes leased entries too")
+
+	rel() // deferred-release must be a safe no-op post-Close
+	assert.Equal(t, 1, tr.count(v.id), "release after Close must not double-close")
+}
+
+// TestPoolStartStopCleanupIdempotent verifies the cleanup lifecycle plumbing.
+func TestPoolStartStopCleanupIdempotent(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 40*time.Millisecond, tr.closer)
+	defer p.Close()
+
+	assert.NotPanics(t, func() {
+		p.StopCleanup() // stop before any start
+		p.StartCleanup(20 * time.Millisecond)
+		p.StartCleanup(20 * time.Millisecond) // second start is a no-op
+		p.StopCleanup()
+		p.StopCleanup() // second stop is a no-op
+	})
+}
+
+// TestPoolStartCleanupNoOpConditions verifies StartCleanup is inert without an idle TTL, with a
+// non-positive interval, or after Close.
+func TestPoolStartCleanupNoOpConditions(t *testing.T) {
+	tr := newCloseTracker()
+
+	noTTL := New(5, 0, tr.closer)
+	defer noTTL.Close()
+	noTTL.StartCleanup(20 * time.Millisecond)
+	noTTL.cleanupMu.Lock()
+	assert.Nil(t, noTTL.cleanupStop, "no idle TTL → no cleanup loop")
+	noTTL.cleanupMu.Unlock()
+
+	withTTL := New(5, 40*time.Millisecond, tr.closer)
+	defer withTTL.Close()
+	withTTL.StartCleanup(0) // non-positive interval
+	withTTL.cleanupMu.Lock()
+	assert.Nil(t, withTTL.cleanupStop, "non-positive interval → no cleanup loop")
+	withTTL.cleanupMu.Unlock()
+
+	closed := New(5, 40*time.Millisecond, tr.closer)
+	require.NoError(t, closed.Close())
+	closed.StartCleanup(20 * time.Millisecond)
+	closed.cleanupMu.Lock()
+	assert.Nil(t, closed.cleanupStop, "closed pool → no cleanup loop")
+	closed.cleanupMu.Unlock()
+}
+
+// TestPoolStatsSnapshot verifies the PoolStats fields reflect configuration and counters.
+func TestPoolStatsSnapshot(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(2, 90*time.Second, tr.closer)
+	defer p.Close()
+	ctx := context.Background()
+
+	st := p.Stats()
+	assert.Equal(t, 0, st.Size)
+	assert.Equal(t, 2, st.MaxSize)
+	assert.Equal(t, 0, st.TotalCreated)
+	assert.Equal(t, 0, st.Evictions)
+	assert.Equal(t, 0, st.IdleCleanups)
+	assert.Equal(t, 0, st.Errors)
+	assert.Equal(t, 90*time.Second, st.IdleTTL)
+
+	get := func(key string) {
+		_, rel, err := p.GetOrCreate(ctx, key, func(c context.Context) (*fakeResource, error) {
+			return keyedConnector()(c, key)
+		})
+		require.NoError(t, err)
+		rel()
+	}
+	get(keyOne)
+	get(keyTwo)
+	get(keyThree) // evicts one
+
+	st = p.Stats()
+	assert.Equal(t, 2, st.Size)
+	assert.Equal(t, 3, st.TotalCreated)
+	assert.Equal(t, 1, st.Evictions)
+}
+
+// TestPoolClosedAccessor verifies Closed tracks shutdown state.
+func TestPoolClosedAccessor(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 0, tr.closer)
+	assert.False(t, p.Closed())
+	require.NoError(t, p.Close())
+	assert.True(t, p.Closed())
+}
+
+// TestPoolConcurrentGetRacesClose stress-tests the closed guard under concurrent Close +
+// GetOrCreate. Each call must either succeed or return ErrPoolClosed — never a different error
+// or a use-after-close panic. Run under -race.
+func TestPoolConcurrentGetRacesClose(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(0, 0, tr.closer)
+
+	const n = 64
+	var creations atomic.Int32
+	results := make(chan error, n)
+	start := make(chan struct{})
+
+	for i := 0; i < n; i++ {
+		go func(id int) {
+			<-start
+			key := fmt.Sprintf("key-%d", id)
+			_, rel, err := p.GetOrCreate(context.Background(), key, countingConnector(&creations))
+			if rel != nil {
+				rel()
+			}
+			results <- err
+		}(i)
+	}
+	go func() {
+		<-start
+		_ = p.Close()
+	}()
+	close(start)
+
+	for i := 0; i < n; i++ {
+		if err := <-results; err != nil && !errors.Is(err, ErrPoolClosed) {
+			t.Errorf("GetOrCreate during Close returned unexpected error: %v", err)
+		}
+	}
+}
+
+// TestPoolThreadSafety exercises concurrent Get/release against a shared pool under -race. With
+// no eviction (unlimited) and no removal, every GetOrCreate must succeed: first touch of a key
+// takes a seed lease (which cannot be closed before it is claimed) and reuse leases the cached
+// entry, so there is no acquire churn.
+func TestPoolThreadSafety(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(0, 0, tr.closer)
+	defer p.Close()
+	ctx := context.Background()
+
+	const workers = 16
+	const ops = 40
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < ops; j++ {
+				key := fmt.Sprintf("key-%d", j%6)
+				_, rel, err := p.GetOrCreate(ctx, key, func(c context.Context) (*fakeResource, error) {
+					return keyedConnector()(c, key)
+				})
+				if err != nil {
+					t.Errorf("GetOrCreate failed: %v", err)
+					continue
+				}
+				rel()
+			}
+		}()
+	}
+	wg.Wait()
+
+	st := p.Stats()
+	assert.GreaterOrEqual(t, st.TotalCreated, st.Size)
+}
+
+// TestPoolConcurrentGetRacesRemove stress-tests concurrent GetOrCreate + Remove under -race.
+// The bounded acquire retry can, under this pathological churn, exhaust its attempts when a
+// peeked entry is removed before it can be claimed — a legitimate, documented outcome (mirrors
+// cache's maxGetAttempts bound). Any OTHER error, a panic, or a double-close is a failure.
+func TestPoolConcurrentGetRacesRemove(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(0, 0, tr.closer)
+	defer p.Close()
+	ctx := context.Background()
+
+	const workers = 16
+	const ops = 40
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < ops; j++ {
+				key := fmt.Sprintf("key-%d", j%6)
+				_, rel, err := p.GetOrCreate(ctx, key, func(c context.Context) (*fakeResource, error) {
+					return keyedConnector()(c, key)
+				})
+				if err != nil {
+					// Only the bounded-retry churn error is tolerated here.
+					assert.Contains(t, err.Error(), "pool churn", "unexpected GetOrCreate error")
+					continue
+				}
+				rel()
+				if j%8 == 0 {
+					if v, shouldClose := p.Remove(key); shouldClose {
+						_ = tr.closer(v)
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/resourcepool/resourcepool_test.go
+++ b/internal/resourcepool/resourcepool_test.go
@@ -73,6 +73,14 @@ func keyedConnector() func(context.Context, string) (*fakeResource, error) {
 	}
 }
 
+// keyedCreate binds keyedConnector to a single key, producing the func(context.Context) shape
+// GetOrCreate expects.
+func keyedCreate(key string) func(context.Context) (*fakeResource, error) {
+	return func(c context.Context) (*fakeResource, error) {
+		return keyedConnector()(c, key)
+	}
+}
+
 // slowConnector returns a create function that sleeps before producing a fixed-id resource,
 // widening the singleflight window so concurrent followers reliably pile up on one create.
 func slowConnector(created *atomic.Int32, id string, delay time.Duration) func(context.Context) (*fakeResource, error) {
@@ -814,6 +822,29 @@ func TestPoolThreadSafety(t *testing.T) {
 	assert.GreaterOrEqual(t, st.TotalCreated, st.Size)
 }
 
+// hammerGetRemove runs ops rounds of GetOrCreate + release, periodically Removing the key, for the
+// concurrent churn stress test. Extracted into a helper so the test body stays under the
+// cognitive-complexity gate.
+func hammerGetRemove(t *testing.T, p *Pool[*fakeResource], tr *closeTracker, ops int) {
+	t.Helper()
+	ctx := context.Background()
+	for j := 0; j < ops; j++ {
+		key := fmt.Sprintf("key-%d", j%6)
+		_, rel, err := p.GetOrCreate(ctx, key, keyedCreate(key))
+		if err != nil {
+			// Only the bounded-retry churn error is tolerated here.
+			assert.Contains(t, err.Error(), "pool churn", "unexpected GetOrCreate error")
+			continue
+		}
+		rel()
+		if j%8 == 0 {
+			if v, shouldClose := p.Remove(key); shouldClose {
+				_ = tr.closer(v)
+			}
+		}
+	}
+}
+
 // TestPoolConcurrentGetRacesRemove stress-tests concurrent GetOrCreate + Remove under -race.
 // The bounded acquire retry can, under this pathological churn, exhaust its attempts when a
 // peeked entry is removed before it can be claimed — a legitimate, documented outcome (mirrors
@@ -822,32 +853,14 @@ func TestPoolConcurrentGetRacesRemove(t *testing.T) {
 	tr := newCloseTracker()
 	p := New(0, 0, tr.closer)
 	defer p.Close()
-	ctx := context.Background()
 
 	const workers = 16
-	const ops = 40
 	var wg sync.WaitGroup
 	wg.Add(workers)
 	for w := 0; w < workers; w++ {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < ops; j++ {
-				key := fmt.Sprintf("key-%d", j%6)
-				_, rel, err := p.GetOrCreate(ctx, key, func(c context.Context) (*fakeResource, error) {
-					return keyedConnector()(c, key)
-				})
-				if err != nil {
-					// Only the bounded-retry churn error is tolerated here.
-					assert.Contains(t, err.Error(), "pool churn", "unexpected GetOrCreate error")
-					continue
-				}
-				rel()
-				if j%8 == 0 {
-					if v, shouldClose := p.Remove(key); shouldClose {
-						_ = tr.closer(v)
-					}
-				}
-			}
+			hammerGetRemove(t, p, tr, 40)
 		}()
 	}
 	wg.Wait()


### PR DESCRIPTION
## What

First PR of a decomposed 3-PR extraction (ADR-032). CacheManager, DbManager, and the messaging publisher pool each re-implement the same ~15-helper "keyed pool of leasable, refcounted, LRU-capped, idle-evicted resources" near-verbatim, and the copies have drifted (notably F22: only cache has a closed-manager guard). This PR extracts the machinery into a generic **`internal/resourcepool.Pool[V]`** and rewires **cache** onto it. Database and messaging follow in PR-B / PR-C (they require migrating their white-box mechanism tests, which is why this is decomposed rather than one PR).

Precedent: `internal/tenantstore` (PR #694).

## Scope

- **New** `internal/resourcepool/` — the generic pool + 98.2%-covered direct tests.
- **Rewired** `cache/manager.go` onto `*resourcepool.Pool[Cache]`; **public API byte-identical** (`go doc ./cache CacheManager` unchanged), `Stats()` maps `PoolStats`→`ManagerStats` 1:1, ctor still auto-starts cleanup.
- `cache/manager_test.go` **unmodified** (it's `package cache_test`, black-box — the whole diff is `cache/manager.go` + `internal/resourcepool/*`).
- **Out of scope**: `database/`, `messaging/` (untouched).

## Design note

`Closer[V] func(v V) error` returns an error (the plan sketch had it void): the pool must observe close outcomes to count `Errors` and return `Close()`'s first error — `TestCacheManagerIdleCleanupWithCloseError` (asserts `Errors==1`) would break otherwise. `Remove` returns `(V, bool)` so cache closes directly and preserves its original "returns but doesn't count the close error" semantics.

## Correctness

An adversarial opus concurrency panel reviewed the pool against the original cache machinery. It confirmed the transliteration preserves the #606 detach-close ordering, the seed-lease handoff, error-counting placement, and Close-while-leased behavior — and found **one real defect** (fixed) plus test-adequacy gaps (addressed):

- **Fixed** a `StartCleanup`/`Close` goroutine-leak race *new to the generic pool* (the original started its loop once in the ctor; the public `StartCleanup` adds a TOCTOU window) — re-check `closed` under `cleanupMu`.
- **Added** pinning tests: `StartCleanup`-after-`Close` no-op; concurrent-follower lease counting (mutation-verified against a dropped `refs++`); concurrent evict-while-leased under `-race` with unique ids to catch double-close.
- **Documented skip**: the defensive bounded-retry "pool churn" path is covered probabilistically (a deterministic test would need production hooks).

## Verification

- `internal/resourcepool`: 98.2% coverage, `-race -count=3`.
- `cache`: pre-existing suite passes **unmodified**, `-race -count=3`.
- Mutation spot-checks: removing the defer-close-if-leased branch fails the #606 tests; dropping the follower `refs++` fails the lease-counting test.
- `make check` green. Exported API unchanged (apidiff-gated); no `!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated cache management to use keyed resource pooling with configurable max capacity and optional idle-time cleanup.
  * Improved on-demand cache creation with safe reuse and enhanced lifecycle/statistics reporting (including idle TTL).

* **Bug Fixes**
  * Prevented cache instances from being closed while still in active use.
  * Ensured cache closure happens at most once, even with eviction, removal, or shutdown concurrency.

* **Tests**
  * Added extensive unit and race-condition coverage for pooling, eviction/removal, idle cleanup, error handling, and close idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->