### PR TITLE
feat(httpclient): config-driven client TLS and client certificates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ GoBricks is an enterprise-grade Go framework for building microservices with mod
 
 **Most Common Commands:**
 ```bash
-make check              # Pre-commit: fmt + lint + test + alloc guards + vuln scan
+make check              # Pre-commit: fmt + lint + test + alloc guards + vuln scan + gosec (mirrors CI)
 make test               # Unit tests with race detection
 make test-integration   # Integration tests (Docker required)
 go test -run TestName   # Run specific test

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,11 @@ clean: ## Clean build cache and test artifacts
 	rm -f coverage.out coverage-integration.out coverage.html coverage.func
 	rm -f *.test
 
-check: fmt lint test test-alloc vuln ## Run fmt, lint, test, alloc guards, and vuln scan (pre-commit checks)
+# `sec` is not redundant with `lint`: golangci-lint's gosec runs under the
+# common-false-positives preset, so classes like G304 are suppressed there and
+# reported only by the standalone scanner CI runs. Leaving it out of `check` meant
+# a clean local run could still fail the security-framework job.
+check: fmt lint test test-alloc vuln sec ## Run fmt, lint, test, alloc guards, vuln scan, and gosec (pre-commit checks; mirrors CI)
 
 vuln: ## Run govulncheck vulnerability scan (pinned; identical to CI)
 	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...

--- a/httpclient/tls.go
+++ b/httpclient/tls.go
@@ -186,6 +186,10 @@ func loadPEM(file, value, what string) ([]byte, error) {
 		if looksLikeKeyMaterial(file) {
 			return nil, fmt.Errorf("httpclient: tls: %s: file looks like key material, not a path (use the value field for inline PEM)", what)
 		}
+		// #nosec G304 -- the path is deployment configuration, not request input:
+		// reading an operator-named file IS this function. Inline material is
+		// rejected above. Same shape as keystore.go's loadKeyBytes, which gosec
+		// leaves alone only because it reads a struct field rather than a parameter.
 		data, err := os.ReadFile(file)
 		if err != nil {
 			return nil, fmt.Errorf("httpclient: tls: %s: read file %s: %w", what, safeFileRef(file), errnoOf(err))

--- a/httpclient/tls.go
+++ b/httpclient/tls.go
@@ -1,0 +1,293 @@
+package httpclient
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net"
+	nethttp "net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const pemTypeCertificate = "CERTIFICATE"
+
+// pemHeaderPrefix opens every PEM block, so a *File value containing it is PEM
+// content pasted into the wrong field rather than a path.
+const pemHeaderPrefix = "-----BEGIN"
+
+// maxPathEcho bounds what a read error quotes back. A *File value longer than
+// this is elided: over-long values are the shape mis-filed material takes, and
+// this error reaches startup logs.
+const maxPathEcho = 256
+
+// ClientTLSConfig describes client-side TLS material declaratively. Each piece
+// comes from a PEM file path (File) or a base64-encoded PEM string (Value) —
+// set exactly one source per provided piece. Cert and Key must be provided
+// together (the client certificate); CA is optional and, when set, REPLACES the
+// system roots for server verification (private-CA pinning), so a client that
+// pins a private CA can no longer verify public-CA endpoints. Providing no
+// material at all is an error — use WithTLSConfig with a hand-built *tls.Config
+// for setups this does not cover.
+//
+// Every field is a comparable type on purpose: a slice or map would make the
+// exported struct non-comparable, which apidiff reports as INCOMPATIBLE.
+type ClientTLSConfig struct {
+	CertFile  string
+	CertValue string
+	KeyFile   string
+	KeyValue  string
+	CAFile    string
+	CAValue   string
+
+	// ServerName overrides SNI / hostname verification (optional).
+	ServerName string
+	// MinVersion is "1.2" (default when empty) or "1.3".
+	MinVersion string
+
+	// RequireClientCert makes a missing client certificate an error instead of
+	// silently producing a server-authentication-only config. Set it whenever the
+	// deployment intends mutual TLS: a CA-only config is valid (root pinning) but
+	// presents no client certificate.
+	RequireClientCert bool
+}
+
+// NewClientTLSConfig loads the declared material into a *tls.Config with a TLS
+// 1.2 floor. It never disables certificate verification; the explicit escape
+// hatch for local testing is passing a hand-built *tls.Config to WithTLSConfig.
+func NewClientTLSConfig(cfg *ClientTLSConfig) (*tls.Config, error) {
+	if cfg == nil {
+		return nil, errors.New("httpclient: tls: config is nil")
+	}
+
+	certPEM, keyPEM, err := loadClientKeyPair(cfg)
+	if err != nil {
+		return nil, err
+	}
+	caPEM, err := loadPEM(cfg.CAFile, cfg.CAValue, "ca")
+	if err != nil {
+		return nil, err
+	}
+	if certPEM == nil && caPEM == nil {
+		return nil, errors.New("httpclient: tls: no material provided: set cert and key, ca, or both")
+	}
+	minVersion, err := parseTLSMinVersion(cfg.MinVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &tls.Config{
+		MinVersion: minVersion,
+		ServerName: cfg.ServerName,
+	}
+	if certPEM != nil {
+		pair, err := tls.X509KeyPair(certPEM, keyPEM)
+		if err != nil {
+			return nil, fmt.Errorf("httpclient: tls: cert/key: %w", err)
+		}
+		out.Certificates = []tls.Certificate{pair}
+	}
+	if caPEM != nil {
+		pool, err := certPoolFromPEM(caPEM)
+		if err != nil {
+			return nil, err
+		}
+		out.RootCAs = pool
+	}
+	return out, nil
+}
+
+// WithTLSConfig installs tlsCfg on a fresh base transport: a clone of
+// http.DefaultTransport, or an equivalently-configured transport when that
+// global has been replaced. It fills the same base-transport slot as
+// WithTransport: whichever of the two is called last wins. Wrapper layers
+// (WithJOSE, for example) always apply on top of this base regardless of call
+// order. A nil tlsCfg is a no-op.
+//
+// The config is cloned, so one loaded config can be shared across clients. The
+// clone is required, not defensive style: net/http appends ALPN protocols to
+// TLSClientConfig.NextProtos in place on a transport's first request, so two
+// clients sharing one config race. The copy is shallow: reference fields such
+// as Certificates and RootCAs stay shared with the caller and must not be
+// mutated in place — rotate certificates through GetClientCertificate, which
+// Clone preserves.
+func (b *Builder) WithTLSConfig(tlsCfg *tls.Config) *Builder {
+	if tlsCfg == nil {
+		return b
+	}
+	var base *nethttp.Transport
+	// Consumers replace nethttp.DefaultTransport (gock, httpmock, APM agents), so
+	// a bare type assertion would panic mid-chain. A replaced global cannot be
+	// recovered, so the fallback mirrors the stdlib http.DefaultTransport values
+	// instead of dropping proxy support and HTTP/2.
+	if dt, ok := nethttp.DefaultTransport.(*nethttp.Transport); ok {
+		base = dt.Clone()
+	} else {
+		base = &nethttp.Transport{
+			Proxy: nethttp.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		}
+	}
+	// net/http skips its own handshake entirely when a TLS dialer is set, so a
+	// cloned one from a replaced global would discard tlsCfg wholesale — pinning,
+	// version floor and client certificate included.
+	//nolint:staticcheck // SA1019: DialTLS is deprecated but still honored when DialTLSContext is nil, so Clone can carry a live TLS bypass in it — clearing it is the point.
+	base.DialTLS = nil
+	base.DialTLSContext = nil
+	base.TLSClientConfig = tlsCfg.Clone()
+	b.transport = base
+	return b
+}
+
+// loadClientKeyPair resolves the client certificate material and enforces the
+// cert/key pairing rules.
+func loadClientKeyPair(cfg *ClientTLSConfig) (certPEM, keyPEM []byte, err error) {
+	certPEM, err = loadPEM(cfg.CertFile, cfg.CertValue, "cert")
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPEM, err = loadPEM(cfg.KeyFile, cfg.KeyValue, "key")
+	if err != nil {
+		return nil, nil, err
+	}
+	switch {
+	case certPEM != nil && keyPEM == nil:
+		return nil, nil, errors.New("httpclient: tls: cert: set without a matching key")
+	case certPEM == nil && keyPEM != nil:
+		return nil, nil, errors.New("httpclient: tls: key: set without a matching cert")
+	case certPEM == nil && cfg.RequireClientCert:
+		return nil, nil, errors.New("httpclient: tls: require client cert: cert and key are empty")
+	}
+	return certPEM, keyPEM, nil
+}
+
+// loadPEM reads one piece of PEM material from a file path or a base64-encoded
+// value, returning (nil, nil) when neither source is set.
+func loadPEM(file, value, what string) ([]byte, error) {
+	switch {
+	case file != "" && value != "":
+		return nil, fmt.Errorf("httpclient: tls: %s: set file or value, not both", what)
+	case file != "":
+		// Never let mis-filed material reach os.ReadFile: both our wrap and the
+		// *os.PathError it wraps would echo it into a startup error.
+		if looksLikeKeyMaterial(file) {
+			return nil, fmt.Errorf("httpclient: tls: %s: file looks like key material, not a path (use the value field for inline PEM)", what)
+		}
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("httpclient: tls: %s: read file %s: %w", what, safeFileRef(file), errnoOf(err))
+		}
+		return data, nil
+	case value != "":
+		data, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return nil, fmt.Errorf("httpclient: tls: %s: base64 decode: %w", what, err)
+		}
+		return data, nil
+	default:
+		return nil, nil
+	}
+}
+
+// looksLikeKeyMaterial reports whether a *File value is inline key material
+// rather than a path. It covers a raw PEM body, its base64 form (what a secret
+// manager hands you, and so the likelier mix-up), and base64 of raw DER — which
+// carries no PEM header at any level and, for EC and Ed25519 keys, is short
+// enough to slip maxPathEcho too. Decoding unpadded accepts both base64 forms:
+// whether a value arrives padded otherwise depends on len(input)%3.
+func looksLikeKeyMaterial(file string) bool {
+	if strings.Contains(file, pemHeaderPrefix) {
+		return true
+	}
+	decoded, err := base64.RawStdEncoding.DecodeString(strings.TrimRight(file, "="))
+	if err != nil {
+		return false
+	}
+	// 0x30 is the ASN.1 SEQUENCE tag that opens PKCS#8, SEC1, PKCS#12 and X.509.
+	return strings.Contains(string(decoded), pemHeaderPrefix) || (len(decoded) > 0 && decoded[0] == 0x30)
+}
+
+// safeFileRef renders a *File value for an error message, eliding anything too
+// long to be a plausible path.
+func safeFileRef(file string) string {
+	if len(file) > maxPathEcho {
+		return fmt.Sprintf("<%d-char value elided>", len(file))
+	}
+	return fmt.Sprintf("%q", file)
+}
+
+// errnoOf strips the *os.PathError wrapper, which carries its own copy of the
+// path and would re-echo a value safeFileRef elided. errors.Is is unaffected:
+// the bare errno still matches fs.ErrNotExist and friends.
+func errnoOf(err error) error {
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		return pathErr.Err
+	}
+	return err
+}
+
+// certPoolFromPEM refuses to pin fewer roots than the bundle asks for, which
+// AppendCertsFromPEM's boolean cannot express: it returns true whenever ANY
+// block parsed. Corruption hides at two layers and both are checked — a mangled
+// base64 body makes pem.Decode skip the block silently (a YAML block scalar that
+// indents the PEM does exactly this), while a well-framed block with bad DER
+// fails x509.ParseCertificate. A staged CA rotation that quietly pins only the
+// outgoing root is the failure this prevents: startup is clean and every call
+// dies the moment the partner cuts over.
+func certPoolFromPEM(caPEM []byte) (*x509.CertPool, error) {
+	declared := bytes.Count(caPEM, []byte(pemHeaderPrefix))
+	pool := x509.NewCertPool()
+	rest := caPEM
+	decoded, certs := 0, 0
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		decoded++
+		// Non-certificate blocks are legitimate: a bundle may carry a key
+		// alongside its chain. Only undecodable ones are an error.
+		if block.Type != pemTypeCertificate {
+			continue
+		}
+		crt, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("httpclient: tls: ca: block %d: %w", decoded-1, err)
+		}
+		pool.AddCert(crt)
+		certs++
+	}
+	if declared != decoded {
+		return nil, fmt.Errorf("httpclient: tls: ca: %d PEM blocks declared but only %d decodable — the bundle is corrupt and would pin fewer roots than intended", declared, decoded)
+	}
+	if certs == 0 {
+		return nil, fmt.Errorf("httpclient: tls: ca: no %s block found", pemTypeCertificate)
+	}
+	return pool, nil
+}
+
+func parseTLSMinVersion(v string) (uint16, error) {
+	switch v {
+	case "", "1.2":
+		return tls.VersionTLS12, nil
+	case "1.3":
+		return tls.VersionTLS13, nil
+	default:
+		return 0, fmt.Errorf("httpclient: tls: minversion %s: accepted values are \"1.2\" and \"1.3\"", safeFileRef(v))
+	}
+}

--- a/httpclient/tls_test.go
+++ b/httpclient/tls_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io/fs"
 	"math/big"
 	"net"
@@ -346,7 +347,10 @@ func TestNewClientTLSConfigRejectsPEMContentInFileField(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, cfg)
 		assert.Contains(t, err.Error(), "tls: ca: read file")
-		assert.Contains(t, err.Error(), missing, "a plausible path stays in the message for diagnosability")
+		// %q-quoted, so on Windows the separators arrive escaped — comparing against
+		// the raw path fails there for a reason that has nothing to do with the code.
+		assert.Contains(t, err.Error(), fmt.Sprintf("%q", missing),
+			"a plausible path stays in the message for diagnosability")
 		assert.ErrorIs(t, err, fs.ErrNotExist, "unwrapping the PathError must not break errors.Is")
 	})
 }

--- a/httpclient/tls_test.go
+++ b/httpclient/tls_test.go
@@ -1,0 +1,635 @@
+package httpclient
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"io/fs"
+	"math/big"
+	"net"
+	nethttp "net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testServerName = "partner.example.com"
+
+// newTestCA returns a self-signed CA and a function minting leaf certs signed by it.
+func newTestCA(t *testing.T, cn string) (caCertPEM []byte, caCert *x509.Certificate, issue func(leafCN string, isServer bool) (certPEM, keyPEM []byte)) {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err = x509.ParseCertificate(der)
+	require.NoError(t, err)
+	caCertPEM = pem.EncodeToMemory(&pem.Block{Type: pemTypeCertificate, Bytes: der})
+
+	serial := int64(1)
+	issue = func(leafCN string, isServer bool) (certPEM, keyPEM []byte) {
+		t.Helper()
+		serial++
+
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		leaf := &x509.Certificate{
+			SerialNumber: big.NewInt(serial),
+			Subject:      pkix.Name{CommonName: leafCN},
+			NotBefore:    time.Now().Add(-time.Minute),
+			NotAfter:     time.Now().Add(time.Hour),
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		}
+		if isServer {
+			leaf.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+			leaf.DNSNames = []string{"127.0.0.1"}
+			leaf.IPAddresses = []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}
+		}
+
+		leafDER, err := x509.CreateCertificate(rand.Reader, leaf, caCert, &key.PublicKey, caKey)
+		require.NoError(t, err)
+		keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+		require.NoError(t, err)
+
+		return pem.EncodeToMemory(&pem.Block{Type: pemTypeCertificate, Bytes: leafDER}),
+			pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	}
+
+	return caCertPEM, caCert, issue
+}
+
+func b64PEM(material []byte) string {
+	return base64.StdEncoding.EncodeToString(material)
+}
+
+// ed25519KeyPEM returns a PKCS#8 Ed25519 key: the compact shape whose DER is short
+// enough to slip maxPathEcho and whose PEM length is not a multiple of 3.
+func ed25519KeyPEM(t *testing.T) []byte {
+	t.Helper()
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}
+
+func writeTestFile(t *testing.T, dir, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+func TestNewClientTLSConfigFromValues(t *testing.T) {
+	caPEM, _, issue := newTestCA(t, "values-ca")
+	certPEM, keyPEM := issue("client", false)
+
+	cfg, err := NewClientTLSConfig(&ClientTLSConfig{
+		CertValue:         b64PEM(certPEM),
+		KeyValue:          b64PEM(keyPEM),
+		CAValue:           b64PEM(caPEM),
+		RequireClientCert: true,
+	})
+	require.NoError(t, err)
+	assert.Len(t, cfg.Certificates, 1)
+	assert.NotNil(t, cfg.RootCAs)
+	assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+}
+
+func TestNewClientTLSConfigFromFiles(t *testing.T) {
+	caPEM, _, issue := newTestCA(t, "files-ca")
+	certPEM, keyPEM := issue("client", false)
+
+	dir := t.TempDir()
+	cfg, err := NewClientTLSConfig(&ClientTLSConfig{
+		CertFile: writeTestFile(t, dir, "client.crt", certPEM),
+		KeyFile:  writeTestFile(t, dir, "client.key", keyPEM),
+		CAFile:   writeTestFile(t, dir, "ca.crt", caPEM),
+	})
+	require.NoError(t, err)
+	assert.Len(t, cfg.Certificates, 1)
+	assert.NotNil(t, cfg.RootCAs)
+}
+
+func TestNewClientTLSConfigValidation(t *testing.T) {
+	caPEM, _, issue := newTestCA(t, "validation-ca")
+	certPEM, keyPEM := issue("client", false)
+	_, otherKeyPEM := issue("other-client", false)
+
+	corruptCA := pem.EncodeToMemory(&pem.Block{Type: pemTypeCertificate, Bytes: []byte("not-a-certificate")})
+
+	tests := []struct {
+		name    string
+		cfg     *ClientTLSConfig
+		wantErr string
+	}{
+		{
+			name:    "nil_config",
+			cfg:     nil,
+			wantErr: "tls: config is nil",
+		},
+		{
+			name:    "nothing_provided",
+			cfg:     &ClientTLSConfig{},
+			wantErr: "tls: no material provided",
+		},
+		{
+			name:    "cert_without_key",
+			cfg:     &ClientTLSConfig{CertValue: b64PEM(certPEM)},
+			wantErr: "tls: cert: set without a matching key",
+		},
+		{
+			name:    "key_without_cert",
+			cfg:     &ClientTLSConfig{KeyValue: b64PEM(keyPEM)},
+			wantErr: "tls: key: set without a matching cert",
+		},
+		{
+			name:    "both_file_and_value",
+			cfg:     &ClientTLSConfig{CertFile: "client.crt", CertValue: b64PEM(certPEM)},
+			wantErr: "tls: cert: set file or value, not both",
+		},
+		{
+			name:    "bad_base64",
+			cfg:     &ClientTLSConfig{CAValue: "!!! not base64 !!!"},
+			wantErr: "tls: ca: base64 decode",
+		},
+		{
+			name:    "bad_pem_keypair",
+			cfg:     &ClientTLSConfig{CertValue: b64PEM(certPEM), KeyValue: b64PEM(otherKeyPEM)},
+			wantErr: "tls: cert/key:",
+		},
+		{
+			name:    "bad_ca_pem",
+			cfg:     &ClientTLSConfig{CAValue: b64PEM(corruptCA)},
+			wantErr: "tls: ca: block 0:",
+		},
+		{
+			name:    "ca_pem_without_certificate_block",
+			cfg:     &ClientTLSConfig{CAValue: b64PEM(keyPEM)},
+			wantErr: "tls: ca: no CERTIFICATE block found",
+		},
+		{
+			name:    "bad_minversion",
+			cfg:     &ClientTLSConfig{CAValue: b64PEM(caPEM), MinVersion: "1.1"},
+			wantErr: `tls: minversion "1.1"`,
+		},
+		{
+			name:    "require_client_cert_without_material",
+			cfg:     &ClientTLSConfig{CAValue: b64PEM(caPEM), RequireClientCert: true},
+			wantErr: "tls: require client cert",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := NewClientTLSConfig(tt.cfg)
+			require.Error(t, err)
+			assert.Nil(t, cfg)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestNewClientTLSConfigMinVersionAndServerName(t *testing.T) {
+	caPEM, _, _ := newTestCA(t, "minversion-ca")
+
+	cfg, err := NewClientTLSConfig(&ClientTLSConfig{
+		CAValue:    b64PEM(caPEM),
+		MinVersion: "1.3",
+		ServerName: testServerName,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion)
+	assert.Equal(t, testServerName, cfg.ServerName)
+	assert.NotNil(t, cfg.RootCAs)
+	// CA-only pins roots for server verification; it presents no client
+	// certificate, so it is not mutual TLS.
+	assert.Empty(t, cfg.Certificates)
+
+	explicit12, err12 := NewClientTLSConfig(&ClientTLSConfig{
+		CAValue:    b64PEM(caPEM),
+		MinVersion: "1.2",
+	})
+	require.NoError(t, err12)
+	assert.Equal(t, uint16(tls.VersionTLS12), explicit12.MinVersion)
+}
+
+func TestNewClientTLSConfigCABundleSkipsNonCertificateBlocks(t *testing.T) {
+	caPEM, _, issue := newTestCA(t, "bundle-ca")
+	_, keyPEM := issue("client", false)
+
+	bundle := append(append([]byte{}, caPEM...), keyPEM...)
+	cfg, err := NewClientTLSConfig(&ClientTLSConfig{CAValue: b64PEM(bundle)})
+	require.NoError(t, err)
+	assert.NotNil(t, cfg.RootCAs)
+}
+
+// A cert-only config must leave RootCAs nil, which is what "verify the server
+// against the system roots" means to crypto/tls.
+func TestNewClientTLSConfigCertOnlyKeepsSystemRoots(t *testing.T) {
+	_, _, issue := newTestCA(t, "cert-only-ca")
+	certPEM, keyPEM := issue("client", false)
+
+	cfg, err := NewClientTLSConfig(&ClientTLSConfig{
+		CertValue:         b64PEM(certPEM),
+		KeyValue:          b64PEM(keyPEM),
+		RequireClientCert: true,
+	})
+	require.NoError(t, err)
+	assert.Len(t, cfg.Certificates, 1)
+	assert.Nil(t, cfg.RootCAs)
+}
+
+func TestNewClientTLSConfigRejectsPEMContentInFileField(t *testing.T) {
+	_, _, issue := newTestCA(t, "pem-in-path-ca")
+	certPEM, keyPEM := issue("client", false)
+
+	t.Run("raw_pem_body", func(t *testing.T) {
+		cfg, err := NewClientTLSConfig(&ClientTLSConfig{
+			CertValue: b64PEM(certPEM),
+			KeyFile:   string(keyPEM),
+		})
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Contains(t, err.Error(), "tls: key: file looks like key material")
+		assert.NotContains(t, err.Error(), "PRIVATE KEY", "the error must not echo the key material")
+	})
+
+	// The likelier transposition: *Value fields take base64 PEM, which is what a
+	// secret manager hands you, so a File/Value mix-up carries the base64 form.
+	t.Run("base64_pem_body", func(t *testing.T) {
+		encoded := b64PEM(keyPEM)
+		cfg, err := NewClientTLSConfig(&ClientTLSConfig{
+			CertValue: b64PEM(certPEM),
+			KeyFile:   encoded,
+		})
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Contains(t, err.Error(), "tls: key: file looks like key material")
+		assert.NotContains(t, err.Error(), encoded, "the error must not echo the encoded key material")
+	})
+
+	// The quadrant the length bound cannot cover: base64 of raw DER carries no PEM
+	// header at any level, and for EC/Ed25519 it is short enough to be echoed in
+	// full. Both defenses previously missed this from opposite sides.
+	t.Run("base64_der_under_the_echo_bound", func(t *testing.T) {
+		_, edKey, genErr := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, genErr)
+		der, derErr := x509.MarshalPKCS8PrivateKey(edKey)
+		require.NoError(t, derErr)
+		encoded := base64.StdEncoding.EncodeToString(der)
+		require.Less(t, len(encoded), maxPathEcho, "the point of this case is that eliding cannot save us")
+
+		cfg, err := NewClientTLSConfig(&ClientTLSConfig{CAFile: encoded})
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Contains(t, err.Error(), "looks like key material")
+		assert.NotContains(t, err.Error(), encoded, "the DER key must never reach the error string")
+	})
+
+	// StdEncoding rejects unpadded input, so whether a RawStdEncoding value is
+	// caught used to depend on len(PEM)%3 — luck, not design. RSA-2048 PEM is 1704
+	// bytes (%3 == 0), so its padded and unpadded forms are identical and cannot
+	// exercise this; Ed25519 PEM is 119 bytes (%3 == 2) and can.
+	t.Run("unpadded_base64_pem", func(t *testing.T) {
+		edPEM := ed25519KeyPEM(t)
+		unpadded := base64.RawStdEncoding.EncodeToString(edPEM)
+		require.NotEqual(t, base64.StdEncoding.EncodeToString(edPEM), unpadded,
+			"this case is vacuous unless the two encodings actually differ")
+
+		cfg, err := NewClientTLSConfig(&ClientTLSConfig{CAFile: unpadded})
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Contains(t, err.Error(), "looks like key material")
+		assert.NotContains(t, err.Error(), unpadded)
+	})
+
+	t.Run("over_long_path_is_elided", func(t *testing.T) {
+		secret := strings.Repeat("s3cr3t", 100)
+		cfg, err := NewClientTLSConfig(&ClientTLSConfig{CAFile: secret})
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.NotContains(t, err.Error(), secret, "an over-long value must not be echoed")
+		assert.Contains(t, err.Error(), "char value elided")
+	})
+
+	t.Run("ordinary_path_still_reports_errno", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "absent.pem")
+		cfg, err := NewClientTLSConfig(&ClientTLSConfig{CAFile: missing})
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Contains(t, err.Error(), "tls: ca: read file")
+		assert.Contains(t, err.Error(), missing, "a plausible path stays in the message for diagnosability")
+		assert.ErrorIs(t, err, fs.ErrNotExist, "unwrapping the PathError must not break errors.Is")
+	})
+}
+
+// A bundle whose second root is mangled at the PEM layer must not load: pem.Decode
+// skips it silently, so without the declared-vs-decoded check a staged CA rotation
+// pins only the outgoing root and fails the moment the partner cuts over.
+func TestNewClientTLSConfigRejectsPartiallyCorruptCABundle(t *testing.T) {
+	firstPEM, _, _ := newTestCA(t, "root-outgoing")
+	secondPEM, _, _ := newTestCA(t, "root-incoming")
+
+	corruptions := map[string]func([]byte) []byte{
+		"mangled_base64_body": func(b []byte) []byte {
+			return bytes.Replace(b, []byte("\nMII"), []byte("\nM!I"), 1)
+		},
+		"indented_by_yaml_block_scalar": func(b []byte) []byte {
+			return bytes.ReplaceAll(b, []byte("\n"), []byte("\n  "))
+		},
+		"truncated_tail": func(b []byte) []byte {
+			return b[:len(b)-40]
+		},
+	}
+
+	for name, corrupt := range corruptions {
+		t.Run(name, func(t *testing.T) {
+			bundle := append(append([]byte{}, firstPEM...), corrupt(secondPEM)...)
+			cfg, err := NewClientTLSConfig(&ClientTLSConfig{CAValue: b64PEM(bundle)})
+			require.Error(t, err, "a bundle that would pin fewer roots than declared must fail at startup")
+			assert.Nil(t, cfg)
+			assert.Contains(t, err.Error(), "tls: ca:")
+		})
+	}
+
+	t.Run("intact_two_root_bundle_loads", func(t *testing.T) {
+		bundle := append(append([]byte{}, firstPEM...), secondPEM...)
+		cfg, err := NewClientTLSConfig(&ClientTLSConfig{CAValue: b64PEM(bundle)})
+		require.NoError(t, err)
+		assert.NotNil(t, cfg.RootCAs)
+	})
+}
+
+func TestWithTLSConfigSetsBaseTransport(t *testing.T) {
+	caPEM, _, issue := newTestCA(t, "transport-ca")
+	certPEM, keyPEM := issue("client", false)
+
+	cfg, err := NewClientTLSConfig(&ClientTLSConfig{
+		CertValue: b64PEM(certPEM),
+		KeyValue:  b64PEM(keyPEM),
+		CAValue:   b64PEM(caPEM),
+	})
+	require.NoError(t, err)
+
+	built := NewBuilder(createTestLogger()).WithTLSConfig(cfg).Build()
+	impl, ok := built.(*client)
+	require.True(t, ok)
+	transport, isTransport := impl.httpClient.Transport.(*nethttp.Transport)
+	require.True(t, isTransport)
+	assert.NotSame(t, nethttp.DefaultTransport, transport)
+
+	require.NotNil(t, transport.TLSClientConfig)
+	assert.NotSame(t, cfg, transport.TLSClientConfig)
+	assert.Equal(t, uint16(tls.VersionTLS12), transport.TLSClientConfig.MinVersion)
+	assert.Len(t, transport.TLSClientConfig.Certificates, 1)
+	assert.NotNil(t, transport.TLSClientConfig.RootCAs)
+
+	// The base is DefaultTransport-equivalent, not a zero-value transport: losing
+	// Proxy alone breaks every call behind a mandatory egress proxy.
+	assert.NotNil(t, transport.Proxy)
+	assert.True(t, transport.ForceAttemptHTTP2)
+	assert.Equal(t, 100, transport.MaxIdleConns)
+	assert.Equal(t, 90*time.Second, transport.IdleConnTimeout)
+
+	if defaultTransport, isDefault := nethttp.DefaultTransport.(*nethttp.Transport); isDefault {
+		assert.NotSame(t, cfg, defaultTransport.TLSClientConfig)
+	}
+}
+
+func TestWithTLSConfigCallOrderPrecedence(t *testing.T) {
+	caPEM, _, issue := newTestCA(t, "precedence-ca")
+	certPEM, keyPEM := issue("client", false)
+
+	cfg, err := NewClientTLSConfig(&ClientTLSConfig{
+		CertValue: b64PEM(certPEM),
+		KeyValue:  b64PEM(keyPEM),
+		CAValue:   b64PEM(caPEM),
+	})
+	require.NoError(t, err)
+
+	builder := NewBuilder(createTestLogger()).WithTLSConfig(nil)
+	assert.Nil(t, builder.transport)
+
+	stub := &stubRoundTripper{name: "tls-base-slot"}
+
+	t.Run("tls_config_after_transport_wins", func(t *testing.T) {
+		b := NewBuilder(createTestLogger()).WithTransport(stub).WithTLSConfig(cfg)
+		tlsBase, isTLSBase := b.transport.(*nethttp.Transport)
+		require.True(t, isTLSBase)
+		require.NotNil(t, tlsBase.TLSClientConfig)
+		assert.Equal(t, uint16(tls.VersionTLS12), tlsBase.TLSClientConfig.MinVersion)
+		assert.Len(t, tlsBase.TLSClientConfig.Certificates, 1)
+		assert.NotNil(t, tlsBase.TLSClientConfig.RootCAs)
+	})
+
+	t.Run("transport_after_tls_config_wins", func(t *testing.T) {
+		b := NewBuilder(createTestLogger()).WithTLSConfig(cfg).WithTransport(stub)
+		assert.Same(t, stub, b.transport)
+	})
+
+	t.Run("nil_tls_config_keeps_existing_transport", func(t *testing.T) {
+		b := NewBuilder(createTestLogger()).WithTransport(stub).WithTLSConfig(nil)
+		assert.Same(t, stub, b.transport)
+	})
+}
+
+func TestWithTLSConfigDefaultTransportReplaced(t *testing.T) {
+	caPEM, _, _ := newTestCA(t, "fallback-ca")
+	cfg, err := NewClientTLSConfig(&ClientTLSConfig{CAValue: b64PEM(caPEM)})
+	require.NoError(t, err)
+
+	// Non-parallel on purpose: the package has no t.Parallel() calls, so swapping
+	// the global here cannot race another test.
+	t.Run("replaced_default_transport_uses_seeded_fallback", func(t *testing.T) {
+		original := nethttp.DefaultTransport
+		t.Cleanup(func() { nethttp.DefaultTransport = original })
+		nethttp.DefaultTransport = &stubRoundTripper{name: "replaced-default"}
+
+		var builder *Builder
+		require.NotPanics(t, func() {
+			builder = NewBuilder(createTestLogger()).WithTLSConfig(cfg)
+		})
+
+		transport, isTransport := builder.transport.(*nethttp.Transport)
+		require.True(t, isTransport)
+		require.NotNil(t, transport.TLSClientConfig)
+		assert.NotNil(t, transport.Proxy)
+		assert.NotNil(t, transport.DialContext)
+		assert.True(t, transport.ForceAttemptHTTP2)
+		assert.Equal(t, 100, transport.MaxIdleConns)
+		assert.Equal(t, 90*time.Second, transport.IdleConnTimeout)
+		assert.Equal(t, 10*time.Second, transport.TLSHandshakeTimeout)
+		assert.Equal(t, time.Second, transport.ExpectContinueTimeout)
+	})
+
+	// net/http consults TLSClientConfig only when no TLS dialer is set, so a dialer
+	// cloned from a replaced global would silently void pinning, the version floor
+	// and the client certificate.
+	t.Run("cloned_tls_dialer_is_cleared", func(t *testing.T) {
+		defaultTransport, isDefault := nethttp.DefaultTransport.(*nethttp.Transport)
+		require.True(t, isDefault)
+
+		original := defaultTransport.DialTLSContext
+		t.Cleanup(func() { defaultTransport.DialTLSContext = original })
+		defaultTransport.DialTLSContext = func(context.Context, string, string) (net.Conn, error) {
+			return nil, errors.New("must never be consulted")
+		}
+
+		builder := NewBuilder(createTestLogger()).WithTLSConfig(cfg)
+		transport, isTransport := builder.transport.(*nethttp.Transport)
+		require.True(t, isTransport)
+		assert.Nil(t, transport.DialTLSContext, "an inherited TLS dialer would discard TLSClientConfig wholesale")
+		//nolint:staticcheck // SA1019: pins that the deprecated field is cleared too — it still bypasses TLSClientConfig when DialTLSContext is nil.
+		assert.Nil(t, transport.DialTLS)
+		assert.NotNil(t, transport.TLSClientConfig)
+	})
+
+	// Without this the clone branch is unpinned: because the fallback is
+	// field-equal to the stdlib default, collapsing WithTLSConfig to always use
+	// the literal would discard a consumer's customization with a green suite.
+	t.Run("intact_default_transport_is_cloned_not_synthesized", func(t *testing.T) {
+		defaultTransport, isDefault := nethttp.DefaultTransport.(*nethttp.Transport)
+		require.True(t, isDefault)
+
+		original := defaultTransport.MaxIdleConnsPerHost
+		t.Cleanup(func() { defaultTransport.MaxIdleConnsPerHost = original })
+		defaultTransport.MaxIdleConnsPerHost = 42
+
+		builder := NewBuilder(createTestLogger()).WithTLSConfig(cfg)
+		transport, isTransport := builder.transport.(*nethttp.Transport)
+		require.True(t, isTransport)
+		assert.Equal(t, 42, transport.MaxIdleConnsPerHost, "the live global must be cloned, not re-synthesized")
+	})
+}
+
+func TestClientTLSMutualAuthentication(t *testing.T) {
+	caPEM, caCert, issue := newTestCA(t, "mtls-ca")
+	serverCertPEM, serverKeyPEM := issue("127.0.0.1", true)
+	clientCertPEM, clientKeyPEM := issue("client", false)
+
+	serverPair, err := tls.X509KeyPair(serverCertPEM, serverKeyPEM)
+	require.NoError(t, err)
+	clientCAs := x509.NewCertPool()
+	clientCAs.AddCert(caCert)
+
+	var hits atomic.Int64
+	srv := httptest.NewUnstartedServer(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		hits.Add(1)
+		w.WriteHeader(nethttp.StatusOK)
+	}))
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverPair},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCAs,
+		MinVersion:   tls.VersionTLS12,
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	get := func(t *testing.T, cfg *tls.Config) (*Response, error) {
+		t.Helper()
+		c := NewBuilder(createTestLogger()).WithTLSConfig(cfg).Build()
+		return c.Get(context.Background(), &Request{URL: srv.URL})
+	}
+
+	t.Run("valid_client_cert_accepted", func(t *testing.T) {
+		cfg, cfgErr := NewClientTLSConfig(&ClientTLSConfig{
+			CertValue:         b64PEM(clientCertPEM),
+			KeyValue:          b64PEM(clientKeyPEM),
+			CAValue:           b64PEM(caPEM),
+			RequireClientCert: true,
+		})
+		require.NoError(t, cfgErr)
+
+		before := hits.Load()
+		resp, reqErr := get(t, cfg)
+		require.NoError(t, reqErr)
+		assert.Equal(t, nethttp.StatusOK, resp.StatusCode)
+		assert.Equal(t, before+1, hits.Load(), "the valid client certificate must reach the handler")
+	})
+
+	t.Run("no_client_cert_rejected", func(t *testing.T) {
+		cfg, cfgErr := NewClientTLSConfig(&ClientTLSConfig{CAValue: b64PEM(caPEM)})
+		require.NoError(t, cfgErr)
+
+		before := hits.Load()
+		_, reqErr := get(t, cfg)
+		require.Error(t, reqErr)
+		assert.Contains(t, reqErr.Error(), "remote error: tls:", "the server must reject us with a TLS alert")
+		assert.NotContains(t, reqErr.Error(), "x509:", "must not be a local server-cert verification failure")
+		assert.Equal(t, before, hits.Load(), "a rejected handshake must not reach the handler")
+	})
+
+	t.Run("untrusted_server_cert_rejected", func(t *testing.T) {
+		otherCAPEM, _, _ := newTestCA(t, "other-ca")
+		cfg, cfgErr := NewClientTLSConfig(&ClientTLSConfig{
+			CertValue: b64PEM(clientCertPEM),
+			KeyValue:  b64PEM(clientKeyPEM),
+			CAValue:   b64PEM(otherCAPEM),
+		})
+		require.NoError(t, cfgErr)
+
+		before := hits.Load()
+		_, reqErr := get(t, cfg)
+		require.Error(t, reqErr)
+		assert.Contains(t, reqErr.Error(), "x509: certificate signed by unknown authority")
+		assert.Equal(t, before, hits.Load(), "a rejected handshake must not reach the handler")
+	})
+
+	// Exercises the httptest server's ClientCAs check rather than go-bricks code;
+	// kept because it is the issue's literal acceptance criterion.
+	t.Run("wrong_ca_client_cert_rejected", func(t *testing.T) {
+		_, _, otherIssue := newTestCA(t, "rogue-ca")
+		rogueCertPEM, rogueKeyPEM := otherIssue("rogue-client", false)
+
+		cfg, cfgErr := NewClientTLSConfig(&ClientTLSConfig{
+			CertValue: b64PEM(rogueCertPEM),
+			KeyValue:  b64PEM(rogueKeyPEM),
+			CAValue:   b64PEM(caPEM),
+		})
+		require.NoError(t, cfgErr)
+		require.Len(t, cfg.Certificates, 1)
+
+		// Go filters Certificates against the server's advertised CAs and would
+		// otherwise send an empty Certificate message, making this case
+		// indistinguishable from no_client_cert_rejected.
+		rogue := cfg.Certificates[0]
+		cfg.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &rogue, nil
+		}
+
+		before := hits.Load()
+		_, reqErr := get(t, cfg)
+		require.Error(t, reqErr)
+		assert.Contains(t, reqErr.Error(), "remote error: tls: unknown certificate authority")
+		assert.Equal(t, before, hits.Load(), "a rejected handshake must not reach the handler")
+	})
+}

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -63,6 +63,87 @@ httpclient.NewBuilder(logger).
 httpclient.NewBuilder(logger).WithTransport(mTLSTransport).WithJOSE(cfg).Build()
 ```
 
