### PR TITLE
feat(jose): add CheckJTIReplay for cache-backed jti replay detection

### DIFF
--- a/jose/jose_properties_test.go
+++ b/jose/jose_properties_test.go
@@ -2,9 +2,11 @@ package jose_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"strings"
 	"testing"
+	"time"
 
 	"pgregory.net/rapid"
 
@@ -80,6 +82,48 @@ func TestOpenSemanticTamperAlwaysFailsProperty(t *testing.T) {
 
 		if _, _, _, err := jose.Open(strings.Join(tamperedParts, "."), fx.PeerInbound, fx.Resolver); err == nil {
 			rt.Fatalf("semantic tamper accepted: segment %d, byte %d, bit flip %#x", seg, idx, bit)
+		}
+	})
+}
+
+// ttlRecordingStore is a local recording fake for the property below —
+// replay_test.go's recordingStore lives in package jose and is not visible
+// from this black-box test package.
+type ttlRecordingStore struct {
+	ttl time.Duration
+}
+
+func (s *ttlRecordingStore) GetOrSet(_ context.Context, _ string, value []byte, ttl time.Duration) (storedValue []byte, wasSet bool, err error) {
+	s.ttl = ttl
+	return value, true, nil
+}
+
+// The stored TTL always equals window exactly, whatever exp is. No reachable
+// exp changes the TTL: deriving it from exp would forget the jti at exp while
+// a caller that allows clock skew still accepts the token until exp+skew, and
+// that gap is a replay hole. A zero TTL ("no expiry" at the cache backend) and
+// a negative one (rejected outright) are excluded a fortiori by the equality.
+func TestCheckJTIReplayTTLStaysInWindowProperty(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		windowSecs := rapid.IntRange(1, 86400).Draw(rt, "window_secs")
+		// Offset spans well past and well future, and includes exactly-now.
+		offsetSecs := rapid.IntRange(-100000, 100000).Draw(rt, "exp_offset_secs")
+		hasExp := rapid.Bool().Draw(rt, "has_exp")
+
+		window := time.Duration(windowSecs) * time.Second
+		claims := &jose.Claims{JTI: "jti-value", Issuer: "issuer"}
+		if hasExp {
+			claims.ExpiresAt = time.Now().Add(time.Duration(offsetSecs) * time.Second)
+		}
+
+		store := &ttlRecordingStore{}
+		_, err := jose.CheckJTIReplay(context.Background(), store, claims, window)
+		if err != nil {
+			rt.Fatalf("CheckJTIReplay: %v", err)
+		}
+
+		if ttl := store.ttl; ttl != window {
+			rt.Fatalf("ttl %v != window %v: exp_offset=%ds has_exp=%v", ttl, window, offsetSecs, hasExp)
 		}
 	})
 }

