### PR TITLE
fix(httpclient): require DER shape before rejecting a path as key material

### DIFF
--- a/httpclient/tls.go
+++ b/httpclient/tls.go
@@ -26,6 +26,10 @@ const pemHeaderPrefix = "-----BEGIN"
 // this error reaches startup logs.
 const maxPathEcho = 256
 
+// minDERKeyBytes is the smallest real case this guard must still catch: an
+// Ed25519 PKCS#8 private key marshals to exactly 48 bytes.
+const minDERKeyBytes = 48
+
 // ClientTLSConfig describes client-side TLS material declaratively. Each piece
 // comes from a PEM file path (File) or a base64-encoded PEM string (Value) —
 // set exactly one source per provided piece. Cert and Key must be provided
@@ -220,8 +224,32 @@ func looksLikeKeyMaterial(file string) bool {
 	if err != nil {
 		return false
 	}
-	// 0x30 is the ASN.1 SEQUENCE tag that opens PKCS#8, SEC1, PKCS#12 and X.509.
-	return strings.Contains(string(decoded), pemHeaderPrefix) || (len(decoded) > 0 && decoded[0] == 0x30)
+	return strings.Contains(string(decoded), pemHeaderPrefix) || looksLikeDER(decoded)
+}
+
+// looksLikeDER reports whether b opens with an ASN.1 SEQUENCE — tag 0x30,
+// which PKCS#8, SEC1, PKCS#12 and X.509 all start with — whose declared length
+// matches the payload. A bare 0x30 first byte is not enough: short
+// base64-alphabet paths such as "MAIN" decode to three bytes starting 0x30.
+// Canonical-length encoding is deliberately not enforced: this is a guard, so a
+// false negative echoes key material while a false positive only rejects a path.
+func looksLikeDER(b []byte) bool {
+	if len(b) < minDERKeyBytes || b[0] != 0x30 {
+		return false
+	}
+	n := int(b[1])
+	if n < 0x80 {
+		return 2+n == len(b)
+	}
+	count := n & 0x7f
+	if count == 0 || count > 4 || len(b) < 2+count {
+		return false
+	}
+	length := 0
+	for _, c := range b[2 : 2+count] {
+		length = length<<8 | int(c)
+	}
+	return 2+count+length == len(b)
 }
 
 // safeFileRef renders a *File value for an error message, eliding anything too

--- a/httpclient/tls_test.go
+++ b/httpclient/tls_test.go
@@ -3,7 +3,9 @@ package httpclient
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -353,6 +355,59 @@ func TestNewClientTLSConfigRejectsPEMContentInFileField(t *testing.T) {
 			"a plausible path stays in the message for diagnosability")
 		assert.ErrorIs(t, err, fs.ErrNotExist, "unwrapping the PathError must not break errors.Is")
 	})
+}
+
+// Pins both directions of the detector: real key material in every encoding it
+// must catch, and ordinary paths — including the base64-alphabet ones that used
+// to trip the bare 0x30-tag check — that it must let through.
+func TestLooksLikeKeyMaterialDetectsKeysNotPaths(t *testing.T) {
+	_, edKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	edPKCS8, err := x509.MarshalPKCS8PrivateKey(edKey)
+	require.NoError(t, err)
+	edPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: edPKCS8})
+
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	ecSEC1, err := x509.MarshalECPrivateKey(ecKey)
+	require.NoError(t, err)
+	ecPKCS8, err := x509.MarshalPKCS8PrivateKey(ecKey)
+	require.NoError(t, err)
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	rsaPKCS1 := x509.MarshalPKCS1PrivateKey(rsaKey)
+	rsaPKCS8, err := x509.MarshalPKCS8PrivateKey(rsaKey)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "ed25519_pkcs8", value: base64.StdEncoding.EncodeToString(edPKCS8), want: true},
+		{name: "ecdsa_p256_sec1", value: base64.StdEncoding.EncodeToString(ecSEC1), want: true},
+		{name: "ecdsa_p256_pkcs8", value: base64.StdEncoding.EncodeToString(ecPKCS8), want: true},
+		{name: "rsa2048_pkcs1", value: base64.StdEncoding.EncodeToString(rsaPKCS1), want: true},
+		{name: "rsa2048_pkcs8", value: base64.StdEncoding.EncodeToString(rsaPKCS8), want: true},
+		{name: "raw_pem_body", value: string(edPEM), want: true},
+		{name: "path_main", value: "MAIN", want: false},
+		{name: "path_mdkeys", value: "MDkeys", want: false},
+		{name: "path_mikeys", value: "MIkeys", want: false},
+		{name: "path_misckey", value: "MIsckey", want: false},
+		{name: "path_mfkeys", value: "MFkeys", want: false},
+		{name: "path_mockkeys", value: "MOCKkeys", want: false},
+		{name: "path_certs", value: "certs", want: false},
+		{name: "path_mycert", value: "MyCert", want: false},
+		{name: "path_tls_server_pem", value: "tls/server.pem", want: false},
+		{name: "path_absolute_cert_pem", value: "/etc/ssl/cert.pem", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, looksLikeKeyMaterial(tt.value))
+		})
+	}
 }
 
 // A bundle whose second root is mangled at the PEM layer must not load: pem.Decode


### PR DESCRIPTION
## What

`looksLikeKeyMaterial` treated any base64-decodable value whose first decoded
byte was `0x30` as inline key material, so ordinary relative paths in the base64
alphabet — `MAIN`, `MDkeys`, `MIkeys`, `MIsckey`, `MFkeys`, `MOCKkeys` — aborted
startup claiming the path was a private key, advice the operator could not act
on. The detector now requires the ASN.1 SEQUENCE's declared length to match the
decoded payload, with a 48-byte floor (an Ed25519 PKCS#8 key, the smallest real
case). The function had no test coverage before this.

## Impact

None for valid configuration. A deployment whose `tls.cert.file`, `tls.key.file`
or `tls.ca.file` is one of the affected paths now starts instead of aborting.
The guard remains heuristic — the commit body records exactly what the 48-byte
floor gives up and why the floor must not be lowered to chase it.

## Verification

Mutation-checked in both directions: reverting to the bare `0x30` check fails
exactly the six path cases, and raising the floor to 64 fails the Ed25519 case —
so the floor is calibrated, not guessed. `LINT_CLEAN=1 make check` green locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of encoded TLS key material by validating its DER structure.
  * Reduced the risk of mistaking file paths or other text values for private keys.
  * Expanded support and validation for common Ed25519, ECDSA, and RSA key formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->