### PR TITLE
fix(httpclient): warn when filling the base slot discards its holder

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -59,13 +59,28 @@ func NewClient(log logger.Logger) Client {
 	return NewBuilder(log).Build()
 }
 
+// baseSource identifies which option last filled the single base-transport slot.
+type baseSource uint8
+
+const (
+	baseNone baseSource = iota
+	baseTransport
+	baseTLS
+)
+
 // Builder provides a fluent interface for configuring the REST client
 type Builder struct {
 	config     *Config
 	logger     logger.Logger
 	httpClient *nethttp.Client
-	transport  nethttp.RoundTripper
+	transport  nethttp.RoundTripper // written only via fillBaseSlot, which maintains baseSlot/displacedBase
 	chain      *transportChain
+	// baseSlot records which option currently holds the base-transport slot;
+	// displacedBase the option whose material a later call overwrote and never
+	// restored. Build warns for the displaced one — last-call-wins is intended,
+	// silently losing a client certificate or a caller's RoundTripper is not.
+	baseSlot      baseSource
+	displacedBase baseSource
 }
 
 // transportLayer orders RoundTripper wrappers independently of the order the
@@ -242,11 +257,35 @@ func (b *Builder) WithHTTPClient(client *nethttp.Client) *Builder {
 	return b
 }
 
+// fillBaseSlot records that actor is taking the single base-transport slot. A
+// different incumbent loses its material; a source retaking the slot clears its
+// own earlier loss. A nil rt vacates the slot without counting as a displacement
+// — an option un-setting its own material is not a collision.
+func (b *Builder) fillBaseSlot(rt nethttp.RoundTripper, actor baseSource) {
+	if b.baseSlot != baseNone && b.baseSlot != actor {
+		b.displacedBase = b.baseSlot
+	}
+	// Only reachable when the slot was vacated: a source reloading into an empty
+	// slot must clear its own earlier loss, or Build reports material that is
+	// back in place.
+	if b.displacedBase == actor {
+		b.displacedBase = baseNone
+	}
+	b.transport = rt
+	if rt == nil {
+		b.baseSlot = baseNone
+		return
+	}
+	b.baseSlot = actor
+}
+
 // WithTransport sets a custom RoundTripper while still letting the builder manage other client settings.
 // It supplies the innermost transport: wrappers registered by other options (WithJOSE, for
-// example) are layered above it at Build time regardless of call order.
+// example) are layered above it at Build time regardless of call order. Passing nil vacates
+// the base-transport slot; if WithTLSConfig had filled it, Build warns that the loaded TLS
+// material is discarded.
 func (b *Builder) WithTransport(transport nethttp.RoundTripper) *Builder {
-	b.transport = transport
+	b.fillBaseSlot(transport, baseTransport)
 	return b
 }
 