--- a/jose/replay.go
+++ b/jose/replay.go
@@ -1,0 +1,99 @@
+package jose
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+var (
+	// ErrClaimsMissing is returned when CheckJTIReplay is handed nil claims,
+	// which means the route was not JOSE-protected. Map it to 500 — it is a
+	// wiring error, not a peer error.
+	ErrClaimsMissing = errors.New("jose: no verified claims")
+
+	// ErrJTIMissing is returned when the verified claim set carries no jti, so
+	// no replay check is possible. Map it to 401 — the peer omitted a claim
+	// the deployment requires, which is a peer error, not a server fault.
+	ErrJTIMissing = errors.New("jose: verified claims carry no jti")
+
+	// ErrReplayRecorderMissing is returned when CheckJTIReplay is handed a nil
+	// recorder. Map it to 500 — like ErrClaimsMissing it is a wiring error, not
+	// anything the peer did.
+	ErrReplayRecorderMissing = errors.New("jose: replay recorder is nil")
+
+	// ErrReplayWindowInvalid is returned when the window argument is not
+	// positive. A zero window would store a jti with no expiry.
+	ErrReplayWindowInvalid = errors.New("jose: replay window must be positive")
+)
+
+// ReplayRecorder is the minimal atomic set-if-absent surface CheckJTIReplay needs.
+// cache.Cache satisfies it structurally, so jose does not import cache (the
+// package deliberately carries no go-bricks dependencies). Mirrors the
+// KeyStoreLike pattern in resolver.go.
+type ReplayRecorder interface {
+	// GetOrSet must be atomic set-if-absent: wasSet is true only when THIS
+	// call inserted a key that was absent, and false when the key already
+	// existed. CheckJTIReplay's replay detection is exactly this bit, so an
+	// implementation that returns true unconditionally silently disables it.
+	GetOrSet(ctx context.Context, key string, value []byte, ttl time.Duration) (storedValue []byte, wasSet bool, err error)
+}
+
+// replayMarker is the stored value. Its content is never read — only the key's
+// presence matters — but GetOrSet requires a non-empty value.
+var replayMarker = []byte{1}
+
+// CheckJTIReplay records the claim set's jti in recorder and reports whether
+// this is the first time it has been seen. fresh=false means the jti was
+// already recorded: a replay, which the caller should reject.
+//
+// window is how long a jti is remembered, measured from the first sighting. It
+// MUST be at least as long as the caller's own acceptance horizon — the point
+// past which the caller's timing checks would reject the token anyway.
+//
+// The TTL is deliberately NOT derived from the token's own exp. Doing so looks
+// tighter but forgets the jti at exp, while a caller that allows clock skew
+// still accepts the token until exp+skew: that difference is a replay window.
+// A caller whose freshness check bounds acceptance at iat+window is safe here,
+// because the key outlives that bound.
+//
+// CheckJTIReplay does NOT enforce exp, nbf, or iat freshness — skew tolerances
+// are partner-specific and remain the application's. Callers should run their
+// timing checks first and only reach here with a token they otherwise accept.
+//
+// Atomicity is the recorder's: with a SET-NX backend, exactly one of N
+// concurrent requests carrying the same jti observes fresh=true.
+func CheckJTIReplay(ctx context.Context, recorder ReplayRecorder, claims *Claims, window time.Duration) (fresh bool, err error) {
+	if claims == nil {
+		return false, ErrClaimsMissing
+	}
+	if recorder == nil {
+		return false, ErrReplayRecorderMissing
+	}
+	if claims.JTI == "" {
+		return false, ErrJTIMissing
+	}
+	if window <= 0 {
+		return false, ErrReplayWindowInvalid
+	}
+
+	_, wasSet, err := recorder.GetOrSet(ctx, replayKey(claims), replayMarker, window)
+	if err != nil {
+		return false, fmt.Errorf("jose: replay recorder: %w", err)
+	}
+	return wasSet, nil
+}
+
+// replayKey namespaces the jti by issuer. Two partners can legitimately mint
+// the same jti value, and a collision would reject a valid request. The length
+// prefix keeps the issuer boundary unambiguous, so no issuer string can alias
+// another issuer's namespace by embedding the separator.
+//
+// Per-tenant separation is already free: deps.Cache(ctx) resolves a
+// tenant-scoped cache instance, so a jti seen on tenant A does not block
+// tenant B.
+func replayKey(c *Claims) string {
+	return "jose:jti:" + strconv.Itoa(len(c.Issuer)) + ":" + c.Issuer + ":" + c.JTI
+}

