### PR TITLE
refactor(server): share validator construction with messaging

### DIFF
--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -1,0 +1,45 @@
+// Package validation constructs the framework's shared go-playground validator
+// instance. It is the framework's only construction site, so server and
+// messaging start from the same custom-rule set. It does not freeze that set:
+// server.Validator() hands out the live instance, so anything registered through
+// it afterwards applies to HTTP alone.
+//
+// SECURITY: as of validator v10.30.3 all four name accessors on a FieldError —
+// Namespace, StructNamespace, Field and StructField — derive from one string
+// built with map keys interpolated verbatim, so a namespace from a dived map
+// embeds payload data. Redact the bracketed span before logging one; the
+// messaging package's PayloadError.Fields does exactly that.
+package validation
+
+import (
+	"regexp"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// mccCodeRegex is pre-compiled for efficiency and to avoid error handling on each validation call.
+// MCC codes are exactly 4 digits (e.g., "5411" for grocery stores).
+var mccCodeRegex = regexp.MustCompile(`^\d{4}$`)
+
+// New returns a validator with the framework's custom rules registered.
+// The panic is unreachable today — RegisterValidation errors only on an empty
+// tag name or a nil function, and every registration below is a static pair of
+// both. It stays as a fail-fast in case that contract changes, since returning
+// a half-configured instance would silently skip the rule at every call site.
+func New() *validator.Validate {
+	v := validator.New()
+	// Every tag registered below also needs a case in server.getErrorMessage;
+	// without one, HTTP callers get the generic "failed validation" message.
+	if err := v.RegisterValidation("mcc_code", validateMCCCode); err != nil {
+		panic("validation: registering mcc_code: " + err.Error())
+	}
+
+	return v
+}
+
+// Custom validator for MCC codes. The anchored regex is the whole rule: a
+// separate length check would make each redundant with the other, so neither
+// could be pinned by a test.
+func validateMCCCode(fl validator.FieldLevel) bool {
+	return mccCodeRegex.MatchString(fl.Field().String())
+}

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -1,0 +1,114 @@
+package validation
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	mccTag       = "mcc_code"
+	validMCCCode = "5411"
+)
+
+type merchant struct {
+	Code string `validate:"mcc_code"`
+}
+
+func TestNewRegistersMCCCode(t *testing.T) {
+	v := New()
+
+	require.NotNil(t, v)
+	require.NoError(t, v.Struct(merchant{Code: validMCCCode}))
+}
+
+func TestNewMCCCodeRejectsMalformedCodes(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+	}{
+		{name: "empty", code: ""},
+		{name: "two_digits", code: "54"},
+		{name: "three_digits", code: "541"},
+		{name: "five_digits", code: "54111"},
+		{name: "four_letters", code: "abcd"},
+		{name: "four_chars_mixed", code: "54a1"},
+		{name: "four_chars_with_space", code: "54 1"},
+		{name: "four_digits_with_trailing_newline", code: "5411\n"},
+		{name: "four_digits_with_leading_newline", code: "\n5411"},
+	}
+
+	v := New()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := v.Struct(merchant{Code: tc.code})
+			require.Error(t, err)
+
+			var verrs validator.ValidationErrors
+			require.ErrorAs(t, err, &verrs)
+			require.Len(t, verrs, 1)
+			assert.Equal(t, "Code", verrs[0].Field())
+			assert.Equal(t, mccTag, verrs[0].Tag())
+		})
+	}
+}
+
+// A non-string field yields reflect.Value.String() == "<int Value>", which the
+// anchored regex rejects — the same answer the removed length guard gave.
+func TestNewMCCCodeRejectsNonStringField(t *testing.T) {
+	type numericMerchant struct {
+		Code int `validate:"mcc_code"`
+	}
+
+	err := New().Struct(numericMerchant{Code: 5411})
+	require.Error(t, err)
+
+	var verrs validator.ValidationErrors
+	require.ErrorAs(t, err, &verrs)
+	require.Len(t, verrs, 1)
+	assert.Equal(t, mccTag, verrs[0].Tag())
+}
+
+// Each call must yield a private registration set: layer-3 consumers and the
+// server each hold their own instance, and a rule added to one must not leak.
+func TestNewReturnsIndependentInstances(t *testing.T) {
+	a, b := New(), New()
+	require.NotSame(t, a, b)
+
+	type probe struct {
+		Field string `validate:"probe_rule"`
+	}
+	require.NoError(t, a.RegisterValidation("probe_rule", func(validator.FieldLevel) bool { return true }))
+
+	assert.NoError(t, a.Struct(probe{}))
+	assert.Panics(t, func() { _ = b.Struct(probe{}) }, "rule registered on a must not exist on b")
+}
+
+// One instance is shared across every consumer worker and tenant, so pin the
+// concurrency safety go-playground documents rather than trusting the doc.
+func TestNewInstanceIsConcurrencySafe(t *testing.T) {
+	v := New()
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(i int) {
+			defer wg.Done()
+
+			code, wantErr := validMCCCode, false
+			if i%2 == 0 {
+				code, wantErr = "54", true
+			}
+
+			// t.Errorf, not require: FailNow outside the test goroutine is undefined.
+			if err := v.Struct(merchant{Code: code}); (err != nil) != wantErr {
+				t.Errorf("code %q: got err %v, wantErr %v", code, err, wantErr)
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/messaging/payload_error.go
+++ b/messaging/payload_error.go
@@ -1,0 +1,229 @@
+package messaging
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// PayloadStage names the half of the typed-payload pipeline that failed.
+type PayloadStage string
+
+// Stage values carried by PayloadError.Stage. A PayloadError whose Stage is
+// none of these matches neither sentinel.
+const (
+	PayloadStageDecode   PayloadStage = "decode"
+	PayloadStageValidate PayloadStage = "validate"
+)
+
+// redactedIndex replaces the contents of every bracketed namespace segment.
+const redactedIndex = "[*]"
+
+// unauditedDecoderSummary is the fail-closed rendering for a decode error whose
+// shape has not been audited for payload content.
+const unauditedDecoderSummary = "cause withheld (unaudited decoder); use errors.Unwrap for the raw error"
+
+var (
+	// ErrPayloadUndecodable reports a message body that could not be decoded into
+	// the consumer's payload type. Match it with errors.Is.
+	ErrPayloadUndecodable = errors.New("messaging: payload could not be decoded")
+
+	// ErrPayloadInvalid reports a payload that decoded but failed struct
+	// validation. Match it with errors.Is.
+	ErrPayloadInvalid = errors.New("messaging: payload failed validation")
+)
+
+// PayloadError describes why a message body could not be turned into a typed
+// payload.
+//
+// SECURITY: AMQP bodies are partner PII/PCI data, so the framework's own
+// rendering must stay free of them. Error() and Fields() are safe to log;
+// Unwrap() is not. Error() composes its text from schema facts only — it never
+// renders the wrapped cause verbatim, because every producer in reach echoes
+// payload bytes in at least one shape:
+//   - json.UnmarshalTypeError.Value carries the raw literal ("number 1234.56")
+//     and, for integer-keyed maps, the raw key.
+//   - json.SyntaxError quotes the offending payload byte.
+//   - json.Decoder.DisallowUnknownFields reports the partner-supplied key verbatim.
+//   - validator namespaces interpolate map keys verbatim ("Limits[4111...]"),
+//     which is why the namespace list is unexported and redacted on read.
+//
+// A new codec (issue #346) inherits the generic fallback in decodeSummary — no
+// rendering at all — until its error shapes are audited and added there.
+type PayloadError struct {
+	// EventType is the declared consumer event type the body was routed to.
+	EventType string
+
+	// Stage is where the failure happened. It is exported to label logs and
+	// metrics with "decode" or "validate"; for control flow, match errors.Is
+	// against ErrPayloadUndecodable or ErrPayloadInvalid instead.
+	Stage PayloadStage
+
+	// fields holds the RAW validator namespaces, which may embed payload values:
+	// validator interpolates map keys into bracketed segments verbatim, so a
+	// dived map yields "CreateReq.Limits[4111111111111111]". Fields() is the
+	// only safe read.
+	fields []string
+
+	err error
+}
+
+// newPayloadDecodeError wraps a decode failure. The cause survives for Unwrap
+// only; Error() renders it through decodeSummary.
+func newPayloadDecodeError(eventType string, cause error) *PayloadError {
+	return &PayloadError{
+		EventType: eventType,
+		Stage:     PayloadStageDecode,
+		err:       cause,
+	}
+}
+
+// newPayloadValidateError wraps a validation failure and records the validator's
+// own field namespaces verbatim. Redaction is Fields()' job, not the
+// constructor's, so no assembly path can produce a PayloadError whose namespace
+// list reads back unsanitized.
+func newPayloadValidateError(eventType string, cause error) *PayloadError {
+	var verrs validator.ValidationErrors
+	var fields []string
+	if errors.As(cause, &verrs) {
+		fields = make([]string, 0, len(verrs))
+		for _, fe := range verrs {
+			fields = append(fields, fe.Namespace())
+		}
+	}
+
+	return &PayloadError{
+		EventType: eventType,
+		Stage:     PayloadStageValidate,
+		fields:    fields,
+		err:       cause,
+	}
+}
+
+// Fields returns the validator field namespaces that failed, e.g.
+// ["CreateReq.Amount"]. It is empty for decode failures and for a nil receiver.
+//
+// SECURITY: the bracketed span is redacted to [*] on the way out, and the result
+// is a fresh slice, so the redaction survives whatever the caller does with it.
+// This is the only read path onto the namespaces.
+func (e *PayloadError) Fields() []string {
+	if e == nil || len(e.fields) == 0 {
+		return nil
+	}
+
+	sanitized := make([]string, len(e.fields))
+	for i, ns := range e.fields {
+		sanitized[i] = sanitizeNamespace(ns)
+	}
+
+	return sanitized
+}
+
+func (e *PayloadError) Error() string {
+	if e == nil {
+		return "messaging: <nil> payload error"
+	}
+
+	msg := fmt.Sprintf("messaging: %s failed for event %q", e.Stage, e.EventType)
+	if fields := e.Fields(); len(fields) > 0 {
+		msg += fmt.Sprintf(" (fields: %s)", strings.Join(fields, ", "))
+	}
+	if e.Stage == PayloadStageDecode && e.err != nil {
+		msg += ": " + decodeSummary(e.err)
+	}
+
+	return msg
+}
+
+// Unwrap exposes the underlying decode or validation error so errors.As can
+// reach the cause.
+//
+// SECURITY: the returned error MAY carry payload-derived text — a rejected
+// numeric literal, an offending byte, an unknown key, a map key. It is the
+// deliberate escape hatch for a caller that needs the raw diagnostic; logging
+// it is opt-in and on the caller.
+func (e *PayloadError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	return e.err
+}
+
+// Is maps the stage onto its sentinel so consumers can discriminate the two
+// failure modes without reading Stage.
+func (e *PayloadError) Is(target error) bool {
+	if e == nil {
+		return false
+	}
+
+	switch e.Stage {
+	case PayloadStageDecode:
+		return target == ErrPayloadUndecodable
+	case PayloadStageValidate:
+		return target == ErrPayloadInvalid
+	default:
+		return false
+	}
+}
+
+// decodeSummary renders a decode failure without any payload bytes.
+// json.UnmarshalTypeError.Value carries the raw literal ("number 1234.56") and
+// json.SyntaxError's message quotes the offending byte, so neither error's own
+// text may be rendered. Field, Type and Offset are destination-schema
+// facts: encoding/json builds Field from the matched destination field's json
+// tag and never from an input key (map keys never enter its FieldStack).
+// Anything else — including json.Decoder.DisallowUnknownFields, which names the
+// partner's key — falls through to a phrase that reveals nothing.
+func decodeSummary(err error) string {
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		wantType := "unknown"
+		if typeErr.Type != nil {
+			wantType = typeErr.Type.String()
+		}
+		if typeErr.Field != "" {
+			return fmt.Sprintf("json: type mismatch at field %q (want %s, offset %d)", typeErr.Field, wantType, typeErr.Offset)
+		}
+
+		return fmt.Sprintf("json: type mismatch (want %s, offset %d)", wantType, typeErr.Offset)
+	}
+
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return fmt.Sprintf("json: syntax error at offset %d", syntaxErr.Offset)
+	}
+
+	return unauditedDecoderSummary
+}
+
+// sanitizeNamespace redacts everything from a namespace's first '[' to its last
+// ']'. validator interpolates map keys verbatim, so Limits[4111111111111111]
+// would otherwise carry a PAN — and a key may itself contain '[', ']' or '.',
+// so no per-segment parse of the flat string is unambiguous. Redacting the whole
+// bracketed span is the only rule a hostile key cannot walk out of: a key of
+// "]4111111111111111" defeats a depth counter, which returns to zero at the
+// key's own ']' and then copies the digits straight through.
+//
+// Numeric indices go too — a digits-only exemption looks safe but is not, since
+// a card number is all digits. A namespace with several bracketed segments
+// collapses to the first, losing the trailing field path; Unwrap() still carries
+// the namespace unredacted.
+func sanitizeNamespace(namespace string) string {
+	open := strings.IndexByte(namespace, '[')
+	if open < 0 {
+		return namespace
+	}
+
+	// Anything past the last ']' is outside every bracket, so it is schema.
+	rest := namespace[open+1:]
+	tail := ""
+	if end := strings.LastIndexByte(rest, ']'); end >= 0 {
+		tail = rest[end+1:]
+	}
+
+	return namespace[:open] + redactedIndex + tail
+}

--- a/messaging/payload_error_test.go
+++ b/messaging/payload_error_test.go
@@ -1,0 +1,517 @@
+package messaging
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaborage/go-bricks/internal/validation"
+)
+
+const (
+	orderEventType = "OrderCreated"
+	// shipmentEventType is a second event type so the constructors are pinned to
+	// carry their argument through instead of hardcoding one.
+	shipmentEventType = "ShipmentDispatched"
+	fieldAmount       = "orderPayload.Amount"
+	fieldReference    = "orderPayload.Reference"
+
+	// payloadMarker stands in for partner PII/PCI: it must never surface in an
+	// error string, so tests plant it as a payload VALUE and assert its absence.
+	payloadMarker = "MARKER-do-not-leak-9e3f"
+
+	// numericMarker is the same idea for a numeric literal — a transaction
+	// amount. json.UnmarshalTypeError echoes it as `Value: "number 1234.56"`,
+	// so the digits must not reach Error().
+	numericMarker = "1234.56"
+
+	// pan is a card-shaped value for the cases where the leak vector is the map
+	// key itself rather than a field value.
+	pan = "4111111111111111"
+
+	// syntaxMarker is a single byte json.SyntaxError would quote back
+	// ("invalid character '~' ..."); it appears nowhere else in a rendered
+	// message, so asserting its absence is unambiguous.
+	syntaxMarker = "~"
+)
+
+type orderPayload struct {
+	Reference string `json:"reference" validate:"max=5"`
+	Amount    int64  `json:"amount"    validate:"required"`
+}
+
+// mapKeyPayload exercises the one shape whose validator namespace embeds
+// payload content: a dived map, whose keys are interpolated verbatim.
+type mapKeyPayload struct {
+	Limits map[string]int `json:"limits" validate:"dive,max=5"`
+}
+
+// intKeyPayload exercises the decode-side twin: encoding/json parses an
+// integer-keyed map's key itself, and folds the rejected key into
+// UnmarshalTypeError.Value.
+type intKeyPayload struct {
+	Limits map[int]int `json:"limits"`
+}
+
+func TestPayloadErrorIsMatchesStageSentinel(t *testing.T) {
+	tests := []struct {
+		name     string
+		stage    PayloadStage
+		match    error
+		notMatch error
+	}{
+		{name: "decode_stage", stage: PayloadStageDecode, match: ErrPayloadUndecodable, notMatch: ErrPayloadInvalid},
+		{name: "validate_stage", stage: PayloadStageValidate, match: ErrPayloadInvalid, notMatch: ErrPayloadUndecodable},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &PayloadError{EventType: orderEventType, Stage: tc.stage}
+
+			assert.ErrorIs(t, err, tc.match)
+			assert.NotErrorIs(t, err, tc.notMatch)
+			assert.NotErrorIs(t, err, ErrNotConnected)
+		})
+	}
+}
+
+// An unrecognized Stage must match neither sentinel rather than defaulting to
+// one: a mistyped stage would otherwise misroute a dead-letter decision.
+func TestPayloadErrorIsRejectsUnknownStage(t *testing.T) {
+	for _, stage := range []PayloadStage{"", "decoding", "DECODE"} {
+		err := &PayloadError{EventType: orderEventType, Stage: stage}
+
+		assert.NotErrorIs(t, err, ErrPayloadUndecodable, "stage %q", stage)
+		assert.NotErrorIs(t, err, ErrPayloadInvalid, "stage %q", stage)
+	}
+}
+
+func TestPayloadErrorUnwrapReachesCause(t *testing.T) {
+	inner := errors.New("inner cause")
+	err := newPayloadDecodeError(orderEventType, inner)
+
+	require.Same(t, inner, err.Unwrap())
+	assert.ErrorIs(t, err, inner)
+	// The sentinel mapping must survive alongside the unwrap chain.
+	assert.ErrorIs(t, err, ErrPayloadUndecodable)
+}
+
+func TestPayloadErrorAsRecoversFromWrappedChain(t *testing.T) {
+	err := &PayloadError{EventType: orderEventType, Stage: PayloadStageValidate, fields: []string{fieldAmount}}
+	wrapped := fmt.Errorf("consumer %q: %w", testConsumer, err)
+
+	var target *PayloadError
+	require.ErrorAs(t, wrapped, &target)
+	assert.Equal(t, orderEventType, target.EventType)
+	assert.Equal(t, PayloadStageValidate, target.Stage)
+	assert.Equal(t, []string{fieldAmount}, target.Fields())
+}
+
+func TestPayloadErrorMessageComposition(t *testing.T) {
+	validateErr := &PayloadError{
+		EventType: orderEventType,
+		Stage:     PayloadStageValidate,
+		fields:    []string{fieldReference, fieldAmount},
+		err:       errors.New("2 validation errors"),
+	}
+
+	// The validator's own text is absent by design — the sanitized field list
+	// already carries everything that is safe to render.
+	assert.Equal(t,
+		`messaging: validate failed for event "OrderCreated" (fields: orderPayload.Reference, orderPayload.Amount)`,
+		validateErr.Error())
+
+	decodeErr := newPayloadDecodeError(orderEventType, errors.New("unexpected EOF"))
+	assert.Equal(t,
+		`messaging: decode failed for event "OrderCreated": cause withheld (unaudited decoder); use errors.Unwrap for the raw error`,
+		decodeErr.Error())
+	assert.Empty(t, decodeErr.Fields(), "decode failures carry no field list")
+}
+
+// Each subtest drives the marker through a REAL producer — encoding/json or the
+// framework validator — so it proves the rendering, not a hand-built literal.
+// Each also asserts a positive premise, so NotContains cannot pass by the error
+// being empty or the failure never happening.
+func TestPayloadErrorNeverRendersPayloadValues(t *testing.T) {
+	t.Run("decode_number_into_int", func(t *testing.T) {
+		// The old fixture used a JSON string into an int, the one shape whose
+		// Value is the payload-free literal "string". A numeric literal is the
+		// leaking shape: Value becomes "number 1234.56".
+		body := fmt.Appendf(nil, `{"amount": %s}`, numericMarker)
+
+		var payload orderPayload
+		decodeErr := json.Unmarshal(body, &payload)
+		require.Error(t, decodeErr)
+		require.Contains(t, decodeErr.Error(), numericMarker, "premise: the raw cause leaks the amount")
+
+		rendered := newPayloadDecodeError(orderEventType, decodeErr).Error()
+		require.Contains(t, rendered, "type mismatch at field", "premise: a decode summary was rendered")
+		assert.NotContains(t, rendered, numericMarker)
+	})
+
+	t.Run("decode_hostile_map_key_stays_out_of_field", func(t *testing.T) {
+		// decodeSummary renders UnmarshalTypeError.Field unsanitized, which is
+		// only safe because encoding/json builds Field from the destination
+		// schema and never admits an input key to its FieldStack. Assert Field
+		// equals the schema name, not merely that it lacks the marker: the
+		// marker never reaches this error's text at all today, so a NotContains
+		// check here would pass no matter what Field held. A Go release that
+		// admitted the key would make Field "limits[MARKER…]" and break this.
+		body := fmt.Appendf(nil, `{"limits":{%q:"notanint"}}`, payloadMarker)
+
+		var payload mapKeyPayload
+		decodeErr := json.Unmarshal(body, &payload)
+		require.Error(t, decodeErr)
+
+		var typeErr *json.UnmarshalTypeError
+		require.ErrorAs(t, decodeErr, &typeErr, "premise: the body produced an UnmarshalTypeError")
+		assert.Equal(t, "limits", typeErr.Field, "Field must name the destination field only")
+
+		rendered := newPayloadDecodeError(orderEventType, decodeErr).Error()
+		require.Contains(t, rendered, "type mismatch at field", "premise: a decode summary was rendered")
+		assert.NotContains(t, rendered, payloadMarker)
+	})
+
+	t.Run("decode_integer_keyed_map_key", func(t *testing.T) {
+		// The second way UnmarshalTypeError.Value turns payload-bearing: for an
+		// integer-keyed map encoding/json parses the KEY, so a rejected key lands
+		// in Value. Field still names only the destination.
+		body := fmt.Appendf(nil, `{"limits":{%q:1}}`, payloadMarker)
+
+		var payload intKeyPayload
+		decodeErr := json.Unmarshal(body, &payload)
+		require.Error(t, decodeErr)
+		require.Contains(t, decodeErr.Error(), payloadMarker, "premise: the raw cause leaks the map key")
+
+		var typeErr *json.UnmarshalTypeError
+		require.ErrorAs(t, decodeErr, &typeErr, "premise: the body produced an UnmarshalTypeError")
+		assert.Equal(t, "limits", typeErr.Field, "Field must name the destination field only")
+
+		rendered := newPayloadDecodeError(orderEventType, decodeErr).Error()
+		require.Contains(t, rendered, "type mismatch at field", "premise: a decode summary was rendered")
+		assert.NotContains(t, rendered, payloadMarker)
+	})
+
+	t.Run("decode_syntax_error", func(t *testing.T) {
+		body := fmt.Appendf(nil, `%s{"amount":1}`, syntaxMarker)
+
+		var payload orderPayload
+		decodeErr := json.Unmarshal(body, &payload)
+		require.Error(t, decodeErr)
+		require.ErrorAs(t, decodeErr, new(*json.SyntaxError), "premise: the body produced a SyntaxError")
+		require.Contains(t, decodeErr.Error(), syntaxMarker, "premise: the raw cause quotes the offending byte")
+
+		rendered := newPayloadDecodeError(orderEventType, decodeErr).Error()
+		require.Contains(t, rendered, "syntax error at offset", "premise: a decode summary was rendered")
+		assert.NotContains(t, rendered, syntaxMarker)
+	})
+
+	t.Run("decode_unknown_field", func(t *testing.T) {
+		// Layer 3 may enable strict decoding; the key is partner-controlled.
+		body := fmt.Appendf(nil, `{%q:1}`, payloadMarker)
+		dec := json.NewDecoder(bytes.NewReader(body))
+		dec.DisallowUnknownFields()
+
+		var payload orderPayload
+		decodeErr := dec.Decode(&payload)
+		require.Error(t, decodeErr)
+		require.Contains(t, decodeErr.Error(), payloadMarker, "premise: the raw cause leaks the key")
+
+		rendered := newPayloadDecodeError(orderEventType, decodeErr).Error()
+		require.Contains(t, rendered, "cause withheld", "premise: the generic fallback rendered")
+		assert.NotContains(t, rendered, payloadMarker)
+	})
+
+	t.Run("validate_map_key_namespace", func(t *testing.T) {
+		validateErr := validation.New().Struct(mapKeyPayload{
+			Limits: map[string]int{payloadMarker: 99},
+		})
+		require.Error(t, validateErr)
+		require.Contains(t, validateErr.Error(), payloadMarker, "premise: the raw cause leaks the map key")
+
+		// Redacting the string is the only depth available: all four name
+		// accessors derive from the same name validator assembled with the key
+		// already embedded, so none of them is a clean alternative to sanitizing.
+		var verrs validator.ValidationErrors
+		require.ErrorAs(t, validateErr, &verrs)
+		require.Len(t, verrs, 1)
+		for name, got := range map[string]string{
+			"Namespace":       verrs[0].Namespace(),
+			"StructNamespace": verrs[0].StructNamespace(),
+			"Field":           verrs[0].Field(),
+			"StructField":     verrs[0].StructField(),
+		} {
+			assert.Contains(t, got, payloadMarker, "premise: %s interpolates the map key", name)
+		}
+
+		err := newPayloadValidateError(orderEventType, validateErr)
+		require.NotEmpty(t, err.Fields(), "premise: fields were derived")
+		require.Contains(t, err.Error(), "(fields: ", "premise: the field list was rendered")
+
+		assert.NotContains(t, err.Error(), payloadMarker)
+		for _, field := range err.Fields() {
+			assert.NotContains(t, field, payloadMarker)
+		}
+		assert.Equal(t, []string{"mapKeyPayload.Limits[*]"}, err.Fields())
+	})
+
+	t.Run("validate_map_key_closing_bracket_cannot_escape_redaction", func(t *testing.T) {
+		// Map keys are partner-controlled, so a key may carry the very character
+		// the redaction scans for. A key that opens with ']' ends a depth-counting
+		// scan at its own bracket and lets the rest through verbatim; the digits
+		// after it reached both Fields() and Error() before the span-based rule.
+		hostileKey := "]" + pan
+		validateErr := validation.New().Struct(mapKeyPayload{
+			Limits: map[string]int{hostileKey: 99},
+		})
+		require.Error(t, validateErr)
+		require.Contains(t, validateErr.Error(), pan, "premise: the raw cause leaks the map key")
+
+		err := newPayloadValidateError(orderEventType, validateErr)
+		require.NotEmpty(t, err.Fields(), "premise: fields were derived")
+
+		assert.Equal(t, []string{"mapKeyPayload.Limits[*]"}, err.Fields())
+		assert.NotContains(t, err.Error(), pan)
+	})
+
+	t.Run("validate_oversized_string", func(t *testing.T) {
+		validateErr := validation.New().Struct(orderPayload{Reference: payloadMarker, Amount: 1})
+		require.Error(t, validateErr)
+		require.Contains(t, validateErr.Error(), "failed on the 'max' tag", "premise: the max rule fired")
+
+		err := newPayloadValidateError(orderEventType, validateErr)
+		require.Contains(t, err.Error(), fieldReference, "premise: the field list was rendered")
+		assert.NotContains(t, err.Error(), payloadMarker)
+	})
+}
+
+func TestPayloadErrorValidateConstructorDerivesFields(t *testing.T) {
+	validateErr := validation.New().Struct(orderPayload{Reference: payloadMarker})
+	require.Error(t, validateErr)
+
+	err := newPayloadValidateError(orderEventType, validateErr)
+
+	assert.Equal(t, PayloadStageValidate, err.Stage)
+	assert.Equal(t, []string{fieldReference, fieldAmount}, err.Fields())
+	assert.ErrorIs(t, err, ErrPayloadInvalid)
+	require.ErrorAs(t, err, new(validator.ValidationErrors))
+
+	// Redaction is Fields()' job, not the constructor's — pin that the stored
+	// namespaces are still the validator's own, so the single read-path design
+	// cannot drift into a second sanitization point unnoticed.
+	mapErr := validation.New().Struct(mapKeyPayload{Limits: map[string]int{pan: 99}})
+	require.Error(t, mapErr)
+	stored := newPayloadValidateError(orderEventType, mapErr)
+	require.Len(t, stored.fields, 1)
+	assert.Contains(t, stored.fields[0], pan, "constructor stores the raw namespace")
+	assert.NotContains(t, stored.Fields()[0], pan, "the accessor is what redacts")
+
+	// A non-validator cause yields no fields rather than a bogus one.
+	plain := newPayloadValidateError(orderEventType, errors.New("boom"))
+	assert.Empty(t, plain.Fields())
+	assert.Equal(t, `messaging: validate failed for event "OrderCreated"`, plain.Error())
+}
+
+// The constructor stores namespaces raw, so redaction has to hold on the read
+// path. Build the dirty state directly — which only in-package code can now do —
+// and drive both readers off it.
+func TestPayloadErrorFieldsRedactsOnRead(t *testing.T) {
+	raw := "orderPayload.Limits[" + payloadMarker + "]"
+	err := &PayloadError{EventType: orderEventType, Stage: PayloadStageValidate, fields: []string{raw}}
+
+	assert.Equal(t, []string{"orderPayload.Limits[*]"}, err.Fields())
+	assert.Equal(t,
+		`messaging: validate failed for event "OrderCreated" (fields: orderPayload.Limits[*])`,
+		err.Error())
+
+	// A fresh slice per call: a caller cannot reach the stored namespaces through
+	// the one it was handed, and cannot spoil the next read.
+	got := err.Fields()
+	got[0] = "tampered"
+	assert.Equal(t, []string{"orderPayload.Limits[*]"}, err.Fields())
+	assert.Equal(t, []string{raw}, err.fields, "the accessor must not rewrite in place")
+}
+
+func TestPayloadErrorConstructorsPropagateEventType(t *testing.T) {
+	cause := errors.New("boom")
+
+	decodeErr := newPayloadDecodeError(shipmentEventType, cause)
+	assert.Equal(t, shipmentEventType, decodeErr.EventType)
+	assert.Contains(t, decodeErr.Error(), shipmentEventType)
+
+	validateErr := newPayloadValidateError(shipmentEventType, cause)
+	assert.Equal(t, shipmentEventType, validateErr.EventType)
+	assert.Contains(t, validateErr.Error(), shipmentEventType)
+}
+
+func TestSanitizeNamespace(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "no_brackets", input: "Req.Amount", want: "Req.Amount"},
+		{name: "slice_index", input: "Req.Items[0]", want: "Req.Items[*]"},
+		{name: "map_key", input: "Req.Limits[PAN-4111111111111111]", want: "Req.Limits[*]"},
+		{name: "all_digit_map_key", input: "Req.Limits[4111111111111111]", want: "Req.Limits[*]"},
+		{name: "nested_brackets", input: "Req.Grid[a[b]].Name", want: "Req.Grid[*].Name"},
+		{name: "empty_brackets", input: "Req.Items[]", want: "Req.Items[*]"},
+		// Several bracketed segments collapse to the first: a key may contain
+		// '.' or ']', so the boundary between the last key and the trailing
+		// field path is not recoverable from the flat string.
+		{name: "multiple_segments", input: "Req.Items[0].Tags[secret]", want: "Req.Items[*]"},
+		{name: "unterminated_bracket", input: "Req.Items[secret", want: "Req.Items[*]"},
+		{name: "already_sanitized", input: "Req.Items[*]", want: "Req.Items[*]"},
+		// Hostile keys. A depth counter closes on the key's own ']' and copies
+		// the remainder verbatim, so each of these leaked a full PAN before the
+		// span-based rule replaced it.
+		{name: "key_leads_with_closing_bracket", input: "Req.Limits[]4111111111111111]", want: "Req.Limits[*]"},
+		{name: "key_embeds_closing_bracket", input: "Req.Limits[pan]=4111111111111111]", want: "Req.Limits[*]"},
+		{name: "key_splits_on_closing_bracket", input: "Req.Limits[4111]1111111111]", want: "Req.Limits[*]"},
+		{name: "key_contains_dot", input: "Req.Limits[a.b]", want: "Req.Limits[*]"},
+		// A namespace that opens on '[' must still redact: the bracket is at
+		// index 0, the boundary an off-by-one in the guard would wave through.
+		{name: "leading_bracket", input: "[4111111111111111]", want: "[*]"},
+		// An empty key puts the closing bracket first in the remainder, so the
+		// trailing field path is only kept if the search is relative to it.
+		{name: "empty_key_keeps_trailing_path", input: "Req.Limits[].Amount", want: "Req.Limits[*].Amount"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, sanitizeNamespace(tc.input))
+		})
+	}
+}
+
+func TestDecodeSummary(t *testing.T) {
+	typeErr := &json.UnmarshalTypeError{
+		Value:  "number " + numericMarker,
+		Type:   reflect.TypeOf(int64(0)),
+		Offset: 18,
+		Struct: "orderPayload",
+		Field:  "amount",
+	}
+	syntaxOffset := int64(1)
+
+	tests := []struct {
+		name        string
+		err         error
+		want        string
+		notContains string
+	}{
+		{
+			name:        "unmarshal_type_error",
+			err:         typeErr,
+			want:        `json: type mismatch at field "amount" (want int64, offset 18)`,
+			notContains: numericMarker,
+		},
+		{
+			name:        "wrapped_unmarshal_type_error",
+			err:         fmt.Errorf("decode: %w", typeErr),
+			want:        `json: type mismatch at field "amount" (want int64, offset 18)`,
+			notContains: numericMarker,
+		},
+		{
+			name: "unmarshal_type_error_without_field",
+			err:  fieldlessTypeError(t),
+			want: "json: type mismatch (want messaging.orderPayload, offset 3)",
+		},
+		{
+			name: "unmarshal_type_error_without_type",
+			err:  &json.UnmarshalTypeError{Value: "object", Offset: 2},
+			want: "json: type mismatch (want unknown, offset 2)",
+		},
+		{
+			name: "syntax_error",
+			err:  syntaxError(t, syntaxOffset),
+			want: "json: syntax error at offset 1",
+		},
+		{
+			name: "wrapped_syntax_error",
+			err:  fmt.Errorf("decode: %w", syntaxError(t, syntaxOffset)),
+			want: "json: syntax error at offset 1",
+		},
+		{
+			name:        "unrelated_error_falls_back",
+			err:         errors.New("json: unknown field " + payloadMarker),
+			want:        unauditedDecoderSummary,
+			notContains: payloadMarker,
+		},
+		{
+			name: "nil_error_falls_back",
+			err:  nil,
+			want: unauditedDecoderSummary,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decodeSummary(tc.err)
+			assert.Equal(t, tc.want, got)
+			if tc.notContains != "" {
+				assert.NotContains(t, got, tc.notContains)
+			}
+		})
+	}
+}
+
+// fieldlessTypeError produces a real *json.UnmarshalTypeError with an empty
+// Field: a bare scalar body never enters a struct field, so encoding/json has no
+// FieldStack to draw one from. Built from the decoder rather than by literal so
+// the Field == "" branch proves its own reachability.
+func fieldlessTypeError(t *testing.T) *json.UnmarshalTypeError {
+	t.Helper()
+
+	var payload orderPayload
+	err := json.Unmarshal([]byte("123"), &payload)
+
+	var typeErr *json.UnmarshalTypeError
+	require.ErrorAs(t, err, &typeErr)
+	require.Empty(t, typeErr.Field)
+
+	return typeErr
+}
+
+// syntaxError produces a real *json.SyntaxError; its msg field is unexported,
+// so it cannot be built by literal.
+func syntaxError(t *testing.T, wantOffset int64) *json.SyntaxError {
+	t.Helper()
+
+	var payload orderPayload
+	err := json.Unmarshal([]byte(`}`), &payload)
+
+	var syntaxErr *json.SyntaxError
+	require.ErrorAs(t, err, &syntaxErr)
+	require.Equal(t, wantOffset, syntaxErr.Offset)
+
+	return syntaxErr
+}
+
+func TestPayloadErrorNilAndZeroValueAreSafe(t *testing.T) {
+	var nilErr *PayloadError
+	assert.NotPanics(t, func() {
+		_ = nilErr.Error()
+		_ = nilErr.Unwrap()
+		_ = nilErr.Fields()
+		_ = nilErr.Is(ErrPayloadInvalid)
+	})
+	assert.Nil(t, nilErr.Unwrap())
+	assert.Nil(t, nilErr.Fields())
+	assert.False(t, nilErr.Is(ErrPayloadInvalid))
+	assert.NotErrorIs(t, error(nilErr), ErrPayloadUndecodable)
+
+	zero := &PayloadError{}
+	assert.NotPanics(t, func() { _ = zero.Error() })
+	assert.Nil(t, zero.Unwrap())
+	assert.Nil(t, zero.Fields())
+	assert.NotErrorIs(t, zero, ErrPayloadUndecodable)
+	assert.NotErrorIs(t, zero, ErrPayloadInvalid)
+}

