### PR TITLE
fix(httpclient): compose WithTLSConfig onto an incumbent transport

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -73,8 +73,10 @@ type Builder struct {
 	config     *Config
 	logger     logger.Logger
 	httpClient *nethttp.Client
-	transport  nethttp.RoundTripper // written only via fillBaseSlot, which maintains baseSlot/displacedBase
-	chain      *transportChain
+	// transport/baseSlot are written only via fillBaseSlot; displacedBase is also
+	// cleared directly by WithTLSConfig (tls.go) when it composed onto the incumbent.
+	transport nethttp.RoundTripper
+	chain     *transportChain
 	// baseSlot records which option currently holds the base-transport slot;
 	// displacedBase the option whose material a later call overwrote and never
 	// restored. Build warns for the displaced one — last-call-wins is intended,
@@ -401,10 +403,9 @@ func (b *Builder) discardsClientTransport() bool {
 // pinned roots into the base slot and a later WithTransport took it over.
 func (b *Builder) discardsTLSConfig() bool { return b.displacedBase == baseTLS }
 
-// discardsProvidedTransport reports the mirror case: WithTransport supplied the
-// base RoundTripper and a later WithTLSConfig replaced it with a fresh base, a
-// clone of nethttp.DefaultTransport or an equivalently-configured transport
-// when that global has been replaced.
+// discardsProvidedTransport is the mirror of discardsTLSConfig: WithTransport's
+// RoundTripper was displaced by a later WithTLSConfig. Cleared by WithTLSConfig
+// when baseTransportForTLS reports the incumbent carried no TLS material to lose.
 func (b *Builder) discardsProvidedTransport() bool { return b.displacedBase == baseTransport }
 
 // WithRequestInterceptor adds a request interceptor
@@ -454,12 +455,17 @@ func (b *Builder) Build() Client {
 
 	if b.discardsProvidedTransport() {
 		b.logger.Warn().Msg("httpclient: WithTLSConfig was called after WithTransport — " +
-			"both fill the same base-transport slot and the last call wins, so the RoundTripper " +
-			"passed to WithTransport is discarded along with any proxy, dialer or TLS settings it " +
-			"carried; WithTLSConfig replaces it with a fresh base, a clone of net/http.DefaultTransport " +
-			"or an equivalently-configured transport when that global has been replaced. Fold TLS " +
-			"settings into the *tls.Config; to keep proxy or dialer settings, drop WithTLSConfig and " +
-			"set TLSClientConfig on your own transport instead")
+			"both fill the same base-transport slot and the last call wins. If the RoundTripper " +
+			"passed to WithTransport is not itself a *http.Transport, it is discarded wholesale: " +
+			"proxy, dialer and any TLS settings it carried are all lost, and WithTLSConfig installs " +
+			"a fresh base instead. If it IS a *http.Transport, its proxy, dialer and connection-pool " +
+			"settings are preserved into the new base, but its TLS material is not: a TLSClientConfig " +
+			"it carried (client certificate, pinned roots, version floor) is replaced by the " +
+			"*tls.Config passed to WithTLSConfig, and a DialTLS or DialTLSContext it carried is " +
+			"cleared outright — net/http skips its own handshake, and so ignores the *tls.Config, " +
+			"whenever a TLS dialer is set. Fold any client certificate or pinned roots into that " +
+			"*tls.Config; to keep the original TLSClientConfig or TLS dialer instead, drop " +
+			"WithTLSConfig and set them directly on your own transport")
 	}
 
 	if rt := b.resolveTransport(); rt != nil {

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -2263,6 +2263,166 @@ func TestBuilderBaseSlotDiscards(t *testing.T) {
 	})
 }
 
+// TestBuilderTLSConfigComposesWithIncumbentTransport pins that WithTLSConfig
+// composes onto an incumbent *nethttp.Transport rather than colliding with
+// it; an opaque incumbent can't be cloned and remains a genuine discard.
+func TestBuilderTLSConfigComposesWithIncumbentTransport(t *testing.T) {
+	caPEM, _, _ := newTestCA(t, "compose-ca")
+	cfg, err := NewClientTLSConfig(&ClientTLSConfig{CAValue: b64PEM(caPEM)})
+	require.NoError(t, err)
+
+	t.Run("nethttp_transport_incumbent_composes", func(t *testing.T) {
+		spy := &warnSpy{}
+		custom := &nethttp.Transport{MaxIdleConns: 7}
+		built := NewBuilder(spy).WithTransport(custom).WithTLSConfig(cfg).Build()
+		assert.Empty(t, spy.msgs, "composing onto a *http.Transport with no TLS material of its own loses nothing, so it must not warn")
+
+		clientImpl, ok := built.(*client)
+		require.True(t, ok)
+		transport, ok := clientImpl.httpClient.Transport.(*nethttp.Transport)
+		require.True(t, ok)
+		assert.NotSame(t, custom, transport, "the base must be a clone, not the caller's live transport")
+		assert.Equal(t, 7, transport.MaxIdleConns, "the incumbent's distinguishing field must survive the clone")
+		require.NotNil(t, transport.TLSClientConfig)
+		assert.Same(t, cfg.RootCAs, transport.TLSClientConfig.RootCAs, "the transport must carry cfg's own RootCAs (Clone is shallow), not merely a non-nil pool")
+	})
+
+	// fillBaseSlot's nil check is an interface check, so WithTransport with a
+	// typed-nil *nethttp.Transport fills the slot with a value that satisfies the
+	// type assertion and panics on Clone(). It must take the empty-slot path.
+	t.Run("typed_nil_incumbent_does_not_panic", func(t *testing.T) {
+		spy := &warnSpy{}
+		var typedNil *nethttp.Transport
+		built := NewBuilder(spy).WithTransport(typedNil).WithTLSConfig(cfg).Build()
+		assert.Empty(t, spy.msgs, "a typed nil carries no material, so there is nothing to report")
+
+		clientImpl, ok := built.(*client)
+		require.True(t, ok)
+		transport, ok := clientImpl.httpClient.Transport.(*nethttp.Transport)
+		require.True(t, ok, "the typed nil must be replaced by a real base, not installed as the transport")
+		require.NotNil(t, transport)
+		assert.Same(t, cfg.RootCAs, transport.TLSClientConfig.RootCAs)
+	})
+
+	t.Run("opaque_incumbent_still_warns", func(t *testing.T) {
+		spy := &warnSpy{}
+		stub := &stubRoundTripper{name: "opaque"}
+		NewBuilder(spy).WithTransport(stub).WithTLSConfig(cfg).Build()
+		assert.Contains(t, spy.joined(), "WithTLSConfig was called after WithTransport",
+			"an opaque RoundTripper cannot be cloned, so this is still a discard")
+	})
+}
+
+// TestBuilderTLSConfigCompositionNeverDropsIncumbentTLSMaterial pins that
+// composition never silently drops the incumbent's own TLS material
+// (certificate, pinned roots, or TLS dialer) and stays deterministic
+// regardless of ALPN-only Clone() side effects or how many builders have
+// already cloned a shared incumbent.
+func TestBuilderTLSConfigCompositionNeverDropsIncumbentTLSMaterial(t *testing.T) {
+	caPEM, _, _ := newTestCA(t, "no-drop-ca")
+	cfg, err := NewClientTLSConfig(&ClientTLSConfig{CAValue: b64PEM(caPEM)})
+	require.NoError(t, err)
+
+	t.Run("incumbent_with_client_cert_is_not_silently_replaced", func(t *testing.T) {
+		spy := &warnSpy{}
+		incumbent := &nethttp.Transport{
+			MaxIdleConns: 55,
+			TLSClientConfig: &tls.Config{
+				Certificates: []tls.Certificate{{Certificate: [][]byte{[]byte("fake-client-cert")}}},
+			},
+		}
+		NewBuilder(spy).WithTransport(incumbent).WithTLSConfig(cfg).Build()
+		joined := spy.joined()
+		assert.Contains(t, joined, "TLSClientConfig",
+			"the warning must name the TLS-material replacement, not just the generic call-order collision")
+		assert.Contains(t, joined, "client certificate")
+	})
+
+	// A custom TLS dialer is material of the same class as TLSClientConfig
+	// (pinning, a TLS tunnel) and must not be silently cleared.
+	t.Run("incumbent_with_tls_dialer_is_not_silently_cleared", func(t *testing.T) {
+		spy := &warnSpy{}
+		pinnedDialContext := func(context.Context, string, string) (net.Conn, error) {
+			return nil, errors.New("must never be dialed by this test")
+		}
+		incumbent := &nethttp.Transport{MaxIdleConns: 55, DialTLSContext: pinnedDialContext}
+		NewBuilder(spy).WithTransport(incumbent).WithTLSConfig(cfg).Build()
+		joined := spy.joined()
+		assert.Contains(t, joined, "WithTLSConfig was called after WithTransport",
+			"an incumbent carrying its own TLS dialer must not be silently cleared by a CA-only config")
+		assert.Contains(t, joined, "DialTLSContext",
+			"the message must name the field that actually triggered it, or a dialer-only caller reads advice about TLSClientConfig they never set")
+	})
+
+	t.Run("incumbent_with_deprecated_dial_tls_is_not_silently_cleared", func(t *testing.T) {
+		spy := &warnSpy{}
+		pinnedDialTLS := func(string, string) (net.Conn, error) {
+			return nil, errors.New("must never be dialed by this test")
+		}
+		incumbent := &nethttp.Transport{MaxIdleConns: 55}
+		//nolint:staticcheck // SA1019: DialTLS is deprecated but still honored when DialTLSContext is nil; this test exercises exactly that fallback field.
+		incumbent.DialTLS = pinnedDialTLS
+		NewBuilder(spy).WithTransport(incumbent).WithTLSConfig(cfg).Build()
+		joined := spy.joined()
+		assert.Contains(t, joined, "WithTLSConfig was called after WithTransport",
+			"an incumbent carrying its own deprecated DialTLS dialer must not be silently cleared by a CA-only config")
+		assert.Contains(t, joined, "DialTLS",
+			"the message must name the field that actually triggered it")
+	})
+
+	t.Run("incumbent_without_tls_config_composes_cleanly", func(t *testing.T) {
+		spy := &warnSpy{}
+		incumbent := &nethttp.Transport{MaxIdleConns: 55}
+		built := NewBuilder(spy).WithTransport(incumbent).WithTLSConfig(cfg).Build()
+		assert.Empty(t, spy.msgs)
+
+		clientImpl, ok := built.(*client)
+		require.True(t, ok)
+		transport, ok := clientImpl.httpClient.Transport.(*nethttp.Transport)
+		require.True(t, ok)
+		assert.Equal(t, 55, transport.MaxIdleConns, "the incumbent's tuning must survive the clone")
+		require.NotNil(t, transport.TLSClientConfig)
+		assert.Same(t, cfg.RootCAs, transport.TLSClientConfig.RootCAs, "the transport must carry cfg's own RootCAs")
+	})
+
+	// Composing from a shared incumbent must be deterministic regardless of
+	// how many builders have already cloned it.
+	t.Run("same_incumbent_across_two_builders_is_deterministic", func(t *testing.T) {
+		shared := &nethttp.Transport{MaxIdleConns: 66}
+
+		spyA := &warnSpy{}
+		NewBuilder(spyA).WithTransport(shared).WithTLSConfig(cfg).Build()
+		require.Empty(t, spyA.msgs, "first builder must compose cleanly")
+
+		spyB := &warnSpy{}
+		builtB := NewBuilder(spyB).WithTransport(shared).WithTLSConfig(cfg).Build()
+		require.Empty(t, spyB.msgs, "a second builder cloning the SAME shared incumbent must see the identical result — composition must not depend on construction order")
+
+		clientImplB, ok := builtB.(*client)
+		require.True(t, ok)
+		transportB, ok := clientImplB.httpClient.Transport.(*nethttp.Transport)
+		require.True(t, ok)
+		assert.Equal(t, 66, transportB.MaxIdleConns, "the incumbent's tuning must still survive on the second build")
+	})
+
+	// ALPN-only defaults from a forced Clone() must not be treated as material.
+	t.Run("incumbent_carrying_only_alpn_defaults_still_composes", func(t *testing.T) {
+		spy := &warnSpy{}
+		incumbent := &nethttp.Transport{MaxIdleConns: 77}
+		_ = incumbent.Clone() // forces onceSetNextProtoDefaults to populate an ALPN-only TLSClientConfig
+		require.NotNil(t, incumbent.TLSClientConfig, "the forced Clone must have populated TLSClientConfig, or this test proves nothing")
+
+		built := NewBuilder(spy).WithTransport(incumbent).WithTLSConfig(cfg).Build()
+		assert.Empty(t, spy.msgs, "ALPN-only defaults are not security material and must not block composition")
+
+		clientImpl, ok := built.(*client)
+		require.True(t, ok)
+		transport, ok := clientImpl.httpClient.Transport.(*nethttp.Transport)
+		require.True(t, ok)
+		assert.Equal(t, 77, transport.MaxIdleConns)
+	})
+}
+
 // wrappingTransport stands in for a signer-layer wrapper; it exposes the
 // RoundTripper it wraps so tests can assert nesting depth.
 type wrappingTransport struct {

--- a/httpclient/tls.go
+++ b/httpclient/tls.go
@@ -97,54 +97,108 @@ func NewClientTLSConfig(cfg *ClientTLSConfig) (*tls.Config, error) {
 	return out, nil
 }
 
-// WithTLSConfig installs tlsCfg on a fresh base transport: a clone of
-// http.DefaultTransport, or an equivalently-configured transport when that
-// global has been replaced. It fills the same base-transport slot as
-// WithTransport: whichever of the two is called last wins. Wrapper layers
-// (WithJOSE, for example) always apply on top of this base regardless of call
-// order. A nil tlsCfg is a no-op.
-//
-// The config is cloned, so one loaded config can be shared across clients. The
-// clone is required, not defensive style: net/http appends ALPN protocols to
-// TLSClientConfig.NextProtos in place on a transport's first request, so two
-// clients sharing one config race. The copy is shallow: reference fields such
-// as Certificates and RootCAs stay shared with the caller and must not be
-// mutated in place — rotate certificates through GetClientCertificate, which
-// Clone preserves.
+// WithTLSConfig fills the base-transport slot: it clones an incumbent
+// *nethttp.Transport when present (or DefaultTransport otherwise) and
+// replaces — never merges — its TLSClientConfig with tlsCfg. Last call
+// between this and WithTransport wins. A nil tlsCfg is a no-op.
+// The clone is shallow: don't mutate tlsCfg's Certificates/RootCAs in
+// place — rotate via GetClientCertificate.
 func (b *Builder) WithTLSConfig(tlsCfg *tls.Config) *Builder {
 	if tlsCfg == nil {
 		return b
 	}
-	var base *nethttp.Transport
-	// Consumers replace nethttp.DefaultTransport (gock, httpmock, APM agents), so
-	// a bare type assertion would panic mid-chain. A replaced global cannot be
-	// recovered, so the fallback mirrors the stdlib http.DefaultTransport values
-	// instead of dropping proxy support and HTTP/2.
-	if dt, ok := nethttp.DefaultTransport.(*nethttp.Transport); ok {
-		base = dt.Clone()
-	} else {
-		base = &nethttp.Transport{
-			Proxy: nethttp.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}).DialContext,
-			ForceAttemptHTTP2:     true,
-			MaxIdleConns:          100,
-			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-		}
-	}
-	// net/http skips its own handshake entirely when a TLS dialer is set, so a
-	// cloned one from a replaced global would discard tlsCfg wholesale — pinning,
-	// version floor and client certificate included.
+	base, losslessOrNoMaterial := b.baseTransportForTLS()
+	// A TLS dialer makes net/http skip its own handshake, silently bypassing tlsCfg.
 	//nolint:staticcheck // SA1019: DialTLS is deprecated but still honored when DialTLSContext is nil, so Clone can carry a live TLS bypass in it — clearing it is the point.
 	base.DialTLS = nil
 	base.DialTLSContext = nil
 	base.TLSClientConfig = tlsCfg.Clone()
 	b.fillBaseSlot(base, baseTLS)
+	if losslessOrNoMaterial {
+		// No material lost, so this is composition, not a reportable displacement.
+		b.displacedBase = baseNone
+	}
 	return b
+}
+
+// tlsConfigCarriesMaterial is not a nil check: Clone() mutates its receiver
+// with an ALPN-only default, so nilness alone is unreliable. Errs toward
+// inclusion — add new tls.Config fields here when in doubt.
+func tlsConfigCarriesMaterial(cfg *tls.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	return len(cfg.Certificates) > 0 ||
+		cfg.GetClientCertificate != nil ||
+		cfg.RootCAs != nil ||
+		cfg.InsecureSkipVerify ||
+		cfg.MinVersion != 0 ||
+		cfg.MaxVersion != 0 ||
+		cfg.ServerName != "" ||
+		len(cfg.CipherSuites) > 0 ||
+		len(cfg.CurvePreferences) > 0 ||
+		cfg.Renegotiation != tls.RenegotiateNever ||
+		cfg.VerifyPeerCertificate != nil ||
+		cfg.VerifyConnection != nil
+}
+
+// transportCarriesTLSMaterial reports whether t decides its own TLS: either a
+// TLSClientConfig holding real material, or a TLS dialer — net/http skips its
+// own handshake, and so ignores TLSClientConfig entirely, whenever one is set.
+// Both base-slot directions ask this same question, so they share one predicate
+// rather than two lists that can drift apart. Everything it names is something
+// WithTLSConfig clears or overwrites — keep the two in sync.
+func transportCarriesTLSMaterial(t *nethttp.Transport) bool {
+	if t == nil {
+		return false
+	}
+	//nolint:staticcheck // SA1019: DialTLS is deprecated but still honored when DialTLSContext is nil, so a caller-set DialTLS is real security material we must not silently drop.
+	return tlsConfigCarriesMaterial(t.TLSClientConfig) || t.DialTLS != nil || t.DialTLSContext != nil
+}
+
+// baseTransportForTLS clones an incumbent *nethttp.Transport as the compose
+// base when possible.
+func (b *Builder) baseTransportForTLS() (base *nethttp.Transport, losslessOrNoMaterial bool) {
+	incumbent, isTransport := b.transport.(*nethttp.Transport)
+	// The incumbent != nil guard is not redundant with isTransport: fillBaseSlot's
+	// nil check is an interface check, so WithTransport((*nethttp.Transport)(nil))
+	// fills the slot with a typed nil that satisfies this assertion and would
+	// panic on Clone().
+	if isTransport && incumbent != nil {
+		// Must run before Clone(): Clone's onceSetNextProtoDefaults mutates the
+		// receiver, populating an ALPN-only TLSClientConfig (see tlsConfigCarriesMaterial).
+		hadNoTLSMaterial := !transportCarriesTLSMaterial(incumbent)
+		return incumbent.Clone(), hadNoTLSMaterial
+	}
+	// Reaching here with isTransport set means that typed nil: it holds nothing to
+	// lose, so replacing it is not a reportable displacement. An opaque
+	// RoundTripper is, which is why this is not simply true.
+	nothingToLose := isTransport
+	// Consumers replace nethttp.DefaultTransport (gock, httpmock, APM agents), so
+	// a bare type assertion would panic mid-chain. A replaced global cannot be
+	// recovered, so the fallback mirrors the stdlib http.DefaultTransport values
+	// instead of dropping proxy support and HTTP/2.
+	if dt, ok := nethttp.DefaultTransport.(*nethttp.Transport); ok {
+		return dt.Clone(), nothingToLose
+	}
+	return &nethttp.Transport{
+		Proxy:                 nethttp.ProxyFromEnvironment,
+		DialContext:           fallbackDialer().DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}, nothingToLose
+}
+
+// fallbackDialer is factored out so its Timeout/KeepAlive — otherwise opaque
+// once bound into a DialContext closure — are directly assertable in a test.
+func fallbackDialer() *net.Dialer {
+	return &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
 }
 
 // loadClientKeyPair resolves the client certificate material and enforces the

