### PR TITLE
fix(keystore): stop echoing mis-filed key material into startup errors

### DIFF
--- a/httpclient/tls.go
+++ b/httpclient/tls.go
@@ -11,24 +11,17 @@ import (
 	"net"
 	nethttp "net/http"
 	"os"
-	"strings"
 	"time"
+
+	"github.com/gaborage/go-bricks/internal/secretfile"
 )
 
 const pemTypeCertificate = "CERTIFICATE"
 
-// pemHeaderPrefix opens every PEM block, so a *File value containing it is PEM
-// content pasted into the wrong field rather than a path.
+// pemHeaderPrefix opens every PEM block, so counting it gives the number of
+// blocks a CA bundle declares — what certPoolFromPEM checks against the number
+// that actually parsed.
 const pemHeaderPrefix = "-----BEGIN"
-
-// maxPathEcho bounds what a read error quotes back. A *File value longer than
-// this is elided: over-long values are the shape mis-filed material takes, and
-// this error reaches startup logs.
-const maxPathEcho = 256
-
-// minDERKeyBytes is the smallest real case this guard must still catch: an
-// Ed25519 PKCS#8 private key marshals to exactly 48 bytes.
-const minDERKeyBytes = 48
 
 // ClientTLSConfig describes client-side TLS material declaratively. Each piece
 // comes from a PEM file path (File) or a base64-encoded PEM string (Value) —
@@ -187,16 +180,15 @@ func loadPEM(file, value, what string) ([]byte, error) {
 	case file != "":
 		// Never let mis-filed material reach os.ReadFile: both our wrap and the
 		// *os.PathError it wraps would echo it into a startup error.
-		if looksLikeKeyMaterial(file) {
+		if secretfile.LooksLikeKeyMaterial(file) {
 			return nil, fmt.Errorf("httpclient: tls: %s: file looks like key material, not a path (use the value field for inline PEM)", what)
 		}
 		// #nosec G304 -- the path is deployment configuration, not request input:
 		// reading an operator-named file IS this function. Inline material is
-		// rejected above. Same shape as keystore.go's loadKeyBytes, which gosec
-		// leaves alone only because it reads a struct field rather than a parameter.
+		// rejected above.
 		data, err := os.ReadFile(file)
 		if err != nil {
-			return nil, fmt.Errorf("httpclient: tls: %s: read file %s: %w", what, safeFileRef(file), errnoOf(err))
+			return nil, fmt.Errorf("httpclient: tls: %s: %w", what, secretfile.ReadError(file, err))
 		}
 		return data, nil
 	case value != "":
@@ -208,68 +200,6 @@ func loadPEM(file, value, what string) ([]byte, error) {
 	default:
 		return nil, nil
 	}
-}
-
-// looksLikeKeyMaterial reports whether a *File value is inline key material
-// rather than a path. It covers a raw PEM body, its base64 form (what a secret
-// manager hands you, and so the likelier mix-up), and base64 of raw DER — which
-// carries no PEM header at any level and, for EC and Ed25519 keys, is short
-// enough to slip maxPathEcho too. Decoding unpadded accepts both base64 forms:
-// whether a value arrives padded otherwise depends on len(input)%3.
-func looksLikeKeyMaterial(file string) bool {
-	if strings.Contains(file, pemHeaderPrefix) {
-		return true
-	}
-	decoded, err := base64.RawStdEncoding.DecodeString(strings.TrimRight(file, "="))
-	if err != nil {
-		return false
-	}
-	return strings.Contains(string(decoded), pemHeaderPrefix) || looksLikeDER(decoded)
-}
-
-// looksLikeDER reports whether b opens with an ASN.1 SEQUENCE — tag 0x30,
-// which PKCS#8, SEC1, PKCS#12 and X.509 all start with — whose declared length
-// matches the payload. A bare 0x30 first byte is not enough: short
-// base64-alphabet paths such as "MAIN" decode to three bytes starting 0x30.
-// Canonical-length encoding is deliberately not enforced: this is a guard, so a
-// false negative echoes key material while a false positive only rejects a path.
-func looksLikeDER(b []byte) bool {
-	if len(b) < minDERKeyBytes || b[0] != 0x30 {
-		return false
-	}
-	n := int(b[1])
-	if n < 0x80 {
-		return 2+n == len(b)
-	}
-	count := n & 0x7f
-	if count == 0 || count > 4 || len(b) < 2+count {
-		return false
-	}
-	length := 0
-	for _, c := range b[2 : 2+count] {
-		length = length<<8 | int(c)
-	}
-	return 2+count+length == len(b)
-}
-
-// safeFileRef renders a *File value for an error message, eliding anything too
-// long to be a plausible path.
-func safeFileRef(file string) string {
-	if len(file) > maxPathEcho {
-		return fmt.Sprintf("<%d-char value elided>", len(file))
-	}
-	return fmt.Sprintf("%q", file)
-}
-
-// errnoOf strips the *os.PathError wrapper, which carries its own copy of the
-// path and would re-echo a value safeFileRef elided. errors.Is is unaffected:
-// the bare errno still matches fs.ErrNotExist and friends.
-func errnoOf(err error) error {
-	var pathErr *os.PathError
-	if errors.As(err, &pathErr) {
-		return pathErr.Err
-	}
-	return err
 }
 
 // certPoolFromPEM refuses to pin fewer roots than the bundle asks for, which
@@ -320,6 +250,6 @@ func parseTLSMinVersion(v string) (uint16, error) {
 	case "1.3":
 		return tls.VersionTLS13, nil
 	default:
-		return 0, fmt.Errorf("httpclient: tls: minversion %s: accepted values are \"1.2\" and \"1.3\"", safeFileRef(v))
+		return 0, fmt.Errorf("httpclient: tls: minversion %s: accepted values are \"1.2\" and \"1.3\"", secretfile.SafeRef(v))
 	}
 }

