### PR TITLE
fix(httpclient): stop reporting a discard the replacement cannot cause

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -286,7 +286,9 @@ func (b *Builder) fillBaseSlot(rt nethttp.RoundTripper, actor baseSource) {
 // It supplies the innermost transport: wrappers registered by other options (WithJOSE, for
 // example) are layered above it at Build time regardless of call order. Passing nil vacates
 // the base-transport slot; if WithTLSConfig had filled it, Build warns that the loaded TLS
-// material is discarded.
+// material is discarded — unless the transport passed here is itself a *nethttp.Transport
+// deciding its own TLS (transportCarriesTLSMaterial). The replacement still wins either
+// way; the two configs are never merged, so that case is silent, not composed.
 func (b *Builder) WithTransport(transport nethttp.RoundTripper) *Builder {
 	b.fillBaseSlot(transport, baseTransport)
 	return b
@@ -399,9 +401,16 @@ func (b *Builder) discardsClientTransport() bool {
 	return b.transport == nil && b.chain != nil && b.httpClient != nil && b.httpClient.Transport != nil
 }
 
-// discardsTLSConfig reports that WithTLSConfig loaded a client certificate and
-// pinned roots into the base slot and a later WithTransport took it over.
-func (b *Builder) discardsTLSConfig() bool { return b.displacedBase == baseTLS }
+// discardsTLSConfig reports WithTLSConfig's material displaced by a later
+// WithTransport, unless the replacement decides its own TLS — the same
+// predicate the compose direction uses, so neither call order can drift.
+func (b *Builder) discardsTLSConfig() bool {
+	if b.displacedBase != baseTLS {
+		return false
+	}
+	replacement, ok := b.transport.(*nethttp.Transport)
+	return !ok || !transportCarriesTLSMaterial(replacement)
+}
 
 // discardsProvidedTransport is the mirror of discardsTLSConfig: WithTransport's
 // RoundTripper was displaced by a later WithTLSConfig. Cleared by WithTLSConfig

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -2423,6 +2423,101 @@ func TestBuilderTLSConfigCompositionNeverDropsIncumbentTLSMaterial(t *testing.T)
 	})
 }
 
