### PR TITLE
test(server,scheduler): wait on ctx.Done() instead of a fixed sleep margin

### DIFF
--- a/scheduler/job_test.go
+++ b/scheduler/job_test.go
@@ -201,8 +201,8 @@ func TestJobContextContextBehavior(t *testing.T) {
 			nil, nilDBResolver, nilMessagingResolver, nil,
 		)
 
-		// Wait for timeout
-		time.Sleep(20 * time.Millisecond)
+		// Wait deterministically for the deadline rather than sleeping past it.
+		<-parentCtx.Done()
 
 		// Should be canceled
 		assert.Error(t, ctx.Err())

--- a/server/timeout_test.go
+++ b/server/timeout_test.go
@@ -204,8 +204,9 @@ func TestTimeoutDuringValidation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 	defer cancel()
 
-	// Wait for context to expire
-	time.Sleep(5 * time.Millisecond)
+	// Wait deterministically for the deadline. A fixed sleep margin loses the race
+	// when the runtime timer goroutine is starved on a loaded CI runner.
+	<-ctx.Done()
 
 	// Explicitly verify context is canceled (defensive test assertion)
 	require.Error(t, ctx.Err(), "Context should be canceled after timeout")


### PR DESCRIPTION
## Problem

`framework-integration-test` failed on an unrelated PR with:

```
--- FAIL: TestTimeoutDuringValidation (0.01s)
    timeout_test.go:211:
        Error:    An error is expected but got nil.
        Messages: Context should be canceled after timeout
```

The test sets a 1 ms deadline, sleeps 5 ms, then asserts the context expired:

```go
ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
time.Sleep(5 * time.Millisecond)
require.Error(t, ctx.Err(), "Context should be canceled after timeout")
```

The 4 ms margin depends on the runtime timer goroutine being scheduled promptly. The integration job runs alongside Docker containers, so that assumption is weakest exactly where the test runs.

`scheduler/job_test.go` had the identical shape (10 ms deadline, 20 ms sleep). It has not failed yet; it is the same latent race.

## Change

Wait on the context instead of sleeping past it:

```go
<-ctx.Done()
require.Error(t, ctx.Err(), "Context should be canceled after timeout")
```

`Done()` closes only after the deadline fires, so the assertion cannot race. No margin to tune, no sleep to lengthen. The scheduler test waits on its `parentCtx`, which is the context that actually carries the deadline.

## Verification

- Both tests pass **50×** locally (`-count=50`), before and after.
- `make check` green: fmt, lint 0 issues, full `-race` suite, alloc guards, govulncheck 0.
- Test-only change: 2 files, +5/−4. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved timeout and cancellation test reliability by waiting for context completion instead of relying on fixed delays.
  * Reduced susceptibility to timing-related failures in slower or heavily loaded environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->