--- a/httpclient/tls_test.go
+++ b/httpclient/tls_test.go
@@ -495,6 +495,15 @@ func TestWithTLSConfigDefaultTransportReplaced(t *testing.T) {
 		assert.Equal(t, time.Second, transport.ExpectContinueTimeout)
 	})
 
+	// The fallback transport's DialContext is a bound method value on a *net.Dialer,
+	// which cannot be introspected once built — so the dialer's own Timeout/KeepAlive
+	// are pinned directly against the factory the fallback transport actually uses.
+	t.Run("fallback_dialer_has_the_documented_timeouts", func(t *testing.T) {
+		dialer := fallbackDialer()
+		assert.Equal(t, 30*time.Second, dialer.Timeout)
+		assert.Equal(t, 30*time.Second, dialer.KeepAlive)
+	})
+
 	// net/http consults TLSClientConfig only when no TLS dialer is set, so a dialer
 	// cloned from a replaced global would silently void pinning, the version floor
 	// and the client certificate.

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -122,19 +122,58 @@ verification. The escape hatch is explicit and greppable: build a `*tls.Config` 
 hand and pass it to `WithTLSConfig`.
 
 **Base-transport slot.** `WithTLSConfig` fills the same base-transport slot as
-`WithTransport` — last call wins — and satisfies the requirement described above
-for `WithJOSE` and the `Build()` composition WARN. Its base is a clone of
-`http.DefaultTransport`, or an equivalently-configured transport (same proxy,
-HTTP/2 and pool settings) when that global has been replaced, so the pitfall above
-does not apply to it. `Build()` warns in both directions: calling
-`WithTransport` after `WithTLSConfig` discards the loaded client certificate and
-pinned roots, and calling `WithTLSConfig` after `WithTransport` discards the
-supplied `RoundTripper` along with any proxy, dialer or TLS settings it carried.
-Wrapper layers always stack on top of it:
+`WithTransport`. When the slot already holds a `*http.Transport` — i.e.
+`WithTransport` was called with one first — `WithTLSConfig` **clones and reuses
+it** as the new base: your proxy, dialer and connection-pool settings survive.
+The TLS material is always **overwritten, not merged**: `TLSClientConfig` on
+the clone becomes exactly the config you pass to `WithTLSConfig`, and the
+incumbent's `TLSClientConfig` — including any non-security fields on it such
+as `NextProtos` — is discarded wholesale; copy anything you need from it into
+`tlsCfg` yourself before calling `WithTLSConfig`. The clone also clears
+`DialTLS`/`DialTLSContext` unconditionally (net/http skips its own TLS
+handshake — and so ignores `tlsCfg` entirely — whenever a TLS dialer is set).
+The rule for whether any of this is reported as a loss keys on whether the
+incumbent carried **meaningful security material** of its own — in
+`TLSClientConfig`: certificates, `RootCAs`, `InsecureSkipVerify`, a version
+floor/ceiling, cipher suites, curve preferences, a non-default renegotiation
+policy, `ServerName`, or a verification hook; or a non-nil `DialTLS`/
+`DialTLSContext` (a custom TLS dialer is material of the same class — it can
+implement certificate pinning or a TLS tunnel) — not on whether
+`TLSClientConfig` is merely non-nil. (`*http.Transport.Clone()` itself can
+leave a transport with a non-nil but ALPN-only `TLSClientConfig`, so a plain
+nil check would produce false positives.) If the incumbent carries none of
+that material, the composition is silent — but silent means *unreported*, not
+lossless: the incumbent's `TLSClientConfig` is replaced whatever it held,
+`NextProtos` and any other non-security fields on it included. Only meaningful
+security material is what the report keys on. If it DOES carry its own client
+certificate, pinned roots, or TLS dialer, that material is still discarded by
+this replacement,
+exactly as before this composition existed; only the tuning fields (proxy,
+dialer, pool limits) are new — and `Build()` still WARNs for that case.
+"Reuses" also never means warm connections: `Transport.Clone()` copies
+exported fields only, never the idle-connection map, so a client built this
+way still starts with a cold connection pool. When the slot is empty, the
+base is a clone of `http.DefaultTransport`, or an equivalently-configured
+transport (same proxy, HTTP/2 and pool settings) when that global has been
+replaced. When the slot holds an opaque (non-`*http.Transport`) `RoundTripper`
+instead, composition is not possible at all: the `RoundTripper` is discarded
+wholesale along with any proxy, dialer or TLS settings it carried, and
+`Build()` WARNs. The mirror direction WARNs too — calling `WithTransport`
+after `WithTLSConfig` discards the loaded client certificate and pinned roots.
+**None of this applies to `WithTLSConfig(nil)`**, which returns immediately: the
+slot keeps whatever it held, nothing is cloned, replaced or cleared, and no
+displacement is recorded. Wrapper layers always stack on top of whichever base
+results:
 
 ```go
 // mTLS base, JOSE on top — call order is irrelevant.
 httpclient.NewBuilder(logger).WithTLSConfig(tlsCfg).WithJOSE(joseCfg).Build()
+```
+
+```go
+// WithTransport supplies a *http.Transport; WithTLSConfig clones it and installs
+// tlsCfg — proxy/dialer/pool settings from customTransport survive.
+httpclient.NewBuilder(logger).WithTransport(customTransport).WithTLSConfig(tlsCfg).Build()
 ```
 
 The passed `*tls.Config` is cloned, so one loaded config can be shared across
