### PR TITLE
fix(outbox)!: fail startup without a usable outbox/inbox database

### DIFF
--- a/inbox/module.go
+++ b/inbox/module.go
@@ -88,7 +88,9 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 		return nil
 	}
 
-	// Fail fast: when the inbox is enabled, the DB resolver is required.
+	// Guards direct construction only: app.RegisterModule always wires a non-nil
+	// resolver, so this never fires through the normal registration path.
+	// verifyStartupDatabase (below) is the real fail-fast for an enabled inbox.
 	if m.getDB == nil {
 		return fmt.Errorf("inbox: database resolver (deps.DB) is required when inbox is enabled")
 	}
@@ -108,6 +110,12 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 		}
 	}
 
+	if m.startupDatabaseCheckApplies() {
+		if err := m.verifyStartupDatabase(); err != nil {
+			return err
+		}
+	}
+
 	m.processor = &Inbox{module: m}
 
 	m.logger.Info().
@@ -115,6 +123,35 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 		Dur("retentionPeriod", m.cfg.RetentionPeriod).
 		Str("tenancy", m.cfg.Tenancy).
 		Msg("Inbox module initialized")
+	return nil
+}
+
+// startupDatabaseCheckApplies reports whether Init can statically resolve the
+// "" key; see tenantstore.StartupCheckApplies for the predicate and its
+// exemptions (shared with outbox so it cannot drift between the two).
+func (m *Module) startupDatabaseCheckApplies() bool {
+	return tenantstore.StartupCheckApplies(m.config, m.sharedLedger())
+}
+
+// verifyStartupDatabase fails Init when the enabled inbox cannot possibly
+// process events: no database configured, database unreachable, or inbox
+// table missing/unusable. DeleteProcessed before the epoch is the probe: a
+// no-op write that still proves table + privileges — MarkProcessed is the only
+// writer and stamps time.Now(), so no framework-written row predates 1970.
+func (m *Module) verifyStartupDatabase() error {
+	ctx, cancel, db, err := tenantstore.StartupDatabase(context.Background(), m.config, "inbox", m.getDB)
+	defer cancel()
+	if err != nil {
+		return err
+	}
+
+	store, err := m.ensureStoreInitialized(ctx)
+	if err != nil {
+		return err // already "inbox: …"-prefixed by the tenantstore cache
+	}
+	if _, err := store.DeleteProcessed(ctx, db, time.Unix(0, 0).UTC()); err != nil {
+		return tenantstore.TableUnusableError("inbox", m.cfg.TableName, "inbox.autocreatetable", err)
+	}
 	return nil
 }
 

