### PR TITLE
ci(release): scripted go-bricks-migrate CLI tag cut + drift-issue auto-close

### DIFF
--- a/.github/workflows/migrate-cli-tag.yml
+++ b/.github/workflows/migrate-cli-tag.yml
@@ -1,0 +1,55 @@
+name: Migrate CLI Tag
+on:
+  push:
+    tags:
+      - 'tools/migration/v*'
+permissions:
+  contents: read
+concurrency:
+  group: migrate-cli-tag-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  close-drift-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # needed to search for and close the drift-tracking issue once the CLI tag is fresh
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Close the CLI-tag drift issue once the CLI tag is fresh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force --quiet
+          cli_ver="${TAG#tools/migration/}"
+          latest_fw="$(git tag --list 'v*' --sort=-v:refname | head -1 || true)"
+          if [ -z "$latest_fw" ]; then
+            echo "no framework tag to compare against — nothing to do"; exit 0
+          fi
+          # Fresh iff the just-pushed CLI version >= the latest framework release.
+          # (Same sort -V idiom as release.yml's freshness check.)
+          if [ "$(printf '%s\n%s\n' "$latest_fw" "$cli_ver" | sort -V | head -1)" != "$latest_fw" ]; then
+            echo "CLI $cli_ver still trails framework $latest_fw — leaving any drift issue open"; exit 0
+          fi
+          echo "CLI $cli_ver is fresh vs framework $latest_fw — closing any open drift issue"
+          nums="$(gh issue list --state open --search 'chore(migrate): cut the tools/migration CLI tag in:title' --json number --jq '.[].number')"
+          if [ -z "$nums" ]; then
+            echo "no open drift issue (ok)"; exit 0
+          fi
+          close_failed=0
+          for n in $nums; do
+            if ! gh issue close "$n" \
+              --comment "Resolved by \`$TAG\`: the go-bricks-migrate CLI is now at $cli_ver, matching framework release $latest_fw. Auto-closed by migrate-cli-tag.yml."
+            then
+              echo "could not close #$n"
+              close_failed=1
+            fi
+          done
+          exit "$close_failed"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all help build test test-integration test-all test-coverage test-coverage-integration test-coverage-combined coverage-report lint fmt update clean check docker-check vuln sec release
+.PHONY: all help build test test-integration test-all test-coverage test-coverage-integration test-coverage-combined coverage-report lint fmt update clean check docker-check vuln sec release release-cli
 
 # Package selection for testing (excludes tools directories)
 PKGS := $(shell go list ./... | grep -vE '/(tools)(/|$$)')
@@ -99,3 +99,7 @@ sec: ## Run gosec security scanner (pinned; identical to CI)
 release: ## Cut a signed release tag (usage: make release VERSION=v0.38.0). Run AFTER merging the release-please PR. Requires 1Password unlocked.
 	@test -n "$(VERSION)" || { echo "Error: VERSION is required, e.g. 'make release VERSION=v0.38.0'"; exit 1; }
 	@VERSION=$(VERSION) ./scripts/release.sh
+
+release-cli: ## Cut a signed go-bricks-migrate CLI tag (usage: make release-cli VERSION=v0.53.0). Run AFTER the framework tag is on the module proxy. Requires 1Password unlocked.
+	@test -n "$(VERSION)" || { echo "Error: VERSION is required, e.g. 'make release-cli VERSION=v0.53.0'"; exit 1; }
+	@VERSION="$(VERSION)" ./scripts/release-cli.sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -110,19 +110,26 @@ retract v0.38.0 // <reason>; use v0.38.1+
 
 ## 6. The go-bricks-migrate CLI
 
-Released manually at the same number as the framework, **after** the framework tag is on the
-module proxy:
+Released manually at the same number as the framework, **after** the framework
+tag is on the module proxy and `tools/migration/go.mod` pins that framework
+version on `main` (Renovate usually lands the pin automatically):
 
 ```bash
-go list -m github.com/gaborage/go-bricks@v0.38.0          # wait until this resolves
-GOWORK=off go -C tools/migration get github.com/gaborage/go-bricks@v0.38.0
-GOWORK=off go -C tools/migration mod tidy
-git commit -S -am "chore(migrate): pin go-bricks v0.38.0"
-git tag -s tools/migration/v0.38.0 -m "go-bricks-migrate v0.38.0"
-git push origin tools/migration/v0.38.0
+go list -m github.com/gaborage/go-bricks@v0.53.0   # wait until this resolves
+make release-cli VERSION=v0.53.0                    # requires 1Password unlocked
 ```
 
