### PR TITLE
docs: refresh README/llms.txt/CLAUDE.md drift to v0.53.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -512,6 +512,8 @@ GoBricks has shipped several breaking changes for idiomatic Go conventions. Gree
 - **MongoDB removed (ADR-012):** Only PostgreSQL and Oracle supported.
 - **Env policy (ADR-022):** `app.env` is no longer enum-validated to `{development, staging, production}`; consumer projects may use any conforming string (`local`, `tst`, `stg`, `prd`, `production-eu`, …). Behavior switches go through `config.IsDevelopment()` / `config.IsProduction()` predicates with documented alias sets (`{development, dev, local}` / `{production, prod, prd}`). `APP_ENV=prd`/`prod` now triggers production-strict CORS; `APP_ENV=dev`/`local` now enable framework dev conveniences and auto-migrate.
 - **CORS dev wildcard opt-in (ADR-038):** the dev-permissive reflect-any-origin + `AllowCredentials` CORS posture now requires `CORS_DEV_WILDCARD=true` in addition to a development-alias (or koanf-defaulted) `APP_ENV`; without the flag, dev fails closed like every other env. `CORS_ORIGINS` strict allowlisting is unchanged. The flag is inert outside development aliases.
+- **Composite resolver order required (ADR-039):** `resolver.order` is mandatory for `multitenant.resolver.type: composite` — no default; a composite deployment fails at startup until it declares one.
+- **Declaration Args reach the broker (ADR-040):** `messaging.AMQPClient.DeclareQueue`/`DeclareExchange`/`BindQueue` now take `(ctx context.Context, *…Declaration)` and forward `Args` to RabbitMQ — may surface `406 PRECONDITION_FAILED` against ops-provisioned queues whose args differ.
 
 ## File Organization
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ go test -run TestName   # Run specific test
 - **Named databases** for accessing multiple databases (including mixed vendors) in single-tenant mode
 - **Redis cache integration** with type-safe serialization, multi-tenant isolation, and automatic lifecycle management
 - **Transactional outbox** for reliable at-least-once event publishing (dual-write problem solved)