--- a/httpclient/tls_test.go
+++ b/httpclient/tls_test.go
@@ -3,9 +3,7 @@ package httpclient
 import (
 	"bytes"
 	"context"
-	"crypto/ecdsa"
 	"crypto/ed25519"
-	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -27,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gaborage/go-bricks/internal/secretfile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -93,7 +92,7 @@ func b64PEM(material []byte) string {
 }
 
 // ed25519KeyPEM returns a PKCS#8 Ed25519 key: the compact shape whose DER is short
-// enough to slip maxPathEcho and whose PEM length is not a multiple of 3.
+// enough to slip secretfile.MaxPathEcho and whose PEM length is not a multiple of 3.
 func ed25519KeyPEM(t *testing.T) []byte {
 	t.Helper()
 	_, key, err := ed25519.GenerateKey(rand.Reader)
@@ -308,7 +307,7 @@ func TestNewClientTLSConfigRejectsPEMContentInFileField(t *testing.T) {
 		der, derErr := x509.MarshalPKCS8PrivateKey(edKey)
 		require.NoError(t, derErr)
 		encoded := base64.StdEncoding.EncodeToString(der)
-		require.Less(t, len(encoded), maxPathEcho, "the point of this case is that eliding cannot save us")
+		require.Less(t, len(encoded), secretfile.MaxPathEcho, "the point of this case is that eliding cannot save us")
 
 		cfg, err := NewClientTLSConfig(&ClientTLSConfig{CAFile: encoded})
 		require.Error(t, err)
@@ -355,59 +354,6 @@ func TestNewClientTLSConfigRejectsPEMContentInFileField(t *testing.T) {
 			"a plausible path stays in the message for diagnosability")
 		assert.ErrorIs(t, err, fs.ErrNotExist, "unwrapping the PathError must not break errors.Is")
 	})
-}
-
-// Pins both directions of the detector: real key material in every encoding it
-// must catch, and ordinary paths — including the base64-alphabet ones that used
-// to trip the bare 0x30-tag check — that it must let through.
-func TestLooksLikeKeyMaterialDetectsKeysNotPaths(t *testing.T) {
-	_, edKey, err := ed25519.GenerateKey(rand.Reader)
-	require.NoError(t, err)
-	edPKCS8, err := x509.MarshalPKCS8PrivateKey(edKey)
-	require.NoError(t, err)
-	edPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: edPKCS8})
-
-	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	ecSEC1, err := x509.MarshalECPrivateKey(ecKey)
-	require.NoError(t, err)
-	ecPKCS8, err := x509.MarshalPKCS8PrivateKey(ecKey)
-	require.NoError(t, err)
-
-	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-	rsaPKCS1 := x509.MarshalPKCS1PrivateKey(rsaKey)
-	rsaPKCS8, err := x509.MarshalPKCS8PrivateKey(rsaKey)
-	require.NoError(t, err)
-
-	tests := []struct {
-		name  string
-		value string
-		want  bool
-	}{
-		{name: "ed25519_pkcs8", value: base64.StdEncoding.EncodeToString(edPKCS8), want: true},
-		{name: "ecdsa_p256_sec1", value: base64.StdEncoding.EncodeToString(ecSEC1), want: true},
-		{name: "ecdsa_p256_pkcs8", value: base64.StdEncoding.EncodeToString(ecPKCS8), want: true},
-		{name: "rsa2048_pkcs1", value: base64.StdEncoding.EncodeToString(rsaPKCS1), want: true},
-		{name: "rsa2048_pkcs8", value: base64.StdEncoding.EncodeToString(rsaPKCS8), want: true},
-		{name: "raw_pem_body", value: string(edPEM), want: true},
-		{name: "path_main", value: "MAIN", want: false},
-		{name: "path_mdkeys", value: "MDkeys", want: false},
-		{name: "path_mikeys", value: "MIkeys", want: false},
-		{name: "path_misckey", value: "MIsckey", want: false},
-		{name: "path_mfkeys", value: "MFkeys", want: false},
-		{name: "path_mockkeys", value: "MOCKkeys", want: false},
-		{name: "path_certs", value: "certs", want: false},
-		{name: "path_mycert", value: "MyCert", want: false},
-		{name: "path_tls_server_pem", value: "tls/server.pem", want: false},
-		{name: "path_absolute_cert_pem", value: "/etc/ssl/cert.pem", want: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, looksLikeKeyMaterial(tt.value))
-		})
-	}
 }
 
 // A bundle whose second root is mangled at the PEM layer must not load: pem.Decode