+### Mutual TLS (client certificates)
+
+`NewClientTLSConfig` turns declarative certificate material into a hardened
+`*tls.Config` (TLS 1.2 floor, `InsecureSkipVerify` never set), and `WithTLSConfig`
+installs it on the client:
+
+```go
+tlsCfg, err := httpclient.NewClientTLSConfig(&httpclient.ClientTLSConfig{
+    CertFile:          os.Getenv("PARTNER_CLIENT_CERT"), // PEM path
+    KeyFile:           os.Getenv("PARTNER_CLIENT_KEY"),
+    CAFile:            os.Getenv("PARTNER_CA"),
+    RequireClientCert: true,
+})
+if err != nil {
+    return err
+}
+client := httpclient.NewBuilder(logger).WithTLSConfig(tlsCfg).Build()
+```
+
+**Sourcing.** Each piece — cert, key, CA — comes from either a PEM file path
+(`CertFile`/`KeyFile`/`CAFile`) or a **base64-encoded PEM** string
+(`CertValue`/`KeyValue`/`CAValue`, for env vars and secret managers). Setting both
+sources for the same piece is an error. `Cert*` and `Key*` must be provided
+together. `MinVersion` accepts `""`/`"1.2"` (default) or `"1.3"`; `ServerName`
+overrides SNI/hostname verification.
+
+**A `CA*` value REPLACES the system roots.** Setting it pins server verification to
+that CA alone, so a client configured for a private partner CA can no longer verify
+any public-CA endpoint. If you need both, build the pool yourself and hand the
+resulting `*tls.Config` to `WithTLSConfig` — and set `MinVersion` explicitly, since
+a hand-built config does not get the loader's TLS 1.2 floor:
+
+```go
+pool, err := x509.SystemCertPool()
+if err != nil {
+    return err
+}
+if !pool.AppendCertsFromPEM(partnerCAPEM) {
+    return errors.New("partner CA: no certificate appended")
+}
+cfg := &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+```
+
+Note `AppendCertsFromPEM` returns `true` when *any* block parsed, so it accepts a
+partially-corrupt bundle and pins fewer roots than you intended — the failure
+`NewClientTLSConfig` rejects outright. Check the count yourself if the bundle
+carries more than one root.
+
+**A CA-only config authenticates the SERVER, not the client.** It is valid (root
+pinning) and `NewClientTLSConfig` accepts it, but no client certificate is
+presented — so a deployment that omitted `Cert*`/`Key*` gets one-way TLS while
+believing it configured mTLS. Set `RequireClientCert: true` whenever mutual TLS is
+intended: the loader then fails loudly instead of silently degrading.
+
+**No `InsecureSkipVerify`.** The loader never produces a config that skips
+verification. The escape hatch is explicit and greppable: build a `*tls.Config` by
+hand and pass it to `WithTLSConfig`.
+
+**Base-transport slot.** `WithTLSConfig` fills the same base-transport slot as
+`WithTransport` — last call wins — and satisfies the requirement described above
+for `WithJOSE` and the `Build()` composition WARN. Its base is a clone of
+`http.DefaultTransport`, or an equivalently-configured transport (same proxy,
+HTTP/2 and pool settings) when that global has been replaced, so the pitfall above
+does not apply to it. Wrapper layers always stack on top of it:
+
+```go
+// mTLS base, JOSE on top — call order is irrelevant.
+httpclient.NewBuilder(logger).WithTLSConfig(tlsCfg).WithJOSE(joseCfg).Build()
+```
+
+The passed `*tls.Config` is cloned, so one loaded config can be shared across
+clients safely. The copy is **shallow**, so treat the config and everything it
+references as immutable once `WithTLSConfig` has seen it: every reference-typed
+field — the `Certificates` slice, the `RootCAs`/`ClientCAs` pools, `NextProtos`,
+`CipherSuites`, `CurvePreferences`, `NameToCertificate` — still points at the
+caller's storage, and writing through one is a data race against every in-flight
+handshake (`tlsCfg.Certificates[0] = newPair` is the tempting one). Reassigning a
+whole field on the original config is inert rather than racy, but only for clients
+already built. Rotate certificates through `GetClientCertificate`, which the clone
+preserves; for anything else, build a fresh config.
+
 ## Metrics
 
 ### Overview

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -37,7 +37,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E50  | v0.49.0 → v0.50.0 | config-break | 4 | none | Flyway migrate surfaces unparseable/failure output as an error; non-empty DB passwords < 8 bytes rejected at config validation + migrate; dev CORS wildcard opt-in; `multitenant.resolver.order` now REQUIRED for `type: composite` (no default — composite deployments fail to start until they declare one) |
 | E51  | v0.50.0 → v0.51.0 | silent-behavior (adopt-only) | 3 | none | none |
 | E52  | v0.51.0 → v0.52.0 | compile-break | 4 | C52.1 | if you set `.Args` on any declaration in ≤v0.51.0, verify current broker state before upgrading |
