### PR TITLE
refactor(messaging): rewire the publisher pool onto internal/resourcepool (closes F22-msg)

### DIFF
--- a/internal/resourcepool/resourcepool_test.go
+++ b/internal/resourcepool/resourcepool_test.go
@@ -1029,3 +1029,77 @@ func TestPoolConcurrentEvictWhileLeasedRace(t *testing.T) {
 
 	require.NoError(t, p.Close())
 }
+
+// TestPoolSlowCloseDoesNotBlockConcurrentGet pins the audit's M3 property: a slow Closer on an
+// evicted entry runs OUTSIDE the pool lock, so it cannot head-of-line-block a concurrent GetOrCreate
+// on a DIFFERENT key. This latency guarantee moved from the managers into the pool with the ADR-032
+// extraction; a regression putting close back under the lock would pass -race but fail this timing pin.
+func TestPoolSlowCloseDoesNotBlockConcurrentGet(t *testing.T) {
+	const slowClose = 200 * time.Millisecond
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) } // idempotent: safe from any path
+	closeStarted := make(chan struct{})
+	closer := func(r *fakeResource) error {
+		if r.id == "slow" {
+			close(closeStarted)
+			<-release // hold the close open until the test releases it
+		}
+		return nil
+	}
+	p := New(1, 0, closer) // capacity 1: creating a new key evicts the previous
+	ctx := context.Background()
+
+	// Seed the slow-close victim and release its lease so it is evictable.
+	_, rel1, err := p.GetOrCreate(ctx, keyOne, func(context.Context) (*fakeResource, error) {
+		return newFakeResource("slow"), nil
+	})
+	require.NoError(t, err)
+	rel1()
+
+	// Evicting the victim (a Get on another key) runs its slow close in the background.
+	evictDone := make(chan struct{})
+	go func() {
+		_, rel2, gErr := p.GetOrCreate(ctx, keyTwo, func(context.Context) (*fakeResource, error) {
+			return newFakeResource("k2"), nil
+		})
+		assert.NoError(t, gErr)
+		rel2()
+		close(evictDone)
+	}()
+
+	// Wait (bounded) for the victim's slow close to begin — it holds NO pool lock.
+	select {
+	case <-closeStarted:
+	case <-time.After(2 * time.Second):
+		unblock()
+		t.Fatal("timed out waiting for the evicted victim's slow close to start")
+	}
+
+	// Run the third-key Get in a goroutine so a REGRESSION (close under the lock) surfaces as a
+	// bounded-time FAILURE rather than hanging until the package test timeout.
+	got := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		_, rel3, gErr := p.GetOrCreate(ctx, keyThree, func(context.Context) (*fakeResource, error) {
+			return newFakeResource("k3"), nil
+		})
+		if gErr == nil {
+			rel3()
+		}
+		got <- time.Since(start)
+	}()
+
+	select {
+	case elapsed := <-got:
+		assert.Less(t, elapsed, slowClose/2,
+			"a slow close on an evicted entry must not block Get on another key (close runs outside the lock)")
+	case <-time.After(slowClose / 2):
+		unblock() // let the slow close finish so the goroutines drain
+		t.Fatal("Get on a third key was blocked by the evicted victim's slow close (M3 regression: close under the lock)")
+	}
+
+	unblock()
+	<-evictDone
+	require.NoError(t, p.Close())
+}

--- a/messaging/amqp_client.go
+++ b/messaging/amqp_client.go
@@ -875,10 +875,10 @@ func (c *AMQPClientImpl) Close() error {
 
 	// Close stays non-blocking: it signals the reconnection goroutine to stop
 	// (via close(c.done)) but does not wait for it. Waiting here would let an
-	// in-flight, uncancellable dial stall callers — and Manager invokes Close
-	// while holding pubMu/consMu (shutdown, LRU eviction, idle cleanup), so a
-	// blocking Close could wedge the publish path. The goroutine exits on its
-	// own at its next select; reconnectDone lets tests confirm that exit.
+	// in-flight, uncancellable dial stall callers — and Close runs on the
+	// shutdown, LRU-eviction, and idle-cleanup paths, so a blocking Close could
+	// wedge the publish path. The goroutine exits on its own at its next
+	// select; reconnectDone lets tests confirm that exit.
 	c.log.Info().Msg("AMQP client closed")
 	return err
 }

--- a/messaging/manager.go
+++ b/messaging/manager.go
@@ -1,14 +1,15 @@
 package messaging
 
 import (
-	"container/list"
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"golang.org/x/sync/singleflight"
 
+	"github.com/gaborage/go-bricks/internal/resourcepool"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/multitenant"
 )
@@ -30,65 +31,36 @@ type ClientFactory func(string, logger.Logger) AMQPClient
 // publisher evicted while leased is closed only once its last lease is released. See ADR-032.
 type ReleaseFunc func()
 
-// maxPublisherAttempts bounds the rare retry where a reused publisher entry is closed before
-// the caller can take a lease (only under extreme pool churn). A new entry carries a seed
-// lease, so the create path always succeeds and the loop converges.
-const maxPublisherAttempts = 4
+// errManagerClosed is returned by Publisher after Close has been called, rather than
+// resurrecting a publisher on a shut-down manager (backlog F22). It is unexported: Manager
+// exposed no closed-state error before the resourcepool rewire, so this closes F22 while
+// keeping the public surface unchanged.
+var errManagerClosed = errors.New("messaging: manager closed")
 
 // Manager manages AMQP clients by string keys with different lifecycle strategies.
 // Publishers are cached with idle eviction (can be recreated easily).
 // Consumers are long-lived (must stay alive to receive messages).
 // The manager is key-agnostic - it doesn't know about tenants, just manages named clients.
+//
+// The publisher side is a thin adapter over internal/resourcepool.Pool, which owns the
+// ADR-032 lease/evict/close protocol (seed leases, LRU eviction, idle cleanup, and the
+// closed-pool guard). The manager keeps only the AMQP-specific client creation. The consumer
+// side is long-lived and managed directly (not pool-shaped).
 type Manager struct {
 	logger         logger.Logger
 	resourceSource BrokerURLProvider
 	clientFactory  ClientFactory // Injected for testability
 
-	// Publishers (evictable)
-	pubMu      sync.RWMutex
-	publishers map[string]*publisherEntry
-	pubLru     *list.List
-	maxPubs    int
-	idleTTL    time.Duration
-	// evictions counts cumulative LRU-driven publisher evictions. Guarded by pubMu.
-	// Mirrors cache.CacheManager's evictions field/locking (cache/manager.go).
-	evictions int
-	// idleCleanups counts cumulative idle-TTL-driven publisher removals. Guarded
-	// by pubMu. Mirrors cache.CacheManager's idleCleanups field/locking.
-	idleCleanups int
+	// Publishers (evictable) — the resourcepool owns lease/LRU/idle-cleanup bookkeeping.
+	pubPool *resourcepool.Pool[AMQPClient]
 
 	// Consumers (long-lived)
 	consMu        sync.RWMutex
 	consumers     map[string]*consumerEntry
 	replayedHashs map[string]uint64 // Tracks declaration hashes to prevent duplicate replay
 
-	// Cleanup management
-	cleanupMu sync.Mutex
-	cleanupCh chan struct{}
-
-	// Singleflight for concurrent initialization
+	// Singleflight for concurrent consumer initialization
 	sfg singleflight.Group
-}
-
-// publisherEntry represents a cached publisher with LRU metadata.
-// refs, seedHeld, detached, and closed are guarded by Manager.pubMu.
-type publisherEntry struct {
-	client   AMQPClient
-	element  *list.Element // for LRU
-	lastUsed time.Time
-	key      string
-
-	// refs counts outstanding leases (current borrowers); a publisher with refs > 0 is in use.
-	refs int
-	// seedHeld is true when one of refs is an unclaimed "seed" lease taken at creation. It
-	// keeps a brand-new entry alive through the window before its first Publisher caller claims
-	// it, so a concurrent evict/idle-cleanup can only detach (never close) it.
-	seedHeld bool
-	// detached marks an entry removed from the map+LRU whose Close() was deferred because a
-	// lease was still outstanding.
-	detached bool
-	// closed guards against a double Close() once the deferred close has run.
-	closed bool
 }
 
 // consumerEntry represents a long-lived consumer