--- a/internal/secretfile/secretfile.go
+++ b/internal/secretfile/secretfile.go
@@ -1,0 +1,119 @@
+// Package secretfile hosts the error-hygiene guards shared by every code path
+// that reads key material from an operator-named file. Both consumers —
+// httpclient's TLS loader and the keystore — have sibling File/Value config
+// fields, so a transposition puts inline material where a path belongs; without
+// these guards it reaches a fatal startup log, which the logger's
+// SensitiveDataFilter cannot mask because that filter matches field names, not
+// error strings. ReadError is the shape both consumers should use at the read
+// site; SafeRef is also useful on its own for any operator-supplied config
+// string that must not be echoed unbounded.
+//
+// LooksLikeKeyMaterial catches PEM, base64 PEM, and base64 DER. It cannot catch
+// raw symmetric secrets, which have no ASN.1 structure and may be short enough
+// to slip MaxPathEcho — Errno still prevents the second copy, but the first is
+// echoed. Widening the check to "any decodable base64" is not the fix: real
+// paths such as /run/secrets/signingkey decode cleanly.
+package secretfile
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// pemHeaderPrefix opens every PEM block, so a *File value containing it is PEM
+// content pasted into the wrong field rather than a path.
+const pemHeaderPrefix = "-----BEGIN"
+
+// MaxPathEcho bounds what a read error quotes back. A *File value longer than
+// this is elided: over-long values are the shape mis-filed material takes, and
+// this error reaches startup logs.
+const MaxPathEcho = 256
+
+// minDERKeyBytes is the smallest real case this guard must still catch: an
+// Ed25519 PKCS#8 private key marshals to exactly 48 bytes.
+const minDERKeyBytes = 48
+
+// LooksLikeKeyMaterial reports whether a *File value is inline key material
+// rather than a path. It covers a raw PEM body, its base64 form (what a secret
+// manager hands you, and so the likelier mix-up), and base64 of raw DER — which
+// carries no PEM header at any level and, for EC and Ed25519 keys, is short
+// enough to slip MaxPathEcho too. Decoding unpadded accepts both base64 forms:
+// whether a value arrives padded otherwise depends on len(input)%3.
+func LooksLikeKeyMaterial(file string) bool {
+	if strings.Contains(file, pemHeaderPrefix) {
+		return true
+	}
+	decoded, err := base64.RawStdEncoding.DecodeString(strings.TrimRight(file, "="))
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(decoded), pemHeaderPrefix) || looksLikeDER(decoded)
+}
+
+// looksLikeDER reports whether b opens with an ASN.1 SEQUENCE — tag 0x30,
+// which PKCS#8, SEC1, PKCS#12 and X.509 all start with — whose declared length
+// matches the payload. A bare 0x30 first byte is not enough: short
+// base64-alphabet paths such as "MAIN" decode to three bytes starting 0x30.
+// Canonical-length encoding is deliberately not enforced: this is a guard, so a
+// false negative echoes key material while a false positive only rejects a path.
+func looksLikeDER(b []byte) bool {
+	if len(b) < minDERKeyBytes || b[0] != 0x30 {
+		return false
+	}
+	n := int(b[1])
+	if n < 0x80 {
+		return 2+n == len(b)
+	}
+	count := n & 0x7f
+	if count == 0 || count > 4 || len(b) < 2+count {
+		return false
+	}
+	length := 0
+	for _, c := range b[2 : 2+count] {
+		length = length<<8 | int(c)
+		// Bail before the shift can overflow int on a 32-bit build: a declared
+		// length past the payload can only grow, and an overflow would wrap to a
+		// false negative — the direction that echoes key material.
+		if length > len(b) {
+			return false
+		}
+	}
+	return 2+count+length == len(b)
+}
+
+// SafeRef renders an operator-supplied config value for an error message,
+// eliding anything too long to be a plausible path.
+// The bound applies to the %q-rendered form, not the raw value: escaping can
+// expand a value well past MaxPathEcho, and the rendered form is what reaches
+// the log.
+func SafeRef(value string) string {
+	quoted := fmt.Sprintf("%q", value)
+	if len(quoted) > MaxPathEcho {
+		return fmt.Sprintf("<%d-char value elided>", len(value))
+	}
+	return quoted
+}
+
+// ReadError shapes the error from a failed read of an operator-named file so a
+// mis-filed value cannot reach a startup log: SafeRef bounds what is quoted and
+// errno drops the *os.PathError that would otherwise re-echo it in full. The
+// message has no package prefix; callers wrap it with their own (e.g.
+// fmt.Errorf("keystore: key %q: %w", name, err)). errors.Is still matches
+// fs.ErrNotExist and friends through the wrap.
+func ReadError(path string, err error) error {
+	return fmt.Errorf("read file %s: %w", SafeRef(path), errno(err))
+}
+
+// errno strips the *os.PathError wrapper, which carries its own copy of the
+// path and would re-echo a value SafeRef elided. errors.Is is unaffected:
+// the bare errno still matches fs.ErrNotExist and friends.
+func errno(err error) error {
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		return pathErr.Err
+	}
+	return err
+}