+// TestBuilderTLSConfigDiscardSuppressedByExplicitTLSClientConfig pins that
+// discardsTLSConfig is suppressed only when the replacement transport carries
+// real TLS material of its own, not merely a non-nil TLSClientConfig.
+func TestBuilderTLSConfigDiscardSuppressedByExplicitTLSClientConfig(t *testing.T) {
+	caPEM, _, _ := newTestCA(t, "suppress-ca")
+	cfg, err := NewClientTLSConfig(&ClientTLSConfig{CAValue: b64PEM(caPEM)})
+	require.NoError(t, err)
+
+	t.Run("replacement_with_tls_client_config_is_not_reported", func(t *testing.T) {
+		spy := &warnSpy{}
+		replacement := &nethttp.Transport{TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12}}
+		built := NewBuilder(spy).WithTLSConfig(cfg).WithTransport(replacement).Build()
+		assert.Empty(t, spy.msgs)
+		clientImpl, ok := built.(*client)
+		require.True(t, ok)
+		assert.Same(t, replacement, clientImpl.httpClient.Transport)
+	})
+
+	t.Run("replacement_without_tls_client_config_still_warns", func(t *testing.T) {
+		spy := &warnSpy{}
+		replacement := &nethttp.Transport{}
+		NewBuilder(spy).WithTLSConfig(cfg).WithTransport(replacement).Build()
+		assert.Contains(t, spy.joined(), "WithTransport was called after WithTLSConfig")
+	})
+
+	// A TLS dialer makes net/http ignore TLSClientConfig outright, so a
+	// replacement carrying only one still decides its own TLS — the compose
+	// direction already treats it as material and both must agree.
+	t.Run("replacement_with_only_a_tls_dialer_is_not_reported", func(t *testing.T) {
+		spy := &warnSpy{}
+		replacement := &nethttp.Transport{
+			DialTLSContext: func(context.Context, string, string) (net.Conn, error) {
+				return nil, errors.New("must never be dialed by this test")
+			},
+		}
+		NewBuilder(spy).WithTLSConfig(cfg).WithTransport(replacement).Build()
+		assert.Empty(t, spy.msgs, "a replacement that performs its own TLS handshake is not an accidental discard")
+	})
+
+	// The deprecated field is a separate branch of transportCarriesTLSMaterial and
+	// net/http still honors it when DialTLSContext is nil, so it needs its own case:
+	// gremlins does not mutate ||, so the mutation gate cannot cover this one.
+	t.Run("replacement_with_only_deprecated_dial_tls_is_not_reported", func(t *testing.T) {
+		spy := &warnSpy{}
+		replacement := &nethttp.Transport{}
+		//nolint:staticcheck // SA1019: DialTLS is deprecated but still honored when DialTLSContext is nil; this test exercises exactly that fallback field.
+		replacement.DialTLS = func(string, string) (net.Conn, error) {
+			return nil, errors.New("must never be dialed by this test")
+		}
+		NewBuilder(spy).WithTLSConfig(cfg).WithTransport(replacement).Build()
+		assert.Empty(t, spy.msgs, "a replacement carrying only the deprecated dialer still performs its own handshake")
+	})
+
+	// Mirror of incumbent_carrying_only_alpn_defaults_still_composes: an
+	// ALPN-only TLSClientConfig must not suppress the discard either.
+	t.Run("replacement_with_alpn_only_tls_config_still_warns", func(t *testing.T) {
+		spy := &warnSpy{}
+		replacement := &nethttp.Transport{}
+		_ = replacement.Clone() // forces onceSetNextProtoDefaults to populate an ALPN-only TLSClientConfig
+		require.NotNil(t, replacement.TLSClientConfig, "the forced Clone must have populated TLSClientConfig, or this test proves nothing")
+
+		NewBuilder(spy).WithTLSConfig(cfg).WithTransport(replacement).Build()
+		assert.Contains(t, spy.joined(), "WithTransport was called after WithTLSConfig",
+			"an ALPN-only TLSClientConfig carries no security material and must not suppress the discard")
+	})
+}
+
+// TestBuilderTLSSuppressionDoesNotSurviveRetake pins that discardsTLSConfig
+// must stay evaluated at Build() time against the final slot occupant, not
+// decided eagerly when a displacing WithTransport call happens — an eager
+// version would miss a later retake that drops the TLS material again.
+func TestBuilderTLSSuppressionDoesNotSurviveRetake(t *testing.T) {
+	caPEM, _, _ := newTestCA(t, "retake-ca")
+	cfg, err := NewClientTLSConfig(&ClientTLSConfig{CAValue: b64PEM(caPEM)})
+	require.NoError(t, err)
+
+	t.Run("suppressed_when_replacement_carries_tls", func(t *testing.T) {
+		spy := &warnSpy{}
+		transportWithTLSClientConfig := &nethttp.Transport{TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12}}
+		NewBuilder(spy).WithTLSConfig(cfg).WithTransport(transportWithTLSClientConfig).Build()
+		assert.Empty(t, spy.msgs)
+	})
+
+	t.Run("not_suppressed_when_a_later_retake_drops_tls", func(t *testing.T) {
+		spy := &warnSpy{}
+		transportWithTLSClientConfig := &nethttp.Transport{TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12}}
+		NewBuilder(spy).
+			WithTLSConfig(cfg).
+			WithTransport(transportWithTLSClientConfig).
+			WithTransport(&nethttp.Transport{}).
+			Build()
+		assert.Contains(t, spy.joined(), "WithTransport was called after WithTLSConfig")
+	})
+}
+
 // wrappingTransport stands in for a signer-layer wrapper; it exposes the
 // RoundTripper it wraps so tests can assert nesting depth.
 type wrappingTransport struct {

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -159,11 +159,12 @@ replaced. When the slot holds an opaque (non-`*http.Transport`) `RoundTripper`
 instead, composition is not possible at all: the `RoundTripper` is discarded
 wholesale along with any proxy, dialer or TLS settings it carried, and
 `Build()` WARNs. The mirror direction WARNs too — calling `WithTransport`
-after `WithTLSConfig` discards the loaded client certificate and pinned roots.
-**None of this applies to `WithTLSConfig(nil)`**, which returns immediately: the
-slot keeps whatever it held, nothing is cloned, replaced or cleared, and no
-displacement is recorded. Wrapper layers always stack on top of whichever base
-results:
+after `WithTLSConfig` discards the loaded client certificate and pinned roots,
+unless the replacement carries meaningful TLS material of its own (see the
+carve-out below). **None of this applies to `WithTLSConfig(nil)`**, which returns
+immediately: the slot keeps whatever it held, nothing is cloned, replaced or
+cleared, and no displacement is recorded. Wrapper layers always stack on top of
+whichever base results:
 
 ```go
 // mTLS base, JOSE on top — call order is irrelevant.
@@ -175,6 +176,32 @@ httpclient.NewBuilder(logger).WithTLSConfig(tlsCfg).WithJOSE(joseCfg).Build()
 // tlsCfg — proxy/dialer/pool settings from customTransport survive.
 httpclient.NewBuilder(logger).WithTransport(customTransport).WithTLSConfig(tlsCfg).Build()
 ```
+
+**One deliberate carve-out:** if the `RoundTripper` passed to `WithTransport`
+*after* `WithTLSConfig` is itself a `*http.Transport` that decides its own TLS —
+a `TLSClientConfig` carrying meaningful material, or a `DialTLS`/`DialTLSContext`
+— `Build()` does not report a discard. This is the same "does it carry TLS
+material" question the compose direction asks, so both call orders answer it
+identically. Be clear about what the carve-out means for precedence, though: it
+is **not** that both configs survive. The replacement is what takes effect on the
+built client; the earlier `tlsCfg` passed to `WithTLSConfig` is entirely ignored
+— last-call-wins still governs which TLS material actually reaches the wire, the
+carve-out just means that outcome isn't a *surprise* to the caller, since they
+configured the replacement themselves:
+
+```go
+// No WARN: replacement carries its own TLSClientConfig — but myTLSConfig on
+// replacement is what the client actually uses; tlsCfg (passed to WithTLSConfig
+// above) is discarded, not merged with it.
+replacement := &http.Transport{TLSClientConfig: myTLSConfig}
+httpclient.NewBuilder(logger).WithTLSConfig(tlsCfg).WithTransport(replacement).Build()
+```
+
+A replacement setting `DialTLSContext` (or the deprecated `DialTLS`) is silent
+for the same reason, and there the precedence is net/http's rather than this
+builder's: for a non-proxied HTTPS request the custom TLS dialer performs the
+handshake, so `TLSClientConfig` is ignored whether it came from `WithTLSConfig`
+or from the replacement itself.
 
 The passed `*tls.Config` is cloned, so one loaded config can be shared across
 clients safely. The copy is **shallow**, so treat the config and everything it


### PR DESCRIPTION
## What

`discardsTLSConfig` reported every `WithTLSConfig`-then-`WithTransport` displacement, including the case where the caller had already done what the warning told them to — "set `TLSClientConfig` on that transport yourself" — because the predicate never inspected the replacement. It now clears when the replacement is a `*http.Transport` that decides its own TLS, through the same `transportCarriesTLSMaterial` predicate the compose direction uses, so neither call order can drift from the other on `TLSClientConfig` material or a `DialTLS`/`DialTLSContext`.

## Impact

None. `Build()`'s signature is unchanged, and the carve-out is about surprise rather than precedence: the replacement still wins and the earlier `tlsCfg` is still discarded, as last-call-wins has always dictated.

## Verification

`make mutate` (local-only gate, scoped to this layer's own diff rather than the default `origin/main` base): all mutants on changed lines killed. Reverting the predicate by hand fails `client_test.go:2415` and `:2455`, confirming the tests carry the fix rather than the one mutant the gate can reach.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS configuration warnings when replacing HTTP transports.
  * Suppressed warnings when replacement transports retain meaningful TLS settings or dialers.
  * Preserved warnings for replacements that do not retain TLS material.

* **Documentation**
  * Clarified TLS transport replacement behavior, configuration precedence, and dialer handling.
  * Documented that `WithTLSConfig(nil)` preserves the existing transport unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->