### PR TITLE
feat(httpclient): OAuth 1.0a request signing with body hash

### DIFF
--- a/httpclient/oauth1.go
+++ b/httpclient/oauth1.go
@@ -1,0 +1,330 @@
+package httpclient
+
+import (
+	"crypto"
+	crand "crypto/rand"
+	"crypto/rsa"
+	_ "crypto/sha1" //#nosec G505 -- RSA-SHA1 OAuth1 variant is partner-mandated legacy (#766); default stays RSA-SHA256
+	_ "crypto/sha256"
+	_ "crypto/sha512"
+	"encoding/base64"
+	"fmt"
+	"maps"
+	"net/url"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// OAuth1SignatureMethod selects the RSA digest for OAuth 1.0a signing.
+type OAuth1SignatureMethod string
+
+const (
+	// OAuth1RSASHA256 is the default signature method.
+	OAuth1RSASHA256 OAuth1SignatureMethod = "RSA-SHA256"
+	// OAuth1RSASHA1 is a legacy signature method some partners still require.
+	OAuth1RSASHA1 OAuth1SignatureMethod = "RSA-SHA1"
+	// OAuth1RSASHA512 is a stronger signature method some partners accept.
+	OAuth1RSASHA512 OAuth1SignatureMethod = "RSA-SHA512"
+)
+
+// oauth_* parameter names, extracted to constants: the test vectors push
+// oauth_nonce past goconst's min-occurrences threshold, and the vendor
+// reference (which this implementation mirrors) uses named constants too.
+const (
+	oauthConsumerKeyParam     = "oauth_consumer_key"
+	oauthNonceParam           = "oauth_nonce"
+	oauthSignatureParam       = "oauth_signature"
+	oauthSignatureMethodParam = "oauth_signature_method"
+	oauthTimestampParam       = "oauth_timestamp"
+	oauthVersionParam         = "oauth_version"
+	oauthBodyHashParam        = "oauth_body_hash"
+)
+
+// oauth1Version is the fixed OAuth 1.0a protocol version emitted in every
+// generated Authorization header.
+const oauth1Version = "1.0"
+
+// PrivateKeyResolver supplies the signing key by name. app.KeyStore and
+// jose.KeyResolver both satisfy it structurally.
+type PrivateKeyResolver interface {
+	PrivateKey(name string) (*rsa.PrivateKey, error)
+}
+
+// OAuth1Config configures Mastercard-style OAuth 1.0a request signing.
+type OAuth1Config struct {
+	// ConsumerKey identifies the caller to the partner (oauth_consumer_key).
+	ConsumerKey string
+	// KeyName is resolved per request via Keys, so key rotation applies
+	// without rebuilding the client.
+	KeyName string
+	// Keys resolves KeyName to the RSA private key used to sign each request.
+	Keys PrivateKeyResolver
+	// Method selects the signing digest. The zero value normalizes to
+	// OAuth1RSASHA256.
+	Method OAuth1SignatureMethod
+}
+
+// validate rejects an OAuth1Config that would fail at request time, so
+// WithOAuth1 can fail fast at build time instead. Method is checked via
+// oauth1HashForMethod — the same single source of truth RoundTrip and
+// oauth1Params use — so the two can never disagree on what counts as valid.
+func (c OAuth1Config) validate() error {
+	if c.Keys == nil {
+		return fmt.Errorf("httpclient: WithOAuth1 requires Config.Keys (PrivateKeyResolver)")
+	}
+	if c.KeyName == "" {
+		return fmt.Errorf("httpclient: WithOAuth1 requires a non-empty Config.KeyName")
+	}
+	if c.ConsumerKey == "" {
+		return fmt.Errorf("httpclient: WithOAuth1 requires a non-empty Config.ConsumerKey")
+	}
+	if _, err := oauth1HashForMethod(c.Method); err != nil {
+		return fmt.Errorf("httpclient: WithOAuth1: %w", err)
+	}
+	return nil
+}
+
+// oauth1PercentEncode percent-encodes s per RFC 3986/RFC 5849: unreserved
+// characters pass through unchanged, everything else becomes uppercase %XX,
+// byte-wise.
+func oauth1PercentEncode(s string) string {
+	const upperHex = "0123456789ABCDEF"
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		// RFC 3986 unreserved set — the same test net/url.shouldEscape uses.
+		if c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z' || c >= '0' && c <= '9' ||
+			c == '-' || c == '.' || c == '_' || c == '~' {
+			b.WriteByte(c)
+		} else {
+			b.WriteByte('%')
+			b.WriteByte(upperHex[c>>4])
+			b.WriteByte(upperHex[c&0xF])
+		}
+	}
+	return b.String()
+}
+
+// oauth1ExtractQueryParams builds a name -> values map from u's query string.
+// It fails closed on a malformed query (fmt.Errorf-wrapped) rather than
+// silently signing a subset of the transmitted parameters: url.ParseQuery
+// skips any segment it cannot parse while still returning the rest, and the
+// wire still sends u.RawQuery verbatim, so signing whatever ParseQuery
+// salvaged would let the signed parameter set silently diverge from what is
+// actually transmitted.
+//
+// When u.RawQuery contains percent-escapes (decoded != raw), every key and
+// value is re-encoded via oauth1PercentEncode so the OAuth base-string
+// construction sees the exact on-the-wire representation. Otherwise keys and
+// values are left decoded. This asymmetric rule is what makes both
+// ?param=token1%3Atoken2 and ?param=token1:token2 sign correctly.
+//
+// The needsEncode flag MUST be derived with the same unescaping url.ParseQuery
+// used to produce `query` above — url.QueryUnescape, which maps '+' to a
+// space. url.PathUnescape does NOT map '+' to a space, so using it here would
+// disagree with `query`'s actual values on any raw query containing '+'
+// (e.g. from url.Values.Encode(), which emits '+' for spaces): the flag would
+// read "no escapes" while `query` already holds a decoded space, so that
+// literal space — not the wire's '+' — would get signed, and any RFC 5849
+// verifier reconstructing the base string from the wire bytes computes a
+// different signature and 401s.
+func oauth1ExtractQueryParams(u *url.URL) (map[string][]string, error) {
+	query, err := url.ParseQuery(u.RawQuery)
+	if err != nil {
+		return nil, fmt.Errorf("httpclient: oauth1: parse query: %w", err)
+	}
+	decoded, decErr := url.QueryUnescape(u.RawQuery)
+	needsEncode := decErr == nil && decoded != u.RawQuery
+	if !needsEncode {
+		// url.ParseQuery already returns a freshly-allocated, unaliased map,
+		// and oauth1ParamString clones value slices before sorting, so a
+		// defensive re-copy here would buy nothing.
+		return query, nil
+	}
+
+	result := make(map[string][]string, len(query))
+	for k, values := range query {
+		vals := make([]string, len(values))
+		for i, v := range values {
+			vals[i] = oauth1PercentEncode(v)
+		}
+		result[oauth1PercentEncode(k)] = vals
+	}
+	return result, nil
+}
+
+// oauth1ParamString merges queryParams and oauthParams into the normalized
+// parameter string used by the OAuth 1.0a signature base string: keys sorted
+// lexicographically, multi-values per key sorted, joined as k=v&k=v with no
+// trailing separator.
+func oauth1ParamString(queryParams map[string][]string, oauthParams map[string]string) string {
+	merged := make(map[string][]string, len(queryParams)+len(oauthParams))
+	for k, v := range queryParams {
+		// Copy the slice: the multi-value sort below mutates in place, and the
+		// caller's slice must not be aliased.
+		merged[k] = slices.Clone(v)
+	}
+	for k, v := range oauthParams {
+		merged[k] = append(merged[k], v)
+	}
+
+	keys := slices.Sorted(maps.Keys(merged))
+
+	var pairs []string
+	for _, k := range keys {
+		values := merged[k]
+		sort.Strings(values)
+		for _, v := range values {
+			pairs = append(pairs, k+"="+v)
+		}
+	}
+	return strings.Join(pairs, "&")
+}
+
+// oauth1BaseURL normalizes u per RFC 5849 §3.4.1.2 (scheme-agnostic port
+// stripping, matching the reference implementation).
+func oauth1BaseURL(u *url.URL) string {
+	scheme := strings.ToLower(u.Scheme)
+	host := oauth1StripDefaultPort(strings.ToLower(u.Host))
+
+	path := u.EscapedPath()
+	if path == "" {
+		path = "/"
+	} else if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	return scheme + "://" + host + path
+}
+
+// oauth1StripDefaultPort removes a trailing ":80" or ":443" from host,
+// scheme-agnostically (matching the vendor reference). IPv6 authorities
+// (e.g. "[::1]:443") are handled via a rightmost-colon search rather than a
+// naive split on every ":", which would mangle the address's own colons.
+func oauth1StripDefaultPort(host string) string {
+	idx := strings.LastIndex(host, ":")
+	if idx < 0 {
+		return host
+	}
+	port := host[idx+1:]
+	if port == "80" || port == "443" {
+		return host[:idx]
+	}
+	return host
+}
+
+// oauth1SignatureBaseString builds the RFC 5849 §3.4.1 signature base string
+// from the HTTP method, a normalized base URL, and the normalized parameter
+// string. Each of the latter two is percent-encoded exactly once here.
+func oauth1SignatureBaseString(method, baseURL, paramString string) string {
+	return strings.ToUpper(method) + "&" + oauth1PercentEncode(baseURL) + "&" + oauth1PercentEncode(paramString)
+}
+
+// oauth1NormalizeMethod normalizes the empty OAuth1SignatureMethod to
+// OAuth1RSASHA256. This is the single source of truth shared by
+// oauth1HashForMethod and oauth1Params' emitted oauth_signature_method
+// string, so the two can never disagree.
+func oauth1NormalizeMethod(m OAuth1SignatureMethod) OAuth1SignatureMethod {
+	if m == "" {
+		return OAuth1RSASHA256
+	}
+	return m
+}
+
+// oauth1HashForMethod maps an OAuth1SignatureMethod to its crypto.Hash.
+func oauth1HashForMethod(m OAuth1SignatureMethod) (crypto.Hash, error) {
+	switch oauth1NormalizeMethod(m) {
+	case OAuth1RSASHA256:
+		return crypto.SHA256, nil
+	case OAuth1RSASHA1:
+		return crypto.SHA1, nil
+	case OAuth1RSASHA512:
+		return crypto.SHA512, nil
+	default:
+		return 0, fmt.Errorf("httpclient: oauth1: unknown signature method %q", m)
+	}
+}
+
+// oauth1BodyHash digests payload with h and base64-encodes (StdEncoding) the
+// result. A nil payload hashes as empty bytes.
+func oauth1BodyHash(payload []byte, h crypto.Hash) string {
+	digest := h.New()
+	digest.Write(payload)
+	return base64.StdEncoding.EncodeToString(digest.Sum(nil))
+}
+
+// oauth1Sign hashes sbs with the method's digest, signs it with key via
+// PKCS#1 v1.5, and base64-encodes (StdEncoding) the signature. PKCS#1 v1.5 is
+// RFC 5849 §3.4.3's mandated signature padding for OAuth 1.0a, not a locally chosen one.
+func oauth1Sign(sbs string, key *rsa.PrivateKey, m OAuth1SignatureMethod) (string, error) {
+	h, err := oauth1HashForMethod(m)
+	if err != nil {
+		return "", err
+	}
+	digest := h.New()
+	digest.Write([]byte(sbs))
+	// S5542 targets RSAES-PKCS1-v1_5 (encryption, Bleichenbacher); this is RSASSA-PKCS1-v1_5 (signature), which RFC 5849 §3.4.3 mandates for OAuth 1.0a — PSS/OAEP would be rejected by every verifier
+	signature, err := rsa.SignPKCS1v15(crand.Reader, key, h, digest.Sum(nil)) // NOSONAR: signature scheme (RSASSA-PKCS1-v1_5), not encryption S5542 targets
+	if err != nil {
+		return "", fmt.Errorf("httpclient: oauth1: sign: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(signature), nil
+}
+
+const (
+	oauth1NonceAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	oauth1NonceLength   = 16
+)
+
+// oauth1Nonce generates a 16-character nonce from crypto/rand, indexed into
+// oauth1NonceAlphabet. Modulo bias from the 256%62 remainder is irrelevant
+// for nonce uniqueness.
+func oauth1Nonce() (string, error) {
+	raw := make([]byte, oauth1NonceLength)
+	if _, err := crand.Read(raw); err != nil {
+		return "", fmt.Errorf("httpclient: oauth1: generate nonce: %w", err)
+	}
+	out := make([]byte, oauth1NonceLength)
+	for i, b := range raw {
+		out[i] = oauth1NonceAlphabet[int(b)%len(oauth1NonceAlphabet)]
+	}
+	return string(out), nil
+}
+
+// oauth1AuthorizationHeader builds the "OAuth ..." Authorization header value
+// from params, with keys sorted lexicographically for determinism (RFC 5849
+// §3.5.1 allows any order). strconv.Quote escapes a stray quote/backslash in
+// a value (byte-identical to fmt's %q); a no-op for every value this code
+// produces.
+func oauth1AuthorizationHeader(params map[string]string) string {
+	keys := slices.Sorted(maps.Keys(params))
+
+	var b strings.Builder
+	b.WriteString("OAuth ")
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(strconv.Quote(params[k]))
+	}
+	return b.String()
+}
+
+// oauth1Params builds the oauth_* parameter set for a single request.
+// oauth_signature_method is always the normalized method string — an empty
+// cfg.Method emits "RSA-SHA256", never "".
+func oauth1Params(cfg *OAuth1Config, bodyHash, nonce, timestamp string) map[string]string {
+	return map[string]string{
+		oauthConsumerKeyParam:     cfg.ConsumerKey,
+		oauthNonceParam:           nonce,
+		oauthSignatureMethodParam: string(oauth1NormalizeMethod(cfg.Method)),
+		oauthTimestampParam:       timestamp,
+		oauthVersionParam:         oauth1Version,
+		oauthBodyHashParam:        bodyHash,
+	}
+}

--- a/httpclient/oauth1_test.go
+++ b/httpclient/oauth1_test.go
@@ -1,0 +1,346 @@
+package httpclient
+
+// Test vectors derived from github.com/mastercard/oauth1-signer-go (MIT),
+// the vendor reference implementation for Mastercard OAuth 1.0a signing.
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"encoding/base64"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaborage/go-bricks/jose"
+)
+
+// jose.KeyResolver satisfies PrivateKeyResolver structurally (documented in
+// wiki/httpclient.md); this pins that claim at compile time. app.KeyStore
+// cannot be asserted the same way — app -> server -> httpclient is an import
+// cycle.
+var _ PrivateKeyResolver = jose.KeyResolver(nil)
+
+func TestOAuth1BodyHashVectors(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		want    string
+	}{
+		{
+			name:    "nil_payload",
+			payload: nil,
+			want:    "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+		},
+		{
+			name:    "utf8_multibyte_payload",
+			payload: []byte("{\"foõ\":\"bar\"}"),
+			want:    "+Z+PWW2TJDnPvRcTgol+nKO3LT7xm8smnsg+//XMIyI=",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := oauth1BodyHash(tc.payload, crypto.SHA256)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestOAuth1ParamStringVectors(t *testing.T) {
+	t.Run("nominal_with_query_and_oauth_params", func(t *testing.T) {
+		queryParams := map[string][]string{
+			"b5":   {"%3D%253D"},
+			"a3":   {"a", "2%20q"},
+			"c%40": {""},
+			"a2":   {"r%20b"},
+			"c2":   {""},
+		}
+		oauthParams := map[string]string{
+			oauthConsumerKeyParam:     "9djdj82h48djs9d2",
+			"oauth_token":             "kkk9d7dh3k39sjv7",
+			oauthSignatureMethodParam: "HMAC-SHA1",
+			oauthTimestampParam:       "137131201",
+			oauthNonceParam:           "7d8f3e4a",
+		}
+		want := "a2=r%20b&a3=2%20q&a3=a&b5=%3D%253D&c%40=&c2=&oauth_consumer_key=9djdj82h48djs9d2&" +
+			"oauth_nonce=7d8f3e4a&oauth_signature_method=HMAC-SHA1&oauth_timestamp=137131201&" +
+			"oauth_token=kkk9d7dh3k39sjv7"
+
+		got := oauth1ParamString(queryParams, oauthParams)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("byte_order_sorting", func(t *testing.T) {
+		queryParams := map[string][]string{
+			"b": {"b"},
+			"A": {"a", "A"},
+			"B": {"B"},
+			"a": {"A", "a"},
+			"0": {"0"},
+		}
+		want := "0=0&A=A&A=a&B=B&a=A&a=a&b=b"
+
+		got := oauth1ParamString(queryParams, map[string]string{})
+		assert.Equal(t, want, got)
+	})
+}
+
+func TestOAuth1ExtractQueryParamsVectors(t *testing.T) {
+	t.Run("bare_and_repeated_keys_no_escapes", func(t *testing.T) {
+		u, err := url.Parse("https://sandbox.api.mastercard.com/audiences/v1/getcountries?offset=0&offset=1&length=10&empty&odd=")
+		require.NoError(t, err)
+
+		got, err := oauth1ExtractQueryParams(u)
+		require.NoError(t, err)
+		require.Len(t, got, 4)
+		assert.Equal(t, []string{"0", "1"}, got["offset"])
+		assert.Equal(t, []string{"10"}, got["length"])
+		assert.Equal(t, []string{""}, got["empty"])
+		assert.Equal(t, []string{""}, got["odd"])
+	})
+
+	t.Run("raw_query_contains_escapes_reencodes", func(t *testing.T) {
+		u, err := url.Parse("https://example.com/request?b5=%3D%253D&a3=a&c%40=&a2=r%20b")
+		require.NoError(t, err)
+
+		got, err := oauth1ExtractQueryParams(u)
+		require.NoError(t, err)
+		require.Len(t, got, 4)
+		assert.Equal(t, []string{"%3D%253D"}, got["b5"])
+		assert.Equal(t, []string{"a"}, got["a3"])
+		assert.Equal(t, []string{""}, got["c%40"])
+		assert.Equal(t, []string{"r%20b"}, got["a2"])
+	})
+
+	// '+' decodes to a space under url.QueryUnescape, so it must trip needsEncode.
+	t.Run("no_escapes_values_stay_decoded", func(t *testing.T) {
+		u, err := url.Parse("https://example.com/request?colon=:&comma=,")
+		require.NoError(t, err)
+
+		got, err := oauth1ExtractQueryParams(u)
+		require.NoError(t, err)
+		assert.Equal(t, []string{":"}, got["colon"])
+		assert.Equal(t, []string{","}, got["comma"])
+	})
+
+	t.Run("plus_is_an_escape_and_forces_encoding", func(t *testing.T) {
+		u, err := url.Parse("https://example.com/request?plus=+&q=a+b")
+		require.NoError(t, err)
+
+		got, err := oauth1ExtractQueryParams(u)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"%20"}, got["plus"])
+		assert.Equal(t, []string{"a%20b"}, got["q"])
+	})
+
+	// needsEncode is a WHOLE-QUERY flag, not per-parameter: "a" carries an escape
+	// (%3A) but "b" is already literal. url.QueryUnescape("a=x%3Ay&b=x:y") decodes
+	// to "a=x:y&b=x:y", which differs from RawQuery, so needsEncode trips for the
+	// ENTIRE query — both values get re-encoded to "x%3Ay", even though "b" was
+	// never escaped on the wire. This is still RFC-correct: a verifier reading
+	// b=x:y off the wire decodes it to x:y and re-encodes to x%3Ay too, landing on
+	// the same string — but it pins that a single escaped parameter changes how
+	// every sibling parameter is signed.
+	t.Run("mixed_escaped_and_literal_encodes_every_value", func(t *testing.T) {
+		u, err := url.Parse("https://example.com/request?a=x%3Ay&b=x:y")
+		require.NoError(t, err)
+
+		got, err := oauth1ExtractQueryParams(u)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"x%3Ay"}, got["a"])
+		assert.Equal(t, []string{"x%3Ay"}, got["b"])
+	})
+
+	t.Run("malformed_query_fails_closed", func(t *testing.T) {
+		u, err := url.Parse("https://example.com/request?a=b;c=d")
+		require.NoError(t, err)
+
+		got, err := oauth1ExtractQueryParams(u)
+		require.Error(t, err, "a semicolon separator must fail the whole extraction, not silently drop the segment")
+		assert.Nil(t, got)
+	})
+}
+
+func TestOAuth1BaseURLVectors(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "no_path_gets_trailing_slash", in: "https://www.example.net:8080", want: "https://www.example.net:8080/"},
+		{name: "default_http_port_stripped_and_lowercased", in: "http://EXAMPLE.COM:80/r%20v/X?id=123", want: "http://example.com/r%20v/X"},
+		{name: "default_https_port_stripped", in: "https://api.mastercard.com:443/test?query=param", want: "https://api.mastercard.com/test"},
+		{name: "non_default_port_kept", in: "https://api.mastercard.com:17443/test?query=param", want: "https://api.mastercard.com:17443/test"},
+		{name: "fragment_dropped", in: "https://api.mastercard.com/test?query=param#fragment", want: "https://api.mastercard.com/test"},
+		{name: "scheme_and_host_lowercased_path_preserved", in: "HTTPS://API.MASTERCARD.COM/TEST", want: "https://api.mastercard.com/TEST"},
+		// IPv6 authorities pin oauth1StripDefaultPort's rightmost-colon search: a
+		// naive strings.Index (first colon) would find one of the address's own
+		// colons instead of the port separator.
+		{name: "ipv6_default_port_stripped", in: "https://[::1]:443/x", want: "https://[::1]/x"},
+		{name: "ipv6_non_default_port_kept", in: "https://[::1]:8443/x", want: "https://[::1]:8443/x"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := url.Parse(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, oauth1BaseURL(u))
+		})
+	}
+}
+
+// TestOAuth1SignatureBaseStringVectors pins oauth1SignatureBaseString ONLY. The base
+// URL is passed as the literal string shown — NOT routed through oauth1BaseURL. The
+// vendor's own tests do exactly this, which is why these expected strings have no
+// trailing slash while TestOAuth1BaseURLVectors' "no_path_gets_trailing_slash" case
+// does: oauth1BaseURL correctly normalizes an empty path to "/", so feeding these
+// URLs through it would yield a trailing %2F and fail these vectors. The two sets of
+// vectors test different functions and are not in conflict.
+func TestOAuth1SignatureBaseStringVectors(t *testing.T) {
+	t.Run("nominal_with_oauth_body_hash", func(t *testing.T) {
+		queryParams := map[string][]string{
+			"param2":      {"hello"},
+			"first_param": {"value", "othervalue"},
+		}
+		oauthParams := map[string]string{
+			oauthNonceParam:    "randomnonce",
+			oauthBodyHashParam: "body/hash",
+		}
+		paramString := oauth1ParamString(queryParams, oauthParams)
+		want := "POST&https%3A%2F%2Fapi.mastercard.com&first_param%3Dothervalue%26first_param%3Dvalue%26" +
+			"oauth_body_hash%3Dbody%2Fhash%26oauth_nonce%3Drandomnonce%26param2%3Dhello"
+
+		got := oauth1SignatureBaseString("POST", "https://api.mastercard.com", paramString)
+		assert.Equal(t, want, got)
+	})
+
+	// These three share one shape: parse URL -> extract -> paramString -> SBS -> compare.
+	tests := []struct {
+		name   string
+		rawURL string
+		want   string
+	}{
+		{
+			name:   "query_value_with_encoded_colon",
+			rawURL: "https://example.com/?param=token1%3Atoken2",
+			want:   "GET&https%3A%2F%2Fexample.com&param%3Dtoken1%253Atoken2",
+		},
+		{
+			name:   "query_value_with_literal_colon",
+			rawURL: "https://example.com/?param=token1:token2",
+			want:   "GET&https%3A%2F%2Fexample.com&param%3Dtoken1%3Atoken2",
+		},
+		// This is the actual interoperability proof: the expected string was
+		// hand-computed from what an RFC 5849 verifier derives from the wire bytes
+		// (url.Values.Encode() emits '+' for a space, so this is the common path for
+		// any query built the idiomatic way).
+		{
+			name:   "query_value_with_plus_encoded_space",
+			rawURL: "https://example.com/?q=a+b",
+			want:   "GET&https%3A%2F%2Fexample.com&q%3Da%2520b",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := url.Parse(tc.rawURL)
+			require.NoError(t, err)
+			queryParams, err := oauth1ExtractQueryParams(u)
+			require.NoError(t, err)
+			paramString := oauth1ParamString(queryParams, map[string]string{})
+
+			got := oauth1SignatureBaseString("GET", "https://example.com", paramString)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestOAuth1SignVerifiesWithPublicKey(t *testing.T) {
+	key := generateOAuth1TestKey(t)
+
+	const sbs = "POST&https%3A%2F%2Fapi.mastercard.com&oauth_nonce%3Dfixed"
+
+	tests := []struct {
+		name   string
+		method OAuth1SignatureMethod
+		hash   crypto.Hash
+	}{
+		{name: "rsa_sha256", method: OAuth1RSASHA256, hash: crypto.SHA256},
+		{name: "rsa_sha1", method: OAuth1RSASHA1, hash: crypto.SHA1},
+		{name: "rsa_sha512", method: OAuth1RSASHA512, hash: crypto.SHA512},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sig, err := oauth1Sign(sbs, key, tc.method)
+			require.NoError(t, err)
+
+			raw, err := base64.StdEncoding.DecodeString(sig)
+			require.NoError(t, err)
+
+			digest := tc.hash.New()
+			digest.Write([]byte(sbs))
+
+			err = rsa.VerifyPKCS1v15(&key.PublicKey, tc.hash, digest.Sum(nil), raw)
+			assert.NoError(t, err)
+		})
+	}
+
+	t.Run("unknown_method_errors", func(t *testing.T) {
+		_, err := oauth1Sign(sbs, key, OAuth1SignatureMethod("HMAC-SHA1"))
+		assert.Error(t, err)
+	})
+}
+
+func TestOAuth1NonceShape(t *testing.T) {
+	const count = 100
+	seen := make(map[string]bool, count)
+
+	for i := 0; i < count; i++ {
+		nonce, err := oauth1Nonce()
+		require.NoError(t, err)
+		require.Len(t, nonce, 16)
+		for _, c := range nonce {
+			assert.True(t,
+				(c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'),
+				"nonce %q contains non-alphanumeric character %q", nonce, c)
+		}
+		assert.False(t, seen[nonce], "nonce %q generated more than once", nonce)
+		seen[nonce] = true
+	}
+}
+
+// TestOAuth1PercentEncode is a direct oracle for oauth1PercentEncode. Without it,
+// deleting '-' or '~' from its unreserved-character test leaves the whole suite
+// green: no existing vector contains a hyphen or tilde in an encoded position, and
+// the transport-level signature tests rebuild the base string with the very helper
+// under test (self-consistency, not interoperability). Hyphens are ubiquitous in
+// real values (ISO dates, UUIDs), so a regression here would only surface against
+// a real partner.
+func TestOAuth1PercentEncode(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "hyphen_passes_through_unchanged", in: "-", want: "-"},
+		{name: "period_passes_through_unchanged", in: ".", want: "."},
+		{name: "underscore_passes_through_unchanged", in: "_", want: "_"},
+		{name: "tilde_passes_through_unchanged", in: "~", want: "~"},
+		{name: "space_encodes_to_percent_20", in: " ", want: "%20"},
+		{name: "slash_encodes_to_percent_2F", in: "/", want: "%2F"},
+		{name: "colon_encodes_to_percent_3A", in: ":", want: "%3A"},
+		{name: "percent_encodes_to_percent_25", in: "%", want: "%25"},
+		{name: "equals_encodes_to_percent_3D", in: "=", want: "%3D"},
+		// UTF-8 multibyte rune encodes byte-wise: 'é' is 0xC3 0xA9 in UTF-8.
+		{name: "multibyte_utf8_rune_encodes_byte_wise", in: "é", want: "%C3%A9"},
+		{name: "empty_string_stays_empty", in: "", want: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, oauth1PercentEncode(tc.in))
+		})
+	}
+}