-The release workflow's `publish` job checks this obligation on every framework tag: if the newest `tools/migration/v*` tag trails the *previous* framework release, it emits a workflow warning and opens/updates a `chore(migrate): cut the tools/migration CLI tag` issue. The tag cut itself stays manual and signed — CI never creates tags.
+`make release-cli` is **read-and-verify-then-sign-and-push**: it asserts
+`VERSION == the go-bricks version pinned in tools/migration/go.mod`, that the
+framework tag resolves on the proxy, that `go mod tidy` is a no-op (the pin is
+already committed), and that the CLI tag is absent + strictly greater than the
+latest; runs the full `GOWORK=off make -C tools/migration check` + `sec` gate
+against the *released* framework; probes signing; creates a **signed annotated**
+tag `tools/migration/vX.Y.Z`; verifies the signature against
+`.github/allowed_signers`; and pushes. It does **not** create a GitHub Release
+(the CLI tag is a plain signed tag; no workflow publishes it).
+
+The release workflow's `publish` job checks this obligation on every framework tag: if the newest `tools/migration/v*` tag trails the *previous* framework release, it emits a workflow warning and opens/updates a `chore(migrate): cut the tools/migration CLI tag` issue. The tag cut itself stays manual and signed — CI never creates tags. Once a fresh `tools/migration/v*` tag is pushed, `migrate-cli-tag.yml` auto-closes that issue.
 
 ## 7. Security properties NOT yet provided (Phase 2)
 

