### PR TITLE
fix(server): check JOSE content type before reading the request body

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -3665,8 +3665,9 @@ func (m *Module) exchange(req ExchangeRequest, ctx server.HandlerContext) (Excha
 
 | Failure | HTTP | Error code | Trust state | Response Content-Type |
 |---|---|---|---|---|
-| Body required / empty | 400 | `JOSE_BODY_REQUIRED` | pre-trust | `application/json` (plaintext envelope) |
-| Wrong Content-Type (not `application/jose`) | 415 | `JOSE_PLAINTEXT_REJECTED` | pre-trust | `application/json` |
+| Wrong Content-Type (not `application/jose`) | 415 | `JOSE_PLAINTEXT_REJECTED` | pre-trust | `application/json` (plaintext envelope) |
+| Body over the 10 MiB JOSE cap, or an unknown-length body overflowing a lower `server.bodylimit` mid-stream | 413 | `JOSE_BODY_TOO_LARGE` | pre-trust | `application/json` |
+| Body required / empty | 400 | `JOSE_BODY_REQUIRED` | pre-trust | `application/json` |
 | Compact JWE parse failure | 400 | `JOSE_MALFORMED` | pre-trust | `application/json` |
 | `enc`/`alg` not in allowlist | 400 | `JOSE_ALGORITHM_DISALLOWED` | pre-trust | `application/json` |
 | `alg=none` (downgrade) | 400 | `JOSE_ALGORITHM_DISALLOWED` | pre-trust | `application/json` |

--- a/server/jose.go
+++ b/server/jose.go
@@ -22,6 +22,27 @@ import (
 	"github.com/labstack/echo/v5"
 )
 
+// maxJOSERequestBytes caps the inbound JOSE body read. It mirrors the value of
+// httpclient.DefaultMaxJOSEBodyBytes (httpclient/jose_transport.go) by convention only —
+// that one is per-transport overridable, this one is a hard ceiling — so if either moves,
+// move both. Peak cost per in-flight request is several times this — io.ReadAll's growth
+// churn plus the string copy jose.Open requires measured ~32 MiB at the cap, and more
+// again once a well-formed JWE is actually opened — and nothing bounds JOSE-route
+// concurrency, so size pods off that figure. Equal to config.DefaultBodyLimitBytes
+// today, which is why an oversize body yields this package's 413 only when its length is
+// unknown; a declared Content-Length over server.bodylimit is rejected upstream. The cap
+// still holds when an operator raises server.bodylimit for an upload route.
+const maxJOSERequestBytes = 10 << 20
+
+// Pre-trust rejection codes, emitted before any crypto runs. Constants so the wire
+// strings cannot drift between rejection sites; the tests assert the literals instead,
+// so changing a value fails there rather than silently agreeing with itself.
+const (
+	errCodeJOSEPlaintextRejected = "JOSE_PLAINTEXT_REJECTED"
+	errCodeJOSEBodyRequired      = "JOSE_BODY_REQUIRED"
+	errCodeJOSEBodyTooLarge      = "JOSE_BODY_TOO_LARGE"
+)
+
 // joseObservability bundles the optional logger / tracer / meter so they thread cleanly
 // through wrap() into joseDecodeRequestWithObs and joseHandleResponseWithObs without bloating
 // those signatures or the HandlerRegistry struct.
@@ -249,8 +270,9 @@ func panicJOSERegistration(d *RouteDescriptor, msg string, cause error) {
 	panic("server: jose registration failed for " + pathInfo + ": " + msg)
 }
 
-// joseDecodeRequestWithObs reads the raw HTTP body, validates its Content-Type, decrypts the
-// JWE, verifies the inner JWS, and replaces c.Request().Body with the verified plaintext.
+// joseDecodeRequestWithObs validates the request Content-Type, reads the raw HTTP body
+// (capped at maxJOSERequestBytes), decrypts the JWE, verifies the inner JWS, and replaces
+// c.Request().Body with the verified plaintext.
 // Wrapped in an OTEL span so operators can isolate JOSE inbound time from total request time.
 //
 // On success: marks the context inbound-verified and stashes the verified Claims.
@@ -277,16 +299,32 @@ func joseDecodeRequestWithObs(c *echo.Context, p *jose.Policy, r jose.KeyResolve
 // joseDecodeRequestInner is the span-free implementation, kept separate so the
 // span/timing wrapper above stays readable.
 func joseDecodeRequestInner(c *echo.Context, p *jose.Policy, r jose.KeyResolver) IAPIError {
-	body, err := io.ReadAll(c.Request().Body)
-	if err != nil {
-		return &joseAPIError{code: "JOSE_BODY_REQUIRED", message: "Failed to read request body", status: http.StatusBadRequest}
-	}
-	if len(bytes.TrimSpace(body)) == 0 {
-		return &joseAPIError{code: "JOSE_BODY_REQUIRED", message: "Request body required", status: http.StatusBadRequest}
+	// Header compare precedes the body read so rejecting an unauthenticated request on the
+	// wrong content type costs a short string compare instead of a full body read.
+	if !jose.IsContentType(c.Request().Header.Get(echo.HeaderContentType)) {
+		return &joseAPIError{code: errCodeJOSEPlaintextRejected, message: "Request must be application/jose", status: http.StatusUnsupportedMediaType}
 	}
 
-	if !jose.IsContentType(c.Request().Header.Get(echo.HeaderContentType)) {
-		return &joseAPIError{code: "JOSE_PLAINTEXT_REJECTED", message: "Request must be application/jose", status: http.StatusUnsupportedMediaType}
+	// A declared length over the cap is rejected without reading a byte, so the minimal
+	// pre-trust envelope is what an oversize peer sees whenever server.bodylimit has been
+	// raised above the cap. An unknown-length body has no length to check and is caught
+	// mid-read below instead.
+	if c.Request().ContentLength > maxJOSERequestBytes {
+		return &joseAPIError{code: errCodeJOSEBodyTooLarge, message: "Request body exceeds the JOSE size limit", status: http.StatusRequestEntityTooLarge}
+	}
+
+	// The nil ResponseWriter is deliberate: MaxBytesReader's connection-close signal is
+	// gated on an unexported net/http method that echo's Response wrapper cannot satisfy,
+	// so passing c.Response() would buy nothing. net/http still closes the connection.
+	body, err := io.ReadAll(http.MaxBytesReader(nil, c.Request().Body, maxJOSERequestBytes))
+	if err != nil {
+		if isRequestTooLarge(err) {
+			return &joseAPIError{code: errCodeJOSEBodyTooLarge, message: "Request body exceeds the JOSE size limit", status: http.StatusRequestEntityTooLarge}
+		}
+		return &joseAPIError{code: errCodeJOSEBodyRequired, message: "Failed to read request body", status: http.StatusBadRequest}
+	}
+	if len(bytes.TrimSpace(body)) == 0 {
+		return &joseAPIError{code: errCodeJOSEBodyRequired, message: "Request body required", status: http.StatusBadRequest}
 	}
 
 	plaintext, claims, _, err := jose.Open(string(body), p, r)
@@ -302,6 +340,17 @@ func joseDecodeRequestInner(c *echo.Context, p *jose.Policy, r jose.KeyResolver)
 	ctx = jose.WithClaims(ctx, claims)
 	c.SetRequest(c.Request().WithContext(ctx))
 	return nil
+}
+
+// isRequestTooLarge distinguishes a size-cap read failure from a genuine transport error.
+// Two caps can fire: maxJOSERequestBytes above (*http.MaxBytesError) and a body-limit
+// middleware, whose reader errors mid-stream once server.bodylimit is passed on an
+// unknown-length body. Both mean 413, not a bad request. The second arm matches on the
+// status echo reports rather than on echo's ErrStatusRequestEntityTooLarge sentinel, so a
+// replacement middleware returning any 413-coded echo error is classified the same way.
+func isRequestTooLarge(err error) bool {
+	var tooLarge *http.MaxBytesError
+	return errors.As(err, &tooLarge) || echo.StatusCode(err) == http.StatusRequestEntityTooLarge
 }
 
 // joseHandleResponseWithObs wraps joseHandleResponse with an OTEL span and records

--- a/server/jose_test.go
+++ b/server/jose_test.go
@@ -5,12 +5,16 @@ import (
 	"context"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"testing/iotest"
 
 	"github.com/labstack/echo/v5"
+	"github.com/labstack/echo/v5/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -143,22 +147,13 @@ func TestJOSETamperedCiphertextReturnsPlaintextError(t *testing.T) {
 	// minimal error envelope. If this test ever observes Content-Type: application/jose
 	// on the failure path, it is a security regression.
 	f := newJOSEFixture(t)
-	e, h := newJOSETestServer(t, f, func(_ joseTokenReq, _ HandlerContext) (joseTokenResp, IAPIError) {
-		t.Fatal("handler must not be invoked when inbound decryption fails")
-		return joseTokenResp{}, nil
-	})
 
 	plainReq := []byte(`{"pan":"4111111111111111"}`)
 	compactReq := jositest.SealForTest(t, plainReq, f.peerOutbound(), f.resolver)
 	tampered := []byte(compactReq)
 	tampered[len(tampered)/2] ^= 0x01
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/tokens", bytes.NewReader(tampered))
-	req.Header.Set(echo.HeaderContentType, "application/jose")
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-
-	require.NoError(t, h(c))
+	rec, body := driveJOSEInbound(t, f, jose.ContentType, bytes.NewReader(tampered), 0, nil)
 
 	// Security invariant assertion #1: response is plaintext JSON, not JOSE.
 	assert.NotEqual(t, "application/jose", rec.Header().Get(echo.HeaderContentType),
@@ -167,8 +162,6 @@ func TestJOSETamperedCiphertextReturnsPlaintextError(t *testing.T) {
 		"tampered request should produce application/json response, got %q", rec.Header().Get(echo.HeaderContentType))
 
 	// Security invariant assertion #2: minimal envelope (no traceId, timestamp, or framework metadata).
-	var body map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	assert.Contains(t, body, "code")
 	assert.Contains(t, body, "message")
 	assert.NotContains(t, body, "data", "minimal envelope must not include data")
@@ -177,26 +170,6 @@ func TestJOSETamperedCiphertextReturnsPlaintextError(t *testing.T) {
 
 	// Status: 4xx (decrypt-failed = 401, malformed = 400 are both acceptable depending on which segment was tampered).
 	assert.Contains(t, []int{http.StatusBadRequest, http.StatusUnauthorized}, rec.Code)
-}
-
-func TestJOSEPlaintextRequestRejectedWith415(t *testing.T) {
-	f := newJOSEFixture(t)
-	e, h := newJOSETestServer(t, f, func(_ joseTokenReq, _ HandlerContext) (joseTokenResp, IAPIError) {
-		t.Fatal("handler must not be invoked when content-type is wrong")
-		return joseTokenResp{}, nil
-	})
-
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/tokens", bytes.NewReader([]byte(`{"pan":"4111111111111111"}`)))
-	req.Header.Set(echo.HeaderContentType, "application/json") // wrong on a JOSE route
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-
-	require.NoError(t, h(c))
-	assert.Equal(t, http.StatusUnsupportedMediaType, rec.Code)
-
-	var body map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
-	assert.Equal(t, "JOSE_PLAINTEXT_REJECTED", body["code"])
 }
 
 func TestJOSEPostTrustErrorIsEncrypted(t *testing.T) {
@@ -488,4 +461,148 @@ func TestNonJOSERouteUnaffectedByResolver(t *testing.T) {
 	require.NotPanics(t, func() {
 		RegisterHandler[plainReq, plainResp](hr, fakeRegistrar{}, http.MethodPost, "/greet", handler)
 	})
+}
+
+// driveJOSEInbound runs the JOSE inbound path with an arbitrary body reader, optionally
+// behind one middleware, and returns the recorder plus the decoded minimal error envelope.
+// A non-zero contentLength overrides whatever httptest infers from the reader, which is
+// how the declared-length rejection is reached without supplying a body that large.
+// Every caller exercises a pre-trust failure, so the handler must never run.
+func driveJOSEInbound(t *testing.T, f *joseFixture, contentType string, body io.Reader, contentLength int64, mw echo.MiddlewareFunc) (rec *httptest.ResponseRecorder, envelope map[string]any) {
+	t.Helper()
+	e, h := newJOSETestServer(t, f, func(_ joseTokenReq, _ HandlerContext) (joseTokenResp, IAPIError) {
+		t.Error("handler must not be invoked on a pre-trust failure")
+		return joseTokenResp{}, nil
+	})
+	if mw != nil {
+		h = mw(h)
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/tokens", body)
+	req.Header.Set(echo.HeaderContentType, contentType)
+	if contentLength != 0 {
+		req.ContentLength = contentLength
+	}
+	rec = httptest.NewRecorder()
+	require.NoError(t, h(e.NewContext(req, rec)))
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &envelope))
+	return rec, envelope
+}
+
+// unreadableBody fails the test if anything reads it, so the cases below observe "the body
+// was not touched" directly instead of inferring it from a swallowed read error.
+type unreadableBody struct{ t *testing.T }
+
+func (b unreadableBody) Read([]byte) (int, error) {
+	b.t.Error("request body must not be read on a header-only rejection path")
+	return 0, io.EOF
+}
+
+// TestJOSEInboundPreTrustFailures is the decision table wiki/jose.md documents: every
+// pre-trust rejection is a (Content-Type, body, middleware) -> (status, code) row. The
+// bodies are built per-subtest so the two 10 MiB buffers are never live at once.
+func TestJOSEInboundPreTrustFailures(t *testing.T) {
+	f := newJOSEFixture(t)
+
+	tests := []struct {
+		name        string
+		contentType string
+		body        func(t *testing.T) io.Reader
+		length      int64
+		mw          echo.MiddlewareFunc
+		wantStatus  int
+		wantCode    string
+	}{
+		{
+			name:        "plaintext_content_type",
+			contentType: echo.MIMEApplicationJSON,
+			body:        func(*testing.T) io.Reader { return bytes.NewReader([]byte(`{"pan":"4111111111111111"}`)) },
+			wantStatus:  http.StatusUnsupportedMediaType,
+			wantCode:    "JOSE_PLAINTEXT_REJECTED",
+		},
+		{
+			// Ordering pin: the reader fails the test on any Read, so the untouched body is
+			// observed rather than inferred from the status.
+			name:        "wrong_content_type_body_never_read",
+			contentType: echo.MIMEApplicationJSON,
+			body:        func(t *testing.T) io.Reader { return unreadableBody{t: t} },
+			wantStatus:  http.StatusUnsupportedMediaType,
+			wantCode:    "JOSE_PLAINTEXT_REJECTED",
+		},
+		{
+			// Both failure conditions at once: the Content-Type wins, so this is 415 rather
+			// than the 400 an empty body alone produces. This is the documented change.
+			name:        "wrong_content_type_with_empty_body",
+			contentType: echo.MIMEApplicationJSON,
+			body:        func(*testing.T) io.Reader { return bytes.NewReader(nil) },
+			wantStatus:  http.StatusUnsupportedMediaType,
+			wantCode:    "JOSE_PLAINTEXT_REJECTED",
+		},
+		{
+			name:        "body_read_error",
+			contentType: jose.ContentType,
+			body:        func(*testing.T) io.Reader { return io.NopCloser(iotest.ErrReader(errors.New("boom"))) },
+			wantStatus:  http.StatusBadRequest,
+			wantCode:    "JOSE_BODY_REQUIRED",
+		},
+		{
+			name:        "empty_body",
+			contentType: jose.ContentType,
+			body:        func(*testing.T) io.Reader { return bytes.NewReader(nil) },
+			wantStatus:  http.StatusBadRequest,
+			wantCode:    "JOSE_BODY_REQUIRED",
+		},
+		{
+			name:        "oversize_body",
+			contentType: jose.ContentType,
+			body: func(*testing.T) io.Reader {
+				return bytes.NewReader(bytes.Repeat([]byte("a"), maxJOSERequestBytes+1))
+			},
+			wantStatus: http.StatusRequestEntityTooLarge,
+			wantCode:   "JOSE_BODY_TOO_LARGE",
+		},
+		{
+			// Declared-length pin: over the cap by Content-Length alone, so it must be
+			// rejected before the reader is ever touched.
+			name:        "declared_length_over_cap_not_read",
+			contentType: jose.ContentType,
+			body:        func(t *testing.T) io.Reader { return unreadableBody{t: t} },
+			length:      maxJOSERequestBytes + 1,
+			wantStatus:  http.StatusRequestEntityTooLarge,
+			wantCode:    "JOSE_BODY_TOO_LARGE",
+		},
+		{
+			// A body-limit middleware errors mid-stream on an unknown-length body over
+			// server.bodylimit, reaching the JOSE path as a read error. Still 413, not the
+			// generic read-failure 400.
+			name:        "body_limit_middleware_overflow",
+			contentType: jose.ContentType,
+			body: func(*testing.T) io.Reader {
+				return io.NopCloser(bytes.NewReader(bytes.Repeat([]byte("a"), 4096))) // NopCloser ⇒ ContentLength -1
+			},
+			mw:         middleware.BodyLimit(1024),
+			wantStatus: http.StatusRequestEntityTooLarge,
+			wantCode:   "JOSE_BODY_TOO_LARGE",
+		},
+		{
+			// Off-by-one pin: exactly the limit must reach jose.Open and fail there, not at 413.
+			name:        "body_at_size_limit_reaches_open",
+			contentType: jose.ContentType,
+			body: func(*testing.T) io.Reader {
+				return bytes.NewReader(bytes.Repeat([]byte("a"), maxJOSERequestBytes))
+			},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "JOSE_MALFORMED",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec, envelope := driveJOSEInbound(t, f, tc.contentType, tc.body(t), tc.length, tc.mw)
+
+			assert.Equal(t, tc.wantStatus, rec.Code)
+			assert.Equal(t, tc.wantCode, envelope["code"])
+		})
+	}
 }

--- a/wiki/jose.md
+++ b/wiki/jose.md
@@ -59,12 +59,13 @@ for _, m := range []app.Module{
 }
 ```
 
-**Failure mode → IAPIError mapping (every code surfaces on the wire):**
+**Failure mode → IAPIError mapping (every code surfaces on the wire).** The rows are listed in evaluation order: the Content-Type is checked before the body is read, so a wrong-Content-Type request is rejected with 415 without its body being consumed. The cap on the read that follows is hard: it holds even when `server.bodylimit` is raised above it. A request whose `Content-Length` exceeds `server.bodylimit` is rejected by echo's `BodyLimit` middleware before the JOSE path runs, and that rejection carries the framework's **standard** error envelope rather than the minimal pre-trust one. The two limits are equal by default, so it is raising `server.bodylimit` above the JOSE cap that puts oversize rejections back on the minimal-envelope path.
 
 | Failure | Status | Code |
 |---|---|---|
-| Body required / empty | 400 | `JOSE_BODY_REQUIRED` |
 | Wrong Content-Type (not `application/jose`) | 415 | `JOSE_PLAINTEXT_REJECTED` |
+| Body over the 10 MiB JOSE cap, or an unknown-length body overflowing a lower `server.bodylimit` mid-stream | 413 | `JOSE_BODY_TOO_LARGE` |
+| Body required / empty | 400 | `JOSE_BODY_REQUIRED` |
 | Compact JWE parse failure | 400 | `JOSE_MALFORMED` |
 | `enc`/`alg` not allowed on the wire | 400 | `JOSE_MALFORMED` |
 | `alg=none` (downgrade attempt) | 400 | `JOSE_MALFORMED` (rejected by allowlist parse) |


### PR DESCRIPTION
## What

On a JOSE-protected route, `joseDecodeRequestInner` read the whole request body before checking the Content-Type, so a fully unauthenticated request paid for a heap read bounded only by `server.bodylimit` before the cheapest possible rejection — a header compare — could run. The prologue is now content-type check, then a capped read, then the emptiness check. The read is capped at 10 MiB via `http.MaxBytesReader`, and an oversize body gets a new `JOSE_BODY_TOO_LARGE` / 413 instead of a misleading read-failure 400; a declared `Content-Length` over the cap is rejected without touching the reader.

## Impact

A request carrying **both** a wrong Content-Type and an empty or unreadable body now returns `415 JOSE_PLAINTEXT_REJECTED` where it previously returned `400 JOSE_BODY_REQUIRED`. Every other code and status is unchanged, and the new 413 emits the same minimal pre-trust plaintext envelope as its siblings. Note the 413 is only reachable when `server.bodylimit` is at or above the JOSE cap — the two are equal by default, and below the global limit echo's `BodyLimit` middleware answers first with the framework's standard envelope; `wiki/jose.md` now states that gap.

## Verification

`make mutate` was **not** run (stopped for thermal reasons) — the only unrun gate. In its place, each half was checked by hand: reverting the reorder fails exactly the four table rows that pin it, removing the declared-length check fails exactly one, and each arm of `isRequestTooLarge` is killed by exactly one row. Two CodeRabbit findings are skipped with rationale in the commit body — a JOSE-route concurrency budget is a separate feature, and passing a `ResponseWriter` to `MaxBytesReader` cannot work because `requestTooLarge()` is unexported on net/http's own response type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a 10 MiB maximum size for JOSE request bodies.
  * Added clear rejection responses for oversized requests, invalid content types, and missing bodies.
  * Added consistent handling for streamed and declared body-size limits.

* **Bug Fixes**
  * Content-Type is now validated before request bodies are read.
  * Oversized requests are rejected reliably, including boundary and middleware cases.

* **Documentation**
  * Updated JOSE failure mappings and documented validation order and size-limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->