### PR TITLE
fix(mutate): NOT COVERED sits outside mutants_total in gremlins

### DIFF
--- a/scripts/mutatediff/merge.go
+++ b/scripts/mutatediff/merge.go
@@ -55,9 +55,12 @@ func readShard(p string, out io.Writer) (shardReport, bool) {
 		return s, false
 	}
 	// Checked subtraction instead of summing — a sum of near-MaxInt counters
-	// wraps negative and would sneak past a plain comparison.
+	// wraps negative and would sneak past a plain comparison. NOT COVERED is
+	// deliberately absent: gremlins counts it OUTSIDE mutants_total (real
+	// capture: total=356 with killed=330, lived=26, not_covered=42) — including
+	// it here silently rejected 49 of 54 shards in the first production merge.
 	remaining := *s.MutantsTotal
-	for _, c := range []int{s.MutantsKilled, s.MutantsLived, s.MutantsNotCovered} {
+	for _, c := range []int{s.MutantsKilled, s.MutantsLived} {
 		if c > remaining {
 			fmt.Fprintf(out, "WARN: skipping %s: counters violate gremlins invariants\n", p)
 			return s, false
@@ -84,13 +87,14 @@ func mergeShards(dir, outPath string, out io.Writer) int {
 
 	var merged mergedReport
 	merged.Files = []json.RawMessage{}
-	readable := 0
+	readable, skipped := 0, 0
 	for _, p := range paths {
 		if abs, absErr := filepath.Abs(p); absErr == nil && abs == absOut {
 			continue // never slurp our own output on a re-run
 		}
 		s, ok := readShard(p, out)
 		if !ok {
+			skipped++
 			continue
 		}
 		if merged.MutantsKilled > math.MaxInt-s.MutantsKilled ||
@@ -122,7 +126,7 @@ func mergeShards(dir, outPath string, out io.Writer) int {
 	if err := os.WriteFile(outPath, encoded, 0o600); err != nil {
 		return fail("%v", err)
 	}
-	fmt.Fprintf(out, "baseline: killed=%d lived=%d not_covered=%d efficacy=%.0f%% (from %d shards)\n",
-		merged.MutantsKilled, merged.MutantsLived, merged.MutantsNotCovered, math.Floor(merged.TestEfficacy), readable)
+	fmt.Fprintf(out, "baseline: killed=%d lived=%d not_covered=%d efficacy=%.0f%% (from %d shards, %d skipped)\n",
+		merged.MutantsKilled, merged.MutantsLived, merged.MutantsNotCovered, math.Floor(merged.TestEfficacy), readable, skipped)
 	return 0
 }

--- a/scripts/mutatediff/merge_test.go
+++ b/scripts/mutatediff/merge_test.go
@@ -77,7 +77,10 @@ func TestMergeShardsNeverSlurpsItsOwnOutputOnRerun(t *testing.T) {
 	if code := mergeShards(dir, outPath, &buf); code != 0 {
 		t.Fatalf("second merge = %d; output: %s", code, buf.String())
 	}
-	data, _ := os.ReadFile(outPath)
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read merged report: %v", err)
+	}
 	if !strings.Contains(string(data), `"mutants_killed":10`) {
 		t.Fatalf("re-run compounded its own output: %s", data)
 	}
@@ -117,7 +120,10 @@ func TestMergeShardsSkipsUnparsableShardWithWarning(t *testing.T) {
 	if !strings.Contains(buf.String(), "skipping unparsable shard") {
 		t.Fatalf("missing WARN for broken shard: %s", buf.String())
 	}
-	data, _ := os.ReadFile(outPath)
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read merged report: %v", err)
+	}
 	if !strings.Contains(string(data), `"mutants_killed":3`) {
 		t.Fatalf("good shard not merged: %s", data)
 	}
@@ -204,7 +210,10 @@ func TestMergeShardsAcceptsRealCaptureShapedShard(t *testing.T) {
 	if !strings.Contains(buf.String(), "from 1 shards, 0 skipped") {
 		t.Fatalf("real-capture-shaped shard must be accepted: %s", buf.String())
 	}
-	data, _ := os.ReadFile(outPath)
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read merged report: %v", err)
+	}
 	if !strings.Contains(string(data), `"mutants_not_covered":42`) {
 		t.Fatalf("not_covered lost in merge: %s", data)
 	}

--- a/scripts/mutatediff/merge_test.go
+++ b/scripts/mutatediff/merge_test.go
@@ -186,3 +186,26 @@ func TestMergeShardsFailsClosedOnAggregateOverflow(t *testing.T) {
 		t.Fatalf("corrupt report must not be written; stat err = %v", err)
 	}
 }
+
+// Regression: gremlins counts NOT COVERED OUTSIDE mutants_total. This fixture
+// mirrors the real Task-1 capture (total=356, killed=330, lived=26,
+// not_covered=42; 330+26+42 > 356) — the first production merge rejected 49 of
+// 54 shards because the invariant wrongly included not_covered.
+func TestMergeShardsAcceptsRealCaptureShapedShard(t *testing.T) {
+	dir := t.TempDir()
+	writeShard(t, dir, "1-config.json",
+		`{"mutants_total":356,"mutants_killed":330,"mutants_lived":26,"mutants_not_covered":42,"files":[]}`)
+
+	outPath := filepath.Join(t.TempDir(), "merged.json")
+	var buf bytes.Buffer
+	if code := mergeShards(dir, outPath, &buf); code != 0 {
+		t.Fatalf("mergeShards = %d; output: %s", code, buf.String())
+	}
+	if !strings.Contains(buf.String(), "from 1 shards, 0 skipped") {
+		t.Fatalf("real-capture-shaped shard must be accepted: %s", buf.String())
+	}
+	data, _ := os.ReadFile(outPath)
+	if !strings.Contains(string(data), `"mutants_not_covered":42`) {
+		t.Fatalf("not_covered lost in merge: %s", data)
+	}
+}


### PR DESCRIPTION
## What
The shard invariant added in #812's review included `mutants_not_covered` in
the check against `mutants_total`, but gremlins counts NOT COVERED outside the
total — so the first production merge rejected 49 of 54 shards and published a
38-mutant baseline instead of 2669. The invariant now covers killed+lived
only, the summary line reports the skipped-shard count, and a regression
fixture mirrors the real capture's shape (total=356, killed=330, lived=26,
not_covered=42).

## Impact
None.

## Verification
Merged the actual 54 production shards from run 30378931148: all accepted —
killed=2301, lived=368, not_covered=734, efficacy 86.21%, 285 files. That
merged result is the repo's real first debt map.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated shard validation to accept valid capture data with higher numbers of uncovered mutants.
  * Merge results now report how many shards were skipped.
  * Improved error handling when reading merged output files.

* **Tests**
  * Added coverage for real-world capture-shaped shard data, ensuring it merges successfully and preserves uncovered mutant counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->