### PR TITLE
feat(messaging): typed consumer payload binding

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@ Enterprise Go microservice toolkit (Go 1.26+). Provides multi-database access, t
 
 ## Version & Compatibility
 
-- Reflects **go-bricks v0.55.0**. The v0.49.0 line applied messaging defaults in *every* deployment mode with mode-aware pool sizing (publisher `maxcached`, `database.manager.maxsize`, cache `maxsize` scale to the tenant limit in multi-tenant), added `database.manager.*` keys, wired `messaging.reconnect` delay/backoff keys live, required unit-suffixed durations (write `"300s"`, not `300`), and hardened the publisher lifecycle (cold-publish readiness wait + 1h single-tenant publisher IdleTTL). Since then: v0.50.0 made dev CORS wildcard opt-in (`CORS_DEV_WILDCARD`, ADR-038) and `multitenant.resolver.order` REQUIRED for `type: composite` (ADR-039); v0.51.0 made `server.bodylimit` configurable (echo v5.3.0 bump); v0.52.0 made messaging declaration `Args` reach the broker via a breaking `AMQPClient.DeclareQueue`/`DeclareExchange`/`BindQueue` signature change (ADR-040); v0.53.0 added `DeclareQueueWithDLQ` declarative dead-lettering; v0.54.0 shipped the `outbox.tenancy`/`inbox.tenancy: shared` control-plane ledger (ADR-041) and duplicate-route-registration fail-fast; v0.55.0 shipped the `database.Execute*` query/exec helpers with `database.Raw` and typed errors (hop E55), deterministic httpclient transport-wrapper layering at `Build()`, config-driven httpclient client TLS, and the `server.tls.*` HTTPS listener (ADR-042). Unreleased on `main` (shipping in v0.56.0): the ALB forwarded-client-cert identity middleware (`server.forwardedclientcert.*`, ADR-043), the `seal-payload` CLI (#776), and a breaking `httpclient.Builder.Build() (Client, error)` signature change — `Build` now fails construction on an unsafe base-transport-slot displacement instead of warning and returning a silently-degraded client (ADR-044). Requires **Go 1.26+**.
+- Reflects **go-bricks v0.55.0**. The v0.49.0 line applied messaging defaults in *every* deployment mode with mode-aware pool sizing (publisher `maxcached`, `database.manager.maxsize`, cache `maxsize` scale to the tenant limit in multi-tenant), added `database.manager.*` keys, wired `messaging.reconnect` delay/backoff keys live, required unit-suffixed durations (write `"300s"`, not `300`), and hardened the publisher lifecycle (cold-publish readiness wait + 1h single-tenant publisher IdleTTL). Since then: v0.50.0 made dev CORS wildcard opt-in (`CORS_DEV_WILDCARD`, ADR-038) and `multitenant.resolver.order` REQUIRED for `type: composite` (ADR-039); v0.51.0 made `server.bodylimit` configurable (echo v5.3.0 bump); v0.52.0 made messaging declaration `Args` reach the broker via a breaking `AMQPClient.DeclareQueue`/`DeclareExchange`/`BindQueue` signature change (ADR-040); v0.53.0 added `DeclareQueueWithDLQ` declarative dead-lettering; v0.54.0 shipped the `outbox.tenancy`/`inbox.tenancy: shared` control-plane ledger (ADR-041) and duplicate-route-registration fail-fast; v0.55.0 shipped the `database.Execute*` query/exec helpers with `database.Raw` and typed errors (hop E55), deterministic httpclient transport-wrapper layering at `Build()`, config-driven httpclient client TLS, and the `server.tls.*` HTTPS listener (ADR-042). Unreleased on `main` (shipping in v0.56.0): the ALB forwarded-client-cert identity middleware (`server.forwardedclientcert.*`, ADR-043), the `seal-payload` CLI (#776), typed AMQP consumer binding (`messaging.DeclareTypedConsumer` / `NewTypedHandler`, #777), and a breaking `httpclient.Builder.Build() (Client, error)` signature change — `Build` now fails construction on an unsafe base-transport-slot displacement instead of warning and returning a silently-degraded client (ADR-044). Requires **Go 1.26+**.
 - Authoritative sources: `CHANGELOG.md` (release log) and `wiki/migrations.md` — the **per-hop migration runbook** (detect → apply → verify atoms, one hop per release, chainable across any version range). This file carries the ladder + agent protocol; the runbook holds the full atoms.
 - Upgrading an existing app? Read that section first. Across v0.40 → v0.45 **most breaks fail silently** — a renamed config key stops binding, a default flips — with no compile error. The compiler-caught API breaks are concentrated in v0.41.0 (CORS / LogEvent / SetupMiddlewares), v0.43.0 (per-tenant `ReleaseFunc`, `PoolKeepAliveConfig.Enabled`), v0.45.0 (echo-free boundary types, the `outbox.Store` interface), and v0.52.0 (the `AMQPClient.DeclareQueue`/`DeclareExchange`/`BindQueue` signature change, ADR-040). Not everything is silent: v0.50.0's required `multitenant.resolver.order` for `type: composite` (ADR-039) fails **fast** at startup with a config-validation error.
 
@@ -2916,10 +2916,12 @@ import (
 	"github.com/gaborage/go-bricks/messaging"
 )
 
+// validate tags are inert on the publish side; they are what the typed consumer
+// below enforces, so one struct describes both ends of the wire.
 type OrderCreatedEvent struct {
-	OrderID    int64   `json:"order_id"`
-	CustomerID int64   `json:"customer_id"`
-	Total      float64 `json:"total"`
+	OrderID    int64   `json:"order_id"    validate:"required"`
+	CustomerID int64   `json:"customer_id" validate:"required"`
+	Total      float64 `json:"total"       validate:"required,gt=0"`
 }
 
 type OrderService struct {
@@ -3022,6 +3024,33 @@ func (h *OrderHandler) Handle(ctx context.Context, delivery *amqp.Delivery) erro
 func (h *OrderHandler) EventType() string { return "OrderCreated" }
 ```
 
+### Typed Consumer Binding (skips the boilerplate above)
+
+`DeclareTypedConsumer` decodes + validates the body and calls a plain typed function — the consumer mirror of `server.POST`. `T` is inferred from the function; `ConsumerOptions.Handler` must be nil (it panics at declaration otherwise).
+
+```go
+// The same OrderCreatedEvent the producer above publishes, repeated here so the
+// block stands alone — the typed consumer is what enforces its validate tags.
+type OrderCreatedEvent struct {
+	OrderID    int64   `json:"order_id"    validate:"required"`
+	CustomerID int64   `json:"customer_id" validate:"required"`
+	Total      float64 `json:"total"       validate:"required,gt=0"`
+}
+
+func (s *OrderService) HandleOrderCreated(ctx context.Context, evt OrderCreatedEvent) error {
+	return s.ProcessOrder(ctx, evt.OrderID) // nil → ACK, error → nack-without-requeue
+}
+
+func (m *Module) DeclareMessaging(decls *messaging.Declarations) {
+	queue := decls.DeclareQueueWithDLQ("orders.events.queue", nil) // park bad payloads
+	messaging.DeclareTypedConsumer(decls, &messaging.ConsumerOptions{
+		Queue: queue.Name, Consumer: "order-processor", EventType: "OrderCreated",
+	}, m.svc.HandleOrderCreated)
+}
+```
+
+Decode/validation failures return a `*messaging.PayloadError` before the function runs — match with `errors.Is(err, messaging.ErrPayloadUndecodable)` / `messaging.ErrPayloadInvalid`. The function's own error passes through unwrapped. `Error()` and `Fields()` carry no payload bytes (map-key namespaces are redacted to `Limits[*]`) and are safe to log; `Unwrap()` returns the raw decoder/validator error and is not. The adapter is stateless, so `Workers` tuning below applies unchanged.
+
 ### Step 5: Wire the Module into `main`
 
 ```go
@@ -3067,6 +3096,7 @@ decls.DeclareConsumer(&messaging.ConsumerOptions{
 | Publish — default exchange | `client.Publish(ctx, queueName, body)` |
 | Atomic publish (with DB) | Use Transactional Outbox — `deps.Outbox.Publish(ctx, tx, event)` |
 | Consumer Handler | `Handle(ctx, *amqp.Delivery) error` + `EventType() string` |
+| Typed consumer (decode + validate) | `messaging.DeclareTypedConsumer(decls, opts, fn)` — `fn` is `func(ctx, T) error` |
 | ACK | Return `nil` |
 | nack-without-requeue (drop) | Return `error` |
 | Concurrency | Auto = `NumCPU * 4` workers; override via `Workers` field |

--- a/messaging/payload_error.go
+++ b/messaging/payload_error.go
@@ -1,7 +1,6 @@
 package messaging
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -51,8 +50,10 @@ var (
 //   - validator namespaces interpolate map keys verbatim ("Limits[4111...]"),
 //     which is why the namespace list is unexported and redacted on read.
 //
-// A new codec (issue #346) inherits the generic fallback in decodeSummary — no
-// rendering at all — until its error shapes are audited and added there.
+// The rendering itself lives on the codec seam (codec.summarize), so a new codec
+// (issue #346) must supply its own audited phrasing; until it does, the
+// constructor substitutes the fail-closed phrase and the cause itself is never
+// rendered.
 type PayloadError struct {
 	// EventType is the declared consumer event type the body was routed to.
 	EventType string
@@ -68,15 +69,28 @@ type PayloadError struct {
 	// only safe read.
 	fields []string
 
+	// summary is the codec's payload-free rendering of a decode cause. It is what
+	// Error() prints; the cause itself is never rendered.
+	summary string
+
 	err error
 }
 
 // newPayloadDecodeError wraps a decode failure. The cause survives for Unwrap
-// only; Error() renders it through decodeSummary.
-func newPayloadDecodeError(eventType string, cause error) *PayloadError {
+// only; Error() prints summary instead, which the codec produced.
+//
+// SECURITY: an empty summary means the codec did not audit this error shape, so
+// the fail-closed phrase substitutes here rather than at the call site — no
+// caller can render an unaudited cause by forgetting the fallback.
+func newPayloadDecodeError(eventType string, cause error, summary string) *PayloadError {
+	if summary == "" {
+		summary = unauditedDecoderSummary
+	}
+
 	return &PayloadError{
 		EventType: eventType,
 		Stage:     PayloadStageDecode,
+		summary:   summary,
 		err:       cause,
 	}
 }
@@ -131,8 +145,8 @@ func (e *PayloadError) Error() string {
 	if fields := e.Fields(); len(fields) > 0 {
 		msg += fmt.Sprintf(" (fields: %s)", strings.Join(fields, ", "))
 	}
-	if e.Stage == PayloadStageDecode && e.err != nil {
-		msg += ": " + decodeSummary(e.err)
+	if e.Stage == PayloadStageDecode && e.summary != "" {
+		msg += ": " + e.summary
 	}
 
 	return msg
@@ -168,36 +182,6 @@ func (e *PayloadError) Is(target error) bool {
 	default:
 		return false
 	}
-}
-
-// decodeSummary renders a decode failure without any payload bytes.
-// json.UnmarshalTypeError.Value carries the raw literal ("number 1234.56") and
-// json.SyntaxError's message quotes the offending byte, so neither error's own
-// text may be rendered. Field, Type and Offset are destination-schema
-// facts: encoding/json builds Field from the matched destination field's json
-// tag and never from an input key (map keys never enter its FieldStack).
-// Anything else — including json.Decoder.DisallowUnknownFields, which names the
-// partner's key — falls through to a phrase that reveals nothing.
-func decodeSummary(err error) string {
-	var typeErr *json.UnmarshalTypeError
-	if errors.As(err, &typeErr) {
-		wantType := "unknown"
-		if typeErr.Type != nil {
-			wantType = typeErr.Type.String()
-		}
-		if typeErr.Field != "" {
-			return fmt.Sprintf("json: type mismatch at field %q (want %s, offset %d)", typeErr.Field, wantType, typeErr.Offset)
-		}
-
-		return fmt.Sprintf("json: type mismatch (want %s, offset %d)", wantType, typeErr.Offset)
-	}
-
-	var syntaxErr *json.SyntaxError
-	if errors.As(err, &syntaxErr) {
-		return fmt.Sprintf("json: syntax error at offset %d", syntaxErr.Offset)
-	}
-
-	return unauditedDecoderSummary
 }
 
 // sanitizeNamespace redacts everything from a namespace's first '[' to its last

--- a/messaging/payload_error_test.go
+++ b/messaging/payload_error_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/go-playground/validator/v10"
@@ -95,7 +94,7 @@ func TestPayloadErrorIsRejectsUnknownStage(t *testing.T) {
 
 func TestPayloadErrorUnwrapReachesCause(t *testing.T) {
 	inner := errors.New("inner cause")
-	err := newPayloadDecodeError(orderEventType, inner)
+	err := newPayloadDecodeError(orderEventType, inner, "")
 
 	require.Same(t, inner, err.Unwrap())
 	assert.ErrorIs(t, err, inner)
@@ -128,7 +127,7 @@ func TestPayloadErrorMessageComposition(t *testing.T) {
 		`messaging: validate failed for event "OrderCreated" (fields: orderPayload.Reference, orderPayload.Amount)`,
 		validateErr.Error())
 
-	decodeErr := newPayloadDecodeError(orderEventType, errors.New("unexpected EOF"))
+	decodeErr := newPayloadDecodeError(orderEventType, errors.New("unexpected EOF"), "")
 	assert.Equal(t,
 		`messaging: decode failed for event "OrderCreated": cause withheld (unaudited decoder); use errors.Unwrap for the raw error`,
 		decodeErr.Error())
@@ -151,7 +150,7 @@ func TestPayloadErrorNeverRendersPayloadValues(t *testing.T) {
 		require.Error(t, decodeErr)
 		require.Contains(t, decodeErr.Error(), numericMarker, "premise: the raw cause leaks the amount")
 
-		rendered := newPayloadDecodeError(orderEventType, decodeErr).Error()
+		rendered := newPayloadDecodeError(orderEventType, decodeErr, jsonCodec{}.summarize(decodeErr)).Error()
 		require.Contains(t, rendered, "type mismatch at field", "premise: a decode summary was rendered")
 		assert.NotContains(t, rendered, numericMarker)
 	})
@@ -174,7 +173,7 @@ func TestPayloadErrorNeverRendersPayloadValues(t *testing.T) {
 		require.ErrorAs(t, decodeErr, &typeErr, "premise: the body produced an UnmarshalTypeError")
 		assert.Equal(t, "limits", typeErr.Field, "Field must name the destination field only")
 
-		rendered := newPayloadDecodeError(orderEventType, decodeErr).Error()
+		rendered := newPayloadDecodeError(orderEventType, decodeErr, jsonCodec{}.summarize(decodeErr)).Error()
 		require.Contains(t, rendered, "type mismatch at field", "premise: a decode summary was rendered")
 		assert.NotContains(t, rendered, payloadMarker)
 	})
@@ -194,7 +193,7 @@ func TestPayloadErrorNeverRendersPayloadValues(t *testing.T) {
 		require.ErrorAs(t, decodeErr, &typeErr, "premise: the body produced an UnmarshalTypeError")
 		assert.Equal(t, "limits", typeErr.Field, "Field must name the destination field only")
 
-		rendered := newPayloadDecodeError(orderEventType, decodeErr).Error()
+		rendered := newPayloadDecodeError(orderEventType, decodeErr, jsonCodec{}.summarize(decodeErr)).Error()
 		require.Contains(t, rendered, "type mismatch at field", "premise: a decode summary was rendered")
 		assert.NotContains(t, rendered, payloadMarker)
 	})
@@ -208,7 +207,7 @@ func TestPayloadErrorNeverRendersPayloadValues(t *testing.T) {
 		require.ErrorAs(t, decodeErr, new(*json.SyntaxError), "premise: the body produced a SyntaxError")
 		require.Contains(t, decodeErr.Error(), syntaxMarker, "premise: the raw cause quotes the offending byte")
 
-		rendered := newPayloadDecodeError(orderEventType, decodeErr).Error()
+		rendered := newPayloadDecodeError(orderEventType, decodeErr, jsonCodec{}.summarize(decodeErr)).Error()
 		require.Contains(t, rendered, "syntax error at offset", "premise: a decode summary was rendered")
 		assert.NotContains(t, rendered, syntaxMarker)
 	})
@@ -224,7 +223,7 @@ func TestPayloadErrorNeverRendersPayloadValues(t *testing.T) {
 		require.Error(t, decodeErr)
 		require.Contains(t, decodeErr.Error(), payloadMarker, "premise: the raw cause leaks the key")
 
-		rendered := newPayloadDecodeError(orderEventType, decodeErr).Error()
+		rendered := newPayloadDecodeError(orderEventType, decodeErr, jsonCodec{}.summarize(decodeErr)).Error()
 		require.Contains(t, rendered, "cause withheld", "premise: the generic fallback rendered")
 		assert.NotContains(t, rendered, payloadMarker)
 	})
@@ -342,7 +341,7 @@ func TestPayloadErrorFieldsRedactsOnRead(t *testing.T) {
 func TestPayloadErrorConstructorsPropagateEventType(t *testing.T) {
 	cause := errors.New("boom")
 
-	decodeErr := newPayloadDecodeError(shipmentEventType, cause)
+	decodeErr := newPayloadDecodeError(shipmentEventType, cause, "")
 	assert.Equal(t, shipmentEventType, decodeErr.EventType)
 	assert.Contains(t, decodeErr.Error(), shipmentEventType)
 
@@ -389,110 +388,6 @@ func TestSanitizeNamespace(t *testing.T) {
 			assert.Equal(t, tc.want, sanitizeNamespace(tc.input))
 		})
 	}
-}
-
-func TestDecodeSummary(t *testing.T) {
-	typeErr := &json.UnmarshalTypeError{
-		Value:  "number " + numericMarker,
-		Type:   reflect.TypeOf(int64(0)),
-		Offset: 18,
-		Struct: "orderPayload",
-		Field:  "amount",
-	}
-	syntaxOffset := int64(1)
-
-	tests := []struct {
-		name        string
-		err         error
-		want        string
-		notContains string
-	}{
-		{
-			name:        "unmarshal_type_error",
-			err:         typeErr,
-			want:        `json: type mismatch at field "amount" (want int64, offset 18)`,
-			notContains: numericMarker,
-		},
-		{
-			name:        "wrapped_unmarshal_type_error",
-			err:         fmt.Errorf("decode: %w", typeErr),
-			want:        `json: type mismatch at field "amount" (want int64, offset 18)`,
-			notContains: numericMarker,
-		},
-		{
-			name: "unmarshal_type_error_without_field",
-			err:  fieldlessTypeError(t),
-			want: "json: type mismatch (want messaging.orderPayload, offset 3)",
-		},
-		{
-			name: "unmarshal_type_error_without_type",
-			err:  &json.UnmarshalTypeError{Value: "object", Offset: 2},
-			want: "json: type mismatch (want unknown, offset 2)",
-		},
-		{
-			name: "syntax_error",
-			err:  syntaxError(t, syntaxOffset),
-			want: "json: syntax error at offset 1",
-		},
-		{
-			name: "wrapped_syntax_error",
-			err:  fmt.Errorf("decode: %w", syntaxError(t, syntaxOffset)),
-			want: "json: syntax error at offset 1",
-		},
-		{
-			name:        "unrelated_error_falls_back",
-			err:         errors.New("json: unknown field " + payloadMarker),
-			want:        unauditedDecoderSummary,
-			notContains: payloadMarker,
-		},
-		{
-			name: "nil_error_falls_back",
-			err:  nil,
-			want: unauditedDecoderSummary,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := decodeSummary(tc.err)
-			assert.Equal(t, tc.want, got)
-			if tc.notContains != "" {
-				assert.NotContains(t, got, tc.notContains)
-			}
-		})
-	}
-}
-
-// fieldlessTypeError produces a real *json.UnmarshalTypeError with an empty
-// Field: a bare scalar body never enters a struct field, so encoding/json has no
-// FieldStack to draw one from. Built from the decoder rather than by literal so
-// the Field == "" branch proves its own reachability.
-func fieldlessTypeError(t *testing.T) *json.UnmarshalTypeError {
-	t.Helper()
-
-	var payload orderPayload
-	err := json.Unmarshal([]byte("123"), &payload)
-
-	var typeErr *json.UnmarshalTypeError
-	require.ErrorAs(t, err, &typeErr)
-	require.Empty(t, typeErr.Field)
-
-	return typeErr
-}
-
-// syntaxError produces a real *json.SyntaxError; its msg field is unexported,
-// so it cannot be built by literal.
-func syntaxError(t *testing.T, wantOffset int64) *json.SyntaxError {
-	t.Helper()
-
-	var payload orderPayload
-	err := json.Unmarshal([]byte(`}`), &payload)
-
-	var syntaxErr *json.SyntaxError
-	require.ErrorAs(t, err, &syntaxErr)
-	require.Equal(t, wantOffset, syntaxErr.Offset)
-
-	return syntaxErr
 }
 
 func TestPayloadErrorNilAndZeroValueAreSafe(t *testing.T) {

--- a/messaging/typed_consumer.go
+++ b/messaging/typed_consumer.go
@@ -1,0 +1,173 @@
+package messaging
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+
+	"github.com/gaborage/go-bricks/internal/validation"
+)
+
+// errNilDelivery is the cause a nil *amqp.Delivery is reported with. The
+// framework's worker loop never produces one, so this only guards a hand-driven
+// Handle call; it stays unexported because no consumer can branch on it usefully.
+var errNilDelivery = errors.New("messaging: nil delivery")
+
+// nilDeliverySummary renders errNilDelivery. It is a constant, so the no-payload
+// -bytes guarantee holds trivially.
+const nilDeliverySummary = "nil delivery"
+
+// typedValidator is the one validator instance every typed handler shares.
+// validator caches struct metadata by reflect.Type, so per-message construction
+// would throw that cache away on every delivery; the instance is safe for
+// concurrent use, which is what lets one adapter serve every worker.
+var typedValidator = sync.OnceValue(validation.New)
+
+// codec decodes a raw payload into T. Unexported by design: schema negotiation
+// and non-JSON payloads (issue #346) widen this seam without an API break.
+type codec interface {
+	Unmarshal(data []byte, v any) error
+	// summarize renders a decode failure with NO payload bytes in it. Returning
+	// "" means the shape was not audited; the PayloadError constructor
+	// substitutes the fail-closed phrase, so a codec never spells it out.
+	summarize(err error) string
+}
+
+// jsonCodec is the only codec today: AMQP bodies are JSON on every path the
+// framework publishes.
+type jsonCodec struct{}
+
+func (jsonCodec) Unmarshal(data []byte, v any) error {
+	return json.Unmarshal(data, v)
+}
+
+// summarize renders a decode failure without any payload bytes.
+// json.UnmarshalTypeError.Value carries the raw literal ("number 1234.56") and
+// json.SyntaxError's message quotes the offending byte, so neither error's own
+// text may be rendered. Field, Type and Offset are destination-schema
+// facts: encoding/json builds Field from the matched destination field's json
+// tag and never from an input key (map keys never enter its FieldStack).
+// Anything else — including json.Decoder.DisallowUnknownFields, which names the
+// partner's key — falls through to a phrase that reveals nothing.
+func (jsonCodec) summarize(err error) string {
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		wantType := "unknown"
+		if typeErr.Type != nil {
+			wantType = typeErr.Type.String()
+		}
+		if typeErr.Field != "" {
+			return fmt.Sprintf("json: type mismatch at field %q (want %s, offset %d)", typeErr.Field, wantType, typeErr.Offset)
+		}
+
+		return fmt.Sprintf("json: type mismatch (want %s, offset %d)", wantType, typeErr.Offset)
+	}
+
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return fmt.Sprintf("json: syntax error at offset %d", syntaxErr.Offset)
+	}
+
+	return ""
+}
+
+// typedHandler adapts a typed function to MessageHandler. Every field is set
+// once at construction and read-only afterwards: one instance is shared by every
+// worker goroutine of a consumer AND by every tenant replaying the same
+// declarations, so any mutable state here would be a data race.
+type typedHandler[T any] struct {
+	eventType string
+	codec     codec
+	fn        func(context.Context, T) error
+}
+
+// NewTypedHandler adapts a typed function to the MessageHandler contract:
+// decode (JSON) → validate (go-playground struct tags) → fn. It is the consumer
+// mirror of the typed HTTP handlers registered with server.POST.
+//
+// Failures short-circuit with a *PayloadError, which the worker loop nacks
+// WITHOUT requeue like any other handler error — decode and validation failures
+// are not retryable, so pair the queue with DeclareQueueWithDLQ to park them.
+// Match them with errors.Is against ErrPayloadUndecodable or ErrPayloadInvalid.
+// fn's own error is returned unwrapped, so a consumer's errors.Is against its
+// business sentinels still works.
+//
+// The returned handler holds no mutable state and is safe to share across
+// workers and tenants. fn must therefore be safe for concurrent use too.
+func NewTypedHandler[T any](eventType string, fn func(context.Context, T) error) MessageHandler {
+	if fn == nil {
+		panic("messaging: NewTypedHandler requires a non-nil handler function (event_type=" + eventType + ")")
+	}
+
+	return &typedHandler[T]{
+		eventType: eventType,
+		codec:     jsonCodec{},
+		fn:        fn,
+	}
+}
+
+func (h *typedHandler[T]) Handle(ctx context.Context, delivery *amqp.Delivery) error {
+	if delivery == nil {
+		return newPayloadDecodeError(h.eventType, errNilDelivery, nilDeliverySummary)
+	}
+
+	// A fresh payload per delivery: workers share the handler, not the value.
+	var payload T
+	if err := h.codec.Unmarshal(delivery.Body, &payload); err != nil {
+		return newPayloadDecodeError(h.eventType, err, h.codec.summarize(err))
+	}
+
+	// A non-struct T reaches this with a *validator.InvalidValidationError, which
+	// yields no fields and still matches ErrPayloadInvalid — fail closed on the
+	// first delivery rather than silently skipping validation forever.
+	if err := typedValidator().Struct(payload); err != nil {
+		return newPayloadValidateError(h.eventType, err)
+	}
+
+	return h.fn(ctx, payload)
+}
+
+func (h *typedHandler[T]) EventType() string {
+	return h.eventType
+}
+
+// DeclareTypedConsumer registers a consumer whose handler is built by
+// NewTypedHandler from fn, so T is inferred from fn and never spelled out.
+//
+// The queue is not declared here: pass it to DeclareQueue or
+// DeclareQueueWithDLQ separately, exactly as an untyped DeclareConsumer with a
+// nil queue does. A consumer naming a queue nobody declared surfaces at
+// Declarations.Validate() as "consumer references non-existent queue", not here.
+//
+// It panics on a nil decls, a nil opts, or an opts that already carries a
+// Handler — all three are declaration-time wiring mistakes, and the package
+// already fails startup that way for duplicate consumer registrations.
+//
+// Failure and concurrency semantics are NewTypedHandler's: decode and validation
+// failures return a *PayloadError that nacks WITHOUT requeue, so pair the queue
+// with DeclareQueueWithDLQ, and fn must be safe for concurrent use.
+func DeclareTypedConsumer[T any](decls *Declarations, opts *ConsumerOptions, fn func(context.Context, T) error) *ConsumerDeclaration {
+	if decls == nil {
+		panic("messaging: DeclareTypedConsumer requires a non-nil *Declarations")
+	}
+	if opts == nil {
+		panic("messaging: DeclareTypedConsumer requires non-nil *ConsumerOptions")
+	}
+	if opts.Handler != nil {
+		panic(fmt.Sprintf(
+			"messaging: DeclareTypedConsumer builds the handler itself, so ConsumerOptions.Handler must be nil\n"+
+				"  queue=%s consumer=%s event_type=%s\n"+
+				"  Use DeclareConsumer for a hand-written MessageHandler, or build a fresh\n"+
+				"  ConsumerOptions if this one was already passed to DeclareTypedConsumer",
+			opts.Queue, opts.Consumer, opts.EventType,
+		))
+	}
+
+	opts.Handler = NewTypedHandler[T](opts.EventType, fn)
+
+	return decls.DeclareConsumer(opts, nil)
+}

--- a/messaging/typed_consumer_test.go
+++ b/messaging/typed_consumer_test.go
@@ -1,0 +1,612 @@
+package messaging
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errBusiness stands in for a consumer's own sentinel: the adapter must return
+// fn's error untouched, or errors.Is against it stops working.
+var errBusiness = errors.New("orders: already processed")
+
+// mccPayload carries a framework-custom tag. validator PANICS on an unregistered
+// tag, so a passing run proves the shared validator came from validation.New and
+// not a bare validator.New().
+type mccPayload struct {
+	MCC string `json:"mcc" validate:"mcc_code"`
+}
+
+func validBody(t *testing.T) []byte {
+	t.Helper()
+
+	body, err := json.Marshal(orderPayload{Reference: "abc", Amount: 7})
+	require.NoError(t, err)
+
+	return body
+}
+
+func TestNewTypedHandlerDecodesAndInvokesFn(t *testing.T) {
+	var got orderPayload
+	var calls int
+	h := NewTypedHandler(orderEventType, func(_ context.Context, p orderPayload) error {
+		got = p
+		calls++
+		return nil
+	})
+
+	require.NoError(t, h.Handle(t.Context(), &amqp.Delivery{Body: validBody(t)}))
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, orderPayload{Reference: "abc", Amount: 7}, got)
+}
+
+// The worker loop hands Handle a context carrying the extracted W3C trace and
+// the per-message lease scope that deps.DB/deps.Cache borrow tenant handles
+// from. Substituting context.Background() would orphan every span and resolve
+// handles outside the scope, with nothing else in the suite noticing.
+func TestNewTypedHandlerPassesCallerContextToFn(t *testing.T) {
+	type ctxKey struct{}
+	var seen any
+	h := NewTypedHandler(orderEventType, func(ctx context.Context, _ orderPayload) error {
+		seen = ctx.Value(ctxKey{})
+		return nil
+	})
+
+	ctx := context.WithValue(t.Context(), ctxKey{}, "lease-scope")
+	require.NoError(t, h.Handle(ctx, &amqp.Delivery{Body: validBody(t)}))
+	assert.Equal(t, "lease-scope", seen)
+}
+
+// Each delivery must decode into a zero-valued T. A shared payload — a struct
+// field, or a sync.Pool added for the allocation win — would leave delivery N+1
+// inheriting the fields N set but N+1 omits, and a mutex would hide that from
+// the race detector.
+func TestNewTypedHandlerAllocatesFreshPayloadPerDelivery(t *testing.T) {
+	var seen []orderPayload
+	h := NewTypedHandler(orderEventType, func(_ context.Context, p orderPayload) error {
+		seen = append(seen, p)
+		return nil
+	})
+
+	require.NoError(t, h.Handle(t.Context(), &amqp.Delivery{Body: []byte(`{"reference":"abc","amount":7}`)}))
+	require.NoError(t, h.Handle(t.Context(), &amqp.Delivery{Body: []byte(`{"amount":9}`)}))
+	require.Len(t, seen, 2)
+	assert.Equal(t, orderPayload{Reference: "", Amount: 9}, seen[1], "Reference must not survive from the previous delivery")
+
+	// A stale Amount would also satisfy `required` and skip the validation error.
+	assert.ErrorIs(t, h.Handle(t.Context(), &amqp.Delivery{Body: []byte(`{"reference":"xy"}`)}), ErrPayloadInvalid)
+}
+
+// The shared validator is a performance contract: go-playground caches struct
+// metadata per instance, so constructing one per delivery re-registers the
+// custom rules and rebuilds the cache every message. Measured, that is ~7-8
+// allocs/op against ~222 — the ceiling has wide margin on both sides and is the
+// only thing that catches Handle bypassing the package-level typedValidator.
+func TestNewTypedHandlerReusesOneValidator(t *testing.T) {
+	h := NewTypedHandler(orderEventType, func(_ context.Context, _ orderPayload) error { return nil })
+	ctx := t.Context()
+	body := validBody(t)
+
+	avg := testing.AllocsPerRun(200, func() {
+		_ = h.Handle(ctx, &amqp.Delivery{Body: body})
+	})
+	assert.Less(t, avg, 40.0, "per-delivery validator construction would push this past 200")
+}
+
+func TestNewTypedHandlerReturnsFnResult(t *testing.T) {
+	h := NewTypedHandler(orderEventType, func(_ context.Context, _ orderPayload) error {
+		return errBusiness
+	})
+
+	err := h.Handle(t.Context(), &amqp.Delivery{Body: validBody(t)})
+
+	require.ErrorIs(t, err, errBusiness)
+	require.Same(t, errBusiness, err, "fn's error must pass through unwrapped")
+	assert.NotErrorIs(t, err, ErrPayloadUndecodable)
+	assert.NotErrorIs(t, err, ErrPayloadInvalid)
+	assert.NotErrorAs(t, err, new(*PayloadError))
+}
+
+// The adapter is the seam where a naive implementation would echo the body, so
+// each subtest plants a marker the raw cause (or the body) carries and asserts a
+// positive premise before the negative one.
+func TestNewTypedHandlerDecodeFailure(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		marker     string
+		wantRender string
+		causeLeaks bool
+	}{
+		{
+			// UnmarshalTypeError.Value becomes "number 1234.56".
+			name:       "numeric_literal_into_int",
+			body:       `{"amount":` + numericMarker + `}`,
+			marker:     numericMarker,
+			wantRender: "json: type mismatch at field",
+			causeLeaks: true,
+		},
+		{
+			name:       "garbage_bytes",
+			body:       "not json " + payloadMarker,
+			marker:     payloadMarker,
+			wantRender: "json: syntax error at offset",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewTypedHandler(orderEventType, func(_ context.Context, _ orderPayload) error {
+				t.Error("fn must not run after a decode failure")
+				return nil
+			})
+
+			err := h.Handle(t.Context(), &amqp.Delivery{Body: []byte(tc.body)})
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrPayloadUndecodable)
+			assert.NotErrorIs(t, err, ErrPayloadInvalid)
+
+			var perr *PayloadError
+			require.ErrorAs(t, err, &perr)
+			assert.Equal(t, PayloadStageDecode, perr.Stage)
+			assert.Equal(t, orderEventType, perr.EventType)
+			assert.Empty(t, perr.Fields())
+
+			require.Contains(t, err.Error(), tc.wantRender, "premise: a decode summary was rendered")
+			if tc.causeLeaks {
+				require.Contains(t, perr.Unwrap().Error(), tc.marker, "premise: the raw cause leaks the value")
+			}
+			assert.NotContains(t, err.Error(), tc.marker)
+		})
+	}
+}
+
+func TestNewTypedHandlerValidationFailure(t *testing.T) {
+	h := NewTypedHandler(orderEventType, func(_ context.Context, _ orderPayload) error {
+		t.Error("fn must not run after a validation failure")
+		return nil
+	})
+	body := fmt.Appendf(nil, `{"reference":%q,"amount":1}`, payloadMarker)
+
+	err := h.Handle(t.Context(), &amqp.Delivery{Body: body})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPayloadInvalid)
+	assert.NotErrorIs(t, err, ErrPayloadUndecodable)
+
+	var perr *PayloadError
+	require.ErrorAs(t, err, &perr)
+	assert.Equal(t, PayloadStageValidate, perr.Stage)
+	assert.Equal(t, []string{fieldReference}, perr.Fields())
+	require.Contains(t, err.Error(), fieldReference, "premise: the field list was rendered")
+	assert.NotContains(t, err.Error(), payloadMarker)
+}
+
+// End-to-end proof that the adapter routes through the sanitizer: a dived map
+// interpolates its key into the validator namespace verbatim, so a PAN-shaped
+// key reaches Fields() unredacted unless PayloadError is doing its job.
+func TestNewTypedHandlerRedactsMapKeyNamespace(t *testing.T) {
+	h := NewTypedHandler(orderEventType, func(_ context.Context, _ mapKeyPayload) error {
+		t.Error("fn must not run after a validation failure")
+		return nil
+	})
+	body := fmt.Appendf(nil, `{"limits":{%q:99}}`, pan)
+
+	err := h.Handle(t.Context(), &amqp.Delivery{Body: body})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrPayloadInvalid)
+
+	var perr *PayloadError
+	require.ErrorAs(t, err, &perr)
+	require.Contains(t, perr.Unwrap().Error(), pan, "premise: the raw cause carries the map key")
+	require.Equal(t, []string{"mapKeyPayload.Limits[*]"}, perr.Fields(), "premise: a namespace was derived and redacted")
+
+	assert.NotContains(t, err.Error(), pan)
+	for _, field := range perr.Fields() {
+		assert.NotContains(t, field, pan)
+	}
+}
+
+// A non-struct T decodes fine and then trips validator's own type guard. It must
+// fail closed on the FIRST delivery rather than skipping validation forever.
+func TestNewTypedHandlerNonStructPayloadFailsClosed(t *testing.T) {
+	h := NewTypedHandler("Ints", func(_ context.Context, _ []int) error {
+		t.Error("fn must not run for a non-struct payload")
+		return nil
+	})
+
+	var err error
+	require.NotPanics(t, func() {
+		err = h.Handle(t.Context(), &amqp.Delivery{Body: []byte(`[1,2,3]`)})
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPayloadInvalid, "the failure is validate-stage, not decode-stage")
+	assert.NotErrorIs(t, err, ErrPayloadUndecodable)
+	require.ErrorAs(t, err, new(*validator.InvalidValidationError))
+
+	var perr *PayloadError
+	require.ErrorAs(t, err, &perr)
+	assert.Empty(t, perr.Fields(), "a non-validator cause yields no field list")
+	assert.Equal(t, `messaging: validate failed for event "Ints"`, err.Error())
+}
+
+func TestNewTypedHandlerNilDeliveryAndEmptyBody(t *testing.T) {
+	tests := []struct {
+		name     string
+		delivery *amqp.Delivery
+		want     string
+	}{
+		{
+			name:     "nil_delivery",
+			delivery: nil,
+			want:     `messaging: decode failed for event "OrderCreated": nil delivery`,
+		},
+		{
+			name:     "nil_body",
+			delivery: &amqp.Delivery{},
+			want:     `messaging: decode failed for event "OrderCreated": json: syntax error at offset 0`,
+		},
+		{
+			name:     "empty_body",
+			delivery: &amqp.Delivery{Body: []byte{}},
+			want:     `messaging: decode failed for event "OrderCreated": json: syntax error at offset 0`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewTypedHandler(orderEventType, func(_ context.Context, _ orderPayload) error {
+				t.Error("fn must not run without a body")
+				return nil
+			})
+
+			var err error
+			require.NotPanics(t, func() { err = h.Handle(t.Context(), tc.delivery) })
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrPayloadUndecodable)
+			assert.Equal(t, tc.want, err.Error())
+		})
+	}
+}
+
+func TestNewTypedHandlerEventType(t *testing.T) {
+	fn := func(_ context.Context, _ orderPayload) error { return nil }
+
+	assert.Equal(t, orderEventType, NewTypedHandler(orderEventType, fn).EventType())
+	assert.Equal(t, shipmentEventType, NewTypedHandler(shipmentEventType, fn).EventType())
+}
+
+// A nil fn would otherwise nil-panic on every delivery — recovered and nacked by
+// the worker loop, so the wiring bug would present as silent message loss.
+func TestNewTypedHandlerNilFuncPanics(t *testing.T) {
+	assert.PanicsWithValue(t,
+		"messaging: NewTypedHandler requires a non-nil handler function (event_type=OrderCreated)",
+		func() { NewTypedHandler[orderPayload](orderEventType, nil) })
+}
+
+func TestTypedHandlerUsesFrameworkValidator(t *testing.T) {
+	// OnceValue's caching is directly observable through pointer identity: two
+	// calls returning the same instance is the whole contract. What CANNOT be
+	// pinned here is a construction COUNT — validation.New is a plain function
+	// with no seam to count through, and the package-level var is already
+	// resolved by the time any test runs.
+	require.Same(t, typedValidator(), typedValidator())
+
+	// The instance is the framework's, not a bare validator.New(): an
+	// unregistered mcc_code tag makes validator panic instead of returning.
+	var calls atomic.Int64
+	h := NewTypedHandler(orderEventType, func(_ context.Context, _ mccPayload) error {
+		calls.Add(1)
+		return nil
+	})
+
+	var invalid error
+	require.NotPanics(t, func() {
+		invalid = h.Handle(t.Context(), &amqp.Delivery{Body: []byte(`{"mcc":"12"}`)})
+	})
+	assert.ErrorIs(t, invalid, ErrPayloadInvalid)
+
+	require.NoError(t, h.Handle(t.Context(), &amqp.Delivery{Body: []byte(`{"mcc":"5411"}`)}))
+	assert.Equal(t, int64(1), calls.Load())
+
+	// A second handler shares the same instance, which is what makes one adapter
+	// per consumer safe across tenants.
+	other := NewTypedHandler(shipmentEventType, func(_ context.Context, _ orderPayload) error { return nil })
+	require.NoError(t, other.Handle(t.Context(), &amqp.Delivery{Body: validBody(t)}))
+
+	// Sharing is not observable from Handle's own allocations — a per-HANDLER
+	// validator costs nothing per delivery, so the sibling per-delivery ceiling
+	// is blind to it. Construction is where it shows: validation.New registers
+	// the custom rules and builds a fresh metadata cache, ~200 allocs against a
+	// handler struct's handful.
+	avg := testing.AllocsPerRun(50, func() {
+		_ = NewTypedHandler(orderEventType, func(_ context.Context, _ orderPayload) error { return nil })
+	})
+	assert.Less(t, avg, 20.0, "a per-handler validator would push construction past 200")
+}
+
+// One adapter instance serves every worker of a consumer AND every tenant, so
+// the -race run here is the actual production shape. Assertions off the test
+// goroutine use t.Errorf: require.* calls runtime.Goexit, which is undefined
+// outside the test goroutine.
+func TestNewTypedHandlerConcurrentDeliveries(t *testing.T) {
+	const goroutines = 24
+
+	valid := validBody(t)
+	invalid := fmt.Appendf(nil, `{"reference":%q,"amount":1}`, payloadMarker)
+	garbage := []byte("not json " + payloadMarker)
+
+	var oks, decodeFails, validateFails atomic.Int64
+	h := NewTypedHandler(orderEventType, func(_ context.Context, p orderPayload) error {
+		if p.Reference != "abc" || p.Amount != 7 {
+			t.Errorf("fn saw a torn payload: %+v", p)
+		}
+		oks.Add(1)
+		return nil
+	})
+
+	ctx := t.Context()
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			switch i % 3 {
+			case 0:
+				if err := h.Handle(ctx, &amqp.Delivery{Body: valid}); err != nil {
+					t.Errorf("valid delivery failed: %v", err)
+				}
+			case 1:
+				err := h.Handle(ctx, &amqp.Delivery{Body: garbage})
+				if !errors.Is(err, ErrPayloadUndecodable) {
+					t.Errorf("garbage delivery: want ErrPayloadUndecodable, got %v", err)
+				}
+				if err != nil && strings.Contains(err.Error(), payloadMarker) {
+					t.Errorf("decode error leaked the payload marker: %v", err)
+				}
+				decodeFails.Add(1)
+			default:
+				err := h.Handle(ctx, &amqp.Delivery{Body: invalid})
+				if !errors.Is(err, ErrPayloadInvalid) {
+					t.Errorf("invalid delivery: want ErrPayloadInvalid, got %v", err)
+				}
+				if err != nil && strings.Contains(err.Error(), payloadMarker) {
+					t.Errorf("validation error leaked the payload marker: %v", err)
+				}
+				validateFails.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(goroutines/3), oks.Load())
+	assert.Equal(t, int64(goroutines/3), decodeFails.Load())
+	assert.Equal(t, int64(goroutines/3), validateFails.Load())
+}
+
+func TestDeclareTypedConsumerRegistersAdapter(t *testing.T) {
+	decls := NewDeclarations()
+	var got orderPayload
+	opts := &ConsumerOptions{Queue: testQueue, Consumer: testConsumer, EventType: orderEventType}
+
+	decl := DeclareTypedConsumer(decls, opts, func(_ context.Context, p orderPayload) error {
+		got = p
+		return nil
+	})
+
+	require.NotNil(t, decl)
+	assert.Same(t, opts.Handler, decl.Handler, "the declaration carries the adapter the options were given")
+
+	// Drive the REGISTERED declaration, not the returned one: RegisterConsumer
+	// copies the handler by reference, and that copy is what the worker calls.
+	registered := decls.Consumers()
+	require.Len(t, registered, 1)
+	require.NotNil(t, registered[0].Handler)
+	assert.Equal(t, orderEventType, registered[0].Handler.EventType())
+
+	require.NoError(t, registered[0].Handler.Handle(t.Context(), &amqp.Delivery{Body: validBody(t)}))
+	assert.Equal(t, orderPayload{Reference: "abc", Amount: 7}, got)
+
+	err := registered[0].Handler.Handle(t.Context(), &amqp.Delivery{Body: []byte("not json")})
+	assert.ErrorIs(t, err, ErrPayloadUndecodable)
+}
+
+func TestDeclareTypedConsumerAppliesConcurrencyDefaults(t *testing.T) {
+	fn := func(_ context.Context, _ orderPayload) error { return nil }
+
+	t.Run("auto_scaled", func(t *testing.T) {
+		decls := NewDeclarations()
+		opts := &ConsumerOptions{Queue: testQueue, Consumer: testConsumer, EventType: orderEventType}
+
+		decl := DeclareTypedConsumer(decls, opts, fn)
+
+		wantWorkers := min(runtime.NumCPU()*4, maxWorkersPerConsumer)
+		assert.Equal(t, wantWorkers, decl.Workers)
+		assert.Equal(t, min(wantWorkers*defaultPrefetchMultiplier, maxDefaultPrefetch), decl.PrefetchCount)
+		assert.Equal(t, decl.Workers, opts.Workers, "DeclareConsumer defaults opts in place")
+	})
+
+	t.Run("explicit_sequential", func(t *testing.T) {
+		decls := NewDeclarations()
+		opts := &ConsumerOptions{
+			Queue: testQueue, Consumer: testConsumer, EventType: orderEventType,
+			Workers: 1, PrefetchCount: 3,
+		}
+
+		decl := DeclareTypedConsumer(decls, opts, fn)
+
+		assert.Equal(t, 1, decl.Workers)
+		assert.Equal(t, 3, decl.PrefetchCount)
+	})
+}
+
+// The queue is the caller's to declare. Passing nil is the same pass-through an
+// untyped DeclareConsumer has, and a missing queue surfaces at Validate().
+func TestDeclareTypedConsumerLeavesQueueToTheCaller(t *testing.T) {
+	fn := func(_ context.Context, _ orderPayload) error { return nil }
+
+	decls := NewDeclarations()
+	DeclareTypedConsumer(decls, &ConsumerOptions{
+		Queue: missingQueue, Consumer: testConsumer, EventType: orderEventType,
+	}, fn)
+	assert.Empty(t, decls.Queues, "the helper declares no queue of its own")
+
+	err := decls.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "consumer references non-existent queue: "+missingQueue)
+
+	decls.DeclareQueue(missingQueue)
+	assert.NoError(t, decls.Validate())
+}
+
+func TestDeclareTypedConsumerPanicsOnWiringMistakes(t *testing.T) {
+	fn := func(_ context.Context, _ orderPayload) error { return nil }
+	opts := func() *ConsumerOptions {
+		return &ConsumerOptions{Queue: testQueue, Consumer: testConsumer, EventType: orderEventType}
+	}
+
+	assert.PanicsWithValue(t, "messaging: DeclareTypedConsumer requires a non-nil *Declarations",
+		func() { DeclareTypedConsumer(nil, opts(), fn) })
+
+	assert.PanicsWithValue(t, "messaging: DeclareTypedConsumer requires non-nil *ConsumerOptions",
+		func() { DeclareTypedConsumer[orderPayload](NewDeclarations(), nil, fn) })
+
+	// A hand-written handler already in opts means the caller wanted
+	// DeclareConsumer; silently replacing it would drop their handler.
+	taken := opts()
+	mine := &MockMessageHandler{eventType: orderEventType}
+	taken.Handler = mine
+	decls := NewDeclarations()
+
+	recovered := func() (msg any) {
+		defer func() { msg = recover() }()
+		DeclareTypedConsumer(decls, taken, fn)
+		return nil
+	}()
+
+	require.NotNil(t, recovered, "a pre-set Handler must panic")
+	assert.Contains(t, recovered, "ConsumerOptions.Handler must be nil")
+	assert.Contains(t, recovered, "queue="+testQueue)
+	assert.Same(t, mine, taken.Handler, "the caller's handler is not overwritten")
+	assert.Empty(t, decls.Consumers(), "nothing is registered when the guard fires")
+}
+
+func TestJSONCodecSummarize(t *testing.T) {
+	typeErr := &json.UnmarshalTypeError{
+		Value:  "number " + numericMarker,
+		Type:   reflect.TypeOf(int64(0)),
+		Offset: 18,
+		Struct: "orderPayload",
+		Field:  "amount",
+	}
+	syntaxOffset := int64(1)
+
+	tests := []struct {
+		name        string
+		err         error
+		want        string
+		notContains string
+	}{
+		{
+			name:        "unmarshal_type_error",
+			err:         typeErr,
+			want:        `json: type mismatch at field "amount" (want int64, offset 18)`,
+			notContains: numericMarker,
+		},
+		{
+			name:        "wrapped_unmarshal_type_error",
+			err:         fmt.Errorf("decode: %w", typeErr),
+			want:        `json: type mismatch at field "amount" (want int64, offset 18)`,
+			notContains: numericMarker,
+		},
+		{
+			name: "unmarshal_type_error_without_field",
+			err:  fieldlessTypeError(t),
+			want: "json: type mismatch (want messaging.orderPayload, offset 3)",
+		},
+		{
+			name: "unmarshal_type_error_without_type",
+			err:  &json.UnmarshalTypeError{Value: "object", Offset: 2},
+			want: "json: type mismatch (want unknown, offset 2)",
+		},
+		{
+			name: "syntax_error",
+			err:  syntaxError(t, syntaxOffset),
+			want: "json: syntax error at offset 1",
+		},
+		{
+			name: "wrapped_syntax_error",
+			err:  fmt.Errorf("decode: %w", syntaxError(t, syntaxOffset)),
+			want: "json: syntax error at offset 1",
+		},
+		{
+			name:        "unrelated_error_falls_back",
+			err:         errors.New("json: unknown field " + payloadMarker),
+			want:        "",
+			notContains: payloadMarker,
+		},
+		{
+			name: "nil_error_falls_back",
+			err:  nil,
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := jsonCodec{}.summarize(tc.err)
+			assert.Equal(t, tc.want, got)
+			if tc.notContains != "" {
+				assert.NotContains(t, got, tc.notContains)
+			}
+		})
+	}
+}
+
+// fieldlessTypeError produces a real *json.UnmarshalTypeError with an empty
+// Field: a bare scalar body never enters a struct field, so encoding/json has no
+// FieldStack to draw one from. Built from the decoder rather than by literal so
+// the Field == "" branch proves its own reachability.
+func fieldlessTypeError(t *testing.T) *json.UnmarshalTypeError {
+	t.Helper()
+
+	var payload orderPayload
+	err := json.Unmarshal([]byte("123"), &payload)
+
+	var typeErr *json.UnmarshalTypeError
+	require.ErrorAs(t, err, &typeErr)
+	require.Empty(t, typeErr.Field)
+
+	return typeErr
+}
+
+// syntaxError produces a real *json.SyntaxError; its msg field is unexported,
+// so it cannot be built by literal.
+func syntaxError(t *testing.T, wantOffset int64) *json.SyntaxError {
+	t.Helper()
+
+	var payload orderPayload
+	err := json.Unmarshal([]byte(`}`), &payload)
+
+	var syntaxErr *json.SyntaxError
+	require.ErrorAs(t, err, &syntaxErr)
+	require.Equal(t, wantOffset, syntaxErr.Offset)
+
+	return syntaxErr
+}