@@ -200,9 +239,18 @@ with a plain `NopCloser` without touching `ContentLength`, which makes an empty
 POST/PUT/PATCH go out chunked with no Content-Length — and partner edges and
 WAFs answer that with 411, 400, or 501, which reads like an auth failure.
 
-**Client TLS still composes.** Unlike a hand-rolled `WithTransport` signer,
-which fills the same base-transport slot as `WithTLSConfig` (last call wins),
-the interceptor path leaves `WithTLSConfig` intact.
+**Client TLS still composes.** A hand-rolled `WithTransport` signer builds fine
+entirely on its own — the base-transport slot only becomes a problem once
+`WithTLSConfig` also joins the chain. When it does, the two fill the same slot,
+and what happens depends on what the signer supplied. A raw `*http.Transport`
+always composes — its proxy, dialer and pool settings survive into the new base
+— and *lossless* composition needs it to carry no meaningful TLS material of its
+own; if it carries a client certificate, pinned roots or a TLS dialer, that
+material is still replaced and `Build()` WARNs. A signer that wraps another
+`RoundTripper` is opaque, cannot be cloned, and so is discarded wholesale —
+also a WARN. The interceptor path sidesteps all of this — it leaves
+`WithTLSConfig` intact regardless, because interceptors never touch the
+base-transport slot.
 
 **Do not let a signed request follow redirects.** go-bricks sets no
 `CheckRedirect`, so the stdlib default follows redirects below `buildRequest`
