### PR TITLE
docs: fix cache examples that don't compile or cache bad data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,16 +259,16 @@ Redis-based caching with type-safe CBOR serialization, multi-tenant isolation, a
 
 ```go
 type Module struct {
+    svc *Service
+}
+
+type Service struct {
     getCache func(context.Context) (cache.Cache, error)  // Store the function, NOT instance
 }
 
 func (m *Module) Init(deps *app.ModuleDeps) error {
-    m.getCache = deps.Cache  // Tenant-aware resolution
+    m.svc = &Service{getCache: deps.Cache}  // Tenant-aware resolution
     return nil
-}
-
-type Service struct {
-    getCache func(context.Context) (cache.Cache, error)  // handed over during Init
 }
 
 func (s *Service) GetUser(ctx context.Context, id int64) (*User, error) {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,10 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
     return nil
 }
 
+type Service struct {
+    getCache func(context.Context) (cache.Cache, error)  // handed over during Init
+}
+
 func (s *Service) GetUser(ctx context.Context, id int64) (*User, error) {
     c, err := s.getCache(ctx)
     if err != nil { return nil, err }

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
 - **Lifecycle Management**: Lazy initialization, LRU eviction (max 100 tenants), idle cleanup (15m default)
 - **Atomic Operations**: `GetOrSet` for deduplication, `CompareAndSet` for distributed locking
 - **Performance**: <1ms latency for Get/Set, 100k ops/sec throughput
-- **Observability**: OpenTelemetry metrics and health checks (no distributed-tracing spans today)
+- **Observability**: OpenTelemetry metrics, plus a non-critical `/ready` probe that leases a cache instance rather than pinging Redis — so a Redis outage does not fail readiness. No distributed-tracing spans today. See [wiki/cache.md](wiki/cache.md)
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ GoBricks provides Redis-based caching with type-safe serialization, multi-tenant
 ```go
 import (
     "context"
+    "fmt"
     "time"
 
     "github.com/gaborage/go-bricks/cache"
@@ -539,9 +540,11 @@ func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
         return nil, err
     }
 
-    // Store in cache with TTL
-    data, _ = cache.Marshal(user)
-    c.Set(ctx, cacheKey, data, 5*time.Minute)
+    // Store in cache with TTL. Best-effort: never cache a failed marshal, and a
+    // write-back failure must not fail a request that already has the value.
+    if serialized, mErr := cache.Marshal(user); mErr == nil {
+        _ = c.Set(ctx, cacheKey, serialized, 5*time.Minute)
+    }
 
     return user, nil
 }
@@ -553,7 +556,7 @@ func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
 - **Lifecycle Management**: Lazy initialization, LRU eviction (max 100 tenants), idle cleanup (15m default)
 - **Atomic Operations**: `GetOrSet` for deduplication, `CompareAndSet` for distributed locking
 - **Performance**: <1ms latency for Get/Set, 100k ops/sec throughput
-- **Observability**: OpenTelemetry spans, metrics, and health checks
+- **Observability**: OpenTelemetry metrics and health checks (no distributed-tracing spans today)
 
 ### Configuration
 