--- a/scripts/release-cli.sh
+++ b/scripts/release-cli.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Cut a signed release tag for the go-bricks-migrate CLI (tools/migration).
+# See RELEASING.md §6. Usage: make release-cli VERSION=v0.53.0
+# Run AFTER the framework tag vX.Y.Z is on the module proxy AND
+# tools/migration/go.mod pins go-bricks vX.Y.Z on main.
+set -euo pipefail
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+ROOT="$(git rev-parse --show-toplevel)" || die "not in a git repo"
+cd "$ROOT"
+
+VERSION="${VERSION:-}"
+[ -n "$VERSION" ] || die "VERSION is required, e.g. VERSION=v0.53.0"
+TAG="tools/migration/$VERSION"
+
+# 1. strict pre-1.0 semver (widen at v1.0)
+[[ "$VERSION" =~ ^v0\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] \
+  || die "VERSION '$VERSION' is not strict v0.MINOR.PATCH (pre-1.0 only)"
+
+# 2. reconciliation: the CLI has no release-please manifest — its version source
+#    of truth is the go-bricks version pinned in tools/migration/go.mod (the CLI
+#    is released at the same number as the framework it links).
+PINNED="$(grep -oE 'gaborage/go-bricks v[0-9]+\.[0-9]+\.[0-9]+' tools/migration/go.mod | grep -oE 'v[0-9.]+' | head -1 || true)"
+[ "$PINNED" = "$VERSION" ] \
+  || die "VERSION ($VERSION) != go-bricks pinned in tools/migration/go.mod (${PINNED:-none}). Cut the CLI tag at the version its go.mod pins."
+
+# 3. on main, clean tree
+[ "$(git rev-parse --abbrev-ref HEAD)" = main ] || die "not on main"
+[ -z "$(git status --porcelain)" ] || die "working tree is dirty"
+
+# 4. gh authenticated AND can read this repo (keyring flips work/personal)
+gh auth status >/dev/null 2>&1 || die "gh not authenticated; run: gh auth login"
+gh repo view gaborage/go-bricks --json name >/dev/null 2>&1 \
+  || die "active gh account cannot read gaborage/go-bricks; run: gh auth switch -u gaborage"
+
+# 5. in sync with origin/main (fetch FIRST so the compare isn't stale)
+git fetch --quiet --prune --tags origin
+LOCAL_SHA="$(git rev-parse HEAD)"
+[ "$LOCAL_SHA" = "$(git rev-parse origin/main)" ] || die "local main not in sync with origin/main; git pull"
+
+# 6. the framework tag must be resolvable on the module proxy (RELEASING.md §6 precondition)
+GOWORK=off go list -m "github.com/gaborage/go-bricks@$VERSION" >/dev/null 2>&1 \
+  || die "go-bricks $VERSION is not resolvable on the module proxy yet; wait and retry"
+
+# 7. the pin must be tidy — no redundant commit needed (Renovate/PR already landed it)
+GOWORK=off go -C tools/migration mod tidy
+[ -z "$(git status --porcelain tools/migration/go.mod tools/migration/go.sum)" ] \
+  || { git checkout -- tools/migration/go.mod tools/migration/go.sum; die "go mod tidy rewrote tools/migration/go.mod/go.sum — the pin on main is not tidy; fix via a normal PR first"; }
+
+# 8. CLI tag absent locally + on origin + strictly greater than the latest CLI tag
+git rev-parse -q --verify "refs/tags/$TAG" >/dev/null 2>&1 && die "tag $TAG already exists locally"
+git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1 && die "tag $TAG already exists on origin"
+LATEST_CLI="$(git tag -l 'tools/migration/v0.*' --sort=-v:refname | head -n1)"
+if [ -n "$LATEST_CLI" ]; then
+  LATEST_VER="${LATEST_CLI#tools/migration/}"
+  { [ "$VERSION" != "$LATEST_VER" ] && [ "$(printf '%s\n%s\n' "$LATEST_VER" "$VERSION" | sort -V | tail -n1)" = "$VERSION" ]; } \
+    || die "VERSION ($VERSION) must be strictly greater than latest CLI tag ($LATEST_VER)"
+fi
+
+# 9. CI status for THIS commit — ADVISORY only. The migrate-tool jobs are
+#    path-skipped when HEAD didn't touch tools/migration, and the local gate
+#    (step 10) re-verifies the CLI against the released framework regardless.
+CI_STATUS="$(gh run list --workflow ci-v2.yml --branch main --commit "$LOCAL_SHA" --limit 20 \
+  --json headSha,status,conclusion \
+  --jq '[.[] | select(.headSha=="'"$LOCAL_SHA"'")] | (map(select(.status=="completed")) | first) // .[0] | if . == null then "absent" else "\(.status):\(.conclusion // "none")" end' 2>/dev/null || echo "absent")"
+case "$CI_STATUS" in
+  completed:success)
+    echo "CI green for $LOCAL_SHA" ;;
+  completed:failure|completed:cancelled|completed:timed_out|completed:startup_failure|completed:action_required)
+    die "CI for $LOCAL_SHA is '$CI_STATUS' — fix before releasing" ;;
+  *)
+    echo "WARN: CI status '$CI_STATUS' for $LOCAL_SHA — proceeding (the local gate below re-verifies the CLI against the released framework)" ;;
+esac
+
+# 10. full local gate against the RELEASED framework. GOWORK=off is MANDATORY —
+#     go.work would otherwise build the CLI against local framework source.
+GOWORK=off make -C tools/migration check
+GOWORK=off make -C tools/migration sec
+# a fmt inside 'check' that rewrote tracked files means the commit isn't fmt-clean,
+# yet the tag would point at the un-rewritten commit. Fail loudly.
+[ -z "$(git status --porcelain)" ] \
+  || { git checkout -- .; die "the CLI gate (fmt) modified tracked files; the commit is not fmt-clean. Fix on main first."; }
+
+# 11. signing probe BEFORE mutating refs (cleans up even if interrupted)
+PROBE="_release-cli-sign-probe-$$"
+trap 'git tag -d "$PROBE" >/dev/null 2>&1 || true' EXIT INT TERM
+git tag -s -m "signing probe" "$PROBE" HEAD \
+  || die "signing failed — unlock 1Password / start the SSH agent and retry. NEVER use --no-sign."
+git tag -d "$PROBE" >/dev/null 2>&1 || true
+trap - EXIT
+
+# 12. signed annotated tag. -s is MANDATORY.
+git tag -s "$TAG" -m "go-bricks-migrate $VERSION"
+
+# 13. BLOCKING local signature verify against the REPO allowlist — the same trust
+#     root CI uses (.github/allowed_signers), NOT personal git config.
+git -c gpg.format=ssh -c gpg.ssh.allowedSignersFile=.github/allowed_signers tag -v "$TAG" \
+  || { git tag -d "$TAG"; die "tag signature failed local verify against .github/allowed_signers (key/principal mismatch?) — tag deleted"; }
+
+# 14. push the tag. Fires migrate-cli-tag.yml (Part B), which closes the drift issue once fresh.
+git push origin "$TAG" || { git tag -d "$TAG"; die "tag push failed; local tag removed — re-run: make release-cli VERSION=$VERSION"; }
+echo "Pushed $TAG. If a CLI-tag drift issue was open, migrate-cli-tag.yml will close it once it confirms freshness."


### PR DESCRIPTION
## What