--- a/jose/replay_test.go
+++ b/jose/replay_test.go
@@ -1,0 +1,203 @@
+package jose
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaborage/go-bricks/cache"
+)
+
+// Compile-time proof that the real cache surface satisfies ReplayRecorder. The
+// import is test-only, so jose's production dependency set is unchanged.
+var _ ReplayRecorder = cache.Cache(nil)
+
+// recordingStore is a hand-rolled fake, not cache/testing.MockCache: MockCache
+// stores an absolute expiration time and never exposes the ttl argument it was
+// given, so it cannot pin the stored TTL, which is exactly what these tests assert.
+type recordingStore struct {
+	key      string
+	value    []byte
+	ttl      time.Duration
+	calls    int
+	existing bool // when true, report the key as already present
+	err      error
+}
+
+func (s *recordingStore) GetOrSet(_ context.Context, key string, value []byte, ttl time.Duration) (storedValue []byte, wasSet bool, err error) {
+	s.calls++
+	s.key, s.value, s.ttl = key, value, ttl
+	if s.err != nil {
+		return nil, false, s.err
+	}
+	if s.existing {
+		return []byte{1}, false, nil
+	}
+	return value, true, nil
+}
+
+func TestCheckJTIReplayFirstUseIsFresh(t *testing.T) {
+	store := &recordingStore{}
+	claims := &Claims{JTI: "abc", Issuer: "visa"}
+
+	fresh, err := CheckJTIReplay(context.Background(), store, claims, 5*time.Minute)
+
+	require.NoError(t, err)
+	assert.True(t, fresh)
+	assert.Equal(t, 1, store.calls)
+	assert.Equal(t, "jose:jti:4:visa:abc", store.key)
+	// Pins the "GetOrSet requires a non-empty value" contract documented on
+	// replayMarker: the stored value is the marker, not something derived
+	// from the claims.
+	assert.Equal(t, []byte{1}, store.value)
+}
+
+func TestCheckJTIReplayDuplicateIsNotFresh(t *testing.T) {
+	store := &recordingStore{existing: true}
+	claims := &Claims{JTI: "abc", Issuer: "visa"}
+
+	fresh, err := CheckJTIReplay(context.Background(), store, claims, 5*time.Minute)
+
+	// A replay is a normal outcome, not an error.
+	require.NoError(t, err)
+	assert.False(t, fresh)
+}
+
+// TestCheckJTIReplayTTLAlwaysWindow pins the stored TTL to the caller's
+// declared window regardless of the claim's exp. Deriving the TTL from exp
+// would forget the jti at exp while a caller that allows clock skew still
+// accepts the token until exp+skew — that gap is a replay hole, so exp must
+// never shorten (or otherwise influence) the stored TTL.
+func TestCheckJTIReplayTTLAlwaysWindow(t *testing.T) {
+	const window = 5 * time.Minute
+
+	tests := []struct {
+		name      string
+		expiresAt time.Time
+	}{
+		{
+			name:      "exp_absent",
+			expiresAt: time.Time{},
+		},
+		{
+			name:      "exp_in_past",
+			expiresAt: time.Now().Add(-time.Hour),
+		},
+		{
+			name:      "exp_far_future",
+			expiresAt: time.Now().Add(time.Hour),
+		},
+		{
+			name:      "exp_within_window",
+			expiresAt: time.Now().Add(30 * time.Second),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &recordingStore{}
+			claims := &Claims{JTI: "abc", Issuer: "visa", ExpiresAt: tc.expiresAt}
+
+			_, err := CheckJTIReplay(context.Background(), store, claims, window)
+			require.NoError(t, err)
+
+			// The stored TTL is exactly the caller's declared window in every row —
+			// exp never shortens it, whatever its value. Equality also carries the
+			// immortal-key guard: window is positive, and a zero TTL would mean
+			// "no expiry" at the cache backend.
+			assert.Equal(t, window, store.ttl)
+		})
+	}
+}
+
+func TestCheckJTIReplayRejectsInvalidInput(t *testing.T) {
+	t.Run("nil_claims", func(t *testing.T) {
+		store := &recordingStore{}
+
+		_, err := CheckJTIReplay(context.Background(), store, nil, 5*time.Minute)
+
+		require.ErrorIs(t, err, ErrClaimsMissing)
+		assert.Equal(t, 0, store.calls)
+	})
+
+	t.Run("nil_recorder", func(t *testing.T) {
+		claims := &Claims{JTI: "abc", Issuer: "visa"}
+
+		_, err := CheckJTIReplay(context.Background(), nil, claims, 5*time.Minute)
+
+		require.ErrorIs(t, err, ErrReplayRecorderMissing)
+	})
+
+	t.Run("empty_jti", func(t *testing.T) {
+		store := &recordingStore{}
+		claims := &Claims{JTI: "", Issuer: "visa"}
+
+		_, err := CheckJTIReplay(context.Background(), store, claims, 5*time.Minute)
+
+		require.ErrorIs(t, err, ErrJTIMissing)
+		assert.Equal(t, 0, store.calls)
+	})
+
+	t.Run("zero_window", func(t *testing.T) {
+		store := &recordingStore{}
+		claims := &Claims{JTI: "abc", Issuer: "visa"}
+
+		_, err := CheckJTIReplay(context.Background(), store, claims, 0)
+
+		require.ErrorIs(t, err, ErrReplayWindowInvalid)
+		assert.Equal(t, 0, store.calls)
+	})
+
+	t.Run("negative_window", func(t *testing.T) {
+		store := &recordingStore{}
+		claims := &Claims{JTI: "abc", Issuer: "visa"}
+
+		_, err := CheckJTIReplay(context.Background(), store, claims, -time.Minute)
+
+		require.ErrorIs(t, err, ErrReplayWindowInvalid)
+		assert.Equal(t, 0, store.calls)
+	})
+}
+
+func TestCheckJTIReplayWrapsStoreError(t *testing.T) {
+	boom := errors.New("boom")
+	store := &recordingStore{err: boom}
+	claims := &Claims{JTI: "abc", Issuer: "visa"}
+
+	fresh, err := CheckJTIReplay(context.Background(), store, claims, 5*time.Minute)
+
+	assert.False(t, fresh)
+	require.ErrorIs(t, err, boom)
+	// Pins the %w wrapping itself — ErrorIs alone would pass even if the
+	// helper returned the store error unchanged.
+	assert.Contains(t, err.Error(), "jose: replay recorder:")
+}
+
+func TestCheckJTIReplayNamespacesByIssuer(t *testing.T) {
+	storeA := &recordingStore{}
+	storeB := &recordingStore{}
+
+	_, err := CheckJTIReplay(context.Background(), storeA, &Claims{JTI: "x", Issuer: "a"}, 5*time.Minute)
+	require.NoError(t, err)
+	_, err = CheckJTIReplay(context.Background(), storeB, &Claims{JTI: "x", Issuer: "bb"}, 5*time.Minute)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, storeA.key, storeB.key)
+
+	// The length prefix proves the issuer boundary is unambiguous: without it,
+	// issuer "a:b" + jti "c" and issuer "a" + jti "b:c" would collide on the
+	// same concatenated string.
+	storeC := &recordingStore{}
+	storeD := &recordingStore{}
+
+	_, err = CheckJTIReplay(context.Background(), storeC, &Claims{JTI: "c", Issuer: "a:b"}, 5*time.Minute)
+	require.NoError(t, err)
+	_, err = CheckJTIReplay(context.Background(), storeD, &Claims{JTI: "b:c", Issuer: "a"}, 5*time.Minute)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, storeC.key, storeD.key)
+}

