### PR TITLE
fix(mutatediff): scale the mutant timeout to the real suite cost

### DIFF
--- a/.gremlins.yaml
+++ b/.gremlins.yaml
@@ -1,3 +1,10 @@
 unleash:
   workers: 4
+  # Fallback for a bare `gremlins unleash`. Both `make mutate` and
+  # `make mutate-baseline` override this per package with
+  # --timeout-coefficient, because a fixed coefficient multiplies a per-package
+  # baseline: 3 leaves any package whose coverage run takes under ~1.3s with a
+  # mutant ceiling below its own build cost, and every mutant then reports
+  # TIMED OUT. See scripts/mutatediff/timeout.go and
+  # wiki/testing.md#mutation-gate.
   timeout-coefficient: 3

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ GREMLINS_VERSION := v0.5.1
 GREMLINS_CMD := go run github.com/go-gremlins/gremlins/cmd/gremlins@$(GREMLINS_VERSION)
 # Hosted runners are 4-vCPU/16GB; 2 workers halves peak memory vs the local default.
 MUTATE_BASELINE_WORKERS ?= 2
+# Used only when the per-package coefficient cannot be computed. Generous on
+# purpose: too small silently reports every mutant as TIMED OUT, which the
+# advisory baseline would publish as a clean score (wiki/testing.md#timeout-ceiling).
+MUTATE_FALLBACK_COEFFICIENT ?= 600
 # Default target
 help: ## Show this help message
 	@echo "Available targets:"
@@ -111,9 +115,16 @@ mutate: ## Diff-scoped mutation gate: mutants on changed lines vs origin/main mu
 # One gremlins process per package: a single full-repo process with 4 workers
 # exhausted a 4-vCPU/16GB hosted runner ~25 min in (runner shutdown signal).
 # Per-package processes bound memory, let partial results survive an eviction,
-# and the merge prefixes file_name with the package dir (gremlins emits
-# basenames, which are ambiguous repo-wide). scripts/ excluded: gremlins
-# misverdicts that nested package main (wiki/testing.md#mutation-gate).
+# and the merge prefixes file_name with the package dir (gremlins emits paths
+# relative to the package it was pointed at, which are ambiguous repo-wide).
+# scripts/ excluded: gremlins misverdicts that nested package main
+# (wiki/testing.md#mutation-gate).
+#
+# The per-package timeout coefficient is not optional: gremlins derives each
+# mutant's ceiling from a CACHE-SERVED replay of the package's tests, while every
+# mutant run is a cache miss that pays the real suite. Left at the default the
+# ceiling lands under what one mutant costs and every mutant reports TIMED OUT —
+# which this job would publish as a clean score. See scripts/mutatediff/timeout.go.
 mutate-baseline: ## Full-repo mutation baseline, one engine process per package (advisory; consumed by the nightly workflow)
 	@rm -rf .gremlins-reports gremlins-report.json && mkdir -p .gremlins-reports
 	@go list ./... > /dev/null   # fail fast on a broken tree — inside the loop pipeline a go list failure would vanish into sort's exit status
@@ -121,7 +132,9 @@ mutate-baseline: ## Full-repo mutation baseline, one engine process per package 
 		i=$$((i+1)); \
 		echo "== mutating ./$$dir"; \
 		out=".gremlins-reports/$$i-$$(echo "$$dir" | tr / -).json"; \
-		$(GREMLINS_CMD) unleash --workers $(MUTATE_BASELINE_WORKERS) --output "$$out" "./$$dir" \
+		coeff=$$(go run ./scripts/mutatediff -coefficient "./$$dir"); \
+		case "$$coeff" in ''|*[!0-9]*) echo "WARN: no coefficient for ./$$dir, falling back to $(MUTATE_FALLBACK_COEFFICIENT)"; coeff=$(MUTATE_FALLBACK_COEFFICIENT);; esac; \
+		$(GREMLINS_CMD) unleash --workers $(MUTATE_BASELINE_WORKERS) --timeout-coefficient "$$coeff" --output "$$out" "./$$dir" \
 			|| echo "WARN: gremlins exited non-zero for ./$$dir (advisory)"; \
 		if [ -f "$$out" ]; then \
 			jq --arg d "$$dir" '.files = ((.files // []) | map(.file_name = ($$d + "/" + .file_name)))' "$$out" > "$$out.tmp" && mv "$$out.tmp" "$$out" \

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,8 @@ mutate-baseline: ## Full-repo mutation baseline, one engine process per package 
 		i=$$((i+1)); \
 		echo "== mutating ./$$dir"; \
 		out=".gremlins-reports/$$i-$$(echo "$$dir" | tr / -).json"; \
-		coeff=$$(go run ./scripts/mutatediff -coefficient "./$$dir"); \
+		coeff=$$(go run ./scripts/mutatediff -coefficient "./$$dir") \
+			|| { echo "ERROR: coefficient measurement for ./$$dir was canceled or could not run — stopping the baseline"; exit 1; }; \
 		case "$$coeff" in ''|*[!0-9]*) echo "WARN: no coefficient for ./$$dir, falling back to $(MUTATE_FALLBACK_COEFFICIENT)"; coeff=$(MUTATE_FALLBACK_COEFFICIENT);; esac; \
 		$(GREMLINS_CMD) unleash --workers $(MUTATE_BASELINE_WORKERS) --timeout-coefficient "$$coeff" --output "$$out" "./$$dir" \
 			|| echo "WARN: gremlins exited non-zero for ./$$dir (advisory)"; \

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,18 @@ GOLANGCI_LINT_VERSION := v2.12.2
 # renovate: datasource=go depName=github.com/go-gremlins/gremlins
 GREMLINS_VERSION := v0.5.1
 GREMLINS_CMD := go run github.com/go-gremlins/gremlins/cmd/gremlins@$(GREMLINS_VERSION)
-# Hosted runners are 4-vCPU/16GB; 2 workers halves peak memory vs the local default.
+# Hosted runners are 4-vCPU/16GB; 2 workers bounds peak memory (each worker keeps its
+# own copy of the module tree).
 MUTATE_BASELINE_WORKERS ?= 2
 # Used only when the per-package coefficient cannot be computed. Generous on
 # purpose: too small silently reports every mutant as TIMED OUT, which the
 # advisory baseline would publish as a clean score (wiki/testing.md#timeout-ceiling).
 MUTATE_FALLBACK_COEFFICIENT ?= 600
+# `make mutate` runs on a developer's machine, where every worker is a concurrent
+# `go test`. Now that mutants run to completion instead of dying at a too-tight
+# ceiling, that is sustained load, so the local gate is deliberately gentler than
+# .gremlins.yaml's 4: raise it for a faster gate, drop it to 1 to keep a laptop cool.
+MUTATE_WORKERS ?= 2
 # Default target
 help: ## Show this help message
 	@echo "Available targets:"
@@ -110,7 +116,7 @@ sec: ## Run gosec security scanner (pinned; identical to CI)
 	go run github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION) -exclude=G103,G104 ./...
 
 mutate: ## Diff-scoped mutation gate: mutants on changed lines vs origin/main must die (see wiki/testing.md#mutation-gate)
-	go run ./scripts/mutatediff -engine "$(GREMLINS_CMD)"
+	go run ./scripts/mutatediff -engine "$(GREMLINS_CMD)" -workers $(MUTATE_WORKERS)
 
 # One gremlins process per package: a single full-repo process with 4 workers
 # exhausted a 4-vCPU/16GB hosted runner ~25 min in (runner shutdown signal).

