### PR TITLE
fix(httpclient): apply transport wrappers in layer order at Build

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -63,6 +63,31 @@ type Builder struct {
 	logger     logger.Logger
 	httpClient *nethttp.Client
 	transport  nethttp.RoundTripper
+	chain      *transportChain
+}
+
+// transportLayer orders RoundTripper wrappers independently of the order the
+// caller happened to invoke the builder's With* options. Lower layers sit
+// closer to the network.
+type transportLayer int
+
+const (
+	// layerSigner runs after body transforms, so a signature covers the bytes
+	// actually placed on the wire.
+	layerSigner transportLayer = iota
+	// layerBodyTransform is outermost: it rewrites the body before anything signs it.
+	layerBodyTransform
+	// layerCount must stay last: it sizes the chain, so a layer declared above it
+	// is applied in iota order without any second edit elsewhere.
+	layerCount
+)
+
+// transportChain buckets wrappers by layer, making the array index the apply
+// order. Builder holds it behind a pointer so Builder stays a comparable type:
+// apidiff reports a comparable-to-not-comparable change on an exported type as
+// INCOMPATIBLE.
+type transportChain struct {
+	byLayer [layerCount][]func(nethttp.RoundTripper) nethttp.RoundTripper
 }
 
 // NewBuilder creates a new client builder
@@ -186,6 +211,8 @@ func (b *Builder) WithHTTPClient(client *nethttp.Client) *Builder {
 }
 
 // WithTransport sets a custom RoundTripper while still letting the builder manage other client settings.