--- a/messaging/typed_consumer_test.go
+++ b/messaging/typed_consumer_test.go
@@ -345,14 +345,27 @@ func TestTypedHandlerUsesFrameworkValidator(t *testing.T) {
 // the -race run here is the actual production shape. Assertions off the test
 // goroutine use t.Errorf: require.* calls runtime.Goexit, which is undefined
 // outside the test goroutine.
+// assertDelivery drives one delivery and reports mismatches with t.Errorf, never
+// require.*: FailNow calls runtime.Goexit, which is undefined off the test
+// goroutine. A want of nil expects success.
+func assertDelivery(ctx context.Context, t *testing.T, h MessageHandler, kind string, body []byte, want error) {
+	t.Helper()
+
+	err := h.Handle(ctx, &amqp.Delivery{Body: body})
+	switch {
+	case want == nil && err != nil:
+		t.Errorf("%s delivery failed: %v", kind, err)
+	case want != nil && !errors.Is(err, want):
+		t.Errorf("%s delivery: want %v, got %v", kind, want, err)
+	case err != nil && strings.Contains(err.Error(), payloadMarker):
+		t.Errorf("%s error leaked the payload marker: %v", kind, err)
+	}
+}
+
 func TestNewTypedHandlerConcurrentDeliveries(t *testing.T) {
 	const goroutines = 24
 
-	valid := validBody(t)
-	invalid := fmt.Appendf(nil, `{"reference":%q,"amount":1}`, payloadMarker)
-	garbage := []byte("not json " + payloadMarker)
-
-	var oks, decodeFails, validateFails atomic.Int64
+	var oks atomic.Int64
 	h := NewTypedHandler(orderEventType, func(_ context.Context, p orderPayload) error {
 		if p.Reference != "abc" || p.Amount != 7 {
 			t.Errorf("fn saw a torn payload: %+v", p)
@@ -361,43 +374,36 @@ func TestNewTypedHandlerConcurrentDeliveries(t *testing.T) {
 		return nil
 	})
 
+	kinds := []struct {
+		name string
+		body []byte
+		want error
+	}{
+		{name: "valid", body: validBody(t)},
+		{name: "garbage", body: []byte("not json " + payloadMarker), want: ErrPayloadUndecodable},
+		{name: "invalid", body: fmt.Appendf(nil, `{"reference":%q,"amount":1}`, payloadMarker), want: ErrPayloadInvalid},
+	}
+	var handled [3]atomic.Int64
+
 	ctx := t.Context()
 	var wg sync.WaitGroup
 	for i := range goroutines {
+		slot := i % len(kinds)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			switch i % 3 {
-			case 0:
-				if err := h.Handle(ctx, &amqp.Delivery{Body: valid}); err != nil {
-					t.Errorf("valid delivery failed: %v", err)
-				}
-			case 1:
-				err := h.Handle(ctx, &amqp.Delivery{Body: garbage})
-				if !errors.Is(err, ErrPayloadUndecodable) {
-					t.Errorf("garbage delivery: want ErrPayloadUndecodable, got %v", err)
-				}
-				if err != nil && strings.Contains(err.Error(), payloadMarker) {
-					t.Errorf("decode error leaked the payload marker: %v", err)
-				}
-				decodeFails.Add(1)
-			default:
-				err := h.Handle(ctx, &amqp.Delivery{Body: invalid})
-				if !errors.Is(err, ErrPayloadInvalid) {
-					t.Errorf("invalid delivery: want ErrPayloadInvalid, got %v", err)
-				}
-				if err != nil && strings.Contains(err.Error(), payloadMarker) {
-					t.Errorf("validation error leaked the payload marker: %v", err)
-				}
-				validateFails.Add(1)
-			}
+			assertDelivery(ctx, t, h, kinds[slot].name, kinds[slot].body, kinds[slot].want)
+			handled[slot].Add(1)
 		}()
 	}
 	wg.Wait()
 
-	assert.Equal(t, int64(goroutines/3), oks.Load())
-	assert.Equal(t, int64(goroutines/3), decodeFails.Load())
-	assert.Equal(t, int64(goroutines/3), validateFails.Load())
+	for i, k := range kinds {
+		assert.Equal(t, int64(goroutines/len(kinds)), handled[i].Load(), "%s deliveries handled", k.name)
+	}
+	// Counted inside fn, so it also proves fn ran for every successful delivery
+	// rather than the adapter short-circuiting.
+	assert.Equal(t, int64(goroutines/len(kinds)), oks.Load())
 }
 
 func TestDeclareTypedConsumerRegistersAdapter(t *testing.T) {

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -85,6 +85,53 @@ func (m *Module) DeclareMessaging(decls *messaging.Declarations) {
 
 See the Troubleshooting section in [CLAUDE.md](../CLAUDE.md) for diagnosing duplicate consumer/module errors.
 
+## Typed Consumers
+
+`DeclareTypedConsumer` is the consumer mirror of `server.POST(hr, r, path, handler)`: it binds the message body to a struct, validates it against the same `validate` tags HTTP handlers use, and calls your function — so `json.Unmarshal`, the validation call, and the two error branches stop being copy-pasted into every `Handle`.
+
+```go
+type OrderCreated struct {
+    OrderID  int64  `json:"orderId"  validate:"required"`
+    Currency string `json:"currency" validate:"required,len=3"`
+}
+
+func (m *Module) DeclareMessaging(decls *messaging.Declarations) {
+    exchange := decls.DeclareTopicExchange("orders.events")
+    queue := decls.DeclareQueueWithDLQ("orders.events.queue", nil)
+    decls.DeclareBinding(queue.Name, exchange.Name, "orders.*")
+
+    messaging.DeclareTypedConsumer(decls, &messaging.ConsumerOptions{
+        Queue:     queue.Name,
+        Consumer:  "order-processor",
+        EventType: "OrderCreated",
+    }, m.svc.HandleOrderCreated) // func(context.Context, OrderCreated) error
+}
+```
+
+`T` is inferred from the function, so it is never spelled out. `ConsumerOptions.Handler` must be nil — the helper builds the handler and panics at declaration time if one is already set (use `DeclareConsumer` for a hand-written `MessageHandler`). The queue argument is deliberately absent: declare the queue yourself, exactly as an untyped `DeclareConsumer(opts, nil)` does. A consumer naming a queue nobody declared surfaces at `Declarations.Validate()` as `consumer references non-existent queue`, not at the call site.
+
+`messaging.NewTypedHandler[T](eventType, fn)` builds the same adapter without registering anything, for a hand-assembled `ConsumerOptions`.
+
+**Failure semantics.** Decode and validation failures return a `*messaging.PayloadError` before `fn` runs, and the worker loop nacks it WITHOUT requeue like any other handler error — which is right, since neither failure gets better on redelivery. Pair the queue with `DeclareQueueWithDLQ` so those messages park instead of being dropped. Discriminate the two with `errors.Is`:
+
+```go
+if errors.Is(err, messaging.ErrPayloadUndecodable) { /* malformed body */ }
+if errors.Is(err, messaging.ErrPayloadInvalid)     { /* decoded, failed validation */ }
+```
+
+`fn`'s own error is returned **unwrapped**, so `errors.Is(err, ErrAlreadyProcessed)` against your own sentinels keeps working and never collides with the two above.
+
+**No payload bytes in the error — and where that guarantee ends.** AMQP bodies carry partner PII/PCI, so `PayloadError.Error()` is composed from schema facts only: the event type, the stage, and the failing field namespaces. `Fields()` redacts every bracketed span (`Limits[4111111111111111]` → `Limits[*]`), because go-playground interpolates map keys verbatim. Both are safe to log. `Unwrap()` is **not** — it returns the raw decoder or validator error, which may quote a rejected literal, an offending byte, an unknown key, or a map key. It is the deliberate escape hatch; logging it is opt-in and on you.
+
+```
+messaging: decode failed for event "OrderCreated": json: type mismatch at field "orderId" (want int64, offset 15)
+messaging: validate failed for event "OrderCreated" (fields: OrderCreated.Currency)
+```
+
+**Concurrency.** One adapter instance serves every worker of the consumer and every tenant replaying the declarations. It holds no mutable state and allocates a fresh payload per delivery, so the concurrency rules below apply unchanged: the default is `NumCPU * 4` workers, and `Workers: 1` still buys sequential processing when ordering matters. Your `fn` must be safe for concurrent use.
+
+**Non-struct `T`** (`[]int`, `map[string]int`, a bare scalar) fails closed on the first delivery with `ErrPayloadInvalid` and no field list — go-playground validates structs only, and skipping validation silently would be worse.
+
 ## Message Error Handling
 
 **IMPORTANT:** GoBricks uses a **no-retry policy** for failed messages to prevent infinite retry loops.

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -123,7 +123,7 @@ if errors.Is(err, messaging.ErrPayloadInvalid)     { /* decoded, failed validati
 
 **No payload bytes in the error — and where that guarantee ends.** AMQP bodies carry partner PII/PCI, so `PayloadError.Error()` is composed from schema facts only: the event type, the stage, and the failing field namespaces. `Fields()` redacts every bracketed span (`Limits[4111111111111111]` → `Limits[*]`), because go-playground interpolates map keys verbatim. Both are safe to log. `Unwrap()` is **not** — it returns the raw decoder or validator error, which may quote a rejected literal, an offending byte, an unknown key, or a map key. It is the deliberate escape hatch; logging it is opt-in and on you.
 
-```
+```text
 messaging: decode failed for event "OrderCreated": json: type mismatch at field "orderId" (want int64, offset 15)
 messaging: validate failed for event "OrderCreated" (fields: OrderCreated.Currency)
 ```

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -128,6 +128,8 @@ messaging: decode failed for event "OrderCreated": json: type mismatch at field 
 messaging: validate failed for event "OrderCreated" (fields: OrderCreated.Currency)
 ```
 
+**Delivery headers are not exposed (yet).** `fn` receives the decoded payload and nothing else, so a typed consumer cannot read `x-outbox-event-id` and wrap its body in `inbox.ProcessOnce`. Outbox delivery is at-least-once, so a consumer fed by the outbox relay still needs that dedup — use the untyped `DeclareConsumer` for those until [#852](https://github.com/gaborage/go-bricks/issues/852) lands.
+
 **Concurrency.** One adapter instance serves every worker of the consumer and every tenant replaying the declarations. It holds no mutable state and allocates a fresh payload per delivery, so the concurrency rules below apply unchanged: the default is `NumCPU * 4` workers, and `Workers: 1` still buys sequential processing when ordering matters. Your `fn` must be safe for concurrent use.
 
 **Non-struct `T`** (`[]int`, `map[string]int`, a bare scalar) fails closed on the first delivery with `ErrPayloadInvalid` and no field list — go-playground validates structs only, and skipping validation silently would be worse.


### PR DESCRIPTION
## What

An AMQP consumer author hand-wrote `json.Unmarshal`, validation, and error branching inside every `Handle`. `messaging.DeclareTypedConsumer(decls, opts, fn)` now binds the body to `T`, validates it against the same `validate` tags HTTP handlers use, and calls `fn` — `T` inferred, never spelled out. Decode and validation failures return a `*PayloadError` onto the existing nack-without-requeue path; `fn`'s own error passes through unwrapped. Decode rendering moves onto an unexported codec seam, so a non-JSON codec (#346) gets a compiler prompt instead of silently inheriting the fail-closed phrase.

Closes #777

## Impact

Additive, adopt-only. Existing `MessageHandler` implementors compile untouched; no migrations atom.

## Verification

One adapter serves every worker and every tenant, so tests pin a fresh payload per delivery (a mutex-guarded shared one is race-free and would otherwise pass), that the caller's context reaches `fn`, and via allocation ceilings that the validator is built once.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed AMQP consumers with automatic JSON decoding, validation, and typed handler callbacks.
  * Added classified handling for invalid or undecodable message payloads, with sanitized error messages.
  * Added support for configurable concurrency and caller-managed queues.

* **Documentation**
  * Added typed consumer usage guidance, API references, error behavior, and validation examples.
  * Updated event examples with validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->