### PR TITLE
build(mutate): shard the nightly baseline one engine process per package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ mutate: ## Diff-scoped mutation gate: mutants on changed lines vs origin/main mu
 # misverdicts that nested package main (wiki/testing.md#mutation-gate).
 mutate-baseline: ## Full-repo mutation baseline, one engine process per package (advisory; consumed by the nightly workflow)
 	@rm -rf .gremlins-reports gremlins-report.json && mkdir -p .gremlins-reports
-	@i=0; for dir in $$(go list -f '{{.Dir}}' ./... | sed "s|^$$(pwd)/||" | grep -v '^scripts/' | sort -u); do \
+	@i=0; for dir in $$(go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)/||" -e "s|^$$(pwd)$$|.|" | grep -v '^scripts/' | sort -u); do \
 		i=$$((i+1)); \
 		echo "== mutating ./$$dir"; \
 		out=".gremlins-reports/$$i-$$(echo "$$dir" | tr / -).json"; \

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ GOLANGCI_LINT_VERSION := v2.12.2
 # renovate: datasource=go depName=github.com/go-gremlins/gremlins
 GREMLINS_VERSION := v0.5.1
 GREMLINS_CMD := go run github.com/go-gremlins/gremlins/cmd/gremlins@$(GREMLINS_VERSION)
+# Hosted runners are 4-vCPU/16GB; 2 workers halves peak memory vs the local default.
+MUTATE_BASELINE_WORKERS ?= 2
 # Default target
 help: ## Show this help message
 	@echo "Available targets:"
@@ -106,8 +108,41 @@ sec: ## Run gosec security scanner (pinned; identical to CI)
 mutate: ## Diff-scoped mutation gate: mutants on changed lines vs origin/main must die (see wiki/testing.md#mutation-gate)
 	go run ./scripts/mutatediff -engine "$(GREMLINS_CMD)"
 