--- a/internal/secretfile/secretfile_test.go
+++ b/internal/secretfile/secretfile_test.go
@@ -1,0 +1,197 @@
+package secretfile
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ed25519KeyPEM returns a PKCS#8 Ed25519 key: the compact shape whose DER is
+// short enough to slip MaxPathEcho and whose PEM length is not a multiple of 3.
+func ed25519KeyPEM(t *testing.T) []byte {
+	t.Helper()
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}
+
+func TestLooksLikeKeyMaterialDetection(t *testing.T) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	privDER, err := x509.MarshalPKCS8PrivateKey(privKey)
+	require.NoError(t, err)
+	pubDER, err := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
+	require.NoError(t, err)
+	rawPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privDER})
+
+	edPEM := ed25519KeyPEM(t)
+	unpadded := base64.RawStdEncoding.EncodeToString(edPEM)
+	require.NotEqual(t, base64.StdEncoding.EncodeToString(edPEM), unpadded,
+		"this case is vacuous unless the two encodings actually differ")
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "raw_pem_body", value: string(rawPEM), want: true},
+		{name: "base64_pem_padded", value: base64.StdEncoding.EncodeToString(rawPEM), want: true},
+		{name: "base64_pem_unpadded_ed25519", value: unpadded, want: true},
+		{name: "base64_pkcs8_der", value: base64.StdEncoding.EncodeToString(privDER), want: true},
+		{name: "base64_pkix_public_der", value: base64.StdEncoding.EncodeToString(pubDER), want: true},
+
+		// The nine-path false-positive fence — must not be trimmed.
+		// Sibling TestLooksLikeKeyMaterialDetectsKeysNotPaths fences a different
+		// class (base64-alphabet paths); extend both or neither.
+		{name: "path_etc_keys_private_der", value: "/etc/keys/private.der", want: false},
+		{name: "path_keys_pub_der", value: "keys/pub.der", want: false},
+		{name: "path_dot_testdata_key_der", value: "./testdata/key.der", want: false},
+		{name: "path_windows_style", value: `C:\keys\private.der`, want: false},
+		{name: "path_run_secrets_signing_key", value: "/run/secrets/signing-key", want: false},
+		{name: "path_bare_privatekey", value: "privatekey", want: false},
+		{name: "path_bare_testdata", value: "testdata", want: false},
+		{name: "path_bare_keys", value: "keys", want: false},
+		{name: "path_serviceaccount_token", value: "/var/run/secrets/kubernetes.io/serviceaccount/token", want: false},
+
+		// Documented residual: raw symmetric secrets have no ASN.1 structure and
+		// cannot be sniffed. Pinned so a future change that starts catching this
+		// is a visible, deliberate decision.
+		{name: "raw_hmac_shaped_secret", value: base64.StdEncoding.EncodeToString([]byte("an-explicitly-32-byte-mac-key!!!")), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, LooksLikeKeyMaterial(tt.value))
+		})
+	}
+}
+
+func TestSafeRefEliding(t *testing.T) {
+	t.Run("short_value_is_quoted", func(t *testing.T) {
+		got := SafeRef("/etc/keys/private.der")
+		assert.Equal(t, `"/etc/keys/private.der"`, got)
+	})
+
+	t.Run("over_long_value_is_elided", func(t *testing.T) {
+		secret := strings.Repeat("s3cr3t", 100)
+		got := SafeRef(secret)
+		assert.Contains(t, got, "char value elided")
+		assert.NotContains(t, got, secret)
+	})
+}
+
+func TestErrnoStripsPathError(t *testing.T) {
+	t.Run("path_error_is_stripped", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "absent.pem")
+		_, err := os.ReadFile(missing)
+		require.Error(t, err)
+
+		stripped := errno(err)
+		assert.NotContains(t, stripped.Error(), missing)
+		assert.ErrorIs(t, stripped, fs.ErrNotExist)
+	})
+
+	t.Run("non_path_error_passes_through_unchanged", func(t *testing.T) {
+		plain := errors.New("plain error, not a PathError")
+		assert.Same(t, plain, errno(plain))
+	})
+}
+
+func TestReadErrorDoesNotEchoOverLongValues(t *testing.T) {
+	t.Run("over_long_value_is_not_echoed", func(t *testing.T) {
+		v := strings.Repeat("s3cr3t", 100)
+		require.Greater(t, len(v), MaxPathEcho, "the point of this case is that eliding cannot save us otherwise")
+
+		_, readErr := os.ReadFile(v)
+		require.Error(t, readErr)
+
+		err := ReadError(v, readErr)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), v)
+		assert.Contains(t, err.Error(), "char value elided")
+		assert.Contains(t, err.Error(), "read file")
+	})
+
+	t.Run("short_missing_path_is_quoted", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "absent.pem")
+
+		_, readErr := os.ReadFile(path)
+		require.Error(t, readErr)
+
+		err := ReadError(path, readErr)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read file")
+		assert.Contains(t, err.Error(), fmt.Sprintf("%q", path))
+		assert.True(t, errors.Is(err, fs.ErrNotExist))
+	})
+}
+
+// Pins both directions of the detector: real key material in every encoding it
+// must catch, and ordinary paths — including the base64-alphabet ones that used
+// to trip the bare 0x30-tag check — that it must let through.
+func TestLooksLikeKeyMaterialDetectsKeysNotPaths(t *testing.T) {
+	_, edKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	edPKCS8, err := x509.MarshalPKCS8PrivateKey(edKey)
+	require.NoError(t, err)
+	edPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: edPKCS8})
+
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	ecSEC1, err := x509.MarshalECPrivateKey(ecKey)
+	require.NoError(t, err)
+	ecPKCS8, err := x509.MarshalPKCS8PrivateKey(ecKey)
+	require.NoError(t, err)
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	rsaPKCS1 := x509.MarshalPKCS1PrivateKey(rsaKey)
+	rsaPKCS8, err := x509.MarshalPKCS8PrivateKey(rsaKey)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "ed25519_pkcs8", value: base64.StdEncoding.EncodeToString(edPKCS8), want: true},
+		{name: "ecdsa_p256_sec1", value: base64.StdEncoding.EncodeToString(ecSEC1), want: true},
+		{name: "ecdsa_p256_pkcs8", value: base64.StdEncoding.EncodeToString(ecPKCS8), want: true},
+		{name: "rsa2048_pkcs1", value: base64.StdEncoding.EncodeToString(rsaPKCS1), want: true},
+		{name: "rsa2048_pkcs8", value: base64.StdEncoding.EncodeToString(rsaPKCS8), want: true},
+		{name: "raw_pem_body", value: string(edPEM), want: true},
+		{name: "path_main", value: "MAIN", want: false},
+		{name: "path_mdkeys", value: "MDkeys", want: false},
+		{name: "path_mikeys", value: "MIkeys", want: false},
+		{name: "path_misckey", value: "MIsckey", want: false},
+		{name: "path_mfkeys", value: "MFkeys", want: false},
+		{name: "path_mockkeys", value: "MOCKkeys", want: false},
+		{name: "path_certs", value: "certs", want: false},
+		{name: "path_mycert", value: "MyCert", want: false},
+		{name: "path_tls_server_pem", value: "tls/server.pem", want: false},
+		{name: "path_absolute_cert_pem", value: "/etc/ssl/cert.pem", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, LooksLikeKeyMaterial(tt.value))
+		})
+	}
+}

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -62,6 +62,7 @@ import (
 	"os"
 
 	"github.com/gaborage/go-bricks/config"
+	"github.com/gaborage/go-bricks/internal/secretfile"
 )
 
 // errKeyNotFoundFmt is the fmt.Errorf format used by every accessor when a
