### PR TITLE
feat(database): add Execute query/exec helpers with typed errors (#772)

### DIFF
--- a/.claude/agents/project-conventions-reviewer.md
+++ b/.claude/agents/project-conventions-reviewer.md
@@ -28,12 +28,17 @@ If that yields nothing, fall back to `git diff HEAD` and `git diff --staged`.
 
 ## Checklist (report every violation; cite file:line)
 
-1. **Raw-SQL annotation (Security First).** Every `f.Raw(` / `jf.Raw(` call
-   site added or modified in the diff MUST have an adjacent
-   `// SECURITY: Manual SQL review completed - <rationale>` comment, and the
-   rationale must name a specific property (identifier quoting, value-side
-   parameterization, no user-input concatenation). Find them with:
-   `git grep -nE 'f\.Raw\(|jf\.Raw\('` and cross-check against the diff.
+1. **Raw-SQL annotation (Security First).** Every `f.Raw(` / `jf.Raw(` /
+   `database.Raw(` call site added or modified in the diff MUST have an
+   adjacent `// SECURITY: Manual SQL review completed - <rationale>` comment,
+   and the rationale must name a specific property (identifier quoting,
+   value-side parameterization, no user-input concatenation). `database.Raw`
+   deserves at least as much scrutiny as the other two: `f.Raw`/`jf.Raw` are
+   fragments inside a builder that still validates its other identifiers,
+   whereas `database.Raw` replaces the whole statement, bypassing the
+   builder's identifier validation entirely. Find them with:
+   `git grep -nE 'f\.Raw\(|jf\.Raw\(|database\.Raw\('` and cross-check against
+   the diff.
 
 2. **S8179 getter naming.** New exported getters must be `X()` not `GetX()`.
    The migration table in CLAUDE.md intentionally keeps old `Get*` names — do

--- a/.claude/commands/security-audit.md
+++ b/.claude/commands/security-audit.md
@@ -5,7 +5,7 @@ Run a comprehensive security audit of the GoBricks codebase.
 ## Workflow
 
 1. **Static analysis**: Run `golangci-lint run --enable gosec ./...` to find security issues.
-2. **Raw-SQL escape hatch audit**: Search for all `f.Raw(` and `jf.Raw(` call sites (the FilterFactory / JoinFilterFactory escape hatches) with `git grep -E 'f\.Raw\(|jf\.Raw\('` and verify each has an inline security annotation matching the prefix `// SECURITY: Manual SQL review completed - ` (the rationale after the prefix is per-site). Flag any call site missing the prefix. The annotation may live directly above the call, or above an enclosing dispatch (e.g. a table-driven loop or a multi-call JoinOn chain) when the safety property is uniform across the calls. See CLAUDE.md "Detailed Security Guidelines" and the godoc on `FilterFactory.Raw` for the policy.
+2. **Raw-SQL escape hatch audit**: Search for all `f.Raw(`, `jf.Raw(`, and `database.Raw(` call sites (the FilterFactory / JoinFilterFactory escape hatches, plus the Execute Helpers' hand-written-SQL adapter) with `git grep -E 'f\.Raw\(|jf\.Raw\(|database\.Raw\('` and verify each has an inline security annotation matching the prefix `// SECURITY: Manual SQL review completed - ` (the rationale after the prefix is per-site). Flag any call site missing the prefix. `database.Raw` deserves at least as much scrutiny as the other two: `f.Raw`/`jf.Raw` produce a WHERE/JOIN fragment inside a builder that still validates its other identifiers, whereas `database.Raw` replaces the **whole statement**, bypassing the builder's identifier validation entirely. The annotation may live directly above the call, or above an enclosing dispatch (e.g. a table-driven loop or a multi-call JoinOn chain) when the safety property is uniform across the calls. See CLAUDE.md "Detailed Security Guidelines" and the godoc on `FilterFactory.Raw` for the policy.
 3. **Secrets scan**: Search for patterns that suggest hardcoded secrets (API keys, passwords, tokens, connection strings) in Go files and config files. Exclude `.example` files and test fixtures.
 4. **Input validation**: Check all HTTP handler request structs for `validate` tags. Flag handlers that accept user input without validation.
 5. **Vulnerability check**: Run `govulncheck ./...` to find known vulnerabilities in dependencies.
@@ -31,6 +31,6 @@ Generated: {date}
 
 ## Severity Classification
 - **Critical**: Hardcoded secrets, SQL injection without sanitization, known CVEs with exploits
-- **High**: Missing input validation on public endpoints, raw-SQL escape hatch (`f.Raw` / `jf.Raw`) without `// SECURITY:` annotation
+- **High**: Missing input validation on public endpoints, raw-SQL escape hatch (`f.Raw` / `jf.Raw` / `database.Raw`) without `// SECURITY:` annotation
 - **Medium**: Missing validation tags, outdated dependencies with vulnerabilities
 - **Low**: Informational findings, minor gosec warnings

--- a/.claude/hooks/check-raw-sql.sh
+++ b/.claude/hooks/check-raw-sql.sh
@@ -39,7 +39,7 @@ block_unparseable() {
 # silently break the fail-closed contract this guard advertises.)
 jq -e . >/dev/null 2>&1 <<<"$input" || block_unparseable
 
-# Cheapest guard first: only Go source files can contain f.Raw()/jf.Raw().
+# Cheapest guard first: only Go source files can contain f.Raw()/jf.Raw()/database.Raw().
 # Extracting just the path keeps the common non-Go edit on a single jq fork.
 file="$(jq -er '.tool_input.file_path // empty' <<<"$input" 2>/dev/null)" || block_unparseable
 case "$file" in

--- a/.claude/hooks/check-raw-sql.sh
+++ b/.claude/hooks/check-raw-sql.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
 # PreToolUse guard for GoBricks.
 #
-# Blocks any Edit/Write/MultiEdit that introduces an f.Raw() or jf.Raw()
-# raw-SQL escape hatch WITHOUT the mandatory inline SECURITY annotation
-# required by CLAUDE.md ("Security Guidelines" / Developer Manifesto).
+# Blocks any Edit/Write/MultiEdit that introduces an f.Raw(), jf.Raw(), or
+# database.Raw() raw-SQL escape hatch WITHOUT the mandatory inline SECURITY
+# annotation required by CLAUDE.md ("Security Guidelines" / Developer
+# Manifesto).
 #
 # Rationale: the annotation is a forcing function for manual SQL review and
 # keeps every call site grep-discoverable. A pre-edit block is strictly
 # better than relying on a human remembering to grep later.
 #
 # Scope note: detection mirrors the canonical discovery grep in CLAUDE.md
-# (git grep -E 'f\.Raw\(|jf\.Raw\(') on purpose — it is tied to the documented
-# convention, not a general static analyzer. Receivers not named f/jf are out
-# of scope by design (the same as the CLAUDE.md grep).
+# (git grep -E 'f\.Raw\(|jf\.Raw\(|database\.Raw\(') on purpose — it is tied
+# to the documented convention, not a general static analyzer. Receivers not
+# named f/jf, and packages not named database, are out of scope by design
+# (the same as the CLAUDE.md grep).
 #
 # Fails CLOSED: a missing dependency or unparseable input blocks rather than
 # silently allowing an unguarded edit.
@@ -56,7 +58,7 @@ added="$(jq -er '
   // ""' <<<"$input" 2>/dev/null)" || block_unparseable
 
 # Does this edit introduce a raw-SQL escape hatch?
-if ! grep -Eq '(^|[^A-Za-z0-9_])(f|jf)\.Raw\(' <<<"$added"; then
+if ! grep -Eq '(^|[^A-Za-z0-9_])(f|jf|database)\.Raw\(' <<<"$added"; then
   exit 0
 fi
 
@@ -73,10 +75,15 @@ fi
 # several Raw calls. A pre-edit hook only sees a string fragment, so strict
 # per-call adjacency would false-block that sanctioned pattern. Semantic
 # adjacency review remains the job of /security-audit + human review.
+#
+# The marker must sit in a // comment AND carry a non-empty rationale after the
+# '-'. A marker inside a plain string literal no longer satisfies it. Residual by
+# design: a string that itself contains '//' before the marker still passes — this
+# is a forcing function for review, not a parser.
 if awk '
-  /SECURITY: Manual SQL review completed/ { seen = 1 }
-  /(^|[^A-Za-z0-9_])(f|jf)\.Raw\(/      { if (!seen) { missing = 1 } }
-  END                                    { exit (missing ? 1 : 0) }
+  /\/\/[^"]*SECURITY: Manual SQL review completed[[:space:]]*-[[:space:]]*[^[:space:]]/ { seen = 1 }
+  /(^|[^A-Za-z0-9_])(f|jf|database)\.Raw\(/      { if (!seen) { missing = 1 } }
+  END                                            { exit (missing ? 1 : 0) }
 ' <<<"$added"; then
   exit 0
 fi
@@ -84,7 +91,8 @@ fi
 cat >&2 <<'EOF'
 BLOCKED — raw-SQL escape hatch added without its mandatory SECURITY annotation.
 
-CLAUDE.md requires, at EVERY f.Raw()/jf.Raw() call site, an adjacent comment:
+CLAUDE.md requires, at EVERY f.Raw()/jf.Raw()/database.Raw() call site, an
+adjacent comment:
 
     // SECURITY: Manual SQL review completed - <what was verified>
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ GoBricks is a **production-grade framework for building MVPs fast**. It provides
 
 ### Security Guidelines
 - Input validation is **mandatory** at all boundaries (HTTP, messaging, database).
-- Raw-SQL escape hatches (`f.Raw()` and `jf.Raw()`) require an inline `// SECURITY: Manual SQL review completed - <what was verified>` annotation at every call site. The annotation is a forcing function for review and makes call sites grep-discoverable (`git grep -E 'f\.Raw\(|jf\.Raw\('`). The rationale should name the specific property checked: identifier quoting for vendor reserved words, parameterization of value sides, absence of user-input concatenation, etc.
+- Raw-SQL escape hatches (`f.Raw()`, `jf.Raw()`, and `database.Raw()`) require an inline `// SECURITY: Manual SQL review completed - <what was verified>` annotation at every call site. The annotation is a forcing function for review and makes call sites grep-discoverable (`git grep -E 'f\.Raw\(|jf\.Raw\(|database\.Raw\('`). The rationale should name the specific property checked: identifier quoting for vendor reserved words, parameterization of value sides, absence of user-input concatenation, etc.
 - Secrets from environment variables or secret managers (AWS Secrets Manager, HashiCorp Vault).
 - No hardcoded credentials, no secrets in logs or error messages. The framework's logger applies a `SensitiveDataFilter` to every log line; for PCI/PII workloads (PAN, CVV2, OTP) extend the default list via `log.sensitivefields` in YAML or `app.Options.LoggerFilterConfig` in code — see [wiki/observability.md#sensitive-data-filtering](wiki/observability.md#sensitive-data-filtering) for the field list, two-seam injection, matching semantics, and defense-in-depth guidance.
 - Audit logging for sensitive operations (access control, data modifications).
@@ -246,7 +246,7 @@ query := qb.Select(cols.Cols("ID", "Name")).
 
 **Type-Safe Methods:** `f.Eq`, `f.NotEq`, `f.Lt/Lte/Gt/Gte`, `f.In/NotIn`, `f.Like`, `f.Regex*`, `f.JSONContains` (PG only), `f.Null/NotNull`, `f.Between`, `f.Exists`, `f.NotExists`, `f.InSubquery`. Use `qb.Expr()` for complex SQL inside type-safe methods (no placeholders).
 
-**Escape hatch:** `f.Raw(...)` and `jf.Raw(...)` require a `// SECURITY: Manual SQL review completed - <rationale>` annotation at every call site.
+**Escape hatch:** `f.Raw(...)`, `jf.Raw(...)`, and `database.Raw(sql, args...)` (the Execute Helpers' hand-written-SQL adapter, broader than `f.Raw` — it replaces the whole statement, see [wiki/database.md#execute-helpers](wiki/database.md#execute-helpers)) require a `// SECURITY: Manual SQL review completed - <rationale>` annotation at every call site.
 
 **Defaults applied automatically:** Connection pooling (25 max, keepalive 60s), session timezone (`UTC` per ADR-016), Oracle reserved word quoting.
 

--- a/database/errors.go
+++ b/database/errors.go
@@ -52,8 +52,11 @@ func IsForeignKeyViolation(err error) bool {
 	return false
 }
 
-// IsNotFound reports whether err is a no-rows result (sql.ErrNoRows). This is a
-// scan-path signal; Exec does not produce it.
+// IsNotFound reports whether err is a no-rows result (sql.ErrNoRows). Scan
+// paths produce it natively; on the write path, ExecuteUpdateOne surfaces it
+// via ErrNoRows (which wraps sql.ErrNoRows) when an UPDATE/DELETE expected to
+// match exactly one row matches none, so IsNotFound matches that too.
+// ExecuteUpdate does not produce it — zero rows affected is (0, nil) there.
 func IsNotFound(err error) bool {
 	return err != nil && errors.Is(err, sql.ErrNoRows)
 }

--- a/database/execute.go
+++ b/database/execute.go
@@ -1,0 +1,255 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// Executor is the minimal query/exec surface shared by a database connection
+// (Interface) and a transaction (Tx), so the Execute* helpers run identically
+// inside or outside a transaction. Executor is a closed 2-method seam: future
+// capabilities (batch, prepared statements) arrive as separate interfaces,
+// never as additional methods here — adding a method to a shipped exported
+// interface is apidiff-INCOMPATIBLE.
+type Executor interface {
+	Query(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	Exec(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+// Both the connection interface and transactions satisfy Executor.
+var (
+	_ Executor = Interface(nil)
+	_ Executor = Tx(nil)
+)
+
+// SQLProvider is the contract of a complete, executable statement: anything
+// that can render itself to SQL + args. Every query builder returned by
+// QueryBuilder (Select/Insert/Update/Delete) already satisfies it; Raw adapts
+// hand-written SQL. A types.Filter/types.JoinFilter WHERE fragment also
+// satisfies SQLProvider structurally (it embeds squirrel.Sqlizer, which
+// declares the same ToSQL()-shaped ToSql()) but is NOT a complete statement
+// and must never be passed to the Execute* helpers directly — buildQuery
+// detects and rejects it at StageBuild instead of letting the driver fail on
+// a bare WHERE fragment.
+type SQLProvider interface {
+	ToSQL() (string, []any, error)
+}
+
+// Raw adapts hand-written SQL (UNION, FOR UPDATE, vendor tricks) to SQLProvider
+// so it reuses the same Execute* helpers as builder output.
+//
+// SECURITY: Raw is an escape hatch on par with Filter.Raw, and broader — the
+// SQL string replaces the whole statement, bypassing the builder's identifier
+// validation entirely. Never concatenate user input into the SQL; carry
+// values in args. Every call site requires an adjacent
+// "// SECURITY: Manual SQL review completed - <what was verified>" comment,
+// exactly as f.Raw()/jf.Raw() do.
+func Raw(query string, args ...any) SQLProvider { return rawQuery{query: query, args: args} }
+
+type rawQuery struct {
+	query string
+	args  []any
+}
+
+func (q rawQuery) ToSQL() (query string, args []any, err error) { return q.query, q.args, nil }
+
+// ErrNoRows reports a zero-row outcome: a SELECT that matched nothing
+// (ExecuteQuerySingle) or an UPDATE/DELETE expected to match exactly one row
+// but matched none (ExecuteUpdateOne). It wraps sql.ErrNoRows so
+// errors.Is(err, sql.ErrNoRows) and IsNotFound(err) also match.
+var ErrNoRows = fmt.Errorf("database: %w", sql.ErrNoRows)
+
+// ExecStage identifies where inside a helper an infrastructure failure occurred.
+type ExecStage string
+
+const (
+	StageBuild   ExecStage = "build"
+	StageExec    ExecStage = "exec"
+	StageScan    ExecStage = "scan"
+	StageIterate ExecStage = "iterate"
+	StageClose   ExecStage = "close"
+	// StageRowsAffected covers two distinct failures at the same point in the
+	// pipeline: the driver's RowsAffected() call itself erroring, or (in
+	// ExecuteUpdateOne only) RowsAffected() succeeding with a count that isn't
+	// the exactly-one cardinality the helper promises.
+	StageRowsAffected ExecStage = "rows_affected"
+)
+
+// ExecError is an infrastructure failure from an Execute* helper: the SQL
+// could not be built, executed, scanned, or iterated. Zero-row outcomes are
+// NOT ExecErrors — they are returned as op-labeled wraps of ErrNoRows.
+type ExecError struct {
+	Op    string // caller-supplied operation label
+	Stage ExecStage
+	Err   error
+}
+
+func (e *ExecError) Error() string { return fmt.Sprintf("%s: %s: %v", e.Op, e.Stage, e.Err) }
+
+func (e *ExecError) Unwrap() error { return e.Err }
+
+func buildQuery(q SQLProvider, op string) (query string, args []any, err error) {
+	// types.Filter/JoinFilter embed squirrel.Sqlizer and so declare ToSql() as well as
+	// ToSQL(); the statement builders declare only ToSQL(). A WHERE fragment therefore
+	// satisfies SQLProvider structurally but is not a complete statement — catch it here
+	// rather than letting the driver reject the SQL with an opaque StageExec error.
+	if _, isFragment := q.(interface {
+		ToSql() (string, []any, error)
+	}); isFragment {
+		return "", nil, &ExecError{
+			Op:    op,
+			Stage: StageBuild,
+			Err:   errors.New("database: a WHERE fragment (Filter/JoinFilter) is not a complete statement; pass a query builder result or database.Raw"),
+		}
+	}
+
+	query, args, err = q.ToSQL()
+	if err != nil {
+		return "", nil, &ExecError{Op: op, Stage: StageBuild, Err: err}
+	}
+	return query, args, nil
+}
+
+// ExecuteQuerySingle runs q and scans the first row into dest. It returns an
+// op-labeled ErrNoRows wrap when the query matches no rows, and *ExecError for
+// infrastructure failures. Extra rows beyond the first are ignored (sql.Row
+// parity): after a successful scan, the rows are closed explicitly (mirroring
+// sql.Row.Scan) so a driver error that only surfaces at Close — a truncated
+// result, a connection fault mid-statement — is not silently swallowed; that
+// failure is reported at StageClose. op labels errors only — it does not feed
+// metrics or tracing; use database.WithRepositoryMethod(ctx, ...) for
+// attribution. Typical mapping in an app:
+//
+//	err := database.ExecuteQuerySingle(ctx, tx, q, "ownership", &row.ID, &row.Name)
+//	switch {
+//	case errors.Is(err, database.ErrNoRows):
+//		return domain.ErrResourceNotFound // business 404
+//	case err != nil:
+//		return fmt.Errorf("load ownership: %w", err) // infra 500
+//	}
+func ExecuteQuerySingle(ctx context.Context, exec Executor, q SQLProvider, op string, dest ...any) error {
+	query, args, err := buildQuery(q, op)
+	if err != nil {
+		return err
+	}
+	rows, err := exec.Query(ctx, query, args...)
+	if err != nil {
+		return &ExecError{Op: op, Stage: StageExec, Err: err}
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		if iterErr := rows.Err(); iterErr != nil {
+			return &ExecError{Op: op, Stage: StageIterate, Err: iterErr}
+		}
+		return fmt.Errorf("%s: %w", op, ErrNoRows)
+	}
+	if err := rows.Scan(dest...); err != nil {
+		return &ExecError{Op: op, Stage: StageScan, Err: err}
+	}
+	// sql.Row.Scan surfaces the Close error after a successful scan so the query is
+	// known to have completed; Close is idempotent, so the deferred Close above
+	// remains the early-return safety net.
+	if err := rows.Close(); err != nil {
+		return &ExecError{Op: op, Stage: StageClose, Err: err}
+	}
+	return nil
+}
+
+// ExecuteQueryMany runs q and invokes scan once per row. Zero rows is not an
+// error (the caller sees an empty result). A scan callback error aborts
+// iteration and is wrapped at StageScan. A nil scan is rejected up front at
+// StageBuild rather than left to panic once a row arrives: unlike a nil q or
+// exec (which fail loudly at the call site, in the caller's own frame), a nil
+// scan is data-dependent — it only panics once the query returns a row, so a
+// zero-row result would let the mistake pass silently in dev and blow up
+// later in prod.
+func ExecuteQueryMany(ctx context.Context, exec Executor, q SQLProvider, op string, scan func(rows *sql.Rows) error) error {
+	if scan == nil {
+		return &ExecError{Op: op, Stage: StageBuild, Err: errors.New("database: ExecuteQueryMany requires a non-nil scan callback")}
+	}
+
+	query, args, err := buildQuery(q, op)
+	if err != nil {
+		return err
+	}
+	rows, err := exec.Query(ctx, query, args...)
+	if err != nil {
+		return &ExecError{Op: op, Stage: StageExec, Err: err}
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		if err := scan(rows); err != nil {
+			return &ExecError{Op: op, Stage: StageScan, Err: err}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return &ExecError{Op: op, Stage: StageIterate, Err: err}
+	}
+	return nil
+}
+
+// ExecuteUpdate runs an UPDATE/DELETE and returns the affected-row count. It
+// does not interpret zero: a legitimately-zero write (e.g. an UPDATE guarded
+// by a WHERE clause that may match nothing, such as an idempotent state
+// transition, or a bulk statement with no matching rows) returns (0, nil).
+// Use ExecuteUpdateOne when zero affected rows should surface as ErrNoRows.
+func ExecuteUpdate(ctx context.Context, exec Executor, q SQLProvider, op string) (int64, error) {
+	query, args, err := buildQuery(q, op)
+	if err != nil {
+		return 0, err
+	}
+	res, err := exec.Exec(ctx, query, args...)
+	if err != nil {
+		return 0, &ExecError{Op: op, Stage: StageExec, Err: err}
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, &ExecError{Op: op, Stage: StageRowsAffected, Err: err}
+	}
+	return n, nil
+}
+
+// ExecuteUpdateOne runs an UPDATE/DELETE expected to match exactly one row and
+// enforces that cardinality: zero rows affected returns an op-labeled
+// ErrNoRows wrap, so "not found" surfaces uniformly with ExecuteQuerySingle;
+// more than one row affected returns *ExecError at StageRowsAffected instead
+// of silently reporting success, because a broader-than-intended WHERE
+// predicate updating several rows is a data-integrity failure, not a "found
+// it" outcome; exactly one row affected returns nil. Use ExecuteUpdate when a
+// non-singular match is legitimate (bulk or idempotent writes), or when only
+// the caller can tell "absent" from "already in the target state".
+func ExecuteUpdateOne(ctx context.Context, exec Executor, q SQLProvider, op string) error {
+	n, err := ExecuteUpdate(ctx, exec, q, op)
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("%s: %w", op, ErrNoRows)
+	}
+	if n > 1 {
+		return &ExecError{
+			Op:    op,
+			Stage: StageRowsAffected,
+			Err:   fmt.Errorf("expected exactly 1 affected row, got %d", n),
+		}
+	}
+	return nil
+}
+
+// ExecuteInsert runs an INSERT. It does not inspect RowsAffected: a successful
+// INSERT is success, and vendor differences around LastInsertId/RETURNING are
+// out of scope here.
+func ExecuteInsert(ctx context.Context, exec Executor, q SQLProvider, op string) error {
+	query, args, err := buildQuery(q, op)
+	if err != nil {
+		return err
+	}
+	if _, err := exec.Exec(ctx, query, args...); err != nil {
+		return &ExecError{Op: op, Stage: StageExec, Err: err}
+	}
+	return nil
+}

--- a/database/execute_test.go
+++ b/database/execute_test.go
@@ -1,0 +1,584 @@
+package database_test
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/gaborage/go-bricks/database"
+	dbtesting "github.com/gaborage/go-bricks/database/testing"
+	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time proof every builder and Raw() satisfy SQLProvider.
+var (
+	_ database.SQLProvider = dbtypes.SelectQueryBuilder(nil)
+	_ database.SQLProvider = dbtypes.InsertQueryBuilder(nil)
+	_ database.SQLProvider = dbtypes.UpdateQueryBuilder(nil)
+	_ database.SQLProvider = dbtypes.DeleteQueryBuilder(nil)
+	// SECURITY: Manual SQL review completed - empty static SQL, compile-time interface assertion only, never executed
+	_ database.SQLProvider = database.Raw("", nil)
+)
+
+// SECURITY: Manual SQL review completed - all SQL in this file is static test
+// literal, no user input is concatenated, values are carried as args.
+func rawQ(query string, args ...any) database.SQLProvider { return database.Raw(query, args...) }
+
+// errBuildBoom is the fixed cause failingQuery.ToSQL fails with, so build
+// failures can be asserted at the same depth as every other infrastructure
+// failure in this file.
+var errBuildBoom = errors.New("build boom")
+
+// failingQuery is a SQLProvider whose ToSQL always errors, to exercise StageBuild.
+type failingQuery struct{}
+
+func (failingQuery) ToSQL() (query string, args []any, err error) {
+	return "", nil, errBuildBoom
+}
+
+// errIterateSentinel is returned by errRows after one good row, to exercise
+// StageIterate — a failure dbtesting.RowSet cannot inject.
+var errIterateSentinel = errors.New("iterate boom")
+
+// errRowsConnector/errRowsConn/errRows model a minimal database/sql/driver
+// implementation (mirroring database/testing/rowset.go's rowSetConnector/
+// rowSetConn/rowSetRows) whose Next returns one good row then a non-io.EOF
+// error, so rows.Err() is non-nil after the loop. This local driver exists
+// (rather than relying solely on dbtesting.RowSet, which can only induce an
+// iterate failure via an unsupported value type in a later row, yielding just
+// a message substring) because it proves the error CHAIN survives —
+// errors.Is(err, errIterateSentinel) — a stronger assertion for an
+// error-taxonomy feature.
+type errRowsConnector struct{}
+
+func (errRowsConnector) Connect(context.Context) (driver.Conn, error) {
+	return &errRowsConn{}, nil
+}
+
+// Driver satisfies driver.Connector; database/sql only calls it via
+// db.Driver(), which the QueryContext path used exclusively below never
+// triggers.
+func (errRowsConnector) Driver() driver.Driver { return nil }
+
+type errRowsConn struct{}
+
+func (*errRowsConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("Prepare not supported for errRowsConn")
+}
+
+func (*errRowsConn) Close() error { return nil }
+
+func (*errRowsConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("transactions not supported for errRowsConn")
+}
+
+func (*errRowsConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return &errRows{}, nil
+}
+
+type errRows struct {
+	idx int
+}
+
+func (*errRows) Columns() []string { return []string{"id"} }
+
+func (*errRows) Close() error { return nil }
+
+func (r *errRows) Next(dest []driver.Value) error {
+	if r.idx == 0 {
+		dest[0] = int64(1)
+		r.idx++
+		return nil
+	}
+	return errIterateSentinel
+}
+
+// errCloseSentinel is returned by closeErrRows.Close, to exercise StageClose —
+// a failure only sql.Row.Scan's post-scan Close call can surface;
+// dbtesting.RowSet cannot induce it, and ExecuteQueryMany never reaches it
+// (Next()==false already closes rows automatically per the database/sql docs).
+var errCloseSentinel = errors.New("close boom")
+
+// closeErrRowsConnector/closeErrRowsConn/closeErrRows model a minimal
+// database/sql/driver implementation (same shape as errRowsConnector/
+// errRowsConn/errRows above) whose Next yields exactly one good row (io.EOF
+// after) and whose Close always fails, so ExecuteQuerySingle's explicit
+// post-scan Close call surfaces a real driver error through the chain.
+type closeErrRowsConnector struct{}
+
+func (closeErrRowsConnector) Connect(context.Context) (driver.Conn, error) {
+	return &closeErrRowsConn{}, nil
+}
+
+func (closeErrRowsConnector) Driver() driver.Driver { return nil }
+
+type closeErrRowsConn struct{}
+
+func (*closeErrRowsConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("Prepare not supported for closeErrRowsConn")
+}
+
+func (*closeErrRowsConn) Close() error { return nil }
+
+func (*closeErrRowsConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("transactions not supported for closeErrRowsConn")
+}
+
+func (*closeErrRowsConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return &closeErrRows{}, nil
+}
+
+type closeErrRows struct {
+	idx int
+}
+
+func (*closeErrRows) Columns() []string { return []string{"id"} }
+
+func (*closeErrRows) Close() error { return errCloseSentinel }
+
+func (r *closeErrRows) Next(dest []driver.Value) error {
+	if r.idx == 0 {
+		dest[0] = int64(1)
+		r.idx++
+		return nil
+	}
+	return io.EOF
+}
+
+// stubExecutor implements database.Executor and always returns the *sql.Rows
+// it was constructed with from Query, so tests can inject rows backed by a
+// custom driver (e.g. errRows) that dbtesting.RowSet cannot produce.
+type stubExecutor struct {
+	rows *sql.Rows
+}
+
+func (s *stubExecutor) Query(context.Context, string, ...any) (*sql.Rows, error) {
+	return s.rows, nil
+}
+
+func (*stubExecutor) Exec(context.Context, string, ...any) (sql.Result, error) {
+	return nil, errors.New("stubExecutor.Exec not implemented")
+}
+
+// errRowsAffected is the failure errRowsAffectedResult.RowsAffected
+// returns, used to prove ExecuteUpdate/ExecuteUpdateOne wrap a RowsAffected()
+// failure at StageRowsAffected — unreachable through dbtesting's TestDB, whose
+// fake sql.Result never fails RowsAffected().
+var errRowsAffected = errors.New("rows affected boom")
+
+// errRowsAffectedResult is a sql.Result whose RowsAffected always errors.
+type errRowsAffectedResult struct{}
+
+func (errRowsAffectedResult) LastInsertId() (int64, error) {
+	return 0, errors.New("errRowsAffectedResult.LastInsertId not implemented")
+}
+
+func (errRowsAffectedResult) RowsAffected() (int64, error) { return 0, errRowsAffected }
+
+// rowsAffectedErrExecutor is a database.Executor whose Exec always succeeds
+// but returns a result that fails RowsAffected.
+type rowsAffectedErrExecutor struct{}
+
+func (rowsAffectedErrExecutor) Query(context.Context, string, ...any) (*sql.Rows, error) {
+	return nil, errors.New("rowsAffectedErrExecutor.Query not implemented")
+}
+
+func (rowsAffectedErrExecutor) Exec(context.Context, string, ...any) (sql.Result, error) {
+	return errRowsAffectedResult{}, nil
+}
+
+// assertExecError asserts err wraps a *database.ExecError with the given
+// stage and op, and — when cause is non-nil — that the error chain reaches
+// cause. Centralizing this keeps every infrastructure-failure test in this
+// file at the same assertion depth.
+func assertExecError(t *testing.T, err error, stage database.ExecStage, op string, cause error) {
+	t.Helper()
+	var ee *database.ExecError
+	require.True(t, errors.As(err, &ee))
+	assert.Equal(t, stage, ee.Stage)
+	assert.Equal(t, op, ee.Op)
+	if cause != nil {
+		assert.ErrorIs(t, err, cause)
+	}
+}
+
+// assertNoRows asserts err is the op-labeled ErrNoRows wrap: both sentinels
+// match via errors.Is, IsNotFound reports true, the message names op, and it
+// is NOT an *ExecError. Centralizing this keeps the zero-row-outcome
+// assertion depth identical across ExecuteQuerySingle and ExecuteUpdateOne.
+func assertNoRows(t *testing.T, err error, op string) {
+	t.Helper()
+	assert.ErrorIs(t, err, database.ErrNoRows)
+	assert.ErrorIs(t, err, sql.ErrNoRows)
+	assert.True(t, database.IsNotFound(err))
+	assert.Contains(t, err.Error(), op)
+	var ee *database.ExecError
+	assert.False(t, errors.As(err, &ee), "no-rows must not be an ExecError")
+}
+
+func TestExecuteQuerySingleScansRow(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectQuery("SELECT").WillReturnRows(dbtesting.NewRowSet("id", "name").AddRow(int64(7), "Alice"))
+
+	var id int64
+	var name string
+	err := database.ExecuteQuerySingle(t.Context(), db,
+		rawQ("SELECT id, name FROM users WHERE id = $1", 7),
+		"user_lookup", &id, &name)
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), id)
+	assert.Equal(t, "Alice", name)
+}
+
+func TestExecuteQuerySingleNoRows(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectQuery("SELECT").WillReturnRows(dbtesting.NewRowSet("id"))
+
+	var id int64
+	err := database.ExecuteQuerySingle(t.Context(), db,
+		rawQ("SELECT id FROM users WHERE id = $1", 7),
+		"user_lookup", &id)
+	require.Error(t, err)
+	assertNoRows(t, err, "user_lookup")
+}
+
+func TestExecuteQuerySingleExecError(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	sentinel := errors.New("boom")
+	db.ExpectQuery("SELECT").WillReturnError(sentinel)
+
+	var id int64
+	err := database.ExecuteQuerySingle(t.Context(), db,
+		rawQ("SELECT id FROM users"), "user_lookup", &id)
+	require.Error(t, err)
+	assertExecError(t, err, database.StageExec, "user_lookup", sentinel)
+}
+
+func TestExecuteQuerySingleBuildError(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+
+	var id int64
+	err := database.ExecuteQuerySingle(t.Context(), db, failingQuery{}, "user_lookup", &id)
+	require.Error(t, err)
+	assertExecError(t, err, database.StageBuild, "user_lookup", errBuildBoom)
+	assert.Empty(t, db.QueryLog(), "ToSQL failure must short-circuit before Query is called")
+}
+
+func TestExecuteQuerySingleScanError(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectQuery("SELECT").WillReturnRows(dbtesting.NewRowSet("id").AddRow("not-an-int"))
+
+	var id int64
+	err := database.ExecuteQuerySingle(t.Context(), db,
+		rawQ("SELECT id FROM users"), "user_lookup", &id)
+	require.Error(t, err)
+	assertExecError(t, err, database.StageScan, "user_lookup", nil)
+}
+
+func TestExecuteQuerySingleCloseError(t *testing.T) {
+	sqlDB := sql.OpenDB(closeErrRowsConnector{})
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	rows, err := sqlDB.QueryContext(t.Context(), "irrelevant")
+	require.NoError(t, err)
+
+	exec := &stubExecutor{rows: rows}
+	var id int64
+	err = database.ExecuteQuerySingle(t.Context(), exec,
+		rawQ("SELECT id FROM users"), "user_lookup", &id)
+	require.Error(t, err)
+	assertExecError(t, err, database.StageClose, "user_lookup", errCloseSentinel)
+}
+
+func TestExecuteQueryManyCollectsRows(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectQuery("SELECT").WillReturnRows(
+		dbtesting.NewRowSet("id").AddRow(int64(1)).AddRow(int64(2)).AddRow(int64(3)),
+	)
+
+	var ids []int64
+	err := database.ExecuteQueryMany(t.Context(), db,
+		rawQ("SELECT id FROM users"), "list_users",
+		func(rows *sql.Rows) error {
+			var id int64
+			if scanErr := rows.Scan(&id); scanErr != nil {
+				return scanErr
+			}
+			ids = append(ids, id)
+			return nil
+		})
+	require.NoError(t, err)
+	assert.Equal(t, []int64{1, 2, 3}, ids)
+}
+
+func TestExecuteQueryManyZeroRowsIsNotError(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectQuery("SELECT").WillReturnRows(dbtesting.NewRowSet("id"))
+
+	called := false
+	err := database.ExecuteQueryMany(t.Context(), db,
+		rawQ("SELECT id FROM users"), "list_users",
+		func(*sql.Rows) error {
+			called = true
+			return nil
+		})
+	require.NoError(t, err)
+	assert.False(t, called)
+}
+
+func TestExecuteQueryManyNilScanCallback(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectQuery("SELECT").WillReturnRows(dbtesting.NewRowSet("id").AddRow(int64(1)))
+
+	err := database.ExecuteQueryMany(t.Context(), db, rawQ("SELECT id FROM users"), "list_users", nil)
+	require.Error(t, err)
+	assertExecError(t, err, database.StageBuild, "list_users", nil)
+	assert.Empty(t, db.QueryLog(), "a nil scan callback must short-circuit before the query ever dispatches")
+}
+
+func TestExecuteQueryManyCallbackError(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectQuery("SELECT").WillReturnRows(
+		dbtesting.NewRowSet("id").AddRow(int64(1)).AddRow(int64(2)),
+	)
+	sentinel := errors.New("callback boom")
+
+	count := 0
+	err := database.ExecuteQueryMany(t.Context(), db,
+		rawQ("SELECT id FROM users"), "list_users",
+		func(rows *sql.Rows) error {
+			count++
+			if count == 2 {
+				return sentinel
+			}
+			var id int64
+			return rows.Scan(&id)
+		})
+	require.Error(t, err)
+	assertExecError(t, err, database.StageScan, "list_users", sentinel)
+}
+
+func TestExecuteQueryManyIterateError(t *testing.T) {
+	sqlDB := sql.OpenDB(errRowsConnector{})
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	rows, err := sqlDB.QueryContext(t.Context(), "irrelevant")
+	require.NoError(t, err)
+
+	exec := &stubExecutor{rows: rows}
+	err = database.ExecuteQueryMany(t.Context(), exec,
+		rawQ("SELECT id FROM users"), "list_users",
+		func(rows *sql.Rows) error {
+			var id int64
+			return rows.Scan(&id)
+		})
+	require.Error(t, err)
+	assertExecError(t, err, database.StageIterate, "list_users", errIterateSentinel)
+}
+
+func TestExecuteUpdateReturnsAffected(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectExec("UPDATE").WillReturnRowsAffected(3)
+
+	n, err := database.ExecuteUpdate(t.Context(), db,
+		rawQ("UPDATE users SET active = true"), "activate_users")
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), n)
+}
+
+func TestExecuteUpdateZeroRowsReturnsCount(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectExec("UPDATE").WillReturnRowsAffected(0)
+
+	n, err := database.ExecuteUpdate(t.Context(), db,
+		rawQ("UPDATE sessions SET expired = true WHERE expires_at < now()"),
+		"expire_sessions")
+	require.NoError(t, err, "zero rows affected is a legitimate outcome, not an error")
+	assert.Equal(t, int64(0), n)
+}
+
+func TestExecuteUpdateExecError(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	sentinel := errors.New("boom")
+	db.ExpectExec("UPDATE").WillReturnError(sentinel)
+
+	n, err := database.ExecuteUpdate(t.Context(), db,
+		rawQ("UPDATE users SET active = true"), "activate_users")
+	require.Error(t, err)
+	assert.Equal(t, int64(0), n)
+	assertExecError(t, err, database.StageExec, "activate_users", sentinel)
+}
+
+func TestExecuteUpdateRowsAffectedError(t *testing.T) {
+	exec := rowsAffectedErrExecutor{}
+
+	n, err := database.ExecuteUpdate(t.Context(), exec,
+		rawQ("UPDATE users SET active = true"), "activate_users")
+	require.Error(t, err)
+	assert.Equal(t, int64(0), n)
+	assertExecError(t, err, database.StageRowsAffected, "activate_users", errRowsAffected)
+}
+
+func TestExecuteUpdateOneSucceeds(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectExec("UPDATE").WillReturnRowsAffected(1)
+
+	err := database.ExecuteUpdateOne(t.Context(), db,
+		rawQ("UPDATE users SET active = true WHERE id = $1", 1), "activate_user")
+	require.NoError(t, err)
+}
+
+func TestExecuteUpdateOneZeroRowsIsErrNoRows(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectExec("UPDATE").WillReturnRowsAffected(0)
+
+	err := database.ExecuteUpdateOne(t.Context(), db,
+		rawQ("UPDATE users SET active = true WHERE id = $1", 999),
+		"activate_user")
+	require.Error(t, err)
+	assertNoRows(t, err, "activate_user")
+}
+
+func TestExecuteUpdateOneRejectsMultipleRows(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectExec("UPDATE").WillReturnRowsAffected(3)
+
+	err := database.ExecuteUpdateOne(t.Context(), db,
+		rawQ("UPDATE users SET active = true WHERE tier = $1", "gold"),
+		"activate_tier")
+	require.Error(t, err)
+	assertExecError(t, err, database.StageRowsAffected, "activate_tier", nil)
+	assert.Contains(t, err.Error(), "3", "message must name the offending count")
+}
+
+func TestExecuteUpdateOneExecError(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	sentinel := errors.New("boom")
+	db.ExpectExec("UPDATE").WillReturnError(sentinel)
+
+	err := database.ExecuteUpdateOne(t.Context(), db,
+		rawQ("UPDATE users SET active = true WHERE id = $1", 1), "activate_user")
+	require.Error(t, err)
+	assertExecError(t, err, database.StageExec, "activate_user", sentinel)
+}
+
+func TestExecuteUpdateOneRowsAffectedError(t *testing.T) {
+	exec := rowsAffectedErrExecutor{}
+
+	err := database.ExecuteUpdateOne(t.Context(), exec,
+		rawQ("UPDATE users SET active = true WHERE id = $1", 1), "activate_user")
+	require.Error(t, err)
+	assertExecError(t, err, database.StageRowsAffected, "activate_user", errRowsAffected)
+}
+
+func TestExecuteInsertSucceeds(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	// 0 rows affected on a successful INSERT is what proves ExecuteInsert does
+	// NOT unify with the zero-rows-is-an-error behavior — that is exactly the
+	// distinction ExecuteUpdateOne exists to draw.
+	db.ExpectExec("INSERT").WillReturnRowsAffected(0)
+
+	err := database.ExecuteInsert(t.Context(), db,
+		rawQ("INSERT INTO users (name) VALUES ($1)", "Alice"),
+		"create_user")
+	require.NoError(t, err)
+}
+
+func TestExecuteInsertExecError(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	sentinel := errors.New("boom")
+	db.ExpectExec("INSERT").WillReturnError(sentinel)
+
+	err := database.ExecuteInsert(t.Context(), db,
+		rawQ("INSERT INTO users (name) VALUES ($1)", "Alice"),
+		"create_user")
+	require.Error(t, err)
+	assertExecError(t, err, database.StageExec, "create_user", sentinel)
+}
+
+func TestExecuteHelpersRunInsideTransaction(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction().ExpectQuery("SELECT").WillReturnRows(dbtesting.NewRowSet("id").AddRow(int64(1)))
+
+	err := database.WithTx(t.Context(), db, func(ctx context.Context, tx dbtypes.Tx) error {
+		var id int64
+		return database.ExecuteQuerySingle(ctx, tx,
+			rawQ("SELECT id FROM users WHERE id = $1", 1),
+			"user_lookup", &id)
+	})
+	require.NoError(t, err)
+}
+
+func TestRawToSQLPassthrough(t *testing.T) {
+	// SECURITY: Manual SQL review completed - static literal, no user input; the value side is carried as an arg
+	query, args, err := database.Raw("SELECT 1", 2).ToSQL()
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT 1", query)
+	assert.Equal(t, []any{2}, args)
+}
+
+func TestBuildersSatisfySQLProvider(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectQuery("SELECT id FROM users").WillReturnRows(dbtesting.NewRowSet("id").AddRow(int64(1)))
+
+	qb := database.NewQueryBuilder(dbtypes.PostgreSQL).Select("id").From("users")
+
+	var ids []int64
+	err := database.ExecuteQueryMany(t.Context(), db, qb, "list_users",
+		func(rows *sql.Rows) error {
+			var id int64
+			if scanErr := rows.Scan(&id); scanErr != nil {
+				return scanErr
+			}
+			ids = append(ids, id)
+			return nil
+		})
+	require.NoError(t, err)
+	assert.Equal(t, []int64{1}, ids)
+}
+
+// TestUpdateBuilderNotRejectedAsFragment is the regression fence for the
+// fragment guard in buildQuery: an UpdateQueryBuilder result carries a WHERE
+// clause internally but its own ToSQL() renders a complete UPDATE statement,
+// so it must reach exec.Exec rather than being rejected at StageBuild the way
+// a bare Filter/JoinFilter is.
+func TestUpdateBuilderNotRejectedAsFragment(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectExec("UPDATE users").WillReturnRowsAffected(1)
+
+	qb := database.NewQueryBuilder(dbtypes.PostgreSQL)
+	q := qb.Update("users").Set("active", true).Where(qb.Filter().Eq("id", 1))
+
+	err := database.ExecuteUpdateOne(t.Context(), db, q, "activate_user")
+	require.NoError(t, err)
+	require.Len(t, db.ExecLog(), 1, "the UPDATE must actually reach Exec, not be rejected at StageBuild")
+}
+
+func TestExecuteRejectsWhereFragment(t *testing.T) {
+	qb := database.NewQueryBuilder(dbtypes.PostgreSQL)
+
+	t.Run("filter", func(t *testing.T) {
+		db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+
+		var id int64
+		err := database.ExecuteQuerySingle(t.Context(), db, qb.Filter().Eq("id", 5), "user_lookup", &id)
+		require.Error(t, err)
+		assertExecError(t, err, database.StageBuild, "user_lookup", nil)
+		assert.Contains(t, err.Error(), "fragment")
+		assert.Empty(t, db.QueryLog(), "a rejected fragment must never reach Query")
+	})
+
+	t.Run("join_filter", func(t *testing.T) {
+		db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+
+		var id int64
+		err := database.ExecuteQuerySingle(t.Context(), db, qb.JoinFilter().EqColumn("a.id", "b.id"), "user_lookup", &id)
+		require.Error(t, err)
+		assertExecError(t, err, database.StageBuild, "user_lookup", nil)
+		assert.Contains(t, err.Error(), "fragment")
+		assert.Empty(t, db.QueryLog(), "a rejected fragment must never reach Query")
+	})
+}

--- a/llms.txt
+++ b/llms.txt
@@ -360,6 +360,7 @@ Per ADR-003, at least one of `host` *or* `connectionstring` must be set, otherwi
 ```go
 import (
 	"context"
+	"database/sql" // needed for the *sql.Rows callback parameter in Step 3(c) / Step 4's ExecuteQueryMany
 	"fmt"
 
 	"github.com/gaborage/go-bricks/app"
@@ -436,31 +437,96 @@ func (m *UserModule) FindActiveUsersBuilder(ctx context.Context) ([]User, error)
 	all := cols.All()
 	allAny := make([]any, len(all))
 	for i, c := range all { allAny[i] = c }
-	sql, args, err := qb.Select(allAny...).
-		From("users").
-		Where(f.Eq(cols.Col("Status"), "active")).
-		ToSQL()
-	if err != nil {
-		return nil, fmt.Errorf("build query: %w", err)
-	}
+	q := qb.Select(allAny...).From("users").Where(f.Eq(cols.Col("Status"), "active"))
 	// PostgreSQL: SELECT id, name, email, status FROM users WHERE status = $1
 	// Oracle:     SELECT id, name, email, status FROM users WHERE status = :1
-
-	rows, err := db.Query(ctx, sql, args...)
-	if err != nil {
-		return nil, fmt.Errorf("query failed: %w", err)
-	}
-	defer rows.Close()
+	// The builder result is a database.SQLProvider — pass it straight in, no .ToSQL() call
 
 	var users []User
-	for rows.Next() {
+	err = database.ExecuteQueryMany(ctx, db, q, "find_active_users", func(rows *sql.Rows) error {
 		var u User
 		if err := rows.Scan(&u.ID, &u.Name, &u.Email, &u.Status); err != nil {
-			return nil, fmt.Errorf("scan failed: %w", err)
+			return err
 		}
 		users = append(users, u)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("find active users: %w", err)
 	}
-	return users, rows.Err()
+	return users, nil
+}
+```
+
+### Step 4: Execute Helpers — skip the ToSQL→Query→Scan boilerplate
+
+The `(b)` loop above (`db.Query` → `defer rows.Close()` → iterate via `rows.Next()` → `Scan` → check `rows.Err()`) is the single most-repeated pattern across SQL repositories. `database.Execute*` collapses it into one call and works identically against a `database.Interface` connection or an in-flight `database.Tx` — both satisfy the 2-method `database.Executor` seam, so the same repository method runs standalone or inside a transaction unchanged.
+
+| Helper | Signature | Use for |
+|---|---|---|
+| `ExecuteQuerySingle` | `(ctx, exec, q, op string, dest ...any) error` | Exactly one row expected; `ErrNoRows` if none matched |
+| `ExecuteQueryMany` | `(ctx, exec, q, op string, scan func(*sql.Rows) error) error` | Zero-or-more rows; `scan` runs once per row — zero rows is NOT an error |
+| `ExecuteUpdate` | `(ctx, exec, q, op string) (int64, error)` | UPDATE/DELETE — returns the raw affected-row count and does **not** treat zero as an error (bulk writes, idempotent state transitions) |
+| `ExecuteUpdateOne` | `(ctx, exec, q, op string) error` | UPDATE/DELETE expected to match exactly one row — zero rows affected becomes `ErrNoRows` (same as `ExecuteQuerySingle`); **more than one** row affected is rejected as `*ExecError` at `StageRowsAffected`, not silently reported as success |
+| `ExecuteInsert` | `(ctx, exec, q, op string) error` | INSERT — success is success; doesn't inspect `RowsAffected` |
+
+`q` is anything satisfying `database.SQLProvider` (`ToSQL() (string, []any, error)`) — every builder result (`qb.Select/Insert/Update/Delete(...)`) already does; use `database.Raw(sql, args...)` for hand-written SQL. **Never** pass a bare `qb.Filter()`/`qb.JoinFilter()` result — a WHERE fragment is not a complete statement and is rejected with a clear error instead of reaching the driver.
+
+**Before** — the loop in Step 3(b) above; **after** (`ExecuteQueryMany`, same behavior):
+
+```go
+// SECURITY: Manual SQL review completed - static SQL, no user input concatenated, value parameterized via arg
+q := database.Raw("SELECT id, name, email, status FROM users WHERE status = $1 ORDER BY id", "active")
+
+var users []User
+err := database.ExecuteQueryMany(ctx, db, q, "list_active_users", func(rows *sql.Rows) error {
+	var u User
+	if err := rows.Scan(&u.ID, &u.Name, &u.Email, &u.Status); err != nil {
+		return err
+	}
+	users = append(users, u)
+	return nil
+})
+if err != nil {
+	return nil, fmt.Errorf("list active users: %w", err)
+}
+return users, nil
+```
+
+A type-safe builder result passes straight through — no `.ToSQL()` call needed: `q := qb.Select(allAny...).From("users").Where(f.Eq(cols.Col("Status"), "active"))`.
+
+**Error contract** — every helper reports failures the same way:
+
+```go
+var execErr *database.ExecError
+switch {
+case errors.Is(err, database.ErrNoRows):
+	return domain.ErrUserNotFound // business 404 — ExecuteQuerySingle / ExecuteUpdateOne, zero rows
+case errors.As(err, &execErr):
+	// infrastructure failure — execErr.Stage (database.ExecStage) is one of:
+	//   StageBuild (bad SQL / rejected WHERE fragment), StageExec (driver/connection),
+	//   StageScan, StageIterate, StageClose (ExecuteQuerySingle only), StageRowsAffected
+	return fmt.Errorf("%s failed at %s: %w", execErr.Op, execErr.Stage, execErr.Err)
+case err != nil:
+	return err
+}
+```
+
+**`ExecuteUpdate` vs `ExecuteUpdateOne`** — pick based on whether zero matched rows is expected:
+
+```go
+// Bulk/idempotent write — zero rows affected is a legitimate outcome, not an error.
+// SECURITY: Manual SQL review completed - static SQL, no user input concatenated
+n, err := database.ExecuteUpdate(ctx, db,
+	database.Raw("UPDATE sessions SET expired = true WHERE expires_at < now()"),
+	"expire_sessions")
+
+// Single-row write — zero rows affected means "not found".
+err = database.ExecuteUpdateOne(ctx, tx,
+	qb.Update("users").Set(cols.Col("Active"), true).Where(f.Eq(cols.Col("ID"), userID)),
+	"activate_user")
+if errors.Is(err, database.ErrNoRows) {
+	return domain.ErrUserNotFound
 }
 ```
 
@@ -515,12 +581,13 @@ func (m *UserModule) PingDB(ctx context.Context) error {
 ```
 
 **Key points:**
-- Connection is config-driven — never call `sql.Open` or import `pgx`/`go-ora` directly; the framework manages pooling, keep-alive, timezone, and lifecycle
+- Connection is config-driven — never call `sql.Open` or import `pgx`/`go-ora` directly; the framework manages pooling, keep-alive, timezone, and lifecycle. This forbids the vendor driver packages, not the standard library: `ExecuteQueryMany`'s scan callback takes `*sql.Rows`, so importing stdlib `database/sql` for that type is expected and fine
 - `deps.DB` is a **function**, not an instance — call `getDB(ctx)` each time so multi-tenant resolution works
-- Use raw SQL (`db.QueryRow`, `db.Query`, `db.Exec`) for simple, vendor-pinned queries
+- **Default to a helper** — `database.Execute*` (Step 4) owns the build→exec→scan→error-wrap glue and the zero-rows decision; reach past it only when you have a specific reason to
+- Builder + a helper by default for queries; `database.Raw(...)` + a helper (with the mandatory `// SECURITY: Manual SQL review completed - ...` annotation) for vendor-pinned SQL; bare `db.QueryRow`/`db.Query`/`db.Exec` only when you genuinely need the raw primitive (no `op` label, no typed error contract)
 - Use `database.NewQueryBuilder(db.DatabaseType())` for type-safe, vendor-agnostic queries (auto-handles placeholders and Oracle reserved-word quoting)
-- Always `defer rows.Close()` after `db.Query` and check `rows.Err()` after the loop
-- For atomicity: `db.Begin(ctx)` → `defer tx.Rollback(ctx)` → `tx.Commit(ctx)` at the end
+- Always `defer rows.Close()` and check `rows.Err()` after the loop — when you hold `*sql.Rows` yourself via `db.Query`; `ExecuteQueryMany`/`ExecuteQuerySingle` own `Close` and `rows.Err()` for you
+- For atomicity: `db.Begin(ctx)` → `defer tx.Rollback(ctx)` → work via `database.Execute*(ctx, tx, q, "op")` (both `Interface` and `Tx` satisfy `database.Executor`) → `tx.Commit(ctx)` at the end
 
 ## Typed HTTP Handlers
 
@@ -1133,58 +1200,63 @@ cols := qb.Columns(&User{})
 selected := cols.Cols("ID", "Email")
 selectedAny := make([]any, len(selected))
 for i, c := range selected { selectedAny[i] = c }
-sql, args, err := qb.Select(selectedAny...).
+q := qb.Select(selectedAny...).
 	From("users").
 	Where(f.And(
 		f.Eq(cols.Col("Status"), "active"),
 		f.Like(cols.Col("Email"), "%@example.com"),
-	)).
-	ToSQL()
-if err != nil {
-	return nil, fmt.Errorf("build query: %w", err)
-}
+	))
+// q is a database.SQLProvider — pass it straight to Execute*, no .ToSQL() call needed
 
-rows, err := db.Query(ctx, sql, args...)
+var users []User
+err = database.ExecuteQueryMany(ctx, db, q, "list_active_users_by_email", func(rows *sql.Rows) error {
+	var u User
+	if err := rows.Scan(&u.ID, &u.Email); err != nil {
+		return err
+	}
+	users = append(users, u)
+	return nil
+})
+if err != nil {
+	return nil, fmt.Errorf("list users: %w", err)
+}
+return users, nil
 ```
 
 | Need                | Builder call / API usage                                               |
 |---------------------|------------------------------------------------------------------------|
-| Filtering           | `f.Eq`, `f.And`, `f.Or`, `f.In`, `f.Between`                           |
+| Filtering           | `f.Eq`, `f.And`, `f.Or`, `f.In`, `f.Between`, `f.Lt`/`f.Lte`/`f.Gt`/`f.Gte` (inequalities — no need to reach for raw SQL) |
 | Pattern matching    | `f.Like` (case-insensitive), `f.Regex`/`f.RegexI`/`f.NotRegex`/`f.NotRegexI` (POSIX regex; PG `~`/`~*`/`!~`/`!~*`, Oracle `REGEXP_LIKE` with `'i'` flag) |
 | JSON containment    | `f.JSONContains(col, value)` — PostgreSQL `@>` on `jsonb`; pass struct/map/slice (auto JSON-marshalled) or pre-encoded `string`/`[]byte`/`json.RawMessage`. Oracle is not yet supported. |
 | Sorting / grouping  | `qb.Select(...).From("...").OrderBy(qb.MustExpr("created_at DESC")).GroupBy("tenant_id")` |
-| Mutations           | `qb.Insert`, `qb.Update`, `qb.Delete`, then `db.Exec`                  |
+| Mutations           | `qb.Insert/Update/Delete` → `database.ExecuteInsert` / `ExecuteUpdate` (raw count, zero legal) / `ExecuteUpdateOne` (zero → `ErrNoRows`). Pass the builder directly — no `.ToSQL()` |
 | Joins               | `qb.JoinOn` with `qb.JoinFilter()`                                     |
 | Subqueries          | Compose another builder clause then `f.Exists(subQuery)`               |
-| Raw escape hatch    | `f.Raw(cond, args...)` / `jf.Raw(cond, args...)` — REQUIRES `// SECURITY: Manual SQL review completed - <rationale>` comment at every call site (manual identifier quoting + parameterized values; never concatenate user input) |
-| Transactions        | `tx, err := db.Begin(ctx); if err != nil { return err }; defer tx.Rollback(ctx); /* work */; if err := tx.Commit(ctx); err != nil { return err }` |
+| Raw escape hatch    | `f.Raw(cond, args...)` / `jf.Raw(cond, args...)` produce a WHERE/JOIN **fragment**; `database.Raw(sql, args...)` replaces the **whole statement** (broader — it bypasses the builder's identifier validation entirely). All three REQUIRE a `// SECURITY: Manual SQL review completed - <rationale>` comment at every call site (manual identifier quoting + parameterized values; never concatenate user input) |
+| Transactions        | `tx, err := db.Begin(ctx); if err != nil { return err }; defer tx.Rollback(ctx); /* work: database.Execute*(ctx, tx, q, "op") — both Interface and Tx satisfy database.Executor */; if err := tx.Commit(ctx); err != nil { return err }` |
 
 **Mutation Examples (INSERT/UPDATE/DELETE):**
 
 ```go
 // INSERT
-sql, args, err := qb.Insert("users").
-    Columns(cols.Col("Name"), cols.Col("Email")).
-    Values("Alice", "alice@example.com").
-    ToSQL()
-if err != nil { return err }
-result, err := db.Exec(ctx, sql, args...)
+if err := database.ExecuteInsert(ctx, db,
+    qb.Insert("users").Columns(cols.Col("Name"), cols.Col("Email")).Values("Alice", "alice@example.com"),
+    "create_user"); err != nil {
+    return err
+}
 
-// UPDATE
-sql, args, err = qb.Update("users").
-    Set(cols.Col("Name"), "Bob").
-    Set(cols.Col("Email"), "bob@example.com").
-    Where(f.Eq(cols.Col("ID"), 123)).
-    ToSQL()
-if err != nil { return err }
-result, err = db.Exec(ctx, sql, args...)
+// UPDATE — exactly one row expected; zero means "not found"
+err := database.ExecuteUpdateOne(ctx, db,
+    qb.Update("users").Set(cols.Col("Name"), "Bob").Where(f.Eq(cols.Col("ID"), 123)),
+    "rename_user")
+if errors.Is(err, database.ErrNoRows) {
+    return ErrUserNotFound
+}
 
-// DELETE
-sql, args, err = qb.Delete("users").
-    Where(f.Eq(cols.Col("ID"), 123)).
-    ToSQL()
-if err != nil { return err }
-result, err = db.Exec(ctx, sql, args...)
+// DELETE — bulk/idempotent; zero rows is a legitimate outcome
+n, err := database.ExecuteUpdate(ctx, db,
+    qb.Delete("users").Where(f.Lt(cols.Col("LastSeen"), cutoff)),
+    "purge_stale_users")
 ```
 
 Access to vendor quirks (Oracle quoting) routes through the same interface; switching drivers requires config only.
@@ -5179,6 +5251,7 @@ package orders
 import (
     "errors"
 
+    "github.com/gaborage/go-bricks/database"
     "github.com/gaborage/go-bricks/server"
 )
 
@@ -5193,11 +5266,30 @@ func mapOrderError(err error) server.IAPIError {
             WithDetails("suggestion", "reduce quantity or wait for restock")
     }
 
+    // Repository "not found" — only the single-row helpers (ExecuteQuerySingle,
+    // ExecuteUpdateOne) ever produce ErrNoRows; a matching call that found no
+    // row collapses to the same 404 as the domain-level sentinel above (mirror
+    // this the way cache.ErrNotFound is checked at the cache boundary): the
+    // repository should translate this into ErrOrderNotFound before it
+    // reaches the handler, but mapping it here too means an untranslated
+    // ErrNoRows never falls through to the generic 500 below.
+    if errors.Is(err, database.ErrNoRows) {
+        return server.NewNotFoundError("Order")
+    }
+
     // Struct-based errors — errors.As()
     var dupErr *DuplicateOrderError
     if errors.As(err, &dupErr) {
         return server.NewConflictError(dupErr.Error()).
             WithDetails("existing_order_id", dupErr.ExistingID)
+    }
+
+    // Infrastructure failure from a database.Execute* helper (build/exec/scan/
+    // iterate/close/rows_affected) — never a 404; "not found" was already
+    // ruled out above.
+    var execErr *database.ExecError
+    if errors.As(err, &execErr) {
+        return server.NewInternalServerError("An internal error occurred")
     }
 
     // Unknown errors — safe fallback (details hidden in production)
@@ -5246,6 +5338,7 @@ import (
 
     amqp "github.com/rabbitmq/amqp091-go"
 
+    "github.com/gaborage/go-bricks/database"
     "github.com/gaborage/go-bricks/logger"
 )
 
@@ -5262,6 +5355,14 @@ func (h *OrderConsumer) Handle(ctx context.Context, delivery *amqp.Delivery) err
 
     err := h.svc.Create(ctx, req.ProductID, req.Quantity)
     if err != nil {
+        // "Not found": retrying won't make a missing order appear, so this is a
+        // skip, not a retry-worthy failure — covers both the translated domain
+        // sentinel and an untranslated repository ErrNoRows reaching this far.
+        if errors.Is(err, ErrOrderNotFound) || errors.Is(err, database.ErrNoRows) {
+            h.logger.Warn().Int64("product_id", req.ProductID).Msg("Order not found, skipping")
+            return nil // ACK — not found is not a transient condition
+        }
+
         // Business-rule violations: log and ACK (skip, don't retry)
         if errors.Is(err, ErrInsufficientStock) {
             h.logger.Warn().Int64("product_id", req.ProductID).Int("quantity", req.Quantity).
@@ -5292,8 +5393,10 @@ Same domain errors, different boundary handling:
 | Domain Error | HTTP Handler (IAPIError) | AMQP Consumer |
 |-------------|--------------------------|---------------|
 | `ErrOrderNotFound` | `NewNotFoundError("Order")` → 404 | Log WARN + ACK (skip) |
+| `database.ErrNoRows` (untranslated repository "not found") | `NewNotFoundError("Order")` → 404 | Log WARN + ACK (skip) |
 | `ErrInsufficientStock` | `NewBusinessLogicError("INSUFFICIENT_STOCK", ...)` → 422 | Log WARN + ACK (skip) |
 | `*DuplicateOrderError` | `NewConflictError(...)` → 409 with details | Log WARN + ACK (idempotent) |
+| `*database.ExecError` (infrastructure failure) | `NewInternalServerError(...)` → 500 | Return error → nack + drop |
 | Unexpected error | `NewInternalServerError(...)` → 500 | Return error → nack + drop |
 
 **Key principle:** Domain errors are defined once in the module. Each boundary (HTTP, AMQP) decides how to translate them — HTTP maps to status codes, AMQP maps to ACK/nack decisions with logging.

--- a/llms.txt
+++ b/llms.txt
@@ -1182,9 +1182,10 @@ func PromoteID(c server.HandlerContext, next func() error) error {
 ```go
 // Define entity with db tags
 type User struct {
-    ID     int64  `db:"id"`
-    Email  string `db:"email"`
-    Status string `db:"status"`
+    ID       int64     `db:"id"`
+    Email    string    `db:"email"`
+    Status   string    `db:"status"`
+    LastSeen time.Time `db:"last_seen"`
 }
 
 // Obtain db from getDB(ctx) — see "Database Connection & Queries" above
@@ -1240,23 +1241,26 @@ return users, nil
 ```go
 // INSERT
 if err := database.ExecuteInsert(ctx, db,
-    qb.Insert("users").Columns(cols.Col("Name"), cols.Col("Email")).Values("Alice", "alice@example.com"),
+    qb.Insert("users").Columns(cols.Col("Email"), cols.Col("Status")).Values("alice@example.com", "active"),
     "create_user"); err != nil {
     return err
 }
 
 // UPDATE — exactly one row expected; zero means "not found"
 err := database.ExecuteUpdateOne(ctx, db,
-    qb.Update("users").Set(cols.Col("Name"), "Bob").Where(f.Eq(cols.Col("ID"), 123)),
-    "rename_user")
+    qb.Update("users").Set(cols.Col("Status"), "inactive").Where(f.Eq(cols.Col("ID"), 123)),
+    "deactivate_user")
 if errors.Is(err, database.ErrNoRows) {
     return ErrUserNotFound
 }
 
 // DELETE — bulk/idempotent; zero rows is a legitimate outcome
-n, err := database.ExecuteUpdate(ctx, db,
+cutoff := time.Now().AddDate(0, 0, -90) // 90 days of inactivity
+if _, err := database.ExecuteUpdate(ctx, db,
     qb.Delete("users").Where(f.Lt(cols.Col("LastSeen"), cutoff)),
-    "purge_stale_users")
+    "purge_stale_users"); err != nil {
+    return fmt.Errorf("purge stale users: %w", err)
+}
 ```
 
 Access to vendor quirks (Oracle quoting) routes through the same interface; switching drivers requires config only.

--- a/wiki/database.md
+++ b/wiki/database.md
@@ -337,6 +337,64 @@ instrumentation.
 (a method or function name). Because it becomes a metric attribute, interpolating
 per-request data such as IDs or emails would explode metric cardinality.
 
+## Execute Helpers
+
+`database.ExecuteQuerySingle` / `ExecuteQueryMany` / `ExecuteUpdate` / `ExecuteUpdateOne` / `ExecuteInsert` collapse the repeated `ToSQL()` → `Query`/`Exec` → `Scan`/`RowsAffected` → error-wrap glue that every SQL repository re-implements. Each helper takes a `database.Executor` (a 2-method `Query`/`Exec` interface satisfied by both `database.Interface` and `database.Tx`, so the same call works inside or outside a transaction) and a `database.SQLProvider` (implemented by every query-builder result, or by `database.Raw(sql, args...)` for hand-written SQL). An `op string` label identifies the call site in errors — it labels errors only and does not feed metrics or tracing; use `database.WithRepositoryMethod(ctx, ...)` for attribution.
+
+| Outcome | Error shape |
+|---|---|
+| Zero-row `SELECT` (`ExecuteQuerySingle`) or an `UPDATE`/`DELETE` that matched no rows when exactly one was expected (`ExecuteUpdateOne`) | `fmt.Errorf("%s: %w", op, database.ErrNoRows)` — `ErrNoRows` wraps `sql.ErrNoRows`, so both `errors.Is(err, database.ErrNoRows)` and `database.IsNotFound(err)` match |
+| Build/exec/scan/iterate/close/rows-affected infrastructure failure | `*database.ExecError{Op, Stage, Err}` — `Stage` (type `database.ExecStage`) is one of `StageBuild`, `StageExec`, `StageScan`, `StageIterate`, `StageClose`, `StageRowsAffected`; `errors.As(err, &execErr)` and `errors.Unwrap` reach the underlying driver error. `StageClose` is specific to `ExecuteQuerySingle`: after a successful scan it closes the rows explicitly (mirroring `sql.Row.Scan`) so a driver error surfacing only at `Close` — a truncated result, a connection fault mid-statement — is reported instead of swallowed; `Close` is idempotent, so the helper's deferred `Close` remains a safe early-return net. `StageRowsAffected` covers two distinct failures: the driver's `RowsAffected()` call itself erroring (any helper that inspects it), or — `ExecuteUpdateOne` only — `RowsAffected()` succeeding with a count greater than one, rejected instead of silently reported as success |
+
+Builder input runs unmodified:
+
+```go
+q := qb.Select(cols.Cols("ID", "Name")).From("users").Where(f.Eq(cols.Col("ID"), id))
+err := database.ExecuteQuerySingle(ctx, tx, q, "user_lookup", &row.ID, &row.Name)
+```
+
+A `types.Filter`/`types.JoinFilter` WHERE fragment (e.g. `f.Eq(...)` on its own) also satisfies `SQLProvider` structurally — both embed `squirrel.Sqlizer`, which declares the same-shaped `ToSql()` alongside `ToSQL()` — but it is not a complete statement. Passing one directly to any `Execute*` helper is rejected at `StageBuild` with a clear error, instead of shipping the bare fragment to the driver as if it were a full statement.
+
+**`ExecuteUpdate` vs `ExecuteUpdateOne`:** `ExecuteUpdate` returns the raw affected-row count and does not interpret it at all — any count, including zero, is `(n, nil)` — use it whenever a non-singular match is legitimate (a bulk statement, or an idempotent state transition like `UPDATE sessions SET expired = true WHERE expires_at < now()`, where "matched nothing" isn't an error). `ExecuteUpdateOne` wraps it and enforces an exactly-one-row contract: zero rows affected maps to the same op-labeled `ErrNoRows` as `ExecuteQuerySingle`; **more than one** row affected is rejected as `*ExecError` at `StageRowsAffected` instead of silently reported as success — a broader-than-intended `WHERE` predicate that updates several rows is a data-integrity failure, not a "found it" outcome. Use it for the common case of an UPDATE/DELETE expected to match exactly one row (e.g. `UPDATE users SET active = true WHERE id = $1`). Both policies ship explicitly because only the caller can tell "absent" from "already in the target state" — for example, `UPDATE payments SET status='captured' WHERE id=$1 AND status='authorized'` returning zero rows could mean either a missing payment (404) or an idempotent replay (already captured, not an error); `ExecuteUpdate` leaves that call to the caller instead of guessing:
+
+```go
+expire := qb.Update("sessions").
+    Set(cols.Col("Expired"), true).
+    Where(f.Lt(cols.Col("ExpiresAt"), time.Now()))
+n, err := database.ExecuteUpdate(ctx, tx, expire, "expire_sessions") // 0 rows is not an error
+if err != nil {
+    return fmt.Errorf("expire sessions: %w", err)
+}
+
+activate := qb.Update("users").
+    Set(cols.Col("Active"), true).
+    Where(f.Eq(cols.Col("ID"), id))
+err = database.ExecuteUpdateOne(ctx, tx, activate, "activate_user") // 0 rows -> ErrNoRows
+if errors.Is(err, database.ErrNoRows) {
+    return domain.ErrUserNotFound
+}
+```
+
+`database.Raw(sql string, args ...any)` adapts hand-written SQL to the same helpers — it is an escape hatch on par with `Filter.Raw`/`JoinFilter.Raw`, and broader (the SQL string replaces the whole statement, bypassing the builder's identifier validation entirely). **Every** call site requires the same review annotation `f.Raw()`/`jf.Raw()` do:
+
+```go
+// SECURITY: Manual SQL review completed - static SQL, no user input concatenated, values parameterized via args
+q := database.Raw("SELECT id, name FROM users WHERE tier = $1 FOR UPDATE", tier)
+err := database.ExecuteQuerySingle(ctx, tx, q, "tier_lookup", &row.ID, &row.Name)
+```
+
+Typical app-side mapping distinguishes the "not found" business outcome from an infrastructure failure:
+
+```go
+err := database.ExecuteQuerySingle(ctx, tx, q, "ownership", &row.ID, &row.Name)
+switch {
+case errors.Is(err, database.ErrNoRows):
+    return domain.ErrResourceNotFound // business 404
+case err != nil:
+    return fmt.Errorf("load ownership: %w", err) // infra 500
+}
+```
+
 ## Session Timezone (Breaking Change — ADR-016)
 
 | Setting | Default | Purpose |

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -17,10 +17,12 @@ A plain `vX.Y.Z` is your current node. `=>` a local path (dev `replace`) means t
 **3 — Select the hop chain** on the Ladder: every edge strictly to the right of CURRENT, up to and including TARGET. Never apply an edge at/left of CURRENT.
 
 ```
-v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0 ─E43─ v0.43.0 ─E44─ v0.44.0 ─E45─ v0.45.0 ─E49─ v0.49.0 ─E50─ v0.50.0 ─E51─ v0.51.0 ─E52─ v0.52.0
+v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0 ─E43─ v0.43.0 ─E44─ v0.44.0 ─E45─ v0.45.0 ─E49─ v0.49.0 ─E50─ v0.50.0 ─E51─ v0.51.0 ─E52─ v0.52.0 ─E55─ v0.55.0
 ```
 
 > v0.46.0–v0.48.0 shipped additive-only changes (route template/path-param accessors, raw-route descriptors, module-contributed global middleware — adopt-only, no migration atoms), so E49 is the next hop after v0.45.0 and applies when crossing from any of v0.45.0–v0.48.0 to v0.49.0.
+>
+> v0.52.0–v0.54.0 shipped additive-only changes (shared control-plane ledger tenancy for outbox/inbox — opt-in, `tenancy` defaults to `per-tenant`; clearer duplicate-route startup diagnostics — the echo router already rejected duplicate method+path registrations), so E55 is the next hop after v0.52.0 and applies when crossing from any of v0.52.0–v0.54.0 to v0.55.0.
 
 | edge | hop | worst risk | atoms | compiler-caught | preflight (run BEFORE the bump) |
 |------|-----|-----------|-------|-----------------|---------------------------------|
@@ -35,6 +37,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E50  | v0.49.0 → v0.50.0 | config-break | 4 | none | Flyway migrate surfaces unparseable/failure output as an error; non-empty DB passwords < 8 bytes rejected at config validation + migrate; dev CORS wildcard opt-in; `multitenant.resolver.order` now REQUIRED for `type: composite` (no default — composite deployments fail to start until they declare one) |
 | E51  | v0.50.0 → v0.51.0 | silent-behavior (adopt-only) | 3 | none | none |
 | E52  | v0.51.0 → v0.52.0 | compile-break | 4 | C52.1 | if you set `.Args` on any declaration in ≤v0.51.0, verify current broker state before upgrading |
+| E55  | v0.52.0 → v0.55.0 | additive (safe) | 1 | none | none |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 - **`when: match`** → act only if `detect` returns ≥1 line (an API/arity/interface change, or a config key you set).
@@ -676,6 +679,41 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 
 - note: `decls.DeclareQueueWithDLQ(name, spec)` declares the fanout DLX + parking queue + binding and sets `x-dead-letter-exchange` (and optionally `x-dead-letter-routing-key`) on the primary queue in one call — failed deliveries park in the default `<queue>.dlq` (or the configured parking queue) instead of dropping. Raw `Args["x-dead-letter-exchange"]` (see "Dead-Lettering" in wiki/messaging.md) remains valid for custom topologies. Purely additive; existing hand-rolled DLX declarations are untouched.
 - ref: #721 · messaging/helpers.go
+
+## E55 · v0.52.0 → v0.55.0 — database Execute* query/exec helpers
+
+- gist: Adds `database.ExecuteQuerySingle` / `ExecuteQueryMany` / `ExecuteUpdate` / `ExecuteUpdateOne` / `ExecuteInsert`, a 2-method `database.Executor` interface (satisfied by both `database.Interface` and `database.Tx`), and `database.Raw(sql, args...)` for hand-written SQL — collapsing the repeated `ToSQL()` → `Query`/`Exec` → scan/`RowsAffected` → error-wrap glue every SQL repository re-implements. No exported go-bricks symbol changes outside this new surface; purely additive.
+- build-caught: none
+- preflight: none
+- exit: `go get github.com/gaborage/go-bricks@v0.55.0 && go mod tidy && go build ./... && go test ./...`
+
+### [C55.1] database Execute* helpers (Executor + Raw + typed errors) · additive-optional
+
+- note: `database.ExecuteQuerySingle/ExecuteQueryMany/ExecuteUpdate/ExecuteUpdateOne/ExecuteInsert`
+  run builder output or `database.Raw(sql, args...)` against either a connection
+  or a `Tx` (both satisfy the new 2-method `database.Executor`), replacing
+  hand-rolled ToSQL→Query/Exec→scan/RowsAffected glue. `ExecuteUpdate` returns
+  the raw affected-row count and does not interpret it at all (any count,
+  including zero, is legitimate for bulk or idempotent writes); `ExecuteUpdateOne`
+  wraps it and enforces an exactly-one-row contract — zero rows maps to
+  `ErrNoRows`, and **more than one** row affected is rejected as `*ExecError` at
+  `StageRowsAffected` instead of silently reported as success (a
+  broader-than-intended `WHERE` predicate updating several rows is a
+  data-integrity failure, not a "found it" outcome). Errors: `errors.Is(err,
+  database.ErrNoRows)` for zero-row outcomes (wraps `sql.ErrNoRows`, so
+  `IsNotFound` matches too); `var execErr *database.ExecError;
+  errors.As(err, &execErr)` for build/exec/scan/iterate/close/rows_affected
+  infrastructure failures (`Stage` is `database.ExecStage`) — `close` covers a
+  `Rows.Close` failure surfaced after a successful `ExecuteQuerySingle` scan;
+  `rows_affected` also covers `ExecuteUpdateOne`'s multi-row rejection.
+  `ExecuteQueryMany` also rejects a nil `scan` callback at `StageBuild` before
+  dispatching the query. Purely additive; existing repository code is untouched.
+- security: every `database.Raw(sql, args...)` call site requires an adjacent
+  `// SECURITY: Manual SQL review completed - <what was verified>` comment, exactly as
+  `f.Raw()`/`jf.Raw()` do — `Raw` replaces the whole statement and so bypasses the
+  builder's identifier validation. Enforced by `.claude/hooks/check-raw-sql.sh`; audit
+  grep `git grep -E 'f\.Raw\(|jf\.Raw\(|database\.Raw\('`.
+- ref: #772 · database/execute.go
 
 ---
 


### PR DESCRIPTION
Closes #772

## Problem

Every consumer's SQL repository re-implements the same glue around the query builder: `ToSQL()` → `Query`/`Exec` → `rows.Next`/`rows.Scan`/`rows.Err` or `RowsAffected` → wrap each failure. One downstream service deleted ~288 lines of duplicated boilerplate in a single module by extracting exactly this helper locally. go-bricks owns every piece the flow needs — `database.Interface`, `types.Tx`, the builders' `ToSQL()` — but not the exec + error-handling glue.

## Change

`database/execute.go` adds:

- **`Executor`** — a 2-method interface (`Query`, `Exec`) satisfied by **both** `database.Interface` and `database.Tx` via structural typing, so the helpers run identically inside or outside a transaction. No adapters. (`Querier` itself is unusable here: it also requires `DatabaseType()`, which `Tx` lacks.)
- **`Queryable`** — `ToSQL()`. Every builder already satisfies it.
- **Five helpers** — `ExecuteQuerySingle`, `ExecuteQueryMany`, `ExecuteUpdate`, `ExecuteUpdateOne`, `ExecuteInsert`.
- **A two-tier error contract** — `ErrNoRows` (wrapping `sql.ErrNoRows`, so the existing `IsNotFound` stays coherent) for zero-row *domain outcomes*, and `*ExecError{Op, ExecStage, Err}` for *infrastructure* failures across five stages. Zero-row outcomes are deliberately **not** `ExecError`.
- **`database.Raw(sql, args...)`** — an escape hatch for hand-written SQL, returning an unexported type.

Purely additive exported API — apidiff-neutral, no ADR.

### Two decisions worth calling out

**1. Both zero-rows policies ship explicitly.** `ExecuteUpdate` returns the raw count and does **not** interpret zero; `ExecuteUpdateOne` maps zero rows to `ErrNoRows`. The reason: for `UPDATE payments SET status='captured' WHERE id=$1 AND status='authorized'`, zero rows means *either* 404 (no such payment) *or* 409 / idempotent replay — only the caller can tell. Baking one policy in would also have made legitimately-zero writes (`UPDATE sessions SET expired=true WHERE expires_at < now()`) require `if err != nil && !errors.Is(err, ErrNoRows)`, i.e. *more* boilerplate than before. Shipping both now matters because adding an option to a shipped function is apidiff-INCOMPATIBLE in this repo.

**2. The new raw-SQL hatch is wired into the audit story, not just documented.** `database.Raw` is *broader* than `f.Raw()` — `f.Raw` is a fragment inside a builder that still validates From/Set/OrderBy identifiers, while `Raw` replaces the whole statement. So this PR also extends the two enforcement surfaces that would otherwise have been blind to it: the fail-closed PreToolUse hook `.claude/hooks/check-raw-sql.sh` and the canonical audit grep published in `CLAUDE.md`, both from `(f|jf)` to `(f|jf|database)`. Verified live against the hook across 8 cases — annotated (same-line and multi-line) allowed, unannotated blocked, annotation-placed-after-the-call blocked, and both `f.Raw` regression cases unchanged.

## Verification

- `make check` green (fmt + lint 0 issues + `-race` all packages + alloc guards + govulncheck 0).
- 21 tests. `StageIterate` is exercised by a small local `database/sql/driver` that returns one good row then a non-`io.EOF` error — a failure the test kit cannot inject — and asserts the error *chain* survives via `errors.Is`, not a message substring.
- **Both halves of the error contract are mutation-checked**: breaking the `ErrNoRows` wrap fails only the sentinel test; mis-attributing the callback-error stage fails only the stage test.
- `database/types/` and `CHANGELOG.md` untouched; `database/errors.go` is a doc-comment-only change.

## Pre-push gates

`/simplify` (4-lens panel) → `/security-audit` → `/code-review`, in order. The panel drove the two decisions above plus uniform assertions across three `StageExec` tests that had drifted to three different assertion depths, coverage for the previously-unreachable `StageRowsAffected`, and a `Stage`→`ExecStage` rename before it became permanent surface. CodeRabbit then found two real issues — a wiki example that reused a SELECT builder for two UPDATE calls, and two `database.Raw` sites missing the annotation this PR itself tightened to "every call site" — both fixed; re-review reports **0 findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized database Execute Helpers for single/many queries, updates, and inserts, with a shared execution interface for both connections and transactions.
  * Added `Raw(...)` as a reviewed escape hatch for hand-written SQL.
* **Documentation**
  * Expanded helper and error-contract documentation, including stage-aware errors and updated per-call security annotation requirements.
  * Added migration runbook guidance and example updates for using Execute Helpers.
* **Bug Fixes**
  * Clarified “not found” behavior for update/delete paths versus query scan-path results.
* **Tests**
  * Added comprehensive test coverage for helper behavior, error stages, and `Raw(...)` integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->