### PR TITLE
refactor(database): rewire DbManager onto internal/resourcepool (closes F22-db)

### DIFF
--- a/database/manager.go
+++ b/database/manager.go
@@ -1,15 +1,13 @@
 package database
 
 import (
-	"container/list"
 	"context"
+	"errors"
 	"fmt"
-	"sync"
 	"time"
 
-	"golang.org/x/sync/singleflight"
-
 	"github.com/gaborage/go-bricks/config"
+	"github.com/gaborage/go-bricks/internal/resourcepool"
 	"github.com/gaborage/go-bricks/logger"
 )
 
@@ -32,57 +30,24 @@ type Connector func(*config.DatabaseConfig, logger.Logger) (Interface, error)
 // lease is released. See ADR-032.
 type ReleaseFunc func()
 
-// maxGetAttempts bounds the rare retry where a freshly resolved entry is evicted before
-// the caller can acquire a lease on it (only reachable under extreme pool churn). A new
-// entry is inserted at the LRU front, so in practice the first attempt always succeeds.
-const maxGetAttempts = 4
+// errManagerClosed is returned by Get after Close has been called, rather than
+// resurrecting a connection on a shut-down manager (backlog F22). It is unexported:
+// DbManager exposed no closed-state error before the resourcepool rewire, so this
+// closes F22 while keeping the public surface unchanged.
+var errManagerClosed = errors.New("database: manager closed")
 
 // DbManager manages database connections by string keys.
 // It provides lazy initialization, LRU eviction, and cleanup for database connections.
 // The manager is key-agnostic - it doesn't know about tenants, just manages named connections.
+//
+// It is a thin adapter over internal/resourcepool.Pool, which owns the ADR-032
+// lease/evict/close protocol (seed leases, LRU eviction, idle cleanup, and the
+// closed-pool guard). The manager keeps only the database-specific config resolution.
 type DbManager struct {
+	pool           *resourcepool.Pool[Interface]
 	logger         logger.Logger
 	resourceSource DBConfigProvider
 	connector      Connector // Injected for testability
-
-	// Connection management
-	mu    sync.RWMutex
-	conns map[string]*dbEntry
-
-	// LRU management
-	lru     *list.List
-	maxSize int
-
-	// Cleanup management
-	idleTTL   time.Duration
-	cleanupMu sync.Mutex
-	cleanupCh chan struct{}
-
-	// Singleflight for concurrent initialization
-	sfg singleflight.Group
-}
-
-// dbEntry represents a database connection with metadata.
-// refs, detached, and closed are guarded by DbManager.mu.
-type dbEntry struct {
-	conn     Interface
-	element  *list.Element // for LRU
-	lastUsed time.Time
-	key      string
-
-	// refs counts outstanding leases (current borrowers). A connection with refs > 0
-	// is in use and must not be closed.
-	refs int
-	// seedHeld is true when one of refs is an unclaimed "seed" lease taken at creation. The
-	// seed keeps a brand-new entry alive (refs >= 1) through the window before its first Get
-	// caller claims it, so a concurrent evict/idle-cleanup can only detach (never close) it.
-	// The first claimOrAcquire takes the seed; later callers increment refs normally.
-	seedHeld bool
-	// detached is set when the entry has been removed from the map+LRU (evicted or
-	// idle-cleaned) but its Close() was deferred because a lease was still outstanding.
-	detached bool
-	// closed guards against a double Close() once the deferred close has run.
-	closed bool
 }
 
 // DbManagerOptions configures the DbManager
@@ -109,10 +74,9 @@ func NewDbManager(resourceSource DBConfigProvider, log logger.Logger, opts DbMan
 		logger:         log,
 		resourceSource: resourceSource,
 		connector:      connector,
-		conns:          make(map[string]*dbEntry),
-		lru:            list.New(),
-		maxSize:        opts.MaxSize,
-		idleTTL:        opts.IdleTTL,
+		pool: resourcepool.New[Interface](opts.MaxSize, opts.IdleTTL, func(conn Interface) error {
+			return conn.Close()
+		}),
 	}
 }
 
