### PR TITLE
fix(keystore): never echo the configured secret source in startup errors

### DIFF
--- a/internal/keymaterial/keymaterial.go
+++ b/internal/keymaterial/keymaterial.go
@@ -50,6 +50,39 @@ func LoadBytes(file, value string) ([]byte, error) {
 	return data, nil
 }
 
+// LoadSecretBytes is LoadBytes for raw symmetric secrets. Secret material has
+// no detectable shape (no PEM/DER structure), so a mis-filed value cannot be
+// caught by LooksLikeKeyMaterial — instead, NO error on this path ever echoes
+// the configured file value or the underlying path.
+// SECURITY: a transposed secret.file/secret.value must not put key material
+// into a fatal startup log line; strip the path from wrapped OS errors.
+func LoadSecretBytes(file, value string) ([]byte, error) {
+	hasFile := file != ""
+	hasValue := value != ""
+	if !hasFile && !hasValue {
+		return nil, nil
+	}
+	if hasFile {
+		if secretfile.LooksLikeKeyMaterial(file) {
+			return nil, errors.New("file looks like key material, not a path (pass inline material via the value source instead)")
+		}
+		data, err := os.ReadFile(file) // #nosec G304 -- deployment configuration, as in LoadBytes
+		if err != nil {
+			var pe *os.PathError
+			if errors.As(err, &pe) {
+				err = pe.Err // strip the embedded path — it may BE the secret
+			}
+			return nil, fmt.Errorf("secret file unreadable (source elided): %w", err)
+		}
+		return data, nil
+	}
+	data, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return nil, errors.New("secret value is not valid base64 (value elided)")
+	}
+	return data, nil
+}
+
 // ParseRSAPublicKey parses PKIX DER into an *rsa.PublicKey.
 func ParseRSAPublicKey(der []byte) (*rsa.PublicKey, error) {
 	pub, err := x509.ParsePKIXPublicKey(der)

--- a/internal/keymaterial/keymaterial_test.go
+++ b/internal/keymaterial/keymaterial_test.go
@@ -1,6 +1,7 @@
 package keymaterial
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -14,6 +15,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// syntheticSecret is a fixed, non-real 32-byte fixture — never key material
+// that could be mistaken for a real secret if echoed by a bug under test.
+var syntheticSecret = bytes.Repeat([]byte{0xAB}, 32)
 
 func TestLoadBytes(t *testing.T) {
 	t.Run("file_path_reads", func(t *testing.T) {
@@ -73,6 +78,77 @@ func TestLoadBytes(t *testing.T) {
 	t.Run("nonexistent_file_errors", func(t *testing.T) {
 		_, err := LoadBytes(filepath.Join(t.TempDir(), "missing.der"), "")
 		require.Error(t, err)
+	})
+}
+
+func TestLoadSecretBytes(t *testing.T) {
+	t.Run("file_path_reads", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "secret.bin")
+		require.NoError(t, os.WriteFile(path, syntheticSecret, 0o600))
+
+		got, err := LoadSecretBytes(path, "")
+		require.NoError(t, err)
+		assert.Equal(t, syntheticSecret, got)
+	})
+
+	t.Run("base64_value_decodes", func(t *testing.T) {
+		encoded := base64.StdEncoding.EncodeToString(syntheticSecret)
+
+		got, err := LoadSecretBytes("", encoded)
+		require.NoError(t, err)
+		assert.Equal(t, syntheticSecret, got)
+	})
+
+	t.Run("neither_set_nil_nil", func(t *testing.T) {
+		got, err := LoadSecretBytes("", "")
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("pem_in_file_field_rejected_echo_free", func(t *testing.T) {
+		asFile := "-----BEGIN PRIVATE KEY-----\nZm9v\n-----END PRIVATE KEY-----\n"
+
+		_, err := LoadSecretBytes(asFile, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "looks like key material")
+		assert.NotContains(t, err.Error(), asFile)
+	})
+
+	t.Run("bad_base64_errors_value_elided", func(t *testing.T) {
+		_, err := LoadSecretBytes("", "!!!not-base64!!!")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "elided")
+	})
+
+	// The regression pin: a base64-encoded 32-byte raw symmetric secret filed
+	// under the wrong field (secret.file instead of secret.value) is below
+	// LooksLikeKeyMaterial's 48-byte DER floor, so it reaches os.ReadFile and
+	// fails to read. LoadSecretBytes must never echo the fixture value or any
+	// path fragment derived from it into the returned error.
+	t.Run("mis_filed_secret_never_echoed", func(t *testing.T) {
+		misFiled := base64.StdEncoding.EncodeToString(syntheticSecret)
+		require.Less(t, len(syntheticSecret), 48, "fixture must decode to fewer than minDERKeyBytes to exercise the regression (LooksLikeKeyMaterial's DER floor)")
+
+		_, err := LoadSecretBytes(misFiled, "")
+		require.Error(t, err)
+		msg := err.Error()
+		assert.NotContains(t, msg, misFiled, "the fixture value must not be echoed")
+		for i := 0; i+8 <= len(misFiled); i += 8 {
+			assert.NotContains(t, msg, misFiled[i:i+8], "no path fragment of the fixture value may be echoed")
+		}
+		assert.Contains(t, msg, "elided")
+	})
+
+	// Mirror assertion: the pre-existing LoadBytes (RSA path) DOES echo the
+	// same input on the same failure — pins the intentional asymmetry between
+	// the RSA and secret loaders (RSA is shape-detected first; secrets are not).
+	t.Run("mirror_load_bytes_does_echo_same_input", func(t *testing.T) {
+		misFiled := base64.StdEncoding.EncodeToString(syntheticSecret)
+
+		_, err := LoadBytes(misFiled, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), misFiled, "LoadBytes is expected to echo — this pins the asymmetry, not a bug")
 	})
 }
 

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -195,8 +195,17 @@ func loadRSAEntry(name string, cfg *config.KeyPairConfig) (*keyEntry, error) {
 // raw key material for secrets. Returns nil if neither file nor value is set.
 // Delegates the file/value resolution mechanism to internal/keymaterial (also
 // consumed by cmd/seal-payload) and adds the keystore error-namespace prefix.
+// Secrets route through LoadSecretBytes: unlike RSA DER, raw symmetric
+// material has no detectable shape, so its loader never echoes the
+// configured source on a failed read.
 func loadKeyBytes(src config.KeySourceConfig, keyName, keyType string) ([]byte, error) {
-	data, err := keymaterial.LoadBytes(src.File, src.Value)
+	var data []byte
+	var err error
+	if keyType == "secret" {
+		data, err = keymaterial.LoadSecretBytes(src.File, src.Value)
+	} else {
+		data, err = keymaterial.LoadBytes(src.File, src.Value)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("keystore: key %q %s: %w", keyName, keyType, err)
 	}

--- a/keystore/keystore_test.go
+++ b/keystore/keystore_test.go
@@ -1,6 +1,7 @@
 package keystore
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -447,6 +448,25 @@ func TestSecretOnRSAEntryRejected(t *testing.T) {
 
 	_, err = s.Secret("signing")
 	assert.ErrorContains(t, err, "has no symmetric secret configured")
+}
+
+// TestNewStoreMisFiledSecretNeverEchoed pins the end-to-end regression: a
+// base64 32-byte raw symmetric secret filed under secret.file (a transposed
+// secret.file/secret.value) is below LooksLikeKeyMaterial's 48-byte DER
+// floor, so it reaches os.ReadFile and fails to read. The resulting keystore
+// construction error must not contain the fixture value.
+func TestNewStoreMisFiledSecretNeverEchoed(t *testing.T) {
+	syntheticSecret := bytes.Repeat([]byte{0xAB}, 32)
+	misFiled := base64.StdEncoding.EncodeToString(syntheticSecret)
+	require.Less(t, len(syntheticSecret), 48, "fixture must decode to fewer than minDERKeyBytes to exercise the regression")
+
+	_, err := newStore(map[string]config.KeyPairConfig{
+		"mac": {Secret: config.KeySourceConfig{File: misFiled}},
+	}, 32)
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), misFiled, "the fixture value must not be echoed")
+	assert.Contains(t, err.Error(), "elided")
 }
 
 func TestPublicKeyOnSecretEntryRejected(t *testing.T) {


### PR DESCRIPTION
## What
A mis-filed 32-byte symmetric secret (e.g. `secret.file`/`secret.value` transposed) slips `LooksLikeKeyMaterial`'s 48-byte DER floor, so `os.ReadFile` failed and echoed the value into a fatal startup log. The keystore's secret path now loads through a new `keymaterial.LoadSecretBytes`, which strips the embedded path from OS errors and elides bad-base64 input instead of wrapping it.

## Impact
None for RSA key loading — `LoadBytes` (public/private) is unchanged and still echoes on failure, since shape detection catches that material first. Operators mis-filing a symmetric secret now get an elided error instead of a value-bearing one.

## Verification
Regression tests assert the returned error contains neither the fixture value nor any 8-char fragment of it, in both `keymaterial.LoadSecretBytes` and end-to-end via `keystore.newStore`; a mirror test pins that `LoadBytes` (RSA path) still echoes the same input, confirming the asymmetry is intentional, not incidental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of symmetric secrets provided as values or file paths.
  * Sensitive secret contents and source paths are now omitted from error messages when loading fails.
  * Added clearer validation for invalid or misconfigured secret inputs.
  * Preserved existing RSA key-loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->