@@ -204,9 +205,15 @@ func loadKeyBytes(src config.KeySourceConfig, keyName, keyType string) ([]byte, 
 	}
 
 	if hasFile {
+		if secretfile.LooksLikeKeyMaterial(src.File) {
+			return nil, fmt.Errorf("keystore: key %q %s: file looks like key material, not a path (use the value field for inline material)", keyName, keyType)
+		}
+		// #nosec G304 -- the path is deployment configuration, not request input:
+		// reading an operator-named file IS this function. Inline material is
+		// rejected above.
 		data, err := os.ReadFile(src.File)
 		if err != nil {
-			return nil, fmt.Errorf("keystore: key %q %s: read file %q: %w", keyName, keyType, src.File, err)
+			return nil, fmt.Errorf("keystore: key %q %s: %w", keyName, keyType, secretfile.ReadError(src.File, err))
 		}
 		return data, nil
 	}

--- a/keystore/keystore_test.go
+++ b/keystore/keystore_test.go
@@ -5,11 +5,16 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gaborage/go-bricks/config"
+	"github.com/gaborage/go-bricks/internal/secretfile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -285,6 +290,76 @@ func TestLoadKeyBytesNeitherSet(t *testing.T) {
 	data, err := loadKeyBytes(config.KeySourceConfig{}, "test", "public")
 	require.NoError(t, err)
 	assert.Nil(t, data)