@@ -331,8 +379,14 @@ verbatim to the redirect target. Install a `CheckRedirect` returning
 `http.ErrUseLastResponse` on your own client, or confirm the partner endpoint does not
 redirect.
 
-**Client TLS still composes.** The interceptor path leaves `WithTLSConfig` intact, whereas a
-hand-rolled `WithTransport` signer fills the same base-transport slot (last call wins).
+**Client TLS still composes.** The interceptor path leaves `WithTLSConfig` intact regardless,
+because interceptors never touch the base-transport slot. A hand-rolled `WithTransport` signer
+builds fine entirely on its own; the slot only becomes a problem once `WithTLSConfig` also
+joins the chain. A raw `*http.Transport` signer always composes — proxy, dialer and pool
+settings survive — and composes *losslessly* only when it carries no meaningful TLS material
+of its own; carrying a client certificate, pinned roots or a TLS dialer means that material is
+replaced and `Build()` WARNs. A signer wrapping another `RoundTripper` is opaque, cannot be
+cloned, and is discarded wholesale — also a WARN.
 Visa presents mutual TLS and x-pay-token as *alternative* authentication methods rather than
 requiring both, but some deployments run mTLS at the egress boundary as well — if yours
 does, use the interceptor, not a custom transport.


### PR DESCRIPTION
## What