+// It supplies the innermost transport: wrappers registered by other options (WithJOSE, for
+// example) are layered above it at Build time regardless of call order.
 func (b *Builder) WithTransport(transport nethttp.RoundTripper) *Builder {
 	b.transport = transport
 	return b
@@ -210,26 +237,70 @@ type JOSEConfig struct {
 // and decrypts+verifies application/jose response bodies. Pass cfg.Inbound = nil when
 // the counterparty does not return JOSE-wrapped responses.
 //
-// Composition: WithJOSE wraps whatever transport was set via an earlier WithTransport
-// call — so that transport customization remains in the chain below the JOSE layer.
-// A Transport configured directly on the *http.Client passed to WithHTTPClient is NOT
-// threaded through: Build() sets the transport on the built client's copied *http.Client
-// whenever WithTransport or WithJOSE set b.transport (the client passed to WithHTTPClient
-// is never modified), so use WithTransport if a custom RoundTripper needs to
-// survive beneath WithJOSE. Calling WithTransport AFTER WithJOSE replaces the JOSE
-// transport entirely.
+// Composition: transport layers are applied at Build time in a fixed order —
+// the base transport from WithTransport is innermost, request signers next, and
+// body transforms such as JOSE outermost — so the result does not depend on the
+// order these options were called. A Transport configured directly on the
+// *http.Client passed to WithHTTPClient is REPLACED, not wrapped: the chain then has
+// no base and dials via nethttp.DefaultTransport, losing client certificates, pinned
+// roots and proxy settings (Build logs a WARN). Always pass a base RoundTripper to
+// WithTransport.
 //
 // Per-attempt freshness: because httpclient retries by re-running the request build
 // loop, each retry produces a freshly-sealed payload — useful for protocols that
 // require unique iat/jti claims per attempt.
 func (b *Builder) WithJOSE(cfg JOSEConfig) *Builder {
-	b.transport = &JOSETransport{
-		Inner:    b.transport,
-		Outbound: cfg.Outbound,
-		Inbound:  cfg.Inbound,
-		Resolver: cfg.Resolver,
-	}
+	b.addTransportWrapper(layerBodyTransform, func(inner nethttp.RoundTripper) nethttp.RoundTripper {
+		return &JOSETransport{
+			Inner:    inner,
+			Outbound: cfg.Outbound,
+			Inbound:  cfg.Inbound,
+			Resolver: cfg.Resolver,
+		}
+	})
 	return b
+}
+
+// addTransportWrapper registers a RoundTripper layer applied at Build time.
+// A wrapper that rewrites the body registers at layerBodyTransform; one that only
+// reads the body to sign it registers at layerSigner, so the signature covers the
+// rewritten bytes. Two obligations on every wrapper: the inner RoundTripper it
+// receives may be nil (no WithTransport base) and must then fall back to
+// nethttp.DefaultTransport rather than dereference, and a layer that reads the body
+// owes the layer below a re-readable body plus a matching GetBody — as
+// JOSETransport.wrapRequest does — or redirect and HTTP/2 replay paths resend an
+// empty payload under a signature computed over the real one.
+func (b *Builder) addTransportWrapper(layer transportLayer, wrap func(nethttp.RoundTripper) nethttp.RoundTripper) {
+	if b.chain == nil {
+		b.chain = &transportChain{}
+	}
+	b.chain.byLayer[layer] = append(b.chain.byLayer[layer], wrap)
+}
+
+// resolveTransport applies registered wrappers to the base transport innermost
+// first; within a layer the first registered wrapper ends up innermost. Returns nil
+// when there is neither a base transport nor a wrapper, so Build leaves the
+// http.Client's own Transport untouched.
+func (b *Builder) resolveTransport() nethttp.RoundTripper {
+	rt := b.transport
+	if b.chain == nil {
+		return rt
+	}
+	for _, wrappers := range b.chain.byLayer {
+		for _, wrap := range wrappers {
+			rt = wrap(rt)
+		}
+	}
+	return rt
+}
+
+// discardsClientTransport reports the one composition that silently downgrades TLS:
+// a registered wrapper with no WithTransport base replaces the WithHTTPClient
+// client's own Transport, so requests dial via nethttp.DefaultTransport. Build only
+// warns — it has no error return, and failing closed here is tracked with the mTLS
+// work.
+func (b *Builder) discardsClientTransport() bool {
+	return b.transport == nil && b.chain != nil && b.httpClient != nil && b.httpClient.Transport != nil
 }
 
 // WithRequestInterceptor adds a request interceptor
@@ -264,8 +335,14 @@ func (b *Builder) Build() Client {
 		httpClient = &c
 	}
 
-	if b.transport != nil {
-		httpClient.Transport = b.transport
+	if rt := b.resolveTransport(); rt != nil {
+		if b.discardsClientTransport() {
+			b.logger.Warn().Msg("httpclient: transport wrapper registered without WithTransport — " +
+				"the *http.Client passed to WithHTTPClient has its own Transport replaced and requests " +
+				"dial via net/http.DefaultTransport, losing client certificates, pinned roots and proxy " +
+				"settings; pass the base RoundTripper to WithTransport instead")
+		}
+		httpClient.Transport = rt
 	}
 
 	return &client{

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -1823,3 +1823,171 @@ func TestClientDoTransportErrorSpan(t *testing.T) {
 	}
 	assert.True(t, foundErrType, "transport error should set error.type on the attempt span")
 }
+
+// Builder must stay a comparable type: apidiff reports a comparable-to-not-comparable
+// change on an exported type as INCOMPATIBLE, which would gate the PR behind an ADR.
+func TestBuilderTransportChainKeepsBuilderComparable(_ *testing.T) {
+	var a, b Builder
+	_ = a == b
+}
+
+func TestBuilderTransportChainOrderIndependence(t *testing.T) {
+	log := createTestLogger()
+
+	cases := []struct {
+		name  string
+		build func(base nethttp.RoundTripper) Client
+	}{
+		{
+			// Regression: WithTransport after WithJOSE used to discard the JOSE layer.
+			name: "jose_then_transport",
+			build: func(base nethttp.RoundTripper) Client {
+				return NewBuilder(log).WithJOSE(JOSEConfig{}).WithTransport(base).Build()
+			},
+		},
+		{
+			name: "transport_then_jose",
+			build: func(base nethttp.RoundTripper) Client {
+				return NewBuilder(log).WithTransport(base).WithJOSE(JOSEConfig{}).Build()
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := &stubRoundTripper{name: "base"}
+			built := tc.build(base)
+
+			clientImpl, ok := built.(*client)
+			require.True(t, ok)
+			joseTransport, ok := clientImpl.httpClient.Transport.(*JOSETransport)
+			require.True(t, ok, "JOSE layer must survive regardless of builder call order")
+			assert.Same(t, base, joseTransport.Inner)
+		})
+	}
+}
+
+func TestBuilderTransportChainLayerOrdering(t *testing.T) {
+	log := createTestLogger()
+
+	assertNesting := func(t *testing.T, built Client, base *stubRoundTripper) {
+		t.Helper()
+		clientImpl, ok := built.(*client)
+		require.True(t, ok)
+		joseTransport, ok := clientImpl.httpClient.Transport.(*JOSETransport)
+		require.True(t, ok, "body-transform layer must be outermost")
+		signer, ok := joseTransport.Inner.(*wrappingTransport)
+		require.True(t, ok, "signer layer must sit between JOSE and the base")
+		assert.Same(t, base, signer.inner)
+	}
+
+	wrapSigner := func(inner nethttp.RoundTripper) nethttp.RoundTripper {
+		return &wrappingTransport{inner: inner}
+	}
+
+	t.Run("signer_registered_first", func(t *testing.T) {
+		base := &stubRoundTripper{name: "base"}
+		b := NewBuilder(log).WithTransport(base)
+		b.addTransportWrapper(layerSigner, wrapSigner)
+		b.WithJOSE(JOSEConfig{})
+		assertNesting(t, b.Build(), base)
+	})
+
+	t.Run("signer_registered_second", func(t *testing.T) {
+		base := &stubRoundTripper{name: "base"}
+		b := NewBuilder(log).WithTransport(base).WithJOSE(JOSEConfig{})
+		b.addTransportWrapper(layerSigner, wrapSigner)
+		assertNesting(t, b.Build(), base)
+	})
+}
+
+func TestBuilderTransportChainDiscardsClientTransport(t *testing.T) {
+	log := createTestLogger()
+	base := &stubRoundTripper{name: "base"}
+	withClient := func() *nethttp.Client { return &nethttp.Client{Transport: base} }
+
+	cases := []struct {
+		name    string
+		want    bool
+		builder func() *Builder
+	}{
+		{
+			// The hazard: no WithTransport base, so the caller's own Transport is replaced.
+			name:    "wrapper_over_client_transport_without_base",
+			want:    true,
+			builder: func() *Builder { return NewBuilder(log).WithHTTPClient(withClient()).WithJOSE(JOSEConfig{}) },
+		},
+		{
+			name: "wrapper_with_explicit_base",
+			want: false,
+			builder: func() *Builder {
+				return NewBuilder(log).WithHTTPClient(withClient()).WithTransport(base).WithJOSE(JOSEConfig{})
+			},
+		},
+		{
+			name:    "no_wrapper_leaves_client_transport_alone",
+			want:    false,
+			builder: func() *Builder { return NewBuilder(log).WithHTTPClient(withClient()) },
+		},
+		{
+			name:    "wrapper_without_caller_client",
+			want:    false,
+			builder: func() *Builder { return NewBuilder(log).WithJOSE(JOSEConfig{}) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.builder().discardsClientTransport())
+		})
+	}
+
+	t.Run("warned_case_really_replaces_the_transport", func(t *testing.T) {
+		built := NewBuilder(log).WithHTTPClient(withClient()).WithJOSE(JOSEConfig{}).Build()
+		clientImpl, ok := built.(*client)
+		require.True(t, ok)
+		assert.NotSame(t, base, clientImpl.httpClient.Transport, "caller's transport is replaced, not wrapped")
+		joseTransport, ok := clientImpl.httpClient.Transport.(*JOSETransport)
+		require.True(t, ok)
+		assert.Nil(t, joseTransport.Inner, "no base: RoundTrip falls back to net/http.DefaultTransport")
+	})
+
+	t.Run("hazard_emits_the_warning", func(t *testing.T) {
+		spy := &warnSpy{}
+		NewBuilder(spy).WithHTTPClient(withClient()).WithJOSE(JOSEConfig{}).Build()
+		assert.Contains(t, spy.msg, "net/http.DefaultTransport")
+	})
+
+	t.Run("explicit_base_emits_no_warning", func(t *testing.T) {
+		spy := &warnSpy{}
+		NewBuilder(spy).WithHTTPClient(withClient()).WithTransport(base).WithJOSE(JOSEConfig{}).Build()
+		assert.Empty(t, spy.msg)
+	})
+}
+
+// warnSpy captures the message Build passes to Warn().Msg. Embedding the interfaces
+// keeps the double to the two methods Build actually calls; any other method would
+// nil-panic, which is the intent.
+type warnSpy struct {
+	logger.Logger
+	msg string
+}
+
+func (s *warnSpy) Warn() logger.LogEvent { return &warnSpyEvent{spy: s} }
+
+type warnSpyEvent struct {
+	logger.LogEvent
+	spy *warnSpy
+}
+
+func (e *warnSpyEvent) Msg(msg string) { e.spy.msg = msg }
+
+// wrappingTransport stands in for a signer-layer wrapper; it exposes the
+// RoundTripper it wraps so tests can assert nesting depth.
+type wrappingTransport struct {
+	inner nethttp.RoundTripper
+}
+
+func (r *wrappingTransport) RoundTrip(req *nethttp.Request) (*nethttp.Response, error) {
+	return r.inner.RoundTrip(req)
+}

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -29,6 +29,38 @@ resp, err := client.Get(ctx, &httpclient.Request{
 
 **Interface:** `Get`, `Post`, `Put`, `Patch`, `Delete` accept `context.Context` and `*Request`; `Do` additionally takes a `method string` (`Do(ctx, method, req)`). All return `*Response` and `error`.
 
+### Transport composition
+
+`RoundTripper` wrappers (e.g. `WithJOSE`) are applied at `Build()` time in a fixed
+layer order, not in the order the `With*` options were called: the base transport
+from `WithTransport` sits innermost, request signers sit next, and body transforms
+such as JOSE sit outermost. This means calling `WithTransport` before or after
+`WithJOSE` produces the same client — the JOSE layer can no longer be silently
+discarded by a later `WithTransport` call:
+
+```go
+// Equivalent — layer order beats call order.
+httpclient.NewBuilder(logger).WithJOSE(cfg).WithTransport(mTLSTransport).Build()
+httpclient.NewBuilder(logger).WithTransport(mTLSTransport).WithJOSE(cfg).Build()
+```
+
+A `Transport` set directly on the `*http.Client` passed to `WithHTTPClient` is
+**replaced, not wrapped**, as soon as any wrapper option is used: the chain then has
+no base transport and dials via `net/http.DefaultTransport` — silently losing your
+client certificate, pinned `RootCAs`, `MinVersion` and proxy settings. `Build()` logs
+a WARN when it detects this. Always supply the base RoundTripper through
+`WithTransport`:
+
+```go
+// WRONG — mTLS transport is replaced; requests dial via net/http.DefaultTransport.
+httpclient.NewBuilder(logger).
+    WithHTTPClient(&http.Client{Transport: mTLSTransport}).
+    WithJOSE(cfg).Build()
+
+// RIGHT — mTLS sits innermost, beneath the JOSE layer.
+httpclient.NewBuilder(logger).WithTransport(mTLSTransport).WithJOSE(cfg).Build()
+```
+
 ## Metrics
 
 ### Overview


### PR DESCRIPTION
## Problem

`httpclient.Builder` holds exactly **one** transport field. Every `With*` option that needs a `RoundTripper` wraps whatever is in that field **at call time**, so the last call wins and becomes outermost. Today only `WithJOSE` does this, and the resulting footgun was merely *documented*: calling `WithTransport` after `WithJOSE` silently discarded the JOSE layer.

Four queued payment-integration transports — #765 (field-level encryption), #766 (OAuth 1.0a signing), #767 (mTLS), #768 (x-pay-token HMAC) — each add another wrapper to that same field. Written independently, they produce a client whose behavior depends on the order the caller happened to call the builder, and two failure modes are silent and security-relevant:

- A client-certificate transport installed **after** a body-transform wrapper is discarded, so the client connects with **no client certificate**.
- A wrapper whose `Inner` is nil falls back to `net/http.DefaultTransport` — again dialing with no client certificate, no error, no log line.

## Change

Wrappers now register into **ordered layers** and are applied at `Build()` time, innermost-first, regardless of call order:

- `layerSigner` (inner) → `layerBodyTransform` (outer). Signers sit beneath body transforms so a signature covers the bytes **actually placed on the wire** — the ordering all four queued transports depend on.
- `transportChain.byLayer` is indexed by layer, so the array index *is* the apply order and there is no separate order list to keep in sync. `layerCount` is an iota sentinel, so a layer declared above it is applied with no second edit elsewhere.
- Ordering within a layer is registration order, first registered innermost.

**Zero new exported identifiers**, so `apidiff` is strictly neutral — no ADR, no `wiki/migrations.md` hop. The chain hangs off a **pointer** field (`chain *transportChain`) specifically so `Builder` stays a comparable type; a bare slice field would make the exported `Builder` non-comparable, which `apidiff` reports as INCOMPATIBLE.

### Also included

`Build()` now emits a WARN for the one composition that silently downgrades TLS: a registered wrapper with **no** `WithTransport` base replaces the `Transport` of a client passed to `WithHTTPClient`, so requests dial via `net/http.DefaultTransport` — losing client certificates, pinned `RootCAs`, `MinVersion` and proxy settings. This is pre-existing behavior (byte-for-byte identical trigger set before and after this change), but this PR adds documentation that markets composition safety, so shipping the guardrail alongside it is the honest move. Failing *closed* there needs an API change (`Build()` has no error return) and stays with the mTLS work in **#767**.

## Behavior notes

- **Intentional behavior change, no API change.** Callers who relied on `WithTransport`-after-`WithJOSE` wiping the JOSE layer now get both. That reliance is implausible and the old behavior was a documented footgun, but it *is* observable. Hence `fix(httpclient):` — not `feat:`, not `fix(...)!:`.
- `WithTransport(nil)` after a registered wrapper no longer *clears* it; it yields wrapper-over-nil-base. This is the only input where the new code returns non-nil where the old returned nil.
- `Build()` mints a fresh `*JOSETransport` per call where the old code reused one instance across repeated `Build()`s. `JOSETransport` is stateless, so this is strictly better isolation.
- `httpclient/jose_transport.go` is **byte-identical** — verified in CI-equivalent checks.

## Verification

- `make check` green (fmt + lint + `-race` across all packages + alloc guards + govulncheck 0 vulns).
- 12 new tests/subtests. **Both halves of the fix are mutation-checked**: reversing layer order fails `TestBuilderTransportChainLayerOrdering` while `…OrderIndependence` stays green (clean isolation, proving the two tests pin different mechanisms); reverting the `Build()` resolution collapses both.
- The five pre-existing `TestBuilder` transport subtests pass **unmodified** — the change to `client_test.go` is machine-verified append-only, so none of them was quietly edited to pass.
- `golangci-lint` (incl. gosec) 0 issues on the changed package; no secrets, no raw-SQL escape hatches in the diff.

## Follow-ups this unblocks

#766 and #768 register at `layerSigner`; #765 registers at `layerBodyTransform` alongside JOSE; #767 supplies the base via `WithTransport` (or a future `WithClientCertificate`). Each should add a composition test asserting its wrapper lands at the right depth, and none should reintroduce wrap-at-call-time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transport wrappers now compose deterministically, independent of the order builder options are applied.
  * JOSE processing integrates correctly with custom transport and signing layers.
  * Added warning when wrapper layers replace a provided client transport in ways that may drop custom TLS/proxy settings.

* **Documentation**
  * Added guidance on transport composition order and correct configuration (including “WRONG/RIGHT” examples).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->