### PR TITLE
test: property-based suites for query builder, config, jose, and resolvers

### DIFF
--- a/config/config_properties_test.go
+++ b/config/config_properties_test.go
@@ -9,11 +9,17 @@ import (
 	"pgregory.net/rapid"
 )
 
+var (
+	printableGen  = rapid.StringMatching(`[!-~]{1,64}`)
+	sliceElemsGen = rapid.SliceOfN(rapid.StringMatching(`[a-z]{1,8}`), 1, 5)
+	yamlValGen    = rapid.StringMatching(`[a-zA-Z0-9]{1,32}`)
+)
+
 func TestInjectIntoEnvStringRoundTripProperty(t *testing.T) {
 	clearEnvironmentVariables()
 	defer clearEnvironmentVariables()
 	rapid.Check(t, func(rt *rapid.T) {
-		val := rapid.StringMatching(`[!-~]{1,64}`).Draw(rt, "val") // printable ASCII, no spaces
+		val := printableGen.Draw(rt, "val") // printable ASCII, no spaces
 		os.Setenv("CUSTOM_PROP_VALUE", val)
 		defer os.Unsetenv("CUSTOM_PROP_VALUE")
 
@@ -81,7 +87,7 @@ func TestInjectIntoStringSliceRoundTripProperty(t *testing.T) {
 	clearEnvironmentVariables()
 	defer clearEnvironmentVariables()
 	rapid.Check(t, func(rt *rapid.T) {
-		elems := rapid.SliceOfN(rapid.StringMatching(`[a-z]{1,8}`), 1, 5).Draw(rt, "elems")
+		elems := sliceElemsGen.Draw(rt, "elems")
 		os.Setenv("CUSTOM_PROP_TAGS", strings.Join(elems, ","))
 		defer os.Unsetenv("CUSTOM_PROP_TAGS")
 
@@ -144,8 +150,8 @@ func TestInjectIntoEnvBeatsYamlProperty(t *testing.T) {
 	clearEnvironmentVariables()
 	defer clearEnvironmentVariables()
 	rapid.Check(t, func(rt *rapid.T) {
-		yamlVal := rapid.StringMatching(`[a-zA-Z0-9]{1,32}`).Draw(rt, "yamlVal")
-		envVal := rapid.StringMatching(`[!-~]{1,64}`).Draw(rt, "envVal")
+		yamlVal := yamlValGen.Draw(rt, "yamlVal")
+		envVal := printableGen.Draw(rt, "envVal")
 		if yamlVal == envVal {
 			return // degenerate draw: no observable precedence signal
 		}

--- a/config/config_properties_test.go
+++ b/config/config_properties_test.go
@@ -1,0 +1,177 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"pgregory.net/rapid"
+)
+
+func TestInjectIntoEnvStringRoundTripProperty(t *testing.T) {
+	clearEnvironmentVariables()
+	defer clearEnvironmentVariables()
+	rapid.Check(t, func(rt *rapid.T) {
+		val := rapid.StringMatching(`[!-~]{1,64}`).Draw(rt, "val") // printable ASCII, no spaces
+		os.Setenv("CUSTOM_PROP_VALUE", val)
+		defer os.Unsetenv("CUSTOM_PROP_VALUE")
+
+		cfg, err := Load()
+		if err != nil {
+			rt.Fatalf("Load: %v", err)
+		}
+		var svc struct {
+			Value string `config:"custom.prop.value" default:"fallback"`
+		}
+		if err := cfg.InjectInto(&svc); err != nil {
+			rt.Fatalf("InjectInto: %v", err)
+		}
+		if svc.Value != val {
+			rt.Fatalf("env round-trip: got %q want %q", svc.Value, val)
+		}
+	})
+}
+
+// Plain regression test, not a property: struct tags are compile-time, so
+// there is nothing meaningful to draw.
+func TestInjectIntoDefaultAppliesWhenEnvAbsent(t *testing.T) {
+	clearEnvironmentVariables()
+	defer clearEnvironmentVariables()
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	var svc struct {
+		Value string `config:"custom.prop.value" default:"placeholder"`
+	}
+	if err := cfg.InjectInto(&svc); err != nil {
+		t.Fatalf("InjectInto: %v", err)
+	}
+	if svc.Value != "placeholder" {
+		t.Fatalf("default not applied: got %q", svc.Value)
+	}
+}
+
+func TestInjectIntoDurationRoundTripProperty(t *testing.T) {
+	clearEnvironmentVariables()
+	defer clearEnvironmentVariables()
+	rapid.Check(t, func(rt *rapid.T) {
+		d := time.Duration(rapid.Int64Range(1, int64(time.Hour)).Draw(rt, "dur"))
+		os.Setenv("CUSTOM_PROP_TIMEOUT", d.String())
+		defer os.Unsetenv("CUSTOM_PROP_TIMEOUT")
+
+		cfg, err := Load()
+		if err != nil {
+			rt.Fatalf("Load: %v", err)
+		}
+		var svc struct {
+			Timeout time.Duration `config:"custom.prop.timeout"`
+		}
+		if err := cfg.InjectInto(&svc); err != nil {
+			rt.Fatalf("InjectInto: %v", err)
+		}
+		if svc.Timeout != d {
+			rt.Fatalf("duration round-trip: got %v want %v", svc.Timeout, d)
+		}
+	})
+}
+
+func TestInjectIntoStringSliceRoundTripProperty(t *testing.T) {
+	clearEnvironmentVariables()
+	defer clearEnvironmentVariables()
+	rapid.Check(t, func(rt *rapid.T) {
+		elems := rapid.SliceOfN(rapid.StringMatching(`[a-z]{1,8}`), 1, 5).Draw(rt, "elems")
+		os.Setenv("CUSTOM_PROP_TAGS", strings.Join(elems, ","))
+		defer os.Unsetenv("CUSTOM_PROP_TAGS")
+
+		cfg, err := Load()
+		if err != nil {
+			rt.Fatalf("Load: %v", err)
+		}
+		var svc struct {
+			Tags []string `config:"custom.prop.tags"`
+		}
+		if err := cfg.InjectInto(&svc); err != nil {
+			rt.Fatalf("InjectInto: %v", err)
+		}
+		if len(svc.Tags) != len(elems) {
+			rt.Fatalf("slice round-trip: got %v want %v", svc.Tags, elems)
+		}
+		for i := range elems {
+			if svc.Tags[i] != elems[i] {
+				rt.Fatalf("slice round-trip: got %v want %v", svc.Tags, elems)
+			}
+		}
+	})
+}
+
+// TestInjectIntoNeverPanicsOnArbitraryValuesProperty guards the Load/InjectInto
+// path against arbitrary environment input, including the control characters,
+// unpaired-looking runes, and BOM/RTL-override code points rapid's default
+// string generator deliberately seeds. A koanf/mapstructure decode error is
+// acceptable behavior; a panic is the only failure this property looks for
+// (rapid surfaces panics as test failures on its own, so nothing about the
+// resulting value is asserted here).
+func TestInjectIntoNeverPanicsOnArbitraryValuesProperty(t *testing.T) {
+	clearEnvironmentVariables()
+	defer clearEnvironmentVariables()
+	rapid.Check(t, func(rt *rapid.T) {
+		val := rapid.String().Draw(rt, "val")
+		if strings.ContainsRune(val, 0) {
+			return // os.Setenv rejects embedded NUL bytes; nothing to exercise
+		}
+		os.Setenv("CUSTOM_PROP_VALUE", val)
+		defer os.Unsetenv("CUSTOM_PROP_VALUE")
+
+		cfg, err := Load()
+		if err != nil {
+			return // a koanf/validation error on wild input is acceptable
+		}
+		var svc struct {
+			Value string `config:"custom.prop.value"`
+		}
+		_ = cfg.InjectInto(&svc) // error acceptable; a panic is the failure
+	})
+}
+
+// TestInjectIntoEnvBeatsYamlProperty pins the precedence Load's doc comment
+// promises (env > yaml > defaults) for an arbitrary service-specific key: a
+// yaml-set value must always lose to a differing env-set value at the same
+// path. Uses the same t.TempDir+t.Chdir seam as TestLoadAppEnvSelectsEnvironmentOverlay
+// (config_test.go), one fresh directory per rapid iteration.
+func TestInjectIntoEnvBeatsYamlProperty(t *testing.T) {
+	clearEnvironmentVariables()
+	defer clearEnvironmentVariables()
+	rapid.Check(t, func(rt *rapid.T) {
+		yamlVal := rapid.StringMatching(`[a-zA-Z0-9]{1,32}`).Draw(rt, "yamlVal")
+		envVal := rapid.StringMatching(`[!-~]{1,64}`).Draw(rt, "envVal")
+		if yamlVal == envVal {
+			return // degenerate draw: no observable precedence signal
+		}
+
+		dir := t.TempDir()
+		t.Chdir(dir)
+		yamlContent := "custom:\n  prop:\n    value: \"" + yamlVal + "\"\n"
+		if err := os.WriteFile("config.yaml", []byte(yamlContent), 0o600); err != nil {
+			rt.Fatalf("write config.yaml: %v", err)
+		}
+
+		os.Setenv("CUSTOM_PROP_VALUE", envVal)
+		defer os.Unsetenv("CUSTOM_PROP_VALUE")
+
+		cfg, err := Load()
+		if err != nil {
+			rt.Fatalf("Load: %v", err)
+		}
+		var svc struct {
+			Value string `config:"custom.prop.value"`
+		}
+		if err := cfg.InjectInto(&svc); err != nil {
+			rt.Fatalf("InjectInto: %v", err)
+		}
+		if svc.Value != envVal {
+			rt.Fatalf("env-beats-yaml: got %q want %q (yaml value was %q)", svc.Value, envVal, yamlVal)
+		}
+	})
+}

--- a/config/config_properties_test.go
+++ b/config/config_properties_test.go
@@ -153,7 +153,7 @@ func TestInjectIntoEnvBeatsYamlProperty(t *testing.T) {
 		dir := t.TempDir()
 		t.Chdir(dir)
 		yamlContent := "custom:\n  prop:\n    value: \"" + yamlVal + "\"\n"
-		if err := os.WriteFile("config.yaml", []byte(yamlContent), 0o600); err != nil {
+		if err := os.WriteFile(testConfigFileYAML, []byte(yamlContent), 0o600); err != nil {
 			rt.Fatalf("write config.yaml: %v", err)
 		}
 

--- a/database/database_properties_test.go
+++ b/database/database_properties_test.go
@@ -59,14 +59,31 @@ func TestQueryBuilderPostgresPlaceholdersSequentialProperty(t *testing.T) {
 	})
 }
 
+// buildFromDraws chains f.Eq/f.And over pre-drawn column/value slices — the
+// same shape as buildEqChain, but parameterized so a caller can build from the
+// same draws more than once instead of drawing fresh values per build.
+func buildFromDraws(qb *QueryBuilder, cols []string, vals []int) (sql string, args []any, err error) {
+	f := qb.Filter()
+	filter := f.Eq(cols[0], vals[0])
+	for i := 1; i < len(cols); i++ {
+		filter = f.And(filter, f.Eq(cols[i], vals[i]))
+	}
+	return qb.Select("id").From("users").Where(filter).ToSQL()
+}
+
 func TestQueryBuilderDeterministicOutputProperty(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
 		vendor := rapid.SampledFrom([]string{PostgreSQL, Oracle}).Draw(rt, "vendor")
-		col := identGen.Draw(rt, "col")
-		val := rapid.Int().Draw(rt, "val")
+		n := rapid.IntRange(2, 6).Draw(rt, "conds")
+		cols := make([]string, n)
+		vals := make([]int, n)
+		for i := 0; i < n; i++ {
+			cols[i] = identGen.Draw(rt, fmt.Sprintf("col%d", i))
+			vals[i] = rapid.Int().Draw(rt, fmt.Sprintf("val%d", i))
+		}
 		build := func() (string, []any) {
 			qb := NewQueryBuilder(vendor)
-			sql, args, err := qb.Select("id").From("users").Where(qb.Filter().Eq(col, val)).ToSQL()
+			sql, args, err := buildFromDraws(qb, cols, vals)
 			if err != nil {
 				rt.Fatalf("ToSQL: %v", err)
 			}
@@ -75,7 +92,7 @@ func TestQueryBuilderDeterministicOutputProperty(t *testing.T) {
 		sql1, args1 := build()
 		sql2, args2 := build()
 		if sql1 != sql2 || fmt.Sprint(args1) != fmt.Sprint(args2) {
-			rt.Fatalf("non-deterministic: %q vs %q", sql1, sql2)
+			rt.Fatalf("non-deterministic: %q/%v vs %q/%v", sql1, args1, sql2, args2)
 		}
 	})
 }

--- a/database/database_properties_test.go
+++ b/database/database_properties_test.go
@@ -54,7 +54,7 @@ func TestQueryBuilderPlaceholdersSequentialProperty(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
 		vendor := vendorGen.Draw(rt, "vendor")
 		n := rapid.IntRange(1, 8).Draw(rt, "conds")
-		sql, _, err := buildEqChain(rt, NewQueryBuilder(vendor), n)
+		sql, args, err := buildEqChain(rt, NewQueryBuilder(vendor), n)
 		if err != nil {
 			rt.Fatalf("ToSQL: %v", err)
 		}
@@ -62,7 +62,11 @@ func TestQueryBuilderPlaceholdersSequentialProperty(t *testing.T) {
 		if vendor == Oracle {
 			re = oraclePlaceholderRe
 		}
-		for i, m := range re.FindAllStringSubmatch(sql, -1) {
+		matches := re.FindAllStringSubmatch(sql, -1)
+		if len(matches) != n || len(args) != n {
+			rt.Fatalf("expected %d placeholders/args, got %d/%d in %q", n, len(matches), len(args), sql)
+		}
+		for i, m := range matches {
 			if m[1] != strconv.Itoa(i+1) {
 				rt.Fatalf("placeholder %d is %s in %q", i+1, m[0], sql)
 			}

--- a/database/database_properties_test.go
+++ b/database/database_properties_test.go
@@ -50,16 +50,21 @@ func TestQueryBuilderPlaceholderArityProperty(t *testing.T) {
 	})
 }
 
-func TestQueryBuilderPostgresPlaceholdersSequentialProperty(t *testing.T) {
+func TestQueryBuilderPlaceholdersSequentialProperty(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
+		vendor := vendorGen.Draw(rt, "vendor")
 		n := rapid.IntRange(1, 8).Draw(rt, "conds")
-		sql, _, err := buildEqChain(rt, NewQueryBuilder(PostgreSQL), n)
+		sql, _, err := buildEqChain(rt, NewQueryBuilder(vendor), n)
 		if err != nil {
 			rt.Fatalf("ToSQL: %v", err)
 		}
-		for i, m := range pgPlaceholderRe.FindAllStringSubmatch(sql, -1) {
+		re := pgPlaceholderRe
+		if vendor == Oracle {
+			re = oraclePlaceholderRe
+		}
+		for i, m := range re.FindAllStringSubmatch(sql, -1) {
 			if m[1] != strconv.Itoa(i+1) {
-				rt.Fatalf("placeholder %d is $%s in %q", i+1, m[1], sql)
+				rt.Fatalf("placeholder %d is %s in %q", i+1, m[0], sql)
 			}
 		}
 	})

--- a/database/database_properties_test.go
+++ b/database/database_properties_test.go
@@ -8,9 +8,14 @@ import (
 	"testing"
 
 	"pgregory.net/rapid"
+
+	"github.com/gaborage/go-bricks/database/types"
 )
 
-var identGen = rapid.StringMatching(`[a-z][a-z0-9_]{0,29}`)
+var (
+	identGen  = rapid.StringMatching(`[a-z][a-z0-9_]{0,29}`)
+	vendorGen = rapid.SampledFrom([]string{PostgreSQL, Oracle})
+)
 
 var (
 	pgPlaceholderRe     = regexp.MustCompile(`\$(\d+)`)
@@ -18,17 +23,18 @@ var (
 )
 
 func buildEqChain(t *rapid.T, qb *QueryBuilder, n int) (sql string, args []any, err error) {
-	f := qb.Filter()
-	filter := f.Eq(identGen.Draw(t, "col0"), rapid.Int().Draw(t, "val0"))
-	for i := 1; i < n; i++ {
-		filter = f.And(filter, f.Eq(identGen.Draw(t, fmt.Sprintf("col%d", i)), rapid.Int().Draw(t, fmt.Sprintf("val%d", i))))
+	cols := make([]string, n)
+	vals := make([]int, n)
+	for i := range cols {
+		cols[i] = identGen.Draw(t, fmt.Sprintf("col%d", i))
+		vals[i] = rapid.Int().Draw(t, fmt.Sprintf("val%d", i))
 	}
-	return qb.Select("id").From("users").Where(filter).ToSQL()
+	return buildFromDraws(qb, cols, vals)
 }
 
 func TestQueryBuilderPlaceholderArityProperty(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
-		vendor := rapid.SampledFrom([]string{PostgreSQL, Oracle}).Draw(rt, "vendor")
+		vendor := vendorGen.Draw(rt, "vendor")
 		n := rapid.IntRange(1, 8).Draw(rt, "conds")
 		sql, args, err := buildEqChain(rt, NewQueryBuilder(vendor), n)
 		if err != nil {
@@ -59,21 +65,25 @@ func TestQueryBuilderPostgresPlaceholdersSequentialProperty(t *testing.T) {
 	})
 }
 
-// buildFromDraws chains f.Eq/f.And over pre-drawn column/value slices — the
-// same shape as buildEqChain, but parameterized so a caller can build from the
-// same draws more than once instead of drawing fresh values per build.
+// buildFromDraws builds an n-condition equality query from pre-drawn
+// column/value slices, so a caller can build from the same draws more than
+// once instead of drawing fresh values per build.
 func buildFromDraws(qb *QueryBuilder, cols []string, vals []int) (sql string, args []any, err error) {
 	f := qb.Filter()
-	filter := f.Eq(cols[0], vals[0])
-	for i := 1; i < len(cols); i++ {
-		filter = f.And(filter, f.Eq(cols[i], vals[i]))
+	eqs := make([]types.Filter, len(cols))
+	for i := range cols {
+		eqs[i] = f.Eq(cols[i], vals[i])
+	}
+	filter := eqs[0]
+	if len(eqs) > 1 {
+		filter = f.And(eqs...)
 	}
 	return qb.Select("id").From("users").Where(filter).ToSQL()
 }
 
 func TestQueryBuilderDeterministicOutputProperty(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
-		vendor := rapid.SampledFrom([]string{PostgreSQL, Oracle}).Draw(rt, "vendor")
+		vendor := vendorGen.Draw(rt, "vendor")
 		n := rapid.IntRange(2, 6).Draw(rt, "conds")
 		cols := make([]string, n)
 		vals := make([]int, n)

--- a/database/database_properties_test.go
+++ b/database/database_properties_test.go
@@ -1,0 +1,94 @@
+package database
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+var identGen = rapid.StringMatching(`[a-z][a-z0-9_]{0,29}`)
+
+var (
+	pgPlaceholderRe     = regexp.MustCompile(`\$(\d+)`)
+	oraclePlaceholderRe = regexp.MustCompile(`:(\d+)`)
+)
+
+func buildEqChain(t *rapid.T, qb *QueryBuilder, n int) (sql string, args []any, err error) {
+	f := qb.Filter()
+	filter := f.Eq(identGen.Draw(t, "col0"), rapid.Int().Draw(t, "val0"))
+	for i := 1; i < n; i++ {
+		filter = f.And(filter, f.Eq(identGen.Draw(t, fmt.Sprintf("col%d", i)), rapid.Int().Draw(t, fmt.Sprintf("val%d", i))))
+	}
+	return qb.Select("id").From("users").Where(filter).ToSQL()
+}
+
+func TestQueryBuilderPlaceholderArityProperty(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		vendor := rapid.SampledFrom([]string{PostgreSQL, Oracle}).Draw(rt, "vendor")
+		n := rapid.IntRange(1, 8).Draw(rt, "conds")
+		sql, args, err := buildEqChain(rt, NewQueryBuilder(vendor), n)
+		if err != nil {
+			rt.Fatalf("ToSQL: %v", err)
+		}
+		re := pgPlaceholderRe
+		if vendor == Oracle {
+			re = oraclePlaceholderRe
+		}
+		if got := len(re.FindAllString(sql, -1)); got != len(args) {
+			rt.Fatalf("placeholders %d != args %d in %q", got, len(args), sql)
+		}
+	})
+}
+
+func TestQueryBuilderPostgresPlaceholdersSequentialProperty(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		n := rapid.IntRange(1, 8).Draw(rt, "conds")
+		sql, _, err := buildEqChain(rt, NewQueryBuilder(PostgreSQL), n)
+		if err != nil {
+			rt.Fatalf("ToSQL: %v", err)
+		}
+		for i, m := range pgPlaceholderRe.FindAllStringSubmatch(sql, -1) {
+			if m[1] != strconv.Itoa(i+1) {
+				rt.Fatalf("placeholder %d is $%s in %q", i+1, m[1], sql)
+			}
+		}
+	})
+}
+
+func TestQueryBuilderDeterministicOutputProperty(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		vendor := rapid.SampledFrom([]string{PostgreSQL, Oracle}).Draw(rt, "vendor")
+		col := identGen.Draw(rt, "col")
+		val := rapid.Int().Draw(rt, "val")
+		build := func() (string, []any) {
+			qb := NewQueryBuilder(vendor)
+			sql, args, err := qb.Select("id").From("users").Where(qb.Filter().Eq(col, val)).ToSQL()
+			if err != nil {
+				rt.Fatalf("ToSQL: %v", err)
+			}
+			return sql, args
+		}
+		sql1, args1 := build()
+		sql2, args2 := build()
+		if sql1 != sql2 || fmt.Sprint(args1) != fmt.Sprint(args2) {
+			rt.Fatalf("non-deterministic: %q vs %q", sql1, sql2)
+		}
+	})
+}
+
+func TestQueryBuilderOracleReservedWordQuotingProperty(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		reserved := rapid.SampledFrom([]string{"number", "level", "size"}).Draw(rt, "reserved")
+		sql, _, err := NewQueryBuilder(Oracle).Select("id", reserved).From("users").ToSQL()
+		if err != nil {
+			rt.Fatalf("ToSQL: %v", err)
+		}
+		if want := `"` + reserved + `"`; !strings.Contains(sql, want) {
+			rt.Fatalf("reserved word %q not quoted in %q", reserved, sql)
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	golang.org/x/sync v0.22.0
 	golang.org/x/term v0.45.0
 	google.golang.org/grpc v1.82.1
+	pgregory.net/rapid v1.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -302,5 +302,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
 gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=
-pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
-pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=

--- a/jose/jose_properties_test.go
+++ b/jose/jose_properties_test.go
@@ -2,6 +2,8 @@ package jose_test
 
 import (
 	"bytes"
+	"encoding/base64"
+	"strings"
 	"testing"
 
 	"pgregory.net/rapid"
@@ -48,6 +50,36 @@ func TestOpenTamperNeverAltersPayloadProperty(t *testing.T) {
 		plain, _, _, err := jose.Open(string(tampered), fx.PeerInbound, fx.Resolver)
 		if err == nil && !bytes.Equal(plain, payload) {
 			rt.Fatalf("tampered token at pos %d opened with ALTERED plaintext", pos)
+		}
+	})
+}
+
+// Semantic complement to the raw-character property above: flipping a bit of
+// a segment's DECODED bytes (then re-encoding canonically) always changes the
+// cryptographic input — header is AAD, key/IV/ciphertext/tag feed OAEP or
+// GCM — so Open must always fail.
+func TestOpenSemanticTamperAlwaysFailsProperty(t *testing.T) {
+	fx := josetest.NewBidirectionalFixture(t)
+	payload := []byte(`{"amount":"100.00","currency":"USD"}`)
+	sealed := josetest.SealForTest(t, payload, fx.ClientOutbound, fx.Resolver)
+	parts := strings.Split(sealed, ".")
+
+	rapid.Check(t, func(rt *rapid.T) {
+		seg := rapid.IntRange(0, len(parts)-1).Draw(rt, "seg")
+		raw, err := base64.RawURLEncoding.DecodeString(parts[seg])
+		if err != nil || len(raw) == 0 {
+			rt.Fatalf("segment %d not decodable base64url (%v) — fixture broke", seg, err)
+		}
+		idx := rapid.IntRange(0, len(raw)-1).Draw(rt, "idx")
+		bit := byte(1) << rapid.IntRange(0, 7).Draw(rt, "bit")
+
+		mutated := append([]byte(nil), raw...)
+		mutated[idx] ^= bit
+		tamperedParts := append([]string(nil), parts...)
+		tamperedParts[seg] = base64.RawURLEncoding.EncodeToString(mutated)
+
+		if _, _, _, err := jose.Open(strings.Join(tamperedParts, "."), fx.PeerInbound, fx.Resolver); err == nil {
+			rt.Fatalf("semantic tamper accepted: segment %d, byte %d, bit flip %#x", seg, idx, bit)
 		}
 	})
 }

--- a/jose/jose_properties_test.go
+++ b/jose/jose_properties_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 
 	"github.com/gaborage/go-bricks/jose"
@@ -35,8 +34,7 @@ func TestSealOpenRoundTripProperty(t *testing.T) {
 func TestOpenTamperNeverAltersPayloadProperty(t *testing.T) {
 	fx := josetest.NewBidirectionalFixture(t)
 	payload := []byte(`{"amount":"100.00","currency":"USD"}`)
-	sealed, err := jose.Seal(payload, fx.ClientOutbound, fx.Resolver)
-	require.NoError(t, err)
+	sealed := josetest.SealForTest(t, payload, fx.ClientOutbound, fx.Resolver)
 
 	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
 	rapid.Check(t, func(rt *rapid.T) {

--- a/jose/jose_properties_test.go
+++ b/jose/jose_properties_test.go
@@ -1,0 +1,55 @@
+package jose_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+
+	"github.com/gaborage/go-bricks/jose"
+	josetest "github.com/gaborage/go-bricks/jose/testing"
+)
+
+func TestSealOpenRoundTripProperty(t *testing.T) {
+	fx := josetest.NewBidirectionalFixture(t) // keygen once; iterations reuse
+	rapid.Check(t, func(rt *rapid.T) {
+		payload := rapid.SliceOfN(rapid.Byte(), 1, 4096).Draw(rt, "payload")
+		sealed, err := jose.Seal(payload, fx.ClientOutbound, fx.Resolver)
+		if err != nil {
+			rt.Fatalf("Seal: %v", err)
+		}
+		plain, _, _, err := jose.Open(sealed, fx.PeerInbound, fx.Resolver)
+		if err != nil {
+			rt.Fatalf("Open: %v", err)
+		}
+		if !bytes.Equal(plain, payload) {
+			rt.Fatalf("round-trip mismatch: %d bytes in, %d out", len(payload), len(plain))
+		}
+	})
+}
+
+// The security invariant is NOT "any tamper errors" — a base64 trailing-bit
+// swap can decode identically. It is: Open never succeeds with plaintext
+// different from the original.
+func TestOpenTamperNeverAltersPayloadProperty(t *testing.T) {
+	fx := josetest.NewBidirectionalFixture(t)
+	payload := []byte(`{"amount":"100.00","currency":"USD"}`)
+	sealed, err := jose.Seal(payload, fx.ClientOutbound, fx.Resolver)
+	require.NoError(t, err)
+
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	rapid.Check(t, func(rt *rapid.T) {
+		pos := rapid.IntRange(0, len(sealed)-1).Draw(rt, "pos")
+		repl := alphabet[rapid.IntRange(0, len(alphabet)-1).Draw(rt, "chr")]
+		if sealed[pos] == repl {
+			return
+		}
+		tampered := []byte(sealed)
+		tampered[pos] = repl
+		plain, _, _, err := jose.Open(string(tampered), fx.PeerInbound, fx.Resolver)
+		if err == nil && !bytes.Equal(plain, payload) {
+			rt.Fatalf("tampered token at pos %d opened with ALTERED plaintext", pos)
+		}
+	})
+}

--- a/multitenant/multitenant_properties_test.go
+++ b/multitenant/multitenant_properties_test.go
@@ -84,6 +84,11 @@ func TestCompositeFirstMatchProperty(t *testing.T) {
 		if got != "tenant-x" {
 			rt.Fatalf("got %q want tenant-x", got)
 		}
+		for i := 0; i <= winner; i++ {
+			if !stubs[i].called {
+				rt.Fatalf("resolver %d skipped before winner %d", i, winner)
+			}
+		}
 		for i := winner + 1; i < n; i++ {
 			if stubs[i].called {
 				rt.Fatalf("resolver %d consulted after winner %d", i, winner)

--- a/multitenant/multitenant_properties_test.go
+++ b/multitenant/multitenant_properties_test.go
@@ -80,3 +80,73 @@ func TestCompositeFirstMatchProperty(t *testing.T) {
 		}
 	})
 }
+
+// Contract-completion: TestResolversNeverPanicOrReturnEmptyProperty draws
+// hosts/paths uninformed by any resolver's success shape, so its never-empty
+// half is vacuous for SubdomainResolver and PathResolver — a random
+// `[a-z0-9.-]{1,40}` host essentially never ends in ".example.com", and a
+// random path essentially never starts with "itsp". This property
+// complements it by constructing guaranteed-success inputs per resolver and
+// pinning the exact resolved tenant, so the success path is actually
+// exercised rather than only reachable in principle.
+//
+// PathResolver's Segment is 1-indexed over ALL path parts split from the
+// full, unmodified req.URL.Path — resolver.go never strips Prefix before
+// splitting; Prefix is purely a gate (via pathutil.StripPathPrefix) on which
+// paths are attempted at all. So for Prefix "itsp" and path "/itsp/<tenant>",
+// parts is ["itsp", "<tenant>"], and Segment 2 resolves parts[1], the
+// tenant — verified by reading resolver.go's ResolveTenant before writing
+// this construction.
+func TestResolversResolveWellFormedInputsProperty(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		tenant := rapid.StringMatching(`[a-z0-9]{1,20}`).Draw(rt, "tenant")
+
+		headerReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
+		headerReq.Header.Set(tenantIDHeader, tenant)
+		got, err := (&HeaderResolver{HeaderName: tenantIDHeader}).ResolveTenant(context.Background(), headerReq)
+		if err != nil {
+			rt.Fatalf("HeaderResolver: unexpected error: %v", err)
+		}
+		if got != tenant {
+			rt.Fatalf("HeaderResolver: got %q want %q", got, tenant)
+		}
+
+		subReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
+		subReq.Host = tenant + ".example.com"
+		got, err = (&SubdomainResolver{RootDomain: "example.com"}).ResolveTenant(context.Background(), subReq)
+		if err != nil {
+			rt.Fatalf("SubdomainResolver: unexpected error: %v", err)
+		}
+		if got != tenant {
+			rt.Fatalf("SubdomainResolver: got %q want %q", got, tenant)
+		}
+
+		pathReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/itsp/"+tenant, http.NoBody)
+		got, err = (&PathResolver{Segment: 2, Prefix: "itsp"}).ResolveTenant(context.Background(), pathReq)
+		if err != nil {
+			rt.Fatalf("PathResolver: unexpected error: %v", err)
+		}
+		if got != tenant {
+			rt.Fatalf("PathResolver: got %q want %q", got, tenant)
+		}
+
+		tenant2 := rapid.StringMatching(`[a-z0-9]{1,20}`).Draw(rt, "tenant2")
+		if tenant2 == tenant {
+			return // degenerate draw: no observable first-match signal
+		}
+		compReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
+		compReq.Host = tenant + ".example.com"
+		compReq.Header.Set(tenantIDHeader, tenant2)
+		composite := &CompositeResolver{Resolvers: []TenantResolver{
+			&SubdomainResolver{RootDomain: "example.com"},
+			&HeaderResolver{HeaderName: tenantIDHeader},
+		}}
+		got, err = composite.ResolveTenant(context.Background(), compReq)
+		if err != nil {
+			rt.Fatalf("CompositeResolver: unexpected error: %v", err)
+		}
+		if got != tenant {
+			rt.Fatalf("CompositeResolver: got %q want %q (subdomain must win over header)", got, tenant)
+		}
+	})
+}

--- a/multitenant/multitenant_properties_test.go
+++ b/multitenant/multitenant_properties_test.go
@@ -9,6 +9,17 @@ import (
 	"pgregory.net/rapid"
 )
 
+var (
+	hostGen   = rapid.StringMatching(`[a-z0-9.-]{1,40}`)
+	pathGen   = rapid.StringMatching(`[a-zA-Z0-9/._-]{0,60}`)
+	hdrGen    = rapid.StringMatching(`[ -~]{0,40}`)
+	tenantGen = rapid.StringMatching(`[a-z0-9]{1,20}`)
+)
+
+func newReq(url string) *http.Request {
+	return httptest.NewRequestWithContext(context.Background(), http.MethodGet, url, http.NoBody)
+}
+
 type stubResolver struct {
 	tenant string
 	err    error
@@ -24,11 +35,11 @@ func (s *stubResolver) ResolveTenant(_ context.Context, _ *http.Request) (string
 // ("", nil). rapid surfaces any panic as a failure with a reproducing seed.
 func TestResolversNeverPanicOrReturnEmptyProperty(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
-		host := rapid.StringMatching(`[a-z0-9.-]{1,40}`).Draw(rt, "host")
-		path := "/" + rapid.StringMatching(`[a-zA-Z0-9/._-]{0,60}`).Draw(rt, "path")
-		hdr := rapid.StringMatching(`[ -~]{0,40}`).Draw(rt, "hdr")
+		host := hostGen.Draw(rt, "host")
+		path := "/" + pathGen.Draw(rt, "path")
+		hdr := hdrGen.Draw(rt, "hdr")
 
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://placeholder/", http.NoBody)
+		req := newReq("http://placeholder/")
 		req.Host = host
 		req.URL.Path = path
 		req.Header.Set(tenantIDHeader, hdr)
@@ -65,7 +76,7 @@ func TestCompositeFirstMatchProperty(t *testing.T) {
 			}
 			chain[i] = stubs[i]
 		}
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/", http.NoBody)
+		req := newReq("http://example.com/")
 		got, err := (&CompositeResolver{Resolvers: chain}).ResolveTenant(context.Background(), req)
 		if err != nil {
 			rt.Fatalf("composite failed with a succeeding resolver at %d: %v", winner, err)
@@ -99,54 +110,40 @@ func TestCompositeFirstMatchProperty(t *testing.T) {
 // this construction.
 func TestResolversResolveWellFormedInputsProperty(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
-		tenant := rapid.StringMatching(`[a-z0-9]{1,20}`).Draw(rt, "tenant")
+		tenant := tenantGen.Draw(rt, "tenant")
 
-		headerReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
+		assertResolves := func(name string, r TenantResolver, req *http.Request, want string) {
+			got, err := r.ResolveTenant(context.Background(), req)
+			if err != nil {
+				rt.Fatalf("%s: unexpected error: %v", name, err)
+			}
+			if got != want {
+				rt.Fatalf("%s: got %q want %q", name, got, want)
+			}
+		}
+
+		headerReq := newReq("/")
 		headerReq.Header.Set(tenantIDHeader, tenant)
-		got, err := (&HeaderResolver{HeaderName: tenantIDHeader}).ResolveTenant(context.Background(), headerReq)
-		if err != nil {
-			rt.Fatalf("HeaderResolver: unexpected error: %v", err)
-		}
-		if got != tenant {
-			rt.Fatalf("HeaderResolver: got %q want %q", got, tenant)
-		}
+		assertResolves("HeaderResolver", &HeaderResolver{HeaderName: tenantIDHeader}, headerReq, tenant)
 
-		subReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
+		subReq := newReq("/")
 		subReq.Host = tenant + ".example.com"
-		got, err = (&SubdomainResolver{RootDomain: "example.com"}).ResolveTenant(context.Background(), subReq)
-		if err != nil {
-			rt.Fatalf("SubdomainResolver: unexpected error: %v", err)
-		}
-		if got != tenant {
-			rt.Fatalf("SubdomainResolver: got %q want %q", got, tenant)
-		}
+		assertResolves("SubdomainResolver", &SubdomainResolver{RootDomain: "example.com"}, subReq, tenant)
 
-		pathReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/itsp/"+tenant, http.NoBody)
-		got, err = (&PathResolver{Segment: 2, Prefix: "itsp"}).ResolveTenant(context.Background(), pathReq)
-		if err != nil {
-			rt.Fatalf("PathResolver: unexpected error: %v", err)
-		}
-		if got != tenant {
-			rt.Fatalf("PathResolver: got %q want %q", got, tenant)
-		}
+		pathReq := newReq("/itsp/" + tenant)
+		assertResolves("PathResolver", &PathResolver{Segment: 2, Prefix: "itsp"}, pathReq, tenant)
 
-		tenant2 := rapid.StringMatching(`[a-z0-9]{1,20}`).Draw(rt, "tenant2")
+		tenant2 := tenantGen.Draw(rt, "tenant2")
 		if tenant2 == tenant {
 			return // degenerate draw: no observable first-match signal
 		}
-		compReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", http.NoBody)
+		compReq := newReq("/")
 		compReq.Host = tenant + ".example.com"
 		compReq.Header.Set(tenantIDHeader, tenant2)
 		composite := &CompositeResolver{Resolvers: []TenantResolver{
 			&SubdomainResolver{RootDomain: "example.com"},
 			&HeaderResolver{HeaderName: tenantIDHeader},
 		}}
-		got, err = composite.ResolveTenant(context.Background(), compReq)
-		if err != nil {
-			rt.Fatalf("CompositeResolver: unexpected error: %v", err)
-		}
-		if got != tenant {
-			rt.Fatalf("CompositeResolver: got %q want %q (subdomain must win over header)", got, tenant)
-		}
+		assertResolves("CompositeResolver (subdomain must win over header)", composite, compReq, tenant)
 	})
 }

--- a/multitenant/multitenant_properties_test.go
+++ b/multitenant/multitenant_properties_test.go
@@ -1,0 +1,82 @@
+package multitenant
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+type stubResolver struct {
+	tenant string
+	err    error
+	called bool
+}
+
+func (s *stubResolver) ResolveTenant(_ context.Context, _ *http.Request) (string, error) {
+	s.called = true
+	return s.tenant, s.err
+}
+
+// Contract: resolution identifies or errors — never panics, never returns
+// ("", nil). rapid surfaces any panic as a failure with a reproducing seed.
+func TestResolversNeverPanicOrReturnEmptyProperty(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		host := rapid.StringMatching(`[a-z0-9.-]{1,40}`).Draw(rt, "host")
+		path := "/" + rapid.StringMatching(`[a-zA-Z0-9/._-]{0,60}`).Draw(rt, "path")
+		hdr := rapid.StringMatching(`[ -~]{0,40}`).Draw(rt, "hdr")
+
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://placeholder/", http.NoBody)
+		req.Host = host
+		req.URL.Path = path
+		req.Header.Set(tenantIDHeader, hdr)
+
+		resolvers := []TenantResolver{
+			&HeaderResolver{HeaderName: tenantIDHeader},
+			&SubdomainResolver{RootDomain: "example.com"},
+			&PathResolver{Segment: rapid.IntRange(1, 4).Draw(rt, "seg"), Prefix: "itsp"},
+			&CompositeResolver{Resolvers: []TenantResolver{
+				&SubdomainResolver{RootDomain: "example.com"},
+				&HeaderResolver{HeaderName: tenantIDHeader},
+			}},
+		}
+		for _, r := range resolvers {
+			tenant, err := r.ResolveTenant(context.Background(), req)
+			if err == nil && tenant == "" {
+				rt.Fatalf("%T returned empty tenant without error", r)
+			}
+		}
+	})
+}
+
+func TestCompositeFirstMatchProperty(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		n := rapid.IntRange(1, 5).Draw(rt, "n")
+		winner := rapid.IntRange(0, n-1).Draw(rt, "winner")
+		stubs := make([]*stubResolver, n)
+		chain := make([]TenantResolver, n)
+		for i := range stubs {
+			if i < winner {
+				stubs[i] = &stubResolver{err: ErrTenantResolutionFailed}
+			} else {
+				stubs[i] = &stubResolver{tenant: "tenant-x"}
+			}
+			chain[i] = stubs[i]
+		}
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/", http.NoBody)
+		got, err := (&CompositeResolver{Resolvers: chain}).ResolveTenant(context.Background(), req)
+		if err != nil {
+			rt.Fatalf("composite failed with a succeeding resolver at %d: %v", winner, err)
+		}
+		if got != "tenant-x" {
+			rt.Fatalf("got %q want tenant-x", got)
+		}
+		for i := winner + 1; i < n; i++ {
+			if stubs[i].called {
+				rt.Fatalf("resolver %d consulted after winner %d", i, winner)
+			}
+		}
+	})
+}

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -370,7 +370,8 @@ Pattern rules:
   errors" (base64 trailing bits can decode identically) but "Open never succeeds
   with altered plaintext".
 - A failing property prints a reproducing seed (`-rapid.seed`); a genuine
-  violation is a framework bug — fix the code, never the generator.
+  violation is a bug in the code under test — fix that code, never the
+  generator or the property.
 - Random generators alone can leave success paths vacuously untested (a random
   host virtually never ends in `.example.com`) — pair them with constructive
   draws that build guaranteed-success inputs.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -350,3 +350,29 @@ Library packages, which the gate actually polices, verdict correctly.
 When the gate fails, strengthen the test so the listed mutant dies (assert the
 boundary, the sign, the branch the operator flipped) — never respond by
 excluding the file.
+
+## Property-Based Tests
+
+Invariant-heavy packages carry a `<pkg>_properties_test.go` suite built on
+[`pgregory.net/rapid`](https://pkg.go.dev/pgregory.net/rapid) — a documented
+exception to the source-to-test 1:1 naming rule, alongside `testhelpers_test.go`.
+Current exemplars: `database` (placeholder arity, Oracle reserved-word quoting,
+determinism), `config` (InjectInto round-trips, never-panic, env-beats-yaml
+precedence), `jose` (seal/open integrity), `multitenant` (resolver contracts,
+composite first-match, constructive success paths).
+
+Pattern rules:
+
+- One `rapid.Check` per invariant; name it `Test<Subject><Invariant>Property`.
+- Expensive setup (key generation) lives OUTSIDE `rapid.Check`; iterations reuse it.
+- State the invariant precisely. Example: tamper-resistance is not "any tamper
+  errors" (base64 trailing bits can decode identically) but "Open never succeeds
+  with altered plaintext".
+- A failing property prints a reproducing seed (`-rapid.seed`); a genuine
+  violation is a framework bug — fix the code, never the generator.
+- Random generators alone can leave success paths vacuously untested (a random
+  host virtually never ends in `.example.com`) — pair them with constructive
+  draws that build guaranteed-success inputs.
+
+Property suites are ordinary `go test` tests: they run in `make test`, under
+`-race`, and count toward coverage.

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -354,8 +354,9 @@ excluding the file.
 ## Property-Based Tests
 
 Invariant-heavy packages carry a `<pkg>_properties_test.go` suite built on
-[`pgregory.net/rapid`](https://pkg.go.dev/pgregory.net/rapid) — a documented
-exception to the source-to-test 1:1 naming rule, alongside `testhelpers_test.go`.
+[`pgregory.net/rapid`](https://pkg.go.dev/pgregory.net/rapid) — an intentional
+exception to the one-`_test.go`-per-source-file convention, alongside
+`testhelpers_test.go`.
 Current exemplars: `database` (placeholder arity, Oracle reserved-word quoting,
 determinism), `config` (InjectInto round-trips, never-panic, env-beats-yaml
 precedence), `jose` (seal/open integrity), `multitenant` (resolver contracts,


### PR DESCRIPTION
## What
Example-based tests can miss whole input classes. Adds `pgregory.net/rapid`
(test-only) and four property suites pinning invariants: query builder
(placeholder arity and sequential numbering on both vendors, determinism over
multi-condition chains, Oracle reserved-word quoting), config InjectInto
(string/duration/[]string round-trips, never-panic on arbitrary unicode env
values, env-beats-yaml precedence), JOSE (seal→open round-trip; tampering never
yields altered plaintext, plus a semantic decoded-byte-flip property that must
always fail), and tenant resolvers (never panic, never empty-without-error,
composite first-match, constructive success paths for all four shapes).

## Impact
New test-only dependency. `<pkg>_properties_test.go` naming and pattern rules
documented in wiki/testing.md.

## Verification
Suites verified under -race with -count=3 and a 7-seed, ~1600-iterations-per-
property depth run; property failures print reproducing seeds. CI gates only
beyond that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added property-based coverage for configuration injection from environment and YAML, including default behavior, precedence, round-trips, and safety against arbitrary inputs.
  * Added property-based tests for database query placeholder generation (arity, sequential ordering), deterministic query building, and reserved-word quoting.
  * Added property-based tests for JOSE seal/open round-trips and tamper detection (character and semantic mutations).
  * Added property-based tests ensuring tenant resolvers never panic, return valid results with errors when needed, and respect composite precedence.
* **Documentation**
  * Expanded testing guidance with a dedicated section on property-based test conventions and how to run/interpret them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->