+- **Consumer-side inbox** for exactly-once *transactional* event processing (dedup ledger written atomically with the handler's DB writes via `InboxProcessor.ProcessOnce`)
 - **Job scheduler** with gocron, overlapping prevention, panic recovery, and system APIs
 - **Named RSA key pair and symmetric secret management** from DER/raw files or base64 environment variables
 - **JOSE middleware** for nested JWE-of-JWS protection on HTTP request/response bodies (Visa-style integrations)
@@ -281,6 +282,12 @@ type RouteRegisterer interface {
 type MessagingDeclarer interface {
     DeclareMessaging(decls *messaging.Declarations)
 }
+
+// Optional — implement to contribute app-wide middleware that runs once per
+// request (after tenant resolution, before handlers; no per-route opt-out)
+type GlobalMiddlewareRegisterer interface {
+    GlobalMiddleware() []server.MiddlewareFunc
+}
 ```
 
 `ModuleDeps` injects shared services into every module:
@@ -380,9 +387,12 @@ Unified interface supporting PostgreSQL and Oracle with vendor-specific optimiza
 
 ### Type-Safe Filter API
 
-GoBricks provides a composable Filter API that works across SELECT, UPDATE, DELETE, and JOIN operations:
+GoBricks provides a composable Filter API that works across SELECT, UPDATE, DELETE, and JOIN operations. The query-builder snippets below are fragments: they assume `db` is the request's `database.Interface`, obtained via `db, err := deps.DB(ctx)`.
 
 ```go
+// qb is a *database.QueryBuilder instance (there is no "qb" package):
+qb := database.NewQueryBuilder(db.DatabaseType()) // db from deps.DB(ctx)
+
 // Build reusable filters
 f := qb.Filter()
 
@@ -430,6 +440,7 @@ type User struct {
     Level int    `db:"level"` // Oracle reserved word — auto-quoted
 }
 
+qb := database.NewQueryBuilder(db.DatabaseType()) // db from deps.DB(ctx)
 cols := qb.Columns(&User{})
 f := qb.Filter()
 
@@ -599,7 +610,7 @@ func TestMyService(t *testing.T) {
 }
 ```
 
-**Features:** Fluent configuration API, operation tracking, 20+ assertion helpers, TTL expiration testing, multi-tenant support.
+**Features:** Fluent configuration API, operation tracking, 17 assertion helpers, TTL expiration testing, multi-tenant support.
 
 **See also:** [database/testing](https://pkg.go.dev/github.com/gaborage/go-bricks/database/testing) for similar patterns.
 
@@ -659,6 +670,8 @@ func (s *OrderService) CreateOrder(ctx context.Context, req CreateOrderReq) erro
 ```
 
 The relay job polls for pending events every `pollinterval` (default 5s), publishes them to AMQP with an `x-outbox-event-id` header for deduplication, and a cleanup job removes published events after `retentionperiod` (default 72h). See [CLAUDE.md](CLAUDE.md) for full configuration options.
+
+**Inbox (consumer side):** the `inbox` package is the outbox's mirror — `deps.Inbox.ProcessOnce(ctx, eventID, fn)` records the event id in a ledger atomically with the handler's writes, giving exactly-once processing of the handler's transactional work on top of the broker's at-least-once delivery. Effects outside that DB transaction (HTTP calls, emails, broker publishes) can still repeat on redelivery — keep them idempotent. Register `inbox.NewModule()`; use the `x-outbox-event-id` header as the dedup key. See [CLAUDE.md](CLAUDE.md) and [wiki/outbox.md](wiki/outbox.md).
 
 ---
 
@@ -736,7 +749,7 @@ Wire it by registering `keystore.NewModule()` **before** any module that declare
 Complete resource isolation with per-tenant database and messaging connections.
 
 ### Key Features
-- **Tenant Resolution**: Headers, subdomains, or custom strategies with validation
+- **Tenant Resolution**: Header, subdomain, path-segment, or composite (first-match chain) resolvers — plus custom strategies — all validated
 - **Resource Isolation**: Separate database/messaging connections per tenant
 - **Context Propagation**: Tenant ID flows automatically through all operations
 - **Declaration Replay**: Messaging infrastructure validated once, replayed per-tenant

--- a/llms.txt
+++ b/llms.txt
@@ -2668,18 +2668,21 @@ func (m *Module) DeclareMessaging(decls *messaging.Declarations) {
 }
 ```
 
-Dead-letter failed messages (handler errors/panics nack without requeue) with the
-declarative helper `DeclareQueueWithDLQ` (v0.53.0) — it auto-derives a
-`<queue>.dlx` fanout exchange, a `<queue>.dlq` parking queue, and the binding, and
-is idempotent across queues sharing a DLX:
+Dead-letter failed messages (handler errors/panics nack without requeue) by declaring
+the queue with `DeclareQueueWithDLQ` **instead of** `DeclareQueue` (v0.53.0) — it
+auto-derives a `<queue>.dlx` fanout exchange, a `<queue>.dlq` parking queue, and the
+binding, and is idempotent across queues sharing a DLX. Declare each queue exactly once:
 
 ```go
-decls.DeclareQueueWithDLQ("orders.processing", &messaging.DeadLetterSpec{})
+// In DeclareMessaging above, swap `decls.DeclareQueue("orders.processing")` for this —
+// DeclareQueueWithDLQ registers the queue itself, so don't also call DeclareQueue for it:
+queue := decls.DeclareQueueWithDLQ("orders.processing", &messaging.DeadLetterSpec{})
 ```
 
-For custom DLX/parking-queue names or bespoke topology, set `Args` BEFORE
-registering — `DeclareQueue` snapshots a deep copy, so mutating the returned
-pointer's `Args` afterward is silently dropped:
+For custom DLX/parking-queue names or bespoke topology, declare a plain queue (again
+*instead of* the `DeclareQueue` above) and set `Args` BEFORE registering — `DeclareQueue`
+snapshots a deep copy, so mutating the returned pointer's `Args` afterward is silently
+dropped:
 
 ```go
 q := messaging.NewQueue("orders.processing")

--- a/llms.txt
+++ b/llms.txt
@@ -4,9 +4,9 @@ Enterprise Go microservice toolkit (Go 1.26+). Provides multi-database access, t
 
 ## Version & Compatibility
 
-- Reflects **go-bricks v0.49.0** (messaging defaults now applied in *every* deployment mode with mode-aware pool sizing — publisher `maxcached`, `database.manager.maxsize`, and cache `maxsize` scale to the tenant limit in multi-tenant; new `database.manager.*` keys; `messaging.reconnect` delay/backoff keys wired live; duration config must be unit-suffixed strings — write `"300s"`, not `300`; publisher lifecycle hardening: cold-publish readiness wait + 1h single-tenant publisher IdleTTL). Requires **Go 1.26+**.
+- Reflects **go-bricks v0.53.0**. The v0.49.0 line applied messaging defaults in *every* deployment mode with mode-aware pool sizing (publisher `maxcached`, `database.manager.maxsize`, cache `maxsize` scale to the tenant limit in multi-tenant), added `database.manager.*` keys, wired `messaging.reconnect` delay/backoff keys live, required unit-suffixed durations (write `"300s"`, not `300`), and hardened the publisher lifecycle (cold-publish readiness wait + 1h single-tenant publisher IdleTTL). Since then: v0.50.0 made dev CORS wildcard opt-in (`CORS_DEV_WILDCARD`, ADR-038) and `multitenant.resolver.order` REQUIRED for `type: composite` (ADR-039); v0.51.0 made `server.bodylimit` configurable (echo v5.3.0 bump); v0.52.0 made messaging declaration `Args` reach the broker via a breaking `AMQPClient.DeclareQueue`/`DeclareExchange`/`BindQueue` signature change (ADR-040); v0.53.0 added `DeclareQueueWithDLQ` declarative dead-lettering. Unreleased on `main` (shipping in the release after v0.53.0): the `outbox.tenancy`/`inbox.tenancy: shared` control-plane ledger (ADR-041) and duplicate-route-registration fail-fast. Requires **Go 1.26+**.
 - Authoritative sources: `CHANGELOG.md` (release log) and `wiki/migrations.md` — the **per-hop migration runbook** (detect → apply → verify atoms, one hop per release, chainable across any version range). This file carries the ladder + agent protocol; the runbook holds the full atoms.
-- Upgrading an existing app? Read that section first. Across v0.40 → v0.45 **most breaks fail silently** — a renamed config key stops binding, a default flips — with no compile error. The compiler-caught API breaks are concentrated in v0.41.0 (CORS / LogEvent / SetupMiddlewares), v0.43.0 (per-tenant `ReleaseFunc`, `PoolKeepAliveConfig.Enabled`), and v0.45.0 (echo-free boundary types, the `outbox.Store` interface); everything else fails silently.
+- Upgrading an existing app? Read that section first. Across v0.40 → v0.45 **most breaks fail silently** — a renamed config key stops binding, a default flips — with no compile error. The compiler-caught API breaks are concentrated in v0.41.0 (CORS / LogEvent / SetupMiddlewares), v0.43.0 (per-tenant `ReleaseFunc`, `PoolKeepAliveConfig.Enabled`), v0.45.0 (echo-free boundary types, the `outbox.Store` interface), and v0.52.0 (the `AMQPClient.DeclareQueue`/`DeclareExchange`/`BindQueue` signature change, ADR-040). Not everything is silent: v0.50.0's required `multitenant.resolver.order` for `type: composite` (ADR-039) fails **fast** at startup with a config-validation error.
 
 ## Quick Start
 - `go get github.com/gaborage/go-bricks`
@@ -353,7 +353,7 @@ database:
   connectionstring: ${DATABASE_URL}      # e.g. postgres://user:pass@host:5432/dbname?sslmode=require
 ```
 
-Per ADR-003, at least one of `host` *or* `connectionstring` must be set, otherwise startup fails fast. Pool defaults are production-safe — override only when you have a measured reason (see CLAUDE.md "Connection Pool Defaults"). Multiple databases can be exposed under `databases.<name>` and accessed via `deps.DBByName(ctx, "name")`.
+Per ADR-003, at least one of `host` *or* `connectionstring` must be set, otherwise startup fails fast. Pool defaults are production-safe — override only when you have a measured reason (see wiki/database.md "Connection Pool Defaults"). Multiple databases can be exposed under `databases.<name>` and accessed via `deps.DBByName(ctx, "name")`.
 
 ### Step 2: Access the Connection from a Module
 
@@ -2668,9 +2668,18 @@ func (m *Module) DeclareMessaging(decls *messaging.Declarations) {
 }
 ```
 
-Dead-letter failed messages (handler errors/panics nack without requeue) by
-setting Args BEFORE registering — `DeclareQueue` snapshots a deep copy, so
-mutating the returned pointer's Args afterward is silently dropped:
+Dead-letter failed messages (handler errors/panics nack without requeue) with the
+declarative helper `DeclareQueueWithDLQ` (v0.53.0) — it auto-derives a
+`<queue>.dlx` fanout exchange, a `<queue>.dlq` parking queue, and the binding, and
+is idempotent across queues sharing a DLX:
+
+```go
+decls.DeclareQueueWithDLQ("orders.processing", &messaging.DeadLetterSpec{})
+```
+
+For custom DLX/parking-queue names or bespoke topology, set `Args` BEFORE
+registering — `DeclareQueue` snapshots a deep copy, so mutating the returned
+pointer's `Args` afterward is silently dropped:
 
 ```go
 q := messaging.NewQueue("orders.processing")
@@ -2997,6 +3006,7 @@ outbox:
   batchsize: 100                   # Events per cycle
   maxretries: 5                    # Before giving up
   retentionperiod: 72h             # Cleanup threshold
+  publishtimeout: 60s              # Per-record relay publish bound
 ```
 
 ### Testing
@@ -3454,7 +3464,26 @@ When `deps.MeterProvider`, `deps.Tracer`, and `deps.Logger` are wired (default w
 
 ### Outbound HTTP JOSE (calling a partner from your service)
 
-The httpclient JOSE wrapper for outbound calls (sign-then-encrypt the request body to a partner, decrypt-then-verify their response) is **planned for a follow-up release**. The current scope is server-side in/out only. Until then, services initiating outbound JOSE calls must hand-roll the seal/open step using the `jose` package primitives or the `go-jose/v4` library directly, sourcing keys from `deps.KeyStore`.
+The httpclient signs+encrypts outbound request bodies and decrypts+verifies
+`application/jose` responses via `Builder.WithJOSE` (an `http.RoundTripper` that
+sits below the retry loop, so each retry re-seals — useful when a partner requires
+unique `iat`/`jti` per attempt). Non-`application/jose` responses pass through
+untouched.
+
+```go
+client := httpclient.NewBuilder(log).
+    WithJOSE(httpclient.JOSEConfig{
+        Outbound: outboundPolicy, // *jose.Policy — required (sign+encrypt requests)
+        Inbound:  inboundPolicy,  // *jose.Policy — optional (decrypt+verify responses); nil = plaintext responses
+        Resolver: resolver,       // jose.KeyResolver — supplies keys for both directions
+    }).
+    Build()
+
+resp, err := client.Post(ctx, &httpclient.Request{URL: partnerURL, Body: body})
+```
+
+See [wiki/jose.md](wiki/jose.md) ("Outbound httpclient JOSE wrapping") and
+`httpclient/jose_transport_test.go` for full examples.
 
 ## Multi-Tenancy
 - Enable with `multitenant.enabled=true`.
@@ -3976,6 +4005,13 @@ go-bricks-migrate migrate --source-url ... --aws-region us-east-1 --json
 ```
 
 Default behavior is **sequential, fail-fast**. `--continue-on-error` keeps iterating after a per-tenant failure. `--parallel <N>` (max 32) processes tenants concurrently while preserving fail-fast: on the first per-tenant error, siblings still queued exit immediately and in-flight Flyway processes are cancelled before `MigrateAll` returns. Combine with `--continue-on-error` to keep iterating instead.
+
+`--timeout <dur>` overrides the per-tenant Flyway timeout (v0.53.0). A separate
+`go-bricks-migrate quiesce {set,clear,status}` command family manages the
+deployment **quiesce flag** in the control-plane database — pausing worker pickup
+and tenant fan-out so a deployment-time migration can drain in-flight work without
+interrupting it (PostgreSQL-only in v1). See
+[wiki/migration_quiesce.md](wiki/migration_quiesce.md).
 
 ### Library usage (back-office calls MigrateAll directly)
 
@@ -5265,15 +5301,15 @@ Same domain errors, different boundary handling:
 - **Configuration injection**: `deps.Config.InjectInto(&cfgStruct)` honors defaults and env overrides.
 - **Testing**: `obtest.NewTestTraceProvider()` captures spans, `obtest.NewTestMeterProvider()` captures metrics; mock `database.Interface` and `messaging.Client` directly.
 
-## Upgrade & Breaking Changes (v0.39 → v0.49)
+## Upgrade & Breaking Changes (v0.39 → v0.52)
 
-The full, executable migration path is the **per-hop runbook in `wiki/migrations.md`** — one hop per release (v0.39 → v0.40 → … → v0.49), every change a gated atom with `detect` / `apply` (inline before/after for compiler-caught API changes) / `verify`, walkable from any current version to any target. This section is the map + protocol; the atoms live in the runbook.
+The full, executable migration path is the **per-hop runbook in `wiki/migrations.md`** — one hop per release (v0.39 → v0.40 → … → v0.52), every change a gated atom with `detect` / `apply` (inline before/after for compiler-caught API changes) / `verify`, walkable from any current version to any target. This section is the map + protocol; the atoms live in the runbook.
 
 Ladder:
 ```
-v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0 ─E43─ v0.43.0 ─E44─ v0.44.0 ─E45─ v0.45.0 ─E49─ v0.49.0
+v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0 ─E43─ v0.43.0 ─E44─ v0.44.0 ─E45─ v0.45.0 ─E49─ v0.49.0 ─E50─ v0.50.0 ─E51─ v0.51.0 ─E52─ v0.52.0
 ```
-> v0.46.0–v0.48.0 shipped additive-only (adopt-only, no migration atoms), so E49 is the next hop after v0.45.0 and applies when crossing from any of v0.45.0–v0.48.0 to v0.49.0.
+> v0.46.0–v0.48.0 shipped additive-only (adopt-only, no migration atoms), so E49 is the next hop after v0.45.0 and applies when crossing from any of v0.45.0–v0.48.0 to v0.49.0. v0.53.0 shipped additive-only (DeclareQueueWithDLQ #741; the ADR-041 shared-ledger tenancy on main ships after v0.53.0) — adopt-only, no migration atom, so this ladder ends at v0.52.0 (the last hop with an atom).
 
 | edge | hop | worst risk | compiler-caught | preflight |
 |------|-----|-----------|-----------------|-----------|
@@ -5284,7 +5320,10 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E43  | v0.42.0 → v0.43.0 | compile-break | 2 | bare section-named env vars |
 | E44  | v0.43.0 → v0.44.0 | noop | none | none |
 | E45  | v0.44.0 → v0.45.0 | compile-break | 6 | outbox re-delivery count |
-| E49  | v0.45.0 → v0.49.0 (unreleased) | silent-config | none | multi-tenant outbox timeout guards / stale `messaging.*` + `database.manager.*` values / reconnect delay keys go live / mode-aware cache pool |
+| E49  | v0.45.0 → v0.49.0 | silent-config | none | multi-tenant outbox timeout guards / stale `messaging.*` + `database.manager.*` values / reconnect delay keys go live / mode-aware cache pool |
+| E50  | v0.49.0 → v0.50.0 | config-break | none | dev CORS wildcard now opt-in (CORS_DEV_WILDCARD, ADR-038); `multitenant.resolver.order` REQUIRED for `type: composite` (ADR-039); non-empty DB password < 8 bytes rejected; Flyway surfaces failure output as an error |
+| E51  | v0.50.0 → v0.51.0 | silent-behavior (adopt-only) | none | none |
+| E52  | v0.51.0 → v0.52.0 | compile-break | 1 | if you set `.Args` on any declaration in ≤v0.51.0, verify current broker state before upgrading (ADR-040) |
 
 Agent protocol (condensed — full version in the runbook):
 1. Detect CURRENT: `go list -m -f '{{.Version}}{{if .Replace}} =>{{.Replace.Path}}{{end}}' github.com/gaborage/go-bricks` (a local `replace` → resolve the checkout's tag).


### PR DESCRIPTION
## What

Refreshes the three top-level docs (`README.md`, `llms.txt`, `CLAUDE.md`) to match the code at **v0.53.0 / HEAD**. Pure documentation — **no Go changed** (`git diff --stat` is 3 markdown files, 0 `.go`).

Found via `/improve plan` (docs-drift detection): four read-only detectors cross-checked every concrete claim against live source, the advisor vetted each survivor, and a fresh-context cold reader hardened the plan before execution.

## Why

`llms.txt` was anchored to **v0.49.0** — four releases stale — and its "Outbound HTTP JOSE" section told readers to *hand-roll* a capability that actually shipped in v0.30.0 (`httpclient.WithJOSE`). `README.md` showed query-builder examples with an undefined `qb` (no `database.NewQueryBuilder(...)`), understated the tenant resolvers, and never surfaced the `inbox` package. `CLAUDE.md`'s Breaking Changes list stopped at ADR-038.

## Changes (14 edits)

**`llms.txt`**
- Version anchor `v0.49.0` → `v0.53.0` (+ a v0.50–v0.53 summary).
- Correct "everything else fails silently" — add the v0.52.0 `AMQPClient` compile-break (ADR-040); note v0.50.0's required `resolver.order` fails *fast* (ADR-039).
- Fix dead cross-reference: "Connection Pool Defaults" moved from `CLAUDE.md` to `wiki/database.md`.
- Lead dead-lettering with the `DeclareQueueWithDLQ` helper (v0.53.0); demote the manual `Args` pattern.
- Add `outbox.publishtimeout` (default 60s) to the config sample.
- Document outbound `httpclient.WithJOSE` (was wrongly "planned for a follow-up release").
- Add the CLI `--timeout` flag and `quiesce {set,clear,status}` family.
- Extend the Upgrade ladder + table through **E52 / v0.52.0** (mirrors `wiki/migrations.md`).

**`README.md`**
- Show `qb := database.NewQueryBuilder(db.DatabaseType())` in the builder examples.
- Name the `path` and `composite` resolvers (were omitted).
- Surface the `inbox` package (Feature Overview bullet + a section paragraph).
- Add the `GlobalMiddlewareRegisterer` module interface (ADR-036).
- `20+` → `17` assertion helpers (actual count in `cache/testing`).

**`CLAUDE.md`**
- Add the ADR-039 (composite resolver order) and ADR-040 (declaration `Args`) breaking-change bullets.

## Verification

- Every edit checked against live source; **22 machine-checkable done-criteria** all pass.
- Fresh-eyes adversarial verification (links resolve, symbols/config keys exist, version/ladder facts match `CHANGELOG.md` + `wiki/migrations.md`, no secrets, no invisible chars, cross-doc consistency).
- `make check` unaffected (no Go touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented exactly-once transactional inbox processing for consumer events.
  * Added guidance for global request middleware and first-match composite tenant resolution.
  * Expanded messaging documentation with dead-letter queues and declaration argument handling.
  * Added documentation for outbound HTTP JOSE encryption, signing, decryption, and verification.
  * Updated database, cache, migration, outbox, version compatibility, and upgrade guidance.
  * Clarified breaking changes, including required composite resolver ordering and updated messaging declaration APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->