### PR TITLE
docs(llms): check discarded errors before dereferencing in examples

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1944,7 +1944,10 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 
 // Use injected config in service methods
 func (m *Module) CacheUser(ctx context.Context, user *User) error {
-    c, _ := m.getCache(ctx)
+    c, err := m.getCache(ctx)
+    if err != nil {
+        return fmt.Errorf("cache not available: %w", err)
+    }
 
     key := fmt.Sprintf("%s:user:%d", m.keyPrefix, user.ID)  // Uses prefix
     data, _ := cache.Marshal(user)
@@ -3024,7 +3027,10 @@ _, err = s.outbox.Publish(ctx, tx, &app.OutboxEvent{
 ### Multiple Events in One Transaction
 
 ```go
-tx, _ := db.Begin(ctx)
+tx, err := db.Begin(ctx)
+if err != nil {
+    return err
+}
 defer tx.Rollback(ctx)
 
 tx.Exec(ctx, "INSERT INTO orders ...", args...)
@@ -3040,7 +3046,7 @@ s.outbox.Publish(ctx, tx, &app.OutboxEvent{
     Exchange: "inventory.events",
 })
 
-tx.Commit(ctx) // Both events guaranteed to be published
+return tx.Commit(ctx) // Both events guaranteed to be published
 ```
 
 ### Consumer Idempotency (Required)
@@ -3837,7 +3843,10 @@ func (s *UserService) Create(ctx context.Context, email, name string) (*User, er
         return nil, errors.New("tenant context required")
     }
 
-    db, _ := s.getDB(ctx)
+    db, err := s.getDB(ctx)
+    if err != nil {
+        return nil, err
+    }
     qb := database.NewQueryBuilder(db.DatabaseType())
     cols := qb.Columns(&User{})
 
@@ -4395,7 +4404,8 @@ observability:
 For rotating tokens or secrets fetched from a manager (Vault, AWS Secrets Manager), override programmatically before `app.Run()`:
 
 ```go
-cfg, _ := config.Load()
+cfg, err := config.Load()
+if err != nil { log.Fatal(err) }
 if apiKey := os.Getenv("OTEL_API_KEY"); apiKey != "" {
     headers := map[string]string{"api-key": apiKey}
     cfg.Observability.Trace.Headers = headers

--- a/llms.txt
+++ b/llms.txt
@@ -3033,20 +3033,20 @@ if err != nil {
 }
 defer tx.Rollback(ctx)
 
-tx.Exec(ctx, "INSERT INTO orders ...", args...)
-tx.Exec(ctx, "UPDATE inventory SET stock = stock - $1 WHERE product_id = $2", qty, productID)
+if _, err := tx.Exec(ctx, "INSERT INTO orders ...", args...); err != nil { return err }
+if _, err := tx.Exec(ctx, "UPDATE inventory SET stock = stock - $1 WHERE product_id = $2", qty, productID); err != nil { return err }
 
 // Multiple events — all atomic with the business writes
-s.outbox.Publish(ctx, tx, &app.OutboxEvent{
+if _, err := s.outbox.Publish(ctx, tx, &app.OutboxEvent{
     EventType: "order.created", AggregateID: orderID, Payload: orderPayload,
     Exchange: "order.events",
-})
-s.outbox.Publish(ctx, tx, &app.OutboxEvent{
+}); err != nil { return err }
+if _, err := s.outbox.Publish(ctx, tx, &app.OutboxEvent{
     EventType: "inventory.reserved", AggregateID: productID, Payload: inventoryPayload,
     Exchange: "inventory.events",
-})
+}); err != nil { return err }
 
-return tx.Commit(ctx) // Both events guaranteed to be published
+return tx.Commit(ctx) // Both events committed to the outbox for relay
 ```
 
 ### Consumer Idempotency (Required)


### PR DESCRIPTION
## What

Four `llms.txt` snippets discarded an error with `x, _ :=`, then dereferenced the
possibly-nil result on the next line — so a copied example turned a recoverable
failure into a nil-pointer or nil-interface panic. `UserService.Create`,
`Module.CacheUser`, the outbox multi-event transaction fragment, and the
observability header-override fragment now check the error, matching the file's own
exemplars (`FindByEmail`, `GetUser`, the canonical bootstrap `main()`).

## Impact

None — docs only, no compiled code changes. Tools that generate code from
`llms.txt` now emit error-checked examples.

## Verification

The file's other 18 `, _ :=` sites were swept: 14 are deliberate idioms (test code,
infallible marshals, discarded non-error values) and stay unchanged.
`grep -cE '^[[:space:]]*[a-zA-Z]+, _ := ' llms.txt` = 14 is now a drift probe for
future audits; the code-fence count is unchanged at 306, confirming no fence was
damaged.

Closes #779
Closes #780


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved framework documentation examples with more robust error handling.
  * Added explicit checks for cache access, database transactions, configuration loading, tenant-specific database access, and transaction commits.
  * Updated examples to stop execution promptly when errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->