-| E55  | v0.52.0 → v0.55.0 | additive (safe) | 1 | none | none |
+| E55  | v0.52.0 → v0.55.0 | additive (safe) | 2 | none | none |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 - **`when: match`** → act only if `detect` returns ≥1 line (an API/arity/interface change, or a config key you set).
@@ -680,9 +680,9 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - note: `decls.DeclareQueueWithDLQ(name, spec)` declares the fanout DLX + parking queue + binding and sets `x-dead-letter-exchange` (and optionally `x-dead-letter-routing-key`) on the primary queue in one call — failed deliveries park in the default `<queue>.dlq` (or the configured parking queue) instead of dropping. Raw `Args["x-dead-letter-exchange"]` (see "Dead-Lettering" in wiki/messaging.md) remains valid for custom topologies. Purely additive; existing hand-rolled DLX declarations are untouched.
 - ref: #721 · messaging/helpers.go
 
-## E55 · v0.52.0 → v0.55.0 — database Execute* query/exec helpers
+## E55 · v0.52.0 → v0.55.0 — database Execute* query/exec helpers + httpclient client TLS
 
-- gist: Adds `database.ExecuteQuerySingle` / `ExecuteQueryMany` / `ExecuteUpdate` / `ExecuteUpdateOne` / `ExecuteInsert`, a 2-method `database.Executor` interface (satisfied by both `database.Interface` and `database.Tx`), and `database.Raw(sql, args...)` for hand-written SQL — collapsing the repeated `ToSQL()` → `Query`/`Exec` → scan/`RowsAffected` → error-wrap glue every SQL repository re-implements. No exported go-bricks symbol changes outside this new surface; purely additive.
+- gist: Adds `database.ExecuteQuerySingle` / `ExecuteQueryMany` / `ExecuteUpdate` / `ExecuteUpdateOne` / `ExecuteInsert`, a 2-method `database.Executor` interface (satisfied by both `database.Interface` and `database.Tx`), and `database.Raw(sql, args...)` for hand-written SQL — collapsing the repeated `ToSQL()` → `Query`/`Exec` → scan/`RowsAffected` → error-wrap glue every SQL repository re-implements. Also adds `httpclient.NewClientTLSConfig` and `httpclient.Builder.WithTLSConfig` for config-driven client certificates / mutual TLS. No exported go-bricks symbol changes outside these new surfaces; purely additive.
 - build-caught: none
 - preflight: none
 - exit: `go get github.com/gaborage/go-bricks@v0.55.0 && go mod tidy && go build ./... && go test ./...`