--- a/llms.txt
+++ b/llms.txt
@@ -3378,15 +3378,25 @@ for _, m := range []app.Module{
 package secureapi
 
 import (
+    "context"
+
     "github.com/gaborage/go-bricks/app"
+    "github.com/gaborage/go-bricks/cache"
     "github.com/gaborage/go-bricks/server"
 )
 
-type Module struct{}
+type Module struct {
+    getCache func(context.Context) (cache.Cache, error)
+}
 
-func (m *Module) Name() string                 { return "secureapi" }
-func (m *Module) Init(_ *app.ModuleDeps) error { return nil }
-func (m *Module) Shutdown() error              { return nil }
+func (m *Module) Name() string { return "secureapi" }
+
+func (m *Module) Init(deps *app.ModuleDeps) error {
+    m.getCache = deps.Cache // tenant-aware resolution
+    return nil
+}
+
+func (m *Module) Shutdown() error { return nil }
 
 // Both types declare matching jose tags. Asymmetric declaration (only one tagged)
 // panics at startup.
@@ -3418,6 +3428,7 @@ The framework verifies the JWS signature and exposes the verified claim set via 
 
 ```go
 import (
+    "errors"
     "time"
     "github.com/gaborage/go-bricks/jose"
 )
@@ -3427,12 +3438,9 @@ const (
     maxClaimAge  = 5 * time.Minute   // hard upper bound on iat freshness
 )
 
-// jtiCache is any deduplication store you trust (Redis SETNX, in-memory LRU, DB row).
-// The framework deliberately does NOT ship a JTI cache — distribution semantics
-// depend on your deployment (single-replica vs. fleet vs. multi-region).
-type jtiCache interface {
-    Seen(ctx context.Context, jti string, ttl time.Duration) (bool, error)
-}
+// The framework ships jose.CheckJTIReplay for the jti half: it needs any
+// SET-NX store (jose.ReplayRecorder) — cache.Cache from deps.Cache satisfies it
+// and is already tenant-scoped, so a jti seen on tenant A never blocks tenant B.
 
 func (m *Module) exchange(req ExchangeRequest, ctx server.HandlerContext) (ExchangeResponse, server.IAPIError) {
     reqCtx := ctx.RequestContext()
@@ -3463,15 +3471,28 @@ func (m *Module) exchange(req ExchangeRequest, ctx server.HandlerContext) (Excha
         return ExchangeResponse{}, server.NewUnauthorizedError("payload not yet valid")
     }
 
-    // 3. jti replay — reject if we've seen this token recently
-    if claims.JTI != "" {
-        seen, err := m.jtiCache.Seen(reqCtx, claims.JTI, maxClaimAge)
-        if err != nil {
-            return ExchangeResponse{}, server.NewInternalServerError("jti check failed")
-        }
-        if seen {
-            return ExchangeResponse{}, server.NewUnauthorizedError("replayed jti")
-        }
+    // 3. jti replay — reject if we've seen this token recently.
+    if claims.JTI == "" {
+        // No jti means no replay check is possible: reject rather than accept
+        // an unprotected payload. Checked here so a cache outage cannot mask a
+        // 401 behind a 500.
+        return ExchangeResponse{}, server.NewUnauthorizedError("missing jti")
+    }
+    c, err := m.getCache(reqCtx)
+    if err != nil {
+        return ExchangeResponse{}, server.NewInternalServerError("cache unavailable")
+    }
+    fresh, err := jose.CheckJTIReplay(reqCtx, c, claims, maxClaimAge)
+    switch {
+    case errors.Is(err, jose.ErrJTIMissing):
+        // Defensive: unreachable given the check above, kept so the mapping is
+        // documented if that check is ever moved.
+        return ExchangeResponse{}, server.NewUnauthorizedError("missing jti")
+    case err != nil:
+        // Fail CLOSED: a replay check that could not run is not a pass.
+        return ExchangeResponse{}, server.NewInternalServerError("jti check failed")
+    case !fresh:
+        return ExchangeResponse{}, server.NewUnauthorizedError("replayed jti")
     }
 
     // 4. Partner-specific extensions live in claims.Raw

--- a/wiki/jose.md
+++ b/wiki/jose.md
@@ -90,7 +90,7 @@ for _, m := range []app.Module{
 
 Vanilla `Result[R]` continues to seal raw `data` so VTS-style vendor-prescribed JSON shapes work unchanged. Handlers explicitly opt into envelope semantics by returning `ResultWithMeta` (see [handler_patterns.md](handler_patterns.md#custom-envelope-meta-resultwithmetar)).
 
-**Replay protection**: the framework verifies the JWS signature and exposes verified claims via `jose.ClaimsFromContext(ctx)`. Applications enforce `iat`/`exp`/`jti` policies (Visa skew rules vary by product).
+**Replay protection**: the framework verifies the JWS signature and exposes verified claims via `jose.ClaimsFromContext(ctx)`. Applications enforce `iat`/`exp`/`jti` policies (Visa skew rules vary by product); `jose.CheckJTIReplay(ctx, recorder, claims, window)` provides the cache-backed `jti` half.
 
 **Test utilities** (`jose/testing/`):
 - `GenerateTestKeyPair(t)` — 2048-bit RSA pair for fast tests


### PR DESCRIPTION
## What

Applications enforcing JOSE `jti` replay protection were pointed at
`cache.GetOrSet` with `ttl = exp - now`. That forgets the jti at `exp` while
callers accept the token until `exp + skew`, so a payload replayed in that gap
passes every check. `jose.CheckJTIReplay` stores the caller's declared `window`
instead and rejects a non-positive one, also closing the immortal-key case
(`ttl == 0` means "no expiry" at the redis backend) and attacker-influenced key
lifetime.

## Impact

Additive. `jose` still imports no go-bricks package — the helper takes a local
one-method `ReplayStore` that `cache.Cache` satisfies structurally. Timing and
skew enforcement stay the application's; #348's pluggable interface stays gated.

## Verification

`make mutate` diff-scoped: all mutants on changed lines killed. Re-adding
exp-derived shortening by hand dies at `replay_test.go:112` and
`jose_properties_test.go:126`. Two CodeRabbit findings skipped by decision,
recorded in the commit body.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JOSE `jti` replay protection via a cache-backed helper that checks replay freshness within a configurable window.
  * Added clear validation behavior for missing claims, missing `jti`, invalid windows, and replay-store errors.
  * Updated the secure API example to reject requests when `jti` is missing, invalid, or replayed, using the new helper.

* **Documentation**
  * Expanded replay-protection guidance, including how to access verified claims from context and recommended `iat`/`exp`/`jti` policy enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->