+}
+
+func TestLoadKeyBytesRejectsMaterialInFileField(t *testing.T) {
+	privKey, pubKey := generateTestKeys(t)
+
+	materialTests := []struct {
+		name    string
+		keyType string
+		encoded string
+	}{
+		{
+			name:    "base64_pkcs8_rsa_private_der_in_file",
+			keyType: "private",
+			encoded: base64.StdEncoding.EncodeToString(marshalPrivateKeyDER(t, privKey)),
+		},
+		{
+			name:    "base64_pkix_rsa_public_der_in_file",
+			keyType: "public",
+			encoded: base64.StdEncoding.EncodeToString(marshalPublicKeyDER(t, pubKey)),
+		},
+	}
+
+	for _, tt := range materialTests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := loadKeyBytes(config.KeySourceConfig{File: tt.encoded}, "test", tt.keyType)
+			require.Error(t, err)
+			assert.Nil(t, data)
+			assert.ErrorContains(t, err, "looks like key material")
+			assert.NotContains(t, err.Error(), tt.encoded, "the error must not echo the key material")
+		})
+	}
+
+	t.Run("legitimate_path_still_loads", func(t *testing.T) {
+		dir := t.TempDir()
+		expected := []byte("test-der-content")
+		path := writeDERFile(t, dir, "test.der", expected)
+
+		data, err := loadKeyBytes(config.KeySourceConfig{File: path}, "test", "public")
+		require.NoError(t, err)
+		assert.Equal(t, expected, data)
+	})
+
+	t.Run("missing_plausible_path", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "absent.der")
+
+		data, err := loadKeyBytes(config.KeySourceConfig{File: missing}, "test", "public")
+		require.Error(t, err)
+		assert.Nil(t, data)
+		assert.ErrorContains(t, err, "read file")
+		// %q-quoted, so on Windows the separators arrive escaped — comparing
+		// against the raw path fails there for a reason unrelated to the code.
+		assert.Contains(t, err.Error(), fmt.Sprintf("%q", missing))
+		assert.True(t, errors.Is(err, fs.ErrNotExist), "Errno must not break errors.Is matching")
+	})
+
+	// The quadrant SafeRef alone cannot cover: an over-long value that is not key
+	// material (so it reaches os.ReadFile) and fails to read. SafeRef elides it in
+	// its own %s slot, but the raw *os.PathError also carries the full value in its
+	// own Error() string — without Errno stripping that wrapper, %w re-embeds it in
+	// full and defeats the elision.
+	t.Run("over_long_value_read_failure_is_not_echoed", func(t *testing.T) {
+		junk := strings.Repeat("s3cr3t", 100)
+		require.Greater(t, len(junk), secretfile.MaxPathEcho, "the point of this case is that eliding cannot save us otherwise")
+
+		data, err := loadKeyBytes(config.KeySourceConfig{File: junk}, "test", "public")
+		require.Error(t, err)
+		assert.Nil(t, data)
+		assert.NotContains(t, err.Error(), junk, "an over-long value must not be echoed")
+		assert.Contains(t, err.Error(), "char value elided")
+	})
 }
 
 // =============================================================================


