### PR TITLE
fix(app): drop db_stats.connections from /ready's 200 body

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -545,19 +545,27 @@ func defaultTestConfig() *config.Config {
 	}
 }
 
-// assertNoCacheCoordinates pins that no Redis coordinate and no raw probe text appears
-// ANYWHERE in a /ready body — not only under the error key, so a future field (cache_stats,
-// or one nobody has written yet) that reintroduces the address is caught too. It asserts
-// nothing about the error key, so it holds for the 200 body as well: a leak has no status code.
-func assertNoCacheCoordinates(t *testing.T, body map[string]any) {
+// assertReadyBodyOmits pins that none of the given strings appears ANYWHERE in a /ready
+// body — not only under the key it was expected on, so a future field (or one nobody has
+// written yet) that reintroduces the value elsewhere is caught too. It asserts nothing about
+// which status code produced the body: a leak has no status code.
+func assertReadyBodyOmits(t *testing.T, body map[string]any, forbidden ...string) {
 	t.Helper()
 
 	raw, err := json.Marshal(body)
 	require.NoError(t, err)
 	rendered := string(raw)
-	assert.NotContains(t, rendered, redisProbeAddress)
-	assert.NotContains(t, rendered, localHost)
-	assert.NotContains(t, rendered, errorRedisDown)
+	for _, s := range forbidden {
+		assert.NotContainsf(t, rendered, s, "/ready is unauthenticated; %q must not reach its body", s)
+	}
+}
+
+// assertNoCacheCoordinates applies the whole-body lens above to the Redis coordinates and the
+// raw probe text the cache probe's error carries.
+func assertNoCacheCoordinates(t *testing.T, body map[string]any) {
+	t.Helper()
+
+	assertReadyBodyOmits(t, body, redisProbeAddress, localHost, errorRedisDown)
 }
 
 // assertCacheErrorSanitized pins the /ready 503 body for a failing cache: the stable public

--- a/app/debug_health_test.go
+++ b/app/debug_health_test.go
@@ -476,7 +476,7 @@ func TestHealthDebugKeepsPooledConnectionKeysWhileReadyOmitsThem(t *testing.T) {
 	}
 	dbManager := database.NewDbManager(&stubTenantResource{}, log,
 		database.DbManagerOptions{MaxSize: 5, IdleTTL: time.Hour}, connector)
-	defer func() { _ = dbManager.Close() }()
+	t.Cleanup(func() { assert.NoError(t, dbManager.Close()) })
 
 	for _, key := range []string{tenantAlpha, tenantBeta} {
 		_, release, err := dbManager.Get(context.Background(), key)

--- a/app/debug_health_test.go
+++ b/app/debug_health_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,6 +15,7 @@ import (
 	"github.com/gaborage/go-bricks/cache"
 	"github.com/gaborage/go-bricks/config"
 	"github.com/gaborage/go-bricks/database"
+	dbtest "github.com/gaborage/go-bricks/database/testing"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
 	"github.com/gaborage/go-bricks/server"
@@ -452,6 +454,85 @@ func TestHealthDebugKeepsFullCacheErrorWhileReadySanitizes(t *testing.T) {
 		"readyCheck must log the full error so operators keep the diagnostic the 503 body drops")
 	assert.Equal(t, componentCache, logged.str["component"],
 		"the sanitized body no longer identifies the failure, so the log must name the component")
+}
+
+// TestHealthDebugKeepsPooledConnectionKeysWhileReadyOmitsThem pins both halves of the
+// db_stats routing contract from a single DbManager. SECURITY: a pooled connection's key is
+// the resourcepool key — the tenant ID in a multi-tenant deployment — so /ready's 200 body
+// used to answer an unauthenticated, unthrottled caller with a live tenant enumeration plus
+// per-tenant timing. It must now carry the scalar counters only, while the access-controlled
+// /health-debug keeps the per-connection detail operators diagnose with. Redacting inside
+// DbManager.Stats() or the probe would satisfy the /ready half alone, so the two are
+// asserted together.
+func TestHealthDebugKeepsPooledConnectionKeysWhileReadyOmitsThem(t *testing.T) {
+	const (
+		tenantAlpha = "tenant-alpha"
+		tenantBeta  = "tenant-beta"
+	)
+
+	log := &recLogger{}
+	connector := func(*config.DatabaseConfig, logger.Logger) (database.Interface, error) {
+		return dbtest.NewTestDB(dbTypePostgres), nil
+	}
+	dbManager := database.NewDbManager(&stubTenantResource{}, log,
+		database.DbManagerOptions{MaxSize: 5, IdleTTL: time.Hour}, connector)
+	defer func() { _ = dbManager.Close() }()
+
+	for _, key := range []string{tenantAlpha, tenantBeta} {
+		_, release, err := dbManager.Get(context.Background(), key)
+		require.NoError(t, err)
+		release()
+	}
+
+	// The premise the /ready assertions rest on: two distinct keys really are pooled, so
+	// their absence below is a redaction rather than an empty fixture asserting nothing.
+	statsConns, err := json.Marshal(dbManager.Stats()[dbConnectionsKey])
+	require.NoError(t, err)
+	require.Contains(t, string(statsConns), tenantAlpha, "Stats() must still carry the pool keys")
+	require.Contains(t, string(statsConns), tenantBeta, "Stats() must still carry the pool keys")
+
+	cfg := &config.Config{App: config.AppConfig{Name: appName, Env: testName, Version: appVersion}}
+	app := &App{cfg: cfg, logger: log, dbManager: dbManager}
+	app.healthProbes = app.createHealthProbes()
+	require.Len(t, app.healthProbes, 1)
+
+	readyReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, readyEndpoint, http.NoBody)
+	readyRec := httptest.NewRecorder()
+	require.NoError(t, app.readyCheck(server.NewHandlerContextForTest(readyRec, readyReq, cfg)))
+
+	debugHandlers := NewDebugHandlers(app, &config.DebugConfig{Enabled: true, PathPrefix: "/_debug"}, log)
+	debugReq := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/health-debug", http.NoBody)
+	debugRec := httptest.NewRecorder()
+	require.NoError(t, debugHandlers.handleHealthDebug(server.NewHandlerContextForTest(debugRec, debugReq, cfg)))
+
+	var readyBody map[string]any
+	require.NoError(t, json.Unmarshal(readyRec.Body.Bytes(), &readyBody))
+	assert.Equal(t, http.StatusOK, readyRec.Code)
+
+	dbStats, ok := readyBody["db_stats"].(map[string]any)
+	require.True(t, ok, "the 200 body must still carry db_stats")
+	assert.Contains(t, dbStats, "active_connections")
+	assert.Contains(t, dbStats, "max_connections")
+	assert.Contains(t, dbStats, "idle_ttl_seconds")
+	assert.Equal(t, healthyStatus, dbStats[statusKey])
+	assert.NotContains(t, dbStats, dbConnectionsKey,
+		"the per-connection array enumerates tenants on an unauthenticated endpoint")
+	assertReadyBodyOmits(t, readyBody, tenantAlpha, tenantBeta)
+
+	assert.Equal(t, http.StatusOK, debugRec.Code)
+	var debugBody struct {
+		Data struct {
+			Components map[string]struct {
+				Details map[string]any `json:"details"`
+			} `json:"components"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(debugRec.Body.Bytes(), &debugBody))
+	debugConns, err := json.Marshal(debugBody.Data.Components[componentDatabase].Details[dbConnectionsKey])
+	require.NoError(t, err)
+	assert.Contains(t, string(debugConns), tenantAlpha,
+		"/health-debug renders the probe's details; redacting in Stats() or the probe would gut it")
+	assert.Contains(t, string(debugConns), tenantBeta)
 }
 
 func TestCalculateHealthSummaryTreatsAbsenceAsHealthy(t *testing.T) {

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
 	"os/signal"
@@ -540,6 +541,30 @@ func publicProbeError(result *HealthStatus) string {
 	return result.Name + " unavailable"
 }
 
+// dbConnectionsKey is the DbManager.Stats() entry publicDBStats withholds from /ready.
+const dbConnectionsKey = "connections"
+
+// publicDBStats renders db_stats for the unauthenticated /ready body: every scalar counter,
+// never the per-connection array.
+//
+// SECURITY: DbManager.Stats()["connections"] holds one entry per live pooled connection, and
+// each entry's "key" is the resourcepool key — the tenant ID in a multi-tenant deployment,
+// the named-database key otherwise — alongside last_used and idle_duration. /ready carries no
+// authentication and no IP allowlist, and its only throttle is the 2000 rps/IP abuse
+// pre-guard, which is no barrier to enumeration — so polling it enumerated which tenants were
+// active and when each was last served.
+//
+// The redaction belongs at this render site and not in DbManager.Stats() or the probe: the
+// access-controlled <debug.pathprefix>/health-debug renders that same details map and
+// operators need the per-key detail there, so this copies rather than mutating the caller's
+// map.
+func publicDBStats(details map[string]any) map[string]any {
+	public := make(map[string]any, len(details))
+	maps.Copy(public, details)
+	delete(public, dbConnectionsKey)
+	return public
+}
+
 // readyCheck handles the health check endpoint
 func (a *App) readyCheck(c server.HandlerContext) error {
 	ctx := c.RequestContext()
@@ -575,7 +600,7 @@ func (a *App) readyCheck(c server.HandlerContext) error {
 		dbStatus.Status = disabledStatus
 		dbStatus.Details = map[string]any{statusKey: disabledStatus}
 	}
-	dbStats := getStatsOrEmpty(dbStatus.Details)
+	dbStats := publicDBStats(dbStatus.Details)
 
 	messagingStatus, messagingStats := componentReport(componentStatus, componentMessaging)
 	cacheStatus, cacheStats := componentReport(componentStatus, componentCache)

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -717,6 +717,44 @@ func TestReadyCheckSanitizesCriticalProbeWithoutPublicError(t *testing.T) {
 	assert.Contains(t, event.err, "10.0.0.5:5432")
 }
 
+// TestPublicDBStatsDropsConnectionsOnACopy pins both halves of the render-site redaction:
+// the /ready view loses the per-connection array, and the map it was built from keeps it.
+// The copy is what keeps the redaction local to the unauthenticated body — the same map is
+// what /_sys/health-debug renders as the database component's details.
+func TestPublicDBStatsDropsConnectionsOnACopy(t *testing.T) {
+	details := map[string]any{
+		"active_connections": 2,
+		"max_connections":    25,
+		"idle_ttl_seconds":   3600,
+		statusKey:            healthyStatus,
+		dbConnectionsKey: []map[string]any{
+			{"key": "tenant-alpha", "last_used": "2026-08-05T10:00:00Z", "idle_duration": 4},
+		},
+	}
+
+	public := publicDBStats(details)
+
+	assert.Equal(t, map[string]any{
+		"active_connections": 2,
+		"max_connections":    25,
+		"idle_ttl_seconds":   3600,
+		statusKey:            healthyStatus,
+	}, public, "every scalar counter must survive; only the keyed array is withheld")
+
+	assert.Contains(t, details, dbConnectionsKey,
+		"redacting in place would strip the array from the debug endpoint's view too")
+}
+
+// TestPublicDBStatsPreservesAbsentDatabaseShape guards the published body for a deployment
+// with no database: db_stats {"status":"disabled"} rather than null or a missing key.
+func TestPublicDBStatsPreservesAbsentDatabaseShape(t *testing.T) {
+	assert.Equal(t, map[string]any{statusKey: disabledStatus},
+		publicDBStats(map[string]any{statusKey: disabledStatus}))
+
+	assert.Equal(t, map[string]any{}, publicDBStats(nil),
+		"a nil details map must still render {} — never JSON null")
+}
+
 // runReadyCheck drives readyCheck over httptest and decodes the JSON body.
 func runReadyCheck(t *testing.T, app *App, cfg *config.Config) (body map[string]any, code int) {
 	t.Helper()

--- a/wiki/adr_048_ready_sanitize_by_default.md
+++ b/wiki/adr_048_ready_sanitize_by_default.md
@@ -127,6 +127,19 @@ covers the case this ADR exists for — a critical probe with no `PublicErr`, dr
 `TestHealthProbeFuncRun`. Deleting it would leave an exported `PublicErr` that the
 framework's own `Prober` implementation could not populate.
 
+**The generalized rule, which outlives this seam.** Everything `/ready` returns is public at
+**any** status code — the `200` body just as much as the `503` this ADR governs, and the `200`
+is the one actually polled. Identity-bearing detail belongs on the access-controlled debug
+endpoint and never here — and "access-controlled" holds only where `debug.allowedips` or
+`debug.bearertoken` actually supplies that control, since `ipWhitelistMiddleware` is a
+pass-through on an empty allowlist and the bearer check registers only when a token is set.
+Adding a key to either body is a disclosure decision a reviewer should treat as such. `[C57.3]` is the second application of that lens rather than of this mechanism: it
+removed `db_stats.connections` from the `200` body, whose per-entry `key` is the resourcepool
+key — the tenant ID in a multi-tenant deployment — so an unauthenticated poll returned a live
+tenant enumeration with per-tenant timing. That redaction sits at the `readyCheck` render site
+(`publicDBStats`), not behind `PublicErr`, because `DbManager.Stats()` must keep serving the
+full detail to the debug endpoint.
+
 See [ADR-046](adr_046_cache_readiness_strict_default.md) for the seam this extends and the
 `cache.critical` decision it sits on, and [migrations.md](migrations.md) `[C57.1]`,
-`[C57.2]` for the upgrade atoms.
+`[C57.2]`, `[C57.3]` for the upgrade atoms.

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -39,7 +39,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E52  | v0.51.0 → v0.52.0 | compile-break | 4 | C52.1 | if you set `.Args` on any declaration in ≤v0.51.0, verify current broker state before upgrading |
 | E55  | v0.52.0 → v0.55.0 | additive (safe) | 3 | none | none |
 | E56  | v0.55.0 → v0.56.0 | compile-break (C56.6 only partially — see its gate) + silent-behavior default flip (C56.11) | 15 | C56.6 C56.9 | grep log-driven alerts, dashboards, and test assertions for card-data / `iban` / `otp` field names — their values render `***` after the bump (C56.3); expect a cold tenant's first messaging request to fail fast instead of blocking (C56.4); if you assemble config in Go, check for `forwardedclientcert.require` without `enabled` — that service was serving unauthenticated traffic and now returns 401 (C56.5); if one queue name is declared from two places, confirm the two shapes agree — a mismatch that used to be silently overwritten now fails startup (C56.7); if you call a JOSE-protected peer, check for payload-free requests of **any** method — `GET`/`HEAD`/`DELETE` as well as `POST`/`PUT`/`PATCH` — since none of them are sealed now and a peer demanding `application/jose` on every request will answer 415 (C56.8); `/ready`'s 200 body gains `cache` and `cache_stats` and, where a cache is configured, every poll now issues a Redis `PING`, so update any test, schema, or dashboard that pins its exact key set and expect a live cache outage to read `unhealthy` (C56.10); if you run with a top-level cache enabled (or supply an `Options.CacheConnector`, which is probed regardless of `cache.enabled`) and have never set `cache.critical`, that outage now also answers `503` and drains every replica from rotation at once — decide before the bump whether to keep the strict default (and set `readinessProbe.failureThreshold: 3`) or add `cache.critical: false` (C56.11); and if any alert or runbook parses the Redis address out of `/ready`'s `503` body, repoint it at the app log or `/_sys/health-debug` (C56.12); and a module that cannot work without a database can now declare `app.DatabaseRequirer` so an absent one aborts startup rather than booting green (C56.13); check every environment that sets any `database.*` identity field for a complete section, since a partial one now fails startup (C56.14); and re-point any alert asserting `/ready` returns 503 for a database-free or multi-tenant service — both now return 200 (C56.15) |
-| E57  | v0.56.0 → v0.57.0 | silent-behavior | 2 | none | if any alert, runbook, synthetic check, or contract test parses the driver error out of `/ready`'s database `503` body, repoint it at the app log or `/_sys/health-debug` — the field is now the fixed string `database unavailable` (C57.1); and if you implement your own critical `app.Prober`, its `503` body now reads `<Name> unavailable` instead of its raw error, since sanitization became the default rather than an opt-in (C57.2) |
+| E57  | v0.56.0 → v0.57.0 | silent-behavior | 3 | none | if any alert, runbook, synthetic check, or contract test parses the driver error out of `/ready`'s database `503` body, repoint it at the app log or `<debug.pathprefix>/health-debug` (default `/_sys`) — the field is now the fixed string `database unavailable` (C57.1); and if you implement your own critical `app.Prober`, its `503` body now reads `<Name> unavailable` instead of its raw error, since sanitization became the default rather than an opt-in (C57.2); and if anything reads `db_stats.connections` out of `/ready`'s **200** body — a per-tenant pool dashboard, an activity alert, a test pinning the key set — repoint it at `<debug.pathprefix>/health-debug` or the OTel database metrics, because that array is gone from `/ready`; a repo-local grep alone will not find an out-of-repo dashboard (C57.3) |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 - **`when: match`** → act only if `detect` returns ≥1 line (an API/arity/interface change, or a config key you set).
@@ -1141,7 +1141,7 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
 - verify: `curl -s -o /dev/null -w '%{http_code}' localhost:8080/ready`
 - ref: ADR-047 · `config/tenant_store.go` (`DBConfig`) · `app/health.go` · `app/debug_health.go` · #872
 
-## E57 · v0.56.0 → v0.57.0 — `/ready` stops carrying probe errors in its `503` body
+## E57 · v0.56.0 → v0.57.0 — `/ready` stops disclosing internals in either body
 
 - gist: The database readiness probe now declares a sanitized public string, so `/ready`'s
   `503` body reports `database unavailable` instead of the driver's error. That error named
@@ -1158,7 +1158,13 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   (C57.1). The same hop then inverts the seam itself: sanitization is the default for
   **every** critical probe rather than something each one opts into, so a critical
   `Prober` you wrote yourself now serves `<Name> unavailable` instead of its raw error
-  (C57.2). For the framework's own probes that flip emits identical bytes.
+  (C57.2). For the framework's own probes that flip emits identical bytes. The hop then
+  closes the same disclosure on the **200** body, which is the one actually polled:
+  `db_stats.connections` carried one entry per live pooled connection, keyed by the
+  resourcepool key — the tenant ID in a multi-tenant deployment — with `last_used` and
+  `idle_duration` alongside it, so an unauthenticated caller read a live tenant enumeration
+  and per-tenant timing. That array is now withheld from `/ready`; the scalar counters stay,
+  and the per-key detail is unchanged on `<debug.pathprefix>/health-debug` (C57.3).
 - build-caught: none
 - exit: `go get github.com/gaborage/go-bricks@v0.57.0 && go mod tidy && go build ./... && go test ./...`
 
@@ -1276,6 +1282,63 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   log line still carries the full error.
 - ref: ADR-048 · `app/lifecycle.go` (`publicProbeError`) · `app/health.go` (`Prober`,
   `HealthStatus.PublicErr`)
+
+### [C57.3] `/ready`'s 200 body drops `db_stats.connections` · silent-behavior · when: match
+
+- detect: `git grep -rn 'db_stats' --` finds the in-repo consumers — a contract test pinning
+  the key set, a checked-in log-pipeline config. **A clean grep is not sufficient on its
+  own**, and treating it as one is how a dashboard breaks on deploy. Most consumers of
+  `/ready` live outside the Go repo, and some are invisible to a literal grep even inside it:
+  Grafana panels, Prometheus / Datadog alert rules, synthetic checks, k6 or Postman scripts,
+  and any code assembling the path dynamically (`body["db_stats"]["connections"][i]["key"]`,
+  a JSONPath expression, a field name held in a variable). Search those by hand for
+  `connections` and for the fields under it — `key`, `last_used`, `idle_duration`. Match =
+  any consumer, inside the repo or outside it, reads the array. Only `db_stats` changes:
+  `messaging_stats` and `cache_stats` were already counters-only and carry no per-key
+  entries, so nothing reading those needs checking.
+- gate: match = your consumer now finds `db_stats` without its array. `/ready` has no
+  authentication and no IP allowlist — load balancers must reach it — and its only throttle is
+  the `app.rate.ippreguard` abuse ceiling (enabled by default at 2000 rps/IP), which is no
+  barrier to enumeration. Each entry's `key` is the resourcepool key, which is the **tenant
+  ID** in a multi-tenant deployment and the named-database key in a multi-DB one. Polling the
+  endpoint therefore returned a live enumeration of which tenants were active, plus
+  `last_used` and `idle_duration` showing when each was last served. This is the 200-body
+  counterpart of C57.1: unlike a `503`, it answers on the healthy path, which is the one actually
+  polled. no-match = nothing reads the array; the change is invisible. The scalar counters
+  (`active_connections`, `max_connections`, `idle_ttl_seconds`, `status`) are untouched, so
+  a consumer reading only those sees no difference.
+- before:
+  ```json
+  {"status":"ready","database":"healthy","db_stats":{"active_connections":3,"max_connections":25,"idle_ttl_seconds":3600,"status":"healthy","connections":[{"key":"acme","last_used":"2026-08-05T10:00:00Z","idle_duration":4},{"key":"globex","last_used":"2026-08-05T09:58:12Z","idle_duration":112}]}}
+  ```
+- after:
+  ```json
+  {"status":"ready","database":"healthy","db_stats":{"active_connections":3,"max_connections":25,"idle_ttl_seconds":3600,"status":"healthy"}}
+  ```
+  (database keys only — the body also carries `messaging`, `cache`, their stats, `time` and
+  `app`.)
+- apply: repoint anything alerting on per-tenant pool activity. Two channels still carry it.
+  The debug health endpoint renders the full array verbatim under
+  `data.components.database.details.connections` at `<debug.pathprefix>/health-debug`
+  (`debug.pathprefix` defaults to `/_sys`), but only where `debug.enabled: true` (default
+  `false`) and `debug.endpoints.health: true` (default `true`) — and its access control is
+  conditional, so confirm `debug.allowedips` is non-empty (it defaults to loopback) or
+  `debug.bearertoken` is set before pointing a scraper at it. The durable answer for a
+  dashboard is the OpenTelemetry database metrics, which carry pool state without publishing
+  it on an unauthenticated port. `database.DbManager.Stats()` is unchanged for code calling
+  it directly — the redaction happens where `/ready` renders, not in the manager — but note
+  the same rule now applies to any surface you render it on: a pool key is tenant identity.
+- verify: with at least two tenants warm, `curl -s localhost:8080/ready | jq '.db_stats'`
+  shows the four scalar keys and no `connections`, and `curl -s localhost:8080/ready` grepped
+  for a known tenant ID returns nothing. For the debug channel, build the URL from your own
+  settings rather than assuming the defaults — with `debug.enabled: true`,
+  `debug.endpoints.health` left at `true`, the request coming from an address inside
+  `debug.allowedips`, and `PREFIX` set to `debug.pathprefix` (`/_sys` unless you changed it):
+  `curl -s -H "Authorization: Bearer $DEBUG_TOKEN" "localhost:8080$PREFIX/health-debug" | jq
+  '.data.components.database.details.connections'` still lists every key (drop the header when
+  `debug.bearertoken` is empty).
+- ref: `app/lifecycle.go` (`publicDBStats`) · `database/manager.go` (`DbManager.Stats`) ·
+  `app/debug_health.go`
 
 ---
 

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -1308,13 +1308,17 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   (`active_connections`, `max_connections`, `idle_ttl_seconds`, `status`) are untouched, so
   a consumer reading only those sees no difference.
 - before:
+
   ```json
   {"status":"ready","database":"healthy","db_stats":{"active_connections":3,"max_connections":25,"idle_ttl_seconds":3600,"status":"healthy","connections":[{"key":"acme","last_used":"2026-08-05T10:00:00Z","idle_duration":4},{"key":"globex","last_used":"2026-08-05T09:58:12Z","idle_duration":112}]}}
   ```
+
 - after:
+
   ```json
   {"status":"ready","database":"healthy","db_stats":{"active_connections":3,"max_connections":25,"idle_ttl_seconds":3600,"status":"healthy"}}
   ```
+
   (database keys only — the body also carries `messaging`, `cache`, their stats, `time` and
   `app`.)
 - apply: repoint anything alerting on per-tenant pool activity. Two channels still carry it.


### PR DESCRIPTION
Stacked on #888 (which is stacked on #887) — merge those first.

## What

`/ready`'s **200** body rendered `db_stats` verbatim from `DbManager.Stats()`, whose
`connections[]` array carries one `key` per live pooled connection — the tenant ID in a
multi-tenant deployment — plus `last_used` and `idle_duration`. That endpoint is
unauthenticated, skipped by the global-middleware auth seam, and throttled only by the
2000 rps/IP abuse pre-guard, so polling it enumerated which tenants were active and when
each was last served. `publicDBStats` now copies the details map and drops that array,
keeping every scalar counter.

## Impact

`db_stats.connections` is gone from the 200 body; the counters and the absent-database
`{"status":"disabled"}` shape are unchanged. The per-key detail still renders in full on
the access-controlled `<debug.pathprefix>/health-debug`. Atom `[C57.3]` flags that a
repo-local grep will not find an out-of-repo dashboard or alert rule reading those fields.

## Verification

Mutation gate informative: one mutant on changed lines, killed. `messaging_stats` and
`cache_stats` were traced and left alone — `Pool.Snapshot()` has exactly one non-test
caller repo-wide, so neither can carry a key. The `/health-debug` test asserts both tenant
keys still render *after* `/ready` has run, which pins copy-not-mutate end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized `/ready` responses to omit tenant- and connection-specific database details.
  * Preserved scalar database statistics in readiness responses.
  * Standardized unavailable database and critical probe messages to prevent sensitive information disclosure.
  * Kept detailed connection information available through the access-controlled health-debug endpoint.

* **Documentation**
  * Documented readiness-response privacy rules and the migration steps for the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->