--- a/httpclient/oauth1_transport.go
+++ b/httpclient/oauth1_transport.go
@@ -1,0 +1,165 @@
+package httpclient
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"maps"
+	nethttp "net/http"
+	"strconv"
+	"time"
+)
+
+// headerAuthorization mirrors headerContentType's rationale in jose_transport.go: avoid repeating the literal at every Get/Set call site.
+const headerAuthorization = "Authorization"
+
+// OAuth1Transport signs every outbound request with an OAuth 1.0a
+// Authorization header (RSA + oauth_body_hash). It sits at the transport
+// chain's signer layer: body transforms such as JOSE run outside it, so the
+// hash covers the bytes actually sent. Each RoundTrip generates a fresh
+// nonce/timestamp, so httpclient retries re-sign automatically.
+type OAuth1Transport struct {
+	// Inner is the underlying RoundTripper that performs the actual HTTP
+	// exchange. Nil defaults to nethttp.DefaultTransport.
+	Inner nethttp.RoundTripper
+
+	// Config supplies the consumer key, signing key resolver, and signature
+	// method.
+	Config OAuth1Config
+
+	// now is a test seam for the timestamp source; nil means time.Now.
+	now func() time.Time
+	// nonce is a test seam for nonce generation; nil means oauth1Nonce.
+	nonce func() (string, error)
+}
+
+// closeRequestBody closes body when non-nil. http.RoundTripper requires
+// RoundTrip to close req.Body on EVERY return path, including errors —
+// http.Client.do does not do this for the transport, so a pre-read error
+// return that skips this leaks the caller's body (e.g. an *os.File or
+// io.Pipe) on every failure.
+func closeRequestBody(body io.ReadCloser) {
+	if body != nil {
+		_ = body.Close()
+	}
+}
+
+// setBufferedBody installs body as req's Body/ContentLength/GetBody. An empty
+// body gets nethttp.NoBody rather than io.NopCloser(bytes.NewReader(nil)):
+// http.Request.outgoingLength() maps ContentLength 0 with a non-nil,
+// non-NoBody Body to -1 (unknown), which pushes POST/PUT/PATCH onto the
+// chunked-encoding path. Using nethttp.NoBody keeps an empty body's wire
+// framing identical to a request built without WithOAuth1 at all
+// (Content-Length: 0, no Transfer-Encoding) instead of silently upgrading it
+// to chunked — some partner edges/WAFs reject chunked with 411/400/501.
+func setBufferedBody(req *nethttp.Request, body []byte) {
+	newBody := func() io.ReadCloser {
+		if len(body) == 0 {
+			return nethttp.NoBody
+		}
+		return io.NopCloser(bytes.NewReader(body))
+	}
+	req.Body = newBody()
+	req.ContentLength = int64(len(body))
+	// GetBody enables stdlib-driven request replay: it's invoked on redirect-following,
+	// connection retry, and HTTP/2 retry-on-RST_STREAM. Without it those paths see an
+	// already-drained body and silently send an empty payload under a signature computed
+	// over the real one. nethttp.NoBody is a stateless singleton, so re-returning it here
+	// is safe.
+	req.GetBody = func() (io.ReadCloser, error) { return newBody(), nil }
+}
+
+// RoundTrip signs req with an OAuth 1.0a Authorization header and delegates
+// to Inner. The Authorization header is Set (not Add): OAuth1Transport owns
+// this header on the client it's installed on.
+func (t *OAuth1Transport) RoundTrip(req *nethttp.Request) (*nethttp.Response, error) {
+	if t.Config.Keys == nil {
+		closeRequestBody(req.Body)
+		return nil, fmt.Errorf("httpclient: oauth1: Config.Keys (PrivateKeyResolver) is required")
+	}
+	key, err := t.Config.Keys.PrivateKey(t.Config.KeyName)
+	if err != nil {
+		closeRequestBody(req.Body)
+		return nil, fmt.Errorf("httpclient: oauth1: resolve private key %q: %w", t.Config.KeyName, err)
+	}
+	// Resolved early, next to the other fail-closed guards: an unknown method now
+	// fails before the caller's body is drained instead of after building the full
+	// param string under a wrong (silently-defaulted) digest.
+	h, err := oauth1HashForMethod(t.Config.Method)
+	if err != nil {
+		closeRequestBody(req.Body)
+		return nil, err
+	}
+
+	body, err := readAndCloseBody(req.Body, -1)
+	if err != nil {
+		return nil, fmt.Errorf("httpclient: oauth1: read request body: %w", err)
+	}
+
+	clone := req.Clone(req.Context())
+	setBufferedBody(clone, body)
+
+	nonce, err := t.resolveNonce()
+	if err != nil {
+		return nil, err
+	}
+	timestamp := strconv.FormatInt(t.resolveNow().Unix(), 10)
+	bodyHash := oauth1BodyHash(body, h)
+	oauthParams := oauth1Params(&t.Config, bodyHash, nonce, timestamp)
+
+	queryParams, err := oauth1ExtractQueryParams(clone.URL)
+	if err != nil {
+		return nil, err
+	}
+	paramString := oauth1ParamString(queryParams, oauthParams)
+	baseURL := oauth1BaseURL(clone.URL)
+	sbs := oauth1SignatureBaseString(clone.Method, baseURL, paramString)
+
+	signature, err := oauth1Sign(sbs, key, t.Config.Method)
+	if err != nil {
+		return nil, err
+	}
+
+	// The OAuth params entered the param string raw; oauth_signature is the ONLY
+	// value percent-encoded before insertion into the header.
+	headerParams := maps.Clone(oauthParams)
+	headerParams[oauthSignatureParam] = oauth1PercentEncode(signature)
+	clone.Header.Set(headerAuthorization, oauth1AuthorizationHeader(headerParams))
+
+	inner := t.Inner
+	if inner == nil {
+		inner = nethttp.DefaultTransport
+	}
+	return inner.RoundTrip(clone)
+}
+
+func (t *OAuth1Transport) resolveNow() time.Time {
+	if t.now != nil {
+		return t.now()
+	}
+	return time.Now()
+}
+
+func (t *OAuth1Transport) resolveNonce() (string, error) {
+	if t.nonce != nil {
+		return t.nonce()
+	}
+	return oauth1Nonce()
+}
+
+// WithOAuth1 signs every request with OAuth 1.0a at the signer layer of the
+// transport chain — beneath body transforms such as WithJOSE, so signatures
+// cover the wire payload, and independent of builder call order.
+//
+// Panics if cfg is invalid (nil Keys, empty ConsumerKey, or an unknown
+// Method): WithOAuth1 is new API, so failing fast here costs nothing, while
+// leaving it to fail on the first signed request would be a silent trap.
+func (b *Builder) WithOAuth1(cfg OAuth1Config) *Builder {
+	if err := cfg.validate(); err != nil {
+		panic(err.Error()) // NOSONAR: Fail-fast on invalid initialization (manifesto: configuration errors crash at startup)
+	}
+	b.addTransportWrapper(layerSigner, func(inner nethttp.RoundTripper) nethttp.RoundTripper {
+		return &OAuth1Transport{Inner: inner, Config: cfg}
+	})
+	return b
+}