@@ -155,12 +127,16 @@ func NewMessagingManager(resourceSource BrokerURLProvider, log logger.Logger, op
 		logger:         log,
 		resourceSource: resourceSource,
 		clientFactory:  clientFactory,
-		publishers:     make(map[string]*publisherEntry),
-		pubLru:         list.New(),
-		maxPubs:        opts.MaxPublishers,
-		idleTTL:        opts.IdleTTL,
-		consumers:      make(map[string]*consumerEntry),
-		replayedHashs:  make(map[string]uint64),
+		// The pool closer surfaces each publisher's raw Close() error; pool.Close() joins them.
+		// Unlike the consumer loop below, these are not wrapped with the per-key label — the
+		// closer receives only the AMQPClient value (and key=="" uses a bare client), matching
+		// the database rewire's deliberate tradeoff: error coverage and the aggregate prefix are
+		// preserved, only the per-publisher-key context is dropped.
+		pubPool: resourcepool.New[AMQPClient](opts.MaxPublishers, opts.IdleTTL, func(client AMQPClient) error {
+			return client.Close()
+		}),
+		consumers:     make(map[string]*consumerEntry),
+		replayedHashs: make(map[string]uint64),
 	}
 }
 
@@ -270,162 +246,38 @@ func (m *Manager) ensureConsumersInternal(ctx context.Context, key string, decls
 // Publisher returns a publisher client for the given key plus a ReleaseFunc the caller must
 // invoke when finished with it for the current unit of work (typically deferred). Publishers
 // are cached with LRU eviction and lazy initialization; the lease prevents a publisher that
-// is evicted while in use from being closed under an active caller (the #606 race). On error
-// the returned ReleaseFunc is nil — check err first.
+// is evicted while in use from being closed under an active caller (the #606 race). Once Close
+// has run, Publisher fails closed rather than resurrecting a publisher (F22). On error the
+// returned ReleaseFunc is nil — check err first.
 func (m *Manager) Publisher(ctx context.Context, key string) (AMQPClient, ReleaseFunc, error) {
-	for attempt := 0; attempt < maxPublisherAttempts; attempt++ {
-		// Fast path: getExistingPublisher increments the refcount atomically with the lookup.
-		if entry := m.getExistingPublisher(key); entry != nil {
-			return entry.client, m.makeRelease(entry), nil
+	if m.pubPool == nil {
+		// Zero-value manager (never built via NewMessagingManager): unusable, fail closed
+		// rather than panic — consistent with the Stats()/Close()/StartCleanup zero-value guards.
+		return nil, nil, errManagerClosed
+	}
+	client, release, err := m.pubPool.GetOrCreate(ctx, key, func(ctx context.Context) (AMQPClient, error) {
+		return m.createPublisher(ctx, key)
+	})
+	if err != nil {
+		if errors.Is(err, resourcepool.ErrPoolClosed) {
+			return nil, nil, errManagerClosed
 		}
-
-		// Slow path: singleflight collapses concurrent creates for the same key into one. It
-		// returns the shared entry (freshly created with a seed lease, or an existing one);
-		// every caller then takes its own lease on that pointer via claimOrAcquire — the first
-		// claims the seed, the rest increment — so each concurrent borrower is counted.
-		v, err, _ := m.sfg.Do("publisher:"+key, func() (any, error) {
-			if e := m.peekPublisher(key); e != nil {
-				return e, nil
-			}
-			return m.createPublisher(ctx, key)
-		})
-		if err != nil {
-			return nil, nil, err
-		}
-
-		entry := v.(*publisherEntry)
-		if m.claimOrAcquire(entry) {
-			return entry.client, m.makeRelease(entry), nil
-		}
-		// The reused entry was closed in the window between lookup and claim; loop to create
-		// a fresh one. The create path always succeeds (seed lease), so this converges.
+		return nil, nil, err
 	}
-
-	return nil, nil, fmt.Errorf("failed to acquire publisher for key %s after %d attempts (pool churn)", key, maxPublisherAttempts)
+	return client, ReleaseFunc(release), nil
 }
 
-// getExistingPublisher returns an existing entry with a lease acquired (refcount incremented)
-// and updates LRU, or nil if not found. The increment happens under the same lock as the
-// lookup so the entry cannot be evicted-and-closed before the lease is taken.
-func (m *Manager) getExistingPublisher(key string) *publisherEntry {
-	m.pubMu.Lock()
-	defer m.pubMu.Unlock()
-
-	entry, exists := m.publishers[key]
-	if !exists {
-		return nil
-	}
-
-	// Update LRU and last used time
-	entry.lastUsed = time.Now()
-	m.pubLru.MoveToFront(entry.element)
-	entry.refs++
-
-	return entry
-}
-
-// peekPublisher reports whether an entry exists without taking a lease or touching LRU.
-func (m *Manager) peekPublisher(key string) *publisherEntry {
-	m.pubMu.RLock()
-	defer m.pubMu.RUnlock()
-	return m.publishers[key]
-}
-
-// claimOrAcquire takes one lease on entry, operating on the shared pointer so it can never
-// "miss" via a map lookup. Returns false only when the entry has already been fully closed
-// (a reused entry that lost a race), signaling the caller to retry with a fresh entry.
-func (m *Manager) claimOrAcquire(entry *publisherEntry) bool {
-	m.pubMu.Lock()
-	defer m.pubMu.Unlock()
-	if entry.closed {
-		return false
-	}
-	if entry.seedHeld {
-		entry.seedHeld = false // claim the seed: that ref becomes this caller's lease
-	} else {
-		entry.refs++
-	}
-	return true
-}
-
-// makeRelease returns an idempotent ReleaseFunc bound to a single lease on entry.
-func (m *Manager) makeRelease(entry *publisherEntry) ReleaseFunc {
-	var once sync.Once
-	return func() {
-		once.Do(func() { m.releasePublisher(entry) })
-	}
-}
-
-// releasePublisher drops one lease. If the entry was detached (evicted/idle-cleaned) while
-// leased and this was the final lease, it closes the publisher now — outside the lock.
-func (m *Manager) releasePublisher(entry *publisherEntry) {
-	m.pubMu.Lock()
-	entry.refs--
-	shouldClose := entry.detached && entry.refs <= 0 && !entry.closed
-	if shouldClose {
-		entry.closed = true
-	}
-	m.pubMu.Unlock()
-
-	if shouldClose {
-		m.closeEvictedPublisher(entry, "Error closing evicted publisher client (deferred until lease release)")
-	}
-}
-
-// createPublisher creates a new publisher client for the given key and registers it with a
-// single seed lease (refs == 1, seedHeld). The seed keeps the entry alive through the window
-// before the caller claims it via claimOrAcquire. Returns an existing entry unchanged on a
-// double-create race.
-func (m *Manager) createPublisher(ctx context.Context, key string) (*publisherEntry, error) {
+// createPublisher creates a new AMQP client for the given key and wraps it so publishes carry
+// the tenant header. It performs only client creation — the pool owns all lease/LRU/eviction
+// bookkeeping. Invoked inside the pool's create callback, so singleflight guarantees one call
+// per key per creation.
+func (m *Manager) createPublisher(ctx context.Context, key string) (AMQPClient, error) {
 	// Create the AMQP client (error is already well-formatted from createAMQPClient)
 	client, err := m.createAMQPClient(ctx, key)
 	if err != nil {
 		return nil, err
 	}
-
-	wrapped := newTenantAwarePublisher(client, key)
-
-	// Store in cache with LRU tracking
-	m.pubMu.Lock()
-
-	// Check if publisher was created by another goroutine while we were waiting
-	if existing, exists := m.publishers[key]; exists {
-		existing.lastUsed = time.Now()
-		m.pubLru.MoveToFront(existing.element)
-		m.pubMu.Unlock()
-
-		// Close our new client outside the lock and return the existing one.
-		m.closeClientOnRollback(client, key, "publisher_double_create_race")
-		return existing, nil
-	}
-
-	// Ensure we don't exceed max size (returns the evicted entry to close outside the lock)
-	evicted := m.evictPublisherIfNeeded()
-
-	// Add to cache with a seed lease.
-	element := m.pubLru.PushFront(key)
-	entry := &publisherEntry{
-		client:   wrapped,
-		element:  element,
-		lastUsed: time.Now(),
-		key:      key,
-		refs:     1,
-		seedHeld: true,
-	}
-	m.publishers[key] = entry
-	m.pubMu.Unlock()
-
-	// Close the evicted client outside the lock so a slow Close() on the LRU victim
-	// does not block concurrent Publisher() calls for other keys.
-	if evicted != nil {
-		m.closeEvictedPublisher(evicted, "Error closing evicted publisher client")
-	}
-
-	m.logger.Info().
-		Str("key", key).
-		Msg("Created new publisher client")
-
-	return entry, nil
+	return newTenantAwarePublisher(client, key), nil
 }
 
 // createAMQPClient creates a new AMQP client for the given key
@@ -451,7 +303,7 @@ func (m *Manager) createAMQPClient(ctx context.Context, key string) (AMQPClient,
 // and logs (but does not propagate) any close failure. The primary error is
 // what the caller cares about; we keep the close failure observable for
 // forensics. The `phase` argument identifies which rollback site triggered
-// the close (e.g. "replay_declarations", "publisher_double_create_race").
+// the close (e.g. "replay_declarations", "declare_infrastructure").
 func (m *Manager) closeClientOnRollback(client AMQPClient, key, phase string) {
 	if err := client.Close(); err != nil {
 		m.logger.Error().
@@ -462,135 +314,24 @@ func (m *Manager) closeClientOnRollback(client AMQPClient, key, phase string) {
 	}
 }
 
-// evictPublisherIfNeeded removes the least recently used publisher from the
-// manager's bookkeeping if at capacity. Must be called with m.pubMu held. It
-// returns the evicted entry (or nil) so the caller can close it OUTSIDE the lock.
-func (m *Manager) evictPublisherIfNeeded() *publisherEntry {
-	if len(m.publishers) < m.maxPubs {
-		return nil
-	}
-
-	// Remove the least recently used publisher
-	oldest := m.pubLru.Back()
-	if oldest == nil {
-		return nil
-	}
-
-	key := oldest.Value.(string)
-	entry := m.publishers[key]
-
-	// Detach from cache (close happens outside the lock, and only when unleased)
-	delete(m.publishers, key)
-	m.pubLru.Remove(oldest)
-	entry.detached = true
-	m.evictions++
-
-	m.logger.Info().
-		Str("key", key).
-		Msg("Evicted publisher client due to LRU limit")
-
-	if entry.refs > 0 {
-		return nil // still leased — defer the close to the final lease release
-	}
-	entry.closed = true
-	return entry
-}
-
-// closeEvictedPublisher closes an evicted/idle publisher client and logs any close
-// error. It is always called WITHOUT m.pubMu held so a slow Close() cannot block
-// other callers.
-func (m *Manager) closeEvictedPublisher(entry *publisherEntry, logMsg string) {
-	if err := entry.client.Close(); err != nil {
-		m.logger.Error().
-			Err(err).
-			Str("key", entry.key).
-			Msg(logMsg)
-	}
-}
-
-// StartCleanup starts the background cleanup routine for idle publishers
+// StartCleanup starts the background cleanup routine for idle publishers. A non-positive
+// interval substitutes the documented 2-minute default.
 func (m *Manager) StartCleanup(interval time.Duration) {
+	if m.pubPool == nil {
+		return // zero-value manager: nothing to run, consistent with the other nil-pool guards
+	}
 	if interval <= 0 {
 		interval = 2 * time.Minute // default cleanup interval for publishers
 	}
-
-	m.cleanupMu.Lock()
-	if m.cleanupCh != nil {
-		m.cleanupMu.Unlock()
-		return
-	}
-	done := make(chan struct{})
-	m.cleanupCh = done
-	m.cleanupMu.Unlock()
-
-	go m.cleanupLoop(interval, done)
+	m.pubPool.StartCleanup(interval)
 }
 
 // StopCleanup stops the background cleanup routine
 func (m *Manager) StopCleanup() {
-	m.cleanupMu.Lock()
-	if m.cleanupCh == nil {
-		m.cleanupMu.Unlock()
-		return
+	if m.pubPool == nil {
+		return // zero-value manager: nothing to stop
 	}
-	close(m.cleanupCh)
-	m.cleanupCh = nil
-	m.cleanupMu.Unlock()
-}
-
-// cleanupLoop runs the periodic cleanup of idle publishers
-func (m *Manager) cleanupLoop(interval time.Duration, done <-chan struct{}) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			m.cleanupIdlePublishers()
-		case <-done:
-			return
-		}
-	}
-}
-
-// cleanupIdlePublishers removes publishers that have been idle longer than idleTTL.
-// Idle entries are detached from the manager's bookkeeping under the lock, then their
-// Close() calls run outside the lock so a slow teardown cannot block concurrent
-// Publisher() calls.
-func (m *Manager) cleanupIdlePublishers() {
-	m.pubMu.Lock()
-
-	now := time.Now()
-	var toClose []*publisherEntry
-
-	// Detach idle publishers from bookkeeping under the lock. A still-leased idle publisher
-	// is detached but its Close() is deferred to the final lease release (the #606 race).
-	for key, entry := range m.publishers {
-		if now.Sub(entry.lastUsed) <= m.idleTTL {
-			continue
-		}
-		delete(m.publishers, key)
-		m.pubLru.Remove(entry.element)
-		entry.detached = true
-		m.idleCleanups++
-
-		m.logger.Info().
-			Str("key", key).
-			Dur("idle_time", now.Sub(entry.lastUsed)).
-			Msg("Cleaned up idle publisher client")
-
-		if entry.refs > 0 {
-			continue // still leased — defer close to release
-		}
-		entry.closed = true
-		toClose = append(toClose, entry)
-	}
-	m.pubMu.Unlock()
-
-	// Close detached publishers outside the lock.
-	for _, entry := range toClose {
-		m.closeEvictedPublisher(entry, "Error closing idle publisher client")
-	}
+	m.pubPool.StopCleanup()
 }
 
 // StopConsumers stops every consumer registry from accepting new messages (canceling their
@@ -610,22 +351,20 @@ func (m *Manager) StopConsumers() {
 	}
 }
 
-// Close closes all clients and stops cleanup.
+// Close closes all clients and stops cleanup. Publisher closes go through the pool (which
+// stops its own cleanup loop and joins every per-publisher close failure); consumer closes
+// are handled directly. Every failure from BOTH sides is surfaced under the historical
+// "errors closing messaging clients" prefix.
 func (m *Manager) Close() error {
-	m.StopCleanup()
+	var allErrs []error
 
-	var errors []error
-
-	// Close all publishers
-	m.pubMu.Lock()
-	for key, entry := range m.publishers {
-		if err := entry.client.Close(); err != nil {
-			errors = append(errors, fmt.Errorf("error closing publisher for key %s: %w", key, err))
+	// Close all publishers via the pool. pool.Close stops the publisher cleanup loop (exactly
+	// once, via its closeOnce) and returns errors.Join of every per-publisher close failure.
+	if m.pubPool != nil {
+		if err := m.pubPool.Close(); err != nil {
+			allErrs = append(allErrs, err)
 		}
 	}
-	m.publishers = make(map[string]*publisherEntry)
-	m.pubLru.Init()
-	m.pubMu.Unlock()
 
 	// Close all consumers (and their registries)
 	m.consMu.Lock()
@@ -634,38 +373,44 @@ func (m *Manager) Close() error {
 			entry.registry.StopConsumers()
 		}
 		if err := entry.client.Close(); err != nil {
-			errors = append(errors, fmt.Errorf("error closing consumer for key %s: %w", key, err))
+			allErrs = append(allErrs, fmt.Errorf("error closing consumer for key %s: %w", key, err))
 		}
 	}
 	m.consumers = make(map[string]*consumerEntry)
 	m.consMu.Unlock()
 
-	if len(errors) > 0 {
-		return fmt.Errorf("errors closing messaging clients: %v", errors)
+	if len(allErrs) > 0 {
+		return fmt.Errorf("errors closing messaging clients: %w", errors.Join(allErrs...))
 	}
 
 	return nil
 }
 
-// Stats returns statistics about the messaging manager
+// Stats returns statistics about the messaging manager. Publisher counters come from the
+// pool; active_consumers comes from the directly-managed consumer map.
 func (m *Manager) Stats() map[string]any {
-	m.pubMu.RLock()
-	pubCount := len(m.publishers)
-	evictions := m.evictions
-	idleCleanups := m.idleCleanups
-	m.pubMu.RUnlock()
-
 	m.consMu.RLock()
 	consCount := len(m.consumers)
 	m.consMu.RUnlock()
 
+	// A zero-value Manager (not built via NewMessagingManager, e.g. the lightweight stand-in
+	// the debug/health endpoint uses) reports zero publisher stats rather than panicking.
 	stats := map[string]any{
-		"active_publishers": pubCount,
-		"max_publishers":    m.maxPubs,
+		"active_publishers": 0,
+		"max_publishers":    0,
 		"active_consumers":  consCount,
-		"idle_ttl_seconds":  int(m.idleTTL.Seconds()),
-		"evictions":         evictions,
-		"idle_cleanups":     idleCleanups,
+		"idle_ttl_seconds":  0,
+		"evictions":         0,
+		"idle_cleanups":     0,
+	}
+
+	if m.pubPool != nil {
+		ps := m.pubPool.Stats()
+		stats["active_publishers"] = ps.Size
+		stats["max_publishers"] = ps.MaxSize
+		stats["idle_ttl_seconds"] = int(ps.IdleTTL.Seconds())
+		stats["evictions"] = ps.Evictions
+		stats["idle_cleanups"] = ps.IdleCleanups
 	}
 
 	return stats

--- a/messaging/manager_test.go
+++ b/messaging/manager_test.go
@@ -190,285 +190,6 @@ func TestMessagingManagerInjectsTenantHeader(t *testing.T) {
 	assert.Equal(t, tenantID, client.lastPublish.Headers[tenantHeader])
 }
 
-func TestMessagingManagerSingleflightPublishers(t *testing.T) {
-	ctx := context.Background()
-	log := logger.New("error", false)
-
-	var mu sync.Mutex
-	calls := 0
-	factory := func(string, logger.Logger) AMQPClient {
-		mu.Lock()
-		calls++
-		mu.Unlock()
-		return &stubAMQPClient{}
-	}
-
-	manager := NewMessagingManager(&stubMessagingSource{urls: map[string]string{tenantID: amqpHost}}, log, ManagerOptions{MaxPublishers: 5, IdleTTL: time.Minute}, factory)
-
-	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			_, _, err := manager.Publisher(ctx, tenantID)
-			require.NoError(t, err)
-		}()
-	}
-	wg.Wait()
-	mu.Lock()
-	defer mu.Unlock()
-	assert.Equal(t, 1, calls)
-}
-
-func TestMessagingManagerCleanupEvictsIdlePublishers(t *testing.T) {
-	ctx := context.Background()
-	log := logger.New("error", false)
-
-	var mu sync.Mutex
-	closed := 0
-	// Slow Close on the idle publisher proves idle cleanup detaches bookkeeping
-	// under the lock and closes OUTSIDE it.
-	releaseClose := make(chan struct{})
-	factory := func(string, logger.Logger) AMQPClient {
-		return &stubAMQPClient{
-			closeHook: func() { <-releaseClose },
-			closeCallback: func() {
-				mu.Lock()
-				defer mu.Unlock()
-				closed++
-			},
-		}
-	}
-
-	manager := NewMessagingManager(&stubMessagingSource{urls: map[string]string{"idle": amqpURLIdle}}, log, ManagerOptions{MaxPublishers: 5, IdleTTL: 10 * time.Millisecond}, factory)
-	_, relIdle, err := manager.Publisher(ctx, "idle")
-	require.NoError(t, err)
-	// Release the lease so cleanup may actually close it (deferred-until-release, ADR-032).
-	relIdle()
-
-	time.Sleep(20 * time.Millisecond)
-
-	// Run cleanup in the background: the idle publisher's Close blocks until
-	// releaseClose. With close-under-lock this would stall every Publisher()/Stats().
-	done := make(chan struct{})
-	go func() {
-		manager.cleanupIdlePublishers()
-		close(done)
-	}()
-
-	// Bookkeeping is detached under the lock, so the publisher count drops to 0 even
-	// while its Close is still blocked.
-	assert.Eventually(t, func() bool {
-		manager.pubMu.RLock()
-		defer manager.pubMu.RUnlock()
-		return len(manager.publishers) == 0
-	}, time.Second, 5*time.Millisecond)
-
-	// Release the slow Close and let cleanup finish.
-	close(releaseClose)
-	<-done
-
-	mu.Lock()
-	defer mu.Unlock()
-	assert.Equal(t, 1, closed)
-}
-
-func TestMessagingManagerEvictsLRU(t *testing.T) {
-	ctx := context.Background()
-	log := logger.New("error", false)
-
-	var mu sync.Mutex
-	evicted := []string{}
-	// The LRU victim "a" (amqpURLA) uses a slow Close to assert eviction detaches
-	// bookkeeping under the lock and closes OUTSIDE it.
-	releaseClose := make(chan struct{})
-	factory := func(url string, _ logger.Logger) AMQPClient {
-		client := &stubAMQPClient{closeCallback: func() {
-			mu.Lock()
-			defer mu.Unlock()
-			evicted = append(evicted, url)
-		}}
-		if url == amqpURLA {
-			client.closeHook = func() { <-releaseClose }
-		}
-		return client
-	}
-
-	source := &stubMessagingSource{urls: map[string]string{
-		"a": amqpURLA,
-		"b": amqpURLB,
-		"c": amqpURLC,
-	}}
-
-	manager := NewMessagingManager(source, log, ManagerOptions{MaxPublishers: 2, IdleTTL: time.Minute}, factory)
-	_, relA, err := manager.Publisher(ctx, "a")
-	require.NoError(t, err)
-	_, _, err = manager.Publisher(ctx, "b")
-	require.NoError(t, err)
-	// Release "a"'s lease so eviction may actually close it — a leased publisher's close
-	// is deferred until its last lease is released (ADR-032).
-	relA()
-
-	// Publisher("c") evicts "a"; its Close blocks until releaseClose, so run it in the
-	// background. With close-under-lock this would hold m.pubMu and stall every Publisher.
-	done := make(chan struct{})
-	go func() {
-		_, _, gErr := manager.Publisher(ctx, "c")
-		assert.NoError(t, gErr)
-		close(done)
-	}()
-
-	// Bookkeeping is detached under the lock, so the publisher count stays at 2 even
-	// though the victim's Close is still blocked.
-	assert.Eventually(t, func() bool {
-		manager.pubMu.RLock()
-		defer manager.pubMu.RUnlock()
-		_, aStillCached := manager.publishers["a"]
-		return len(manager.publishers) == 2 && !aStillCached
-	}, time.Second, 5*time.Millisecond)
-
-	// Release the slow Close and let the eviction finish.
-	close(releaseClose)
-	<-done
-
-	mu.Lock()
-	defer mu.Unlock()
-	assert.Contains(t, evicted, amqpURLA)
-}
-
-// TestMessagingManagerEvictionWithSlowCloseDoesNotBlockConcurrentPublisher guards the
-// M3 audit finding: evictPublisherIfNeeded must NOT hold the publisher mutex while
-// closing the evicted client. A slow Close() on an evicted tenant's publisher must not
-// block a concurrent Publisher() that targets a different, still-cached tenant
-// (head-of-line blocking). Mirrors the collect-then-close pattern in cache/manager.go.
-func TestMessagingManagerEvictionWithSlowCloseDoesNotBlockConcurrentPublisher(t *testing.T) {
-	ctx := context.Background()
-	log := logger.New("error", false)
-
-	const slowClose = 200 * time.Millisecond
-	closeStarted := make(chan struct{})
-
-	factory := func(url string, _ logger.Logger) AMQPClient {
-		client := &stubAMQPClient{}
-		if url == amqpURLA {
-			// Tenant "a" is the LRU victim. Its Close blocks for slowClose to simulate
-			// a stuck connection teardown. Signal once so the test can race a Publisher.
-			var once sync.Once
-			client.closeHook = func() {
-				once.Do(func() { close(closeStarted) })
-				time.Sleep(slowClose)
-			}
-		}
-		return client
-	}
-
-	source := &stubMessagingSource{urls: map[string]string{
-		"a": amqpURLA,
-		"b": amqpURLB,
-		"c": amqpURLC,
-	}}
-
-	manager := NewMessagingManager(source, log, ManagerOptions{MaxPublishers: 2, IdleTTL: time.Minute}, factory)
-
-	_, relA, err := manager.Publisher(ctx, "a")
-	require.NoError(t, err)
-	_, _, err = manager.Publisher(ctx, "b")
-	require.NoError(t, err)
-	// Release "a"'s lease so the eviction can close it (deferred-until-release, ADR-032).
-	relA()
-
-	// Creating "c" evicts the LRU victim "a", whose Close blocks for slowClose.
-	go func() {
-		_, _, _ = manager.Publisher(ctx, "c")
-	}()
-
-	// Wait until the slow Close has actually begun before measuring.
-	select {
-	case <-closeStarted:
-	case <-time.After(time.Second):
-		t.Fatal("eviction Close never started")
-	}
-
-	// "b" is still cached: this Publisher only needs getExistingPublisher's lock. If
-	// eviction holds the publisher mutex across Close (the M3 bug), this blocks ~slowClose.
-	start := time.Now()
-	_, _, err = manager.Publisher(ctx, "b")
-	require.NoError(t, err)
-	elapsed := time.Since(start)
-
-	assert.Less(t, elapsed, slowClose/2,
-		"Publisher on a cached tenant must not block on another tenant's slow eviction Close (close-under-lock)")
-}
-
-// TestMessagingManagerCreatePublisherReturnsExistingOnDoubleCreate guards the
-// concurrent double-create branch in createPublisher: when another goroutine
-// populated the cache while this caller was building its client, createPublisher
-// must return the already-cached publisher and close the freshly-created client
-// outside the lock. Mirrors database's
-// TestCreateConnectionReturnsExistingInstanceWhenAlreadyCached.
-func TestMessagingManagerCreatePublisherReturnsExistingOnDoubleCreate(t *testing.T) {
-	ctx := context.Background()
-	log := logger.New("error", false)
-
-	// The freshly-created client that createPublisher builds; it must be closed
-	// once the cache is found already populated.
-	fresh := &stubAMQPClient{}
-	factory := func(string, logger.Logger) AMQPClient { return fresh }
-	manager := NewMessagingManager(&stubMessagingSource{urls: map[string]string{tenantID: amqpHost}}, log, ManagerOptions{MaxPublishers: 5, IdleTTL: time.Minute}, factory)
-
-	// Pre-seed the cache to simulate another goroutine winning the race.
-	existing := newTenantAwarePublisher(&stubAMQPClient{}, tenantID)
-	manager.pubMu.Lock()
-	element := manager.pubLru.PushFront(tenantID)
-	manager.publishers[tenantID] = &publisherEntry{client: existing, element: element, lastUsed: time.Now(), key: tenantID}
-	manager.pubMu.Unlock()
-
-	got, err := manager.createPublisher(ctx, tenantID)
-	require.NoError(t, err)
-	assert.Same(t, existing, got.client, "createPublisher must return the already-cached publisher")
-
-	fresh.closedMu.Lock()
-	closed := fresh.closed
-	fresh.closedMu.Unlock()
-	assert.True(t, closed, "the redundant freshly-created client must be closed on the double-create branch")
-}
-
-// TestMessagingManagerCleanupIdlePublishersLogsCloseError drives the close-error
-// branch of closeEvictedPublisher through the idle-cleanup path: the idle entry
-// is detached from bookkeeping and Close() is still attempted even when it returns
-// an error. Mirrors database's TestCleanupIdleConnectionsLogsCloseError.
-func TestMessagingManagerCleanupIdlePublishersLogsCloseError(t *testing.T) {
-	ctx := context.Background()
-	log := logger.New("error", false)
-
-	failing := &stubAMQPClient{closeErr: errors.New("broker fault on close")}
-	factory := func(string, logger.Logger) AMQPClient { return failing }
-	manager := NewMessagingManager(&stubMessagingSource{urls: map[string]string{"idle": amqpURLIdle}}, log, ManagerOptions{MaxPublishers: 5, IdleTTL: time.Hour}, factory)
-	defer func() { _ = manager.Close() }()
-
-	_, relIdle, err := manager.Publisher(ctx, "idle")
-	require.NoError(t, err)
-	// Release the lease so cleanup may close it (deferred-until-release, ADR-032).
-	relIdle()
-
-	// Backdate lastUsed so the cleanup pass sees the entry as idle.
-	manager.pubMu.Lock()
-	manager.publishers["idle"].lastUsed = time.Now().Add(-2 * time.Hour)
-	manager.pubMu.Unlock()
-
-	manager.cleanupIdlePublishers()
-
-	manager.pubMu.RLock()
-	n := len(manager.publishers)
-	manager.pubMu.RUnlock()
-	assert.Equal(t, 0, n, "idle publisher removed from cache despite Close() error")
-
-	failing.closedMu.Lock()
-	closed := failing.closed
-	failing.closedMu.Unlock()
-	assert.True(t, closed, "Close was attempted even though it returned an error")
-}
-
 func TestMessagingManagerEnsureConsumersIdempotent(t *testing.T) {
 	ctx := context.Background()
 	log := logger.New("error", false)
@@ -737,94 +458,9 @@ func TestMessagingManagerHashBasedIdempotency(t *testing.T) {
 	})
 }
 
-// TestMessagingManagerStartCleanupZeroIntervalDefaults verifies StartCleanup
-// substitutes the default 2-minute interval when given a non-positive value.
-// We can't assert the exact ticker period without timing flakiness, but we can
-// confirm StartCleanup wires up the loop (cleanupCh non-nil) and StopCleanup
-// then tears it down cleanly.
-func TestMessagingManagerStartCleanupZeroIntervalDefaults(t *testing.T) {
-	log := logger.New("error", false)
-	factory := func(string, logger.Logger) AMQPClient { return &stubAMQPClient{} }
-	manager := NewMessagingManager(&stubMessagingSource{}, log, ManagerOptions{MaxPublishers: 1, IdleTTL: time.Minute}, factory)
-
-	manager.StartCleanup(0)
-	manager.cleanupMu.Lock()
-	assert.NotNil(t, manager.cleanupCh, "StartCleanup should arm the cleanup loop even with interval=0 (defaults applied)")
-	manager.cleanupMu.Unlock()
-
-	manager.StopCleanup()
-}
-
-func TestMessagingManagerStartCleanupIdempotent(t *testing.T) {
-	log := logger.New("error", false)
-	factory := func(string, logger.Logger) AMQPClient { return &stubAMQPClient{} }
-	manager := NewMessagingManager(&stubMessagingSource{}, log, ManagerOptions{MaxPublishers: 1, IdleTTL: time.Minute}, factory)
-
-	manager.StartCleanup(50 * time.Millisecond)
-	manager.cleanupMu.Lock()
-	first := manager.cleanupCh
-	manager.cleanupMu.Unlock()
-	require.NotNil(t, first)
-
-	manager.StartCleanup(50 * time.Millisecond)
-	manager.cleanupMu.Lock()
-	second := manager.cleanupCh
-	manager.cleanupMu.Unlock()
-	assert.True(t, first == second, "second StartCleanup must be a no-op while a loop is already running (cleanupCh unchanged)")
-
-	manager.StopCleanup()
-}
-
-func TestMessagingManagerStopCleanupBeforeStartIsNoOp(t *testing.T) {
-	log := logger.New("error", false)
-	factory := func(string, logger.Logger) AMQPClient { return &stubAMQPClient{} }
-	manager := NewMessagingManager(&stubMessagingSource{}, log, ManagerOptions{MaxPublishers: 1, IdleTTL: time.Minute}, factory)
-
-	manager.StopCleanup()
-	manager.cleanupMu.Lock()
-	assert.Nil(t, manager.cleanupCh)
-	manager.cleanupMu.Unlock()
-}
-
-// TestMessagingManagerCleanupLoopEvictsOnTick exercises the cleanupLoop goroutine
-// end-to-end: arm a short interval, seed an idle publisher, wait for at least
-// one tick, then verify the entry was cleaned up.
-func TestMessagingManagerCleanupLoopEvictsOnTick(t *testing.T) {
-	ctx := context.Background()
-	log := logger.New("error", false)
-
-	var closed int
-	var mu sync.Mutex
-	factory := func(string, logger.Logger) AMQPClient {
-		return &stubAMQPClient{closeCallback: func() {
-			mu.Lock()
-			defer mu.Unlock()
-			closed++
-		}}
-	}
-
-	manager := NewMessagingManager(
-		&stubMessagingSource{urls: map[string]string{"idle": amqpURLIdle}},
-		log,
-		ManagerOptions{MaxPublishers: 5, IdleTTL: 10 * time.Millisecond},
-		factory,
-	)
-	_, relIdle, err := manager.Publisher(ctx, "idle")
-	require.NoError(t, err)
-	// Release the lease so the cleanup loop may close it (deferred-until-release, ADR-032).
-	relIdle()
-
-	manager.StartCleanup(20 * time.Millisecond)
-	t.Cleanup(manager.StopCleanup)
-
-	// Wait long enough for IdleTTL (10ms) + at least one cleanup tick (20ms).
-	require.Eventually(t, func() bool {
-		mu.Lock()
-		defer mu.Unlock()
-		return closed >= 1
-	}, time.Second, 10*time.Millisecond, "cleanup loop should evict the idle publisher within a few ticks")
-}
-
+// TestMessagingManagerCloseClosesPublishersAndConsumers drives Close through the public
+// surface and pins that it spans BOTH sides: every cached publisher AND every consumer
+// client is closed, the publisher pool is drained, and the consumer map is reset.
 func TestMessagingManagerCloseClosesPublishersAndConsumers(t *testing.T) {
 	ctx := context.Background()
 	log := logger.New("error", false)
@@ -861,31 +497,28 @@ func TestMessagingManagerCloseClosesPublishersAndConsumers(t *testing.T) {
 	require.NoError(t, manager.Close())
 
 	mu.Lock()
-	defer mu.Unlock()
-	assert.GreaterOrEqual(t, closedCount, 2, "Close should close at least the publisher clients")
+	got := closedCount
+	mu.Unlock()
+	// Two publisher clients + one consumer client.
+	assert.GreaterOrEqual(t, got, 3, "Close must close both publisher clients AND the consumer client")
 
-	// Cleanup loop should be stopped after Close.
-	manager.cleanupMu.Lock()
-	assert.Nil(t, manager.cleanupCh, "Close must stop the cleanup loop")
-	manager.cleanupMu.Unlock()
-
-	// Internal maps are reset.
-	manager.pubMu.RLock()
-	assert.Empty(t, manager.publishers)
-	manager.pubMu.RUnlock()
+	// Publisher pool drained and consumer map reset (Close stops the cleanup loop too — no panic).
+	assert.Equal(t, 0, manager.Stats()["active_publishers"], "Close must drain the publisher pool")
 	manager.consMu.RLock()
-	assert.Empty(t, manager.consumers)
+	assert.Empty(t, manager.consumers, "Close must reset the consumer map")
 	manager.consMu.RUnlock()
 }
 
 // TestMessagingManagerCloseSurfacesClientErrors checks the aggregated-error path
-// when a publisher Close() returns an error.
+// when a publisher Close() returns an error: it surfaces under the historical
+// "errors closing messaging clients" prefix, wrapping the underlying cause.
 func TestMessagingManagerCloseSurfacesClientErrors(t *testing.T) {
 	ctx := context.Background()
 	log := logger.New("error", false)
 
+	wantErr := errors.New("client close failed")
 	factory := func(string, logger.Logger) AMQPClient {
-		return &stubAMQPClient{closeCallback: func() {}}
+		return &stubAMQPClient{closeErr: wantErr}
 	}
 
 	manager := NewMessagingManager(
@@ -897,19 +530,39 @@ func TestMessagingManagerCloseSurfacesClientErrors(t *testing.T) {
 	_, _, err := manager.Publisher(ctx, tenant1ID)
 	require.NoError(t, err)
 
-	// Swap in a failing client behind the cache so Close() surfaces an aggregated error.
-	wantErr := errors.New("client close failed")
-	manager.pubMu.Lock()
-	for key, entry := range manager.publishers {
-		entry.client = &stubAMQPClient{closeErr: wantErr}
-		manager.publishers[key] = entry
-	}
-	manager.pubMu.Unlock()
-
 	err = manager.Close()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "errors closing messaging clients")
 	assert.Contains(t, err.Error(), wantErr.Error(), "aggregated error should include the underlying client-close message")
+	assert.ErrorIs(t, err, wantErr, "the wrapped cause must remain matchable with errors.Is")
+}
+
+// TestMessagingManagerCloseAggregatesErrors pins the aggregate Close contract: when MULTIPLE
+// cached publishers fail to close, Close surfaces EVERY failure (not just the first), under the
+// historical "errors closing messaging clients" prefix. Black-box via Publisher + Close.
+func TestMessagingManagerCloseAggregatesErrors(t *testing.T) {
+	ctx := context.Background()
+	log := logger.New("error", false)
+
+	// Distinct per-broker close errors so we can assert BOTH surface.
+	factory := func(url string, _ logger.Logger) AMQPClient {
+		return &stubAMQPClient{closeErr: errors.New("close failure " + url)}
+	}
+	source := &stubMessagingSource{urls: map[string]string{tenant1ID: amqpURLTenant1, tenant2ID: amqpURLTenant2}}
+	manager := NewMessagingManager(source, log, ManagerOptions{MaxPublishers: 5, IdleTTL: time.Minute}, factory)
+
+	_, relA, err := manager.Publisher(ctx, tenant1ID)
+	require.NoError(t, err)
+	relA()
+	_, relB, err := manager.Publisher(ctx, tenant2ID)
+	require.NoError(t, err)
+	relB()
+
+	err = manager.Close()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "errors closing messaging clients")
+	assert.Contains(t, err.Error(), "close failure "+amqpURLTenant1)
+	assert.Contains(t, err.Error(), "close failure "+amqpURLTenant2, "Close must surface ALL publisher close errors, not just the first")
 }
 
 // TestMessagingManagerCloseClientOnRollback verifies the load-bearing
@@ -932,7 +585,7 @@ func TestMessagingManagerCloseClientOnRollback(t *testing.T) {
 	t.Run("close errors are logged not propagated", func(t *testing.T) {
 		client := &stubAMQPClient{closeErr: errors.New("rollback close failed")}
 		// No panic, no return — failure observable via logger only.
-		manager.closeClientOnRollback(client, tenant1ID, "publisher_double_create_race")
+		manager.closeClientOnRollback(client, tenant1ID, "declare_infrastructure")
 
 		client.closedMu.Lock()
 		defer client.closedMu.Unlock()
@@ -940,6 +593,10 @@ func TestMessagingManagerCloseClientOnRollback(t *testing.T) {
 	})
 }
 
+// TestMessagingManagerStats drives Stats() through the public surface and pins every key,
+// including active_consumers (from the consumer map) and the evictions counter (surfaced from
+// the pool after an LRU eviction). The per-pool counter semantics are exercised directly in
+// internal/resourcepool; this pins the manager's map-key mapping.
 func TestMessagingManagerStats(t *testing.T) {
 	ctx := context.Background()
 	log := logger.New("error", false)
@@ -948,26 +605,68 @@ func TestMessagingManagerStats(t *testing.T) {
 	manager := NewMessagingManager(
 		&stubMessagingSource{urls: map[string]string{tenant1ID: amqpURLTenant1, tenant2ID: amqpURLTenant2}},
 		log,
-		ManagerOptions{MaxPublishers: 7, IdleTTL: 90 * time.Second},
+		ManagerOptions{MaxPublishers: 1, IdleTTL: 90 * time.Second},
 		factory,
 	)
+	defer func() { _ = manager.Close() }()
 
+	// Empty manager: full key set, publisher counters zero, config max/idle_ttl surfaced.
 	stats := manager.Stats()
 	assert.Equal(t, 0, stats["active_publishers"])
-	assert.Equal(t, 7, stats["max_publishers"])
+	assert.Equal(t, 1, stats["max_publishers"])
 	assert.Equal(t, 0, stats["active_consumers"])
 	assert.Equal(t, 90, stats["idle_ttl_seconds"])
+	assert.Equal(t, 0, stats["evictions"])
+	assert.Equal(t, 0, stats["idle_cleanups"])
 
-	_, _, err := manager.Publisher(ctx, tenant1ID)
+	// One live publisher.
+	_, rel1, err := manager.Publisher(ctx, tenant1ID)
 	require.NoError(t, err)
-	_, _, err = manager.Publisher(ctx, tenant2ID)
-	require.NoError(t, err)
+	rel1()
+	assert.Equal(t, 1, manager.Stats()["active_publishers"])
 
+	// MaxPublishers=1 forces the second key to evict the first: the evictions counter surfaces.
+	_, rel2, err := manager.Publisher(ctx, tenant2ID)
+	require.NoError(t, err)
+	rel2()
 	stats = manager.Stats()
-	assert.Equal(t, 2, stats["active_publishers"])
+	assert.Equal(t, 1, stats["active_publishers"], "eviction keeps the pool at its cap")
+	assert.Equal(t, 1, stats["evictions"], "LRU eviction increments the evictions counter surfaced by Stats")
+	assert.Equal(t, 0, stats["idle_cleanups"], "LRU eviction must not bump idle_cleanups")
+}
+
+// TestMessagingManagerStatsTracksIdleCleanups pins that Stats() surfaces the pool's idle-cleanup
+// counter under the "idle_cleanups" key with a NON-zero value — the sibling of the "evictions" pin
+// above. A released publisher left idle past the TTL is reaped by the pool's cleanup loop, and that
+// count must reach the manager's map (guarding against a mismapping to an always-zero field).
+func TestMessagingManagerStatsTracksIdleCleanups(t *testing.T) {
+	ctx := context.Background()
+	log := logger.New("error", false)
+	factory := func(string, logger.Logger) AMQPClient { return &stubAMQPClient{} }
+	manager := NewMessagingManager(
+		&stubMessagingSource{urls: map[string]string{tenant1ID: amqpURLTenant1}},
+		log,
+		ManagerOptions{MaxPublishers: 5, IdleTTL: 10 * time.Millisecond},
+		factory,
+	)
+	defer func() { _ = manager.Close() }()
+
+	_, rel, err := manager.Publisher(ctx, tenant1ID)
+	require.NoError(t, err)
+	rel() // release so the idle publisher becomes eligible for cleanup
+
+	manager.StartCleanup(10 * time.Millisecond)
+	defer manager.StopCleanup()
+
+	assert.Eventually(t, func() bool {
+		count, _ := manager.Stats()["idle_cleanups"].(int)
+		return count >= 1
+	}, 2*time.Second, 20*time.Millisecond, "Stats must surface the pool's idle-cleanup count under idle_cleanups")
 }
 
 // --- Lease/refcount: eviction-while-in-use race (issue #606, ADR-032) ---
+// The lease/evict/close protocol itself is exercised directly in internal/resourcepool;
+// these black-box helpers drive the manager's public Publisher/Close surface.
 
 // leasedClosableFactory builds publisher clients that record each Close() in the shared
 // `closed` map (keyed by broker URL) under `mu`.
@@ -1005,173 +704,83 @@ func TestMessagingManagerPublisherReturnsNonNilReleaseFunc(t *testing.T) {
 	assert.False(t, wasClosed, "releasing a lease on a live cached publisher must not close it")
 }
 
-func TestMessagingManagerEvictionWhileLeasedDefersCloseUntilRelease(t *testing.T) {
+// TestMessagingManagerPublisherAfterCloseReturnsError pins the F22 fix: once Close() has run,
+// Publisher() fails closed (returning the manager's closed error) instead of resurrecting a
+// publisher on a shut-down manager. The resourcepool closed guard supplies this; before the
+// rewire, Publisher would silently create and leak a fresh publisher.
+func TestMessagingManagerPublisherAfterCloseReturnsError(t *testing.T) {
 	ctx := context.Background()
 	var mu sync.Mutex
 	closed := map[string]bool{}
 	m := NewMessagingManager(twoPublisherSource(), logger.New("error", false),
-		ManagerOptions{MaxPublishers: 1, IdleTTL: time.Minute}, leasedClosableFactory(&mu, closed))
-	defer func() { _ = m.Close() }()
+		ManagerOptions{MaxPublishers: 5, IdleTTL: time.Minute}, leasedClosableFactory(&mu, closed))
+	require.NoError(t, m.Close())
 
-	_, releaseA, err := m.Publisher(ctx, "a")
-	require.NoError(t, err)
-
-	_, releaseB, err := m.Publisher(ctx, "b") // evicts "a", which is still leased
-	require.NoError(t, err)
-	defer releaseB()
-
-	mu.Lock()
-	closedWhileLeased := closed[amqpURLA]
-	mu.Unlock()
-	assert.False(t, closedWhileLeased,
-		"an evicted-but-leased publisher must not be closed while a lease is held (the #606 race)")
-
-	releaseA()
-	mu.Lock()
-	closedAfterRelease := closed[amqpURLA]
-	mu.Unlock()
-	assert.True(t, closedAfterRelease,
-		"an evicted publisher must be closed once its last lease is released")
+	pub, release, err := m.Publisher(ctx, "a")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errManagerClosed, "Publisher after Close must fail closed, not resurrect a publisher (F22)")
+	assert.Nil(t, pub)
+	assert.Nil(t, release)
 }
 
-func TestMessagingManagerTwoLeasesKeepPublisherAliveUntilBothReleased(t *testing.T) {
-	ctx := context.Background()
-	var mu sync.Mutex
-	closed := map[string]bool{}
-	m := NewMessagingManager(twoPublisherSource(), logger.New("error", false),
-		ManagerOptions{MaxPublishers: 1, IdleTTL: time.Minute}, leasedClosableFactory(&mu, closed))
-	defer func() { _ = m.Close() }()
+// TestMessagingManagerZeroValueMethodsAreSafe pins that a zero-value Manager (never built via
+// NewMessagingManager — the lightweight stand-in the debug/health endpoint uses) does not panic
+// on any of Stats/Publisher/StartCleanup/StopCleanup/Close, matching the pre-resourcepool
+// nil-map-safe behavior (Publisher is guarded to fail closed rather than panic).
+func TestMessagingManagerZeroValueMethodsAreSafe(t *testing.T) {
+	m := &Manager{}
 
-	_, release1, err := m.Publisher(ctx, "a")
-	require.NoError(t, err)
-	_, release2, err := m.Publisher(ctx, "a") // same key, second borrower → refcount 2
-	require.NoError(t, err)
-
-	_, releaseB, err := m.Publisher(ctx, "b") // evict "a"
-	require.NoError(t, err)
-	defer releaseB()
-
-	release1()
-	mu.Lock()
-	closedAfterFirst := closed[amqpURLA]
-	mu.Unlock()
-	assert.False(t, closedAfterFirst, "publisher must stay open while a second lease is outstanding")
-
-	release2()
-	mu.Lock()
-	closedAfterSecond := closed[amqpURLA]
-	mu.Unlock()
-	assert.True(t, closedAfterSecond, "publisher must close when the final lease is released")
-}
-
-func TestMessagingManagerPublisherReleaseIsIdempotent(t *testing.T) {
-	ctx := context.Background()
-	var mu sync.Mutex
-	closed := map[string]bool{}
-	m := NewMessagingManager(twoPublisherSource(), logger.New("error", false),
-		ManagerOptions{MaxPublishers: 1, IdleTTL: time.Minute}, leasedClosableFactory(&mu, closed))
-	defer func() { _ = m.Close() }()
-
-	_, releaseA, err := m.Publisher(ctx, "a")
-	require.NoError(t, err)
-	_, releaseB, err := m.Publisher(ctx, "b") // evict "a"
-	require.NoError(t, err)
-	defer releaseB()
-
-	assert.NotPanics(t, func() {
-		releaseA()
-		releaseA() // double release must be a safe no-op
-	})
-}
-
-// TestMessagingManagerColdRecreateAfterIdleEviction reproduces the issue #655
-// timeline: a once-daily publisher goes idle past IdleTTL, gets evicted, and
-// the NEXT Publisher() call must hand back a freshly created (cold) client
-// rather than reusing the evicted one. This is not a fail-on-main regression
-// test (stubAMQPClient has no not-ready state to model the readiness bug
-// itself — see Task 1.1's client-level tests for that); it documents and
-// locks in the eviction → cold-recreate sequence that triggers the bug.
-func TestMessagingManagerColdRecreateAfterIdleEviction(t *testing.T) {
-	ctx := context.Background()
-	log := logger.New("error", false)
-
-	var mu sync.Mutex
-	created := make([]*stubAMQPClient, 0, 2)
-	factory := func(string, logger.Logger) AMQPClient {
-		c := &stubAMQPClient{}
-		mu.Lock()
-		created = append(created, c)
-		mu.Unlock()
-		return c
-	}
-
-	manager := NewMessagingManager(&stubMessagingSource{urls: map[string]string{tenantID: amqpHost}}, log, ManagerOptions{MaxPublishers: 5, IdleTTL: time.Hour}, factory)
-	defer func() { _ = manager.Close() }()
-
-	first, relFirst, err := manager.Publisher(ctx, tenantID)
-	require.NoError(t, err)
-	relFirst()
-
-	// Backdate lastUsed so the cleanup pass sees the entry as idle, mirroring
-	// TestMessagingManagerCleanupIdlePublishersLogsCloseError's idiom.
-	manager.pubMu.Lock()
-	manager.publishers[tenantID].lastUsed = time.Now().Add(-2 * time.Hour)
-	manager.pubMu.Unlock()
-
-	manager.cleanupIdlePublishers()
-
-	second, relSecond, err := manager.Publisher(ctx, tenantID)
-	require.NoError(t, err)
-	defer relSecond()
-
-	mu.Lock()
-	defer mu.Unlock()
-	require.Len(t, created, 2, "idle eviction must force a fresh client on the next Publisher() call")
-	assert.NotSame(t, first, second, "publisher after idle eviction must be a newly created (cold) client")
-}
-
-// TestMessagingManagerStatsTracksEvictionsAndIdleCleanups mirrors
-// cache.ManagerStats' Evictions/IdleCleanups counters (cache/manager.go),
-// exposed here as additional keys on messaging's existing map[string]any
-// Stats() (changing its return type would be a breaking API change).
-func TestMessagingManagerStatsTracksEvictionsAndIdleCleanups(t *testing.T) {
-	ctx := context.Background()
-	log := logger.New("error", false)
-
-	factory := func(string, logger.Logger) AMQPClient { return &stubAMQPClient{} }
-	manager := NewMessagingManager(
-		&stubMessagingSource{urls: map[string]string{tenant1ID: amqpURLTenant1, tenant2ID: amqpURLTenant2}},
-		log,
-		ManagerOptions{MaxPublishers: 1, IdleTTL: time.Hour},
-		factory,
-	)
-	defer func() { _ = manager.Close() }()
-
-	stats := manager.Stats()
+	stats := m.Stats()
+	assert.Equal(t, 0, stats["active_publishers"])
+	assert.Equal(t, 0, stats["max_publishers"])
+	assert.Equal(t, 0, stats["active_consumers"])
+	assert.Equal(t, 0, stats["idle_ttl_seconds"])
 	assert.Equal(t, 0, stats["evictions"])
 	assert.Equal(t, 0, stats["idle_cleanups"])
 
-	// LRU eviction: MaxPublishers=1 forces the second Publisher() call to evict the first.
-	_, rel1, err := manager.Publisher(ctx, tenant1ID)
-	require.NoError(t, err)
-	rel1()
-	_, rel2, err := manager.Publisher(ctx, tenant2ID)
-	require.NoError(t, err)
-	rel2()
+	pub, release, err := m.Publisher(context.Background(), "any")
+	assert.ErrorIs(t, err, errManagerClosed, "zero-value Publisher must fail closed, not panic")
+	assert.Nil(t, pub)
+	assert.Nil(t, release)
 
-	stats = manager.Stats()
-	assert.Equal(t, 1, stats["evictions"])
-	assert.Equal(t, 0, stats["idle_cleanups"], "LRU eviction must not bump idle_cleanups")
+	assert.NotPanics(t, func() {
+		m.StartCleanup(time.Minute)
+		m.StopCleanup()
+	}, "zero-value StartCleanup/StopCleanup must be no-ops, not panic")
 
-	// Idle cleanup: backdate the survivor's lastUsed and run cleanup directly.
-	manager.pubMu.Lock()
-	manager.publishers[tenant2ID].lastUsed = time.Now().Add(-2 * time.Hour)
-	manager.pubMu.Unlock()
-	manager.cleanupIdlePublishers()
+	assert.NoError(t, m.Close(), "closing a never-initialized manager is a no-op")
+}
 
-	stats = manager.Stats()
-	assert.Equal(t, 1, stats["idle_cleanups"])
-	assert.Equal(t, 1, stats["evictions"], "idle cleanup must not bump evictions")
+// TestMessagingManagerStartCleanupIsIdempotent pins that a second StartCleanup observes the
+// already-running pool cleanup loop and short-circuits, and StopCleanup is a safe no-op when
+// called again. The manager's StartCleanup is a thin passthrough to the pool.
+func TestMessagingManagerStartCleanupIsIdempotent(t *testing.T) {
+	factory := func(string, logger.Logger) AMQPClient { return &stubAMQPClient{} }
+	m := NewMessagingManager(&stubMessagingSource{}, logger.New("error", false),
+		ManagerOptions{MaxPublishers: 1, IdleTTL: time.Hour}, factory)
+	defer func() { _ = m.Close() }()
+
+	m.StartCleanup(10 * time.Second)
+	require.NotPanics(t, func() { m.StartCleanup(10 * time.Second) })
+
+	m.StopCleanup()
+	require.NotPanics(t, func() { m.StopCleanup() })
+}
+
+// TestMessagingManagerStartCleanupAppliesDefaultForNonPositive pins the manager-specific
+// default-interval substitution (2 minutes) for a non-positive interval. We can't inspect the
+// ticker directly, so the contract is "no panic + clean stop".
+func TestMessagingManagerStartCleanupAppliesDefaultForNonPositive(t *testing.T) {
+	factory := func(string, logger.Logger) AMQPClient { return &stubAMQPClient{} }
+	m := NewMessagingManager(&stubMessagingSource{}, logger.New("error", false),
+		ManagerOptions{MaxPublishers: 1, IdleTTL: time.Hour}, factory)
+	defer func() { _ = m.Close() }()
+
+	require.NotPanics(t, func() { m.StartCleanup(0) })
+	m.StopCleanup()
+
+	require.NotPanics(t, func() { m.StartCleanup(-5 * time.Second) })
+	m.StopCleanup()
 }
 
 // TestNewMessagingManagerDefaultFactoryForwardsReconnectOptions pins that the


### PR DESCRIPTION
## What

Final PR of the ADR-032 extraction (after #748 pool+cache, #750 database). Rewires **only the messaging PUBLISHER pool** onto the shared `resourcepool.Pool[AMQPClient]`, deleting the triplicated lease/refcount/LRU/idle-evict machinery, and **closes backlog F22 for messaging**: `Publisher()` after `Close()` fails closed instead of resurrecting a leaked publisher. **The consumer side is untouched.**

## Scope

- `messaging/manager.go` — publisher pool → thin adapter; `createPublisher` (client + tenant-wrap) moves into the pool create callback. Consumer path (`EnsureConsumers`/`consumers`/`registry`, incl. plan-034's `setupCtx`) is byte-identical.
- `messaging/manager_test.go` — publisher-machinery white-box tests **superseded** by the direct `internal/resourcepool` suite (deleted); manager-specific tests **rewritten black-box**; consumer tests unchanged.
- `messaging/amqp_client.go` — one comment fix (removed a reference to the deleted `pubMu` field).
- `internal/resourcepool/resourcepool_test.go` — one added pool test (see M3 below).

## Behavior preserved (the delicate parts — messaging owns two pools)

- **`Close()` spans both.** Publisher closes go through `pubPool.Close()` (stops the cleanup loop exactly once, joins per-publisher failures); consumer closes stay in their loop; both aggregate under the original `"errors closing messaging clients"` prefix with `%w` + `errors.Join`.
- **`Stats()` blends** pool counters (`active_publishers`/`max_publishers`/`evictions`/`idle_cleanups`/`idle_ttl_seconds`) with `active_consumers` from the consumer map — every key preserved.
- **Zero-value safety:** all five publisher-pool-dereferencing methods (`Publisher`/`Stats`/`Close`/`StartCleanup`/`StopCleanup`) nil-guard the pool (the health endpoint uses a zero-value `Manager{}` stand-in).
- `go doc ./messaging Manager` unchanged (apidiff-gated; no `!`).

## Review

An opus panel (behavior-equivalence + test-migration fidelity vs `e6dacaa`) confirmed the consumer side is byte-identical and drove two hardening fixes:
- **`TestPoolSlowCloseDoesNotBlockConcurrentGet`** — re-covers the audit's **M3** property (a slow close on an evicted entry runs outside the pool lock, so it can't head-of-line-block a concurrent `Get` on another key) where it now lives. Deterministic, `-race ×5` stable.
- **`TestMessagingManagerStatsTracksIdleCleanups`** — pins the `idle_cleanups` key to a **non-zero** value (the migrated Stats test only pinned `0`).

**Known deliberate reduction** (consistent with the database rewire): publisher close errors lose their per-key label (the pool closer receives only the client value); error coverage + prefix preserved, consumer errors still labeled. Documented at the closer.

## Verification

`make check` green; `messaging` + `internal/resourcepool` + `cache` + `database` + `app` all pass `-race`. Net **−593 LoC**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved messaging client lifecycle management during publisher eviction, idle cleanup, and shutdown.
  * Prevented slow client cleanup from blocking new publisher acquisitions.
  * Publisher requests now fail safely after the messaging manager is closed or unavailable.
  * Shutdown now reports multiple client-close errors together while preserving individual error details.

* **Improvements**
  * Publisher statistics and cleanup metrics now remain accurate across lifecycle events.
  * Cleanup startup and shutdown are safer and more predictable, including repeated or invalid configuration calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->