### PR TITLE
ci: exclude Claude workflow scripts from GitHub language detection

### DIFF
--- a/.claude/workflows/README.md
+++ b/.claude/workflows/README.md
@@ -1,0 +1,64 @@
+# Claude Code workflow scripts
+
+The `.js` files in this directory are **Claude Code Workflow-tool scripts**,
+not standalone JavaScript. The dialect uses an ESM `export const meta = {…}`
+header plus **top-level `return`** and top-level `await` — the Workflow
+runtime wraps the script body in an async function before executing it, and
+injects orchestration globals (`agent()`, `parallel()`, `pipeline()`,
+`phase()`, `log()`). Run them via the Workflow tool by name (e.g.
+`Workflow({name: "doc-drift"})` or the `/doc-drift` skill), never with
+`node`.
+
+## These files are not parseable as standard JavaScript — by design
+
+Standard parsers reject top-level `return` outside a function. Reproduce with
+a module-mode syntax check reading the file on stdin:
+
+```bash
+node --input-type=module --check < .claude/workflows/doc-drift.js
+# [stdin]:298
+# return {
+# ^^^^^^
+# SyntaxError: Illegal return statement
+```
+
+Note that `node --check <file>` alone does NOT reproduce it and exits 0 —
+`--check` on a file path parses as CommonJS, and Node wraps CommonJS modules
+in a function, which makes top-level `return` legal there. Consequences:
+
+- **Do not** add these files to any JS toolchain (ESLint, tsc, bundlers,
+  CodeQL javascript-typescript analysis). They will always fail to parse.
+- **Do not** "fix" the syntax to appease a scanner — the dialect is what the
+  Workflow runtime executes; wrapping the body in a function or removing the
+  top-level `return` breaks the scripts.
+- A `.gitattributes` rule (`.claude/workflows/*.js linguist-detectable=false`)
+  keeps these files out of GitHub language detection so the repo is not
+  classified as containing JavaScript. New workflow scripts added here are
+  covered automatically by the glob.
+
+## Incident record (June 2026)
+
+When the first scripts landed (PR #505, 2026-05-31), GitHub language
+detection began reporting JavaScript, and CodeQL **default setup**
+(GitHub-managed, no workflow file in this repo) automatically added an
+`Analyze (javascript-typescript)` job. With zero parseable JS in the repo,
+the extractor failed every run (exit 32, "no source code seen"):
+scheduled scan on `main` 2026-06-01
+(actions/runs/26734254677) and PR #572 2026-06-10. Resolution, in layers:
+
+1. **Settings**: default setup was pinned to an explicit language list.
+   That state lives in GitHub settings only — the current list and the date
+   it was set are recorded in `wiki/troubleshooting.md` ("CI/CD Issues");
+   inspect live with
+   `gh api repos/gaborage/go-bricks/code-scanning/default-setup`.
+2. **This repo**: the `.gitattributes` rule above is intended to keep GitHub
+   language detection from classifying the repo as JavaScript, so a future
+   default-setup reset to automatic detection should not resurrect the
+   failing job. (The effect shows up only after GitHub recomputes language
+   stats, which happens asynchronously and may take more than one
+   default-branch push.)
+
+If CodeQL javascript-typescript analysis is ever wanted again (i.e. real
+JavaScript/TypeScript enters the repo), it will only succeed if at least one
+standard-grammar JS/TS file exists — the workflow scripts will still be
+per-file extraction errors, which CodeQL tolerates when other files parse.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Claude Code workflow scripts use the Workflow-tool dialect (top-level
+# return — not standalone JavaScript) and must stay out of GitHub language
+# detection. Incident record + rationale: .claude/workflows/README.md
+.claude/workflows/*.js linguist-detectable=false

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # But not these files...
 !/.gitignore
+!/.gitattributes
 
 !*.go
 !go.sum

--- a/wiki/troubleshooting.md
+++ b/wiki/troubleshooting.md
@@ -182,6 +182,30 @@ observability:
 # Coverage below 80%
 # → Run: make test-coverage
 # → Check SonarCloud quality gate requirements
+
+# CodeQL job "Analyze (javascript-typescript)" fails: exit 32,
+# "CodeQL detected code written in JavaScript/TypeScript but could not process any of it"
+# → The only .js files in this repo are Claude Code workflow scripts
+#   (.claude/workflows/*.js) in the Workflow-tool dialect — NOT valid
+#   standalone JavaScript (top-level return) and never will be.
+#   See .claude/workflows/README.md for the June 2026 incident record.
+# → Fix lives in TWO places:
+#   1. GitHub settings: CodeQL default setup analyzes an explicit language
+#      list ["actions","go"] (set 2026-07-20). Inspect (read-only):
+#      gh api repos/gaborage/go-bricks/code-scanning/default-setup
+#   2. In-repo: .gitattributes marks the scripts linguist-detectable=false,
+#      intended to keep language detection from re-classifying the repo as
+#      containing JavaScript after a default-setup reset.
+# → Do NOT re-add javascript-typescript as a remedy for THIS failure, and do
+#   NOT edit the workflow scripts' syntax to appease the scanner. Re-enabling
+#   it is only sensible once real, parseable JS/TS actually enters the repo
+#   — see .claude/workflows/README.md for that case.
+
+# Repo language bar / Languages API still shows "JavaScript"
+# → Expected for a while after the .gitattributes change lands; GitHub
+#   recomputes language stats asynchronously, so it may take one or more
+#   pushes to the default branch to clear.
+#   Check: gh api repos/gaborage/go-bricks/languages   # JavaScript key drops out
 ```
 
 ## Multi-Tenant Issues


### PR DESCRIPTION
## What

GitHub language detection classified this repo as containing JavaScript, because `.claude/workflows/*.js` are Claude Code Workflow-tool dialect scripts (top-level `return`, not valid standalone JS). CodeQL default setup therefore spun up an `Analyze (javascript-typescript)` job that failed every run with exit 32 until the language list was pinned in GitHub settings on 2026-07-20 — a fix invisible in git. A `.gitattributes` rule now marks those scripts `linguist-detectable=false`, and the incident plus the settings-level state are recorded in `.claude/workflows/README.md` and `wiki/troubleshooting.md`.

## Impact

None for consumers. The `.gitattributes` glob covers future workflow scripts automatically; the mutable settings snapshot lives in exactly one place (`wiki/troubleshooting.md`, "CI/CD Issues").

## Verification

Post-merge only: `gh api repos/gaborage/go-bricks/languages` should drop the `JavaScript` key once GitHub recomputes stats asynchronously, and CodeQL should keep running only `Analyze (go)` + `Analyze (actions)`. Neither is observable from this PR's checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated workflow documentation to clarify how the workflow scripts are executed and why they aren’t compatible with standard JavaScript tooling.
  * Added a troubleshooting section for CodeQL failures related to “Analyze (javascript-typescript)”, including confirmation steps when language detection behaves inconsistently.
* **Chores**
  * Updated repository language-detection settings to keep workflow scripts from being classified as JavaScript.
  * Ensured the language-detection configuration file at the repo root remains tracked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->