--- a/server/handler.go
+++ b/server/handler.go
@@ -139,9 +139,7 @@ func NewHandlerContextForTestWithOptions(w http.ResponseWriter, r *http.Request,
 	e := echo.New()
 	// Register the framework validator so contexts built here drive the typed pipeline
 	// (which calls c.Validate) exactly as a live request would.
-	if v := NewValidator(); v != nil {
-		e.Validator = v
-	}
+	e.Validator = NewValidator()
 	c := newHandlerContext(e.NewContext(r, w), cfg)
 	for _, opt := range opts {
 		opt(&c)

--- a/server/server.go
+++ b/server/server.go
@@ -102,11 +102,7 @@ func New(cfg *config.Config, log logger.Logger) *Server {
 	// Without this, v5.1.0+ only returns request.RemoteAddr.
 	// Trusted-proxy-aware extractors are a follow-up item documented in ADR-015.
 	e.IPExtractor = echo.LegacyIPExtractor()
-	if v := NewValidator(); v != nil {
-		e.Validator = v
-	} else {
-		log.Fatal().Msg("failed to initialize request validator")
-	}
+	e.Validator = NewValidator()
 
 	// Initialize server with path configuration
 	basePath := normalizeBasePath(cfg.Server.Path.Base)

--- a/server/validator.go
+++ b/server/validator.go
@@ -1,18 +1,16 @@
-// Package server provides request validation functionality.
-// It wraps go-playground/validator with custom validation logic and error formatting.
+// Formats go-playground/validator errors into the framework's structured
+// field-error shape. The validator instance itself, with the framework's custom
+// rules already registered, is constructed in internal/validation.
 package server
 
 import (
 	"errors"
 	"fmt"
-	"regexp"
 
 	"github.com/go-playground/validator/v10"
-)
 
-// mccCodeRegex is pre-compiled for efficiency and to avoid error handling on each validation call.
-// MCC codes are exactly 4 digits (e.g., "5411" for grocery stores).
-var mccCodeRegex = regexp.MustCompile(`^\d{4}$`)
+	"github.com/gaborage/go-bricks/internal/validation"
+)
 
 // Validator wraps go-playground/validator with custom validation logic.
 // It provides request validation functionality with custom validators.
@@ -20,17 +18,12 @@ type Validator struct {
 	validate *validator.Validate
 }
 
-// NewValidator creates a new Validator instance with custom validation rules registered.
+// NewValidator creates a new Validator instance with custom validation rules
+// registered. It never returns nil: the shared constructor in internal/validation
+// panics if a rule fails to register rather than yielding a partly-configured
+// instance.
 func NewValidator() *Validator {
-	v := validator.New()
-
-	// Register custom validators
-	err := v.RegisterValidation("mcc_code", validateMCCCode)
-	if err != nil {
-		return nil
-	}
-
-	return &Validator{validate: v}
+	return &Validator{validate: validation.New()}
 }
 
 // Validator returns the underlying validator instance.
@@ -111,20 +104,10 @@ func getErrorMessage(fe validator.FieldError) string {
 		return fmt.Sprintf("%s must be exactly %s characters", fe.Field(), fe.Param())
 	case "url":
 		return fmt.Sprintf("%s must be a valid URL", fe.Field())
+	// mcc_code is registered in internal/validation.New, not here.
 	case "mcc_code":
 		return fmt.Sprintf("%s must be a valid 4-digit MCC code", fe.Field())
 	default:
 		return fmt.Sprintf("%s failed validation", fe.Field())
 	}
-}
-
-// Custom validator for MCC codes
-func validateMCCCode(fl validator.FieldLevel) bool {
-	mccCode := fl.Field().String()
-	if len(mccCode) != 4 {
-		return false
-	}
-
-	// Check if all characters are digits using pre-compiled regex
-	return mccCodeRegex.MatchString(mccCode)
 }

--- a/server/validator_test.go
+++ b/server/validator_test.go
@@ -657,17 +657,17 @@ func TestValidatorEdgeCases(t *testing.T) {
 // internal/validation panics if a custom rule fails to register. The server and
 // test-context call sites therefore assign the result directly, with no nil check.
 func TestValidatorNeverNilAndFullyRegistered(t *testing.T) {
-	validator := NewValidator()
-	require.NotNil(t, validator)
-	require.NotNil(t, validator.validate)
+	v := NewValidator()
+	require.NotNil(t, v)
+	require.NotNil(t, v.validate)
 
 	// The custom rule must be live, not merely present: an unregistered tag would
 	// panic on Validate, and a registered-but-inert one would accept "54".
 	type mccOnly struct {
 		Code string `validate:"mcc_code"`
 	}
-	require.NoError(t, validator.Validate(mccOnly{Code: "5411"}))
-	require.Error(t, validator.Validate(mccOnly{Code: "54"}))
+	require.NoError(t, v.Validate(mccOnly{Code: "5411"}))
+	require.Error(t, v.Validate(mccOnly{Code: "54"}))
 
 	// Test behavior with a struct containing all validation rule types
 	allRulesStruct := struct {
@@ -688,6 +688,6 @@ func TestValidatorNeverNilAndFullyRegistered(t *testing.T) {
 		MCCCode:     "1234",
 	}
 
-	err := validator.Validate(allRulesStruct)
+	err := v.Validate(allRulesStruct)
 	assert.NoError(t, err)
 }

--- a/server/validator_test.go
+++ b/server/validator_test.go
@@ -365,7 +365,7 @@ func TestValidationErrorJSON(t *testing.T) {
 	assert.Equal(t, "invalid-email", result.Errors[1].Value)
 }
 
-func TestValidateMCCCode(t *testing.T) {
+func TestValidatorMCCCodeRule(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -653,12 +653,21 @@ func TestValidatorEdgeCases(t *testing.T) {
 	})
 }
 
-func TestValidatorNilValidation(t *testing.T) {
-	// Test what happens if validator creation fails (hypothetical scenario)
-	// Since we can't easily mock the RegisterValidation failure,
-	// we'll just test the current behavior
+// NewValidator never returns nil and never returns a half-configured instance:
+// internal/validation panics if a custom rule fails to register. The server and
+// test-context call sites therefore assign the result directly, with no nil check.
+func TestValidatorNeverNilAndFullyRegistered(t *testing.T) {
 	validator := NewValidator()
 	require.NotNil(t, validator)
+	require.NotNil(t, validator.validate)
+
+	// The custom rule must be live, not merely present: an unregistered tag would
+	// panic on Validate, and a registered-but-inert one would accept "54".
+	type mccOnly struct {
+		Code string `validate:"mcc_code"`
+	}
+	require.NoError(t, validator.Validate(mccOnly{Code: "5411"}))
+	require.Error(t, validator.Validate(mccOnly{Code: "54"}))
 
 	// Test behavior with a struct containing all validation rule types
 	allRulesStruct := struct {


### PR DESCRIPTION
## What

`server` and `messaging` needed one validator with the same custom-rule registrations. Construction moves to `internal/validation.New()`, which panics on registration failure instead of `NewValidator()`'s silent `return nil` — so the two production nil-checks that guarded it (including a `log.Fatal` branch) are now unreachable and removed. Adds the `messaging` payload-error surface the typed consumer in #849 returns: `PayloadError`, `PayloadStage`, and the `ErrPayloadUndecodable` / `ErrPayloadInvalid` sentinels. Both pieces are inert until #849 wires them.

## Impact

None. `server.NewValidator()`'s signature is unchanged and its nil return was already unreachable, so no migrations atom.

## Verification

`PayloadError.Error()` and `Fields()` are asserted to carry no payload bytes across five leak vectors driven through real producers — a numeric literal into an int, a syntax error, `DisallowUnknownFields`, an integer-keyed map key, and a validator map-key namespace. `Unwrap()` still returns the raw cause by design.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent validation for four-digit MCC values.
  - Added structured payload error handling for decoding and validation failures.
  - Errors now identify the failure stage and preserve underlying error details for troubleshooting.

- **Bug Fixes**
  - Improved error messages with safe, redacted field information.
  - Prevented payload values, map keys, and sensitive syntax details from appearing in error output.
  - Improved validator consistency and safe concurrent use across server operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->