### PR TITLE
fix(cache): fail closed on zero-value CacheManager instead of panicking

### DIFF
--- a/cache/errors.go
+++ b/cache/errors.go
@@ -24,8 +24,9 @@ var (
 	// ErrInvalidTTL is returned when a TTL value is invalid (e.g., negative).
 	ErrInvalidTTL = errors.New("cache: invalid TTL")
 
-	// ErrManagerClosed is returned by CacheManager operations (Get, Remove)
-	// after Close() has been called. Callers can errors.Is(err, ErrManagerClosed)
+	// ErrManagerClosed is returned by CacheManager operations (Get, Remove) after
+	// Close() has been called, or from a zero-value CacheManager that was never built
+	// via NewCacheManager. Callers can use errors.Is(err, ErrManagerClosed)
 	// to distinguish "manager is gone" from per-cache failures and decide
 	// whether to abort or fall back to a non-cache path.
 	ErrManagerClosed = errors.New("cache: manager closed")

--- a/cache/manager.go
+++ b/cache/manager.go
@@ -40,9 +40,18 @@ type Connector func(ctx context.Context, key string) (Cache, error)
 // See ADR-032.
 type ReleaseFunc func()
 
-// CacheManager implements the Manager interface for multi-tenant cache instances. It is a thin
-// adapter over internal/resourcepool.Pool, which owns the ADR-032 lease/evict/close protocol
-// (seed leases, LRU eviction, idle cleanup, and the closed-pool guard).
+// CacheManager manages per-tenant cache instances. It is a thin adapter over
+// internal/resourcepool.Pool, which owns the ADR-032 lease/evict/close protocol (seed leases,
+// LRU eviction, idle cleanup, and the closed-pool guard).
+//
+// The zero value is safe to call but unusable: rather than dereferencing the nil pool, Get
+// and Remove return ErrManagerClosed, Close reports success (there is nothing to close), and
+// Stats returns empty statistics — matching database.DbManager and messaging.Manager. That is
+// a panic guard, not a test fixture: a zero-value manager serves nothing, so a test built on
+// one only ever exercises the caller's no-cache branch. Construct a real manager over
+// cache/testing's MockCache to exercise cache behavior. The guard covers a zero-value manager
+// only — a nil *CacheManager still panics, so a caller holding one from a failed construction
+// must nil-check it.
 //
 //nolint:revive // CacheManager is intentional - Manager is the interface name
 type CacheManager struct {
@@ -104,10 +113,16 @@ func NewCacheManager(cfg ManagerConfig, connector Connector) (*CacheManager, err
 
 // Get retrieves or creates a cache instance for the given key, plus a ReleaseFunc the
 // caller must invoke when finished with it for the current unit of work (typically
-// deferred). Returns ErrManagerClosed if Close() has been called. The lease prevents a
-// cache instance evicted while in use from being closed under an active caller (the #606
-// race). On error the returned ReleaseFunc is nil — check err first.
+// deferred). Returns ErrManagerClosed if Close() has been called, or if the manager is a
+// zero value that was never built via NewCacheManager. The lease prevents a cache instance
+// evicted while in use from being closed under an active caller (the #606 race). On error
+// the returned ReleaseFunc is nil — check err first.
 func (m *CacheManager) Get(ctx context.Context, key string) (Cache, ReleaseFunc, error) {
+	if m.pool == nil {
+		// Zero-value manager (never built via NewCacheManager): unusable, fail closed rather
+		// than panic — consistent with the Remove()/Close()/Stats() zero-value guards.
+		return nil, nil, ErrManagerClosed
+	}
 	value, release, err := m.pool.GetOrCreate(ctx, key, func(ctx context.Context) (Cache, error) {
 		inst, cerr := m.connector(ctx, key)
 		if cerr != nil {
@@ -125,9 +140,12 @@ func (m *CacheManager) Get(ctx context.Context, key string) (Cache, ReleaseFunc,
 }
 
 // Remove explicitly removes a cache instance from the manager.
-// Returns ErrManagerClosed if Close() has been called.
+// Returns ErrManagerClosed if Close() has been called, or if the manager is a zero value
+// that was never built via NewCacheManager.
 func (m *CacheManager) Remove(key string) error {
-	if m.pool.Closed() {
+	// Unusable either way: never built via NewCacheManager, or already closed. The nil test
+	// must come first — Pool.Closed() takes the pool's mutex and would panic on a nil pool.
+	if m.pool == nil || m.pool.Closed() {
 		return ErrManagerClosed
 	}
 
@@ -147,12 +165,19 @@ func (m *CacheManager) Remove(key string) error {
 
 // Close shuts down all managed cache instances and stops the cleanup goroutine.
 // After Close() returns, subsequent calls to Get() and Remove() return ErrManagerClosed.
+// Closing a zero-value manager is a no-op.
 func (m *CacheManager) Close() error {
+	if m.pool == nil {
+		return nil // zero-value manager: nothing to close
+	}
 	return m.pool.Close()
 }
 
 // Stats returns current manager statistics.
 func (m *CacheManager) Stats() ManagerStats {
+	if m.pool == nil {
+		return ManagerStats{} // zero-value manager: empty stats
+	}
 	ps := m.pool.Stats()
 	return ManagerStats{
 		ActiveCaches: ps.Size,

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -1167,3 +1167,21 @@ func TestCacheManagerCreateRacingCloseDoesNotResurrect(t *testing.T) {
 	assert.True(t, instanceClosed.Load(), "the just-created instance must be closed, not leaked")
 	assert.Equal(t, 0, mgr.Stats().ActiveCaches, "the map must not be resurrected with a new entry")
 }
+
+// TestCacheManagerZeroValueMethodsAreSafe pins that a zero-value CacheManager (never built via
+// NewCacheManager — the lightweight stand-in shape the DbManager/messaging.Manager siblings
+// already support) does not panic on any of Get/Remove/Stats/Close.
+func TestCacheManagerZeroValueMethodsAreSafe(t *testing.T) {
+	m := &cache.CacheManager{}
+
+	inst, release, getErr := m.Get(context.Background(), tenantOne)
+	assert.ErrorIs(t, getErr, cache.ErrManagerClosed, "zero-value Get must fail closed, not panic")
+	assert.Nil(t, inst)
+	assert.Nil(t, release)
+
+	assert.ErrorIs(t, m.Remove(tenantOne), cache.ErrManagerClosed, "zero-value Remove must fail closed, not panic")
+
+	assert.Equal(t, cache.ManagerStats{}, m.Stats(), "zero-value Stats must report empty stats, not panic")
+
+	assert.NoError(t, m.Close(), "closing a never-initialized manager is a no-op")
+}


### PR DESCRIPTION
## What

`&cache.CacheManager{}` panicked with a nil-pointer dereference on all four of its methods, because each dereferences `m.pool`. Its two sibling managers — `database.DbManager` and `messaging.Manager` — already survive as zero values, and this repo's own tests use them that way. `Get` and `Remove` now return the exported `ErrManagerClosed`, `Close` reports success, and `Stats` returns empty statistics.

## Impact

None for existing code: the zero-value state is unreachable through framework wiring, so no path that worked before behaves differently. The exported `ErrManagerClosed` gains a cause — "never constructed" alongside "closed" — which `errors.Is` consumers already match; a second sentinel would have split that branch. No migration atom, matching how the identical sibling guards shipped in #750 and #751.

## Verification

`make mutate` was **not** run (stopped for thermal reasons) — the only unrun gate. Each of the four guards was reverted individually instead; every one failed the new test with a nil-pointer panic naming both the guard line and the calling test line. A review pass also found and fixed a false claim in the type doc — `CacheManager` does not implement `cache.Manager`, whose `Stats()` returns a different type — and that dead interface is now tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety when using an uninitialized cache manager.
  * Cache operations now return a clear closed-state error instead of risking a panic.
  * Closing an uninitialized manager is safe and completes without error.
  * Statistics for an uninitialized manager now return empty results.

* **Documentation**
  * Clarified closed-state errors and how to identify them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->