### PR TITLE
feat(httpclient): add BuildStrict for fail-closed transport composition

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -419,8 +419,16 @@ func (b *Builder) WithResponseInterceptor(interceptor ResponseInterceptor) *Buil
 	return b
 }
 
-// Build creates the REST client with the configured options
-func (b *Builder) Build() Client {
+// warnPrefix is prepended to each composition-issue message when Build logs it as a
+// WARN; BuildStrict wraps the same unprefixed issues with its own error prefix instead.
+const warnPrefix = "httpclient: "
+
+// build constructs the client and reports the base-transport-slot
+// displacements that Build only warns about. One issue per triggered
+// predicate, in Build's historical warn order (TLS, provided transport,
+// client transport). Issues carry no "httpclient: " prefix — Build adds it
+// when logging, BuildStrict adds its own when wrapping.
+func (b *Builder) build() (built Client, issues []string) {
 	if b == nil || b.config == nil || isNilLogger(b.logger) {
 		panic("httpclient: Build requires a Builder created by NewBuilder") // NOSONAR: Fail-fast on invalid initialization (manifesto: configuration errors crash at startup)
 	}
@@ -444,41 +452,72 @@ func (b *Builder) Build() Client {
 	}
 
 	if b.discardsTLSConfig() {
-		b.logger.Warn().Msg("httpclient: WithTransport was called after WithTLSConfig — " +
-			"both fill the same base-transport slot and the last call wins, so the *tls.Config " +
-			"installed by WithTLSConfig is discarded with whatever it carried (client certificate, " +
-			"pinned roots, version floor), and TLS now depends entirely on the RoundTripper passed " +
-			"to WithTransport; set TLSClientConfig on that transport yourself, or drop the " +
+		issues = append(issues, "WithTransport was called after WithTLSConfig — "+
+			"both fill the same base-transport slot and the last call wins, so the *tls.Config "+
+			"installed by WithTLSConfig is discarded with whatever it carried (client certificate, "+
+			"pinned roots, version floor), and TLS now depends entirely on the RoundTripper passed "+
+			"to WithTransport; set TLSClientConfig on that transport yourself, or drop the "+
 			"WithTransport call if WithTLSConfig alone is enough")
 	}
 
 	if b.discardsProvidedTransport() {
-		b.logger.Warn().Msg("httpclient: WithTLSConfig was called after WithTransport — " +
-			"both fill the same base-transport slot and the last call wins, so the RoundTripper " +
-			"passed to WithTransport is discarded along with any proxy, dialer or TLS settings it " +
-			"carried; WithTLSConfig replaces it with a fresh base, a clone of net/http.DefaultTransport " +
-			"or an equivalently-configured transport when that global has been replaced. Fold TLS " +
-			"settings into the *tls.Config; to keep proxy or dialer settings, drop WithTLSConfig and " +
+		issues = append(issues, "WithTLSConfig was called after WithTransport — "+
+			"both fill the same base-transport slot and the last call wins, so the RoundTripper "+
+			"passed to WithTransport is discarded along with any proxy, dialer or TLS settings it "+
+			"carried; WithTLSConfig replaces it with a fresh base, a clone of net/http.DefaultTransport "+
+			"or an equivalently-configured transport when that global has been replaced. Fold TLS "+
+			"settings into the *tls.Config; to keep proxy or dialer settings, drop WithTLSConfig and "+
 			"set TLSClientConfig on your own transport instead")
 	}
 
 	if rt := b.resolveTransport(); rt != nil {
 		if b.discardsClientTransport() {
-			b.logger.Warn().Msg("httpclient: transport wrapper registered without WithTransport — " +
-				"the *http.Client passed to WithHTTPClient has its own Transport replaced and requests " +
-				"dial via net/http.DefaultTransport, losing client certificates, pinned roots and proxy " +
+			issues = append(issues, "transport wrapper registered without WithTransport — "+
+				"the *http.Client passed to WithHTTPClient has its own Transport replaced and requests "+
+				"dial via net/http.DefaultTransport, losing client certificates, pinned roots and proxy "+
 				"settings; pass the base RoundTripper to WithTransport instead")
 		}
 		httpClient.Transport = rt
 	}
 
-	return &client{
+	built = &client{
 		httpClient:           httpClient,
 		logger:               b.logger,
 		config:               cfg,
 		requestInterceptors:  cfg.RequestInterceptors,
 		responseInterceptors: cfg.ResponseInterceptors,
 	}
+	return built, issues
+}
+
+// Build creates the REST client with the configured options. Compositions that
+// would silently discard TLS material or a provided transport are logged as
+// WARNs, not rejected — see BuildStrict for a fail-closed variant.
+func (b *Builder) Build() Client {
+	c, issues := b.build()
+	for _, msg := range issues {
+		b.logger.Warn().Msg(warnPrefix + msg)
+	}
+	return c
+}
+
+// BuildStrict is Build with fail-closed transport-composition checking: it returns an
+// error instead of a client when a builder call silently discarded the *tls.Config or
+// base transport an earlier call installed.
+//
+// Deployments relying on client certificates or pinned roots should prefer BuildStrict,
+// so a displaced *tls.Config is a startup failure rather than a silent runtime downgrade
+// to net/http.DefaultTransport.
+//
+// WithTransport or WithTLSConfig called after WithHTTPClient also replaces that client's
+// own Transport, but is treated as a deliberate override and is not one of the three
+// rejected compositions. The nil-logger/nil-config panic behavior is identical to Build.
+func (b *Builder) BuildStrict() (Client, error) {
+	c, issues := b.build()
+	if len(issues) > 0 {
+		return nil, fmt.Errorf("httpclient: unsafe transport composition: %s", strings.Join(issues, "; "))
+	}
+	return c, nil
 }
 
 // deepCopyConfig creates a deep copy of the provided Config to ensure

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -2325,4 +2325,161 @@ func TestNewBuilderAndBuildRejectNilLogger(t *testing.T) {
 			b.Build()
 		})
 	})
+
+	t.Run("nil_builder_receiver_buildstrict", func(t *testing.T) {
+		assert.PanicsWithValue(t, buildMsg, func() {
+			var b *Builder
+			_, _ = b.BuildStrict()
+		})
+	})
+}
+
+// TestBuildStrictErrorsOnDiscardedClientTransport is the mtls-composition pin: the
+// natural NewBuilder(log).WithHTTPClient(mtlsClient).WithJOSE(cfg).Build() call
+// silently drops the client's own Transport (and any client certificate or
+// pinned roots it carried). BuildStrict must reject it instead.
+func TestBuildStrictErrorsOnDiscardedClientTransport(t *testing.T) {
+	log := createTestLogger()
+	base := &stubRoundTripper{name: "mtls-base"}
+	withClient := func() *nethttp.Client { return &nethttp.Client{Transport: base} }
+
+	built, err := NewBuilder(log).WithHTTPClient(withClient()).WithJOSE(JOSEConfig{}).BuildStrict()
+
+	require.Error(t, err)
+	assert.Nil(t, built)
+	assert.Contains(t, err.Error(), "transport wrapper registered without WithTransport")
+	assert.True(t, strings.HasPrefix(err.Error(), "httpclient: unsafe transport composition: transport wrapper"),
+		"error must carry exactly one httpclient prefix, got: %s", err.Error())
+}
+
+func TestBuildStrictErrorsOnDiscardedTLSConfig(t *testing.T) {
+	log := createTestLogger()
+	stub := &stubRoundTripper{name: "stub"}
+	caPEM, _, _ := newTestCA(t, "buildstrict-discards-tls-config-ca")
+	tlsCfg, err := NewClientTLSConfig(&ClientTLSConfig{CAValue: b64PEM(caPEM)})
+	require.NoError(t, err)
+
+	built, err := NewBuilder(log).WithTLSConfig(tlsCfg).WithTransport(stub).BuildStrict()
+
+	require.Error(t, err)
+	assert.Nil(t, built)
+	assert.Contains(t, err.Error(), "WithTransport was called after WithTLSConfig")
+}
+
+func TestBuildStrictErrorsOnDiscardedProvidedTransport(t *testing.T) {
+	log := createTestLogger()
+	stub := &stubRoundTripper{name: "stub"}
+	caPEM, _, _ := newTestCA(t, "buildstrict-discards-transport-ca")
+	tlsCfg, err := NewClientTLSConfig(&ClientTLSConfig{CAValue: b64PEM(caPEM)})
+	require.NoError(t, err)
+
+	built, err := NewBuilder(log).WithTransport(stub).WithTLSConfig(tlsCfg).BuildStrict()
+
+	require.Error(t, err)
+	assert.Nil(t, built)
+	assert.Contains(t, err.Error(), "WithTLSConfig was called after WithTransport")
+}
+
+func TestBuildStrictHappyPath(t *testing.T) {
+	log := createTestLogger()
+
+	server := newIPv4TestServer(t, nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		w.WriteHeader(nethttp.StatusOK)
+		if _, err := w.Write([]byte(`{"status": "ok"}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	built, err := NewBuilder(log).WithTimeout(5 * time.Second).BuildStrict()
+	require.NoError(t, err)
+	require.NotNil(t, built)
+
+	resp, err := built.Get(context.Background(), &Request{URL: server.URL})
+	require.NoError(t, err)
+	assert.Equal(t, nethttp.StatusOK, resp.StatusCode)
+	assert.Equal(t, `{"status": "ok"}`, string(resp.Body))
+}
+
+// TestBuildStillWarnsOnly pins compatibility: Build must keep constructing a
+// usable client from a discarding composition, never fail it — only BuildStrict does.
+// WithTransport(nil) vacates the base slot rather than installing a blocking
+// stub, so the request below still resolves through the real network to the
+// local httptest server while the TLS material is discarded (and warned about).
+func TestBuildStillWarnsOnly(t *testing.T) {
+	caPEM, _, _ := newTestCA(t, "build-still-warns-only-ca")
+	tlsCfg, err := NewClientTLSConfig(&ClientTLSConfig{CAValue: b64PEM(caPEM)})
+	require.NoError(t, err)
+
+	t.Run("warn_line_carries_the_httpclient_prefix", func(t *testing.T) {
+		// Build-only, no request: warnSpy implements only Warn(), so a real
+		// request (which also calls Info()/Debug()) would nil-panic on it.
+		spy := &warnSpy{}
+		NewBuilder(spy).WithTLSConfig(tlsCfg).WithTransport(nil).Build()
+		require.Len(t, spy.msgs, 1)
+		assert.True(t, strings.HasPrefix(spy.msgs[0], "httpclient: WithTransport was called after WithTLSConfig"),
+			"Build's emitted WARN must stay byte-identical, prefix included; got: %s", spy.msgs[0])
+	})
+
+	t.Run("client_still_works", func(t *testing.T) {
+		log := createTestLogger()
+		server := newIPv4TestServer(t, nethttp.HandlerFunc(func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+			w.WriteHeader(nethttp.StatusOK)
+			if _, err := w.Write([]byte(`{"status": "ok"}`)); err != nil {
+				t.Errorf("write response: %v", err)
+			}
+		}))
+		defer server.Close()
+
+		built := NewBuilder(log).WithTLSConfig(tlsCfg).WithTransport(nil).Build()
+		require.NotNil(t, built)
+
+		resp, err := built.Get(context.Background(), &Request{URL: server.URL})
+		require.NoError(t, err)
+		assert.Equal(t, nethttp.StatusOK, resp.StatusCode)
+	})
+}
+
+// TestBuildStrictAllowsExplicitTransportOverride pins deliberate-override semantics:
+// WithHTTPClient never participates in the base-transport slot, so a later
+// WithTransport/WithTLSConfig call replaces that client's own Transport without
+// tripping any of the three compositions BuildStrict rejects.
+func TestBuildStrictAllowsExplicitTransportOverride(t *testing.T) {
+	log := createTestLogger()
+
+	t.Run("explicit_transport_after_http_client", func(t *testing.T) {
+		mtls := &stubRoundTripper{name: "mtls"}
+		withClient := func() *nethttp.Client { return &nethttp.Client{Transport: mtls} }
+		override := &stubRoundTripper{name: "override"}
+
+		built, err := NewBuilder(log).WithHTTPClient(withClient()).WithTransport(override).BuildStrict()
+
+		require.NoError(t, err)
+		require.NotNil(t, built)
+		clientImpl, ok := built.(*client)
+		require.True(t, ok)
+		assert.Same(t, override, clientImpl.httpClient.Transport)
+		assert.NotSame(t, mtls, clientImpl.httpClient.Transport, "WithTransport after WithHTTPClient must win — this is a deliberate override, not a rejected composition")
+	})
+
+	t.Run("explicit_tls_config_after_http_client", func(t *testing.T) {
+		mtls := &stubRoundTripper{name: "mtls"}
+		withClient := func() *nethttp.Client { return &nethttp.Client{Transport: mtls} }
+		caPEM, _, _ := newTestCA(t, "buildstrict-allows-override-ca")
+		tlsCfg, err := NewClientTLSConfig(&ClientTLSConfig{CAValue: b64PEM(caPEM)})
+		require.NoError(t, err)
+
+		built, err := NewBuilder(log).WithHTTPClient(withClient()).WithTLSConfig(tlsCfg).BuildStrict()
+
+		require.NoError(t, err)
+		require.NotNil(t, built)
+		clientImpl, ok := built.(*client)
+		require.True(t, ok)
+		assert.NotSame(t, mtls, clientImpl.httpClient.Transport, "WithTLSConfig after WithHTTPClient must win — this is a deliberate override, not a rejected composition")
+
+		transportImpl, ok := clientImpl.httpClient.Transport.(*nethttp.Transport)
+		require.True(t, ok, "WithTLSConfig's base is a *http.Transport")
+		require.NotNil(t, transportImpl.TLSClientConfig)
+		assert.Same(t, tlsCfg.RootCAs, transportImpl.TLSClientConfig.RootCAs, "replacement transport must carry the CA pool WithTLSConfig installed, not just any different transport")
+	})
 }

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -148,6 +148,36 @@ whole field on the original config is inert rather than racy, but only for clien
 already built. Rotate certificates through `GetClientCertificate`, which the clone
 preserves; for anything else, build a fresh config.
 
+### Fail-closed builds (`BuildStrict`)
+
+The three base-transport-slot displacements above — `WithTransport` after
+`WithTLSConfig`, `WithTLSConfig` after `WithTransport`, and a wrapper (e.g.
+`WithJOSE`) replacing a `WithHTTPClient` client's own Transport — are only a
+`Build()` WARN: against a peer that doesn't enforce mTLS, the resulting client
+still works, just without the client certificate or pinned roots it should
+carry. `BuildStrict()` is the fail-closed alternative — same client `Build()` would
+return, but an error instead whenever one of those three compositions
+triggered:
+
+```go
+client, err := httpclient.NewBuilder(logger).
+    WithHTTPClient(mtlsClient). // has its own Transport
+    WithJOSE(cfg).
+    BuildStrict()
+if err != nil {
+    return err // caught at startup, not silently downgraded at runtime
+}
+```
+
+`BuildStrict` rejects exactly those three displacement compositions — no more.
+Calling `WithTransport` or `WithTLSConfig` *after* `WithHTTPClient` also
+replaces that client's own Transport, but is treated as a deliberate override
+and is NOT rejected: an explicit base-transport call wins on purpose. If the
+client certificate lives on the `WithHTTPClient` client, pass its base
+RoundTripper to `WithTransport` instead of relying on `BuildStrict` to catch the
+override. `Build()` is unchanged and still compiles, so existing call sites
+are unaffected.
+
 ### OAuth 1.0a request signing (partner APIs)
 
 Some partner gateways (e.g. Mastercard APIs) authenticate outbound requests with

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -38,7 +38,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E51  | v0.50.0 → v0.51.0 | silent-behavior (adopt-only) | 3 | none | none |
 | E52  | v0.51.0 → v0.52.0 | compile-break | 4 | C52.1 | if you set `.Args` on any declaration in ≤v0.51.0, verify current broker state before upgrading |
 | E55  | v0.52.0 → v0.55.0 | additive (safe) | 3 | none | none |
-| E56  | v0.55.0 → v0.56.0 | silent-behavior | 5 | none | grep log-driven alerts, dashboards, and test assertions for card-data / `iban` / `otp` field names — their values render `***` after the bump (C56.3); expect a cold tenant's first messaging request to fail fast instead of blocking (C56.4); if you assemble config in Go, check for `forwardedclientcert.require` without `enabled` — that service was serving unauthenticated traffic and now returns 401 (C56.5) |
+| E56  | v0.55.0 → v0.56.0 | silent-behavior | 6 | none | grep log-driven alerts, dashboards, and test assertions for card-data / `iban` / `otp` field names — their values render `***` after the bump (C56.3); expect a cold tenant's first messaging request to fail fast instead of blocking (C56.4); if you assemble config in Go, check for `forwardedclientcert.require` without `enabled` — that service was serving unauthenticated traffic and now returns 401 (C56.5) |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 - **`when: match`** → act only if `detect` returns ≥1 line (an API/arity/interface change, or a config key you set).
@@ -759,7 +759,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 
 ## E56 · v0.55.0 → v0.56.0 — ALB forwarded-client-cert identity middleware + seal-payload CLI + widened logger mask list
 
-- gist: Adds `server.forwardedclientcert.*` (`enabled`, `require`) for a config-gated middleware that parses ALB verify-mode `X-Amzn-Mtls-Clientcert-*` identity headers into a typed `server.ForwardedClientCert` (ADR-043; identification, not authorization). Also adds the installable `cmd/seal-payload` CLI for curl-testing jose-tagged endpoints. No exported go-bricks symbol changes outside this new surface — but `logger.DefaultFilterConfig()` gains eleven card-data/PII field names, which silently changes log output for anyone on the defaults (C56.3). Multi-tenant lazy consumer setup also stops blocking over-budget callers: `messaging.Manager.EnsureConsumers` now returns as soon as the caller's own context ends, while the setup itself still completes (C56.4). And `server.forwardedclientcert.require: true` now registers the middleware even when `enabled` was left false, so a programmatically-assembled config that skipped `config.Validate` stops serving unauthenticated traffic and starts returning 401 (C56.5).
+- gist: Adds `server.forwardedclientcert.*` (`enabled`, `require`) for a config-gated middleware that parses ALB verify-mode `X-Amzn-Mtls-Clientcert-*` identity headers into a typed `server.ForwardedClientCert` (ADR-043; identification, not authorization). Also adds the installable `cmd/seal-payload` CLI for curl-testing jose-tagged endpoints. No exported go-bricks symbol changes outside this new surface — but `logger.DefaultFilterConfig()` gains eleven card-data/PII field names, which silently changes log output for anyone on the defaults (C56.3). Multi-tenant lazy consumer setup also stops blocking over-budget callers: `messaging.Manager.EnsureConsumers` now returns as soon as the caller's own context ends, while the setup itself still completes (C56.4). And `server.forwardedclientcert.require: true` now registers the middleware even when `enabled` was left false, so a programmatically-assembled config that skipped `config.Validate` stops serving unauthenticated traffic and starts returning 401 (C56.5). Also adds `httpclient.Builder.BuildStrict`, a fail-closed alternative to `Build` for compositions that would otherwise silently discard TLS material or a provided transport (C56.6).
 - build-caught: none
 - preflight: none
 - exit: `go get github.com/gaborage/go-bricks@v0.56.0 && go mod tidy && go build ./... && go test ./...`
@@ -825,6 +825,29 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - apply: set `enabled: true` explicitly (`Enabled: true` in the Go literal) — your service was accepting unauthenticated requests and will now reject them with 401, which is the fix. The framework registers the middleware regardless and emits one startup WARN naming both keys, so the flip is never silent; setting `Enabled` clears the WARN. If you did **not** intend to require client-certificate identity, drop `Require: true` instead.
 - verify: start the service and check startup output — the WARN is present only while `enabled` is still false. Then issue one request carrying no `X-Amzn-Mtls-Clientcert-*` headers and confirm 401 (before this bump it returned the handler's normal response). Health/ready probes stay exempt: confirm they still return 200, because ALB health checks present no client certificate.
 - ref: ADR-043 · `server/middleware.go` (`setupIdentityMiddlewares`) · `config/validation.go` (`validateServerForwardedClientCert`) · wiki/forwarded_client_cert.md
+
+### [C56.6] `Builder.BuildStrict` — fail-closed transport-composition errors · additive-optional
+
+- note: New `(*httpclient.Builder).BuildStrict() (Client, error)` is `Build` with
+  fail-closed composition checking: the three base-transport-slot
+  displacements `Build` only warns about — `WithTransport` called after
+  `WithTLSConfig`, `WithTLSConfig` called after `WithTransport`, and a
+  registered wrapper (e.g. `WithJOSE`) replacing a `WithHTTPClient` client's
+  own Transport with `net/http.DefaultTransport` — now return an error
+  instead of a client. Affects any call site with `WithTransport` called
+  after `WithTLSConfig`, `WithTLSConfig` called after `WithTransport`, or a
+  registered wrapper (e.g. `WithJOSE`) paired with a `WithHTTPClient` client
+  that carries its own `Transport`; switch that composition from `Build()`
+  to `BuildStrict()` and handle the error. `WithTLSConfig` combined with a
+  wrapper is the correct composition and is never rejected — it fills the
+  base-transport slot itself, so no material is displaced; no change needed.
+  `Build()` is unchanged and still compiles, so nothing breaks if you do not
+  adopt it.
+- security: mTLS/pinned-root deployments should prefer `BuildStrict` — the
+  discarding compositions above are the same ones that already silently drop
+  a client certificate or pinned CA at runtime (C55.2); `Build` only logs a
+  WARN, so the downgrade is easy to miss outside startup logs.
+- ref: httpclient/client.go (`BuildStrict`) · wiki/httpclient.md
 
 ---
 


### PR DESCRIPTION
## What

`Build()` only WARNs when a builder composition silently drops the base-transport slot's previous occupant: `WithHTTPClient(mtlsClient).WithJOSE(cfg)` replaces the mTLS client's Transport with a wrapper over `net/http.DefaultTransport`, so the client certificate and pinned roots vanish at runtime and requests still succeed. `Build()`'s signature can't gain an error return without breaking apidiff, so this adds `BuildStrict() (Client, error)`, which rejects those three compositions instead of returning a client. Both share a private `build()`, so transport wrappers run exactly once and `Build()`'s WARN output stays byte-identical.

## Impact

Adopt-only — `Build()` is unchanged and still compiles. Deployments whose security depends on what `WithTLSConfig` or `WithHTTPClient` puts in the base-transport slot should switch to `BuildStrict` (migration atom `C56.6`). `WithTransport`/`WithTLSConfig` called after `WithHTTPClient` also replaces that client's Transport but is a deliberate override, not a rejected composition — pass its base RoundTripper to `WithTransport` instead.

## Verification

`make mutate` (local-only gate): `all mutants on changed lines killed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `BuildStrict` for client construction that fails safely when transport or TLS settings would be discarded.
  * Valid explicit transport and TLS overrides continue to work as expected.

* **Bug Fixes**
  * Improved detection of unsafe transport composition while preserving existing warning-only behavior.

* **Documentation**
  * Added usage guidance and migration notes for strict client building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->