### PR DESCRIPTION
## What

`keystore.loadKeyBytes` echoed the operator's file value **twice** on a failed
read — once via `%q`, again inside the wrapped `*os.PathError`, which prints its
own `Path`. `KeySourceConfig` has sibling `File`/`Value` fields where `Value`
holds base64 DER, so filling the wrong one put RSA key material in a fatal
startup log, which `SensitiveDataFilter` cannot mask (it matches field names, not
error strings). The three guards `httpclient` already had for this move to
`internal/secretfile` and now cover both consumers.

## Impact

None for valid configuration; no public API changes (`internal/**` is invisible
to consumers and apidiff). A mis-filed key is now rejected before the read with
an actionable message. One documented residual survives — raw symmetric secrets
have no ASN.1 structure, so a mis-filed HMAC key is still echoed once; the commit
body records a narrower fix that was deliberately deferred as an operator's call.

## Verification

Both guards mutation-checked: dropping the `LooksLikeKeyMaterial` call fails the
two material-in-`File` cases, and dropping `errno` from `ReadError` fails an
over-long-value case in **both** packages. `keystore/module_test.go` is
byte-unchanged — it asserts the `read file` substring and is the canary that the
error text stayed compatible. `LINT_CLEAN=1 make check` green locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS and keystore configuration errors when key material is mistakenly entered as a file path.
  * Prevented sensitive or excessively long key values and file paths from being exposed in error messages.
  * Preserved useful file-read error details, including missing-file detection, while safely limiting echoed input.

* **Tests**
  * Added coverage for PEM, Base64, and DER key formats, path handling, error redaction, and missing-file scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->