@@ -270,13 +309,14 @@ type JOSEConfig struct {
 // the counterparty does not return JOSE-wrapped responses.
 //
 // Composition: transport layers are applied at Build time in a fixed order —
-// the base transport from WithTransport is innermost, request signers next, and
-// body transforms such as JOSE outermost — so the result does not depend on the
-// order these options were called. A Transport configured directly on the
-// *http.Client passed to WithHTTPClient is REPLACED, not wrapped: the chain then has
-// no base and dials via nethttp.DefaultTransport, losing client certificates, pinned
-// roots and proxy settings (Build logs a WARN). Always pass a base RoundTripper to
-// WithTransport.
+// the base transport from WithTransport or WithTLSConfig is innermost, request
+// signers next, and body transforms such as JOSE outermost — so the result does
+// not depend on the order these options were called. A Transport configured
+// directly on the *http.Client passed to WithHTTPClient is REPLACED, not
+// wrapped: the chain then has no base and dials via nethttp.DefaultTransport,
+// losing client certificates, pinned roots and proxy settings (Build logs a
+// WARN). Always fill the base slot — with WithTransport, or with WithTLSConfig
+// when the base is a TLS config.
 //
 // Per-attempt freshness: because httpclient retries by re-running the request build
 // loop, each retry produces a freshly-sealed payload — useful for protocols that
@@ -346,14 +386,25 @@ func (b *Builder) resolveTransport() nethttp.RoundTripper {
 	return rt
 }
 
-// discardsClientTransport reports the one composition that silently downgrades TLS:
-// a registered wrapper with no WithTransport base replaces the WithHTTPClient
-// client's own Transport, so requests dial via nethttp.DefaultTransport. Build only
-// warns — it has no error return, and failing closed here is tracked with the mTLS
-// work.
+// discardsClientTransport reports one of the three compositions that silently
+// drop the previous occupant of the base-transport slot: a registered wrapper
+// with no WithTransport base replaces the WithHTTPClient client's own
+// Transport, so requests dial via nethttp.DefaultTransport. See
+// discardsTLSConfig and discardsProvidedTransport for the others. Build only
+// warns — it has no error return.
 func (b *Builder) discardsClientTransport() bool {
 	return b.transport == nil && b.chain != nil && b.httpClient != nil && b.httpClient.Transport != nil
 }
+
+// discardsTLSConfig reports that WithTLSConfig loaded a client certificate and
+// pinned roots into the base slot and a later WithTransport took it over.
+func (b *Builder) discardsTLSConfig() bool { return b.displacedBase == baseTLS }
+
+// discardsProvidedTransport reports the mirror case: WithTransport supplied the
+// base RoundTripper and a later WithTLSConfig replaced it with a fresh base, a
+// clone of nethttp.DefaultTransport or an equivalently-configured transport
+// when that global has been replaced.
+func (b *Builder) discardsProvidedTransport() bool { return b.displacedBase == baseTransport }
 
 // WithRequestInterceptor adds a request interceptor
 func (b *Builder) WithRequestInterceptor(interceptor RequestInterceptor) *Builder {
@@ -389,6 +440,25 @@ func (b *Builder) Build() Client {
 			c.Timeout = cfg.Timeout
 		}
 		httpClient = &c
+	}
+
+	if b.discardsTLSConfig() {
+		b.logger.Warn().Msg("httpclient: WithTransport was called after WithTLSConfig — " +
+			"both fill the same base-transport slot and the last call wins, so the *tls.Config " +
+			"installed by WithTLSConfig is discarded with whatever it carried (client certificate, " +
+			"pinned roots, version floor), and TLS now depends entirely on the RoundTripper passed " +
+			"to WithTransport; set TLSClientConfig on that transport yourself, or drop the " +
+			"WithTransport call if WithTLSConfig alone is enough")
+	}
+
+	if b.discardsProvidedTransport() {
+		b.logger.Warn().Msg("httpclient: WithTLSConfig was called after WithTransport — " +
+			"both fill the same base-transport slot and the last call wins, so the RoundTripper " +
+			"passed to WithTransport is discarded along with any proxy, dialer or TLS settings it " +
+			"carried; WithTLSConfig replaces it with a fresh base, a clone of net/http.DefaultTransport " +
+			"or an equivalently-configured transport when that global has been replaced. Fold TLS " +
+			"settings into the *tls.Config; to keep proxy or dialer settings, drop WithTLSConfig and " +
+			"set TLSClientConfig on your own transport instead")
 	}
 
 	if rt := b.resolveTransport(); rt != nil {

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -259,8 +259,9 @@ func (b *Builder) WithHTTPClient(client *nethttp.Client) *Builder {
 
 // fillBaseSlot records that actor is taking the single base-transport slot. A
 // different incumbent loses its material; a source retaking the slot clears its
-// own earlier loss. A nil rt vacates the slot without counting as a displacement
-// — an option un-setting its own material is not a collision.
+// own earlier loss. A nil rt vacates the slot rather than claiming it: un-setting
+// your own material is not a collision, but a nil call that evicts the other
+// option's material still records the displacement — the material is gone either way.
 func (b *Builder) fillBaseSlot(rt nethttp.RoundTripper, actor baseSource) {
 	if b.baseSlot != baseNone && b.baseSlot != actor {
 		b.displacedBase = b.baseSlot

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -2078,32 +2078,190 @@ func TestBuilderTransportChainDiscardsClientTransport(t *testing.T) {
 	t.Run("hazard_emits_the_warning", func(t *testing.T) {
 		spy := &warnSpy{}
 		NewBuilder(spy).WithHTTPClient(withClient()).WithJOSE(JOSEConfig{}).Build()
-		assert.Contains(t, spy.msg, "net/http.DefaultTransport")
+		assert.Contains(t, spy.joined(), "net/http.DefaultTransport")
 	})
 
 	t.Run("explicit_base_emits_no_warning", func(t *testing.T) {
 		spy := &warnSpy{}
 		NewBuilder(spy).WithHTTPClient(withClient()).WithTransport(base).WithJOSE(JOSEConfig{}).Build()
-		assert.Empty(t, spy.msg)
+		assert.Empty(t, spy.msgs)
 	})
 }
 
-// warnSpy captures the message Build passes to Warn().Msg. Embedding the interfaces
+// warnSpy captures every message Build passes to Warn().Msg. Embedding the interfaces
 // keeps the double to the two methods Build actually calls; any other method would
 // nil-panic, which is the intent.
 type warnSpy struct {
 	logger.Logger
-	msg string
+	msgs []string
 }
 
 func (s *warnSpy) Warn() logger.LogEvent { return &warnSpyEvent{spy: s} }
+
+// joined flattens all recorded warnings for substring assertions.
+func (s *warnSpy) joined() string { return strings.Join(s.msgs, "\n") }
 
 type warnSpyEvent struct {
 	logger.LogEvent
 	spy *warnSpy
 }
 
-func (e *warnSpyEvent) Msg(msg string) { e.spy.msg = msg }
+func (e *warnSpyEvent) Msg(msg string) { e.spy.msgs = append(e.spy.msgs, msg) }
+
+func TestBuilderBaseSlotDiscards(t *testing.T) {
+	log := createTestLogger()
+	stub := &stubRoundTripper{name: "stub"}
+	caPEM, _, _ := newTestCA(t, "discards-tls-config-ca")
+	newCfg := func() *tls.Config {
+		cfg, err := NewClientTLSConfig(&ClientTLSConfig{CAValue: b64PEM(caPEM)})
+		require.NoError(t, err)
+		return cfg
+	}
+
+	cases := []struct {
+		name          string
+		wantTLS       bool
+		wantTransport bool
+		builder       func() *Builder
+	}{
+		{
+			name:          "tls_then_transport_discards_tls",
+			wantTLS:       true,
+			wantTransport: false,
+			builder:       func() *Builder { return NewBuilder(log).WithTLSConfig(newCfg()).WithTransport(stub) },
+		},
+		{
+			name:          "transport_then_tls_discards_transport",
+			wantTLS:       false,
+			wantTransport: true,
+			builder:       func() *Builder { return NewBuilder(log).WithTransport(stub).WithTLSConfig(newCfg()) },
+		},
+		{
+			name:          "tls_only_discards_nothing",
+			wantTLS:       false,
+			wantTransport: false,
+			builder:       func() *Builder { return NewBuilder(log).WithTLSConfig(newCfg()) },
+		},
+		{
+			name:          "transport_only_discards_nothing",
+			wantTLS:       false,
+			wantTransport: false,
+			builder:       func() *Builder { return NewBuilder(log).WithTransport(stub) },
+		},
+		{
+			name:          "tls_retaken_clears_tls_but_discards_transport",
+			wantTLS:       false,
+			wantTransport: true,
+			builder: func() *Builder {
+				return NewBuilder(log).WithTLSConfig(newCfg()).WithTransport(stub).WithTLSConfig(newCfg())
+			},
+		},
+		{
+			name:          "transport_retaken_clears_transport_but_discards_tls",
+			wantTLS:       true,
+			wantTransport: false,
+			builder: func() *Builder {
+				return NewBuilder(log).WithTransport(stub).WithTLSConfig(newCfg()).WithTransport(stub)
+			},
+		},
+		{
+			name:          "repeated_transport_discards_nothing",
+			wantTLS:       false,
+			wantTransport: false,
+			builder:       func() *Builder { return NewBuilder(log).WithTransport(stub).WithTransport(stub) },
+		},
+		{
+			name:          "repeated_tls_discards_nothing",
+			wantTLS:       false,
+			wantTransport: false,
+			builder:       func() *Builder { return NewBuilder(log).WithTLSConfig(newCfg()).WithTLSConfig(newCfg()) },
+		},
+		{
+			name:          "nil_tls_config_is_inert",
+			wantTLS:       false,
+			wantTransport: false,
+			builder:       func() *Builder { return NewBuilder(log).WithTransport(stub).WithTLSConfig(nil) },
+		},
+		{
+			name:          "nil_transport_after_tls_still_discards_tls",
+			wantTLS:       true,
+			wantTransport: false,
+			builder:       func() *Builder { return NewBuilder(log).WithTLSConfig(newCfg()).WithTransport(nil) },
+		},
+		{
+			name:          "nil_transport_then_tls_discards_nothing",
+			wantTLS:       false,
+			wantTransport: false,
+			builder:       func() *Builder { return NewBuilder(log).WithTransport(nil).WithTLSConfig(newCfg()) },
+		},
+		{
+			name:          "transport_then_nil_transport_discards_nothing",
+			wantTLS:       false,
+			wantTransport: false,
+			builder:       func() *Builder { return NewBuilder(log).WithTransport(stub).WithTransport(nil) },
+		},
+		{
+			name:          "tls_vacated_then_transport_refill_still_discards_tls",
+			wantTLS:       true,
+			wantTransport: false,
+			builder: func() *Builder {
+				return NewBuilder(log).WithTLSConfig(newCfg()).WithTransport(nil).WithTransport(stub)
+			},
+		},
+		{
+			name:          "tls_reloaded_after_vacating_clears_the_loss",
+			wantTLS:       false,
+			wantTransport: false,
+			builder: func() *Builder {
+				return NewBuilder(log).WithTLSConfig(newCfg()).WithTransport(nil).WithTLSConfig(newCfg())
+			},
+		},
+		{
+			name:          "transport_reloaded_after_vacating_discards_nothing",
+			wantTLS:       false,
+			wantTransport: false,
+			builder: func() *Builder {
+				return NewBuilder(log).WithTransport(stub).WithTransport(nil).WithTransport(stub)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := tc.builder()
+			assert.Equal(t, tc.wantTLS, b.discardsTLSConfig())
+			assert.Equal(t, tc.wantTransport, b.discardsProvidedTransport())
+		})
+	}
+
+	t.Run("hazard_emits_the_warning", func(t *testing.T) {
+		spy := &warnSpy{}
+		NewBuilder(spy).WithTLSConfig(newCfg()).WithTransport(stub).Build()
+		assert.Contains(t, spy.joined(), "WithTransport was called after WithTLSConfig")
+	})
+
+	t.Run("mirror_hazard_emits_the_warning", func(t *testing.T) {
+		spy := &warnSpy{}
+		NewBuilder(spy).WithTransport(stub).WithTLSConfig(newCfg()).Build()
+		assert.Contains(t, spy.joined(), "WithTLSConfig was called after WithTransport")
+	})
+
+	t.Run("no_collision_emits_no_warning", func(t *testing.T) {
+		spy := &warnSpy{}
+		NewBuilder(spy).WithTLSConfig(newCfg()).Build()
+		assert.Empty(t, spy.msgs)
+	})
+
+	t.Run("both_hazards_emit_both_warnings", func(t *testing.T) {
+		spy := &warnSpy{}
+		withClient := func() *nethttp.Client { return &nethttp.Client{Transport: stub} }
+		NewBuilder(spy).WithTLSConfig(newCfg()).WithHTTPClient(withClient()).WithTransport(nil).WithJOSE(JOSEConfig{}).Build()
+		require.Len(t, spy.msgs, 2)
+		joined := spy.joined()
+		assert.Contains(t, joined, "WithTransport was called after WithTLSConfig")
+		assert.Contains(t, joined, "net/http.DefaultTransport")
+	})
+}
 
 // wrappingTransport stands in for a signer-layer wrapper; it exposes the
 // RoundTripper it wraps so tests can assert nesting depth.

--- a/httpclient/tls.go
+++ b/httpclient/tls.go
@@ -145,7 +145,7 @@ func (b *Builder) WithTLSConfig(tlsCfg *tls.Config) *Builder {
 	base.DialTLS = nil
 	base.DialTLSContext = nil
 	base.TLSClientConfig = tlsCfg.Clone()
-	b.transport = base
+	b.fillBaseSlot(base, baseTLS)
 	return b
 }
 

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -126,7 +126,11 @@ hand and pass it to `WithTLSConfig`.
 for `WithJOSE` and the `Build()` composition WARN. Its base is a clone of
 `http.DefaultTransport`, or an equivalently-configured transport (same proxy,
 HTTP/2 and pool settings) when that global has been replaced, so the pitfall above
-does not apply to it. Wrapper layers always stack on top of it:
+does not apply to it. `Build()` warns in both directions: calling
+`WithTransport` after `WithTLSConfig` discards the loaded client certificate and
+pinned roots, and calling `WithTLSConfig` after `WithTransport` discards the
+supplied `RoundTripper` along with any proxy, dialer or TLS settings it carried.
+Wrapper layers always stack on top of it:
 
 ```go
 // mTLS base, JOSE on top — call order is irrelevant.


### PR DESCRIPTION
## What

`WithTransport` and `WithTLSConfig` fill the same base-transport slot, last call wins, and whichever ran second silently discarded what the first installed — a client certificate and pinned roots in one direction, the caller's RoundTripper with its proxy/dialer settings in the other. `Build()` now warns in both directions, tracked by a single slot-provenance state machine that both options route through. Passing nil to `WithTransport` vacates the slot without counting as a displacement, so self-resets never report a phantom collision.

## Impact

None for existing callers: signal-only, no change to which transport wins. Deployments composing both options now get a WARN naming what was lost and how to keep it.

## Verification

Every mechanism mutation-checked: each deleted guard, the flag-conflation bug shape, and an `&&`→`||` operator flip fail exactly the pinning subtest. Local gates ran: /simplify (two rounds), /security-audit, CodeRabbit with zero findings on the final diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transport configuration handling when combining custom transports, TLS settings, HTTP clients, and JOSE wrappers.
  - Added clear build-time warnings when one configuration replaces another, including cases that may discard TLS, proxy, dialer, or client-certificate settings.
  - Preserved warnings when wrapper layers are configured without a base transport.

- **Documentation**
  - Clarified transport composition, replacement behavior, TLS configuration precedence, and wrapper layering.
  - Documented how mutual TLS settings interact with custom transports and HTTP clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->