### PR TITLE
ci(renovate): hold go-ora on v2 until the v3 FastLogin fix ships

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,12 @@
         "github.com/labstack/echo-opentelemetry"
       ],
       "groupName": "echo (engine + otel)"
+    },
+    {
+      "description": "Hold the Oracle driver on go-ora v2 until upstream ships the FastLogin cookie-replay fix. v3.0.1 breaks every connection after the first in a process: v3 added a process-global cookieStore whose replayed handshake truncates OracleVersion (7230/8030/8100) through uint8, so the server closes the socket mid-handshake; because that never yields driver.ErrBadConn the driver's own retry never fires and the poisoned cookie is never evicted. database/sql hits this as soon as a pool opens its second physical connection. Measured against gvenzl/oracle-free:23.26.2-slim on 2026-07-25: v2.9.0 integration suite green, an imports-only v3.0.1 rewrite fails every connection-opening test with a bare EOF, and FAST LOGIN=false restores them. Upstream sijms/go-ora#732 is fixed on master (a968e590) but NOT released — the newest tag is still v3.0.1. Delete this rule once a tagged release carries the fix, then redo the import rewrite (go-bricks#756).",
+      "matchDatasources": ["go"],
+      "matchPackageNames": ["github.com/sijms/go-ora/v2"],
+      "allowedVersions": "<3"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## What

Renovate #756 proposes go-ora `v2.9.0` → `v3.0.1`, but v3.0.1 breaks every Oracle connection after the first one opened in a process: v3's new process-global FastLogin cookie replays a handshake that truncates `OracleVersion` through `uint8`, so the server closes the socket mid-handshake and the driver's `ErrBadConn`-only retry never fires. This adds one `packageRules` entry holding the driver at `<3`.

## Impact

None — no dependency version changes. Delete this rule once a tagged go-ora release carries the upstream fix (`sijms/go-ora#732`, fixed on master in `a968e590`; no tag has it yet, newest is still v3.0.1), then redo the import rewrite.

## Verification

CI does not lint `renovate.json`; schema-validated locally with `renovate-config-validator@43.280.4`. The hold rests on a measured comparison against `gvenzl/oracle-free:23.26.2-slim`: the v2.9.0 integration suite is green, while an imports-only v3.0.1 rewrite fails all 29 connection-opening tests, including the four ADR-016 session-timezone tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted automatic updates for the Go Oracle driver to versions below 3.0.
  * Added context for the version restriction while awaiting an upstream fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->