Hardens the `go-bricks-migrate` CLI (`tools/migration`) release lifecycle so cutting its tag is a single guarded command and the drift-tracking issue closes itself. Two independent, self-contained commits:

**Commit 1 — `ci(release): add make release-cli for a guarded signed CLI tag cut`**
- New `scripts/release-cli.sh` + `make release-cli VERSION=vX.Y.Z`, mirroring `scripts/release.sh`'s guard structure for the framework tag. Before it signs/pushes a `tools/migration/vX.Y.Z` tag it asserts: strict pre-1.0 semver; `VERSION` == the `go-bricks` version pinned in `tools/migration/go.mod` (the CLI's version source of truth — it has no release-please manifest); on `main` + clean tree + in sync with `origin/main`; the framework tag resolves on the module proxy; `go mod tidy` is a no-op; the CLI tag is absent locally/on origin and strictly greater than the latest; runs the full `GOWORK=off make -C tools/migration check` + `sec` gate against the *released* framework; then a signing probe, the signed annotated tag, a blocking signature verify against `.github/allowed_signers`, and push-with-cleanup.
- `RELEASING.md` §6 updated to the one-command path.

**Commit 2 — `ci(release): auto-close the CLI-tag drift issue on a fresh tag`**
- New `.github/workflows/migrate-cli-tag.yml` — the only workflow that fires on a `tools/migration/v*` tag. It reuses `release.yml`'s `sort -V` freshness idiom to close the singleton `chore(migrate): cut the tools/migration CLI tag` drift issue once the pushed CLI version has caught up to the latest framework release. Minimal perms (`contents: read`, `issues: write`), tag passed via `env:` (not `${{ }}` in `run:`), `persist-credentials: false`.
- `RELEASING.md` §6 gains one sentence noting the auto-close.

## Why

The CLI tag is cut by a manual, unscripted §6 procedure (raw `git tag -s` + `git push`, no guard rails), while the framework tag has `make release` → `scripts/release.sh` with ~12 invariants. That asymmetry let the CLI tag drift from `v0.38.0` to a framework at `v0.53.0` (15 missed releases) and left the auto-filed drift issue lingering open with no path to close. This gives the CLI cut the same one-command, fully-guarded ergonomics and makes the tracking issue self-closing.

## Scope / notes

- **No behavior change to the framework release path** — `scripts/release.sh`, `make release`, `release.yml`, and `release-please*.yml` are untouched. The new script deliberately *mirrors* (does not share a library with) `release.sh`: the two have different version sources and gates, and coupling them is riskier than mirroring.
- **Does not cut any tag** and **does not close #752** — that is the one-time cut itself (tracked separately). This PR only lands the tooling; the next real cut becomes `make release-cli VERSION=…` and its push auto-closes the drift issue.
- The two commits are independent (they share only the `RELEASING.md` §6 edit) and could ship as two PRs; bundled here since the combined diff is small (~170 LoC / 4 files).
- Validated with `bash -n`, `shellcheck`, `actionlint`, a guard-smoke (each early-dying guard fires correctly, no tag created), and the workflow's freshness-gate dry-run — plus the mandatory pre-push gates (`/simplify` → `/security-audit` → `/code-review`), whose findings were applied (quote `$(VERSION)` in the recipe, surface `gh` list/close failures, `-c gpg.format=ssh` on the signature verify, guard the `PINNED` lookup under `set -e`).

### Two deliberate review decisions (pre-empting the bots)

- **`actions/checkout@v7` stays tag-pinned (not SHA-pinned).** `checkout` is a first-party GitHub action; the repo tag-pins first-party actions everywhere (`release.yml` ×3, `ci-v2.yml` ×6) and SHA-pins only third-party ones. Pinning this one to a SHA would make it the lone outlier.
- **The auto-close targets the drift issue by the exact title `release.yml` searches for, gated on the freshness comparison** (`cli_ver ≥ latest_fw`). It intentionally does *not* add label/body-metadata filtering: the issue is a title-keyed singleton (`release.yml` updates the existing one rather than opening duplicates), the freshness gate already prevents closing before catch-up, and the plan requires Part B to match `release.yml`'s search string exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated, signed CLI release process with extensive version, repository, CI, and validation checks.
  * Added a `release-cli` command for creating and publishing CLI tags.
  * Added automation to identify and close CLI version drift issues after a current CLI tag is published.

* **Documentation**
  * Updated release instructions with the new CLI release workflow, verification steps, signing requirements, and tag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->