### PR TITLE
build(mutate): move the baseline shard merge into the Go wrapper

### DIFF
--- a/.github/workflows/mutation-nightly.yml
+++ b/.github/workflows/mutation-nightly.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Publish score summary
         if: always()
         run: |
-          if [ ! -f gremlins-report.json ]; then
+          if [ ! -s gremlins-report.json ]; then
             echo "no report produced" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
@@ -57,5 +57,11 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: gremlins-report
-          path: gremlins-report.json
+          path: |
+            gremlins-report.json
+            .gremlins-reports/
+          # dot-dirs are excluded by default since upload-artifact v4 — without
+          # this the shard reports silently vanish from the artifact
+          include-hidden-files: true
+          if-no-files-found: warn
           retention-days: 30

--- a/Makefile
+++ b/Makefile
@@ -128,22 +128,11 @@ mutate-baseline: ## Full-repo mutation baseline, one engine process per package 
 				|| { echo "WARN: ./$$dir produced an unparsable report, dropped (advisory)"; rm -f "$$out" "$$out.tmp"; }; \
 		fi; \
 	done
-	@if ls .gremlins-reports/*.json >/dev/null 2>&1; then \
-		jq -s '(map(.mutants_killed // 0) | add) as $$k \
-			| (map(.mutants_lived // 0) | add) as $$l \
-			| (map(.mutants_not_covered // 0) | add) as $$n \
-			| { \
-				mutants_killed: $$k, \
-				mutants_lived: $$l, \
-				mutants_not_covered: $$n, \
-				test_efficacy: (if ($$k + $$l) > 0 then ($$k * 100 / ($$k + $$l)) else 0 end), \
-				mutations_coverage: (if ($$k + $$l + $$n) > 0 then (($$k + $$l) * 100 / ($$k + $$l + $$n)) else 0 end), \
-				files: (map(.files // []) | add) \
-			}' .gremlins-reports/*.json > gremlins-report.json; \
-		jq -r '"baseline: killed=\(.mutants_killed) lived=\(.mutants_lived) not_covered=\(.mutants_not_covered) efficacy=\(.test_efficacy | floor)%"' gremlins-report.json; \
-	else \
-		echo "WARN: no package reports produced — skipping merge (advisory)"; \
-	fi
+# The merge lives in Go (scripts/mutatediff -merge), not inline jq: make's
+# backslash continuations land literal backslashes inside a single-quoted jq
+# program, which cost the first sharded run its entire report (jq compile
+# error swallowed by the advisory guard, 0-byte artifact uploaded).
+	@go run ./scripts/mutatediff -merge .gremlins-reports -out gremlins-report.json
 
 release: ## Cut a signed release tag (usage: make release VERSION=v0.38.0). Run AFTER merging the release-please PR. Requires 1Password unlocked.
 	@test -n "$(VERSION)" || { echo "Error: VERSION is required, e.g. 'make release VERSION=v0.38.0'"; exit 1; }

--- a/scripts/mutatediff/main.go
+++ b/scripts/mutatediff/main.go
@@ -15,7 +15,12 @@ import (
 func main() {
 	engine := flag.String("engine", "", "mutation engine command prefix, e.g. 'go run github.com/go-gremlins/gremlins/cmd/gremlins@v0.5.0'")
 	base := flag.String("base", "origin/main", "ref to compute merge-base against")
+	mergeDir := flag.String("merge", "", "merge mode: directory of per-package shard reports to aggregate (skips the diff gate)")
+	mergeOut := flag.String("out", "gremlins-report.json", "merge mode: output path for the aggregated report")
 	flag.Parse()
+	if *mergeDir != "" {
+		os.Exit(mergeShards(*mergeDir, *mergeOut, os.Stdout))
+	}
 	if *engine == "" {
 		fmt.Fprintln(os.Stderr, "mutatediff: -engine is required")
 		os.Exit(2)

--- a/scripts/mutatediff/merge.go
+++ b/scripts/mutatediff/merge.go
@@ -50,10 +50,19 @@ func readShard(p string, out io.Writer) (shardReport, bool) {
 		fmt.Fprintf(out, "WARN: skipping %s: JSON but not a gremlins report\n", p)
 		return s, false
 	}
-	if *s.MutantsTotal < 0 || s.MutantsKilled < 0 || s.MutantsLived < 0 || s.MutantsNotCovered < 0 ||
-		s.MutantsKilled+s.MutantsLived+s.MutantsNotCovered > *s.MutantsTotal {
+	if *s.MutantsTotal < 0 || s.MutantsKilled < 0 || s.MutantsLived < 0 || s.MutantsNotCovered < 0 {
 		fmt.Fprintf(out, "WARN: skipping %s: counters violate gremlins invariants\n", p)
 		return s, false
+	}
+	// Checked subtraction instead of summing — a sum of near-MaxInt counters
+	// wraps negative and would sneak past a plain comparison.
+	remaining := *s.MutantsTotal
+	for _, c := range []int{s.MutantsKilled, s.MutantsLived, s.MutantsNotCovered} {
+		if c > remaining {
+			fmt.Fprintf(out, "WARN: skipping %s: counters violate gremlins invariants\n", p)
+			return s, false
+		}
+		remaining -= c
 	}
 	return s, true
 }
@@ -83,6 +92,11 @@ func mergeShards(dir, outPath string, out io.Writer) int {
 		s, ok := readShard(p, out)
 		if !ok {
 			continue
+		}
+		if merged.MutantsKilled > math.MaxInt-s.MutantsKilled ||
+			merged.MutantsLived > math.MaxInt-s.MutantsLived ||
+			merged.MutantsNotCovered > math.MaxInt-s.MutantsNotCovered {
+			return fail("aggregate counters would overflow at %s — refusing to write a corrupt report", p)
 		}
 		readable++
 		merged.MutantsKilled += s.MutantsKilled

--- a/scripts/mutatediff/merge.go
+++ b/scripts/mutatediff/merge.go
@@ -29,6 +29,35 @@ type mergedReport struct {
 	Files             []json.RawMessage `json:"files"`
 }
 
+// readShard loads and validates one shard; ok=false means skip (already
+// warned). Identity keys on mutants_total — the baseline loop's jq rewrite
+// normalizes files to [] on any parseable JSON, so files proves nothing.
+// Counter sanity: non-negative, and the verdicted counters cannot exceed the
+// total (killed+lived+not_covered < total is legitimate — the remainder is
+// TIMED OUT / NOT VIABLE, which gremlins reports separately).
+func readShard(p string, out io.Writer) (shardReport, bool) {
+	var s shardReport
+	data, err := os.ReadFile(p) // #nosec G304 -- paths come from a glob over the loop's own report dir
+	if err != nil {
+		fmt.Fprintf(out, "WARN: skipping unreadable shard %s: %v\n", p, err)
+		return s, false
+	}
+	if err := json.Unmarshal(data, &s); err != nil {
+		fmt.Fprintf(out, "WARN: skipping unparsable shard %s: %v\n", p, err)
+		return s, false
+	}
+	if s.MutantsTotal == nil {
+		fmt.Fprintf(out, "WARN: skipping %s: JSON but not a gremlins report\n", p)
+		return s, false
+	}
+	if *s.MutantsTotal < 0 || s.MutantsKilled < 0 || s.MutantsLived < 0 || s.MutantsNotCovered < 0 ||
+		s.MutantsKilled+s.MutantsLived+s.MutantsNotCovered > *s.MutantsTotal {
+		fmt.Fprintf(out, "WARN: skipping %s: counters violate gremlins invariants\n", p)
+		return s, false
+	}
+	return s, true
+}
+
 // mergeShards aggregates every *.json shard in dir into a single report at
 // outPath. An unparsable shard is skipped with a WARN (the baseline is
 // advisory; one bad shard must not erase the rest). Zero readable shards is
@@ -51,21 +80,8 @@ func mergeShards(dir, outPath string, out io.Writer) int {
 		if abs, absErr := filepath.Abs(p); absErr == nil && abs == absOut {
 			continue // never slurp our own output on a re-run
 		}
-		data, readErr := os.ReadFile(p) // #nosec G304 -- paths come from a glob over the loop's own report dir
-		if readErr != nil {
-			fmt.Fprintf(out, "WARN: skipping unreadable shard %s: %v\n", p, readErr)
-			continue
-		}
-		var s shardReport
-		if jsonErr := json.Unmarshal(data, &s); jsonErr != nil {
-			fmt.Fprintf(out, "WARN: skipping unparsable shard %s: %v\n", p, jsonErr)
-			continue
-		}
-		// Identity check must not lean on files: the baseline loop's jq rewrite
-		// normalizes files to [] on any parseable JSON. mutants_total is the
-		// gremlins-specific marker.
-		if s.MutantsTotal == nil {
-			fmt.Fprintf(out, "WARN: skipping %s: JSON but not a gremlins report\n", p)
+		s, ok := readShard(p, out)
+		if !ok {
 			continue
 		}
 		readable++

--- a/scripts/mutatediff/merge.go
+++ b/scripts/mutatediff/merge.go
@@ -61,7 +61,10 @@ func mergeShards(dir, outPath string, out io.Writer) int {
 			fmt.Fprintf(out, "WARN: skipping unparsable shard %s: %v\n", p, jsonErr)
 			continue
 		}
-		if s.MutantsTotal == nil && s.Files == nil {
+		// Identity check must not lean on files: the baseline loop's jq rewrite
+		// normalizes files to [] on any parseable JSON. mutants_total is the
+		// gremlins-specific marker.
+		if s.MutantsTotal == nil {
 			fmt.Fprintf(out, "WARN: skipping %s: JSON but not a gremlins report\n", p)
 			continue
 		}

--- a/scripts/mutatediff/merge.go
+++ b/scripts/mutatediff/merge.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+)
+
+// shardReport carries the per-package gremlins fields the merge aggregates.
+// Unknown fields are ignored; files entries pass through verbatim (the
+// baseline loop has already prefixed file_name with the package dir).
+type shardReport struct {
+	MutantsTotal      *int              `json:"mutants_total"`
+	MutantsKilled     int               `json:"mutants_killed"`
+	MutantsLived      int               `json:"mutants_lived"`
+	MutantsNotCovered int               `json:"mutants_not_covered"`
+	Files             []json.RawMessage `json:"files"`
+}
+
+type mergedReport struct {
+	MutantsKilled     int               `json:"mutants_killed"`
+	MutantsLived      int               `json:"mutants_lived"`
+	MutantsNotCovered int               `json:"mutants_not_covered"`
+	TestEfficacy      float64           `json:"test_efficacy"`
+	MutationsCoverage float64           `json:"mutations_coverage"`
+	Files             []json.RawMessage `json:"files"`
+}
+
+// mergeShards aggregates every *.json shard in dir into a single report at
+// outPath. An unparsable shard is skipped with a WARN (the baseline is
+// advisory; one bad shard must not erase the rest). Zero readable shards is
+// an error — writing an empty report would silently pass downstream guards.
+func mergeShards(dir, outPath string, out io.Writer) int {
+	paths, err := filepath.Glob(filepath.Join(dir, "*.json")) // Glob returns lexicographic order
+	if err != nil {
+		return fail("%v", err)
+	}
+
+	absOut, err := filepath.Abs(outPath)
+	if err != nil {
+		return fail("%v", err)
+	}
+
+	var merged mergedReport
+	merged.Files = []json.RawMessage{}
+	readable := 0
+	for _, p := range paths {
+		if abs, absErr := filepath.Abs(p); absErr == nil && abs == absOut {
+			continue // never slurp our own output on a re-run
+		}
+		data, readErr := os.ReadFile(p) // #nosec G304 -- paths come from a glob over the loop's own report dir
+		if readErr != nil {
+			fmt.Fprintf(out, "WARN: skipping unreadable shard %s: %v\n", p, readErr)
+			continue
+		}
+		var s shardReport
+		if jsonErr := json.Unmarshal(data, &s); jsonErr != nil {
+			fmt.Fprintf(out, "WARN: skipping unparsable shard %s: %v\n", p, jsonErr)
+			continue
+		}
+		if s.MutantsTotal == nil && s.Files == nil {
+			fmt.Fprintf(out, "WARN: skipping %s: JSON but not a gremlins report\n", p)
+			continue
+		}
+		readable++
+		merged.MutantsKilled += s.MutantsKilled
+		merged.MutantsLived += s.MutantsLived
+		merged.MutantsNotCovered += s.MutantsNotCovered
+		merged.Files = append(merged.Files, s.Files...)
+	}
+	if readable == 0 {
+		return fail("no readable shards in %s — refusing to write an empty report", dir)
+	}
+
+	if verdicted := merged.MutantsKilled + merged.MutantsLived; verdicted > 0 {
+		merged.TestEfficacy = float64(merged.MutantsKilled) * 100 / float64(verdicted)
+	}
+	if seen := merged.MutantsKilled + merged.MutantsLived + merged.MutantsNotCovered; seen > 0 {
+		merged.MutationsCoverage = float64(merged.MutantsKilled+merged.MutantsLived) * 100 / float64(seen)
+	}
+
+	encoded, err := json.Marshal(merged)
+	if err != nil {
+		return fail("%v", err)
+	}
+	if err := os.WriteFile(outPath, encoded, 0o600); err != nil {
+		return fail("%v", err)
+	}
+	fmt.Fprintf(out, "baseline: killed=%d lived=%d not_covered=%d efficacy=%.0f%% (from %d shards)\n",
+		merged.MutantsKilled, merged.MutantsLived, merged.MutantsNotCovered, math.Floor(merged.TestEfficacy), readable)
+	return 0
+}

--- a/scripts/mutatediff/merge_test.go
+++ b/scripts/mutatediff/merge_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeShard(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMergeShardsAggregatesAndPrefixedFilesPassThrough(t *testing.T) {
+	dir := t.TempDir()
+	writeShard(t, dir, "1-config.json",
+		`{"mutants_killed":51,"mutants_lived":7,"mutants_not_covered":2,"files":[{"file_name":"config/injection.go","mutations":[{"line":1,"type":"X","status":"LIVED"}]}]}`)
+	writeShard(t, dir, "2-multitenant.json",
+		`{"mutants_killed":7,"mutants_lived":0,"mutants_not_covered":0,"files":[]}`)
+
+	outPath := filepath.Join(dir, "merged.json")
+	var buf bytes.Buffer
+	if code := mergeShards(dir, outPath, &buf); code != 0 {
+		t.Fatalf("mergeShards = %d, want 0; output: %s", code, buf.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "merged.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		MutantsKilled     int     `json:"mutants_killed"`
+		MutantsLived      int     `json:"mutants_lived"`
+		MutantsNotCovered int     `json:"mutants_not_covered"`
+		TestEfficacy      float64 `json:"test_efficacy"`
+		MutationsCoverage float64 `json:"mutations_coverage"`
+		Files             []struct {
+			FileName string `json:"file_name"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("merged report not valid JSON: %v", err)
+	}
+	if got.MutantsKilled != 58 || got.MutantsLived != 7 || got.MutantsNotCovered != 2 {
+		t.Fatalf("sums wrong: %+v", got)
+	}
+	if got.TestEfficacy < 89.2 || got.TestEfficacy > 89.3 {
+		t.Fatalf("efficacy = %v, want ~89.23", got.TestEfficacy)
+	}
+	if got.MutationsCoverage < 97.0 || got.MutationsCoverage > 97.1 {
+		t.Fatalf("coverage = %v, want ~97.01", got.MutationsCoverage)
+	}
+	if len(got.Files) != 1 || got.Files[0].FileName != "config/injection.go" {
+		t.Fatalf("files pass-through wrong: %+v", got.Files)
+	}
+
+	if !strings.Contains(buf.String(), "from 2 shards") {
+		t.Fatalf("missing shard count in output: %s", buf.String())
+	}
+}
+
+func TestMergeShardsNeverSlurpsItsOwnOutputOnRerun(t *testing.T) {
+	dir := t.TempDir()
+	writeShard(t, dir, "1-config.json", `{"mutants_killed":10,"mutants_lived":0,"files":[]}`)
+
+	outPath := filepath.Join(dir, "merged.json") // output INSIDE the shard dir
+	var buf bytes.Buffer
+	if code := mergeShards(dir, outPath, &buf); code != 0 {
+		t.Fatalf("first merge = %d; output: %s", code, buf.String())
+	}
+	buf.Reset()
+	if code := mergeShards(dir, outPath, &buf); code != 0 {
+		t.Fatalf("second merge = %d; output: %s", code, buf.String())
+	}
+	data, _ := os.ReadFile(outPath)
+	if !strings.Contains(string(data), `"mutants_killed":10`) {
+		t.Fatalf("re-run compounded its own output: %s", data)
+	}
+	if !strings.Contains(buf.String(), "from 1 shards") {
+		t.Fatalf("re-run should still see exactly 1 shard: %s", buf.String())
+	}
+}
+
+func TestMergeShardsSkipsJSONThatIsNotAReport(t *testing.T) {
+	dir := t.TempDir()
+	writeShard(t, dir, "1-good.json", `{"mutants_killed":2,"mutants_lived":0,"files":[]}`)
+	writeShard(t, dir, "2-notareport.json", `{"hello":"world"}`)
+
+	outPath := filepath.Join(t.TempDir(), "merged.json")
+	var buf bytes.Buffer
+	if code := mergeShards(dir, outPath, &buf); code != 0 {
+		t.Fatalf("mergeShards = %d; output: %s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "not a gremlins report") {
+		t.Fatalf("missing WARN for non-report JSON: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "from 1 shards") {
+		t.Fatalf("non-report must not count as a shard: %s", buf.String())
+	}
+}
+
+func TestMergeShardsSkipsUnparsableShardWithWarning(t *testing.T) {
+	dir := t.TempDir()
+	writeShard(t, dir, "1-good.json", `{"mutants_killed":3,"mutants_lived":1,"files":[]}`)
+	writeShard(t, dir, "2-broken.json", `{truncated`)
+
+	var buf bytes.Buffer
+	outPath := filepath.Join(t.TempDir(), "merged.json")
+	if code := mergeShards(dir, outPath, &buf); code != 0 {
+		t.Fatalf("mergeShards = %d, want 0; output: %s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "skipping unparsable shard") {
+		t.Fatalf("missing WARN for broken shard: %s", buf.String())
+	}
+	data, _ := os.ReadFile(outPath)
+	if !strings.Contains(string(data), `"mutants_killed":3`) {
+		t.Fatalf("good shard not merged: %s", data)
+	}
+}
+
+func TestMergeShardsFailsClosedOnZeroReadableShards(t *testing.T) {
+	dir := t.TempDir()
+	writeShard(t, dir, "1-broken.json", `{nope`)
+
+	outPath := filepath.Join(t.TempDir(), "merged.json")
+	var buf bytes.Buffer
+	if code := mergeShards(dir, outPath, &buf); code != 2 {
+		t.Fatalf("mergeShards = %d, want 2 for zero readable shards", code)
+	}
+	if _, err := os.Stat(outPath); !os.IsNotExist(err) {
+		t.Fatalf("empty merged report must not be written; stat err = %v", err)
+	}
+}

--- a/scripts/mutatediff/merge_test.go
+++ b/scripts/mutatediff/merge_test.go
@@ -136,3 +136,22 @@ func TestMergeShardsFailsClosedOnZeroReadableShards(t *testing.T) {
 		t.Fatalf("empty merged report must not be written; stat err = %v", err)
 	}
 }
+
+func TestMergeShardsSkipsInvariantViolatingCounters(t *testing.T) {
+	dir := t.TempDir()
+	writeShard(t, dir, "1-good.json", `{"mutants_total":5,"mutants_killed":5,"mutants_lived":0,"files":[]}`)
+	writeShard(t, dir, "2-negative.json", `{"mutants_total":3,"mutants_killed":-1,"mutants_lived":0,"files":[]}`)
+	writeShard(t, dir, "3-overtotal.json", `{"mutants_total":1,"mutants_killed":2,"mutants_lived":1,"files":[]}`)
+
+	outPath := filepath.Join(t.TempDir(), "merged.json")
+	var buf bytes.Buffer
+	if code := mergeShards(dir, outPath, &buf); code != 0 {
+		t.Fatalf("mergeShards = %d; output: %s", code, buf.String())
+	}
+	if got := strings.Count(buf.String(), "counters violate gremlins invariants"); got != 2 {
+		t.Fatalf("want 2 invariant WARNs, got %d: %s", got, buf.String())
+	}
+	if !strings.Contains(buf.String(), "from 1 shards") {
+		t.Fatalf("only the sane shard may count: %s", buf.String())
+	}
+}

--- a/scripts/mutatediff/merge_test.go
+++ b/scripts/mutatediff/merge_test.go
@@ -155,3 +155,34 @@ func TestMergeShardsSkipsInvariantViolatingCounters(t *testing.T) {
 		t.Fatalf("only the sane shard may count: %s", buf.String())
 	}
 }
+
+func TestMergeShardsRejectsWrappingCounterSums(t *testing.T) {
+	dir := t.TempDir()
+	writeShard(t, dir, "1-good.json", `{"mutants_total":1,"mutants_killed":1,"files":[]}`)
+	writeShard(t, dir, "2-wrap.json",
+		`{"mutants_total":9223372036854775807,"mutants_killed":9223372036854775807,"mutants_lived":1,"files":[]}`)
+
+	outPath := filepath.Join(t.TempDir(), "merged.json")
+	var buf bytes.Buffer
+	if code := mergeShards(dir, outPath, &buf); code != 0 {
+		t.Fatalf("mergeShards = %d; output: %s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "from 1 shards") {
+		t.Fatalf("wrapping shard must be skipped: %s", buf.String())
+	}
+}
+
+func TestMergeShardsFailsClosedOnAggregateOverflow(t *testing.T) {
+	dir := t.TempDir()
+	writeShard(t, dir, "1-max.json", `{"mutants_total":9223372036854775807,"mutants_killed":9223372036854775807,"files":[]}`)
+	writeShard(t, dir, "2-max.json", `{"mutants_total":9223372036854775807,"mutants_killed":9223372036854775807,"files":[]}`)
+
+	outPath := filepath.Join(t.TempDir(), "merged.json")
+	var buf bytes.Buffer
+	if code := mergeShards(dir, outPath, &buf); code != 2 {
+		t.Fatalf("mergeShards = %d, want 2 on aggregate overflow", code)
+	}
+	if _, err := os.Stat(outPath); !os.IsNotExist(err) {
+		t.Fatalf("corrupt report must not be written; stat err = %v", err)
+	}
+}

--- a/scripts/mutatediff/merge_test.go
+++ b/scripts/mutatediff/merge_test.go
@@ -19,9 +19,9 @@ func writeShard(t *testing.T, dir, name, content string) {
 func TestMergeShardsAggregatesAndPrefixedFilesPassThrough(t *testing.T) {
 	dir := t.TempDir()
 	writeShard(t, dir, "1-config.json",
-		`{"mutants_killed":51,"mutants_lived":7,"mutants_not_covered":2,"files":[{"file_name":"config/injection.go","mutations":[{"line":1,"type":"X","status":"LIVED"}]}]}`)
+		`{"mutants_total":60,"mutants_killed":51,"mutants_lived":7,"mutants_not_covered":2,"files":[{"file_name":"config/injection.go","mutations":[{"line":1,"type":"X","status":"LIVED"}]}]}`)
 	writeShard(t, dir, "2-multitenant.json",
-		`{"mutants_killed":7,"mutants_lived":0,"mutants_not_covered":0,"files":[]}`)
+		`{"mutants_total":7,"mutants_killed":7,"mutants_lived":0,"mutants_not_covered":0,"files":[]}`)
 
 	outPath := filepath.Join(dir, "merged.json")
 	var buf bytes.Buffer
@@ -66,7 +66,7 @@ func TestMergeShardsAggregatesAndPrefixedFilesPassThrough(t *testing.T) {
 
 func TestMergeShardsNeverSlurpsItsOwnOutputOnRerun(t *testing.T) {
 	dir := t.TempDir()
-	writeShard(t, dir, "1-config.json", `{"mutants_killed":10,"mutants_lived":0,"files":[]}`)
+	writeShard(t, dir, "1-config.json", `{"mutants_total":10,"mutants_killed":10,"mutants_lived":0,"files":[]}`)
 
 	outPath := filepath.Join(dir, "merged.json") // output INSIDE the shard dir
 	var buf bytes.Buffer
@@ -88,8 +88,8 @@ func TestMergeShardsNeverSlurpsItsOwnOutputOnRerun(t *testing.T) {
 
 func TestMergeShardsSkipsJSONThatIsNotAReport(t *testing.T) {
 	dir := t.TempDir()
-	writeShard(t, dir, "1-good.json", `{"mutants_killed":2,"mutants_lived":0,"files":[]}`)
-	writeShard(t, dir, "2-notareport.json", `{"hello":"world"}`)
+	writeShard(t, dir, "1-good.json", `{"mutants_total":2,"mutants_killed":2,"mutants_lived":0,"files":[]}`)
+	writeShard(t, dir, "2-notareport.json", `{"hello":"world","files":[]}`)
 
 	outPath := filepath.Join(t.TempDir(), "merged.json")
 	var buf bytes.Buffer
@@ -106,7 +106,7 @@ func TestMergeShardsSkipsJSONThatIsNotAReport(t *testing.T) {
 
 func TestMergeShardsSkipsUnparsableShardWithWarning(t *testing.T) {
 	dir := t.TempDir()
-	writeShard(t, dir, "1-good.json", `{"mutants_killed":3,"mutants_lived":1,"files":[]}`)
+	writeShard(t, dir, "1-good.json", `{"mutants_total":4,"mutants_killed":3,"mutants_lived":1,"files":[]}`)
 	writeShard(t, dir, "2-broken.json", `{truncated`)
 
 	var buf bytes.Buffer

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -336,9 +336,9 @@ Engine version is pinned via `GREMLINS_VERSION` in the Makefile;
 runtime knobs live in `.gremlins.yaml`. The nightly `Mutation Baseline`
 workflow runs every package except the excluded `scripts/` in advisory mode
 (one engine process per package,
-so a crashed engine process only loses that package's shard — though the JSON
-artifact uploads only after the final merge, so a full runner eviction still
-loses the run) and publishes overall efficacy
+so a crashed engine process only loses that package's shard; the artifact
+carries the raw per-package shards alongside the merged report, so even a
+failed merge keeps the run's data) and publishes overall efficacy
 plus a table of files with LIVED / NOT COVERED findings (first 50 rows) to the
 job summary; the JSON artifact is the complete record.
 


### PR DESCRIPTION
## What
The first sharded baseline uploaded a 0-byte report: make's backslash
continuations corrupt a multi-line single-quoted jq program, the redirect had
already truncated the file, the advisory guard swallowed the error, and the
summary's `-f` guard passed (jq exits 0 on empty input). The merge now lives
in the tested Go wrapper (`scripts/mutatediff -merge`): WARN-and-skip for bad
shards, fail-closed on zero readable shards, self-output exclusion on re-runs.
The workflow guard is `-s`, and the artifact now carries the raw shards
(`include-hidden-files: true` — v4+ drops dot-dirs by default).

## Impact
None for `make mutate`. Baseline artifact now contains the shard directory
alongside the merged report.

## Verification
Unit tests per failure path; live end-to-end (two real gremlins shards → Go
merge → the workflow's summary jq, efficacy 89.23%). Fourth CodeRabbit CLI
pass rate-limited; final delta since the last clean pass is the 4-line
include-hidden-files addition. Re-dispatch the workflow after merge for the
real proof.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated merge flow that aggregates per-package mutation report shards into a single report, including coverage and efficacy metrics.
  * Nightly artifacts now include both the merged report and the underlying shard data (including hidden report directories).

* **Bug Fixes**
  * Improved handling of missing/empty reports to prevent silent artifact loss.
  * Merge logic now skips non-relevant, unparsable, or invalid shard reports and refuses to produce an empty merged output.

* **Documentation**
  * Updated “Mutation Gate” guidance to reflect that a crash only affects the shard for the affected package and preserves shard artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->