@@ -120,116 +84,34 @@ func NewDbManager(resourceSource DBConfigProvider, log logger.Logger, opts DbMan
 // invoke when finished with it for the current unit of work (typically deferred). For
 // single-tenant, use key "". For multi-tenant, use the tenant ID. Connections are created
 // lazily and cached with LRU eviction; the lease prevents a connection that is evicted
-// while in use from being closed under an active caller (the #606 race). On error the
-// returned ReleaseFunc is nil — check err first.
+// while in use from being closed under an active caller (the #606 race). Once Close has
+// run, Get fails closed rather than resurrecting a connection (F22). On error the returned
+// ReleaseFunc is nil — check err first.
 func (m *DbManager) Get(ctx context.Context, key string) (Interface, ReleaseFunc, error) {
-	for attempt := 0; attempt < maxGetAttempts; attempt++ {
-		// Fast path: getExisting increments the refcount atomically with the lookup, so the
-		// connection cannot be evicted-and-closed before the lease is taken.
-		if entry := m.getExisting(key); entry != nil {
-			return entry.conn, m.makeRelease(entry), nil
+	if m.pool == nil {
+		// Zero-value manager (never built via NewDbManager): unusable, fail closed rather
+		// than panic — consistent with the Stats()/Close()/Size() zero-value guards.
+		return nil, nil, errManagerClosed
+	}
+	conn, release, err := m.pool.GetOrCreate(ctx, key, func(ctx context.Context) (Interface, error) {
+		return m.createConnection(ctx, key)
+	})
+	if err != nil {
+		if errors.Is(err, resourcepool.ErrPoolClosed) {
+			return nil, nil, errManagerClosed
 		}
-
-		// Slow path: singleflight collapses concurrent creates for the same key into one. It
-		// returns the shared entry (freshly created with a seed lease, or an existing one);
-		// every caller then takes its own lease on that pointer via claimOrAcquire — the first
-		// claims the seed, the rest increment — so each concurrent borrower is counted.
-		v, err, _ := m.sfg.Do(key, func() (any, error) {
-			if e := m.peek(key); e != nil {
-				return e, nil
-			}
-			return m.createConnection(ctx, key)
-		})
-		if err != nil {
-			return nil, nil, err
-		}
-
-		entry := v.(*dbEntry)
-		if m.claimOrAcquire(entry) {
-			return entry.conn, m.makeRelease(entry), nil
-		}
-		// The reused entry was closed in the window between lookup and claim (a concurrent
-		// idle-cleanup of an unleased entry); loop to create a fresh one. The create path
-		// always succeeds because a new entry carries a seed lease, so this converges.
+		return nil, nil, err
 	}
-
-	return nil, nil, fmt.Errorf("failed to acquire database connection for key %s after %d attempts (pool churn)", key, maxGetAttempts)
+	return conn, ReleaseFunc(release), nil
 }
 
-// claimOrAcquire takes one lease on entry, operating on the shared pointer so it can never
-// "miss" via a map lookup. It returns false only when the entry has already been fully closed
-// (a reused entry that lost a race), signaling the caller to retry with a fresh entry.
-func (m *DbManager) claimOrAcquire(entry *dbEntry) bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if entry.closed {
-		return false
-	}
-	if entry.seedHeld {
-		entry.seedHeld = false // claim the seed: that ref becomes this caller's lease
-	} else {
-		entry.refs++
-	}
-	return true
-}
-
-// getExisting returns an existing entry with a lease acquired (refcount incremented) and
-// updates LRU, or nil if not found. The refcount increment happens under the same lock as
-// the lookup so the entry cannot be evicted-and-closed before the lease is taken.
-func (m *DbManager) getExisting(key string) *dbEntry {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	entry, exists := m.conns[key]
-	if !exists {
-		return nil
-	}
-
-	// Update LRU and last used time
-	entry.lastUsed = time.Now()
-	m.lru.MoveToFront(entry.element)
-	entry.refs++
-
-	return entry
-}
-
-// peek reports whether an entry exists for the key without taking a lease or touching LRU.
-// Used inside the singleflight callback to decide whether a new connection is needed.
-func (m *DbManager) peek(key string) *dbEntry {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.conns[key]
-}
-
-// makeRelease returns an idempotent ReleaseFunc bound to a single lease on entry.
-func (m *DbManager) makeRelease(entry *dbEntry) ReleaseFunc {
-	var once sync.Once
-	return func() {
-		once.Do(func() { m.releaseEntry(entry) })
-	}
-}
-
-// releaseEntry drops one lease. If the entry was detached (evicted/idle-cleaned) while
-// leased and this was the final lease, it closes the connection now — outside the lock.
-func (m *DbManager) releaseEntry(entry *dbEntry) {
-	m.mu.Lock()
-	entry.refs--
-	shouldClose := entry.detached && entry.refs <= 0 && !entry.closed
-	if shouldClose {
-		entry.closed = true
-	}
-	m.mu.Unlock()
-
-	if shouldClose {
-		m.closeEvicted(entry, "Error closing evicted database connection (deferred until lease release)")
-	}
-}
-
-// createConnection creates a new database connection for the given key and registers it
-// with a single seed lease (refs == 1, seedHeld). The seed keeps the entry alive through
-// the window before the caller claims it via claimOrAcquire, so a concurrent evict/idle
-// cleanup can only detach it. Returns an existing entry unchanged on a double-create race.
-func (m *DbManager) createConnection(ctx context.Context, key string) (*dbEntry, error) {
+// createConnection resolves the per-key database configuration and opens a new connection.
+// It applies the standard pool defaults to a shallow clone of the provider's config so a
+// long-lived, shared provider config stays pristine, then hands off to the injected
+// connector. It performs only config resolution and connection opening — the pool owns all
+// lease/LRU/eviction bookkeeping. Invoked inside the pool's create callback, so singleflight
+// guarantees one call per key per creation.
+func (m *DbManager) createConnection(ctx context.Context, key string) (Interface, error) {
 	dbConfig, err := m.resourceSource.DBConfig(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get database config for key %s: %w", key, err)
@@ -245,244 +127,92 @@ func (m *DbManager) createConnection(ctx context.Context, key string) (*dbEntry,
 		return nil, fmt.Errorf("failed to create database connection for key %s: %w", key, err)
 	}
 
-	// Store in cache with LRU tracking
-	m.mu.Lock()
-
-	// Check if connection was created by another goroutine while we were waiting
-	if existing, exists := m.conns[key]; exists {
-		existing.lastUsed = time.Now()
-		m.lru.MoveToFront(existing.element)
-		m.mu.Unlock()
-
-		// Close our new connection outside the lock and return the existing one.
-		if err := conn.Close(); err != nil {
-			m.logger.Error().
-				Err(err).
-				Str("key", key).
-				Msg("Error closing redundant database connection")
-		}
-		return existing, nil
-	}
-
-	// Ensure we don't exceed max size (returns the evicted entry to close outside the lock)
-	evicted := m.evictIfNeeded()
-
-	// Add to cache with a seed lease.
-	element := m.lru.PushFront(key)
-	entry := &dbEntry{
-		conn:     conn,
-		element:  element,
-		lastUsed: time.Now(),
-		key:      key,
-		refs:     1,
-		seedHeld: true,
-	}
-	m.conns[key] = entry
-	m.mu.Unlock()
-
-	// Close the evicted connection outside the lock so a slow Close() on the LRU
-	// victim does not block concurrent Get() calls for other keys.
-	if evicted != nil {
-		m.closeEvicted(evicted, "Error closing evicted database connection")
-	}
-
 	m.logger.Info().
 		Str("key", key).
 		Str("db_type", cfgCopy.Type).
 		Msg("Created new database connection")
 
-	return entry, nil
+	return conn, nil
 }
 
-// evictIfNeeded removes the least recently used connection from the manager's
-// bookkeeping if at capacity. Must be called with m.mu held. It detaches the entry
-// (removing it from the map+LRU) and returns it for the caller to close OUTSIDE the
-// lock — but ONLY when the entry has no outstanding leases. If the LRU victim is still
-// leased, its Close() is deferred (detached=true) until the last lease is released, so
-// an in-use connection is never closed (the #606 race). Returns nil when nothing should
-// be closed now.
-func (m *DbManager) evictIfNeeded() *dbEntry {
-	if len(m.conns) < m.maxSize {
-		return nil
-	}
-
-	// Remove the least recently used connection
-	oldest := m.lru.Back()
-	if oldest == nil {
-		return nil
-	}
-
-	key := oldest.Value.(string)
-	entry := m.conns[key]
-
-	// Remove from cache (close happens outside the lock, and only when unleased)
-	delete(m.conns, key)
-	m.lru.Remove(oldest)
-	entry.detached = true
-
-	m.logger.Debug().
-		Str("key", key).
-		Msg("Evicted database connection due to LRU limit")
-
-	if entry.refs > 0 {
-		// Still in use — defer the close to the final lease release.
-		return nil
-	}
-	entry.closed = true
-	return entry
-}
-
-// closeEvicted closes an evicted/idle connection and logs any close error.
-// It is always called WITHOUT m.mu held so a slow Close() cannot block other callers.
-func (m *DbManager) closeEvicted(entry *dbEntry, logMsg string) {
-	if err := entry.conn.Close(); err != nil {
-		m.logger.Error().
-			Err(err).
-			Str("key", entry.key).
-			Msg(logMsg)
-	}
-}
-
-// StartCleanup starts the background cleanup routine for idle connections
+// StartCleanup starts the background cleanup routine for idle connections. A non-positive
+// interval substitutes the documented 5-minute default.
 func (m *DbManager) StartCleanup(interval time.Duration) {
+	if m.pool == nil {
+		return // zero-value manager: nothing to run, consistent with the other nil-pool guards
+	}
 	if interval <= 0 {
 		interval = 5 * time.Minute // default cleanup interval
 	}
-
-	m.cleanupMu.Lock()
-	if m.cleanupCh != nil {
-		m.cleanupMu.Unlock()
-		return
-	}
-	done := make(chan struct{})
-	m.cleanupCh = done
-	m.cleanupMu.Unlock()
-
-	go m.cleanupLoop(interval, done)
+	m.pool.StartCleanup(interval)
 }
 
 // StopCleanup stops the background cleanup routine
 func (m *DbManager) StopCleanup() {
-	m.cleanupMu.Lock()
-	if m.cleanupCh == nil {
-		m.cleanupMu.Unlock()
-		return
+	if m.pool == nil {
+		return // zero-value manager: nothing to stop
 	}
-	close(m.cleanupCh)
-	m.cleanupCh = nil
-	m.cleanupMu.Unlock()
-}
-
-// cleanupLoop runs the periodic cleanup of idle connections
-func (m *DbManager) cleanupLoop(interval time.Duration, done <-chan struct{}) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			m.cleanupIdleConnections()
-		case <-done:
-			return
-		}
-	}
-}
-
-// cleanupIdleConnections removes connections that have been idle longer than idleTTL.
-// Idle entries are detached from the manager's bookkeeping under the lock, then their
-// Close() calls run outside the lock so a slow teardown cannot block concurrent Get()s.
-func (m *DbManager) cleanupIdleConnections() {
-	m.mu.Lock()
-
-	now := time.Now()
-	var toClose []*dbEntry
-
-	// Detach idle connections from bookkeeping under the lock. A still-leased idle
-	// connection is detached but its Close() is deferred to the final lease release,
-	// so an in-use connection is never closed (the #606 race).
-	for key, entry := range m.conns {
-		if now.Sub(entry.lastUsed) <= m.idleTTL {
-			continue
-		}
-		delete(m.conns, key)
-		m.lru.Remove(entry.element)
-		entry.detached = true
-
-		m.logger.Debug().
-			Str("key", key).
-			Dur("idle_time", now.Sub(entry.lastUsed)).
-			Msg("Cleaned up idle database connection")
-
-		if entry.refs > 0 {
-			continue // still leased — defer close to release
-		}
-		entry.closed = true
-		toClose = append(toClose, entry)
-	}
-	m.mu.Unlock()
-
-	// Close detached connections outside the lock.
-	for _, entry := range toClose {
-		m.closeEvicted(entry, "Error closing idle database connection")
-	}
+	m.pool.StopCleanup()
 }
 
 // Close closes all database connections and stops cleanup
 func (m *DbManager) Close() error {
-	m.StopCleanup()
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	var errors []error
-
-	for key, entry := range m.conns {
-		if err := entry.conn.Close(); err != nil {
-			errors = append(errors, fmt.Errorf("error closing connection for key %s: %w", key, err))
-		}
+	if m.pool == nil {
+		return nil // zero-value manager (never built via NewDbManager): nothing to close
 	}
-
-	// Clear the cache
-	m.conns = make(map[string]*dbEntry)
-	m.lru.Init()
-
-	if len(errors) > 0 {
-		return fmt.Errorf("errors closing database connections: %v", errors)
+	// pool.Close joins every per-connection close error; preserve DbManager's original
+	// aggregate contract (all failures surfaced under one prefix), matching the pre-resourcepool
+	// "errors closing database connections: %v" wrapping.
+	if err := m.pool.Close(); err != nil {
+		return fmt.Errorf("errors closing database connections: %w", err)
 	}
-
 	return nil
 }
 
 // Size returns the number of active connections
 func (m *DbManager) Size() int {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return len(m.conns)
+	if m.pool == nil {
+		return 0 // zero-value manager: preserve the original len(nil-map) == 0 behavior
+	}
+	return m.pool.Size()
 }
 
 // Stats returns statistics about the connection pool
 func (m *DbManager) Stats() map[string]any {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	stats := make(map[string]any)
-	stats["active_connections"] = len(m.conns)
-	stats["max_connections"] = m.maxSize
-	stats["idle_ttl_seconds"] = int(m.idleTTL.Seconds())
-
-	// Connection details
-	connections := make([]map[string]any, 0, len(m.conns))
-	now := time.Now()
-
-	for key, entry := range m.conns {
-		connStats := map[string]any{
-			"key":           key,
-			"last_used":     entry.lastUsed.Format(time.RFC3339),
-			"idle_duration": int(now.Sub(entry.lastUsed).Seconds()),
+	if m.pool == nil {
+		// A zero-value DbManager (not built via NewDbManager, e.g. a lightweight test
+		// stand-in) reports empty stats rather than panicking, preserving the
+		// pre-resourcepool behavior the debug/health endpoint relies on.
+		return map[string]any{
+			"active_connections": 0,
+			"max_connections":    0,
+			"idle_ttl_seconds":   0,
+			"connections":        []map[string]any{},
 		}
-		connections = append(connections, connStats)
 	}
 
+	ps := m.pool.Stats()
+
+	stats := map[string]any{
+		"active_connections": ps.Size,
+		"max_connections":    ps.MaxSize,
+		"idle_ttl_seconds":   int(ps.IdleTTL.Seconds()),
+	}
+
+	// Rebuild the per-connection detail array from the pool's entry snapshot so the shape
+	// (key, RFC3339 last_used, idle_duration seconds) is preserved for Stats() consumers such
+	// as the debug/health endpoint.
+	snap := m.pool.Snapshot()
+	connections := make([]map[string]any, 0, len(snap))
+	now := time.Now()
+	for _, e := range snap {
+		connections = append(connections, map[string]any{
+			"key":           e.Key,
+			"last_used":     e.LastUsed.Format(time.RFC3339),
+			"idle_duration": int(now.Sub(e.LastUsed).Seconds()),
+		})
+	}
 	stats["connections"] = connections
+
 	return stats
 }

--- a/database/manager_test.go
+++ b/database/manager_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"strings"
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -59,12 +60,11 @@ func (s *stubTx) Commit(_ context.Context) error   { return nil }
 func (s *stubTx) Rollback(_ context.Context) error { return nil }
 
 type stubDB struct {
-	key       string
-	closedMu  sync.Mutex
-	closed    bool
-	closeErr  error
-	onClosed  func(string)
-	closeHook func() // optional: invoked at the start of Close (e.g. to simulate a slow close)
+	key      string
+	closedMu sync.Mutex
+	closed   bool
+	closeErr error
+	onClosed func(string)
 }
 
 func (s *stubDB) Query(_ context.Context, _ string, _ ...any) (*sql.Rows, error) { return nil, nil }
@@ -78,12 +78,6 @@ func (s *stubDB) BeginTx(_ context.Context, _ *sql.TxOptions) (Tx, error) { retu
 func (s *stubDB) Health(_ context.Context) error                          { return nil }
 func (s *stubDB) Stats() (map[string]any, error)                          { return map[string]any{"key": s.key}, nil }
 func (s *stubDB) Close() error {
-	s.closedMu.Lock()
-	hook := s.closeHook
-	s.closedMu.Unlock()
-	if hook != nil {
-		hook()
-	}
 	s.closedMu.Lock()
 	s.closed = true
 	callback := s.onClosed
@@ -117,144 +111,6 @@ func TestDbManagerReturnsSameInstanceForSameKey(t *testing.T) {
 	assert.Same(t, first, second)
 	assert.Equal(t, 1, connectorCalls)
 	assert.Equal(t, 1, manager.Size())
-}
-
-func TestDbManagerSingleflight(t *testing.T) {
-	ctx := context.Background()
-	log := newErrorTestLogger()
-
-	var mu sync.Mutex
-	connectorCalls := 0
-	manager := NewDbManager(&stubResourceSource{configs: map[string]*config.DatabaseConfig{
-		"tenant-b": {Type: "postgresql"},
-	}}, log, DbManagerOptions{MaxSize: 5, IdleTTL: time.Minute}, func(cfg *config.DatabaseConfig, _ logger.Logger) (Interface, error) {
-		mu.Lock()
-		connectorCalls++
-		mu.Unlock()
-		return &stubDB{key: cfg.Database}, nil
-	})
-
-	var wg sync.WaitGroup
-	for range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			_, _, err := manager.Get(ctx, "tenant-b")
-			require.NoError(t, err)
-		}()
-	}
-	wg.Wait()
-	assert.Equal(t, 1, connectorCalls)
-}
-
-func TestDbManagerEvictsLRU(t *testing.T) {
-	ctx := context.Background()
-	log := newErrorTestLogger()
-
-	var mu sync.Mutex
-	evicted := []string{}
-	// The LRU victim "a" uses a slow Close to assert eviction detaches bookkeeping
-	// under the lock and closes OUTSIDE it: a concurrent Get must not block on it.
-	releaseClose := make(chan struct{})
-	connector := func(cfg *config.DatabaseConfig, _ logger.Logger) (Interface, error) {
-		db := &stubDB{key: cfg.Database, onClosed: func(key string) {
-			mu.Lock()
-			defer mu.Unlock()
-			evicted = append(evicted, key)
-		}}
-		if cfg.Database == "a" {
-			db.closeHook = func() { <-releaseClose }
-		}
-		return db, nil
-	}
-
-	resource := &stubResourceSource{configs: map[string]*config.DatabaseConfig{
-		"a": {Type: "postgresql", Database: "a"},
-		"b": {Type: "postgresql", Database: "b"},
-		"c": {Type: "postgresql", Database: "c"},
-	}}
-
-	manager := NewDbManager(resource, log, DbManagerOptions{MaxSize: 2, IdleTTL: time.Minute}, connector)
-
-	_, relA, err := manager.Get(ctx, "a")
-	require.NoError(t, err)
-	_, _, err = manager.Get(ctx, "b")
-	require.NoError(t, err)
-	// Release "a"'s lease so eviction may actually close it — a leased connection's
-	// close is deferred until its last lease is released (ADR-032).
-	relA()
-
-	// Get("c") evicts "a"; its Close blocks until releaseClose, so run it in the
-	// background. With close-under-lock this would hold m.mu and stall every Get.
-	done := make(chan struct{})
-	go func() {
-		_, _, gErr := manager.Get(ctx, "c")
-		assert.NoError(t, gErr)
-		close(done)
-	}()
-
-	// Bookkeeping is detached under the lock, so Size drops to 2 even though the
-	// victim's Close is still blocked. This would deadlock under close-under-lock.
-	assert.Eventually(t, func() bool { return manager.Size() == 2 }, time.Second, 5*time.Millisecond)
-
-	// Release the slow Close and let the eviction finish.
-	close(releaseClose)
-	<-done
-
-	mu.Lock()
-	defer mu.Unlock()
-	assert.Contains(t, evicted, "a")
-}
-
-func TestDbManagerCleanupRemovesIdleConnections(t *testing.T) {
-	ctx := context.Background()
-	log := newErrorTestLogger()
-
-	var mu sync.Mutex
-	evicted := []string{}
-	// Slow Close on the idle connection proves idle cleanup detaches bookkeeping
-	// under the lock and closes OUTSIDE it.
-	releaseClose := make(chan struct{})
-	connector := func(cfg *config.DatabaseConfig, _ logger.Logger) (Interface, error) {
-		return &stubDB{key: cfg.Database, closeHook: func() { <-releaseClose }, onClosed: func(key string) {
-			mu.Lock()
-			defer mu.Unlock()
-			evicted = append(evicted, key)
-		}}, nil
-	}
-
-	resource := &stubResourceSource{configs: map[string]*config.DatabaseConfig{
-		"idle": {Type: "postgresql", Database: "idle"},
-	}}
-
-	manager := NewDbManager(resource, log, DbManagerOptions{MaxSize: 2, IdleTTL: 10 * time.Millisecond}, connector)
-	_, relIdle, err := manager.Get(ctx, "idle")
-	require.NoError(t, err)
-	// Release the lease so idle cleanup may actually close it (deferred-until-release, ADR-032).
-	relIdle()
-
-	time.Sleep(20 * time.Millisecond)
-
-	// Run cleanup in the background: the idle connection's Close blocks until
-	// releaseClose. With close-under-lock this would stall every Size()/Get().
-	done := make(chan struct{})
-	go func() {
-		manager.cleanupIdleConnections()
-		close(done)
-	}()
-
-	// Bookkeeping is detached under the lock, so Size drops to 0 even while the
-	// idle connection's Close is still blocked.
-	assert.Eventually(t, func() bool { return manager.Size() == 0 }, time.Second, 5*time.Millisecond)
-
-	// Release the slow Close and let cleanup finish.
-	close(releaseClose)
-	<-done
-
-	mu.Lock()
-	defer mu.Unlock()
-	assert.Contains(t, evicted, "idle")
-	assert.Equal(t, 0, manager.Size())
 }
 
 func TestDbManagerCloseClosesAllConnections(t *testing.T) {
@@ -291,16 +147,20 @@ func TestDbManagerCloseClosesAllConnections(t *testing.T) {
 	assert.ElementsMatch(t, []string{"x", "y"}, evicted)
 }
 
+// TestCreateConnectionReturnsErrorWhenConfigFails proves a config-resolution failure in the
+// create callback surfaces through the public Get surface as a wrapped error.
 func TestCreateConnectionReturnsErrorWhenConfigFails(t *testing.T) {
 	ctx := context.Background()
 	configErr := errors.New("config failure")
 	manager := NewDbManager(&failingResourceSource{err: configErr}, newErrorTestLogger(), DbManagerOptions{}, nil)
 
-	_, err := manager.createConnection(ctx, "tenant")
+	_, _, err := manager.Get(ctx, "tenant")
 	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "failed to get database config"))
+	assert.ErrorContains(t, err, "failed to get database config")
 }
 
+// TestCreateConnectionPropagatesConnectorError proves a connector failure surfaces through
+// the public Get surface as a wrapped error.
 func TestCreateConnectionPropagatesConnectorError(t *testing.T) {
 	ctx := context.Background()
 	authErr := errors.New("connector failure")
@@ -310,69 +170,87 @@ func TestCreateConnectionPropagatesConnectorError(t *testing.T) {
 	}
 	manager := NewDbManager(resource, newErrorTestLogger(), DbManagerOptions{}, connector)
 
-	_, err := manager.createConnection(ctx, "tenant")
+	_, _, err := manager.Get(ctx, "tenant")
 	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "failed to create database connection"))
+	assert.ErrorContains(t, err, "failed to create database connection")
 }
 
-func TestCreateConnectionReturnsExistingInstanceWhenAlreadyCached(t *testing.T) {
+// TestDbManagerGetAfterCloseReturnsError pins the F22 fix: once Close() has run, Get()
+// fails closed (returning the manager's closed error) instead of resurrecting a
+// connection on a shut-down manager. The resourcepool closed guard supplies this; before
+// the rewire, DbManager.Get would silently create and leak a fresh connection.
+func TestDbManagerGetAfterCloseReturnsError(t *testing.T) {
 	ctx := context.Background()
-	resource := &stubResourceSource{configs: map[string]*config.DatabaseConfig{"tenant": {Type: "postgresql"}}}
+	var mu sync.Mutex
+	closed := map[string]bool{}
+	m := NewDbManager(twoTenantSource(), newErrorTestLogger(),
+		DbManagerOptions{MaxSize: 5, IdleTTL: time.Minute}, newClosableDB(&mu, closed))
+	require.NoError(t, m.Close())
 
-	connector := func(cfg *config.DatabaseConfig, _ logger.Logger) (Interface, error) {
-		return &stubDB{key: cfg.Database}, nil
-	}
-	manager := NewDbManager(resource, newErrorTestLogger(), DbManagerOptions{MaxSize: 5, IdleTTL: time.Minute}, connector)
-
-	existing := &stubDB{key: "existing"}
-	manager.mu.Lock()
-	element := manager.lru.PushFront("tenant")
-	manager.conns["tenant"] = &dbEntry{conn: existing, element: element, lastUsed: time.Now(), key: "tenant"}
-	manager.mu.Unlock()
-
-	entry, err := manager.createConnection(ctx, "tenant")
-	require.NoError(t, err)
-	assert.Same(t, existing, entry.conn)
-}
-
-func TestStartCleanupDoesNotCreateMultipleRoutines(t *testing.T) {
-	resource := &stubResourceSource{configs: map[string]*config.DatabaseConfig{"tenant": {Type: "postgresql"}}}
-	manager := NewDbManager(resource, newErrorTestLogger(), DbManagerOptions{}, func(*config.DatabaseConfig, logger.Logger) (Interface, error) {
-		return &stubDB{}, nil
-	})
-
-	manager.StartCleanup(5 * time.Millisecond)
-	manager.cleanupMu.Lock()
-	first := manager.cleanupCh
-	manager.cleanupMu.Unlock()
-
-	manager.StartCleanup(5 * time.Millisecond)
-	manager.cleanupMu.Lock()
-	second := manager.cleanupCh
-	manager.cleanupMu.Unlock()
-
-	assert.Equal(t, first, second)
-	manager.StopCleanup()
-}
-
-func TestCloseAggregatesErrors(t *testing.T) {
-	resource := &stubResourceSource{configs: map[string]*config.DatabaseConfig{}}
-	manager := NewDbManager(resource, newErrorTestLogger(), DbManagerOptions{}, nil)
-
-	errA := errors.New("close a")
-	errB := errors.New("close b")
-
-	manager.mu.Lock()
-	elementA := manager.lru.PushFront("a")
-	manager.conns["a"] = &dbEntry{conn: &stubDB{key: "a", closeErr: errA}, element: elementA, lastUsed: time.Now(), key: "a"}
-	elementB := manager.lru.PushFront("b")
-	manager.conns["b"] = &dbEntry{conn: &stubDB{key: "b", closeErr: errB}, element: elementB, lastUsed: time.Now(), key: "b"}
-	manager.mu.Unlock()
-
-	err := manager.Close()
+	conn, release, err := m.Get(ctx, "a")
 	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "close b"))
-	assert.True(t, strings.Contains(err.Error(), "close a"))
+	assert.ErrorIs(t, err, errManagerClosed, "Get after Close must fail closed, not resurrect a connection (F22)")
+	assert.Nil(t, conn)
+	assert.Nil(t, release)
+	assert.Equal(t, 0, m.Size(), "no connection may be created on a closed manager")
+}
+
+// TestDbManagerCloseAggregatesErrors pins the aggregate Close contract: when MULTIPLE cached
+// connections fail to close, Close surfaces EVERY failure (not just the first), under the
+// historical "errors closing database connections" prefix. Black-box via Get + Close.
+func TestDbManagerCloseAggregatesErrors(t *testing.T) {
+	var n atomic.Int32
+	connector := func(_ *config.DatabaseConfig, _ logger.Logger) (Interface, error) {
+		id := n.Add(1)
+		return &stubDB{key: fmt.Sprintf("k%d", id), closeErr: fmt.Errorf("close failure %d", id)}, nil
+	}
+	src := &stubResourceSource{configs: map[string]*config.DatabaseConfig{
+		"a": {Type: "postgresql"},
+		"b": {Type: "postgresql"},
+	}}
+	m := NewDbManager(src, newErrorTestLogger(), DbManagerOptions{MaxSize: 5, IdleTTL: time.Minute}, connector)
+
+	ctx := context.Background()
+	_, relA, err := m.Get(ctx, "a")
+	require.NoError(t, err)
+	relA()
+	_, relB, err := m.Get(ctx, "b")
+	require.NoError(t, err)
+	relB()
+
+	err = m.Close()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "errors closing database connections")
+	assert.Contains(t, err.Error(), "close failure 1")
+	assert.Contains(t, err.Error(), "close failure 2", "Close must surface ALL connection close errors, not just the first")
+}
+
+// TestDbManagerZeroValueMethodsAreSafe pins that a zero-value DbManager (never built via
+// NewDbManager — the lightweight stand-in the debug/health endpoint and prewarm paths use) does
+// not panic on any of Stats/Close/Get/Size, matching the pre-resourcepool field-based behavior
+// (Stats/Size/Close were nil-map-safe; Get is guarded to fail closed rather than panic).
+func TestDbManagerZeroValueMethodsAreSafe(t *testing.T) {
+	m := &DbManager{}
+
+	stats := m.Stats()
+	assert.Equal(t, 0, stats["active_connections"])
+	assert.Equal(t, 0, stats["max_connections"])
+	assert.Equal(t, 0, stats["idle_ttl_seconds"])
+	assert.Empty(t, stats["connections"])
+
+	assert.Equal(t, 0, m.Size(), "zero-value Size must be 0, not panic")
+
+	conn, release, err := m.Get(context.Background(), "any")
+	assert.ErrorIs(t, err, errManagerClosed, "zero-value Get must fail closed, not panic")
+	assert.Nil(t, conn)
+	assert.Nil(t, release)
+
+	assert.NotPanics(t, func() {
+		m.StartCleanup(time.Minute)
+		m.StopCleanup()
+	}, "zero-value StartCleanup/StopCleanup must be no-ops, not panic")
+
+	assert.NoError(t, m.Close(), "closing a never-initialized manager is a no-op")
 }
 
 func TestDbManagerStatsEmptyManager(t *testing.T) {
@@ -390,6 +268,10 @@ func TestDbManagerStatsEmptyManager(t *testing.T) {
 	assert.Empty(t, conns, "empty manager has no connection entries")
 }
 
+// TestDbManagerStatsPopulatedManager drives Stats() through the public Get surface and pins
+// the per-connection detail array: one entry per live connection, each with its key, an
+// RFC3339 last_used string, and an int idle_duration. This shape feeds the debug/health
+// endpoint, so it must be preserved exactly.
 func TestDbManagerStatsPopulatedManager(t *testing.T) {
 	stubA := &stubDB{key: "a"}
 	stubB := &stubDB{key: "b"}
@@ -408,22 +290,29 @@ func TestDbManagerStatsPopulatedManager(t *testing.T) {
 	defer func() { _ = m.Close() }()
 
 	ctx := context.Background()
-	_, _, err := m.Get(ctx, "a")
+	_, relA, err := m.Get(ctx, "a")
 	require.NoError(t, err)
-	_, _, err = m.Get(ctx, "b")
+	defer relA()
+	_, relB, err := m.Get(ctx, "b")
 	require.NoError(t, err)
+	defer relB()
 
 	stats := m.Stats()
 	assert.Equal(t, 2, stats["active_connections"])
-	conns, ok := stats["connections"].([]map[string]any)
-	require.True(t, ok)
-	require.Len(t, conns, 2)
+	assert.Equal(t, 5, stats["max_connections"])
+	assert.Equal(t, int(time.Hour.Seconds()), stats["idle_ttl_seconds"])
 
+	conns, ok := stats["connections"].([]map[string]any)
+	require.True(t, ok, "connections key must be []map[string]any")
+	require.Len(t, conns, 2, "per-connection detail must be surfaced for each live connection")
+
+	keys := make([]any, 0, len(conns))
 	for _, c := range conns {
-		assert.Contains(t, []any{"a", "b"}, c["key"])
-		assert.IsType(t, "", c["last_used"])
-		assert.IsType(t, 0, c["idle_duration"])
+		keys = append(keys, c["key"])
+		assert.IsType(t, "", c["last_used"], "last_used must be an RFC3339 string")
+		assert.IsType(t, 0, c["idle_duration"], "idle_duration must be an int seconds count")
 	}
+	assert.ElementsMatch(t, []any{"a", "b"}, keys)
 }
 
 func TestStartCleanupIsIdempotent(t *testing.T) {
@@ -434,14 +323,14 @@ func TestStartCleanupIsIdempotent(t *testing.T) {
 	defer func() { _ = m.Close() }()
 
 	m.StartCleanup(10 * time.Second)
-	// Second call must observe cleanupCh != nil and short-circuit rather
+	// Second call must observe an already-running cleanup loop and short-circuit rather
 	// than spawning a duplicate goroutine.
 	require.NotPanics(t, func() {
 		m.StartCleanup(10 * time.Second)
 	})
 
 	m.StopCleanup()
-	// Second StopCleanup hits the early-return path (cleanupCh == nil).
+	// Second StopCleanup hits the early-return path (no loop running).
 	require.NotPanics(t, func() {
 		m.StopCleanup()
 	})
@@ -463,103 +352,8 @@ func TestStartCleanupAppliesDefaultIntervalForNonPositive(t *testing.T) {
 	m.StopCleanup()
 }
 
-// TestDbManagerEvictionWithSlowCloseDoesNotBlockConcurrentGet guards the M3 audit
-// finding: evictIfNeeded must NOT hold the manager mutex while closing the evicted
-// connection. A slow Close() on an evicted tenant's connection must not block a
-// concurrent Get() that targets a different, still-cached tenant (head-of-line
-// blocking). Mirrors the safe collect-then-close pattern in cache/manager.go.
-func TestDbManagerEvictionWithSlowCloseDoesNotBlockConcurrentGet(t *testing.T) {
-	ctx := context.Background()
-	log := newErrorTestLogger()
-
-	const slowClose = 200 * time.Millisecond
-	closeStarted := make(chan struct{})
-
-	connector := func(cfg *config.DatabaseConfig, _ logger.Logger) (Interface, error) {
-		db := &stubDB{key: cfg.Database}
-		if cfg.Database == "a" {
-			// Tenant "a" is the LRU victim. Its Close blocks for slowClose to simulate
-			// a stuck connection teardown. Signal once so the test can race a Get.
-			var once sync.Once
-			db.closeHook = func() {
-				once.Do(func() { close(closeStarted) })
-				time.Sleep(slowClose)
-			}
-		}
-		return db, nil
-	}
-
-	resource := &stubResourceSource{configs: map[string]*config.DatabaseConfig{
-		"a": {Type: "postgresql", Database: "a"},
-		"b": {Type: "postgresql", Database: "b"},
-		"c": {Type: "postgresql", Database: "c"},
-	}}
-
-	manager := NewDbManager(resource, log, DbManagerOptions{MaxSize: 2, IdleTTL: time.Minute}, connector)
-
-	_, relA, err := manager.Get(ctx, "a")
-	require.NoError(t, err)
-	_, _, err = manager.Get(ctx, "b")
-	require.NoError(t, err)
-	// Release "a"'s lease so the eviction can close it (deferred-until-release, ADR-032).
-	relA()
-
-	// Creating "c" evicts the LRU victim "a", whose Close blocks for slowClose.
-	go func() {
-		_, _, _ = manager.Get(ctx, "c")
-	}()
-
-	// Wait until the slow Close has actually begun before measuring.
-	select {
-	case <-closeStarted:
-	case <-time.After(time.Second):
-		t.Fatal("eviction Close never started")
-	}
-
-	// "b" is still cached: this Get only needs getExisting's lock. If eviction holds
-	// the manager mutex across Close (the M3 bug), this blocks for ~slowClose.
-	start := time.Now()
-	_, _, err = manager.Get(ctx, "b")
-	require.NoError(t, err)
-	elapsed := time.Since(start)
-
-	assert.Less(t, elapsed, slowClose/2,
-		"Get on a cached tenant must not block on another tenant's slow eviction Close (close-under-lock)")
-}
-
-func TestCleanupIdleConnectionsLogsCloseError(t *testing.T) {
-	failingStub := &stubDB{key: "x", closeErr: errors.New("driver fault on close")}
-	connector := func(*config.DatabaseConfig, logger.Logger) (Interface, error) { return failingStub, nil }
-
-	m := NewDbManager(&stubResourceSource{}, newTestLogger(), DbManagerOptions{
-		MaxSize: 5,
-		IdleTTL: time.Hour,
-	}, connector)
-	defer func() { _ = m.Close() }()
-
-	ctx := context.Background()
-	_, relX, err := m.Get(ctx, "x")
-	require.NoError(t, err)
-	// Release the lease so idle cleanup may close it (deferred-until-release, ADR-032).
-	relX()
-
-	// Backdate lastUsed so the cleanup pass sees the entry as idle. Direct
-	// field access under m.mu matches the pattern in
-	// TestCloseAggregatesErrors above.
-	m.mu.Lock()
-	m.conns["x"].lastUsed = time.Now().Add(-2 * time.Hour)
-	m.mu.Unlock()
-
-	m.cleanupIdleConnections()
-
-	assert.Equal(t, 0, m.Size(), "idle connection removed from cache despite Close() error")
-	failingStub.closedMu.Lock()
-	closed := failingStub.closed
-	failingStub.closedMu.Unlock()
-	assert.True(t, closed, "Close was attempted even though it returned an error")
-}
-
-// --- Lease/refcount: eviction-while-in-use race (issue #606, ADR-032) ---
+// --- Black-box helpers for the manager's public Get/Close surface (ADR-032 lease semantics
+// are exercised directly in internal/resourcepool). ---
 
 // newClosableDB returns a connector that records each connection's Close() in the
 // shared `closed` map under `mu`, keyed by the connection's config Database value.
@@ -602,120 +396,11 @@ func TestDbManagerGetReturnsNonNilReleaseFunc(t *testing.T) {
 	assert.Equal(t, 1, m.Size())
 }
 
-func TestDbManagerEvictionWhileLeasedDefersCloseUntilRelease(t *testing.T) {
-	ctx := context.Background()
-	var mu sync.Mutex
-	closed := map[string]bool{}
-	// MaxSize 1 → getting a second key evicts the first.
-	m := NewDbManager(twoTenantSource(), newErrorTestLogger(),
-		DbManagerOptions{MaxSize: 1, IdleTTL: time.Minute}, newClosableDB(&mu, closed))
-	defer func() { _ = m.Close() }()
-
-	_, releaseA, err := m.Get(ctx, "a")
-	require.NoError(t, err)
-
-	// Borrowing "b" evicts "a" from the LRU. "a" is still leased, so it must NOT close.
-	_, releaseB, err := m.Get(ctx, "b")
-	require.NoError(t, err)
-	defer releaseB()
-
-	mu.Lock()
-	closedWhileLeased := closed["a"]
-	mu.Unlock()
-	assert.False(t, closedWhileLeased,
-		"an evicted-but-leased connection must not be closed while a lease is held (the #606 race)")
-
-	// Releasing the last lease closes the evicted connection now.
-	releaseA()
-	mu.Lock()
-	closedAfterRelease := closed["a"]
-	mu.Unlock()
-	assert.True(t, closedAfterRelease,
-		"an evicted connection must be closed once its last lease is released")
-}
-
-func TestDbManagerTwoLeasesKeepConnectionAliveUntilBothReleased(t *testing.T) {
-	ctx := context.Background()
-	var mu sync.Mutex
-	closed := map[string]bool{}
-	m := NewDbManager(twoTenantSource(), newErrorTestLogger(),
-		DbManagerOptions{MaxSize: 1, IdleTTL: time.Minute}, newClosableDB(&mu, closed))
-	defer func() { _ = m.Close() }()
-
-	_, release1, err := m.Get(ctx, "a")
-	require.NoError(t, err)
-	_, release2, err := m.Get(ctx, "a") // same key, second borrower → refcount 2
-	require.NoError(t, err)
-
-	// Evict "a".
-	_, releaseB, err := m.Get(ctx, "b")
-	require.NoError(t, err)
-	defer releaseB()
-
-	release1()
-	mu.Lock()
-	closedAfterFirst := closed["a"]
-	mu.Unlock()
-	assert.False(t, closedAfterFirst, "connection must stay open while a second lease is outstanding")
-
-	release2()
-	mu.Lock()
-	closedAfterSecond := closed["a"]
-	mu.Unlock()
-	assert.True(t, closedAfterSecond, "connection must close when the final lease is released")
-}
-
-func TestDbManagerIdleCleanupWhileLeasedDefersClose(t *testing.T) {
-	ctx := context.Background()
-	var mu sync.Mutex
-	closed := map[string]bool{}
-	m := NewDbManager(twoTenantSource(), newErrorTestLogger(),
-		DbManagerOptions{MaxSize: 5, IdleTTL: time.Nanosecond}, newClosableDB(&mu, closed))
-	defer func() { _ = m.Close() }()
-
-	_, releaseA, err := m.Get(ctx, "a")
-	require.NoError(t, err)
-
-	time.Sleep(time.Millisecond) // ensure idle threshold passed
-	m.cleanupIdleConnections()   // detaches "a" (idle) but it is still leased
-
-	mu.Lock()
-	closedWhileLeased := closed["a"]
-	mu.Unlock()
-	assert.False(t, closedWhileLeased, "idle cleanup must not close a leased connection")
-
-	releaseA()
-	mu.Lock()
-	closedAfterRelease := closed["a"]
-	mu.Unlock()
-	assert.True(t, closedAfterRelease, "idle-cleaned connection closes when its last lease is released")
-}
-
-func TestDbManagerReleaseIsIdempotent(t *testing.T) {
-	ctx := context.Background()
-	var mu sync.Mutex
-	closed := map[string]bool{}
-	m := NewDbManager(twoTenantSource(), newErrorTestLogger(),
-		DbManagerOptions{MaxSize: 1, IdleTTL: time.Minute}, newClosableDB(&mu, closed))
-	defer func() { _ = m.Close() }()
-
-	_, releaseA, err := m.Get(ctx, "a")
-	require.NoError(t, err)
-	_, releaseB, err := m.Get(ctx, "b") // evict "a"
-	require.NoError(t, err)
-	defer releaseB()
-
-	assert.NotPanics(t, func() {
-		releaseA()
-		releaseA() // double release must be a safe no-op (no double close, no negative refcount)
-	})
-}
-
 // TestDbManagerDynamicConfigGetsPoolDefaults proves a dynamic DBConfigProvider
 // (source.type=dynamic) that returns a zero-value Pool no longer reaches the
-// connector unnormalized: DbManager.createConnection must apply the same pool
-// defaults config.Validate applies to static config, so the PostgreSQL/Oracle
-// connectors never call SetMaxOpenConns(0) (unlimited connections).
+// connector unnormalized: the create callback applies the same pool defaults
+// config.Validate applies to static config, so the PostgreSQL/Oracle connectors
+// never call SetMaxOpenConns(0) (unlimited connections).
 func TestDbManagerDynamicConfigGetsPoolDefaults(t *testing.T) {
 	ctx := context.Background()
 	resource := &stubResourceSource{configs: map[string]*config.DatabaseConfig{
@@ -728,9 +413,11 @@ func TestDbManagerDynamicConfigGetsPoolDefaults(t *testing.T) {
 		return &stubDB{}, nil
 	}
 	manager := NewDbManager(resource, newErrorTestLogger(), DbManagerOptions{}, connector)
+	defer func() { _ = manager.Close() }()
 
-	_, err := manager.createConnection(ctx, "tenant")
+	_, release, err := manager.Get(ctx, "tenant")
 	require.NoError(t, err)
+	release()
 	require.NotNil(t, captured)
 
 	assert.Equal(t, int32(25), captured.Pool.Max.Connections, "max connections defaults to 25")
@@ -771,9 +458,11 @@ func TestDbManagerDynamicConfigExplicitPoolPreserved(t *testing.T) {
 		return &stubDB{}, nil
 	}
 	manager := NewDbManager(resource, newErrorTestLogger(), DbManagerOptions{}, connector)
+	defer func() { _ = manager.Close() }()
 
-	_, err := manager.createConnection(ctx, "tenant")
+	_, release, err := manager.Get(ctx, "tenant")
 	require.NoError(t, err)
+	release()
 	require.NotNil(t, captured)
 
 	assert.Equal(t, int32(40), captured.Pool.Max.Connections, "explicit max connections preserved")
@@ -781,7 +470,8 @@ func TestDbManagerDynamicConfigExplicitPoolPreserved(t *testing.T) {
 }
 
 // TestDbManagerDynamicConfigInvalidPoolRejected proves an invalid dynamic pool
-// config fails createConnection before the connector is ever invoked.
+// config fails the create callback before the connector is ever invoked, surfacing
+// through Get.
 func TestDbManagerDynamicConfigInvalidPoolRejected(t *testing.T) {
 	ctx := context.Background()
 	resource := &stubResourceSource{configs: map[string]*config.DatabaseConfig{
@@ -801,7 +491,7 @@ func TestDbManagerDynamicConfigInvalidPoolRejected(t *testing.T) {
 	}
 	manager := NewDbManager(resource, newErrorTestLogger(), DbManagerOptions{}, connector)
 
-	_, err := manager.createConnection(ctx, "tenant")
+	_, _, err := manager.Get(ctx, "tenant")
 	require.Error(t, err)
 	require.ErrorContains(t, err, "failed to apply pool defaults for key")
 	var cfgErr *config.ConfigError
@@ -810,29 +500,38 @@ func TestDbManagerDynamicConfigInvalidPoolRejected(t *testing.T) {
 	assert.False(t, connectorCalled, "connector must not run with an invalid pool config")
 }
 
-// TestDbManagerDynamicConfigConcurrentCreateSharedConfig guards the clone in
-// createConnection: concurrent creates against a shared provider config must
-// not race (make check runs -race).
+// TestDbManagerDynamicConfigConcurrentCreateSharedConfig guards the clone in the create
+// callback: every key resolves to the SAME shared provider config pointer, so concurrent
+// creates for distinct keys each shallow-clone that one struct simultaneously. Under -race
+// this proves the clone never races the shared config, expressed through the public Get
+// surface (singleflight would collapse same-key creates, so distinct keys are used).
 func TestDbManagerDynamicConfigConcurrentCreateSharedConfig(t *testing.T) {
 	ctx := context.Background()
-	resource := &stubResourceSource{configs: map[string]*config.DatabaseConfig{
-		"tenant": {Type: "postgresql", Host: "localhost"},
-	}}
+	shared := &config.DatabaseConfig{Type: "postgresql", Host: "localhost"}
+	const goroutines = 8
+	configs := make(map[string]*config.DatabaseConfig, goroutines)
+	for i := range goroutines {
+		configs[fmt.Sprintf("tenant-%d", i)] = shared
+	}
+	resource := &stubResourceSource{configs: configs}
 	connector := func(*config.DatabaseConfig, logger.Logger) (Interface, error) {
 		return &stubDB{}, nil
 	}
-	manager := NewDbManager(resource, newErrorTestLogger(), DbManagerOptions{MaxSize: 5, IdleTTL: time.Minute}, connector)
+	manager := NewDbManager(resource, newErrorTestLogger(), DbManagerOptions{MaxSize: 20, IdleTTL: time.Minute}, connector)
+	defer func() { _ = manager.Close() }()
 
-	const goroutines = 8
 	errs := make(chan error, goroutines)
 	var wg sync.WaitGroup
-	for range goroutines {
+	for i := range goroutines {
 		wg.Add(1)
-		go func() {
+		go func(i int) {
 			defer wg.Done()
-			_, err := manager.createConnection(ctx, "tenant")
+			_, release, err := manager.Get(ctx, fmt.Sprintf("tenant-%d", i))
+			if release != nil {
+				release()
+			}
 			errs <- err
-		}()
+		}(i)
 	}
 	wg.Wait()
 	close(errs)

--- a/internal/resourcepool/resourcepool.go
+++ b/internal/resourcepool/resourcepool.go
@@ -60,6 +60,13 @@ type PoolStats struct {
 	IdleTTL      time.Duration // Idle timeout duration
 }
 
+// EntrySnapshot is a point-in-time view of one pooled entry's identity and idle age, for
+// managers that surface per-resource detail in Stats (e.g. DbManager's "connections" array).
+type EntrySnapshot struct {
+	Key      string
+	LastUsed time.Time
+}
+
 // entry represents a pooled resource in the LRU.
 // refs, seedHeld, detached, and closed are guarded by Pool.mu.
 type entry[V any] struct {
@@ -439,11 +446,13 @@ func (p *Pool[V]) cleanupIdle() {
 	}
 }
 
-// Close shuts down all pooled resources and stops the cleanup loop. After Close returns,
-// GetOrCreate returns ErrPoolClosed. It is idempotent and returns the first close error
-// encountered (if any); all close errors are counted.
+// Close shuts down all pooled resources, stops the cleanup loop, and makes subsequent
+// GetOrCreate calls return ErrPoolClosed. It is idempotent and returns EVERY close error joined
+// via errors.Join (nil if none) — so consumers whose Close contract aggregates all failures
+// (e.g. DbManager) can surface them all, while errors.Is still matches any individual error.
+// Every close failure is also counted.
 func (p *Pool[V]) Close() error {
-	var first error
+	var closeErrs []error
 
 	p.closeOnce.Do(func() {
 		// Flip closed BEFORE any teardown so concurrent GetOrCreate callers immediately see
@@ -466,14 +475,12 @@ func (p *Pool[V]) Close() error {
 		for _, e := range toClose {
 			if err := p.closer(e.value); err != nil {
 				p.incErrors()
-				if first == nil {
-					first = err
-				}
+				closeErrs = append(closeErrs, err)
 			}
 		}
 	})
 
-	return first
+	return errors.Join(closeErrs...)
 }
 
 // Closed reports whether Close has been called.
@@ -501,6 +508,18 @@ func (p *Pool[V]) Stats() PoolStats {
 		Errors:       p.errors,
 		IdleTTL:      p.idleTTL,
 	}
+}
+
+// Snapshot returns a point-in-time snapshot of every live entry (key + last-used), in
+// unspecified order. Observability/Stats surfaces only — it takes no lease and does not touch LRU.
+func (p *Pool[V]) Snapshot() []EntrySnapshot {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]EntrySnapshot, 0, len(p.entries))
+	for key, e := range p.entries {
+		out = append(out, EntrySnapshot{Key: key, LastUsed: e.lastUsed})
+	}
+	return out
 }
 
 // incErrors bumps the error counter. Must be called without mu held.

--- a/internal/resourcepool/resourcepool_test.go
+++ b/internal/resourcepool/resourcepool_test.go
@@ -597,38 +597,40 @@ func TestPoolReleaseCloseErrorCounted(t *testing.T) {
 
 // TestPoolCloseClosesAllAndReturnsFirstError verifies Close closes every entry, counts close
 // failures, and returns the first error.
-func TestPoolCloseClosesAllAndReturnsFirstError(t *testing.T) {
+func TestPoolCloseClosesAllAndJoinsErrors(t *testing.T) {
 	tr := newCloseTracker()
 	p := New(5, 0, tr.closer)
 	ctx := context.Background()
 
-	closeErr := errors.New("close failed")
-	// key-2 fails to close; the others succeed.
-	makeCreate := func(key string, fail bool) func(context.Context) (*fakeResource, error) {
+	errTwo := errors.New("close key-2 failed")
+	errThree := errors.New("close key-3 failed")
+	// key-2 and key-3 both fail to close with distinct errors; key-1 succeeds.
+	makeCreate := func(key string, closeErr error) func(context.Context) (*fakeResource, error) {
 		return func(context.Context) (*fakeResource, error) {
 			r := newFakeResource(key)
-			if fail {
-				r.closeErr = closeErr
-			}
+			r.closeErr = closeErr
 			return r, nil
 		}
 	}
 	for _, kv := range []struct {
-		key  string
-		fail bool
-	}{{keyOne, false}, {keyTwo, true}, {keyThree, false}} {
-		_, rel, err := p.GetOrCreate(ctx, kv.key, makeCreate(kv.key, kv.fail))
+		key      string
+		closeErr error
+	}{{keyOne, nil}, {keyTwo, errTwo}, {keyThree, errThree}} {
+		_, rel, err := p.GetOrCreate(ctx, kv.key, makeCreate(kv.key, kv.closeErr))
 		require.NoError(t, err)
 		rel()
 	}
 
 	err := p.Close()
-	assert.ErrorIs(t, err, closeErr, "Close returns the first close error")
+	// Close joins EVERY close failure via errors.Join — errors.Is matches each individual one,
+	// so a consumer aggregating them (DbManager) surfaces all, not just the first.
+	assert.ErrorIs(t, err, errTwo, "Close surfaces the key-2 close error")
+	assert.ErrorIs(t, err, errThree, "Close surfaces the key-3 close error")
 	assert.True(t, tr.wasClosed(keyOne))
 	assert.True(t, tr.wasClosed(keyTwo))
 	assert.True(t, tr.wasClosed(keyThree))
 	assert.Equal(t, 0, p.Size())
-	assert.Equal(t, 1, p.Stats().Errors)
+	assert.Equal(t, 2, p.Stats().Errors, "each close failure counts once")
 }
 
 // TestPoolCloseIsIdempotent verifies Close can be called repeatedly.
@@ -739,6 +741,47 @@ func TestPoolStatsSnapshot(t *testing.T) {
 	assert.Equal(t, 2, st.Size)
 	assert.Equal(t, 3, st.TotalCreated)
 	assert.Equal(t, 1, st.Evictions)
+}
+
+// TestPoolSnapshotReportsLiveEntries pins the observability-only Snapshot accessor: one
+// EntrySnapshot per live entry (key + non-zero LastUsed), shrinking as entries are removed or
+// the pool is closed. It takes no lease and does not touch LRU.
+func TestPoolSnapshotReportsLiveEntries(t *testing.T) {
+	tr := newCloseTracker()
+	p := New(5, 0, tr.closer)
+	ctx := context.Background()
+
+	// Empty pool → empty snapshot.
+	assert.Empty(t, p.Snapshot())
+
+	_, relA, err := p.GetOrCreate(ctx, keyOne, keyedCreate(keyOne))
+	require.NoError(t, err)
+	_, relB, err := p.GetOrCreate(ctx, keyTwo, keyedCreate(keyTwo))
+	require.NoError(t, err)
+
+	snap := p.Snapshot()
+	require.Len(t, snap, 2, "one snapshot entry per live key")
+	byKey := make(map[string]EntrySnapshot, len(snap))
+	for _, e := range snap {
+		byKey[e.Key] = e
+		assert.False(t, e.LastUsed.IsZero(), "LastUsed must be populated")
+	}
+	require.Contains(t, byKey, keyOne)
+	require.Contains(t, byKey, keyTwo)
+
+	// Remove one (release its lease first so Remove closes it) → snapshot shrinks.
+	relA()
+	if v, shouldClose := p.Remove(keyOne); shouldClose {
+		_ = tr.closer(v)
+	}
+	snap = p.Snapshot()
+	require.Len(t, snap, 1)
+	assert.Equal(t, keyTwo, snap[0].Key)
+
+	// Close → snapshot empties.
+	relB()
+	require.NoError(t, p.Close())
+	assert.Empty(t, p.Snapshot(), "closed pool reports no live entries")
 }
 
 // TestPoolClosedAccessor verifies Closed tracks shutdown state.


### PR DESCRIPTION
## What

Second PR of the decomposed ADR-032 extraction (after #748 landed `internal/resourcepool` + cache). Rewires **DbManager** onto the shared `resourcepool.Pool[Interface]`, deleting its hand-rolled copy of the lease/refcount/LRU/idle-evict machinery, and **closes backlog F22 for the database manager**: `Get()` after `Close()` now fails closed instead of resurrecting a leaked connection.

## Scope

- `database/manager.go` — thin adapter over the pool; DB-specific config resolution (DBConfig lookup → shallow clone → pool-default application) moves into the pool's create callback.
- `database/manager_test.go` — white-box pool-machinery tests **superseded** by the direct `internal/resourcepool` suite (removed); DB-specific tests **rewritten black-box** through `Get()/Stats()/Close()`.
- `internal/resourcepool/{resourcepool.go,resourcepool_test.go}` — two additive/behavioral changes the database contract needs (see below).

## Public API & behavior preserved

- `go doc ./database DbManager` **identical** to main; closed error is an unexported sentinel (no exported symbol added; apidiff-gated, no `!`).
- **`Stats()` byte-for-byte**, including the per-connection `connections` detail (`key`/RFC3339 `last_used`/int `idle_duration`) that the debug/health endpoint (`app/debug_health.go`) serializes. To keep the pool config-agnostic while preserving this, added an observability-only **`Pool.Snapshot()`** (lease-free, no LRU touch) that `DbManager.Stats()` rebuilds the array from.
- **`Close()` aggregation preserved.** DbManager historically returned *all* connection close failures; the pool returned only the first. `Pool.Close()` now joins every close error via `errors.Join` (`errors.Is` still matches any individual one), and DbManager re-wraps under the original `"errors closing database connections"` prefix. Cache is unaffected — `errors.Join` of a single error is transparent to its `errors.Is`-based tests.

## Review

An opus panel (test-migration fidelity + behavior-equivalence vs `6db7683`) drove the last two items — it caught the silent `Close()` all→first narrowing and the uncovered nil-pool `Stats()` branch. Both fixed and pinned:
- `TestDbManagerCloseAggregatesErrors` (mutation-verified: the first-error-only form fails it)
- `TestDbManagerZeroValueStatsAndCloseAreSafe` (nil-pool guards)
- `TestPoolSnapshotReportsLiveEntries`; strengthened pool Close test to pin the joined shape.
- New black-box F22 regression test.

**Known deliberate reduction:** the pool-churn acquire-exhaustion error text is now the generic pool message (non-sentinel, `errors.Is` unaffected, effectively unreachable — new entries seed at the LRU front so the first attempt always succeeds).

## Verification

`make check` green; `database` + `internal/resourcepool` + `cache` + `app` all pass `-race`. Net **−536 LoC** (triplication + white-box tests removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Upgraded database connection pooling with delegated lifecycle management and streamlined cleanup behavior.
  - Enhanced connection statistics with clearer live-entry tracking, including last-used timing.
- **Bug Fixes**
  - Attempts to acquire connections after manager closure now reliably return a clear, manager-closed error.
  - Improved robustness for zero-value manager usage and concurrent access.
  - Ensured connection acquisition/release and shutdown behavior remains consistent, including correct release handling.  
- **Other**
  - Manager close now aggregates *all* underlying connection close failures (instead of stopping at the first).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->