--- a/httpclient/oauth1_transport_test.go
+++ b/httpclient/oauth1_transport_test.go
@@ -1,0 +1,670 @@
+package httpclient
+
+import (
+	"context"
+	"crypto"
+	crand "crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	jositest "github.com/gaborage/go-bricks/jose/testing"
+)
+
+// mapKeys is a minimal PrivateKeyResolver backed by a name -> key map.
+type mapKeys map[string]*rsa.PrivateKey
+
+func (m mapKeys) PrivateKey(name string) (*rsa.PrivateKey, error) {
+	key, ok := m[name]
+	if !ok {
+		return nil, fmt.Errorf("mapKeys: no key named %q", name)
+	}
+	return key, nil
+}
+
+// spyBody wraps a *strings.Reader and records whether Close was called, so
+// tests can assert http.RoundTripper's close-on-every-path contract without
+// depending on a real file descriptor or pipe.
+type spyBody struct {
+	r      *strings.Reader
+	closed bool
+}
+
+func newSpyBody(s string) *spyBody {
+	return &spyBody{r: strings.NewReader(s)}
+}
+
+func (s *spyBody) Read(p []byte) (int, error) { return s.r.Read(p) }
+func (s *spyBody) Close() error {
+	s.closed = true
+	return nil
+}
+
+// oauth1TestKeyName is the fixed key name used across this file's tests.
+const oauth1TestKeyName = "signing-key"
+
+// oauth1SharedTestKey generates one 2048-bit RSA key, shared by every test in
+// the package. No test needs key isolation — each verifies a signature
+// against its own key's public half — and re-generating one per test is real
+// wall-clock cost on the Ubuntu×Windows CI matrix.
+var oauth1SharedTestKey = sync.OnceValue(func() *rsa.PrivateKey {
+	key, err := rsa.GenerateKey(crand.Reader, 2048)
+	if err != nil {
+		panic(err) // test-only fixture: crypto/rand failing here means the environment is broken
+	}
+	return key
+})
+
+func generateOAuth1TestKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	return oauth1SharedTestKey()
+}
+
+// newOAuth1TestConfig returns an OAuth1Config wired to the shared test key,
+// plus the key itself (for verifying signatures against its public half).
+// The negative-path configs (nil Keys / a resolver that always errors) keep
+// their own literals — they are deliberately different.
+func newOAuth1TestConfig(t *testing.T) (OAuth1Config, *rsa.PrivateKey) {
+	t.Helper()
+	key := generateOAuth1TestKey(t)
+	return OAuth1Config{
+		ConsumerKey: "consumer123",
+		KeyName:     oauth1TestKeyName,
+		Keys:        mapKeys{oauth1TestKeyName: key},
+	}, key
+}
+
+// oauth1Capture is a mutex-guarded record of what an httptest handler
+// observed, appended once per request it serves. The handler always runs on
+// a goroutine distinct from the test goroutine, and only the actual
+// request/response synchronizes them, so unguarded field writes are a race
+// -race can flag under scheduling that isn't guaranteed to repeat.
+type oauth1Capture struct {
+	mu          sync.Mutex
+	authHeaders []string
+	bodies      [][]byte
+}
+
+// record appends one request's Authorization header and body under the
+// mutex. Safe to call from an httptest handler goroutine.
+func (c *oauth1Capture) record(authHeader string, body []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.authHeaders = append(c.authHeaders, authHeader)
+	c.bodies = append(c.bodies, body)
+}
+
+// Hits reports how many requests have been recorded so far.
+func (c *oauth1Capture) Hits() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.authHeaders)
+}
+
+// AuthHeaders returns a copy of every Authorization header recorded so far.
+func (c *oauth1Capture) AuthHeaders() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.authHeaders)
+}
+
+// Bodies returns a copy of every request body recorded so far.
+func (c *oauth1Capture) Bodies() [][]byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.bodies)
+}
+
+// newCapturingServer starts an httptest server whose handler records every
+// request's Authorization header and body into the returned capture, then
+// responds 200 with an empty body. Handler failures use t.Errorf (not
+// require.*): the handler runs on a goroutine distinct from the test
+// goroutine, where require.*'s FailNow (-> runtime.Goexit) is undefined
+// behavior per the testing package docs.
+func newCapturingServer(t *testing.T) (*httptest.Server, *oauth1Capture) {
+	t.Helper()
+	capture := &oauth1Capture{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("server: read body failed: %v", err)
+			return
+		}
+		capture.record(r.Header.Get(headerAuthorization), body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	return server, capture
+}
+
+// parseOAuth1AuthHeader splits an "OAuth k="v", k="v"" header value into a
+// plain map. Every value except oauth_signature was emitted raw by the
+// transport, so only oauth_signature is percent-decoded here.
+func parseOAuth1AuthHeader(t *testing.T, header string) map[string]string {
+	t.Helper()
+	require.True(t, strings.HasPrefix(header, "OAuth "))
+	rest := strings.TrimPrefix(header, "OAuth ")
+	pairs := strings.Split(rest, ", ")
+	out := make(map[string]string, len(pairs))
+	for _, pair := range pairs {
+		eq := strings.IndexByte(pair, '=')
+		require.GreaterOrEqual(t, eq, 0, "malformed header pair %q", pair)
+		key := pair[:eq]
+		val, err := strconv.Unquote(pair[eq+1:])
+		require.NoError(t, err)
+		if key == oauthSignatureParam {
+			decoded, err := url.QueryUnescape(val)
+			require.NoError(t, err)
+			val = decoded
+		}
+		out[key] = val
+	}
+	return out
+}
+
+// reconstructRequestURL rebuilds the absolute URL the client signed, from the
+// server's view of the request (r.Host + r.URL's path/query). This mirrors
+// what OAuth1Transport saw as clone.URL when it computed the signature.
+func reconstructRequestURL(r *http.Request) *url.URL {
+	return &url.URL{
+		Scheme:   "http",
+		Host:     r.Host,
+		Path:     r.URL.Path,
+		RawPath:  r.URL.RawPath,
+		RawQuery: r.URL.RawQuery,
+	}
+}
+
+func TestOAuth1TransportSetsAuthorizationHeader(t *testing.T) {
+	// Method deliberately left unset: this test pins the zero-value
+	// default (RSA-SHA256) end-to-end.
+	cfg, _ := newOAuth1TestConfig(t)
+
+	const sentBody = `{"hello":"world"}`
+	server, capture := newCapturingServer(t)
+	defer server.Close()
+
+	transport := &OAuth1Transport{Config: cfg}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL, strings.NewReader(sentBody))
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, 1, capture.Hits())
+	authHeader := capture.AuthHeaders()[0]
+	receivedBody := capture.Bodies()[0]
+
+	require.True(t, strings.HasPrefix(authHeader, "OAuth "))
+	assert.Contains(t, authHeader, `oauth_consumer_key="consumer123"`)
+	assert.Contains(t, authHeader, `oauth_signature_method="RSA-SHA256"`,
+		"zero-value Method must normalize to RSA-SHA256, not emit an empty string")
+	assert.Contains(t, authHeader, `oauth_version="1.0"`)
+
+	sum := sha256.Sum256(receivedBody)
+	wantBodyHash := base64.StdEncoding.EncodeToString(sum[:])
+	assert.Contains(t, authHeader, fmt.Sprintf("oauth_body_hash=%q", wantBodyHash))
+
+	assert.Equal(t, sentBody, string(receivedBody), "the signed body must reach the server intact")
+}
+
+func TestOAuth1TransportSignatureVerifies(t *testing.T) {
+	cfg, key := newOAuth1TestConfig(t)
+
+	// This test needs method+URL alongside the header, which oauth1Capture doesn't
+	// carry, so it stays a bespoke server — but still under mutex discipline: the
+	// handler runs on a goroutine distinct from the test goroutine, and only the
+	// actual request/response synchronizes them.
+	var mu sync.Mutex
+	var authHeader string
+	var capturedMethod string
+	var capturedURL *url.URL
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		authHeader = r.Header.Get(headerAuthorization)
+		capturedMethod = r.Method
+		capturedURL = reconstructRequestURL(r)
+		mu.Unlock()
+		_, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	transport := &OAuth1Transport{Config: cfg}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL+"/verify?x=1",
+		strings.NewReader(`{"a":1}`))
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	mu.Lock()
+	gotAuthHeader, gotMethod, gotURL := authHeader, capturedMethod, capturedURL
+	mu.Unlock()
+
+	params := parseOAuth1AuthHeader(t, gotAuthHeader)
+	signature := params[oauthSignatureParam]
+	delete(params, oauthSignatureParam)
+
+	queryParams, err := oauth1ExtractQueryParams(gotURL)
+	require.NoError(t, err)
+	paramString := oauth1ParamString(queryParams, params)
+	baseURL := oauth1BaseURL(gotURL)
+	sbs := oauth1SignatureBaseString(gotMethod, baseURL, paramString)
+
+	sigBytes, err := base64.StdEncoding.DecodeString(signature)
+	require.NoError(t, err)
+	digest := sha256.Sum256([]byte(sbs))
+	err = rsa.VerifyPKCS1v15(&key.PublicKey, crypto.SHA256, digest[:], sigBytes)
+	require.NoError(t, err)
+}
+
+func TestOAuth1TransportFreshNoncePerAttempt(t *testing.T) {
+	t.Run("two_direct_roundtrips", func(t *testing.T) {
+		cfg, _ := newOAuth1TestConfig(t)
+
+		server, capture := newCapturingServer(t)
+		defer server.Close()
+
+		transport := &OAuth1Transport{Config: cfg}
+
+		for i := 0; i < 2; i++ {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, http.NoBody)
+			require.NoError(t, err)
+			resp, err := transport.RoundTrip(req)
+			require.NoError(t, err)
+			resp.Body.Close()
+		}
+
+		headers := capture.AuthHeaders()
+		require.Len(t, headers, 2)
+		n1 := parseOAuth1AuthHeader(t, headers[0])[oauthNonceParam]
+		n2 := parseOAuth1AuthHeader(t, headers[1])[oauthNonceParam]
+		assert.NotEqual(t, n1, n2, "each RoundTrip must generate a fresh nonce")
+	})
+
+	// Proves the now/nonce test seams are actually wired: RoundTrip must use
+	// them when set, rather than always falling back to time.Now/oauth1Nonce.
+	t.Run("now_and_nonce_seams_are_wired", func(t *testing.T) {
+		cfg, _ := newOAuth1TestConfig(t)
+
+		server, capture := newCapturingServer(t)
+		defer server.Close()
+
+		fixedTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		transport := &OAuth1Transport{
+			Config: cfg,
+			now:    func() time.Time { return fixedTime },
+			nonce:  func() (string, error) { return "fixed-nonce-value", nil },
+		}
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, http.NoBody)
+		require.NoError(t, err)
+		resp, err := transport.RoundTrip(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+
+		require.Equal(t, 1, capture.Hits())
+		params := parseOAuth1AuthHeader(t, capture.AuthHeaders()[0])
+		assert.Equal(t, "fixed-nonce-value", params[oauthNonceParam], "nonce seam must be wired")
+		assert.Equal(t, strconv.FormatInt(fixedTime.Unix(), 10), params[oauthTimestampParam], "now seam must be wired")
+	})
+
+	// Stronger variant: drive the real retry loop (503 then 200) instead of
+	// calling RoundTrip twice directly, exercising the actual
+	// buildRequest-per-attempt path. The 503-then-200 status logic stays
+	// bespoke — it drives its decision off the shared capture's hit count.
+	t.Run("real_retry_loop_resigns_each_attempt", func(t *testing.T) {
+		cfg, _ := newOAuth1TestConfig(t)
+
+		capture := &oauth1Capture{}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("server: read body failed: %v", err)
+				return
+			}
+			capture.record(r.Header.Get(headerAuthorization), body)
+
+			if capture.Hits() == 1 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		log := createTestLogger()
+		c := NewBuilder(log).WithOAuth1(cfg).WithRetries(2, 10*time.Millisecond).Build()
+
+		resp, err := c.Post(context.Background(), &Request{URL: server.URL, Body: []byte(`{"retry":true}`)})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		headers := capture.AuthHeaders()
+		require.Len(t, headers, 2, "server must observe exactly two attempts")
+
+		p1 := parseOAuth1AuthHeader(t, headers[0])
+		p2 := parseOAuth1AuthHeader(t, headers[1])
+		assert.NotEqual(t, p1[oauthNonceParam], p2[oauthNonceParam], "nonce must differ across retry attempts")
+		assert.NotEqual(t, p1[oauthSignatureParam], p2[oauthSignatureParam], "signature must differ across retry attempts")
+
+		bodies := capture.Bodies()
+		require.Len(t, bodies, 2)
+		assert.Equal(t, string(bodies[0]), string(bodies[1]), "the retried body must stay identical across attempts")
+	})
+}
+
+func TestOAuth1TransportEmptyBodyGET(t *testing.T) {
+	cfg, _ := newOAuth1TestConfig(t)
+
+	server, capture := newCapturingServer(t)
+	defer server.Close()
+
+	transport := &OAuth1Transport{Config: cfg}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil) //nolint:gocritic // nil body is the path readAndCloseBody must tolerate
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, 1, capture.Hits())
+	params := parseOAuth1AuthHeader(t, capture.AuthHeaders()[0])
+	assert.Equal(t, "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=", params[oauthBodyHashParam])
+}
+
+// TestOAuth1TransportEmptyBodyPOSTFraming pins the wire-framing invariant: an
+// empty-body POST through OAuth1Transport must stay Content-Length: 0 with no
+// Transfer-Encoding, exactly like a POST built without WithOAuth1 at all.
+// GET doesn't exercise this — net/http's outgoingLength() only special-cases
+// ContentLength==0 with a non-nil, non-NoBody Body for methods that can carry
+// a body (POST/PUT/PATCH), which is why TestOAuth1TransportEmptyBodyGET alone
+// cannot catch a regression here.
+func TestOAuth1TransportEmptyBodyPOSTFraming(t *testing.T) {
+	cfg, _ := newOAuth1TestConfig(t)
+
+	// This test needs TransferEncoding+ContentLength, which oauth1Capture doesn't
+	// carry, so it stays a bespoke server — but still under mutex discipline (see
+	// TestOAuth1TransportSignatureVerifies).
+	var mu sync.Mutex
+	var transferEncoding []string
+	var contentLength int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		transferEncoding = r.TransferEncoding
+		contentLength = r.ContentLength
+		mu.Unlock()
+		_, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	transport := &OAuth1Transport{Config: cfg}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL, http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	mu.Lock()
+	gotTransferEncoding, gotContentLength := transferEncoding, contentLength
+	mu.Unlock()
+
+	assert.Empty(t, gotTransferEncoding, "an empty-body POST must not be silently upgraded to chunked transfer encoding")
+	assert.Equal(t, int64(0), gotContentLength, "an empty-body POST must report Content-Length: 0, not -1 (unknown)")
+}
+
+func TestOAuth1TransportResolverErrorFailsClosed(t *testing.T) {
+	server, capture := newCapturingServer(t)
+	defer server.Close()
+
+	cfg := OAuth1Config{
+		ConsumerKey: "consumer123",
+		KeyName:     "missing-key",
+		Keys:        mapKeys{}, // resolver returns an error for any name
+	}
+	transport := &OAuth1Transport{Config: cfg}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, http.NoBody)
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req) //nolint:bodyclose // RoundTrip fails before any HTTP exchange; no body to close
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing-key", "the error must name the key that failed to resolve, not just fail generically")
+	assert.Equal(t, 0, capture.Hits(), "no request should reach the server when key resolution fails")
+}
+
+// TestOAuth1TransportClosesBodyOnEarlyReturn pins the http.RoundTripper
+// contract: RoundTrip must close req.Body on EVERY return path, including
+// errors — http.Client.do will not do it for the transport. The nil-Keys
+// guard and the resolver-error return both fire BEFORE readAndCloseBody, so
+// without the fix a consumer using OAuth1Transport directly with an *os.File
+// or io.Pipe body leaks the descriptor on every failure. The nil_keys case
+// also covers the nil Config.Keys guard, which has no other coverage: every
+// other test in this file supplies a non-nil (if sometimes empty) resolver,
+// so deleting the guard would leave the suite green while a misconfigured
+// client nil-panics inside RoundTrip instead of failing closed. The
+// unknown_signature_method case covers the THIRD early return
+// (oauth1HashForMethod failure), added when hash resolution moved earlier in
+// RoundTrip: it also closes the body, but nothing else exercised that guard,
+// so deleting its closeRequestBody call would leave the suite green too. It
+// constructs OAuth1Transport directly (not through WithOAuth1) so it reaches
+// RoundTrip's guard even after WithOAuth1 gained its own build-time
+// validation — that validation never sees this cfg.
+func TestOAuth1TransportClosesBodyOnEarlyReturn(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  OAuth1Config
+	}{
+		{name: "nil_keys", cfg: OAuth1Config{ConsumerKey: "c", KeyName: "k", Keys: nil}},
+		{name: "resolver_error", cfg: OAuth1Config{ConsumerKey: "c", KeyName: "missing-key", Keys: mapKeys{}}},
+		{
+			name: "unknown_signature_method",
+			cfg: OAuth1Config{
+				ConsumerKey: "c",
+				KeyName:     oauth1TestKeyName,
+				Keys:        mapKeys{oauth1TestKeyName: generateOAuth1TestKey(t)},
+				Method:      OAuth1SignatureMethod("HMAC-SHA1"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := newSpyBody(`{"a":1}`)
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.invalid", body)
+			require.NoError(t, err)
+
+			transport := &OAuth1Transport{Config: tc.cfg}
+			_, err = transport.RoundTrip(req) //nolint:bodyclose // RoundTrip fails before any HTTP exchange; the spy body is what's under test
+			require.Error(t, err)
+			assert.True(t, body.closed, "req.Body must be closed even on this early-return path")
+		})
+	}
+}
+
+// TestOAuth1TransportMalformedQueryFailsClosed pins the RoundTrip-level
+// invariant: url.ParseQuery skips a segment it cannot parse (e.g. a
+// semicolon separator) while still returning the rest, and the wire still
+// sends req.URL.RawQuery verbatim — so signing whatever ParseQuery salvaged
+// would silently sign a strict subset of what is actually transmitted.
+// RoundTrip must fail closed instead.
+func TestOAuth1TransportMalformedQueryFailsClosed(t *testing.T) {
+	cfg, _ := newOAuth1TestConfig(t)
+
+	server, capture := newCapturingServer(t)
+	defer server.Close()
+
+	transport := &OAuth1Transport{Config: cfg}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/x?a=b;c=d", http.NoBody)
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req) //nolint:bodyclose // RoundTrip fails before any HTTP exchange; no body to close
+	require.Error(t, err, "a malformed (semicolon-separated) query must fail closed rather than sign a partial parameter set")
+	assert.Equal(t, 0, capture.Hits(), "no request should reach the server when the query fails to parse")
+}
+
+// TestOAuth1TransportOverwritesStaleAuthorizationHeader pins that
+// OAuth1Transport.Set()s the Authorization header rather than Add()ing to it.
+// The collision is reachable from the public API: Request.Headers and
+// WithDefaultHeader both flow through applyHeaders (which itself Sets, not
+// Adds) before the transport chain runs, so a caller-supplied Authorization
+// header — stale or otherwise — must not survive alongside the OAuth1 one.
+func TestOAuth1TransportOverwritesStaleAuthorizationHeader(t *testing.T) {
+	cfg, _ := newOAuth1TestConfig(t)
+
+	// This test needs every Authorization VALUE (r.Header.Values, not .Get) to
+	// prove Set-not-Add — a distinction oauth1Capture's single-value Get-based
+	// AuthHeaders() would silently mask — so it stays a bespoke server, but still
+	// under mutex discipline (see TestOAuth1TransportSignatureVerifies).
+	var mu sync.Mutex
+	var authHeaders []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		authHeaders = r.Header.Values(headerAuthorization)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	log := createTestLogger()
+	c := NewBuilder(log).WithOAuth1(cfg).Build()
+
+	resp, err := c.Post(context.Background(), &Request{
+		URL:     server.URL,
+		Headers: map[string]string{headerAuthorization: "Bearer stale-token"},
+		Body:    []byte(`{"a":1}`),
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	mu.Lock()
+	gotAuthHeaders := authHeaders
+	mu.Unlock()
+
+	require.Len(t, gotAuthHeaders, 1, "the server must see exactly one Authorization value, not the stale one plus the OAuth1 one")
+	assert.True(t, strings.HasPrefix(gotAuthHeaders[0], "OAuth "), "the surviving Authorization value must be the OAuth1 one, not the caller-supplied stale token")
+}
+
+// TestBuilderWithOAuth1ValidatesConfig pins that WithOAuth1 fails fast at
+// build time on an invalid OAuth1Config, rather than deferring the failure to
+// the first signed request. WithOAuth1 is new API in this release, so adding
+// this now costs nothing; adding it after release would be a breaking change.
+func TestBuilderWithOAuth1ValidatesConfig(t *testing.T) {
+	log := createTestLogger()
+	validKey := generateOAuth1TestKey(t)
+
+	tests := []struct {
+		name string
+		cfg  OAuth1Config
+	}{
+		{name: "nil_keys", cfg: OAuth1Config{ConsumerKey: "c", KeyName: "k", Keys: nil}},
+		{name: "empty_key_name", cfg: OAuth1Config{ConsumerKey: "c", KeyName: "", Keys: mapKeys{"k": validKey}}},
+		{name: "empty_consumer_key", cfg: OAuth1Config{ConsumerKey: "", KeyName: "k", Keys: mapKeys{"k": validKey}}},
+		{
+			name: "unknown_signature_method",
+			cfg: OAuth1Config{
+				ConsumerKey: "c",
+				KeyName:     "k",
+				Keys:        mapKeys{"k": validKey},
+				Method:      OAuth1SignatureMethod("HMAC-SHA1"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Panics(t, func() {
+				NewBuilder(log).WithOAuth1(tc.cfg)
+			})
+		})
+	}
+
+	t.Run("valid_config_does_not_panic", func(t *testing.T) {
+		cfg := OAuth1Config{ConsumerKey: "c", KeyName: "k", Keys: mapKeys{"k": validKey}}
+		assert.NotPanics(t, func() {
+			NewBuilder(log).WithOAuth1(cfg)
+		})
+	})
+}
+
+func TestBuilderWithOAuth1RegistersSignerLayer(t *testing.T) {
+	log := createTestLogger()
+
+	assertNesting := func(t *testing.T, built Client, base *stubRoundTripper) {
+		t.Helper()
+		clientImpl, ok := built.(*client)
+		require.True(t, ok)
+		joseTransport, ok := clientImpl.httpClient.Transport.(*JOSETransport)
+		require.True(t, ok, "body-transform layer must be outermost")
+		signer, ok := joseTransport.Inner.(*OAuth1Transport)
+		require.True(t, ok, "signer layer must sit between JOSE and the base")
+		assert.Same(t, base, signer.Inner)
+	}
+
+	t.Run("oauth1_registered_first", func(t *testing.T) {
+		base := &stubRoundTripper{name: "base"}
+		cfg := OAuth1Config{ConsumerKey: "c", KeyName: "k", Keys: mapKeys{}}
+		built := NewBuilder(log).WithOAuth1(cfg).WithJOSE(JOSEConfig{}).WithTransport(base).Build()
+		assertNesting(t, built, base)
+	})
+
+	t.Run("jose_registered_first", func(t *testing.T) {
+		base := &stubRoundTripper{name: "base"}
+		cfg := OAuth1Config{ConsumerKey: "c", KeyName: "k", Keys: mapKeys{}}
+		built := NewBuilder(log).WithJOSE(JOSEConfig{}).WithOAuth1(cfg).WithTransport(base).Build()
+		assertNesting(t, built, base)
+	})
+}
+
+func TestOAuth1SignsSealedJOSEBody(t *testing.T) {
+	f := jositest.NewBidirectionalFixture(t)
+	oauthCfg, _ := newOAuth1TestConfig(t)
+
+	server, capture := newCapturingServer(t)
+	defer server.Close()
+
+	log := createTestLogger()
+	c := NewBuilder(log).
+		WithJOSE(JOSEConfig{Outbound: f.ClientOutbound, Inbound: f.ClientInbound, Resolver: f.Resolver}).
+		WithOAuth1(oauthCfg).
+		Build()
+
+	resp, err := c.Post(context.Background(), &Request{URL: server.URL, Body: []byte(`{"pan":"4111111111111111"}`)})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.Equal(t, 1, capture.Hits())
+	rawBody := capture.Bodies()[0]
+	require.NotEmpty(t, rawBody)
+	// This is the actual sealing proof: asserting oauth_body_hash == sha256(rawBody)
+	// alone would hold even if JOSE sealed nothing at all, since rawBody is simply
+	// whatever arrived on the wire. Asserting the plaintext PAN is absent is what
+	// discriminates "the hash covers the wire bytes" from "the wire bytes are
+	// ciphertext".
+	assert.NotContains(t, string(rawBody), "4111111111111111", "the wire body must be JOSE ciphertext, not the plaintext PAN")
+
+	sum := sha256.Sum256(rawBody)
+	wantBodyHash := base64.StdEncoding.EncodeToString(sum[:])
+
+	params := parseOAuth1AuthHeader(t, capture.AuthHeaders()[0])
+	assert.Equal(t, wantBodyHash, params[oauthBodyHashParam],
+		"oauth_body_hash must cover the sealed (ciphertext) body, not the plaintext")
+}

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -144,6 +144,41 @@ whole field on the original config is inert rather than racy, but only for clien
 already built. Rotate certificates through `GetClientCertificate`, which the clone
 preserves; for anything else, build a fresh config.
 
+### OAuth 1.0a request signing
+
+Use `WithOAuth1` for Mastercard-style partner APIs that authenticate with
+OAuth 1.0a request signing (RSA-SHA256 by default, plus the `oauth_body_hash`
+extension) rather than OAuth2/JWT. It registers an `OAuth1Transport` at the
+transport chain's signer layer, so signing happens automatically on every
+outbound request:
+
+```go
+client := httpclient.NewBuilder(logger).
+    WithOAuth1(httpclient.OAuth1Config{
+        ConsumerKey: "your-consumer-key",
+        KeyName:     "mastercard-signing",
+        Keys:        deps.KeyStore, // app.KeyStore satisfies PrivateKeyResolver directly
+    }).
+    Build()
+```
+
+**Layer ordering.** The signer layer sits beneath body-transform layers such
+as `WithJOSE` (`### Transport composition` above), so composing the two signs
+the bytes actually placed on the wire: `oauth_body_hash` covers the sealed
+JOSE ciphertext, not the plaintext, regardless of which `With*` option was
+called first.
+
+**Per-retry freshness.** Because httpclient retries by rebuilding the request
+per attempt, `OAuth1Transport.RoundTrip` runs again on every attempt — each
+retry gets a fresh `oauth_nonce`/`oauth_timestamp` and a re-computed
+signature, not a replay of the first attempt's.
+
+**Key resolution.** The signing key is resolved per request by name through
+the one-method `httpclient.PrivateKeyResolver` interface, so key rotation
+(swapping the key material behind `KeyName`) applies without rebuilding the
+client. `app.KeyStore` and `jose.KeyResolver` both satisfy it structurally —
+pass `deps.KeyStore` directly, no adapter required.
+
 ## Metrics
 
 ### Overview

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -37,7 +37,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E50  | v0.49.0 → v0.50.0 | config-break | 4 | none | Flyway migrate surfaces unparseable/failure output as an error; non-empty DB passwords < 8 bytes rejected at config validation + migrate; dev CORS wildcard opt-in; `multitenant.resolver.order` now REQUIRED for `type: composite` (no default — composite deployments fail to start until they declare one) |
 | E51  | v0.50.0 → v0.51.0 | silent-behavior (adopt-only) | 3 | none | none |
 | E52  | v0.51.0 → v0.52.0 | compile-break | 4 | C52.1 | if you set `.Args` on any declaration in ≤v0.51.0, verify current broker state before upgrading |
-| E55  | v0.52.0 → v0.55.0 | additive (safe) | 2 | none | none |
+| E55  | v0.52.0 → v0.55.0 | additive (safe) | 3 | none | none |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 - **`when: match`** → act only if `detect` returns ≥1 line (an API/arity/interface change, or a config key you set).
@@ -680,9 +680,9 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - note: `decls.DeclareQueueWithDLQ(name, spec)` declares the fanout DLX + parking queue + binding and sets `x-dead-letter-exchange` (and optionally `x-dead-letter-routing-key`) on the primary queue in one call — failed deliveries park in the default `<queue>.dlq` (or the configured parking queue) instead of dropping. Raw `Args["x-dead-letter-exchange"]` (see "Dead-Lettering" in wiki/messaging.md) remains valid for custom topologies. Purely additive; existing hand-rolled DLX declarations are untouched.
 - ref: #721 · messaging/helpers.go
 
-## E55 · v0.52.0 → v0.55.0 — database Execute* query/exec helpers + httpclient client TLS
+## E55 · v0.52.0 → v0.55.0 — database Execute* query/exec helpers + httpclient client TLS + OAuth 1.0a signing
 
-- gist: Adds `database.ExecuteQuerySingle` / `ExecuteQueryMany` / `ExecuteUpdate` / `ExecuteUpdateOne` / `ExecuteInsert`, a 2-method `database.Executor` interface (satisfied by both `database.Interface` and `database.Tx`), and `database.Raw(sql, args...)` for hand-written SQL — collapsing the repeated `ToSQL()` → `Query`/`Exec` → scan/`RowsAffected` → error-wrap glue every SQL repository re-implements. Also adds `httpclient.NewClientTLSConfig` and `httpclient.Builder.WithTLSConfig` for config-driven client certificates / mutual TLS. No exported go-bricks symbol changes outside these new surfaces; purely additive.
+- gist: Adds `database.ExecuteQuerySingle` / `ExecuteQueryMany` / `ExecuteUpdate` / `ExecuteUpdateOne` / `ExecuteInsert`, a 2-method `database.Executor` interface (satisfied by both `database.Interface` and `database.Tx`), and `database.Raw(sql, args...)` for hand-written SQL — collapsing the repeated `ToSQL()` → `Query`/`Exec` → scan/`RowsAffected` → error-wrap glue every SQL repository re-implements. Also adds `httpclient.NewClientTLSConfig` and `httpclient.Builder.WithTLSConfig` for config-driven client certificates / mutual TLS, and `httpclient.Builder.WithOAuth1` for Mastercard-style OAuth 1.0a request signing (RSA-SHA256 + `oauth_body_hash`). No exported go-bricks symbol changes outside these new surfaces; purely additive.
 - build-caught: none
 - preflight: none
 - exit: `go get github.com/gaborage/go-bricks@v0.55.0 && go mod tidy && go build ./... && go test ./...`
@@ -737,6 +737,20 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
   `RequireClientCert: true` so a missing cert/key pair fails at load instead of
   silently downgrading intended mTLS to one-way TLS.
 - ref: #767 · httpclient/tls.go
+
+### [C55.3] httpclient OAuth 1.0a request signing (WithOAuth1) · additive-optional
+
+- note: `httpclient.NewBuilder(log).WithOAuth1(httpclient.OAuth1Config{…})`
+  signs every request with an OAuth 1.0a `Authorization` header (RSA-SHA256 by
+  default, plus `oauth_body_hash`) for Mastercard-style partner APIs. The
+  signer registers at the transport chain's signer layer, so it signs the bytes
+  actually sent — composed with `WithJOSE` the hash covers the sealed payload —
+  and each retry attempt re-signs with a fresh nonce/timestamp. The signing key
+  is resolved per request by name through the 1-method
+  `httpclient.PrivateKeyResolver`, which `app.KeyStore` already satisfies
+  (pass `deps.KeyStore` directly). Purely additive; no existing client
+  behavior changes.
+- ref: #766 · httpclient/oauth1_transport.go
 
 ---
 


### PR DESCRIPTION
## What

go-bricks had no OAuth 1.0a support, so any service calling a Mastercard-style
partner API hand-rolled RFC 5849 percent-encoding and base-string construction.
`WithOAuth1` now installs an `OAuth1Transport` at the transport chain's signer
layer, so it signs the bytes actually sent — composed with `WithJOSE`,
`oauth_body_hash` covers the sealed ciphertext — and re-signs every retry
attempt with a fresh nonce.

## Impact

Purely additive: `client.go` and `jose_transport.go` take zero hunks. Adopters
pass `deps.KeyStore` straight in, since `app.KeyStore` already satisfies the new
one-method `PrivateKeyResolver` structurally. Two related defects surfaced in
files this PR freezes and are left as follow-ups: `JOSETransport.wrapRequest`
leaks `req.Body` on its nil-Resolver return, and `addTransportWrapper`'s godoc
lists two wrapper obligations when there are three.

## Verification

Both halves mutation-checked: reverting the `+`-in-query encoding fix fails
exactly the two `+` vectors, and dropping `~` from the unreserved set fails
`TestOAuth1PercentEncode`. Encoding and base-string construction are pinned
against mastercard/oauth1-signer-go's published vectors.

Closes #766


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth 1.0a request signing for HTTP clients with RSA-SHA1, RSA-SHA256, or RSA-SHA512.
  * Automatically generates and attaches an `Authorization` header, including OAuth body hashing, nonces, and per-attempt timestamps.
  * Resolves signing keys per request for key rotation, and re-signs requests on retries.

* **Bug Fixes**
  * Fails safely (no request sent) when signing prerequisites or query inputs are invalid.
  * Overwrites any caller-provided `Authorization` value.

* **Documentation**
  * Added user guidance and migration details for configuring OAuth 1.0a signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->