--- a/inbox/module_test.go
+++ b/inbox/module_test.go
@@ -2,6 +2,7 @@ package inbox
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -31,11 +32,21 @@ func (r *fakeRegistrar) WeeklyAt(string, any, time.Weekday, time.Time) error { r
 func (r *fakeRegistrar) HourlyAt(string, any, int) error                     { return nil }
 func (r *fakeRegistrar) MonthlyAt(string, any, int, time.Time) error         { return nil }
 
+// probeReadyDB returns a fresh TestDB whose DELETE expectation satisfies Init's
+// startup-database probe (verifyStartupDatabase's DeleteProcessed call).
+func probeReadyDB() *dbtesting.TestDB {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectExec("DELETE").WillReturnRowsAffected(0)
+	return db
+}
+
+// testDeps' DB resolver mints a fresh, probe-ready TestDB on every call, so any
+// test that reaches the startup-database probe passes it.
 func testDeps() *app.ModuleDeps {
 	return &app.ModuleDeps{
 		Logger: logger.New("info", false),
 		DB: func(context.Context) (dbtypes.Interface, error) {
-			return dbtesting.NewTestDB(dbtypes.PostgreSQL), nil
+			return probeReadyDB(), nil
 		},
 	}
 }
@@ -81,6 +92,161 @@ func TestModuleInitRejectsBadTableName(t *testing.T) {
 	err := m.Init(deps)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unqualified")
+}
+
+// TestModuleInitFailsWhenDatabaseNotConfigured guards gap (a) from issue #876:
+// an enabled inbox with no database configured must fail startup, not boot green.
+func TestModuleInitFailsWhenDatabaseNotConfigured(t *testing.T) {
+	m := NewModule()
+	deps := testDeps()
+	deps.Config = &config.Config{Inbox: config.InboxConfig{Enabled: true}}
+	deps.DB = func(_ context.Context) (dbtypes.Interface, error) {
+		return nil, config.NewNotConfiguredError("database", "DATABASE_TYPE", "database")
+	}
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a database, but none is configured")
+}
+
+// TestModuleInitFailsWhenDatabaseUnreachable guards gap (b): a configured but
+// unreachable database must fail startup rather than let every ProcessOnce call
+// fail against a store that was never usable.
+func TestModuleInitFailsWhenDatabaseUnreachable(t *testing.T) {
+	m := NewModule()
+	deps := testDeps()
+	deps.Config = &config.Config{Inbox: config.InboxConfig{Enabled: true}}
+	deps.DB = func(_ context.Context) (dbtypes.Interface, error) {
+		return nil, errors.New("dial tcp 10.0.0.1:5432: connect: connection refused")
+	}
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database unreachable at startup")
+}
+
+// TestModuleInitFailsWhenTableMissing guards gap (c): a reachable database whose
+// inbox table does not exist (or is unwritable) must fail startup — the fixture
+// has no exec expectations, so the probe's DELETE goes unmatched.
+func TestModuleInitFailsWhenTableMissing(t *testing.T) {
+	m := NewModule()
+	deps := testDeps()
+	deps.Config = &config.Config{Inbox: config.InboxConfig{Enabled: true}}
+	deps.DB = func(_ context.Context) (dbtypes.Interface, error) {
+		return dbtesting.NewTestDB(dbtypes.PostgreSQL), nil
+	}
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not usable")
+}
+
+// TestModuleInitPerTenantMultitenantSkipsStartupProbe pins
+// startupDatabaseCheckApplies' Multitenant clause: the failing getDB must not fail Init.
+func TestModuleInitPerTenantMultitenantSkipsStartupProbe(t *testing.T) {
+	m := NewModule()
+	deps := testDeps()
+	deps.Config = &config.Config{
+		Inbox: config.InboxConfig{Enabled: true},
+		Multitenant: config.MultitenantConfig{
+			Enabled: true,
+			Tenants: map[string]config.TenantEntry{"tenant-a": {}},
+		},
+	}
+	deps.DB = func(_ context.Context) (dbtypes.Interface, error) {
+		return nil, errors.New("would fail the probe if it ran")
+	}
+
+	err := m.Init(deps)
+	require.NoError(t, err, "per-tenant fan-out resolves databases at runtime, not at Init")
+}
+
+// TestModuleInitDynamicSourceSkipsStartupProbe pins
+// startupDatabaseCheckApplies' Source.Type clause: the failing getDB must not fail Init.
+func TestModuleInitDynamicSourceSkipsStartupProbe(t *testing.T) {
+	m := NewModule()
+	deps := testDeps()
+	deps.Config = &config.Config{
+		Inbox:  config.InboxConfig{Enabled: true},
+		Source: config.SourceConfig{Type: config.SourceTypeDynamic},
+	}
+	deps.DB = func(_ context.Context) (dbtypes.Interface, error) {
+		return nil, errors.New("would fail the probe if it ran")
+	}
+
+	err := m.Init(deps)
+	require.NoError(t, err, "a dynamic source resolves the \"\" key at runtime, not at Init")
+}
+
+// TestModuleInitSharedTenancyStaticSourceProbesControlPlaneDatabase closes gap
+// (3): tenancy=shared with a static source resolves the "" key statically, so
+// Init must now probe the control-plane database — previously this mode was
+// never probed at startup at all.
+func TestModuleInitSharedTenancyStaticSourceProbesControlPlaneDatabase(t *testing.T) {
+	m := NewModule()
+	failingDB := func(_ context.Context) (dbtypes.Interface, error) {
+		return nil, errors.New("dial tcp control-plane-db: connection refused")
+	}
+	m.SetSharedResolvers(failingDB, nil)
+	deps := testDeps()
+	deps.Config = &config.Config{
+		Inbox:       config.InboxConfig{Enabled: true, Tenancy: config.TenancyShared},
+		Multitenant: config.MultitenantConfig{Enabled: true}, // pins the sharedLedger() clause, not just !Multitenant.Enabled
+	}
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database unreachable at startup",
+		"tenancy=shared with a static source must probe the control-plane \"\" database at startup")
+}
+
+// TestModuleInitDisabledInboxSkipsStartupProbe pins that a disabled inbox never
+// reaches the probe, regardless of how the DB resolver would behave.
+func TestModuleInitDisabledInboxSkipsStartupProbe(t *testing.T) {
+	m := NewModule()
+	deps := testDeps()
+	deps.Config = &config.Config{Inbox: config.InboxConfig{Enabled: false}}
+	deps.DB = func(_ context.Context) (dbtypes.Interface, error) {
+		return nil, errors.New("would fail the probe if it ran")
+	}
+
+	err := m.Init(deps)
+	require.NoError(t, err)
+}
+
+// TestModuleInitDefaultsZeroStartupTimeoutToTenSeconds pins the timeout <= 0
+// default: an unset App.Startup.Database must bound the probe's context at
+// 10s, not 0 (an immediately-expired context) or another arithmetic result.
+func TestModuleInitDefaultsZeroStartupTimeoutToTenSeconds(t *testing.T) {
+	m := NewModule()
+	var deadline time.Time
+	var hasDeadline bool
+	deps := testDeps()
+	deps.Config = &config.Config{Inbox: config.InboxConfig{Enabled: true}} // App.Startup.Database left at zero
+	deps.DB = func(ctx context.Context) (dbtypes.Interface, error) {
+		deadline, hasDeadline = ctx.Deadline()
+		return probeReadyDB(), nil
+	}
+
+	err := m.Init(deps)
+	require.NoError(t, err)
+	require.True(t, hasDeadline, "verifyStartupDatabase must derive a bounded context")
+	assert.InDelta(t, float64(10*time.Second), float64(time.Until(deadline)), float64(2*time.Second),
+		"a zero App.Startup.Database must default the probe timeout to 10s")
+}
+
+// TestModuleInitFailsWhenDatabaseResolverReturnsNilDatabase pins the nil-db
+// contract-violation guard: without it, ensureStoreInitialized's
+// db.DatabaseType() call would panic inside Init instead of erroring.
+func TestModuleInitFailsWhenDatabaseResolverReturnsNilDatabase(t *testing.T) {
+	m := NewModule()
+	deps := testDeps()
+	deps.Config = &config.Config{Inbox: config.InboxConfig{Enabled: true}}
+	deps.DB = func(_ context.Context) (dbtypes.Interface, error) { return nil, nil }
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "returned a nil database")
 }
 
 func TestRegisterJobsFailsFastForDynamicMultitenant(t *testing.T) {

--- a/internal/tenantstore/tenantstore.go
+++ b/internal/tenantstore/tenantstore.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/gaborage/go-bricks/config"
 	dbtypes "github.com/gaborage/go-bricks/database/types"
@@ -133,4 +134,74 @@ func RejectSharedWithStaticTenants(module string, cfg *config.Config) error {
 			"use the default per-tenant tenancy, or a dynamic source", module)
 	}
 	return nil
+}
+
+// defaultStartupTimeout bounds the Init-time database probe when
+// app.startup.database is unset. config.Validate always defaults that key to
+// the same 10s, so this only matters for a hand-built *config.Config.
+const defaultStartupTimeout = 10 * time.Second
+
+// StartupCheckApplies reports whether the "" key is statically resolvable at
+// Init time: single-tenant, or shared-ledger tenancy, both with a static
+// source. Per-tenant fan-out resolves databases per tenant at runtime, and
+// dynamic sources resolve "" at runtime. The app builder's skipPreInit and
+// app.rootDatabaseAbsent exempt a third mode this predicate cannot see: a
+// dynamic Options.ResourceSource behind a static source.type, which is
+// invisible from config alone and is therefore probed here. Shared by the
+// outbox and inbox modules' Init so the predicate cannot drift between them.
+func StartupCheckApplies(cfg *config.Config, sharedLedger bool) bool {
+	return cfg != nil &&
+		cfg.Source.Type != config.SourceTypeDynamic &&
+		(!cfg.Multitenant.Enabled || sharedLedger)
+}
+
+// StartupDatabase derives a bounded context from cfg.App.Startup.Database
+// (defaulting to defaultStartupTimeout when unset), resolves the "" database
+// via getDB, and classifies a resolver failure: a config.IsNotConfigured
+// error becomes an actionable "requires a database" message, any other error
+// becomes "database unreachable at startup", and a (nil, nil) result — a
+// resolver contract violation — is rejected explicitly (without this guard,
+// the caller's next call, db.DatabaseType(), would panic instead of
+// erroring). The returned cancel is always non-nil; callers must defer it
+// unconditionally and use the returned context for every subsequent call
+// (ensureStoreInitialized, the probe) so they all share one deadline. Shared
+// by the outbox and inbox modules so the error text and classification
+// cannot drift between them.
+func StartupDatabase(
+	parent context.Context,
+	cfg *config.Config,
+	module string,
+	getDB func(context.Context) (dbtypes.Interface, error),
+) (ctx context.Context, cancel context.CancelFunc, db dbtypes.Interface, err error) {
+	timeout := cfg.App.Startup.Database
+	if timeout <= 0 {
+		timeout = defaultStartupTimeout
+	}
+	ctx, cancel = context.WithTimeout(parent, timeout)
+
+	db, err = getDB(ctx)
+	if err != nil {
+		if config.IsNotConfigured(err) {
+			return ctx, cancel, nil, fmt.Errorf("%s: %s.enabled=true requires a database, but none is configured; "+
+				"configure the database section (or the control-plane database for tenancy=shared) "+
+				"or set %s.enabled=false: %w", module, module, module, err)
+		}
+		return ctx, cancel, nil, fmt.Errorf("%s: database unreachable at startup: %w", module, err)
+	}
+	if db == nil {
+		// Contract violation (resolver returned nil, nil). Without this guard the
+		// caller's db.DatabaseType() call panics inside Init instead of erroring.
+		return ctx, cancel, nil, fmt.Errorf("%s: database resolver returned a nil database", module)
+	}
+	return ctx, cancel, db, nil
+}
+
+// TableUnusableError formats the startup-probe's table-unusable error: the
+// database is reachable, but the module's table is missing, or the
+// credentials can't use it. autocreateKey is the config key that would have
+// created it, e.g. "outbox.autocreatetable". Shared so the message cannot
+// drift between outbox and inbox.
+func TableUnusableError(module, tableName, autocreateKey string, cause error) error {
+	return fmt.Errorf("%s: table %q is not usable (missing table or insufficient privileges); "+
+		"run migrations or set %s=true: %w", module, tableName, autocreateKey, cause)
 }