--- a/cache/types.go
+++ b/cache/types.go
@@ -74,6 +74,12 @@ type Cache interface {
 	//	    return ErrLockHeld
 	//	}
 	//	defer cache.Delete(ctx, lockKey)
+	//
+	// Delete releases unconditionally: if the work outruns the TTL, the lock expires,
+	// another holder acquires it, and this Delete clears theirs. There is no
+	// compare-and-delete on this interface, so keep the TTL above worst-case work
+	// duration and make the guarded work idempotent — this is contention reduction,
+	// not guaranteed mutual exclusion.
 	CompareAndSet(ctx context.Context, key string, expectedValue, newValue []byte, ttl time.Duration) (success bool, err error)
 
 	// Health checks the health of the cache connection.

--- a/llms.txt
+++ b/llms.txt
@@ -2081,8 +2081,15 @@ if !success {
     return errors.New("lock already held by another worker")
 }
 
-// Lock acquired - perform work. Release is best-effort: the lock carries a 30s TTL,
-// so a failed Delete self-heals rather than deadlocking the job.
+// Lock acquired - perform work.
+//
+// CAUTION: Delete releases unconditionally. If processJob outruns the 30s TTL, the
+// lock expires, another worker acquires it, and this Delete clears THEIR lock. The
+// cache surface has no compare-and-delete, so a token-verified release is not
+// expressible here (CompareAndSet only ever SETs, and acquisition requires the key
+// to be absent). Until then: set the TTL above worst-case job duration, and keep
+// processJob idempotent — treat the lock as contention reduction, not mutual
+// exclusion.
 defer func() { _ = c.Delete(ctx, lockKey) }()
 
 return processJob(ctx)

--- a/llms.txt
+++ b/llms.txt
@@ -893,7 +893,9 @@ func (h *Handler) getOrder(req GetOrderReq, ctx server.HandlerContext) (server.R
     reqCtx := ctx.RequestContext()  // already has the 5s deadline
 
     // No wrapping needed — every call below observes the inherited deadline:
-    _, _ = h.cache.Get(reqCtx, fmt.Sprintf("order:%d", req.ID))
+    if c, cErr := h.getCache(reqCtx); cErr == nil {
+        _, _ = c.Get(reqCtx, fmt.Sprintf("order:%d", req.ID))
+    }
     order, err := h.svc.FindByID(reqCtx, req.ID)
     if err != nil {
         return server.Result[Order]{}, server.NewInternalServerError(err.Error())
@@ -908,8 +910,10 @@ func (s *UserService) Get(ctx context.Context, id int64) (*User, error) {
     // Cap cache lookup at 200ms; fall through to DB on miss/timeout.
     cacheCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
     defer cancel()
-    if data, err := s.cache.Get(cacheCtx, fmt.Sprintf("user:%d", id)); err == nil {
-        return cache.Unmarshal[*User](data)
+    if c, err := s.getCache(cacheCtx); err == nil {
+        if data, err := c.Get(cacheCtx, fmt.Sprintf("user:%d", id)); err == nil {
+            return cache.Unmarshal[*User](data)
+        }
     }
     return s.queryDatabase(ctx, id) // keeps remaining ~4.8s of inherited budget
 }
@@ -1887,9 +1891,16 @@ func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
         return nil, err
     }
 
-    // Store in cache
-    serialized, _ := cache.Marshal(user)
-    c.Set(ctx, cacheKey, serialized, 5*time.Minute)
+    // Store in cache. A write-back failure must not fail a request that already
+    // has the value, so log it rather than returning it.
+    serialized, err := cache.Marshal(user)
+    if err != nil {
+        s.logger.Warn().Err(err).Str("key", cacheKey).Msg("Cache marshal failed, value not cached")
+        return user, nil
+    }
+    if err := c.Set(ctx, cacheKey, serialized, 5*time.Minute); err != nil {
+        s.logger.Warn().Err(err).Str("key", cacheKey).Msg("Cache write-back failed")
+    }
 
     return user, nil
 }
@@ -1967,7 +1978,10 @@ func (m *Module) CacheUser(ctx context.Context, user *User) error {
     }
 
     key := fmt.Sprintf("%s:user:%d", m.keyPrefix, user.ID)  // Uses prefix
-    data, _ := cache.Marshal(user)
+    data, err := cache.Marshal(user)
+    if err != nil {
+        return fmt.Errorf("marshal user: %w", err)  // Never cache a failed marshal
+    }
 
     return c.Set(ctx, key, data, m.defaultTTL)  // Uses default TTL
 }
@@ -1993,47 +2007,32 @@ type User struct {
     Email string `cbor:"3,keyasint"`
 }
 
-// Serialize and cache
-user := User{ID: 123, Name: "Alice", Email: "alice@example.com"}
-data, err := cache.Marshal(user)
-if err != nil {
-    return err
-}
-err = m.cache.Set(ctx, "user:123", data, 5*time.Minute)
-
-// Retrieve and deserialize
-data, err := m.cache.Get(ctx, "user:123")
-if err != nil {
-    return err
-}
-user, err := cache.Unmarshal[User](data)
-```
-
-**Query Result Caching Pattern:**
-
-```go
-func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
-    cacheKey := fmt.Sprintf("user:%d", id)
-
-    // Try cache first
-    data, err := s.cache.Get(ctx, cacheKey)
-    if err == nil {
-        return cache.Unmarshal[*User](data)
-    }
-
-    // Cache miss - query database
-    user, err := s.queryDatabase(ctx, id)
+func (m *Module) roundTripUser(ctx context.Context) (User, error) {
+    c, err := m.getCache(ctx)
     if err != nil {
-        return nil, err
+        return User{}, err
     }
 
-    // Store in cache for future requests
-    data, _ = cache.Marshal(user)
-    s.cache.Set(ctx, cacheKey, data, 5*time.Minute)
+    // Serialize and cache
+    user := User{ID: 123, Name: "Alice", Email: "alice@example.com"}
+    data, err := cache.Marshal(user)
+    if err != nil {
+        return User{}, err
+    }
+    if err := c.Set(ctx, "user:123", data, 5*time.Minute); err != nil {
+        return User{}, err
+    }
 
-    return user, nil
+    // Retrieve and deserialize
+    raw, err := c.Get(ctx, "user:123")
+    if err != nil {
+        return User{}, err
+    }
+    return cache.Unmarshal[User](raw)
 }
 ```
+
+**Query Result Caching Pattern:** see `UserService.GetUser` above.
 
 **Deduplication with GetOrSet:**
 
@@ -2042,7 +2041,12 @@ func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
 idempotencyKey := "process:batch:abc-123"
 taskData := []byte("task-payload")
 
-storedValue, wasSet, err := m.cache.GetOrSet(ctx, idempotencyKey, taskData, 10*time.Minute)
+c, err := m.getCache(ctx)
+if err != nil {
+    return err
+}
+
+storedValue, wasSet, err := c.GetOrSet(ctx, idempotencyKey, taskData, 10*time.Minute)
 if err != nil {
     return err
 }
@@ -2063,7 +2067,12 @@ return getCachedResult(storedValue)
 lockKey := "lock:job:456"
 workerID := []byte("worker-1")
 
-success, err := m.cache.CompareAndSet(ctx, lockKey, nil, workerID, 30*time.Second)
+c, err := m.getCache(ctx)
+if err != nil {
+    return err
+}
+
+success, err := c.CompareAndSet(ctx, lockKey, nil, workerID, 30*time.Second)
 if err != nil {
     return err
 }
@@ -2072,8 +2081,9 @@ if !success {
     return errors.New("lock already held by another worker")
 }
 
-// Lock acquired - perform work
-defer m.cache.Delete(ctx, lockKey) // Release lock
+// Lock acquired - perform work. Release is best-effort: the lock carries a 30s TTL,
+// so a failed Delete self-heals rather than deadlocking the job.
+defer func() { _ = c.Delete(ctx, lockKey) }()
 
 return processJob(ctx)
 ```
@@ -2142,7 +2152,7 @@ func TestMultiTenantCacheIsolation(t *testing.T) {
 
 ```go
 // Graceful degradation - cache failure doesn't break request
-func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
+func (s *UserService) getUserWithDegradation(ctx context.Context, id int64) (*User, error) {
     cacheKey := fmt.Sprintf("user:%d", id)
 
     // Try cache first with timeout
@@ -2151,15 +2161,17 @@ func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
 
     if c, err := s.getCache(cacheCtx); err == nil {
         data, err := c.Get(cacheCtx, cacheKey)
-        if err == nil {
-            user, err := cache.Unmarshal[*User](data)
-            if err == nil {
-                return user, nil  // Cache hit - return immediately
+        switch {
+        case err == nil:
+            // decodeErr keeps the decode failure distinguishable from the Get error
+            user, decodeErr := cache.Unmarshal[*User](data)
+            if decodeErr == nil {
+                return user, nil // Cache hit - return immediately
             }
-        }
-
-        // Log cache errors but don't fail the request
-        if !errors.Is(err, cache.ErrNotFound) {
+            s.logger.Warn().Err(decodeErr).Str("key", cacheKey).Msg("Cached value is invalid, falling back to database")
+        case errors.Is(err, cache.ErrNotFound):
+            // Plain miss - expected, not worth logging
+        default:
             s.logger.Warn().Err(err).Str("key", cacheKey).Msg("Cache operation failed, falling back to database")
         }
     }
@@ -2248,7 +2260,7 @@ func (s *UserService) fetchAndCache(ctx context.Context, c cache.Cache, id int64
 |-------|-------|---------------------|
 | `cache.ErrNotFound` | Key expired or never set | Query database, repopulate cache |
 | `cache.ErrClosed` | Cache closed during shutdown | Skip cache, query database directly |
-| `cache.ErrInvalidTTL` | Zero or negative TTL provided | Fix code - TTL must be positive |
+| `cache.ErrInvalidTTL` | Negative TTL provided (zero is valid — it means no expiration) | Fix code - TTL must be non-negative |
 | `cache.OperationError` | Network/Redis error | Log error, fallback to database |
 | `context.DeadlineExceeded` | Operation timeout | Skip cache, continue with database |
 | `config.ConfigError` (category `not_configured`, check with `config.IsNotConfigured(err)`) | Cache not enabled | Disable cache features gracefully |

--- a/wiki/cache.md
+++ b/wiki/cache.md
@@ -63,6 +63,12 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
     return nil
 }
 
+// The service carries the same accessor, handed over during Init.
+type Service struct {
+    getCache func(context.Context) (cache.Cache, error)
+    logger   logger.Logger
+}
+
 func (s *Service) GetUser(ctx context.Context, id int64) (*User, error) {
     c, err := s.getCache(ctx)  // Resolves tenant from context
     if err != nil {
@@ -75,12 +81,24 @@ func (s *Service) GetUser(ctx context.Context, id int64) (*User, error) {
         return cache.Unmarshal[*User](data)
     }
 
-    // Cache miss - query database
+    // Cache miss - query database. Check this error: without it a DB failure
+    // returns (nil, nil) and then caches a CBOR null, so every later Get is a
+    // hit that decodes to nil for the whole TTL.
     user, err := s.queryDatabase(ctx, id)
+    if err != nil {
+        return nil, err
+    }
 
-    // Store in cache with TTL
-    data, _ = cache.Marshal(user)
-    c.Set(ctx, fmt.Sprintf("user:%d", id), data, 5*time.Minute)
+    // Store in cache with TTL. Write-back failures are logged, not returned —
+    // the caller already has the value.
+    serialized, err := cache.Marshal(user)
+    if err != nil {
+        s.logger.Warn().Err(err).Int64("id", id).Msg("Cache marshal failed, value not cached")
+        return user, nil
+    }
+    if err := c.Set(ctx, fmt.Sprintf("user:%d", id), serialized, 5*time.Minute); err != nil {
+        s.logger.Warn().Err(err).Int64("id", id).Msg("Cache write-back failed")
+    }
 
     return user, nil
 }

--- a/wiki/cache.md
+++ b/wiki/cache.md
@@ -55,18 +55,20 @@ cache:
 **Module Setup Pattern:**
 ```go
 type Module struct {
-    getCache func(context.Context) (cache.Cache, error)  // Store function, NOT instance
+    svc *Service
 }
 
-func (m *Module) Init(deps *app.ModuleDeps) error {
-    m.getCache = deps.Cache  // Tenant-aware resolution
-    return nil
-}
-
-// The service carries the same accessor, handed over during Init.
+// The service holds the accessor function, never a resolved cache instance.
 type Service struct {
     getCache func(context.Context) (cache.Cache, error)
     logger   logger.Logger
+}
+
+func (m *Module) Init(deps *app.ModuleDeps) error {
+    // Hand both dependencies over here; a Service built any other way has a nil
+    // getCache and panics on first use.
+    m.svc = &Service{getCache: deps.Cache, logger: deps.Logger}
+    return nil
 }
 
 func (s *Service) GetUser(ctx context.Context, id int64) (*User, error) {

--- a/wiki/context_deadlines.md
+++ b/wiki/context_deadlines.md
@@ -35,7 +35,9 @@ func (h *Handler) getOrder(req GetOrderReq, ctx server.HandlerContext) (server.R
     reqCtx := ctx.RequestContext()  // inherits the 5s deadline
 
     // Each call below observes the inherited deadline — no manual wrapping needed:
-    _, _ = h.cache.Get(reqCtx, fmt.Sprintf("order:%d", req.ID))  // Redis dial/read/write
+    if c, cErr := h.getCache(reqCtx); cErr == nil {              // Redis dial/read/write
+        _, _ = c.Get(reqCtx, fmt.Sprintf("order:%d", req.ID))
+    }
     order, err := h.svc.FindByID(reqCtx, req.ID)                 // DB query
     if err != nil {
         return server.Result[Order]{}, server.NewInternalServerError(err.Error())
@@ -58,8 +60,10 @@ func (s *UserService) Get(ctx context.Context, id int64) (*User, error) {
     cacheCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
     defer cancel()
 
-    if data, err := s.cache.Get(cacheCtx, fmt.Sprintf("user:%d", id)); err == nil {
-        return cache.Unmarshal[*User](data)
+    if c, err := s.getCache(cacheCtx); err == nil {
+        if data, err := c.Get(cacheCtx, fmt.Sprintf("user:%d", id)); err == nil {
+            return cache.Unmarshal[*User](data)
+        }
     }
 
     // DB query keeps the rest of the request budget (~4.8s).


### PR DESCRIPTION
## What

Follow-up to #819, which corrected cache claims inside its own diff hunks; a
whole-file review found the same defect classes elsewhere, where a diff-scoped
reviewer could not see them. `wiki/cache.md`'s cache-aside example dropped
`queryDatabase`'s error, returning `(nil, nil)` and then caching a CBOR null — so a
brief database failure made every later read a *hit* decoding to nil for the full
5-minute TTL. `llms.txt`'s serialization block had two real `no new variables on left
side of :=` compile errors, and nine call sites across three files pinned a
`cache.Cache` in a struct field the surrounding types never declared, contradicting
the file's own `IMPORTANT: Store Cache function, NOT cache instance` rule.

## Impact

None for consumers — documentation only, no API or behavior change. Three
same-signature `UserService.GetUser` examples are now one canonical `GetUser` plus a
distinctly-named `getUserWithDegradation`, so anyone who copied by name should
re-check which they meant. `README.md`, `CLAUDE.md`, and `wiki/context_deadlines.md`
move with the cache docs because each carried a stale copy of a corrected claim.

## Verification

`make mutate` reported `no mutatable changes vs merge-base`, expected for a diff
touching zero Go files. Every claim was checked against source rather than the
report: `cache/redis/client.go:145` rejects only `ttl < 0` (so zero TTL is valid),
and `cache/` contains no tracing symbols (so README's OTel-spans claim was false).

Two sites left deliberately: `llms.txt:2485` marshals a literal into a mock during
test setup, and `wiki/adr_011_redis_cache.md:258` is a point-in-time ADR record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated cache examples (README and wiki) to be more production-safe with tenant-aware cache access, structured error handling, and best-effort cache write-back.
  * Added/expanded “degradation” and database-fallback examples distinguishing not-found vs decode vs other errors.
  * Refreshed distributed-locking guidance, including lock release behavior and TTL considerations.
  * Revised context deadline/timeout examples to acquire a cache handle via an accessor with explicit error checks.
  * Clarified observability wording and that `0` TTL is valid while negative TTL is invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->