### PR TITLE
docs: fix non-compiling OTLP header snippet, check README example errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,10 @@ GoBricks uses Koanf for configuration management with layered loading: defaults 
 
 ### Access Patterns
 ```go
-cfg, _ := config.Load()
+cfg, err := config.Load()
+if err != nil {
+    log.Fatal(err)
+}
 
 // Simple values with defaults
 host := cfg.String("server.host", "0.0.0.0")
@@ -643,12 +646,14 @@ Solves the dual-write problem: events are written to an outbox table in the **sa
 
 ```go
 func (s *OrderService) CreateOrder(ctx context.Context, req CreateOrderReq) error {
-    db, _ := s.getDB(ctx)
-    tx, _ := db.Begin(ctx)
+    db, err := s.getDB(ctx)
+    if err != nil { return err }
+    tx, err := db.Begin(ctx)
+    if err != nil { return err }
     defer tx.Rollback(ctx)
 
     // 1. Write business data
-    _, err := tx.Exec(ctx, "INSERT INTO orders (id, customer_id) VALUES ($1, $2)",
+    _, err = tx.Exec(ctx, "INSERT INTO orders (id, customer_id) VALUES ($1, $2)",
         req.ID, req.CustomerID)
     if err != nil { return err }
 

--- a/llms.txt
+++ b/llms.txt
@@ -4394,11 +4394,12 @@ The framework attaches the following resource attributes to every signal: `servi
 Never hardcode OTLP auth headers in committed YAML. The framework declares header *structure* in YAML, but GoBricks has **no `${VAR}` interpolation** inside YAML values — a literal `${NEW_RELIC_API_KEY}` string would be sent as-is. Env vars can't carry the value either: header names like `api-key` contain dashes that the `OBSERVABILITY_*` env-to-key mapping cannot express.
 
 ```yaml
-# config.production.yaml — checked into git
+# config.production.yaml.tmpl — committed template; render to
+# config.production.yaml (gitignored) before startup, so the real value never lands in a tracked file
 observability:
   trace:
     headers:
-      api-key: ${NEW_RELIC_API_KEY}  # rendered into the file before startup, never committed
+      api-key: ${NEW_RELIC_API_KEY}
 ```
 
 There is no override hook for `observability.*` — `config.Config` has no observability section — so the placeholder must already be a literal when `config.Load()` runs. Render it before startup either programmatically in your own `main()` (fetch the secret, render the template, write the file — see "Programmatic secret injection" in wiki/observability_headers_auth.md) or with an infra-level step: `envsubst`, a Vault Agent template, Helm/Kustomize, or an init container.
@@ -4784,7 +4785,7 @@ observability:
     insecure: false
     compression: gzip
     headers:
-      api-key: ${NEW_RELIC_API_KEY}    # SAFE: resolved from env at startup
+      api-key: ${NEW_RELIC_API_KEY}    # rendered before startup — see Secrets Hygiene
 ```
 
 ```yaml

--- a/llms.txt
+++ b/llms.txt
@@ -4363,7 +4363,7 @@ observability:
     insecure: false                   # TLS required for vendor endpoints
     compression: gzip
     headers:
-      api-key: ${OTEL_API_KEY}        # From env var — never commit
+      api-key: ${OTEL_API_KEY}        # rendered before startup — see Secrets Hygiene below
 ```
 
 ### Endpoint Format Rules (CRITICAL)
@@ -4391,28 +4391,17 @@ The framework attaches the following resource attributes to every signal: `servi
 
 ### Secrets Hygiene
 
-Never hardcode OTLP auth headers in committed YAML. The framework declares header *structure* in YAML, but GoBricks has **no `${VAR}` interpolation** inside YAML values — a literal `${NEW_RELIC_API_KEY}` string would be sent as-is. Render the file before `config.Load()` runs (see wiki/observability_headers_auth.md) or inject the value through the environment-variable override path.
+Never hardcode OTLP auth headers in committed YAML. The framework declares header *structure* in YAML, but GoBricks has **no `${VAR}` interpolation** inside YAML values — a literal `${NEW_RELIC_API_KEY}` string would be sent as-is. Env vars can't carry the value either: header names like `api-key` contain dashes that the `OBSERVABILITY_*` env-to-key mapping cannot express.
 
 ```yaml
 # config.production.yaml — checked into git
 observability:
   trace:
     headers:
-      api-key: ""    # value rendered into the file before startup, never committed
+      api-key: ${NEW_RELIC_API_KEY}  # rendered into the file before startup, never committed
 ```
 
-For rotating tokens or secrets fetched from a manager (Vault, AWS Secrets Manager), override programmatically before `app.Run()`:
-
-```go
-cfg, err := config.Load()
-if err != nil { log.Fatal(err) }
-if apiKey := os.Getenv("OTEL_API_KEY"); apiKey != "" {
-    headers := map[string]string{"api-key": apiKey}
-    cfg.Observability.Trace.Headers = headers
-    cfg.Observability.Metrics.Headers = headers
-    cfg.Observability.Logs.Headers = headers
-}
-```
+There is no override hook for `observability.*` — `config.Config` has no observability section — so the placeholder must already be a literal when `config.Load()` runs. Render it before startup either programmatically in your own `main()` (fetch the secret, render the template, write the file — see "Programmatic secret injection" in wiki/observability_headers_auth.md) or with an infra-level step: `envsubst`, a Vault Agent template, Helm/Kustomize, or an init container.
 
 ## Structured Logging with Custom Fields
 

--- a/wiki/new_relic_otlp.md
+++ b/wiki/new_relic_otlp.md
@@ -2,10 +2,12 @@
 
 GoBricks supports all New Relic OTLP optimizations for bandwidth reduction and performance.
 
+`${NEW_RELIC_API_KEY}` below is a placeholder, not interpolated by GoBricks — render it into the runtime file before startup; see [Headers & Authentication](observability_headers_auth.md).
+
 ## Complete New Relic Configuration (gRPC - Recommended)
 
 ```yaml
-# config.production.yaml
+# config.production.yaml.tmpl — committed template; rendered to config.production.yaml (gitignored) before startup
 observability:
   enabled: true
   service:
@@ -20,7 +22,7 @@ observability:
     insecure: false  # TLS required for New Relic
     compression: gzip  # ~70% bandwidth reduction
     headers:
-      api-key: your-new-relic-license-key-here
+      api-key: ${NEW_RELIC_API_KEY}
 
   # Metrics with New Relic optimizations
   metrics:
@@ -31,7 +33,7 @@ observability:
     temporality: delta  # New Relic recommendation (lower memory, better performance)
     histogramaggregation: exponential  # Better precision, ~10x lower memory
     headers:
-      api-key: your-new-relic-license-key-here
+      api-key: ${NEW_RELIC_API_KEY}
 
   # Logs with gRPC
   logs:
@@ -41,7 +43,7 @@ observability:
     compression: gzip
     samplingrate: 0.1  # Export 10% of INFO/DEBUG logs (ERROR/WARN always exported)
     headers:
-      api-key: your-new-relic-license-key-here
+      api-key: ${NEW_RELIC_API_KEY}
 ```
 
 ## New Relic HTTP Alternative (Port 4318)
@@ -59,7 +61,7 @@ observability:
     protocol: http
     compression: gzip
     headers:
-      api-key: your-license-key
+      api-key: ${NEW_RELIC_API_KEY}
 
   metrics:
     enabled: true
@@ -69,7 +71,7 @@ observability:
     temporality: delta
     histogramaggregation: exponential
     headers:
-      api-key: your-license-key
+      api-key: ${NEW_RELIC_API_KEY}
 
   logs:
     enabled: true
@@ -77,7 +79,7 @@ observability:
     protocol: http
     compression: gzip
     headers:
-      api-key: your-license-key
+      api-key: ${NEW_RELIC_API_KEY}
 ```
 
 ## New Relic Port 443 Alternative

--- a/wiki/observability.md
+++ b/wiki/observability.md
@@ -221,14 +221,14 @@ See [llms.txt](../llms.txt) Custom Metrics section for complete code examples in
 
 ## Observability Headers & Authentication
 
-The OTLP exporter reads headers from `observability.trace.headers` (and the equivalent `metrics.headers` / `logs.headers`) in YAML — there is no built-in support for separate `OBSERVABILITY_*_HEADERS_*` env vars. **The header structure goes in YAML; the secret values come from environment variables via Koanf substitution** (the same pattern used elsewhere in `config.example.yaml`). Hardcoding API keys or bearer tokens directly in committed YAML is forbidden.
+The OTLP exporter reads headers from `observability.trace.headers` (and the equivalent `metrics.headers` / `logs.headers`) in YAML — there is no built-in support for separate `OBSERVABILITY_*_HEADERS_*` env vars. **The header structure goes in YAML; the secret value is rendered into the runtime file before startup** — GoBricks has no `${VAR}` interpolation inside YAML values, so an un-rendered placeholder would be sent to the vendor as-is. Hardcoding API keys or bearer tokens directly in committed YAML is forbidden.
 
 ```yaml
-# config.production.yaml — SAFE: header structure in YAML, value from env
+# config.production.yaml.tmpl — committed template; rendered to config.production.yaml (gitignored) before startup
 observability:
   trace:
     headers:
-      api-key: ${NEW_RELIC_API_KEY}   # resolved at startup from environment
+      api-key: ${NEW_RELIC_API_KEY}   # placeholder — rendered before startup, see observability_headers_auth.md
 
 # UNSAFE — never commit:
 #   api-key: "nrak-ABC123..."         # hardcoded secret

--- a/wiki/observability_headers_auth.md
+++ b/wiki/observability_headers_auth.md
@@ -9,7 +9,8 @@
 Reference env vars from YAML using `${VAR_NAME}` placeholders — **but render them before GoBricks reads the file; GoBricks itself does not.** `config.Load()` (backed by Koanf) loads the YAML file verbatim via `file.Provider` and layers env vars onto the config tree only by matching variable *names* onto config key paths — it never scans an already-loaded string value for a `${...}` token. Left un-rendered, `api-key: ${NEW_RELIC_API_KEY}` is read back as the literal string `${NEW_RELIC_API_KEY}`, not the secret. Resolve the placeholder with an external render step — `envsubst`, a Vault Agent template, Helm/Kustomize, or an init container — that writes the real value into the file *before* the process starts.
 
 ```yaml
-# config.production.yaml — checked into git
+# config.production.yaml.tmpl — committed template (placeholders only);
+# rendered to config.production.yaml (gitignored) before startup
 observability:
   enabled: true
   service:
@@ -53,7 +54,7 @@ The actual secret lives in the deployment environment (Kubernetes Secret, AWS Se
 
 2. **Separate config files per environment** (no secrets in any of them):
    - `config.yaml` — Base config (committed)
-   - `config.production.yaml` — Production overrides (committed; references `${VAR}`)
+   - `config.production.yaml.tmpl` — Production overrides template (committed; references `${VAR}`); rendered to `config.production.yaml` (gitignored) before startup
    - `config.development.yaml` — Dev settings (committed; references `${VAR}` or default literals for local-only test keys)
 
 3. **Programmatic secret injection** (when a sidecar or secret manager provides the value at process start — e.g., rotating tokens): render the YAML file itself before calling `config.Load()` / `app.Run()`. GoBricks has no `${VAR}` interpolation step and no override hook for `observability.*` values, so the placeholder must already be a literal by the time the file is read.
@@ -62,9 +63,15 @@ The actual secret lives in the deployment environment (Kubernetes Secret, AWS Se
    // In main.go, before app.Run()
    apiKey, err := vault.GetSecret(ctx, "otel/api-key")
    if err != nil { return err }
+   tmpl, err := os.ReadFile("config.production.yaml.tmpl")
+   if err != nil { return err }
    // strconv.Quote yields a valid YAML double-quoted scalar, so secrets containing
    // quotes, ':', '#', or newlines cannot corrupt the rendered document.
-   rendered := strings.ReplaceAll(string(configTemplate), "${NEW_RELIC_API_KEY}", strconv.Quote(apiKey))
+   rendered := strings.ReplaceAll(string(tmpl), "${NEW_RELIC_API_KEY}", strconv.Quote(apiKey))
+   // The rendered target is gitignored — the real value never lands in a tracked file.
+   // os.WriteFile applies 0o600 only when it CREATES the file; remove any stale
+   // rendered copy first so a pre-existing looser-permissioned file can't expose the secret.
+   _ = os.Remove("config.production.yaml")
    if err := os.WriteFile("config.production.yaml", []byte(rendered), 0o600); err != nil { return err }
    // GoBricks reads the rendered file when config.Load() runs inside app.Run() —
    // no ${VAR} placeholder left to resolve.

--- a/wiki/troubleshooting.md
+++ b/wiki/troubleshooting.md
@@ -165,7 +165,7 @@ observability:
     insecure: false  # TLS required
     compression: gzip
     headers:
-      api-key: your-license-key
+      api-key: ${NEW_RELIC_API_KEY}  # rendered before startup — see observability_headers_auth.md
 ```
 
 **HTTP endpoint format:**


### PR DESCRIPTION
## What

llms.txt's programmatic OTLP-header-override snippet assigned `cfg.Observability.*` — a field `config.Config` doesn't have — and would be inert even if it compiled, since the provider unmarshals `observability.*` from the koanf tree at bootstrap. Replaced with the two supported paths (in-`main()` render per the wiki's "Programmatic secret injection" section, or an infra render step), corrected the env-var claim, and aligned the vendor-direct example with the Secrets Hygiene section. README's three discarded-error sites (`config.Load`, `getDB`, `Begin`) now check errors.

Closes #787

## Impact

None. Docs only; infallible struct-marshal discards and the two ADR snippets stay, per the issue's scope and #786's triage criterion.

## Verification

Local `make check` green (docs-only diff skips the CI framework matrix). llms.txt error-discard baseline holds at 14; fence parity intact. Gates: /simplify applied 3 findings; /security-audit clean; CodeRabbit CLI 1 minor (tracked-template split), deferred as a coordinated wiki+llms follow-up — rationale in the commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved configuration examples to handle loading and transaction setup errors explicitly.
  * Clarified OTLP authentication guidance, including pre-rendering YAML header values before startup.
  * Updated secrets-handling examples with recommended infrastructure-based templating approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->