### PR TITLE
test(multitenant): reduce first-match property complexity (S3776)

### DIFF
--- a/multitenant/multitenant_properties_test.go
+++ b/multitenant/multitenant_properties_test.go
@@ -62,20 +62,42 @@ func TestResolversNeverPanicOrReturnEmptyProperty(t *testing.T) {
 	})
 }
 
+// buildStubChain returns n stub resolvers where every stub before winner
+// fails with the sentinel and the rest succeed with "tenant-x".
+func buildStubChain(n, winner int) ([]*stubResolver, []TenantResolver) {
+	stubs := make([]*stubResolver, n)
+	chain := make([]TenantResolver, n)
+	for i := range stubs {
+		if i < winner {
+			stubs[i] = &stubResolver{err: ErrTenantResolutionFailed}
+		} else {
+			stubs[i] = &stubResolver{tenant: "tenant-x"}
+		}
+		chain[i] = stubs[i]
+	}
+	return stubs, chain
+}
+
+// assertConsultationOrder pins first-match semantics: every resolver up to
+// and including the winner was consulted, none after it.
+func assertConsultationOrder(rt *rapid.T, stubs []*stubResolver, winner int) {
+	for i := 0; i <= winner; i++ {
+		if !stubs[i].called {
+			rt.Fatalf("resolver %d skipped before winner %d", i, winner)
+		}
+	}
+	for i := winner + 1; i < len(stubs); i++ {
+		if stubs[i].called {
+			rt.Fatalf("resolver %d consulted after winner %d", i, winner)
+		}
+	}
+}
+
 func TestCompositeFirstMatchProperty(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
 		n := rapid.IntRange(1, 5).Draw(rt, "n")
 		winner := rapid.IntRange(0, n-1).Draw(rt, "winner")
-		stubs := make([]*stubResolver, n)
-		chain := make([]TenantResolver, n)
-		for i := range stubs {
-			if i < winner {
-				stubs[i] = &stubResolver{err: ErrTenantResolutionFailed}
-			} else {
-				stubs[i] = &stubResolver{tenant: "tenant-x"}
-			}
-			chain[i] = stubs[i]
-		}
+		stubs, chain := buildStubChain(n, winner)
 		req := newReq("http://example.com/")
 		got, err := (&CompositeResolver{Resolvers: chain}).ResolveTenant(context.Background(), req)
 		if err != nil {
@@ -84,16 +106,7 @@ func TestCompositeFirstMatchProperty(t *testing.T) {
 		if got != "tenant-x" {
 			rt.Fatalf("got %q want tenant-x", got)
 		}
-		for i := 0; i <= winner; i++ {
-			if !stubs[i].called {
-				rt.Fatalf("resolver %d skipped before winner %d", i, winner)
-			}
-		}
-		for i := winner + 1; i < n; i++ {
-			if stubs[i].called {
-				rt.Fatalf("resolver %d consulted after winner %d", i, winner)
-			}
-		}
+		assertConsultationOrder(rt, stubs, winner)
 	})
 }
 


### PR DESCRIPTION
## What
SonarCloud flagged `TestCompositeFirstMatchProperty` at cognitive complexity
20 (limit 15) — the analysis landed after PR #808 merged. The stub-chain
construction and consultation-order assertions now live in named helpers;
assertions and behavior unchanged.

## Impact
None.

## Verification
CI gates only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined multitenant resolver tests to validate first-match behavior.
  * Added coverage for resolver consultation order when earlier resolvers fail and a later resolver succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->