@@ -714,6 +714,29 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
   builder's identifier validation. Enforced by `.claude/hooks/check-raw-sql.sh`; audit
   grep `git grep -E 'f\.Raw\(|jf\.Raw\(|database\.Raw\('`.
 - ref: #772 · database/execute.go
+
+### [C55.2] httpclient client TLS / client certificates · additive-optional
+
+- note: `httpclient.NewClientTLSConfig(*httpclient.ClientTLSConfig)` loads client
+  certificate, key and CA material — each from a PEM file path (`CertFile`/`KeyFile`/
+  `CAFile`) or a base64-encoded PEM value (`CertValue`/`KeyValue`/`CAValue`) — into a
+  `*tls.Config` with a TLS 1.2 floor (`MinVersion: "1.3"` opts up), and the new
+  `Builder.WithTLSConfig(*tls.Config)` installs it as the client's base transport —
+  a clone of `http.DefaultTransport`, or an equivalently-configured transport when
+  that global has been replaced. It shares the base-transport slot with
+  `WithTransport` — last call wins — and wrapper layers such as `WithJOSE` still
+  stack on top regardless of call order. Purely additive; no existing signature or
+  default changes, so mTLS toward partners no longer needs a hand-built
+  `http.Transport` per consumer.
+- security: the loader never sets `InsecureSkipVerify`; the escape hatch is an
+  explicit hand-built `*tls.Config` passed to `WithTLSConfig`. Two silent-weakening
+  shapes to check when adopting: a configured CA **replaces** the system roots (a
+  client pinned to a private partner CA can no longer verify public-CA endpoints —
+  build your own pool from `x509.SystemCertPool()` if you need both), and a CA-only
+  config authenticates the **server** only, presenting no client certificate — set
+  `RequireClientCert: true` so a missing cert/key pair fails at load instead of
+  silently downgrading intended mTLS to one-way TLS.
+- ref: #767 · httpclient/tls.go
 
 ---
 