--- a/scripts/mutatediff/main.go
+++ b/scripts/mutatediff/main.go
@@ -17,9 +17,13 @@ func main() {
 	base := flag.String("base", "origin/main", "ref to compute merge-base against")
 	mergeDir := flag.String("merge", "", "merge mode: directory of per-package shard reports to aggregate (skips the diff gate)")
 	mergeOut := flag.String("out", "gremlins-report.json", "merge mode: output path for the aggregated report")
+	coeffPkg := flag.String("coefficient", "", "coefficient mode: print the engine timeout-coefficient that holds this package's per-mutant ceiling at the floor")
 	flag.Parse()
 	if *mergeDir != "" {
 		os.Exit(mergeShards(*mergeDir, *mergeOut, os.Stdout))
+	}
+	if *coeffPkg != "" {
+		os.Exit(printCoefficient(*coeffPkg, measureSuite, ceilingFloor(), os.Stdout, os.Stderr))
 	}
 	if *engine == "" {
 		fmt.Fprintln(os.Stderr, "mutatediff: -engine is required")
@@ -61,7 +65,7 @@ func run(engine, baseRef string, out io.Writer) int {
 		return fail("%v", err)
 	}
 	defer os.RemoveAll(reportDir)
-	var failures, warnings []mutantVerdict
+	var failures, warnings, unjudged []mutantVerdict
 	for _, pkg := range packagesOf(changed) {
 		f, w, mErr := mutatePackage(engineArgs, pkg, reportDir, changed, out)
 		if mErr != nil {
@@ -69,9 +73,25 @@ func run(engine, baseRef string, out io.Writer) int {
 		}
 		failures = append(failures, f...)
 		warnings = append(warnings, w...)
+		if vacuousPkg(pkg, reportDir, out) {
+			unjudged = append(unjudged, mutantVerdict{File: pkg})
+		}
 	}
-	for _, w := range warnings {
-		fmt.Fprintf(out, "WARN not covered: %s:%d %s\n", w.File, w.Line, w.Operator)
+	return reportVerdict(failures, warnings, unjudged, out)
+}
+
+// reportVerdict prints every result and returns the process exit code. Vacuous
+// packages are checked before surviving mutants: if the engine judged nothing,
+// an empty failure list means nothing, and saying so is the point.
+func reportVerdict(failures, warnings, unjudged []mutantVerdict, out io.Writer) int {
+	timedOut := reportWarnings(warnings, out)
+	if len(unjudged) > 0 {
+		fmt.Fprintln(out, "FAIL the engine returned no verdict for these packages — every mutant timed out, so nothing was tested:")
+		for _, p := range unjudged {
+			fmt.Fprintf(out, "  %s\n", p.File)
+		}
+		fmt.Fprintf(out, "raise %s (currently %s) and re-run\n", ceilingFloorEnv, ceilingFloor())
+		return 1
 	}
 	if len(failures) > 0 {
 		fmt.Fprintln(out, "FAIL surviving mutants on changed lines:")
@@ -80,15 +100,56 @@ func run(engine, baseRef string, out io.Writer) int {
 		}
 		return 1
 	}
+	// Never claim a clean sweep while indeterminate mutants are outstanding.
+	if timedOut > 0 {
+		fmt.Fprintf(out, "mutatediff: no surviving mutants on changed lines, but %d timed out without a verdict\n", timedOut)
+		return 0
+	}
 	fmt.Fprintln(out, "mutatediff: all mutants on changed lines killed")
 	return 0
 }
 
+// reportWarnings prints every non-blocking verdict and returns how many were
+// indeterminate, which the caller needs in order not to claim a clean sweep.
+func reportWarnings(warnings []mutantVerdict, out io.Writer) (timedOut int) {
+	for _, w := range warnings {
+		if w.Status == statusTimedOut {
+			timedOut++
+			fmt.Fprintf(out, "WARN timed out (indeterminate — the mutant may hang the code, or the ceiling was too tight): %s:%d %s\n",
+				w.File, w.Line, w.Operator)
+			continue
+		}
+		fmt.Fprintf(out, "WARN not covered: %s:%d %s\n", w.File, w.Line, w.Operator)
+	}
+	return timedOut
+}
+
+// vacuousPkg re-reads pkg's report to check whether the engine returned any
+// verdict at all. A read or parse failure here is not fatal: mutatePackage has
+// already judged the same file, so this only ever adds a signal.
+func vacuousPkg(pkg, reportDir string, out io.Writer) bool {
+	reportJSON, err := os.ReadFile(reportPathFor(pkg, reportDir)) // #nosec G304 -- per-run os.MkdirTemp dir + package-derived name
+	if err != nil {
+		return false
+	}
+	timedOut, isVacuous, err := vacuous(reportJSON)
+	if err != nil || !isVacuous {
+		return false
+	}
+	fmt.Fprintf(out, "mutatediff: %s produced %d timeouts and zero verdicts\n", pkg, timedOut)
+	return true
+}
+
+func reportPathFor(pkg, reportDir string) string {
+	name := "gremlins-" + strings.ReplaceAll(strings.TrimPrefix(pkg, "./"), "/", "-") + ".json"
+	return filepath.Join(reportDir, name)
+}
+
 func mutatePackage(engineArgs []string, pkg, reportDir string, changed map[string][]lineRange, out io.Writer) (failures, warnings []mutantVerdict, err error) {
 	fmt.Fprintf(out, "mutatediff: mutating %s\n", pkg)
-	reportName := "gremlins-" + strings.ReplaceAll(strings.TrimPrefix(pkg, "./"), "/", "-") + ".json"
-	reportPath := filepath.Join(reportDir, reportName)
-	args := slices.Concat(engineArgs, []string{"unleash", "--output", reportPath, pkg})
+	coefficient := coefficientFor(pkg, measureSuite, ceilingFloor(), out)
+	reportPath := reportPathFor(pkg, reportDir)
+	args := slices.Concat(engineArgs, []string{"unleash"}, gremlinsTimeoutArgs(coefficient), []string{"--output", reportPath, pkg})
 	cmd := exec.CommandContext(context.Background(), args[0], args[1:]...) // #nosec G204 -- dev tool; engine comes from the Makefile pin, not user input
 	cmd.Stdout = out
 	cmd.Stderr = os.Stderr

--- a/scripts/mutatediff/main.go
+++ b/scripts/mutatediff/main.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
 )
 
 func main() {
@@ -20,29 +22,39 @@ func main() {
 	coeffPkg := flag.String("coefficient", "", "coefficient mode: print the engine timeout-coefficient that holds this package's per-mutant ceiling at the floor")
 	workers := flag.Int("workers", 0, "engine workers; each is a concurrent `go test`. 0 inherits .gremlins.yaml")
 	flag.Parse()
-	if *mergeDir != "" {
-		os.Exit(mergeShards(*mergeDir, *mergeOut, os.Stdout))
-	}
-	if *coeffPkg != "" {
-		os.Exit(printCoefficient(*coeffPkg, measureSuite, ceilingFloor(), os.Stdout, os.Stderr))
-	}
-	if *engine == "" {
+
+	// Signal-derived so Ctrl-C or a CI cancel reaches the long-running git,
+	// go test, and gremlins subprocesses instead of leaving orphaned trees.
+	// No defer: os.Exit below skips deferred calls, so stop is invoked
+	// explicitly on every path instead.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+
+	var code int
+	switch {
+	case *mergeDir != "":
+		code = mergeShards(*mergeDir, *mergeOut, os.Stdout)
+	case *coeffPkg != "":
+		code = printCoefficient(ctx, *coeffPkg, measureSuite, ceilingFloor(), os.Stdout, os.Stderr)
+	case *engine == "":
 		fmt.Fprintln(os.Stderr, "mutatediff: -engine is required")
-		os.Exit(2)
+		code = 2
+	default:
+		code = run(ctx, *engine, *base, *workers, os.Stdout)
 	}
-	os.Exit(run(*engine, *base, *workers, os.Stdout))
+	stop()
+	os.Exit(code)
 }
 
-func run(engine, baseRef string, workers int, out io.Writer) int {
+func run(ctx context.Context, engine, baseRef string, workers int, out io.Writer) int {
 	engineArgs := strings.Fields(engine)
 	if len(engineArgs) == 0 {
 		return fail("engine command is blank")
 	}
-	mergeBase, err := gitOutput("merge-base", "HEAD", baseRef)
+	mergeBase, err := gitOutput(ctx, "merge-base", "HEAD", baseRef)
 	if err != nil {
 		return fail("%v", err)
 	}
-	diff, err := gitOutput("diff", "-U0", "--no-color", mergeBase, "HEAD", "--", "*.go")
+	diff, err := gitOutput(ctx, "diff", "-U0", "--no-color", mergeBase, "HEAD", "--", "*.go")
 	if err != nil {
 		return fail("%v", err)
 	}
@@ -51,7 +63,7 @@ func run(engine, baseRef string, workers int, out io.Writer) int {
 		return fail("%v", perr)
 	}
 	changed := mutationScope(parsed)
-	switch status, statusErr := gitOutput("status", "--porcelain"); {
+	switch status, statusErr := gitOutput(ctx, "status", "--porcelain"); {
 	case statusErr != nil:
 		fmt.Fprintf(out, "WARN: could not check the working tree for uncommitted changes: %v\n", statusErr)
 	case status != "":
@@ -68,7 +80,7 @@ func run(engine, baseRef string, workers int, out io.Writer) int {
 	defer os.RemoveAll(reportDir)
 	var failures, warnings, unjudged []mutantVerdict
 	for _, pkg := range packagesOf(changed) {
-		f, w, mErr := mutatePackage(engineArgs, pkg, reportDir, changed, workers, out)
+		f, w, mErr := mutatePackage(ctx, engineArgs, pkg, reportDir, changed, workers, out)
 		if mErr != nil {
 			return fail("%v", mErr)
 		}
@@ -148,9 +160,9 @@ func reportPathFor(pkg, reportDir string) string {
 
 // runEngine invokes gremlins for pkg and returns the report it wrote. extra
 // carries mode-specific flags (--dry-run, the coefficient, the worker count).
-func runEngine(engineArgs []string, pkg, reportPath string, extra []string, out io.Writer) ([]byte, error) {
+func runEngine(ctx context.Context, engineArgs []string, pkg, reportPath string, extra []string, out io.Writer) ([]byte, error) {
 	args := slices.Concat(engineArgs, []string{"unleash"}, extra, []string{"--output", reportPath, pkg})
-	cmd := exec.CommandContext(context.Background(), args[0], args[1:]...) // #nosec G204 -- dev tool; engine comes from the Makefile pin, not user input
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...) // #nosec G204 -- dev tool; engine comes from the Makefile pin, not user input
 	cmd.Stdout = out
 	cmd.Stderr = os.Stderr
 	if runErr := cmd.Run(); runErr != nil {
@@ -163,7 +175,7 @@ func runEngine(engineArgs []string, pkg, reportPath string, extra []string, out 
 	return reportJSON, nil
 }
 
-func mutatePackage(engineArgs []string, pkg, reportDir string, changed map[string][]lineRange, workers int, out io.Writer) (failures, warnings []mutantVerdict, err error) {
+func mutatePackage(ctx context.Context, engineArgs []string, pkg, reportDir string, changed map[string][]lineRange, workers int, out io.Writer) (failures, warnings []mutantVerdict, err error) {
 	// A dry run enumerates mutants without executing any, so it costs one coverage
 	// pass instead of mutants x (build + suite). gremlins mutates the whole subtree
 	// it is pointed at while the gate only judges changed lines, so most
@@ -173,7 +185,7 @@ func mutatePackage(engineArgs []string, pkg, reportDir string, changed map[strin
 	// coverage pass warms the test cache measureSuite reads next.
 	// One worker: a dry run executes no tests, so extra workers only multiply
 	// copies of the module tree.
-	dryJSON, err := runEngine(engineArgs, pkg, reportPathFor(pkg, reportDir)+".dry",
+	dryJSON, err := runEngine(ctx, engineArgs, pkg, reportPathFor(pkg, reportDir)+".dry",
 		[]string{"--dry-run", workersFlag, "1"}, out)
 	if err != nil {
 		return nil, nil, err
@@ -188,8 +200,8 @@ func mutatePackage(engineArgs []string, pkg, reportDir string, changed map[strin
 	}
 
 	fmt.Fprintf(out, "mutatediff: mutating %s (%d mutants on changed lines)\n", pkg, onChanged)
-	coefficient := coefficientFor(pkg, measureSuite, ceilingFloor(), out)
-	reportJSON, err := runEngine(engineArgs, pkg, reportPathFor(pkg, reportDir),
+	coefficient := coefficientFor(ctx, pkg, measureSuite, ceilingFloor(), out)
+	reportJSON, err := runEngine(ctx, engineArgs, pkg, reportPathFor(pkg, reportDir),
 		slices.Concat(gremlinsTimeoutArgs(coefficient), workerArgs(workers)), out)
 	if err != nil {
 		return nil, nil, err
@@ -206,8 +218,8 @@ func fail(format string, a ...any) int {
 	return 2
 }
 
-func gitOutput(args ...string) (string, error) {
-	out, err := exec.CommandContext(context.Background(), "git", args...).Output() // #nosec G204 -- call-site literals plus the -base flag value, not user input
+func gitOutput(ctx context.Context, args ...string) (string, error) {
+	out, err := exec.CommandContext(ctx, "git", args...).Output() // #nosec G204 -- call-site literals plus the -base flag value, not user input
 	if err != nil {
 		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
 	}

--- a/scripts/mutatediff/main.go
+++ b/scripts/mutatediff/main.go
@@ -18,6 +18,7 @@ func main() {
 	mergeDir := flag.String("merge", "", "merge mode: directory of per-package shard reports to aggregate (skips the diff gate)")
 	mergeOut := flag.String("out", "gremlins-report.json", "merge mode: output path for the aggregated report")
 	coeffPkg := flag.String("coefficient", "", "coefficient mode: print the engine timeout-coefficient that holds this package's per-mutant ceiling at the floor")
+	workers := flag.Int("workers", 0, "engine workers; each is a concurrent `go test`. 0 inherits .gremlins.yaml")
 	flag.Parse()
 	if *mergeDir != "" {
 		os.Exit(mergeShards(*mergeDir, *mergeOut, os.Stdout))
@@ -29,10 +30,10 @@ func main() {
 		fmt.Fprintln(os.Stderr, "mutatediff: -engine is required")
 		os.Exit(2)
 	}
-	os.Exit(run(*engine, *base, os.Stdout))
+	os.Exit(run(*engine, *base, *workers, os.Stdout))
 }
 
-func run(engine, baseRef string, out io.Writer) int {
+func run(engine, baseRef string, workers int, out io.Writer) int {
 	engineArgs := strings.Fields(engine)
 	if len(engineArgs) == 0 {
 		return fail("engine command is blank")
@@ -67,7 +68,7 @@ func run(engine, baseRef string, out io.Writer) int {
 	defer os.RemoveAll(reportDir)
 	var failures, warnings, unjudged []mutantVerdict
 	for _, pkg := range packagesOf(changed) {
-		f, w, mErr := mutatePackage(engineArgs, pkg, reportDir, changed, out)
+		f, w, mErr := mutatePackage(engineArgs, pkg, reportDir, changed, workers, out)
 		if mErr != nil {
 			return fail("%v", mErr)
 		}
@@ -145,20 +146,53 @@ func reportPathFor(pkg, reportDir string) string {
 	return filepath.Join(reportDir, name)
 }
 
-func mutatePackage(engineArgs []string, pkg, reportDir string, changed map[string][]lineRange, out io.Writer) (failures, warnings []mutantVerdict, err error) {
-	fmt.Fprintf(out, "mutatediff: mutating %s\n", pkg)
-	coefficient := coefficientFor(pkg, measureSuite, ceilingFloor(), out)
-	reportPath := reportPathFor(pkg, reportDir)
-	args := slices.Concat(engineArgs, []string{"unleash"}, gremlinsTimeoutArgs(coefficient), []string{"--output", reportPath, pkg})
+// runEngine invokes gremlins for pkg and returns the report it wrote. extra
+// carries mode-specific flags (--dry-run, the coefficient, the worker count).
+func runEngine(engineArgs []string, pkg, reportPath string, extra []string, out io.Writer) ([]byte, error) {
+	args := slices.Concat(engineArgs, []string{"unleash"}, extra, []string{"--output", reportPath, pkg})
 	cmd := exec.CommandContext(context.Background(), args[0], args[1:]...) // #nosec G204 -- dev tool; engine comes from the Makefile pin, not user input
 	cmd.Stdout = out
 	cmd.Stderr = os.Stderr
 	if runErr := cmd.Run(); runErr != nil {
-		return nil, nil, fmt.Errorf("engine failed for %s: %w", pkg, runErr)
+		return nil, fmt.Errorf("engine failed for %s: %w", pkg, runErr)
 	}
 	reportJSON, readErr := os.ReadFile(reportPath) // #nosec G304 -- path built from a per-run os.MkdirTemp dir + package-derived name, not user input
 	if readErr != nil {
-		return nil, nil, fmt.Errorf("no report for %s: %w", pkg, readErr)
+		return nil, fmt.Errorf("no report for %s: %w", pkg, readErr)
+	}
+	return reportJSON, nil
+}
+
+func mutatePackage(engineArgs []string, pkg, reportDir string, changed map[string][]lineRange, workers int, out io.Writer) (failures, warnings []mutantVerdict, err error) {
+	// A dry run enumerates mutants without executing any, so it costs one coverage
+	// pass instead of mutants x (build + suite). gremlins mutates the whole subtree
+	// it is pointed at while the gate only judges changed lines, so most
+	// invocations would otherwise pay for hundreds of mutants to rule on a handful
+	// — a one-line edit in ./database enumerates 616 runnable mutants. Skipping
+	// cannot change the verdict, since judge discards those mutants anyway, and the
+	// coverage pass warms the test cache measureSuite reads next.
+	// One worker: a dry run executes no tests, so extra workers only multiply
+	// copies of the module tree.
+	dryJSON, err := runEngine(engineArgs, pkg, reportPathFor(pkg, reportDir)+".dry",
+		[]string{"--dry-run", workersFlag, "1"}, out)
+	if err != nil {
+		return nil, nil, err
+	}
+	onChanged, cErr := countOnChangedLines(dryJSON, pkg, changed)
+	if cErr != nil {
+		return nil, nil, fmt.Errorf("parse dry-run report for %s: %w", pkg, cErr)
+	}
+	if onChanged == 0 {
+		fmt.Fprintf(out, "mutatediff: %s has no mutants on changed lines, skipping\n", pkg)
+		return nil, nil, nil
+	}
+
+	fmt.Fprintf(out, "mutatediff: mutating %s (%d mutants on changed lines)\n", pkg, onChanged)
+	coefficient := coefficientFor(pkg, measureSuite, ceilingFloor(), out)
+	reportJSON, err := runEngine(engineArgs, pkg, reportPathFor(pkg, reportDir),
+		slices.Concat(gremlinsTimeoutArgs(coefficient), workerArgs(workers)), out)
+	if err != nil {
+		return nil, nil, err
 	}
 	f, w, jerr := judge(reportJSON, pkg, changed)
 	if jerr != nil {

--- a/scripts/mutatediff/main_test.go
+++ b/scripts/mutatediff/main_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestRunNoOpDiffExitsCleanWithoutEngine(t *testing.T) {
 	var buf bytes.Buffer
-	if got := run("false", "HEAD", 0, &buf); got != 0 {
+	if got := run(t.Context(), "false", "HEAD", 0, &buf); got != 0 {
 		t.Fatalf("run = %d, want 0; output: %s", got, buf.String())
 	}
 	if !strings.Contains(buf.String(), "no mutatable changes") {
@@ -74,7 +74,7 @@ func TestReportVerdictCleanSweepOnlyWhenFullyJudged(t *testing.T) {
 
 func TestRunBlankEngineFailsFast(t *testing.T) {
 	var buf bytes.Buffer
-	if got := run("   ", "HEAD", 0, &buf); got != 2 {
+	if got := run(t.Context(), "   ", "HEAD", 0, &buf); got != 2 {
 		t.Fatalf("run = %d, want 2 for whitespace-only engine", got)
 	}
 }

--- a/scripts/mutatediff/main_test.go
+++ b/scripts/mutatediff/main_test.go
@@ -16,6 +16,62 @@ func TestRunNoOpDiffExitsCleanWithoutEngine(t *testing.T) {
 	}
 }
 
+func TestReportWarningsDistinguishesTimeoutsFromUncovered(t *testing.T) {
+	var buf bytes.Buffer
+	got := reportWarnings([]mutantVerdict{
+		{File: "observability/logs.go", Line: 27, Operator: "CONDITIONALS_NEGATION", Status: statusTimedOut},
+		{File: "observability/logs.go", Line: 33, Operator: "ARITHMETIC_BASE", Status: statusNotCovered},
+		{File: "messaging/client.go", Line: 91, Operator: "CONDITIONALS_BOUNDARY", Status: statusTimedOut},
+	}, &buf)
+	if got != 2 {
+		t.Errorf("timedOut = %d, want 2", got)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "WARN timed out") || !strings.Contains(out, "indeterminate") {
+		t.Errorf("timeouts must read as indeterminate, got: %s", out)
+	}
+	if !strings.Contains(out, "WARN not covered: observability/logs.go:33") {
+		t.Errorf("uncovered mutant lost its own message, got: %s", out)
+	}
+}
+
+// TestReportVerdictFailsVacuousBeforeSurvivors pins the ordering: with nothing
+// judged, an empty failure list carries no information, so the vacuous packages
+// must be what the operator is told about.
+func TestReportVerdictFailsVacuousBeforeSurvivors(t *testing.T) {
+	var buf bytes.Buffer
+	code := reportVerdict(nil,
+		[]mutantVerdict{{File: "observability/logs.go", Line: 27, Status: statusTimedOut}},
+		[]mutantVerdict{{File: "./observability"}}, &buf)
+	if code != 1 {
+		t.Errorf("reportVerdict = %d, want 1 for a vacuous package", code)
+	}
+	if !strings.Contains(buf.String(), "no verdict for these packages") {
+		t.Errorf("output must name the vacuous packages, got: %s", buf.String())
+	}
+	if strings.Contains(buf.String(), "all mutants on changed lines killed") {
+		t.Error("must not claim a clean sweep")
+	}
+}
+
+func TestReportVerdictCleanSweepOnlyWhenFullyJudged(t *testing.T) {
+	var clean, withTimeout bytes.Buffer
+	if code := reportVerdict(nil, nil, nil, &clean); code != 0 {
+		t.Errorf("reportVerdict = %d, want 0", code)
+	}
+	if !strings.Contains(clean.String(), "all mutants on changed lines killed") {
+		t.Errorf("want the clean-sweep line, got: %s", clean.String())
+	}
+	// A timeout without a vacuous package still passes, but not as a clean sweep.
+	code := reportVerdict(nil, []mutantVerdict{{File: "a.go", Line: 1, Status: statusTimedOut}}, nil, &withTimeout)
+	if code != 0 {
+		t.Errorf("reportVerdict = %d, want 0 (a timeout alone must not block)", code)
+	}
+	if strings.Contains(withTimeout.String(), "all mutants on changed lines killed") {
+		t.Errorf("must not claim a clean sweep with a timeout outstanding, got: %s", withTimeout.String())
+	}
+}
+
 func TestRunBlankEngineFailsFast(t *testing.T) {
 	var buf bytes.Buffer
 	if got := run("   ", "HEAD", &buf); got != 2 {

--- a/scripts/mutatediff/main_test.go
+++ b/scripts/mutatediff/main_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestRunNoOpDiffExitsCleanWithoutEngine(t *testing.T) {
 	var buf bytes.Buffer
-	if got := run("false", "HEAD", &buf); got != 0 {
+	if got := run("false", "HEAD", 0, &buf); got != 0 {
 		t.Fatalf("run = %d, want 0; output: %s", got, buf.String())
 	}
 	if !strings.Contains(buf.String(), "no mutatable changes") {
@@ -74,7 +74,7 @@ func TestReportVerdictCleanSweepOnlyWhenFullyJudged(t *testing.T) {
 
 func TestRunBlankEngineFailsFast(t *testing.T) {
 	var buf bytes.Buffer
-	if got := run("   ", "HEAD", &buf); got != 2 {
+	if got := run("   ", "HEAD", 0, &buf); got != 2 {
 		t.Fatalf("run = %d, want 2 for whitespace-only engine", got)
 	}
 }

--- a/scripts/mutatediff/report.go
+++ b/scripts/mutatediff/report.go
@@ -36,19 +36,20 @@ const (
 	statusTimedOut   = "TIMED OUT"
 )
 
-// judge buckets report mutants that land on changed lines: LIVED fails the
-// gate; NOT COVERED warns (SonarCloud owns coverage) and so does TIMED OUT,
-// which is indeterminate rather than clean — see timeout.go for why the
-// engine reports it for reasons that have nothing to do with the mutant.
-// pkgDir is the package the report was generated for — gremlins emits paths
-// relative to it (a bare basename for the package's own files, a slashed path
-// for files in subpackages, which it also mutates), so the repo-relative path
-// is pkgDir + file_name.
-func judge(reportJSON []byte, pkgDir string, changed map[string][]lineRange) (failures, warnings []mutantVerdict, err error) {
+// changedMutants is the single selector for "mutants that land on changed
+// lines". judge classifies its output and the dry-run pre-check counts it, so the
+// pre-check cannot select a different set than the verdict does — the property
+// the skip's soundness rests on holds by construction rather than by two walks
+// agreeing. pkgDir is the package the report was generated for: gremlins emits
+// paths relative to it (a bare basename for the package's own files, a slashed
+// path for subpackages, which it also mutates), so the repo-relative path is
+// pkgDir + file_name.
+func changedMutants(reportJSON []byte, pkgDir string, changed map[string][]lineRange) ([]mutantVerdict, error) {
 	var rep gremlinsReport
 	if err := json.Unmarshal(reportJSON, &rep); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
+	var out []mutantVerdict
 	for _, f := range rep.Files {
 		name := path.Join(pkgDir, f.FileName)
 		ranges, ok := changed[name]
@@ -56,20 +57,47 @@ func judge(reportJSON []byte, pkgDir string, changed map[string][]lineRange) (fa
 			continue
 		}
 		for _, m := range f.Mutations {
-			if !inRanges(m.Line, ranges) {
-				continue
+			if inRanges(m.Line, ranges) {
+				out = append(out, mutantVerdict{File: name, Line: m.Line, Operator: m.Type, Status: m.Status})
 			}
-			v := mutantVerdict{File: name, Line: m.Line, Operator: m.Type, Status: m.Status}
-			switch m.Status {
-			case statusLived:
-				failures = append(failures, v)
-			case statusNotCovered, statusTimedOut:
-				warnings = append(warnings, v)
-			case "KILLED", "NOT VIABLE", "RUNNABLE":
-				// pass: died, didn't compile, or dry-run marker
-			default:
-				return nil, nil, fmt.Errorf("unrecognized mutant status %q at %s:%d — failing closed", m.Status, name, m.Line)
-			}
+		}
+	}
+	return out, nil
+}
+
+// countOnChangedLines answers "is the expensive pass worth starting?" from a
+// --dry-run report. Mutants of any status count: gremlins recomputes coverage on
+// the real run, so a dry NOT COVERED can come back RUNNABLE, and skipping on a
+// RUNNABLE-only count would drop verdicts.
+func countOnChangedLines(reportJSON []byte, pkgDir string, changed map[string][]lineRange) (int, error) {
+	ms, err := changedMutants(reportJSON, pkgDir, changed)
+	return len(ms), err
+}
+
+// SKIPPED is deliberately absent from every branch below, so it reaches the
+// fail-closed default. gremlins emits it for mutants its own `--diff <ref>` mode
+// filtered out, and that mode is unusable here: it marks *everything* SKIPPED on
+// this repo. Passing it would empty the gate; leave it failing closed.
+//
+// judge buckets the selected mutants: LIVED fails the gate; NOT COVERED warns
+// (SonarCloud owns coverage) and so does TIMED OUT, which is indeterminate rather
+// than clean — see timeout.go for why the engine reports it for reasons that have
+// nothing to do with the mutant.
+func judge(reportJSON []byte, pkgDir string, changed map[string][]lineRange) (failures, warnings []mutantVerdict, err error) {
+	ms, err := changedMutants(reportJSON, pkgDir, changed)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, v := range ms {
+		switch v.Status {
+		case statusLived:
+			failures = append(failures, v)
+		case statusNotCovered, statusTimedOut:
+			warnings = append(warnings, v)
+		case "KILLED", "NOT VIABLE", "RUNNABLE":
+			// pass: died, didn't compile, or dry-run marker
+		default:
+			return nil, nil, fmt.Errorf("unrecognized mutant status %q at %s:%d — failing closed", v.Status, v.File, v.Line)
 		}
 	}
 	return failures, warnings, nil

--- a/scripts/mutatediff/report.go
+++ b/scripts/mutatediff/report.go
@@ -28,14 +28,22 @@ type mutantVerdict struct {
 	Status   string
 }
 
-// statusLived is gremlins' "mutant survived" verdict — a constant because
-// judge and its tests both key off the literal often enough to trip goconst.
-const statusLived = "LIVED"
+// Gremlins verdicts judge and its tests both key off often enough to trip
+// goconst.
+const (
+	statusLived      = "LIVED"
+	statusNotCovered = "NOT COVERED"
+	statusTimedOut   = "TIMED OUT"
+)
 
 // judge buckets report mutants that land on changed lines: LIVED fails the
-// gate, NOT COVERED warns (SonarCloud owns coverage), anything else passes.
-// pkgDir is the package the report was generated for — gremlins emits
-// basenames, so the repo-relative path is pkgDir + file_name.
+// gate; NOT COVERED warns (SonarCloud owns coverage) and so does TIMED OUT,
+// which is indeterminate rather than clean — see timeout.go for why the
+// engine reports it for reasons that have nothing to do with the mutant.
+// pkgDir is the package the report was generated for — gremlins emits paths
+// relative to it (a bare basename for the package's own files, a slashed path
+// for files in subpackages, which it also mutates), so the repo-relative path
+// is pkgDir + file_name.
 func judge(reportJSON []byte, pkgDir string, changed map[string][]lineRange) (failures, warnings []mutantVerdict, err error) {
 	var rep gremlinsReport
 	if err := json.Unmarshal(reportJSON, &rep); err != nil {
@@ -55,16 +63,43 @@ func judge(reportJSON []byte, pkgDir string, changed map[string][]lineRange) (fa
 			switch m.Status {
 			case statusLived:
 				failures = append(failures, v)
-			case "NOT COVERED":
+			case statusNotCovered, statusTimedOut:
 				warnings = append(warnings, v)
-			case "KILLED", "TIMED OUT", "NOT VIABLE", "RUNNABLE":
-				// pass: died, hung (test timeout noticed), didn't compile, or dry-run marker
+			case "KILLED", "NOT VIABLE", "RUNNABLE":
+				// pass: died, didn't compile, or dry-run marker
 			default:
 				return nil, nil, fmt.Errorf("unrecognized mutant status %q at %s:%d — failing closed", m.Status, name, m.Line)
 			}
 		}
 	}
 	return failures, warnings, nil
+}
+
+// vacuous reports whether the engine produced no verdict at all for a package:
+// mutants timed out and not one was killed or survived. That state has no
+// innocent reading — the ceiling was below the cost of running the mutant, so
+// nothing was actually tested — and it is what let the first nightly baseline
+// publish 86% efficacy over packages in which no mutant ran. It is deliberately
+// judged over the WHOLE report rather than the changed lines, and independently
+// of the ceiling arithmetic in timeout.go, so a mis-scaled coefficient is caught
+// by observation instead of trusted not to happen.
+func vacuous(reportJSON []byte) (timedOut int, isVacuous bool, err error) {
+	var rep gremlinsReport
+	if err := json.Unmarshal(reportJSON, &rep); err != nil {
+		return 0, false, err
+	}
+	decided := 0
+	for _, f := range rep.Files {
+		for _, m := range f.Mutations {
+			switch m.Status {
+			case statusTimedOut:
+				timedOut++
+			case "KILLED", statusLived:
+				decided++
+			}
+		}
+	}
+	return timedOut, timedOut > 0 && decided == 0, nil
 }
 
 func inRanges(line int, ranges []lineRange) bool {

--- a/scripts/mutatediff/report_test.go
+++ b/scripts/mutatediff/report_test.go
@@ -183,6 +183,47 @@ func TestJudgePkgDirFormsEquivalent(t *testing.T) {
 	}
 }
 
+// TestJudgeFailsClosedOnSkipped guards a live footgun. gremlins' --diff mode
+// marks filtered-out mutants SKIPPED, and on this repo it marks EVERY mutant
+// SKIPPED because it matches git paths against the engine's temp workdir
+// (v0.5.1: --diff HEAD~1 over a committed one-line change in ./database skipped
+// all 747). If SKIPPED ever becomes a pass, adding that flag silently empties the
+// gate. It must stay an error.
+func TestJudgeFailsClosedOnSkipped(t *testing.T) {
+	const rep = `{"files":[{"file_name":"injection.go","mutations":[{"line":27,"type":"CONDITIONALS_NEGATION","status":"SKIPPED"}]}]}`
+	changed := map[string][]lineRange{"config/injection.go": {{Start: 26, End: 29}}}
+	if _, _, err := judge([]byte(rep), "./config", changed); err == nil {
+		t.Error("SKIPPED must fail closed, not pass — see the comment on judge")
+	}
+}
+
+// TestCountOnChangedLinesGatesTheExpensivePass backs the dry-run pre-check: only
+// mutants inside a changed range justify paying mutants x (build + suite).
+func TestCountOnChangedLinesGatesTheExpensivePass(t *testing.T) {
+	const dry = `{"files":[
+		{"file_name":"injection.go","mutations":[
+			{"line":27,"type":"CONDITIONALS_NEGATION","status":"RUNNABLE"},
+			{"line":44,"type":"CONDITIONALS_BOUNDARY","status":"NOT COVERED"},
+			{"line":900,"type":"ARITHMETIC_BASE","status":"RUNNABLE"}]},
+		{"file_name":"untouched.go","mutations":[
+			{"line":5,"type":"CONDITIONALS_NEGATION","status":"RUNNABLE"}]}]}`
+	changed := map[string][]lineRange{"config/injection.go": {{Start: 26, End: 29}, {Start: 44, End: 45}}}
+	got, err := countOnChangedLines([]byte(dry), "./config", changed)
+	if err != nil {
+		t.Fatalf("countOnChangedLines: %v", err)
+	}
+	// Lines 27 and 44 count; line 900 and the untouched file do not.
+	if got != 2 {
+		t.Errorf("countOnChangedLines = %d, want 2", got)
+	}
+	none, err := countOnChangedLines([]byte(dry), "./config", map[string][]lineRange{
+		"config/injection.go": {{Start: 100, End: 200}},
+	})
+	if err != nil || none != 0 {
+		t.Errorf("countOnChangedLines = (%d, %v), want (0, nil) so the package is skipped", none, err)
+	}
+}
+
 func TestJudgeFailsClosedOnUnknownStatus(t *testing.T) {
 	const rep = `{"files":[{"file_name":"injection.go","mutations":[{"line":27,"type":"CONDITIONALS_NEGATION","status":"SOMETHING NEW"}]}]}`
 	changed := map[string][]lineRange{"config/injection.go": {{Start: 26, End: 29}}}

--- a/scripts/mutatediff/report_test.go
+++ b/scripts/mutatediff/report_test.go
@@ -42,13 +42,85 @@ func TestJudgeAppliesVerdictPolicyOnChangedLines(t *testing.T) {
 		{File: "config/injection.go", Line: 27, Operator: "CONDITIONALS_NEGATION", Status: statusLived},
 	}
 	wantWarn := []mutantVerdict{
-		{File: "config/injection.go", Line: 44, Operator: "CONDITIONALS_BOUNDARY", Status: "NOT COVERED"},
+		{File: "config/injection.go", Line: 44, Operator: "CONDITIONALS_BOUNDARY", Status: statusNotCovered},
+		{File: "config/injection.go", Line: 28, Operator: "INVERT_NEGATIVES", Status: statusTimedOut},
 	}
 	if !reflect.DeepEqual(failures, wantFail) {
 		t.Errorf("failures = %#v, want %#v", failures, wantFail)
 	}
 	if !reflect.DeepEqual(warnings, wantWarn) {
 		t.Errorf("warnings = %#v, want %#v", warnings, wantWarn)
+	}
+}
+
+// TestJudgeWarnsRatherThanSilentlyPassingTimedOut pins the lesson of the first
+// nightly baseline: TIMED OUT does not mean "the mutant hung the code". It also
+// fires whenever the engine's derived ceiling lands under the cost of building
+// the mutated test binary, which silently waved whole packages through. It stays
+// non-blocking (a hang the suite notices really is a kill) but must be visible.
+func TestJudgeWarnsRatherThanSilentlyPassingTimedOut(t *testing.T) {
+	changed := map[string][]lineRange{
+		"config/injection.go": {{Start: 28, End: 29}},
+	}
+	failures, warnings, err := judge([]byte(fixtureReport), "./config", changed)
+	if err != nil {
+		t.Fatalf("judge: %v", err)
+	}
+	if len(failures) != 0 {
+		t.Errorf("failures = %#v, want none — a timeout must not block the gate", failures)
+	}
+	want := []mutantVerdict{
+		{File: "config/injection.go", Line: 28, Operator: "INVERT_NEGATIVES", Status: statusTimedOut},
+	}
+	if !reflect.DeepEqual(warnings, want) {
+		t.Errorf("warnings = %#v, want %#v", warnings, want)
+	}
+}
+
+// TestVacuousDetectsAnAllTimeoutPackage covers the state the first nightly
+// baseline shipped 249 times in ./observability alone: mutants ran, every one
+// timed out, and gremlins still published a score. No verdict exists, so the
+// package cannot be reported as clean.
+func TestVacuousDetectsAnAllTimeoutPackage(t *testing.T) {
+	const allTimeout = `{"files":[{"file_name":"metrics.go","mutations":[
+		{"line":24,"type":"CONDITIONALS_NEGATION","status":"TIMED OUT"},
+		{"line":30,"type":"CONDITIONALS_NEGATION","status":"TIMED OUT"},
+		{"line":34,"type":"CONDITIONALS_NEGATION","status":"NOT COVERED"}]}]}`
+	timedOut, isVacuous, err := vacuous([]byte(allTimeout))
+	if err != nil {
+		t.Fatalf("vacuous: %v", err)
+	}
+	if timedOut != 2 || !isVacuous {
+		t.Errorf("vacuous = (%d, %v), want (2, true)", timedOut, isVacuous)
+	}
+}
+
+func TestVacuousAcceptsAnyRealVerdict(t *testing.T) {
+	cases := map[string]string{
+		// One kill is enough to prove the ceiling cleared the build cost, so the
+		// remaining timeouts are the engine catching real hangs.
+		"one_killed_among_timeouts": `{"files":[{"file_name":"a.go","mutations":[
+			{"line":1,"type":"X","status":"TIMED OUT"},{"line":2,"type":"X","status":"KILLED"}]}]}`,
+		"one_lived_among_timeouts": `{"files":[{"file_name":"a.go","mutations":[
+			{"line":1,"type":"X","status":"TIMED OUT"},{"line":2,"type":"X","status":"LIVED"}]}]}`,
+		// No timeouts at all: an untested package is a real result, not a broken
+		// measurement, and SonarCloud owns coverage.
+		"all_not_covered": `{"files":[{"file_name":"a.go","mutations":[
+			{"line":1,"type":"X","status":"NOT COVERED"}]}]}`,
+		"no_mutants": `{"files":[]}`,
+	}
+	for name, rep := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, isVacuous, err := vacuous([]byte(rep)); err != nil || isVacuous {
+				t.Errorf("vacuous = (%v, %v), want (false, nil)", isVacuous, err)
+			}
+		})
+	}
+}
+
+func TestVacuousRejectsMalformedJSON(t *testing.T) {
+	if _, _, err := vacuous([]byte("{nope")); err == nil {
+		t.Error("expected error for malformed JSON")
 	}
 }
 

--- a/scripts/mutatediff/timeout.go
+++ b/scripts/mutatediff/timeout.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// gremlins derives each mutant's wall-clock ceiling as
+// coverage_elapsed × unleash.timeout-coefficient and enforces it with a hard
+// context deadline that also has to cover compiling and linking the mutated
+// test binary. Scaling the coefficient per package holds that ceiling above
+// the build cost, without which the engine reports TIMED OUT for every mutant
+// and the gate has nothing to judge. See wiki/testing.md#timeout-ceiling.
+const (
+	// minTimeoutCoefficient is gremlins' own default: never go below it.
+	minTimeoutCoefficient = 3
+	// maxTimeoutCoefficient bounds how long a genuinely hanging mutant runs
+	// before it is cut off, and caps the damage when elapsed is unmeasurable.
+	maxTimeoutCoefficient = 600
+	// defaultCeilingFloor is the minimum ceiling, which matters for suites too
+	// fast for buildBudget alone to dominate. ~7x the largest ceiling that still
+	// produced mass timeouts in the first nightly baseline (database, 1.07s).
+	defaultCeilingFloor = 30 * time.Second
+	// buildBudget is headroom added to the measured suite time for compiling and
+	// linking the mutated test binary, which gremlins' ceiling must also cover.
+	buildBudget = 20 * time.Second
+	// ceilingFloorEnv lets an operator retune the floor without a code change.
+	ceilingFloorEnv = "MUTATE_CEILING_FLOOR"
+	// coefficientFlag is the lever. gremlins also documents
+	// GREMLINS_UNLEASH_TIMEOUT_COEFFICIENT, but that is silently ignored: its
+	// configuration.Get[T] does an unchecked `viper.Get(k).(T)`, and viper hands
+	// back environment values as strings, so the assertion for an int fails and
+	// yields 0 — which the engine reads as "unset" and replaces with its default
+	// 3. Values in .gremlins.yaml are parsed as ints and do work.
+	coefficientFlag = "--timeout-coefficient"
+)
+
+// ceilingFloor is the minimum per-mutant ceiling the gate will accept,
+// overridable via MUTATE_CEILING_FLOOR (any time.ParseDuration string).
+func ceilingFloor() time.Duration {
+	raw := os.Getenv(ceilingFloorEnv)
+	if raw == "" {
+		return defaultCeilingFloor
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return defaultCeilingFloor
+	}
+	return d
+}
+
+// suiteTiming holds the two different durations this calculation needs. They can
+// differ by two orders of magnitude and conflating them is the whole trap.
+type suiteTiming struct {
+	// Uncached is what one mutant run actually costs: a mutant edits the source,
+	// so its test run is always a cache miss and pays the real suite.
+	Uncached time.Duration
+	// Baseline is what gremlins measures for itself and multiplies the
+	// coefficient by. Its command omits -count=1, so this is a cache-served
+	// replay — ~0.3s of process overhead for a suite that really takes 25s.
+	Baseline time.Duration
+}
+
+// timeoutCoefficient returns the smallest coefficient that holds gremlins'
+// derived ceiling (Baseline × coefficient) above what a mutant run actually
+// costs. Because the two inputs measure different things, targeting a fixed
+// wall-clock floor is not enough: a package with a 25s suite needs a 25s+
+// ceiling however fast its cached baseline replays.
+//
+// An unmeasurable Baseline fails generous rather than reinstating the vacuous
+// pass this whole mechanism exists to prevent.
+func timeoutCoefficient(t suiteTiming, floor time.Duration) int {
+	target := t.Uncached + buildBudget
+	if target < floor {
+		target = floor
+	}
+	if t.Baseline <= 0 {
+		return maxTimeoutCoefficient
+	}
+	// Integer ceiling division, so the product never lands just under target.
+	coefficient := int((target + t.Baseline - 1) / t.Baseline)
+	if coefficient < minTimeoutCoefficient {
+		return minTimeoutCoefficient
+	}
+	if coefficient > maxTimeoutCoefficient {
+		return maxTimeoutCoefficient
+	}
+	return coefficient
+}
+
+// suiteMeasurer times pkg's suite both ways; see suiteTiming.
+type suiteMeasurer func(pkg string) (suiteTiming, error)
+
+// coefficientFor measures pkg and converts the result into a coefficient,
+// reporting both timings so a surprising ceiling is visible in the log rather
+// than buried in the engine's behavior.
+func coefficientFor(pkg string, measure suiteMeasurer, floor time.Duration, out io.Writer) int {
+	t, err := measure(pkg)
+	if err != nil {
+		fmt.Fprintf(out, "WARN: could not time %s's tests (%v) — using the maximum timeout coefficient %d\n",
+			pkg, err, maxTimeoutCoefficient)
+		return maxTimeoutCoefficient
+	}
+	coefficient := timeoutCoefficient(t, floor)
+	fmt.Fprintf(out, "mutatediff: %s suite %s, engine baseline %s — timeout coefficient %d (ceiling ~%s)\n",
+		pkg, t.Uncached.Round(time.Millisecond), t.Baseline.Round(time.Millisecond),
+		coefficient, (t.Baseline * time.Duration(coefficient)).Round(time.Second))
+	return coefficient
+}
+
+// measureSuite times pkg's tests using gremlins' own baseline command
+// (internal/coverage/coverage.go: `go test -cover -coverprofile <file>
+// ./pkg/...`, recursive) in three passes:
+//
+//  1. with -count=1, which forces a real run and writes nothing to the test
+//     cache — this is Uncached, the cost a mutant actually pays;
+//  2. without it, discarded, purely to populate the test cache;
+//  3. without it again, which is the cache hit gremlins will get — Baseline.
+//
+// The third pass is why the result is exact rather than a guess. Measuring only
+// the suite and dividing the floor by it collapses the coefficient to the
+// engine's default for exactly the packages that need it most: ./observability
+// measures 25s but replays in 0.34s, which yields 3 and reproduces the bug.
+//
+// A failing suite still yields usable durations — a failed test is never cached,
+// so passes 2 and 3 simply cost the same as 1 — and the exit status is
+// deliberately ignored. This errors only when the toolchain cannot start at all,
+// a state in which gremlins could not run either.
+func measureSuite(pkg string) (suiteTiming, error) {
+	profile, err := os.CreateTemp("", "mutatediff-cover-*")
+	if err != nil {
+		return suiteTiming{}, fmt.Errorf("coverage scratch file for %s: %w", pkg, err)
+	}
+	_ = profile.Close()
+	defer func() { _ = os.Remove(profile.Name()) }()
+
+	var exitErr *exec.ExitError
+	run := func(stage string, countOne bool) (time.Duration, error) {
+		args := []string{"test", "-cover", "-coverprofile", profile.Name()}
+		if countOne {
+			args = append(args, "-count=1")
+		}
+		args = append(args, strings.TrimSuffix(pkg, "/")+"/...")
+		start := time.Now()
+		// #nosec G204 -- pkg comes from `git diff` paths resolved to package dirs, not user input
+		runErr := exec.CommandContext(context.Background(), "go", args...).Run()
+		if runErr != nil && !errors.As(runErr, &exitErr) {
+			return 0, fmt.Errorf("%s %s: %w", stage, pkg, runErr)
+		}
+		return time.Since(start), nil
+	}
+	uncached, err := run("timing", true)
+	if err != nil {
+		return suiteTiming{}, err
+	}
+	if _, warmErr := run("warming", false); warmErr != nil {
+		return suiteTiming{}, warmErr
+	}
+	baseline, err := run("re-timing", false)
+	if err != nil {
+		return suiteTiming{}, err
+	}
+	return suiteTiming{Uncached: uncached, Baseline: baseline}, nil
+}
+
+// printCoefficient backs the -coefficient mode, which exists so the Makefile's
+// baseline loop scales the ceiling through this same code path instead of
+// reimplementing the arithmetic in shell. The number goes to stdout alone;
+// diagnostics go to stderr.
+func printCoefficient(pkg string, measure suiteMeasurer, floor time.Duration, stdout, stderr io.Writer) int {
+	fmt.Fprintln(stdout, coefficientFor(pkg, measure, floor, stderr))
+	return 0
+}
+
+// gremlinsTimeoutArgs returns the engine flag that pins the computed
+// coefficient. See coefficientFlag for why this is a flag and not an env var.
+func gremlinsTimeoutArgs(coefficient int) []string {
+	return []string{coefficientFlag, strconv.Itoa(coefficient)}
+}

--- a/scripts/mutatediff/timeout.go
+++ b/scripts/mutatediff/timeout.go
@@ -141,6 +141,27 @@ func coverageArgs(profile, pkg string, forceRun bool) []string {
 	return append(args, "-cover", "-coverprofile", profile, strings.TrimSuffix(pkg, "/")+"/...")
 }
 
+// measurementFailure decides whether a measurement pass produced a usable
+// timing. A failing suite does: a red test is never cached, so passes 2 and 3
+// simply cost the same as pass 1, and refusing to measure a package whose tests
+// are broken would only replace a scaled ceiling with the vacuous pass this
+// mechanism exists to prevent.
+//
+// Cancellation does not. CommandContext kills the child on cancel, and a killed
+// process surfaces as *exec.ExitError too — the same type a red suite produces,
+// so ctxErr is the only thing that separates them. Accepting it would time a
+// process that was shot partway through and pass that fraction off as the suite.
+func measurementFailure(ctxErr, runErr error) error {
+	if ctxErr != nil {
+		return ctxErr
+	}
+	var exitErr *exec.ExitError
+	if runErr != nil && !errors.As(runErr, &exitErr) {
+		return runErr
+	}
+	return nil
+}
+
 // measureSuite times pkg's tests using gremlins' own baseline command
 // (internal/coverage/coverage.go: `go test -cover -coverprofile <file>
 // ./pkg/...`, recursive) in three passes:
@@ -167,14 +188,13 @@ func measureSuite(ctx context.Context, pkg string) (suiteTiming, error) {
 	_ = profile.Close()
 	defer func() { _ = os.Remove(profile.Name()) }()
 
-	var exitErr *exec.ExitError
 	run := func(stage string, forceRun bool) (time.Duration, error) {
 		args := coverageArgs(profile.Name(), pkg, forceRun)
 		start := time.Now()
 		// #nosec G204 -- pkg comes from `git diff` paths resolved to package dirs, not user input
 		runErr := exec.CommandContext(ctx, "go", args...).Run()
-		if runErr != nil && !errors.As(runErr, &exitErr) {
-			return 0, fmt.Errorf("%s %s: %w", stage, pkg, runErr)
+		if failErr := measurementFailure(ctx.Err(), runErr); failErr != nil {
+			return 0, fmt.Errorf("%s %s: %w", stage, pkg, failErr)
 		}
 		return time.Since(start), nil
 	}
@@ -196,8 +216,19 @@ func measureSuite(ctx context.Context, pkg string) (suiteTiming, error) {
 // baseline loop scales the ceiling through this same code path instead of
 // reimplementing the arithmetic in shell. The number goes to stdout alone;
 // diagnostics go to stderr.
+//
+// A canceled run emits nothing and exits nonzero. coefficientFor falls back to
+// the maximum whenever measurement fails, which is right for a genuine failure
+// and wrong for Ctrl-C: printing it would hand the caller a fabricated number
+// that its numeric guard accepts, making an interrupted measurement
+// indistinguishable from a completed one.
 func printCoefficient(ctx context.Context, pkg string, measure suiteMeasurer, floor time.Duration, stdout, stderr io.Writer) int {
-	fmt.Fprintln(stdout, coefficientFor(ctx, pkg, measure, floor, stderr))
+	coefficient := coefficientFor(ctx, pkg, measure, floor, stderr)
+	if err := ctx.Err(); err != nil {
+		fmt.Fprintf(stderr, "mutatediff: %s measurement canceled (%v) — no coefficient emitted\n", pkg, err)
+		return 1
+	}
+	fmt.Fprintln(stdout, coefficient)
 	return 0
 }
 

--- a/scripts/mutatediff/timeout.go
+++ b/scripts/mutatediff/timeout.go
@@ -33,6 +33,16 @@ const (
 	buildBudget = 20 * time.Second
 	// ceilingFloorEnv lets an operator retune the floor without a code change.
 	ceilingFloorEnv = "MUTATE_CEILING_FLOOR"
+	// measureTimeout bounds the forced Uncached pass, above go test's 10m default
+	// so a genuinely slow (not hung) suite is measured rather than truncated. It is
+	// applied ONLY to that pass: -timeout participates in go test's cache key, so
+	// adding it to the cached passes would warm an entry gremlins never reads,
+	// leaving its own coverage run a cache miss whose Elapsed is the real suite.
+	// The coefficient is then multiplied by the suite instead of the replay —
+	// 148 x 24.7s is a 60-minute ceiling on ./observability, and `vacuous` cannot
+	// see it because it only catches ceilings that are too tight. -count=1 already
+	// disables caching, so the flag is free exactly where it is needed.
+	measureTimeout = "20m"
 	// coefficientFlag is the lever. gremlins also documents
 	// GREMLINS_UNLEASH_TIMEOUT_COEFFICIENT, but that is silently ignored: its
 	// configuration.Get[T] does an unchecked `viper.Get(k).(T)`, and viper hands
@@ -40,6 +50,9 @@ const (
 	// yields 0 — which the engine reads as "unset" and replaces with its default
 	// 3. Values in .gremlins.yaml are parsed as ints and do work.
 	coefficientFlag = "--timeout-coefficient"
+	// workersFlag caps concurrent `go test` processes; each also keeps its own copy
+	// of the module tree.
+	workersFlag = "--workers"
 )
 
 // ceilingFloor is the minimum per-mutant ceiling the gate will accept,
@@ -115,6 +128,19 @@ func coefficientFor(pkg string, measure suiteMeasurer, floor time.Duration, out 
 	return coefficient
 }
 
+// coverageArgs builds the `go test` argv for a measurement pass. With forceRun
+// false it MUST stay byte-identical to gremlins' own coverage command
+// (internal/coverage/coverage.go), because that is the cache entry gremlins will
+// read and the coefficient divides by. Any extra flag here splits the cache key
+// and silently un-measures the thing being measured — see measureTimeout.
+func coverageArgs(profile, pkg string, forceRun bool) []string {
+	args := []string{"test"}
+	if forceRun {
+		args = append(args, "-count=1", "-timeout", measureTimeout)
+	}
+	return append(args, "-cover", "-coverprofile", profile, strings.TrimSuffix(pkg, "/")+"/...")
+}
+
 // measureSuite times pkg's tests using gremlins' own baseline command
 // (internal/coverage/coverage.go: `go test -cover -coverprofile <file>
 // ./pkg/...`, recursive) in three passes:
@@ -142,12 +168,8 @@ func measureSuite(pkg string) (suiteTiming, error) {
 	defer func() { _ = os.Remove(profile.Name()) }()
 
 	var exitErr *exec.ExitError
-	run := func(stage string, countOne bool) (time.Duration, error) {
-		args := []string{"test", "-cover", "-coverprofile", profile.Name()}
-		if countOne {
-			args = append(args, "-count=1")
-		}
-		args = append(args, strings.TrimSuffix(pkg, "/")+"/...")
+	run := func(stage string, forceRun bool) (time.Duration, error) {
+		args := coverageArgs(profile.Name(), pkg, forceRun)
 		start := time.Now()
 		// #nosec G204 -- pkg comes from `git diff` paths resolved to package dirs, not user input
 		runErr := exec.CommandContext(context.Background(), "go", args...).Run()
@@ -183,4 +205,14 @@ func printCoefficient(pkg string, measure suiteMeasurer, floor time.Duration, st
 // coefficient. See coefficientFlag for why this is a flag and not an env var.
 func gremlinsTimeoutArgs(coefficient int) []string {
 	return []string{coefficientFlag, strconv.Itoa(coefficient)}
+}
+
+// workerArgs returns the engine's worker flag, or nothing when workers is 0 so
+// .gremlins.yaml stays in charge. Each worker is a concurrent `go test`, which is
+// the knob that matters on a laptop now that mutants run to completion.
+func workerArgs(workers int) []string {
+	if workers <= 0 {
+		return nil
+	}
+	return []string{workersFlag, strconv.Itoa(workers)}
 }

--- a/scripts/mutatediff/timeout.go
+++ b/scripts/mutatediff/timeout.go
@@ -109,13 +109,13 @@ func timeoutCoefficient(t suiteTiming, floor time.Duration) int {
 }
 
 // suiteMeasurer times pkg's suite both ways; see suiteTiming.
-type suiteMeasurer func(pkg string) (suiteTiming, error)
+type suiteMeasurer func(ctx context.Context, pkg string) (suiteTiming, error)
 
 // coefficientFor measures pkg and converts the result into a coefficient,
 // reporting both timings so a surprising ceiling is visible in the log rather
 // than buried in the engine's behavior.
-func coefficientFor(pkg string, measure suiteMeasurer, floor time.Duration, out io.Writer) int {
-	t, err := measure(pkg)
+func coefficientFor(ctx context.Context, pkg string, measure suiteMeasurer, floor time.Duration, out io.Writer) int {
+	t, err := measure(ctx, pkg)
 	if err != nil {
 		fmt.Fprintf(out, "WARN: could not time %s's tests (%v) — using the maximum timeout coefficient %d\n",
 			pkg, err, maxTimeoutCoefficient)
@@ -159,7 +159,7 @@ func coverageArgs(profile, pkg string, forceRun bool) []string {
 // so passes 2 and 3 simply cost the same as 1 — and the exit status is
 // deliberately ignored. This errors only when the toolchain cannot start at all,
 // a state in which gremlins could not run either.
-func measureSuite(pkg string) (suiteTiming, error) {
+func measureSuite(ctx context.Context, pkg string) (suiteTiming, error) {
 	profile, err := os.CreateTemp("", "mutatediff-cover-*")
 	if err != nil {
 		return suiteTiming{}, fmt.Errorf("coverage scratch file for %s: %w", pkg, err)
@@ -172,7 +172,7 @@ func measureSuite(pkg string) (suiteTiming, error) {
 		args := coverageArgs(profile.Name(), pkg, forceRun)
 		start := time.Now()
 		// #nosec G204 -- pkg comes from `git diff` paths resolved to package dirs, not user input
-		runErr := exec.CommandContext(context.Background(), "go", args...).Run()
+		runErr := exec.CommandContext(ctx, "go", args...).Run()
 		if runErr != nil && !errors.As(runErr, &exitErr) {
 			return 0, fmt.Errorf("%s %s: %w", stage, pkg, runErr)
 		}
@@ -196,8 +196,8 @@ func measureSuite(pkg string) (suiteTiming, error) {
 // baseline loop scales the ceiling through this same code path instead of
 // reimplementing the arithmetic in shell. The number goes to stdout alone;
 // diagnostics go to stderr.
-func printCoefficient(pkg string, measure suiteMeasurer, floor time.Duration, stdout, stderr io.Writer) int {
-	fmt.Fprintln(stdout, coefficientFor(pkg, measure, floor, stderr))
+func printCoefficient(ctx context.Context, pkg string, measure suiteMeasurer, floor time.Duration, stdout, stderr io.Writer) int {
+	fmt.Fprintln(stdout, coefficientFor(ctx, pkg, measure, floor, stderr))
 	return 0
 }
 

--- a/scripts/mutatediff/timeout_test.go
+++ b/scripts/mutatediff/timeout_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
+	"os/exec"
 	"slices"
 	"strings"
 	"testing"
@@ -102,6 +104,57 @@ func TestCoefficientForReportsBothTimings(t *testing.T) {
 		if !strings.Contains(buf.String(), want) {
 			t.Errorf("log %q missing %q", buf.String(), want)
 		}
+	}
+}
+
+// TestMeasurementFailureSeparatesCancellationFromRedTests pins a distinction the
+// error type cannot make on its own: CommandContext kills the child on cancel,
+// and a killed process surfaces as *exec.ExitError — exactly what a red suite
+// produces, which measureSuite deliberately tolerates. Tolerating the kill too
+// would time a process shot partway through and pass that off as the suite.
+func TestMeasurementFailureSeparatesCancellationFromRedTests(t *testing.T) {
+	killed := &exec.ExitError{ProcessState: &os.ProcessState{}}
+	if err := measurementFailure(nil, killed); err != nil {
+		t.Errorf("a red suite must still yield a timing, got %v", err)
+	}
+	if err := measurementFailure(context.Canceled, killed); !errors.Is(err, context.Canceled) {
+		t.Errorf("measurementFailure(canceled, ExitError) = %v, want context.Canceled", err)
+	}
+	// Cancellation racing a clean exit is still cancellation.
+	if err := measurementFailure(context.Canceled, nil); !errors.Is(err, context.Canceled) {
+		t.Errorf("measurementFailure(canceled, nil) = %v, want context.Canceled", err)
+	}
+	if err := measurementFailure(nil, nil); err != nil {
+		t.Errorf("measurementFailure(nil, nil) = %v, want nil", err)
+	}
+	notStarted := errors.New(`exec: "go": executable file not found in $PATH`)
+	if err := measurementFailure(nil, notStarted); !errors.Is(err, notStarted) {
+		t.Errorf("a toolchain that cannot start must propagate, got %v", err)
+	}
+}
+
+// TestPrintCoefficientEmitsNothingWhenCanceled pins the other half. coefficientFor
+// falls back to the maximum on any measurement failure, which is right for a
+// genuine one and wrong for Ctrl-C: 600 is numeric, so the Makefile's guard would
+// accept it and an interrupted measurement would be indistinguishable from a
+// package that legitimately needs a 600x ceiling.
+func TestPrintCoefficientEmitsNothingWhenCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var stdout, stderr bytes.Buffer
+	measure := func(ctx context.Context, _ string) (suiteTiming, error) {
+		return suiteTiming{}, ctx.Err()
+	}
+	if code := printCoefficient(ctx, "./observability", measure, 30*time.Second, &stdout, &stderr); code == 0 {
+		t.Errorf("printCoefficient = 0 on a canceled run, want nonzero")
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "" {
+		t.Errorf("stdout = %q, want empty — the Makefile's numeric guard would accept that as a real coefficient", got)
+	}
+	// Not just "canceled": coefficientFor's fallback WARN already carries that
+	// word, so matching it would pass even with the guard removed.
+	if !strings.Contains(stderr.String(), "no coefficient emitted") {
+		t.Errorf("stderr = %q, want the cancellation diagnostic", stderr.String())
 	}
 }
 

--- a/scripts/mutatediff/timeout_test.go
+++ b/scripts/mutatediff/timeout_test.go
@@ -145,7 +145,7 @@ func TestPrintCoefficientEmitsNothingWhenCanceled(t *testing.T) {
 	measure := func(ctx context.Context, _ string) (suiteTiming, error) {
 		return suiteTiming{}, ctx.Err()
 	}
-	if code := printCoefficient(ctx, "./observability", measure, 30*time.Second, &stdout, &stderr); code == 0 {
+	if printCoefficient(ctx, "./observability", measure, 30*time.Second, &stdout, &stderr) == 0 {
 		t.Errorf("printCoefficient = 0 on a canceled run, want nonzero")
 	}
 	if got := strings.TrimSpace(stdout.String()); got != "" {

--- a/scripts/mutatediff/timeout_test.go
+++ b/scripts/mutatediff/timeout_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestTimeoutCoefficientCoversTheRealMutantCost is the regression this whole
+// file exists for. ./observability's suite takes ~25s but its engine baseline is
+// a cached replay of ~0.34s. Scaling a fixed 30s floor by the baseline alone
+// yields a ceiling that does not cover one real run of the suite, which is how
+// the first nightly baseline produced 241 timeouts and zero verdicts there.
+func TestTimeoutCoefficientCoversTheRealMutantCost(t *testing.T) {
+	obs := suiteTiming{Uncached: 25 * time.Second, Baseline: 340 * time.Millisecond}
+	got := timeoutCoefficient(obs, 30*time.Second)
+	ceiling := obs.Baseline * time.Duration(got)
+	if ceiling < obs.Uncached {
+		t.Fatalf("coefficient %d gives a %s ceiling, under the %s the suite really needs",
+			got, ceiling, obs.Uncached)
+	}
+	// Naively dividing the floor by the cached baseline would have been enough;
+	// dividing it by the SUITE is what collapsed to the engine default of 3.
+	if naive := timeoutCoefficient(
+		suiteTiming{Uncached: 25 * time.Second, Baseline: 25 * time.Second},
+		30*time.Second); naive > minTimeoutCoefficient+1 {
+		t.Errorf("sanity: conflating the two timings should collapse the coefficient, got %d", naive)
+	}
+}
+
+func TestTimeoutCoefficientFloorsFastSuites(t *testing.T) {
+	// A trivial suite: the floor, not the suite time, sets the ceiling.
+	fast := suiteTiming{Uncached: 50 * time.Millisecond, Baseline: 100 * time.Millisecond}
+	if got := timeoutCoefficient(fast, 30*time.Second); got != 300 {
+		t.Errorf("timeoutCoefficient(fast, 30s floor) = %d, want 300 (ceil(30/0.1))", got)
+	}
+}
+
+func TestTimeoutCoefficientRoundsUpToClearTheTarget(t *testing.T) {
+	// target 30s, baseline 7s: 30/7 = 4.28, and truncating to 4 leaves 28s.
+	tim := suiteTiming{Uncached: time.Second, Baseline: 7 * time.Second}
+	got := timeoutCoefficient(tim, 30*time.Second)
+	if got != 5 {
+		t.Fatalf("timeoutCoefficient = %d, want 5", got)
+	}
+	if ceiling := tim.Baseline * time.Duration(got); ceiling < 30*time.Second {
+		t.Errorf("ceiling %s is below the 30s target", ceiling)
+	}
+}
+
+func TestTimeoutCoefficientKeepsEngineDefaultWhenBaselineIsAlreadyAmple(t *testing.T) {
+	// A failing suite is never cached, so baseline == uncached. 3x the real cost
+	// is ample, and inflating it only lengthens a genuinely hanging mutant.
+	tim := suiteTiming{Uncached: 40 * time.Second, Baseline: 40 * time.Second}
+	if got := timeoutCoefficient(tim, 30*time.Second); got != minTimeoutCoefficient {
+		t.Errorf("timeoutCoefficient = %d, want %d", got, minTimeoutCoefficient)
+	}
+}
+
+func TestTimeoutCoefficientClampsPathologicalValues(t *testing.T) {
+	tiny := suiteTiming{Uncached: time.Second, Baseline: time.Microsecond}
+	if got := timeoutCoefficient(tiny, 30*time.Second); got != maxTimeoutCoefficient {
+		t.Errorf("timeoutCoefficient(1µs baseline) = %d, want %d", got, maxTimeoutCoefficient)
+	}
+	for _, baseline := range []time.Duration{0, -time.Second} {
+		tim := suiteTiming{Uncached: time.Second, Baseline: baseline}
+		if got := timeoutCoefficient(tim, 30*time.Second); got != maxTimeoutCoefficient {
+			t.Errorf("timeoutCoefficient(baseline %s) = %d, want %d (unmeasurable must fail generous)",
+				baseline, got, maxTimeoutCoefficient)
+		}
+	}
+}
+
+func TestCoefficientForFallsBackGenerouslyWhenMeasurementFails(t *testing.T) {
+	var buf bytes.Buffer
+	measure := func(string) (suiteTiming, error) { return suiteTiming{}, errors.New("go test unavailable") }
+	got := coefficientFor("./observability", measure, 30*time.Second, &buf)
+	if got != maxTimeoutCoefficient {
+		t.Errorf("coefficientFor with failed measurement = %d, want %d", got, maxTimeoutCoefficient)
+	}
+	if !strings.Contains(buf.String(), "WARN") {
+		t.Errorf("a failed measurement must be visible, got: %q", buf.String())
+	}
+}
+
+func TestCoefficientForReportsBothTimings(t *testing.T) {
+	var buf bytes.Buffer
+	measure := func(string) (suiteTiming, error) {
+		return suiteTiming{Uncached: 25 * time.Second, Baseline: 100 * time.Millisecond}, nil
+	}
+	// target = 25s + 20s budget = 45s; 45/0.1 = 450.
+	if got := coefficientFor("./observability", measure, 30*time.Second, &buf); got != 450 {
+		t.Errorf("coefficientFor = %d, want 450", got)
+	}
+	for _, want := range []string{"suite 25s", "engine baseline 100ms", "coefficient 450"} {
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("log %q missing %q", buf.String(), want)
+		}
+	}
+}
+
+// TestPrintCoefficientKeepsStdoutParseable pins the contract the Makefile's
+// baseline loop relies on: the number alone on stdout, diagnostics on stderr,
+// so `coeff=$(mutatediff -coefficient ./pkg)` captures an integer.
+func TestPrintCoefficientKeepsStdoutParseable(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	measure := func(string) (suiteTiming, error) {
+		return suiteTiming{Uncached: 10 * time.Second, Baseline: 100 * time.Millisecond}, nil
+	}
+	if code := printCoefficient("./observability", measure, 30*time.Second, &stdout, &stderr); code != 0 {
+		t.Fatalf("printCoefficient = %d, want 0", code)
+	}
+	// target = max(30s, 10s+20s) = 30s; 30/0.1 = 300.
+	if got := strings.TrimSpace(stdout.String()); got != "300" {
+		t.Errorf("stdout = %q, want %q", got, "300")
+	}
+	if !strings.Contains(stderr.String(), "timeout coefficient") {
+		t.Errorf("stderr = %q, want the diagnostic line", stderr.String())
+	}
+}
+
+// TestGremlinsTimeoutArgsUsesTheFlag pins the lever; see coefficientFlag for why
+// the env var gremlins documents cannot be used. Verified on v0.5.1 against
+// ./internal/sqlid: env var gave 6 TIMED OUT and no verdicts, the flag gave
+// 5 KILLED and 1 LIVED.
+func TestGremlinsTimeoutArgsUsesTheFlag(t *testing.T) {
+	got := gremlinsTimeoutArgs(212)
+	want := []string{"--timeout-coefficient", "212"}
+	if !slices.Equal(got, want) {
+		t.Errorf("gremlinsTimeoutArgs(212) = %v, want %v", got, want)
+	}
+}
+
+func TestCeilingFloorReadsOverrideFromEnv(t *testing.T) {
+	t.Setenv(ceilingFloorEnv, "45s")
+	if got := ceilingFloor(); got != 45*time.Second {
+		t.Errorf("ceilingFloor() = %s, want 45s", got)
+	}
+	t.Setenv(ceilingFloorEnv, "not-a-duration")
+	if got := ceilingFloor(); got != defaultCeilingFloor {
+		t.Errorf("ceilingFloor() on unparsable override = %s, want the %s default", got, defaultCeilingFloor)
+	}
+	t.Setenv(ceilingFloorEnv, "")
+	if got := ceilingFloor(); got != defaultCeilingFloor {
+		t.Errorf("ceilingFloor() unset = %s, want %s", got, defaultCeilingFloor)
+	}
+}

--- a/scripts/mutatediff/timeout_test.go
+++ b/scripts/mutatediff/timeout_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"slices"
 	"strings"
@@ -76,8 +77,10 @@ func TestTimeoutCoefficientClampsPathologicalValues(t *testing.T) {
 
 func TestCoefficientForFallsBackGenerouslyWhenMeasurementFails(t *testing.T) {
 	var buf bytes.Buffer
-	measure := func(string) (suiteTiming, error) { return suiteTiming{}, errors.New("go test unavailable") }
-	got := coefficientFor("./observability", measure, 30*time.Second, &buf)
+	measure := func(context.Context, string) (suiteTiming, error) {
+		return suiteTiming{}, errors.New("go test unavailable")
+	}
+	got := coefficientFor(t.Context(), "./observability", measure, 30*time.Second, &buf)
 	if got != maxTimeoutCoefficient {
 		t.Errorf("coefficientFor with failed measurement = %d, want %d", got, maxTimeoutCoefficient)
 	}
@@ -88,11 +91,11 @@ func TestCoefficientForFallsBackGenerouslyWhenMeasurementFails(t *testing.T) {
 
 func TestCoefficientForReportsBothTimings(t *testing.T) {
 	var buf bytes.Buffer
-	measure := func(string) (suiteTiming, error) {
+	measure := func(context.Context, string) (suiteTiming, error) {
 		return suiteTiming{Uncached: 25 * time.Second, Baseline: 100 * time.Millisecond}, nil
 	}
 	// target = 25s + 20s budget = 45s; 45/0.1 = 450.
-	if got := coefficientFor("./observability", measure, 30*time.Second, &buf); got != 450 {
+	if got := coefficientFor(t.Context(), "./observability", measure, 30*time.Second, &buf); got != 450 {
 		t.Errorf("coefficientFor = %d, want 450", got)
 	}
 	for _, want := range []string{"suite 25s", "engine baseline 100ms", "coefficient 450"} {
@@ -107,10 +110,10 @@ func TestCoefficientForReportsBothTimings(t *testing.T) {
 // so `coeff=$(mutatediff -coefficient ./pkg)` captures an integer.
 func TestPrintCoefficientKeepsStdoutParseable(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	measure := func(string) (suiteTiming, error) {
+	measure := func(context.Context, string) (suiteTiming, error) {
 		return suiteTiming{Uncached: 10 * time.Second, Baseline: 100 * time.Millisecond}, nil
 	}
-	if code := printCoefficient("./observability", measure, 30*time.Second, &stdout, &stderr); code != 0 {
+	if code := printCoefficient(t.Context(), "./observability", measure, 30*time.Second, &stdout, &stderr); code != 0 {
 		t.Fatalf("printCoefficient = %d, want 0", code)
 	}
 	// target = max(30s, 10s+20s) = 30s; 30/0.1 = 300.

--- a/scripts/mutatediff/timeout_test.go
+++ b/scripts/mutatediff/timeout_test.go
@@ -148,3 +148,37 @@ func TestCeilingFloorReadsOverrideFromEnv(t *testing.T) {
 		t.Errorf("ceilingFloor() unset = %s, want %s", got, defaultCeilingFloor)
 	}
 }
+
+func TestWorkerArgsOnlyOverridesWhenAsked(t *testing.T) {
+	if got := workerArgs(2); !slices.Equal(got, []string{workersFlag, "2"}) {
+		t.Errorf("workerArgs(2) = %v, want [--workers 2]", got)
+	}
+	for _, n := range []int{0, -1} {
+		if got := workerArgs(n); got != nil {
+			t.Errorf("workerArgs(%d) = %v, want nil so .gremlins.yaml stays in charge", n, got)
+		}
+	}
+}
+
+// TestCoverageArgsMatchTheEngineWhenCached pins the invariant a regression already
+// broke once: the cached passes must be argv-identical to gremlins' own coverage
+// command, because -timeout participates in go test's cache key. Warming a
+// different argv leaves gremlins' run a cache miss, so its Elapsed becomes the
+// real suite and the coefficient multiplies the suite instead of the replay —
+// verified on go1.26.5: after `go clean -testcache` and warming only the
+// -timeout variant, the engine's command took the full 24.5s.
+func TestCoverageArgsMatchTheEngineWhenCached(t *testing.T) {
+	// gremlins: `go test -cover -coverprofile <file> ./pkg/...` and nothing else.
+	want := []string{"test", "-cover", "-coverprofile", "/tmp/p", "./observability/..."}
+	if got := coverageArgs("/tmp/p", "./observability", false); !slices.Equal(got, want) {
+		t.Errorf("coverageArgs(cached) = %v, want exactly %v", got, want)
+	}
+	forced := coverageArgs("/tmp/p", "./observability", true)
+	if !slices.Contains(forced, "-count=1") || !slices.Contains(forced, measureTimeout) {
+		t.Errorf("coverageArgs(forceRun) = %v, want -count=1 and -timeout %s", forced, measureTimeout)
+	}
+	// -count=1 disables caching, so the extra flag is free only on that pass.
+	if slices.Contains(coverageArgs("/tmp/p", "./x", false), "-timeout") {
+		t.Error("the cached pass must not carry -timeout — it splits the cache key")
+	}
+}

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -386,7 +386,7 @@ giving a ~45s ceiling. Scaling a fixed floor by the *suite* instead collapses to
 the engine's default 3 (a 1.03s ceiling) for exactly the packages that need it
 most, which is the trap the first attempt at this fell into.
 
-Two further notes for anyone touching it:
+Further notes for anyone touching it:
 
 - **Use the flag, not the environment variable.** gremlins documents
   `GREMLINS_UNLEASH_TIMEOUT_COEFFICIENT`, but it is silently ignored:
@@ -402,6 +402,14 @@ Two further notes for anyone touching it:
   instead of the replay (a 60-minute ceiling on `observability`). `vacuous` cannot
   catch that, because it only sees ceilings that are too *tight*. The flag goes on
   the `-count=1` pass only, where caching is already off.
+- **A canceled measurement must not become a number.** `CommandContext` kills the
+  child on Ctrl-C, and a killed process surfaces as `*exec.ExitError` — the same
+  error a red suite produces, which the measurement deliberately tolerates (a red
+  suite is never cached, so its three passes still time correctly). Only
+  `ctx.Err()` separates the two, so `mutatediff -coefficient` consults it, emits
+  nothing, and exits nonzero; otherwise the generous fallback of 600 would reach
+  stdout, pass the loop's numeric guard, and make an interrupted run
+  indistinguishable from a completed one.
 - **Mutation now costs real time.** Those 90 advisory minutes were cheap because
   nothing ran. A package's mutation cost is roughly
   `mutants × (build + suite)`, so a slow suite dominates — `observability`'s

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -334,6 +334,24 @@ Additionally, a package for which the engine returns **timeouts and not one
 `KILLED` or `LIVED`** fails the gate outright. That state means nothing was
 tested, and it is what the ceiling arithmetic below exists to prevent.
 
+Each package is dry-run first (mutants enumerated, none executed). If no mutant
+lands on a changed line the package is **skipped and the gate passes** — an
+intended pass-without-running, not a vacuous one. gremlins mutates the whole
+subtree it is pointed at while the gate judges only changed lines, so a one-line
+edit in `./database` would otherwise run 616 mutants to rule on a handful; a
+comment-only edit there costs 3.7s instead. The skip is sound because `judge` and
+the pre-check share one selector (`changedMutants`), so the set skipped is exactly
+the set that would have been discarded.
+
+Knobs (all `?=`, so the environment overrides):
+
+| Variable | Default | Effect |
+|---|---|---|
+| `MUTATE_WORKERS` | 2 | Concurrent `go test` processes for `make mutate`. Each is sustained CPU load; drop to 1 to keep a laptop cool. |
+| `MUTATE_BASELINE_WORKERS` | 2 | Same, for the nightly baseline; also bounds peak memory. |
+| `MUTATE_CEILING_FLOOR` | 30s | Minimum per-mutant ceiling (any `time.ParseDuration` string). |
+| `MUTATE_FALLBACK_COEFFICIENT` | 600 | Used only when a package's coefficient cannot be computed. |
+
 ### Timeout ceiling
 
 gremlins derives each mutant's wall-clock ceiling as
@@ -377,6 +395,13 @@ Two further notes for anyone touching it:
   yields 0 — which the engine reads as unset and replaces with 3. Values in
   `.gremlins.yaml` are parsed as ints and *do* work; the flag is used because it
   can vary per package.
+- **Keep the cached measurement passes argv-identical to the engine's.**
+  `-timeout` participates in `go test`'s cache key, so adding it to those passes
+  warms an entry gremlins never reads — leaving its own coverage run a cache miss
+  whose elapsed is the real suite, and multiplying the coefficient by the suite
+  instead of the replay (a 60-minute ceiling on `observability`). `vacuous` cannot
+  catch that, because it only sees ceilings that are too *tight*. The flag goes on
+  the `-count=1` pass only, where caching is already off.
 - **Mutation now costs real time.** Those 90 advisory minutes were cheap because
   nothing ran. A package's mutation cost is roughly
   `mutants × (build + suite)`, so a slow suite dominates — `observability`'s

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -327,8 +327,67 @@ and applies this policy to mutants that land on changed lines:
 |---|---|---|
 | `LIVED` | **fail** (exit 1) | A mutant on a line you wrote survived your tests |
 | `NOT COVERED` | warn | Coverage is SonarCloud's gate; no double-gating |
-| `TIMED OUT` | pass | The mutant hung the code and the test timeout noticed |
+| `TIMED OUT` | warn | Indeterminate — see the timeout ceiling below |
 | `KILLED` | pass | |
+
+Additionally, a package for which the engine returns **timeouts and not one
+`KILLED` or `LIVED`** fails the gate outright. That state means nothing was
+tested, and it is what the ceiling arithmetic below exists to prevent.
+
+### Timeout ceiling
+
+gremlins derives each mutant's wall-clock ceiling as
+`baseline_elapsed × unleash.timeout-coefficient` and enforces it with a hard
+deadline that must cover the mutant's whole `go test` invocation — **compiling
+and linking the mutated binary, then running the suite**. With the engine's
+default coefficient of 3 that ceiling routinely lands below what a single mutant
+costs, and every mutant reports `TIMED OUT` without ever being evaluated.
+
+That status is excluded from both of gremlins' published metrics
+(`efficacy = KILLED/(KILLED+LIVED)`, `coverage = (KILLED+LIVED)/(KILLED+LIVED+NOT COVERED)`),
+so the failure is invisible in the score. The first nightly baseline
+(run `30423362023`) hit it in roughly half the repo's packages —
+`observability` produced 241 timeouts and zero verdicts, `messaging` 219 — and
+published a clean 86.2% efficacy over a run in which 38% of mutants never
+produced a verdict. Because the gate treated `TIMED OUT` as a pass, changes to
+those packages went through it vacuously.
+
+Both entry points therefore compute the coefficient per package and pass
+`--timeout-coefficient`. The arithmetic lives in
+`scripts/mutatediff/timeout.go`; `mutatediff -coefficient <pkg>` prints the
+value so the baseline loop shares one implementation. Retune the minimum with
+`MUTATE_CEILING_FLOOR` (any `time.ParseDuration` string).
+
+**Two timings, not one — this is the whole subtlety.** gremlins' baseline
+command omits `-count=1`, so what it measures is a *cache-served replay* of the
+suite. A mutant edits the source, so its own run is always a cache miss and pays
+the *real* suite. On `./observability` those differ by 70×: 302ms replay versus a
+24.7s suite. The coefficient is therefore
+`ceil((real_suite + build_budget) / cached_replay)` — 148 for that package,
+giving a ~45s ceiling. Scaling a fixed floor by the *suite* instead collapses to
+the engine's default 3 (a 1.03s ceiling) for exactly the packages that need it
+most, which is the trap the first attempt at this fell into.
+
+Two further notes for anyone touching it:
+
+- **Use the flag, not the environment variable.** gremlins documents
+  `GREMLINS_UNLEASH_TIMEOUT_COEFFICIENT`, but it is silently ignored:
+  `configuration.Get[T]` does an unchecked `viper.Get(k).(T)`, and viper returns
+  environment values as **strings**, so the assertion for an `int` fails and
+  yields 0 — which the engine reads as unset and replaces with 3. Values in
+  `.gremlins.yaml` are parsed as ints and *do* work; the flag is used because it
+  can vary per package.
+- **Mutation now costs real time.** Those 90 advisory minutes were cheap because
+  nothing ran. A package's mutation cost is roughly
+  `mutants × (build + suite)`, so a slow suite dominates — `observability`'s
+  single 20s `TestNewProviderEnvironmentAwareBatchTimeout` sets the price for all
+  268 of its mutants. Speeding up the slowest tests is the lever, not raising the
+  ceiling.
+
+A `TIMED OUT` mutant warns rather than passing silently: a mutant that hangs the
+code really is caught by the suite, so it should not block a push, but it carries
+no verdict and must stay visible. A run with outstanding timeouts does not report
+"all mutants killed".
 
 Excluded from scope: `_test.go` files, `testdata/`, `tools/` (separate Go
 module), and `scripts/` (the wrapper itself — see the operational notes).


### PR DESCRIPTION
## What

`make mutate` could pass without evaluating a single mutant. gremlins derives each mutant's timeout from a **cache-served replay** of the package's tests, while every mutant run is a cache miss paying the **real** suite — on `./observability` a 302ms replay versus a 24.7s suite. The default ceiling therefore landed under one mutant's cost, every mutant reported `TIMED OUT`, and the gate treated that as a pass. Both entry points now scale `--timeout-coefficient` per package, `TIMED OUT` warns instead of passing, and a package returning timeouts with zero verdicts fails outright.

## Impact

`make mutate` adds a measurement pass per changed package and now spends real wall-clock where mutants used to die instantly. Mutation cost is roughly `mutants × (build + suite)`, so the nightly baseline's 240-minute timeout likely needs raising — the lever is faster tests, not a higher ceiling.

## Verification

Four packages the first baseline reported as 100% `TIMED OUT` with zero verdicts now judge fully, surfacing **10 surviving mutants the timeouts had hidden** (`internal/sqlid` 1, `internal/resourcepool` 4, `messaging/internal/tracking` 4, `database/types` 1). `make mutate` cannot self-verify — `scripts/` is excluded from its own scope — so the wrapper's unit tests are the net.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Mutation verdicts now treat **TIMED OUT** mutants as non-fatal warnings rather than passes.
  - Packages containing only timeouts are marked indeterminate and fail the mutation gate.
  - “All mutants killed” is reported only when all mutants are fully judged.

- **Improvements**
  - Mutation timeouts are calculated per package from measured test runtime, with safe fallbacks.
  - Mutation runs support configurable worker counts and provide clearer warnings for unjudged results.

- **Documentation**
  - Updated testing guidance covering mutation gates, timeout ceilings, coefficients, and timeout-related outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->