--- a/internal/tenantstore/tenantstore_test.go
+++ b/internal/tenantstore/tenantstore_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gaborage/go-bricks/config"
 	dbtesting "github.com/gaborage/go-bricks/database/testing"
@@ -310,6 +311,115 @@ func TestRejectSharedWithStaticTenants(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStartupCheckApplies(t *testing.T) {
+	tests := []struct {
+		name         string
+		cfg          *config.Config
+		sharedLedger bool
+		want         bool
+	}{
+		{name: "nil_config", cfg: nil, sharedLedger: false, want: false},
+		{name: "single_tenant_static_source", cfg: &config.Config{}, sharedLedger: false, want: true},
+		{name: "dynamic_source_skips",
+			cfg:          &config.Config{Source: config.SourceConfig{Type: config.SourceTypeDynamic}},
+			sharedLedger: false, want: false},
+		{name: "per_tenant_multitenant_skips",
+			cfg:          &config.Config{Multitenant: config.MultitenantConfig{Enabled: true}},
+			sharedLedger: false, want: false},
+		{name: "shared_ledger_multitenant_applies",
+			cfg:          &config.Config{Multitenant: config.MultitenantConfig{Enabled: true}},
+			sharedLedger: true, want: true},
+		{name: "shared_ledger_dynamic_source_skips",
+			cfg: &config.Config{
+				Multitenant: config.MultitenantConfig{Enabled: true},
+				Source:      config.SourceConfig{Type: config.SourceTypeDynamic},
+			}, sharedLedger: true, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, StartupCheckApplies(tt.cfg, tt.sharedLedger))
+		})
+	}
+}
+
+func TestStartupDatabaseNotConfigured(t *testing.T) {
+	cfg := &config.Config{}
+	getDB := func(context.Context) (dbtypes.Interface, error) {
+		return nil, config.NewNotConfiguredError("database", "DATABASE_TYPE", "database")
+	}
+
+	ctx, cancel, db, err := StartupDatabase(context.Background(), cfg, "outbox", getDB)
+	defer cancel()
+	require.Error(t, err)
+	assert.Equal(t, "outbox: outbox.enabled=true requires a database, but none is configured; "+
+		"configure the database section (or the control-plane database for tenancy=shared) "+
+		"or set outbox.enabled=false: config_not_configured: database (optional) to enable: "+
+		"set DATABASE_TYPE env var or add database to config.yaml", err.Error())
+	assert.Nil(t, db)
+	assert.NotNil(t, ctx)
+}
+
+func TestStartupDatabaseUnreachable(t *testing.T) {
+	cfg := &config.Config{}
+	cause := errors.New("dial tcp: connection refused")
+	getDB := func(context.Context) (dbtypes.Interface, error) { return nil, cause }
+
+	_, cancel, db, err := StartupDatabase(context.Background(), cfg, "inbox", getDB)
+	defer cancel()
+	require.Error(t, err)
+	assert.Equal(t, "inbox: database unreachable at startup: dial tcp: connection refused", err.Error())
+	assert.ErrorIs(t, err, cause)
+	assert.Nil(t, db)
+}
+
+func TestStartupDatabaseNilDatabase(t *testing.T) {
+	cfg := &config.Config{}
+	getDB := func(context.Context) (dbtypes.Interface, error) { return nil, nil }
+
+	_, cancel, db, err := StartupDatabase(context.Background(), cfg, "outbox", getDB)
+	defer cancel()
+	require.Error(t, err)
+	assert.Equal(t, "outbox: database resolver returned a nil database", err.Error())
+	assert.Nil(t, db)
+}
+
+func TestStartupDatabaseSuccess(t *testing.T) {
+	cfg := &config.Config{}
+	want := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	getDB := func(context.Context) (dbtypes.Interface, error) { return want, nil }
+
+	ctx, cancel, db, err := StartupDatabase(context.Background(), cfg, "outbox", getDB)
+	defer cancel()
+	require.NoError(t, err)
+	assert.Same(t, want, db)
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok, "StartupDatabase must derive a bounded context")
+	assert.InDelta(t, float64(defaultStartupTimeout), float64(time.Until(deadline)), float64(2*time.Second),
+		"a zero App.Startup.Database must default the probe timeout to 10s")
+}
+
+func TestStartupDatabaseUsesConfiguredTimeout(t *testing.T) {
+	cfg := &config.Config{App: config.AppConfig{Startup: config.StartupConfig{Database: 2 * time.Second}}}
+	getDB := func(context.Context) (dbtypes.Interface, error) { return dbtesting.NewTestDB(dbtypes.PostgreSQL), nil }
+
+	ctx, cancel, _, err := StartupDatabase(context.Background(), cfg, "outbox", getDB)
+	defer cancel()
+	require.NoError(t, err)
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok)
+	assert.InDelta(t, float64(2*time.Second), float64(time.Until(deadline)), float64(500*time.Millisecond),
+		"a configured App.Startup.Database must be used verbatim, not overridden by the 10s default")
+}
+
+func TestTableUnusableError(t *testing.T) {
+	cause := errors.New("relation does not exist")
+	err := TableUnusableError("outbox", "gobricks_outbox", "outbox.autocreatetable", cause)
+	require.Error(t, err)
+	assert.Equal(t, `outbox: table "gobricks_outbox" is not usable (missing table or insufficient privileges); `+
+		`run migrations or set outbox.autocreatetable=true: relation does not exist`, err.Error())
+	assert.ErrorIs(t, err, cause)
 }
 
 // waitForGoroutineBlockedOnTenantLock spins until some goroutine's stack shows