`WithTLSConfig` always cloned `net/http.DefaultTransport` as its base, so `WithTransport(custom).WithTLSConfig(cfg)` discarded `custom`'s proxy, dialer and pool settings and warned about a combination that has an obvious correct answer. It now clones the incumbent `*http.Transport` when the base slot holds one, so that tuning survives and only the TLS material is replaced. An incumbent carrying security material of its own — a client certificate, pinned roots, or a `DialTLS`/`DialTLSContext` the clone clears — is still reported.

## Impact

None. `Build()`'s signature is unchanged; this only narrows what counts as a displacement and preserves tuning that was previously lost. Bottom of a three-PR stack replacing #840 — both layers above depend on `tlsConfigCarriesMaterial`, introduced here.

## Verification

`make mutate` (local-only gate, scoped to this layer's own diff rather than the default `origin/main` base): all mutants on changed lines killed.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS configuration handling with existing HTTP transports.
  * Preserved compatible transport settings while replacing TLS-specific settings safely.
  * Added clear warnings when TLS material or unsupported transports are replaced.
  * Ensured consistent behavior for shared, typed-nil, and default transports.

* **Documentation**
  * Clarified TLS composition, transport replacement, warning conditions, connection-pool behavior, and nil configuration handling.
  * Expanded OAuth 1.0a and Visa integration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->