### PR DESCRIPTION
## What

`httpclient` offered only the generic `WithTransport` escape hatch for mutual TLS, so every service hand-built an `http.Transport`, hand-loaded PEM, and usually forgot `MinVersion`. Adds `NewClientTLSConfig` (cert/key/CA from PEM files or base64-PEM values, TLS 1.2 floor, no `InsecureSkipVerify`) and `WithTLSConfig`, which fills the same base-transport slot as `WithTransport` — last call wins, JOSE/OAuth1 wrappers stack on top. Purely additive: `client.go` has zero hunks.

## Impact

Adopt-only — no existing behavior changes. `RequireClientCert: true` is the opt-in that makes a missing client certificate fail at startup rather than silently yielding one-way TLS. Two silent-weakening shapes are documented in `wiki/httpclient.md` because no test can catch them: a `CA*` value **replaces** the system roots (breaking public-CA verification), and a CA-only config authenticates the server, not the client.

## Verification

Mutation-checked: dropping the `Certificates` assignment fails `valid_client_cert_accepted`; dropping `RootCAs` additionally turns `no_client_cert_rejected` red via its `NotContains("x509:")` discriminator. Two `//nolint:staticcheck` directives are load-bearing — SA1019 flags the deprecated `Transport.DialTLS`, and clearing it is the point: verified against a live TLS server that it still bypasses `TLSClientConfig` when `DialTLSContext` is nil.

Refs: #767


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added declarative client-side TLS support for HTTP requests, including client certificates, private keys, and CA pinning from file paths or base64-encoded PEM values.
  * Enabled mutual TLS with configurable server name and TLS minimum version, plus transport-level integration.
* **Documentation**
  * Documented TLS input rules, CA behavior (root replacement), and transport precedence/immutability expectations.
  * Updated migration guidance to cover the new HTTP client TLS capabilities.
* **Tests**
  * Added thorough unit and integration coverage for TLS configuration validation, builder behavior, and mutual TLS handshakes.
* **Chores**
  * Expanded the `check` target to include an additional security scan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->