### PR TITLE
fix(httpclient): close req.Body on JOSETransport's pre-read error return

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -296,23 +296,34 @@ func (b *Builder) WithJOSE(cfg JOSEConfig) *Builder {
 // addTransportWrapper registers a RoundTripper layer applied at Build time.
 // A wrapper that rewrites the body registers at layerBodyTransform; one that only
 // reads the body to sign it registers at layerSigner, so the signature covers the
-// rewritten bytes. Every wrapper has three obligations:
+// rewritten bytes. Two obligations the type system cannot express:
 //
-//  1. The inner RoundTripper it receives may be nil (no WithTransport base) and
-//     must then fall back to nethttp.DefaultTransport rather than dereference.
-//  2. A layer that reads the body owes the layer below a re-readable body plus a
+//  1. A layer that reads the body owes the layer below a re-readable body plus a
 //     matching GetBody — as JOSETransport.wrapRequest does — or redirect and
 //     HTTP/2 replay paths resend an empty payload under a signature computed
 //     over the real one.
-//  3. RoundTrip must close req.Body before any error return that precedes
-//     draining it. On a transport error http.Client.do sets reqBodyClosed and
-//     skips its own fallback close, on the stated assumption that the transport
-//     already closed it — so a caller's *os.File or io.Pipe body leaks.
+//  2. RoundTrip must close req.Body before any error return that precedes
+//     draining it; after a failed send, http.Client.do sets reqBodyClosed and
+//     skips its own close, so the caller's body leaks.
 func (b *Builder) addTransportWrapper(layer transportLayer, wrap func(nethttp.RoundTripper) nethttp.RoundTripper) {
 	if b.chain == nil {
 		b.chain = &transportChain{}
 	}
 	b.chain.byLayer[layer] = append(b.chain.byLayer[layer], wrap)
+}
+
+// defaultTransportShim stands in for a missing WithTransport base so chain wrappers
+// never receive a nil inner. It resolves nethttp.DefaultTransport per request rather
+// than capturing it at Build, because consumers replace that global after a client is
+// built (gock, httpmock, APM agents) — the same constraint WithTLSConfig documents.
+type defaultTransportShim struct{}
+
+func (defaultTransportShim) RoundTrip(req *nethttp.Request) (*nethttp.Response, error) {
+	rt := nethttp.DefaultTransport
+	if rt == nil {
+		return nil, errors.New("httpclient: net/http.DefaultTransport is nil, so the transport chain has no base")
+	}
+	return rt.RoundTrip(req)
 }
 
 // resolveTransport applies registered wrappers to the base transport innermost
@@ -323,6 +334,9 @@ func (b *Builder) resolveTransport() nethttp.RoundTripper {
 	rt := b.transport
 	if b.chain == nil {
 		return rt
+	}
+	if rt == nil {
+		rt = defaultTransportShim{}
 	}
 	for _, wrappers := range b.chain.byLayer {
 		for _, wrap := range wrappers {

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -296,12 +296,18 @@ func (b *Builder) WithJOSE(cfg JOSEConfig) *Builder {
 // addTransportWrapper registers a RoundTripper layer applied at Build time.
 // A wrapper that rewrites the body registers at layerBodyTransform; one that only
 // reads the body to sign it registers at layerSigner, so the signature covers the
-// rewritten bytes. Two obligations on every wrapper: the inner RoundTripper it
-// receives may be nil (no WithTransport base) and must then fall back to
-// nethttp.DefaultTransport rather than dereference, and a layer that reads the body
-// owes the layer below a re-readable body plus a matching GetBody — as
-// JOSETransport.wrapRequest does — or redirect and HTTP/2 replay paths resend an
-// empty payload under a signature computed over the real one.
+// rewritten bytes. Every wrapper has three obligations:
+//
+//  1. The inner RoundTripper it receives may be nil (no WithTransport base) and
+//     must then fall back to nethttp.DefaultTransport rather than dereference.
+//  2. A layer that reads the body owes the layer below a re-readable body plus a
+//     matching GetBody — as JOSETransport.wrapRequest does — or redirect and
+//     HTTP/2 replay paths resend an empty payload under a signature computed
+//     over the real one.
+//  3. RoundTrip must close req.Body before any error return that precedes
+//     draining it. On a transport error http.Client.do sets reqBodyClosed and
+//     skips its own fallback close, on the stated assumption that the transport
+//     already closed it — so a caller's *os.File or io.Pipe body leaks.
 func (b *Builder) addTransportWrapper(layer transportLayer, wrap func(nethttp.RoundTripper) nethttp.RoundTripper) {
 	if b.chain == nil {
 		b.chain = &transportChain{}

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -213,7 +213,7 @@ func TestBuilder(t *testing.T) {
 		require.True(t, ok)
 		joseTransport, ok := clientImpl.httpClient.Transport.(*JOSETransport)
 		require.True(t, ok, "built client must carry the JOSE transport")
-		assert.Nil(t, joseTransport.Inner)
+		assert.IsType(t, defaultTransportShim{}, joseTransport.Inner, "no explicit base: chain seeds the DefaultTransport shim, never nil")
 	})
 
 	t.Run("with custom transport", func(t *testing.T) {
@@ -1901,6 +1901,72 @@ func TestBuilderTransportChainLayerOrdering(t *testing.T) {
 	})
 }
 
+func TestBuilderTransportChainNeverPassesNilInner(t *testing.T) {
+	log := createTestLogger()
+	var gotInner nethttp.RoundTripper
+	applied := false
+	b := NewBuilder(log)
+	b.addTransportWrapper(layerSigner, func(inner nethttp.RoundTripper) nethttp.RoundTripper {
+		gotInner, applied = inner, true
+		return &wrappingTransport{inner: inner}
+	})
+	b.Build()
+	require.True(t, applied, "wrapper must have been applied")
+	assert.IsType(t, defaultTransportShim{}, gotInner, "chain must seed the DefaultTransport shim, never a nil inner")
+}
+
+func TestBuilderTransportChainResolvesDefaultTransportPerRequest(t *testing.T) {
+	log := createTestLogger()
+	var captured nethttp.RoundTripper
+	b := NewBuilder(log)
+	b.addTransportWrapper(layerSigner, func(inner nethttp.RoundTripper) nethttp.RoundTripper {
+		captured = inner
+		return inner
+	})
+	b.Build() // Build happens BEFORE the global is swapped — that is the point.
+	require.NotNil(t, captured)
+
+	// Non-parallel on purpose: the package has no t.Parallel() calls, so swapping
+	// the global here cannot race another test.
+	orig := nethttp.DefaultTransport
+	t.Cleanup(func() { nethttp.DefaultTransport = orig })
+	stub := &recordingRoundTripper{}
+	nethttp.DefaultTransport = stub
+
+	//nolint:gocritic // literal nil, not http.NoBody, matches a real GET's nil req.Body
+	req, err := nethttp.NewRequestWithContext(context.Background(), nethttp.MethodGet, "http://example.invalid", nil)
+	require.NoError(t, err)
+	_, _ = captured.RoundTrip(req) //nolint:bodyclose // recordingRoundTripper returns no body
+
+	assert.True(t, stub.called, "chain must resolve DefaultTransport per request, not capture it at Build")
+}
+
+func TestBuilderTransportChainErrorsWhenDefaultTransportIsNil(t *testing.T) {
+	log := createTestLogger()
+	var captured nethttp.RoundTripper
+	b := NewBuilder(log)
+	b.addTransportWrapper(layerSigner, func(inner nethttp.RoundTripper) nethttp.RoundTripper {
+		captured = inner
+		return inner
+	})
+	b.Build()
+	require.NotNil(t, captured)
+
+	// Non-parallel on purpose: the package has no t.Parallel() calls, so swapping
+	// the global here cannot race another test.
+	orig := nethttp.DefaultTransport
+	t.Cleanup(func() { nethttp.DefaultTransport = orig })
+	nethttp.DefaultTransport = nil
+
+	//nolint:gocritic // literal nil, not http.NoBody, matches a real GET's nil req.Body
+	req, err := nethttp.NewRequestWithContext(context.Background(), nethttp.MethodGet, "http://example.invalid", nil)
+	require.NoError(t, err)
+	_, err = captured.RoundTrip(req) //nolint:bodyclose // shim errors before returning a response; no body to close
+
+	require.Error(t, err, "shim must error, not panic, when net/http.DefaultTransport is nil")
+	assert.Contains(t, err.Error(), "DefaultTransport")
+}
+
 func TestBuilderTransportChainDiscardsClientTransport(t *testing.T) {
 	log := createTestLogger()
 	base := &stubRoundTripper{name: "base"}
@@ -1949,7 +2015,7 @@ func TestBuilderTransportChainDiscardsClientTransport(t *testing.T) {
 		assert.NotSame(t, base, clientImpl.httpClient.Transport, "caller's transport is replaced, not wrapped")
 		joseTransport, ok := clientImpl.httpClient.Transport.(*JOSETransport)
 		require.True(t, ok)
-		assert.Nil(t, joseTransport.Inner, "no base: RoundTrip falls back to net/http.DefaultTransport")
+		assert.IsType(t, defaultTransportShim{}, joseTransport.Inner, "no base: chain seeds the shim, which resolves net/http.DefaultTransport per request")
 	})
 
 	t.Run("hazard_emits_the_warning", func(t *testing.T) {
@@ -1990,6 +2056,17 @@ type wrappingTransport struct {
 
 func (r *wrappingTransport) RoundTrip(req *nethttp.Request) (*nethttp.Response, error) {
 	return r.inner.RoundTrip(req)
+}
+
+// recordingRoundTripper records whether RoundTrip was invoked, so a test that swaps
+// nethttp.DefaultTransport can observe late binding rather than capture-at-Build.
+type recordingRoundTripper struct {
+	called bool
+}
+
+func (r *recordingRoundTripper) RoundTrip(_ *nethttp.Request) (*nethttp.Response, error) {
+	r.called = true
+	return nil, errors.New("recordingRoundTripper: no response configured")
 }
 
 func TestNewBuilderAndBuildRejectNilLogger(t *testing.T) {

--- a/httpclient/jose_transport.go
+++ b/httpclient/jose_transport.go
@@ -38,7 +38,8 @@ const DefaultMaxJOSEBodyBytes int64 = 10 << 20 // 10 MiB
 // attempt to decrypt those.
 type JOSETransport struct {
 	// Inner is the underlying RoundTripper that performs the actual HTTP exchange.
-	// Nil defaults to nethttp.DefaultTransport.
+	// Nil defaults to nethttp.DefaultTransport — relevant only when JOSETransport is
+	// hand-constructed, since httpclient.Builder-produced clients always seed a non-nil Inner.
 	Inner nethttp.RoundTripper
 
 	// Outbound is required: the policy used to sign+encrypt every outbound request body.

--- a/httpclient/jose_transport.go
+++ b/httpclient/jose_transport.go
@@ -98,6 +98,9 @@ func (t *JOSETransport) wrapRequest(req *nethttp.Request) (*nethttp.Request, err
 		return req, nil
 	}
 	if t.Resolver == nil {
+		if req.Body != nil {
+			_ = req.Body.Close()
+		}
 		return nil, fmt.Errorf("httpclient: JOSETransport requires a KeyResolver when Outbound is set")
 	}
 

--- a/httpclient/jose_transport_test.go
+++ b/httpclient/jose_transport_test.go
@@ -18,6 +18,20 @@ import (
 	"github.com/gaborage/go-bricks/logger"
 )
 
+// closeTrackingBody is a bytes.Reader-backed io.ReadCloser that records whether
+// Close was called, so tests can observe a RoundTripper's close-on-error obligation.
+type closeTrackingBody struct {
+	r      *bytes.Reader
+	closed bool
+}
+
+func newCloseTrackingBody(s string) *closeTrackingBody {
+	return &closeTrackingBody{r: bytes.NewReader([]byte(s))}
+}
+
+func (b *closeTrackingBody) Read(p []byte) (int, error) { return b.r.Read(p) }
+func (b *closeTrackingBody) Close() error               { b.closed = true; return nil }
+
 // joseEchoServer simulates a JOSE-aware partner: it decrypts the request, echoes the
 // plaintext back inside an encrypted response.
 //
@@ -238,9 +252,24 @@ func TestJOSETransportRespectsMaxResponseBytes(t *testing.T) {
 func TestJOSETransportOutboundRequiresResolver(t *testing.T) {
 	f := jositest.NewBidirectionalFixture(t)
 	transport := &httpclient.JOSETransport{Outbound: f.ClientOutbound, Resolver: nil}
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.invalid", bytes.NewReader([]byte(`{}`)))
+	body := newCloseTrackingBody(`{}`)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.invalid", body)
 	require.NoError(t, err)
 
+	_, err = transport.RoundTrip(req) //nolint:bodyclose // RoundTrip returns the configuration error before any HTTP exchange; no body to close
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "KeyResolver")
+	assert.True(t, body.closed, "RoundTrip must close req.Body even when it fails before reading it")
+}
+
+func TestJOSETransportOutboundRequiresResolverNilBody(t *testing.T) {
+	f := jositest.NewBidirectionalFixture(t)
+	transport := &httpclient.JOSETransport{Outbound: f.ClientOutbound, Resolver: nil}
+	//nolint:gocritic // literal nil, not http.NoBody, keeps req.Body nil to hit the guarded path
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.invalid", nil)
+	require.NoError(t, err)
+
+	// A nil req.Body (e.g. a GET) must reach the error return without a close attempt.
 	_, err = transport.RoundTrip(req) //nolint:bodyclose // RoundTrip returns the configuration error before any HTTP exchange; no body to close
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "KeyResolver")


### PR DESCRIPTION
## What

`JOSETransport` violated `net/http`'s RoundTripper contract: `wrapRequest`'s
`Resolver == nil` guard returned before `readAndCloseBody`, so nothing closed
`req.Body` — leaking an `*os.File` or blocking an `io.Pipe` writer. It now closes
the body, nil-checked because GETs have none. Separately, the chain seeded
wrappers with a nil inner, so `addTransportWrapper`'s godoc had to *ask* each
wrapper to fall back to `DefaultTransport`; it now seeds a shim resolving that
global per request — an invariant, not an obligation.

## Impact

None for consumers: no API change, both success paths untouched. Wrapper authors
owe two obligations instead of three, and `JOSETransport.Inner` is non-nil on
every Builder-built client, so its nil fallback covers hand-construction only.

## Verification

Every half is mutation-pinned and no test masks another's mutation: removing the
body close, its nil guard, the chain seed, that seed's per-request resolution, or
the nil-`DefaultTransport` guard each fails exactly one named test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when using custom HTTP transport wrappers without explicitly configured base transports.
  * Ensured default HTTP transport settings are applied for each request.
  * Replaced potential transport-chain panics with clear errors when no default transport is available.
  * Prevented request-body leaks when signing or transport configuration fails before sending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->