-mutate-baseline: ## Full-repo mutation baseline (advisory; consumed by the nightly workflow)
-	$(GREMLINS_CMD) unleash --output gremlins-report.json
+# One gremlins process per package: a single full-repo process with 4 workers
+# exhausted a 4-vCPU/16GB hosted runner ~25 min in (runner shutdown signal).
+# Per-package processes bound memory, let partial results survive an eviction,
+# and the merge prefixes file_name with the package dir (gremlins emits
+# basenames, which are ambiguous repo-wide). scripts/ excluded: gremlins
+# misverdicts that nested package main (wiki/testing.md#mutation-gate).
+mutate-baseline: ## Full-repo mutation baseline, one engine process per package (advisory; consumed by the nightly workflow)
+	@rm -rf .gremlins-reports gremlins-report.json && mkdir -p .gremlins-reports
+	@i=0; for dir in $$(go list -f '{{.Dir}}' ./... | sed "s|^$$(pwd)/||" | grep -v '^scripts/' | sort -u); do \
+		i=$$((i+1)); \
+		echo "== mutating ./$$dir"; \
+		out=".gremlins-reports/$$i-$$(echo "$$dir" | tr / -).json"; \
+		$(GREMLINS_CMD) unleash --workers $(MUTATE_BASELINE_WORKERS) --output "$$out" "./$$dir" \
+			|| echo "WARN: gremlins exited non-zero for ./$$dir (advisory)"; \
+		if [ -f "$$out" ]; then \
+			jq --arg d "$$dir" '.files = ((.files // []) | map(.file_name = ($$d + "/" + .file_name)))' "$$out" > "$$out.tmp" && mv "$$out.tmp" "$$out" \
+				|| { echo "WARN: ./$$dir produced an unparsable report, dropped (advisory)"; rm -f "$$out" "$$out.tmp"; }; \
+		fi; \
+	done
+	@if ls .gremlins-reports/*.json >/dev/null 2>&1; then \
+		jq -s '(map(.mutants_killed // 0) | add) as $$k \
+			| (map(.mutants_lived // 0) | add) as $$l \
+			| (map(.mutants_not_covered // 0) | add) as $$n \
+			| { \
+				mutants_killed: $$k, \
+				mutants_lived: $$l, \
+				mutants_not_covered: $$n, \
+				test_efficacy: (if ($$k + $$l) > 0 then ($$k * 100 / ($$k + $$l)) else 0 end), \
+				mutations_coverage: (if ($$k + $$l + $$n) > 0 then (($$k + $$l) * 100 / ($$k + $$l + $$n)) else 0 end), \
+				files: (map(.files // []) | add) \
+			}' .gremlins-reports/*.json > gremlins-report.json; \
+		jq -r '"baseline: killed=\(.mutants_killed) lived=\(.mutants_lived) not_covered=\(.mutants_not_covered) efficacy=\(.test_efficacy | floor)%"' gremlins-report.json; \
+	else \
+		echo "WARN: no package reports produced — skipping merge (advisory)"; \
+	fi
 
 release: ## Cut a signed release tag (usage: make release VERSION=v0.38.0). Run AFTER merging the release-please PR. Requires 1Password unlocked.
 	@test -n "$(VERSION)" || { echo "Error: VERSION is required, e.g. 'make release VERSION=v0.38.0'"; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ mutate: ## Diff-scoped mutation gate: mutants on changed lines vs origin/main mu
 # misverdicts that nested package main (wiki/testing.md#mutation-gate).
 mutate-baseline: ## Full-repo mutation baseline, one engine process per package (advisory; consumed by the nightly workflow)
 	@rm -rf .gremlins-reports gremlins-report.json && mkdir -p .gremlins-reports
+	@go list ./... > /dev/null   # fail fast on a broken tree — inside the loop pipeline a go list failure would vanish into sort's exit status
 	@i=0; for dir in $$(go list -f '{{.Dir}}' ./... | sed -e "s|^$$(pwd)/||" -e "s|^$$(pwd)$$|.|" | grep -v '^scripts/' | sort -u); do \
 		i=$$((i+1)); \
 		echo "== mutating ./$$dir"; \

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -335,7 +335,9 @@ module), and `scripts/` (the wrapper itself — see the operational notes).
 Engine version is pinned via `GREMLINS_VERSION` in the Makefile;
 runtime knobs live in `.gremlins.yaml`. The nightly `Mutation Baseline`
 workflow runs the full repo in advisory mode (one engine process per package,
-so a runner eviction only loses the in-flight package) and publishes overall efficacy
+so a crashed engine process only loses that package's shard — though the JSON
+artifact uploads only after the final merge, so a full runner eviction still
+loses the run) and publishes overall efficacy
 plus a table of files with LIVED / NOT COVERED findings (first 50 rows) to the
 job summary; the JSON artifact is the complete record.
 

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -334,7 +334,8 @@ Excluded from scope: `_test.go` files, `testdata/`, `tools/` (separate Go
 module), and `scripts/` (the wrapper itself — see the operational notes).
 Engine version is pinned via `GREMLINS_VERSION` in the Makefile;
 runtime knobs live in `.gremlins.yaml`. The nightly `Mutation Baseline`
-workflow runs the full repo in advisory mode and publishes overall efficacy
+workflow runs the full repo in advisory mode (one engine process per package,
+so a runner eviction only loses the in-flight package) and publishes overall efficacy
 plus a table of files with LIVED / NOT COVERED findings (first 50 rows) to the
 job summary; the JSON artifact is the complete record.
 

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -334,7 +334,8 @@ Excluded from scope: `_test.go` files, `testdata/`, `tools/` (separate Go
 module), and `scripts/` (the wrapper itself — see the operational notes).
 Engine version is pinned via `GREMLINS_VERSION` in the Makefile;
 runtime knobs live in `.gremlins.yaml`. The nightly `Mutation Baseline`
-workflow runs the full repo in advisory mode (one engine process per package,
+workflow runs every package except the excluded `scripts/` in advisory mode
+(one engine process per package,
 so a crashed engine process only loses that package's shard — though the JSON
 artifact uploads only after the final merge, so a full runner eviction still
 loses the run) and publishes overall efficacy


### PR DESCRIPTION
## What
The first Mutation Baseline run exhausted its 4-vCPU/16GB runner ~25 minutes
into a single full-repo gremlins process (runner shutdown signal). The target
now runs one engine process per package (58 shards, 2 workers), so memory is
bounded and an eviction loses only the in-flight package. Shard reports get
dir-prefixed file names (fixes the basename ambiguity in the summary table),
corrupt shards are dropped with a WARN instead of poisoning the merge, and the
merged report keeps the keys the workflow summary reads.

## Impact
`MUTATE_BASELINE_WORKERS` (default 2) tunes shard concurrency. `make mutate`
unchanged.

## Verification
Merge + summary jq validated against two real per-package runs (efficacy 89%,
dir-prefixed rows); corrupt-shard drop path exercised with a synthetic
truncated report. The real proof is the next nightly run — re-dispatch after
merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mutation baseline now runs Gremlins separately per Go package, then merges results into a single overall `gremlins-report.json` with computed efficacy and coverage metrics.
  * Added configurable worker concurrency for the mutation baseline (default: 2).

* **Bug Fixes**
  * Non-zero exit for an individual package no longer blocks collection for other packages; failures are reported as warnings.
  * If no per-package reports are produced, the overall merge step is skipped with an advisory message.

* **Documentation**
  * Updated mutation gate guidance to reflect per-package advisory behavior and when artifacts are published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->