--- a/outbox/module.go
+++ b/outbox/module.go
@@ -95,8 +95,9 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 		return nil
 	}
 
-	// Fail fast: when outbox is enabled, DB and Messaging resolvers are required.
-	// Without them, the relay job would panic on first poll instead of failing at startup.
+	// Guards direct construction only: app.RegisterModule always wires non-nil
+	// resolvers, so these never fire through the normal registration path.
+	// verifyStartupDatabase (below) is the real fail-fast for an enabled outbox.
 	if m.getDB == nil {
 		return fmt.Errorf("outbox: database resolver (deps.DB) is required when outbox is enabled")
 	}
@@ -122,9 +123,14 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 		return err
 	}
 
-	// Store creation is deferred until first use (lazy init like scheduler)
-	// because we need to know the database vendor type, which requires a DB connection.
-	// The publisher wraps the store and handles lazy initialization.
+	if m.startupDatabaseCheckApplies() {
+		if err := m.verifyStartupDatabase(); err != nil {
+			return err
+		}
+	}
+
+	// The "" store is already warm when verifyStartupDatabase ran; every other key
+	// (per-tenant fan-out, dynamic sources) is still created lazily on first use.
 	m.publisher = &lazyPublisher{module: m}
 
 	m.logger.Info().
@@ -197,6 +203,34 @@ func (m *Module) checkTenancyFanOutGuards() error {
 				"the relay would never deliver any events. Configure multitenant.tenants, set outbox.tenancy=shared, " +
 				"or set outbox.enabled=false")
 		}
+	}
+	return nil
+}
+
+// startupDatabaseCheckApplies reports whether Init can statically resolve the
+// "" key; see tenantstore.StartupCheckApplies for the predicate and its
+// exemptions (shared with inbox so it cannot drift between the two).
+func (m *Module) startupDatabaseCheckApplies() bool {
+	return tenantstore.StartupCheckApplies(m.config, m.sharedLedger())
+}
+
+// verifyStartupDatabase fails Init when the enabled outbox cannot possibly
+// relay: no database configured, database unreachable, or outbox table
+// missing/unusable. FetchPending(…, 1) is the probe: the exact read the relay
+// performs every poll, side-effect free.
+func (m *Module) verifyStartupDatabase() error {
+	ctx, cancel, db, err := tenantstore.StartupDatabase(context.Background(), m.config, "outbox", m.getDB)
+	defer cancel()
+	if err != nil {
+		return err
+	}
+
+	store, err := m.ensureStoreInitialized(ctx)
+	if err != nil {
+		return err // already "outbox: …"-prefixed by the tenantstore cache
+	}
+	if _, err := store.FetchPending(ctx, db, 1); err != nil {
+		return tenantstore.TableUnusableError("outbox", m.cfg.TableName, "outbox.autocreatetable", err)
 	}
 	return nil
 }

--- a/outbox/module_test.go
+++ b/outbox/module_test.go
@@ -125,7 +125,7 @@ func TestModuleInitEnabledWithBothResolvers(t *testing.T) {
 			},
 		},
 		DB: func(_ context.Context) (dbtypes.Interface, error) {
-			return nil, nil
+			return probeReadyDB("postgresql"), nil
 		},
 		Messaging: func(_ context.Context) (messaging.AMQPClient, error) {
 			return nil, nil
@@ -266,7 +266,7 @@ func TestModuleInitAllowsShortPublishTimeoutWhenNoRetries(t *testing.T) {
 				},
 			},
 		},
-		DB:        func(_ context.Context) (dbtypes.Interface, error) { return nil, nil },
+		DB:        func(_ context.Context) (dbtypes.Interface, error) { return probeReadyDB("postgresql"), nil },
 		Messaging: func(_ context.Context) (messaging.AMQPClient, error) { return nil, nil },
 	}
 
@@ -384,6 +384,169 @@ func TestModuleInitEnabledMessagingUnconfiguredMultiTenant(t *testing.T) {
 	assert.NotNil(t, m.publisher, "Publisher should be initialized in static multi-tenant mode even with empty global broker URL")
 }
 
+// outboxTestConfig returns a minimal enabled, single-tenant, static-source
+// config whose messaging/publishtimeout guards already pass — the shared base
+// for the startup-database verification tests below.
+func outboxTestConfig() *config.Config {
+	return &config.Config{
+		Outbox:    config.OutboxConfig{Enabled: true},
+		Messaging: config.MessagingConfig{Broker: config.BrokerConfig{URL: "amqp://localhost"}},
+	}
+}
+
+// initDeps builds the ModuleDeps for the Init tests; the config and the DB
+// resolver are the only axes they vary.
+func initDeps(cfg *config.Config, db func(context.Context) (dbtypes.Interface, error)) *app.ModuleDeps {
+	return &app.ModuleDeps{
+		Logger:    logger.New("disabled", true),
+		Config:    cfg,
+		DB:        db,
+		Messaging: func(_ context.Context) (messaging.AMQPClient, error) { return nil, nil },
+	}
+}
+
+// TestModuleInitFailsWhenDatabaseNotConfigured guards gap (a) from issue #876:
+// an enabled outbox with no database configured must fail startup, not boot green.
+func TestModuleInitFailsWhenDatabaseNotConfigured(t *testing.T) {
+	m := NewModule()
+	deps := initDeps(outboxTestConfig(), func(_ context.Context) (dbtypes.Interface, error) {
+		return nil, config.NewNotConfiguredError("database", "DATABASE_TYPE", "database")
+	})
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a database, but none is configured")
+}
+
+// TestModuleInitFailsWhenDatabaseUnreachable guards gap (b): a configured but
+// unreachable database must fail startup rather than let the relay fail once per
+// poll interval forever.
+func TestModuleInitFailsWhenDatabaseUnreachable(t *testing.T) {
+	m := NewModule()
+	deps := initDeps(outboxTestConfig(), func(_ context.Context) (dbtypes.Interface, error) {
+		return nil, errors.New("dial tcp 10.0.0.1:5432: connect: connection refused")
+	})
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database unreachable at startup")
+}
+
+// TestModuleInitFailsWhenTableMissing guards gap (c): a reachable database whose
+// outbox table does not exist (or is unreadable) must fail startup — the fixture
+// has no query expectations, so the probe's SELECT goes unmatched.
+func TestModuleInitFailsWhenTableMissing(t *testing.T) {
+	m := NewModule()
+	deps := initDeps(outboxTestConfig(), func(_ context.Context) (dbtypes.Interface, error) {
+		return dbtesting.NewTestDB("postgresql"), nil
+	})
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not usable")
+}
+
+// TestModuleInitPerTenantMultitenantSkipsStartupProbe pins
+// startupDatabaseCheckApplies' Multitenant clause: the failing getDB must not fail Init.
+func TestModuleInitPerTenantMultitenantSkipsStartupProbe(t *testing.T) {
+	m := NewModule()
+	deps := initDeps(&config.Config{
+		Outbox: config.OutboxConfig{Enabled: true},
+		Multitenant: config.MultitenantConfig{
+			Enabled: true,
+			Tenants: map[string]config.TenantEntry{"tenant-a": {}},
+		},
+	}, func(_ context.Context) (dbtypes.Interface, error) {
+		return nil, errors.New("would fail the probe if it ran")
+	})
+
+	err := m.Init(deps)
+	require.NoError(t, err, "per-tenant fan-out resolves databases at runtime, not at Init")
+}
+
+// TestModuleInitDynamicSourceSkipsStartupProbe pins
+// startupDatabaseCheckApplies' Source.Type clause: the failing getDB must not fail Init.
+func TestModuleInitDynamicSourceSkipsStartupProbe(t *testing.T) {
+	m := NewModule()
+	deps := initDeps(&config.Config{
+		Outbox:    config.OutboxConfig{Enabled: true},
+		Messaging: config.MessagingConfig{Broker: config.BrokerConfig{URL: "amqp://localhost"}},
+		Source:    config.SourceConfig{Type: config.SourceTypeDynamic},
+	}, func(_ context.Context) (dbtypes.Interface, error) {
+		return nil, errors.New("would fail the probe if it ran")
+	})
+
+	err := m.Init(deps)
+	require.NoError(t, err, "a dynamic source resolves the \"\" key at runtime, not at Init")
+}
+
+// TestModuleInitSharedTenancyStaticSourceProbesControlPlaneDatabase closes gap
+// (3): tenancy=shared with a static source resolves the "" key statically, so
+// Init must now probe the control-plane database — previously this mode was
+// never probed at startup at all.
+func TestModuleInitSharedTenancyStaticSourceProbesControlPlaneDatabase(t *testing.T) {
+	m := NewModule()
+	failingDB := func(_ context.Context) (dbtypes.Interface, error) {
+		return nil, errors.New("dial tcp control-plane-db: connection refused")
+	}
+	m.SetSharedResolvers(failingDB, stubSharedMsg)
+	deps := sharedTenancyDeps(&config.Config{
+		Outbox:      config.OutboxConfig{Enabled: true, Tenancy: config.TenancyShared},
+		Messaging:   config.MessagingConfig{Broker: config.BrokerConfig{URL: "amqp://localhost"}},
+		Multitenant: config.MultitenantConfig{Enabled: true}, // pins the sharedLedger() clause, not just !Multitenant.Enabled
+	})
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database unreachable at startup",
+		"tenancy=shared with a static source must probe the control-plane \"\" database at startup")
+}
+
+// TestModuleInitDisabledOutboxSkipsStartupProbe pins that a disabled outbox never
+// reaches the probe, regardless of how the DB resolver would behave.
+func TestModuleInitDisabledOutboxSkipsStartupProbe(t *testing.T) {
+	m := NewModule()
+	deps := initDeps(&config.Config{Outbox: config.OutboxConfig{Enabled: false}},
+		func(_ context.Context) (dbtypes.Interface, error) {
+			return nil, errors.New("would fail the probe if it ran")
+		})
+
+	err := m.Init(deps)
+	require.NoError(t, err)
+}
+
+// TestModuleInitDefaultsZeroStartupTimeoutToTenSeconds pins the timeout <= 0
+// default: an unset App.Startup.Database must bound the probe's context at
+// 10s, not 0 (an immediately-expired context) or another arithmetic result.
+func TestModuleInitDefaultsZeroStartupTimeoutToTenSeconds(t *testing.T) {
+	m := NewModule()
+	var deadline time.Time
+	var hasDeadline bool
+	// App.Startup.Database left at its zero value.
+	deps := initDeps(outboxTestConfig(), func(ctx context.Context) (dbtypes.Interface, error) {
+		deadline, hasDeadline = ctx.Deadline()
+		return probeReadyDB("postgresql"), nil
+	})
+
+	err := m.Init(deps)
+	require.NoError(t, err)
+	require.True(t, hasDeadline, "verifyStartupDatabase must derive a bounded context")
+	assert.InDelta(t, float64(10*time.Second), float64(time.Until(deadline)), float64(2*time.Second),
+		"a zero App.Startup.Database must default the probe timeout to 10s")
+}
+
+// TestModuleInitFailsWhenDatabaseResolverReturnsNilDatabase pins the nil-db
+// contract-violation guard: without it, ensureStoreInitialized's
+// db.DatabaseType() call would panic inside Init instead of erroring.
+func TestModuleInitFailsWhenDatabaseResolverReturnsNilDatabase(t *testing.T) {
+	m := NewModule()
+	deps := initDeps(outboxTestConfig(), func(_ context.Context) (dbtypes.Interface, error) { return nil, nil })
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "returned a nil database")
+}
+
 func TestModuleInitFailsFastForDynamicMultitenant(t *testing.T) {
 	m := NewModule()
 	deps := &app.ModuleDeps{
@@ -439,12 +602,7 @@ func stubSharedMsg(_ context.Context) (messaging.AMQPClient, error) {
 // sharedTenancyDeps builds the ModuleDeps used by the shared-tenancy tests;
 // only Config varies between them.
 func sharedTenancyDeps(cfg *config.Config) *app.ModuleDeps {
-	return &app.ModuleDeps{
-		Logger:    logger.New("disabled", true),
-		Config:    cfg,
-		DB:        stubSharedDB,
-		Messaging: stubSharedMsg,
-	}
+	return initDeps(cfg, stubSharedDB)
 }
 
 func TestModuleInitSharedTenancyDynamicMultitenantSucceeds(t *testing.T) {
@@ -528,12 +686,22 @@ func TestRegisterJobsSharedTenancySinglePass(t *testing.T) {
 		"logCycle derives the tenancy stamp from the relay's config copy")
 }
 
+// probeReadyDB returns a fresh TestDB whose SELECT expectation satisfies Init's
+// startup-database probe (verifyStartupDatabase's FetchPending call), for tests
+// that only need Init to succeed. vendor must be one FetchPending supports
+// (postgresql/oracle) or Init fails on the probe's ensureStoreInitialized.
+func probeReadyDB(vendor string) *dbtesting.TestDB {
+	db := dbtesting.NewTestDB(vendor)
+	db.ExpectQuery("SELECT").WillReturnRows(dbtesting.NewRowSet("id"))
+	return db
+}
+
 // initEnabledModule returns an outbox Module that has gone through Init
 // against the supplied dbVendor (no auto-create-table). getDB is wired to
 // return a TestDB of that vendor.
 func initEnabledModule(t *testing.T, dbVendor string, retention time.Duration) (*Module, *dbtesting.TestDB) {
 	t.Helper()
-	db := dbtesting.NewTestDB(dbVendor)
+	db := probeReadyDB(dbVendor)
 	m := NewModule()
 	deps := &app.ModuleDeps{
 		Logger: logger.New("disabled", true),
@@ -569,8 +737,21 @@ func TestModuleEnsureStoreInitializedOracle(t *testing.T) {
 	assert.NotNil(t, store, "store created for oracle vendor")
 }
 
+// directModule constructs a Module bypassing Init, so ensureStoreInitialized's own
+// error handling is exercised in isolation — Init's startup-database probe would
+// otherwise surface the same failure earlier, via verifyStartupDatabase.
+func directModule(getDB func(context.Context) (dbtypes.Interface, error)) *Module {
+	return &Module{
+		logger: logger.New("disabled", true),
+		cfg:    config.OutboxConfig{TableName: DefaultTableName},
+		getDB:  getDB,
+	}
+}
+
 func TestModuleEnsureStoreInitializedUnknownVendor(t *testing.T) {
-	m, _ := initEnabledModule(t, "mysql", 0)
+	m := directModule(func(_ context.Context) (dbtypes.Interface, error) {
+		return dbtesting.NewTestDB("mysql"), nil
+	})
 	store, err := m.ensureStoreInitialized(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported database vendor")
@@ -578,19 +759,9 @@ func TestModuleEnsureStoreInitializedUnknownVendor(t *testing.T) {
 }
 
 func TestModuleEnsureStoreInitializedDBResolverError(t *testing.T) {
-	m := NewModule()
-	deps := &app.ModuleDeps{
-		Logger: logger.New("disabled", true),
-		Config: &config.Config{
-			Outbox:    config.OutboxConfig{Enabled: true},
-			Messaging: config.MessagingConfig{Broker: config.BrokerConfig{URL: "amqp://x"}},
-		},
-		DB: func(_ context.Context) (dbtypes.Interface, error) {
-			return nil, errors.New("connection refused")
-		},
-		Messaging: func(_ context.Context) (messaging.AMQPClient, error) { return nil, nil },
-	}
-	require.NoError(t, m.Init(deps))
+	m := directModule(func(_ context.Context) (dbtypes.Interface, error) {
+		return nil, errors.New("connection refused")
+	})
 
 	store, err := m.ensureStoreInitialized(context.Background())
 	require.Error(t, err)
@@ -673,10 +844,13 @@ func TestModuleRegisterJobsPropagatesCleanupError(t *testing.T) {
 	assert.Len(t, reg.FixedRateCalls, 1, "relay registered before cleanup failure")
 }
 
-func TestLazyPublisherPublishLazilyInitializesStore(t *testing.T) {
+// TestLazyPublisherPublishReusesEagerlyInitializedStore pins that Init's startup
+// probe (verifyStartupDatabase) already warms the tenant store — Publish must
+// reuse that same instance rather than creating a second one.
+func TestLazyPublisherPublishReusesEagerlyInitializedStore(t *testing.T) {
 	m, db := initEnabledModule(t, "postgresql", 0)
-	_, ok := m.stores.Cached("")
-	require.False(t, ok, "store is nil before first Publish")
+	preInit, ok := m.stores.Cached("")
+	require.True(t, ok, "the startup probe eagerly initializes the store")
 
 	// Wire the tx's INSERT expectation matching postgresStore.Insert.
 	db.ExpectTransaction().
@@ -695,8 +869,8 @@ func TestLazyPublisherPublishLazilyInitializesStore(t *testing.T) {
 	id, err := m.OutboxPublisher().Publish(context.Background(), tx, event)
 	require.NoError(t, err)
 	assert.NotEmpty(t, id, "Publish returns a generated event ID")
-	_, ok = m.stores.Cached("")
-	assert.True(t, ok, "store initialized lazily on first Publish")
+	postPublish, _ := m.stores.Cached("")
+	assert.Same(t, preInit, postPublish, "Publish must reuse the store the startup probe already initialized")
 }
 
 func TestLazyStoreDelegatesAllMethodsAfterInit(t *testing.T) {

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -39,7 +39,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E52  | v0.51.0 → v0.52.0 | compile-break | 4 | C52.1 | if you set `.Args` on any declaration in ≤v0.51.0, verify current broker state before upgrading |
 | E55  | v0.52.0 → v0.55.0 | additive (safe) | 3 | none | none |
 | E56  | v0.55.0 → v0.56.0 | compile-break (C56.6 only partially — see its gate) + silent-behavior default flip (C56.11) | 15 | C56.6 C56.9 | grep log-driven alerts, dashboards, and test assertions for card-data / `iban` / `otp` field names — their values render `***` after the bump (C56.3); expect a cold tenant's first messaging request to fail fast instead of blocking (C56.4); if you assemble config in Go, check for `forwardedclientcert.require` without `enabled` — that service was serving unauthenticated traffic and now returns 401 (C56.5); if one queue name is declared from two places, confirm the two shapes agree — a mismatch that used to be silently overwritten now fails startup (C56.7); if you call a JOSE-protected peer, check for payload-free requests of **any** method — `GET`/`HEAD`/`DELETE` as well as `POST`/`PUT`/`PATCH` — since none of them are sealed now and a peer demanding `application/jose` on every request will answer 415 (C56.8); `/ready`'s 200 body gains `cache` and `cache_stats` and, where a cache is configured, every poll now issues a Redis `PING`, so update any test, schema, or dashboard that pins its exact key set and expect a live cache outage to read `unhealthy` (C56.10); if you run with a top-level cache enabled (or supply an `Options.CacheConnector`, which is probed regardless of `cache.enabled`) and have never set `cache.critical`, that outage now also answers `503` and drains every replica from rotation at once — decide before the bump whether to keep the strict default (and set `readinessProbe.failureThreshold: 3`) or add `cache.critical: false` (C56.11); and if any alert or runbook parses the Redis address out of `/ready`'s `503` body, repoint it at the app log or `/_sys/health-debug` (C56.12); and a module that cannot work without a database can now declare `app.DatabaseRequirer` so an absent one aborts startup rather than booting green (C56.13); check every environment that sets any `database.*` identity field for a complete section, since a partial one now fails startup (C56.14); and re-point any alert asserting `/ready` returns 503 for a database-free or multi-tenant service — both now return 200 (C56.15) |
-| E57  | v0.56.0 → v0.57.0 | silent-behavior | 3 | none | if any alert, runbook, synthetic check, or contract test parses the driver error out of `/ready`'s database `503` body, repoint it at the app log or `<debug.pathprefix>/health-debug` (default `/_sys`) — the field is now the fixed string `database unavailable` (C57.1); and if you implement your own critical `app.Prober`, its `503` body now reads `<Name> unavailable` instead of its raw error, since sanitization became the default rather than an opt-in (C57.2); and if anything reads `db_stats.connections` out of `/ready`'s **200** body — a per-tenant pool dashboard, an activity alert, a test pinning the key set — repoint it at `<debug.pathprefix>/health-debug` or the OTel database metrics, because that array is gone from `/ready`; a repo-local grep alone will not find an out-of-repo dashboard (C57.3) |
+| E57  | v0.56.0 → v0.57.0 | silent-behavior + breaking (C57.4 aborts startup) | 4 | none | if any alert, runbook, synthetic check, or contract test parses the driver error out of `/ready`'s database `503` body, repoint it at the app log or `<debug.pathprefix>/health-debug` (default `/_sys`) — the field is now the fixed string `database unavailable` (C57.1); and if you implement your own critical `app.Prober`, its `503` body now reads `<Name> unavailable` instead of its raw error, since sanitization became the default rather than an opt-in (C57.2); and if anything reads `db_stats.connections` out of `/ready`'s **200** body — a per-tenant pool dashboard, an activity alert, a test pinning the key set — repoint it at `<debug.pathprefix>/health-debug` or the OTel database metrics, because that array is gone from `/ready`; a repo-local grep alone will not find an out-of-repo dashboard (C57.3); and check every environment with `outbox.enabled: true` or `inbox.enabled: true` (outside per-tenant fan-out or a dynamic source) for a configured, reachable database whose ledger table exists — or whose `autocreatetable` can create it — because Init now aborts startup instead of booting green (C57.4) |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 - **`when: match`** → act only if `detect` returns ≥1 line (an API/arity/interface change, or a config key you set).
@@ -1141,7 +1141,7 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
 - verify: `curl -s -o /dev/null -w '%{http_code}' localhost:8080/ready`
 - ref: ADR-047 · `config/tenant_store.go` (`DBConfig`) · `app/health.go` · `app/debug_health.go` · #872
 
-## E57 · v0.56.0 → v0.57.0 — `/ready` stops disclosing internals in either body
+## E57 · v0.56.0 → v0.57.0 — `/ready` stops disclosing internals in either body + outbox/inbox startup database verification
 
 - gist: The database readiness probe now declares a sanitized public string, so `/ready`'s
   `503` body reports `database unavailable` instead of the driver's error. That error named
@@ -1164,7 +1164,21 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   resourcepool key — the tenant ID in a multi-tenant deployment — with `last_used` and
   `idle_duration` alongside it, so an unauthenticated caller read a live tenant enumeration
   and per-tenant timing. That array is now withheld from `/ready`; the scalar counters stay,
-  and the per-key detail is unchanged on `<debug.pathprefix>/health-debug` (C57.3).
+  and the per-key detail is unchanged on `<debug.pathprefix>/health-debug` (C57.3). Separately,
+  an enabled outbox or inbox now verifies at `Init` that its ledger database and table are
+  actually usable — previously `outbox.enabled: true`/`inbox.enabled: true` with no database
+  configured (or an unreachable one, or a missing ledger table) booted green and only failed
+  once per poll interval, forever, with a relay log line that misleadingly read
+  `database (optional)`. The check runs the read/write the relay or cleanup job already performs
+  every cycle (the outbox's `FetchPending(…, 1)`; the inbox's `DeleteProcessed` before the Unix
+  epoch, which matches no row) against the same database and table, so `Init` now fails fast
+  with an actionable error instead. It is a reachability-and-table check, not a full capability
+  check: the outbox probe covers exactly what the relay reads, but the inbox probe is the
+  *cleanup* job's `DELETE`, so it does not prove `ProcessOnce`'s `INSERT` — a role holding
+  `DELETE` but not `INSERT` still passes `Init` and fails at the first processed event. Per-tenant fan-out and `source.type: dynamic` deployments are
+  unaffected — those resolve their database at runtime, not at `Init`. A custom dynamic
+  `Options.ResourceSource` behind a *static* `source.type` is not among them: a module cannot see
+  that resource source, so such a deployment is probed (C57.4).
 - build-caught: none
 - exit: `go get github.com/gaborage/go-bricks@v0.57.0 && go mod tidy && go build ./... && go test ./...`
 
@@ -1343,6 +1357,71 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   `debug.bearertoken` is empty).
 - ref: `app/lifecycle.go` (`publicDBStats`) · `database/manager.go` (`DbManager.Stats`) ·
   `app/debug_health.go`
+
+### [C57.4] An enabled outbox/inbox now fails startup without a usable database · breaking · when: match
+
+- detect: `git grep -n 'outbox:\|inbox:' -- '*.yaml' '*.yml' 'config*.yaml'` and
+  `git grep -nE 'OUTBOX_ENABLED|INBOX_ENABLED'` across your deployment manifests and env
+  files for every environment that sets `outbox.enabled: true` or `inbox.enabled: true`, then
+  check each one against the exempt-mode list in `scope` below — anything not exempt is a
+  match if its database is absent, unreachable, its outbox/inbox table has not been migrated
+  yet and `autocreatetable` is off, or its runtime role lacks the privilege the probe needs
+  (outbox `SELECT`, inbox `DELETE`, plus table DDL wherever `autocreatetable` is on).
+- scope: `outbox.Module.Init` / `inbox.Module.Init` now run a startup probe
+  (`verifyStartupDatabase`) whenever the `""` key is statically resolvable at `Init` time —
+  single-tenant, or `tenancy: shared` with a static `source.type` (the same set
+  `checkTenancyFanOutGuards` already gated). The probe is the exact read/write the relay or
+  cleanup job already performs every cycle (outbox: `FetchPending(…, 1)`; inbox:
+  `DeleteProcessed` before the Unix epoch, a write that matches no row), so it fails for the
+  same reasons the job would have — just at startup instead of once per `pollinterval`/day,
+  forever. The inbox probe therefore needs `DELETE` on the inbox table even where nothing else
+  deletes from it: `ProcessOnce` only issues an `INSERT`, and the retention cleanup job — the
+  sole runtime `DELETE` — is registered only when a scheduler module is present, so a
+  least-privilege runtime role for a `ProcessOnce`-only deployment must be granted `DELETE`
+  before the bump. With `autocreatetable` enabled the table DDL moves to `Init` as well, since
+  the probe initializes the store. **Exempt** (unaffected, still runtime-resolved): per-tenant
+  fan-out (`multitenant.enabled: true` with the default tenancy) and a dynamic source
+  (`source.type: dynamic`). **Not exempt, unlike elsewhere in the framework:** a custom
+  dynamic `Options.ResourceSource` behind a static `source.type` — the app builder's
+  pre-init and `/ready` skip that mode, but a module sees only `*config.Config` and cannot
+  detect it, so such a deployment is probed at startup where it previously wasn't. Set
+  `source.type: dynamic` to opt out.
+- gate: match = an enabled outbox/inbox in a non-exempt mode has no database configured, an
+  unreachable database, or a table the probe cannot use. `Init` now returns one of:
+  `outbox.enabled=true requires a database, but none is configured` (or `inbox`, same
+  wording) for an unconfigured database; `database unreachable at startup` for a
+  network/auth/DNS failure; or `table %q is not usable (missing table or insufficient
+  privileges)` when the table is missing, or the runtime role cannot run the probe's statement
+  (outbox: `SELECT`; inbox: `DELETE`). no-match = the database is configured and reachable and
+  the table exists — or `autocreatetable` is on and its DDL succeeds — or the deployment is
+  exempt.
+- before:
+  ```yaml
+  outbox:
+    enabled: true
+  # no database: block — the service booted green; the relay then logged a
+  # poll-interval failure forever, captioned "database (optional)"
+  ```
+- after:
+  ```yaml
+  database:
+    type: postgresql
+    host: db.internal
+    port: 5432
+    database: appdb
+    username: app
+  outbox:
+    enabled: true
+  # …and the outbox table must already exist (run migrations), or set
+  # outbox.autocreatetable: true
+  ```
+- verify: `go build ./... && go test ./...` exercises the probe logic itself, but no test can
+  see your environment's config — start the service against each non-exempt environment and
+  confirm it now exits non-zero (instead of logging a relay/cleanup failure once per interval)
+  when the database is absent or unreachable, or its table is missing with `autocreatetable`
+  off (or on, but the DDL fails); confirm a healthy environment still starts cleanly.
+- ref: wiki/outbox.md#startup-verification · `outbox/module.go` (`verifyStartupDatabase`) ·
+  `inbox/module.go` (`verifyStartupDatabase`) · #876
 
 ---
 

--- a/wiki/outbox.md
+++ b/wiki/outbox.md
@@ -188,6 +188,57 @@ outbox:
   retentionperiod: 168h      # 7-day retention
 ```
 
+## Startup Verification
+
+When `outbox.enabled: true` (or `inbox.enabled: true`), `Init` verifies the `""`-key ledger database
+and table are actually usable before the app finishes booting — instead of booting green and failing
+once per poll interval forever. The check probes that database with the operation the relay or
+cleanup job already performs every cycle — the outbox's `FetchPending(…, 1)`, a read; the inbox's
+`DeleteProcessed` before the Unix epoch, a write that matches no row (so it changes nothing, but it
+is still a write and will fail against a read-only replica) — and fails `Init` with one of:
+
+- `outbox.enabled=true requires a database, but none is configured` / same for `inbox` — the
+  `""`-key database resolver reports `config.IsNotConfigured`.
+- `database unreachable at startup` — the resolver returned a different error (network, auth, DNS).
+- `table %q is not usable (missing table or insufficient privileges)` — the database is reachable but
+  the table is missing, or the runtime role lacks the privilege the probe needs (outbox: `SELECT`;
+  inbox: `DELETE`). Missing table → run migrations, or set
+  `outbox.autocreatetable`/`inbox.autocreatetable` where the role also holds DDL rights. Privilege
+  failure → grant that privilege; auto-creation does not help.
+- `database resolver returned a nil database` — a resolver contract violation (`(nil, nil)`).
+
+**Exempt modes** (the `""` key is not statically resolvable at `Init` time, so the check is skipped —
+these deployments keep today's runtime-resolution behavior):
+
+- **Per-tenant fan-out** (`multitenant.enabled: true`, default `outbox.tenancy`/`inbox.tenancy`) —
+  each tenant's database is resolved per-poll via the resource source, not at `Init`.
+- **Dynamic source** (`source.type: dynamic`) — the `""` key itself resolves at runtime.
+
+`tenancy: shared` with a **static** source IS checked: the shared ledger's control-plane database is
+statically known at `Init`, so a slow or unreachable control-plane database now delays startup by up
+to `app.startup.database` (10s default) instead of failing silently on the first relay/cleanup cycle.
+
+Three further consequences of running the check inside `Init`:
+
+- The inbox probe requires **`DELETE`** on the inbox table even where nothing else deletes from it:
+  `ProcessOnce` only ever issues an `INSERT`, and the retention cleanup job — the sole runtime
+  `DELETE` — is registered only when a scheduler module is present. A least-privilege runtime role
+  for a `ProcessOnce`-only deployment (no scheduler registered) must be granted `DELETE` before
+  upgrading, or `Init` fails with `table … is not usable`. The converse also holds: because the
+  inbox probe is the cleanup job's `DELETE`, it does **not** prove `ProcessOnce`'s `INSERT`, so a
+  role granted `DELETE` but not `INSERT` still passes `Init` and fails at the first processed
+  event. The outbox probe has no such gap — `FetchPending` is exactly what the relay reads.
+- A **custom dynamic `Options.ResourceSource` behind a static `source.type`** is NOT exempt, although
+  the app builder's own pre-init and `/ready` database probe both skip it. The module sees only
+  `*config.Config`, so it cannot detect that resource source; such a deployment is probed at startup
+  where it previously wasn't. Set `source.type: dynamic` to opt out until the exemption is threaded
+  down to modules — that opt-out is open to single-tenant and `tenancy: shared` deployments only. A
+  per-tenant fan-out deployment is already exempt by the rule above and must **not** set it: the
+  outbox relay (and the inbox cleanup job) reject dynamic multi-tenant sources outright.
+- With `outbox.autocreatetable`/`inbox.autocreatetable` enabled, the `""` key's table DDL now runs at
+  `Init` rather than on the first publish or poll — the probe initializes that store, which is what
+  creates the table. The exempt modes above run no probe, so their DDL still waits for first use.
+
 ## Multi-Tenant
 
 In multi-tenant mode the outbox/inbox support two tenancy modes, set via `outbox.tenancy` /


### PR DESCRIPTION
## What

An enabled outbox or inbox booted green with no database configured, an
unreachable one, or a missing ledger table; the background job then failed once
per cycle forever. `Init` now probes the `""`-key database with the exact
read/write the job already performs, and fails startup instead.

## Impact

Single-tenant and `tenancy: shared` with a static source now abort startup when
the database is absent, unreachable, or unmigrated; per-tenant fan-out and
`source.type: dynamic` stay exempt. Shared-ledger gains a startup dial it never
had — a slow control-plane database delays boot by up to `app.startup.database`
(10s default). The inbox probe is a `DELETE`, so a `ProcessOnce`-only
deployment's least-privilege role now needs that grant.

## Verification

`make mutate` cannot reach the mode predicate: gremlins leaves `INVERT_LOGICAL`
off, so `||` is never mutated. Hand-mutated instead — deleting
`|| m.sharedLedger()` fails both packages at
`TestModuleInitSharedTenancyStaticSourceProbesControlPlaneDatabase`.

Closes #876


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled inbox and outbox modules now verify statically configured databases and ledger tables during startup.
  * Startup reports clear errors for missing, unreachable, unusable, or unresolved databases.
  * Dynamic and per-tenant configurations continue to skip checks when they cannot be verified at startup.
* **Bug Fixes**
  * Improved handling of startup timeouts and shared-tenancy database validation.
* **Documentation**
  * Updated migration and operations guidance, including readiness error handling and required database privileges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->