### PR TITLE
fix(config)!: infer database.type from the connectionstring scheme

### DIFF
--- a/app/app_builder.go
+++ b/app/app_builder.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -215,6 +216,19 @@ func (b *Builder) ConfigureRuntimeHelpers() *Builder {
 		return b
 	}
 
+	// ADR-050: with the built-in connector, an untyped connection string can
+	// never dispatch (database.NewConnection switches on Type). A custom
+	// Options.DatabaseConnector owns DSN parsing and is exempt.
+	if b.opts == nil || b.opts.DatabaseConnector == nil {
+		if paths := untypedConnectionStringPaths(b.cfg); len(paths) > 0 {
+			b.err = fmt.Errorf(
+				"database configuration at %v: connectionstring has no resolved database type; "+
+					"run config.Validate or set <path>.type to postgresql or oracle",
+				paths)
+			return b
+		}
+	}
+
 	b.app.messagingInitializer = NewMessagingInitializer(b.logger, b.app.messagingManager, b.cfg.Multitenant.Enabled)
 	b.app.connectionPreWarmer = NewConnectionPreWarmer(b.logger, b.app.dbManager, b.app.messagingManager)
 	// Thread the operator's readiness budget (messaging.reconnect.readytimeout)
@@ -244,6 +258,38 @@ func (b *Builder) ConfigureRuntimeHelpers() *Builder {
 	}
 
 	return b
+}
+
+// untypedConnectionStringPaths collects every config path whose database section
+// carries a connection string with an unresolved type. That covers both ways the
+// type can still be empty here: scheme inference (config/validation.go) ran and did
+// not recognize the DSN, or it never ran because the caller handed the builder a
+// hand-built config without config.Validate (app.NewWithConfig).
+// Sorted for deterministic startup errors.
+func untypedConnectionStringPaths(cfg *config.Config) []string {
+	var paths []string
+	if cfg.Database.ConnectionString != "" && cfg.Database.Type == "" {
+		paths = append(paths, "database")
+	}
+	for name := range cfg.Databases {
+		db := cfg.Databases[name]
+		if db.ConnectionString != "" && db.Type == "" {
+			paths = append(paths, "databases."+name)
+		}
+	}
+	// Gated: config.validateMultitenant returns early when multitenancy is
+	// disabled, so tenant DSNs never reach inference. A disabled tenants block is
+	// inert config — policing it would abort startup on DSNs we do recognize.
+	if cfg.Multitenant.Enabled {
+		for id := range cfg.Multitenant.Tenants {
+			t := cfg.Multitenant.Tenants[id]
+			if t.Database.ConnectionString != "" && t.Database.Type == "" {
+				paths = append(paths, "multitenant.tenants."+id+".database")
+			}
+		}
+	}
+	slices.Sort(paths)
+	return paths
 }
 
 // performPreInitialization attempts to establish connections during app startup.

--- a/app/app_builder_test.go
+++ b/app/app_builder_test.go
@@ -21,6 +21,9 @@ import (
 const (
 	shouldSkipWithPreviousError = "with previous error should skip"
 	missingAppInstanceErrorMsg  = "missing app instance"
+	// A well-formed DSN whose scheme config's inference does not recognize, so it
+	// reaches ConfigureRuntimeHelpers still carrying an empty Type.
+	unrecognizedSchemeDSN = "sqlserver://user:pass@localhost:1433/db"
 )
 
 func TestNewAppBuilder(t *testing.T) {
@@ -463,6 +466,122 @@ func TestAppBuilderConfigureRuntimeHelpersThreadsReadyTimeout(t *testing.T) {
 
 	require.NoError(t, result.err)
 	assert.Equal(t, 20*time.Second, result.app.connectionPreWarmer.readinessTimeout)
+}
+
+// TestAppBuilderConfigureRuntimeHelpersRejectsUntypedConnectionString pins ADR-050: with
+// the built-in connector, a connection string whose scheme inference (config/validation.go)
+// didn't recognize it and that carries no explicit type can never dispatch, so the builder
+// must fail fast rather than let startup succeed into a dead database.
+func TestAppBuilderConfigureRuntimeHelpersRejectsUntypedConnectionString(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Database.ConnectionString = unrecognizedSchemeDSN
+
+	builder := &Builder{cfg: cfg, logger: logger.New("error", false), app: &App{}}
+	result := builder.ConfigureRuntimeHelpers()
+
+	require.Error(t, result.err)
+	assert.Contains(t, result.err.Error(), "connectionstring has no resolved database type")
+	// Bracketed: the message's own prefix is "database configuration at …", so a bare
+	// "database" substring holds for every path list and would pin nothing.
+	assert.Contains(t, result.err.Error(), "[database]")
+}
+
+// TestAppBuilderConfigureRuntimeHelpersGuardsWhenOptionsLackDatabaseConnector pins the
+// DatabaseConnector-nil half of the guard: a non-nil Options set for an unrelated reason
+// (here, MessagingClientFactory) is the common consumer shape, and the guard must still
+// fire on the built-in connector rather than being defeated by Options merely being non-nil.
+func TestAppBuilderConfigureRuntimeHelpersGuardsWhenOptionsLackDatabaseConnector(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Database.ConnectionString = unrecognizedSchemeDSN
+
+	opts := &Options{
+		MessagingClientFactory: func(string, logger.Logger) messaging.AMQPClient {
+			return testmocks.NewMockAMQPClient()
+		},
+	}
+	builder := &Builder{cfg: cfg, opts: opts, logger: logger.New("error", false), app: &App{}}
+	result := builder.ConfigureRuntimeHelpers()
+
+	require.Error(t, result.err)
+	assert.Contains(t, result.err.Error(), "connectionstring has no resolved database type")
+	// Bracketed: the message's own prefix is "database configuration at …", so a bare
+	// "database" substring holds for every path list and would pin nothing.
+	assert.Contains(t, result.err.Error(), "[database]")
+}
+
+// TestAppBuilderConfigureRuntimeHelpersGuardsRecognizedSchemeWithoutValidation pins the
+// app.NewWithConfig path: it skips config.Validate, so even a recognized scheme reaches the
+// guard untyped and the message must report the state, not blame the scheme.
+func TestAppBuilderConfigureRuntimeHelpersGuardsRecognizedSchemeWithoutValidation(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Database.ConnectionString = "postgres://user:pass@localhost:5432/db"
+
+	builder := &Builder{cfg: cfg, logger: logger.New("error", false), app: &App{}}
+	result := builder.ConfigureRuntimeHelpers()
+
+	require.Error(t, result.err)
+	assert.Contains(t, result.err.Error(),
+		"database configuration at [database]: connectionstring has no resolved database type")
+	assert.Contains(t, result.err.Error(), "run config.Validate")
+}
+
+// TestAppBuilderConfigureRuntimeHelpersExemptsCustomConnector pins that a custom
+// Options.DatabaseConnector owns DSN parsing and is exempt from the untyped-DSN guard.
+func TestAppBuilderConfigureRuntimeHelpersExemptsCustomConnector(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Database.ConnectionString = unrecognizedSchemeDSN
+	cfg.Multitenant.Enabled = true // skip pre-initialization; only the guard is under test
+
+	opts := &Options{
+		DatabaseConnector: func(*config.DatabaseConfig, logger.Logger) (database.Interface, error) {
+			return &testmocks.MockDatabase{}, nil
+		},
+	}
+	builder := &Builder{cfg: cfg, opts: opts, logger: logger.New("error", false), app: &App{}}
+	result := builder.ConfigureRuntimeHelpers()
+
+	require.NoError(t, result.err)
+}
+
+// TestAppBuilderConfigureRuntimeHelpersListsAllUntypedPaths pins the sorted, multi-path
+// error shape. TWO entries in cfg.Databases is what makes slices.Sort load-bearing: Go
+// randomizes map iteration, so without the sort "analytics" and "reporting" would flip
+// between runs. Asserting the rendered slice pins the exact set AND the order.
+func TestAppBuilderConfigureRuntimeHelpersListsAllUntypedPaths(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Databases = map[string]config.DatabaseConfig{
+		"reporting": {ConnectionString: "sqlserver://h1:1433/db1"},
+		"analytics": {ConnectionString: "sqlserver://h3:1433/db3"},
+	}
+	cfg.Multitenant.Enabled = true // tenant DSNs reach inference only when multitenancy is on
+	cfg.Multitenant.Tenants = map[string]config.TenantEntry{
+		"acme": {Database: config.DatabaseConfig{ConnectionString: "sqlserver://h2:1433/db2"}},
+	}
+
+	builder := &Builder{cfg: cfg, logger: logger.New("error", false), app: &App{}}
+	result := builder.ConfigureRuntimeHelpers()
+
+	require.Error(t, result.err)
+	assert.Contains(t, result.err.Error(),
+		"[databases.analytics databases.reporting multitenant.tenants.acme.database]")
+}
+
+// TestAppBuilderConfigureRuntimeHelpersIgnoresTenantsWhenMultitenantDisabled pins that a
+// leftover tenants block under multitenant.enabled=false cannot abort startup: config skips
+// tenant validation entirely there, so inference never ran and even a recognized scheme
+// would otherwise be reported as untyped.
+func TestAppBuilderConfigureRuntimeHelpersIgnoresTenantsWhenMultitenantDisabled(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Multitenant.Tenants = map[string]config.TenantEntry{
+		"acme": {Database: config.DatabaseConfig{ConnectionString: "postgres://user:pass@localhost:5432/db"}},
+	}
+
+	// Empty bundle: single-tenant static config runs pre-initialization, which no-ops
+	// on nil managers.
+	builder := &Builder{cfg: cfg, logger: logger.New("error", false), app: &App{}, bundle: &dependencyBundle{}}
+	result := builder.ConfigureRuntimeHelpers()
+
+	require.NoError(t, result.err)
 }
 
 func TestAppBuilderCreateHealthProbesErrors(t *testing.T) {

--- a/config/validation.go
+++ b/config/validation.go
@@ -442,13 +442,20 @@ func validateDatabase(cfg *DatabaseConfig) error {
 }
 
 // validateDatabaseWithConnectionString validates database settings when a connection
-// string is provided and applies the full database pool/session defaults via
-// applyDatabasePoolDefaults (timezone, connection counts, idle time, lifetime,
-// keep-alive, and query logging/slow-threshold) when zero.
-// It checks (and returns an error for) an explicit database Type that is not allowed,
-// an invalid optional Port, and negative values for Pool/Query fields.
-// The cfg argument is mutated for those default assignments.
+// string is provided. It mutates cfg: pool/session defaults via
+// applyDatabasePoolDefaults, plus ADR-050 Type inference from the DSN scheme (an
+// explicit Type that contradicts the scheme is an error rather than an override).
 func validateDatabaseWithConnectionString(cfg *DatabaseConfig) error {
+	if inferred := inferDatabaseTypeFromConnectionString(cfg.ConnectionString); inferred != "" {
+		if cfg.Type == "" {
+			cfg.Type = inferred
+		} else if cfg.Type != inferred {
+			return NewInvalidFieldError("database.type",
+				fmt.Sprintf("conflicts with the connectionstring scheme (which implies %s)", inferred),
+				[]string{inferred})
+		}
+	}
+
 	if cfg.Type != "" {
 		if err := validateDatabaseType(cfg.Type); err != nil {
 			return err
@@ -469,6 +476,20 @@ func validateDatabaseWithConnectionString(cfg *DatabaseConfig) error {
 	}
 
 	return nil
+}
+
+// inferDatabaseTypeFromConnectionString maps a recognized DSN scheme to its vendor.
+// An unrecognized scheme returns "" and is deliberately not an error here: whether
+// an untyped DSN is fatal depends on who connects (ADR-050).
+func inferDatabaseTypeFromConnectionString(cs string) string {
+	lower := strings.ToLower(cs)
+	switch {
+	case strings.HasPrefix(lower, "postgres://"), strings.HasPrefix(lower, "postgresql://"):
+		return PostgreSQL
+	case strings.HasPrefix(lower, "oracle://"):
+		return Oracle
+	}
+	return ""
 }
 
 // validateDatabaseType validates that dbType is one of the supported database type
@@ -1043,7 +1064,8 @@ func validatePostgreSQLFields(cfg *DatabaseConfig) error {
 
 // validateOracleFields validates Oracle-specific configuration fields.
 // It ensures that exactly one of Service.Name, SID, or Database is configured,
-// mirroring the DSN selection logic in database/oracle/connection.go.
+// mirroring the DSN selection logic in database/oracle/connection.go — except in
+// connection-string mode, where the DSN supplies the identifier and none is required.
 func validateOracleFields(cfg *DatabaseConfig) error {
 	// Oracle TLS (tcps/wallet) is not implemented, so reject TLS material rather than
 	// silently ignoring it — otherwise an operator who configures database.tls.cert/key/ca
@@ -1072,7 +1094,10 @@ func validateOracleFields(cfg *DatabaseConfig) error {
 		count++
 	}
 
-	if count == 0 {
+	// buildOracleDSN returns ConnectionString verbatim, so none of these fields is
+	// consulted in that mode — the DSN carries the identifier. Requiring a separate
+	// one that is then ignored would reject a valid connection-string-only config.
+	if count == 0 && cfg.ConnectionString == "" {
 		return &ConfigError{
 			Category: errCategoryMissing,
 			Field:    "oracle connection identifier",

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -14,6 +14,7 @@ import (
 const (
 	testConnectionString         = "postgresql://user:pass@localhost/db"
 	testOracleConnectionString   = "oracle://user:pass@localhost:1521/XEPDB1"
+	testUnknownSchemeConnString  = "sqlserver://user:pass@localhost:1433/db"
 	testOracleHost               = "oracle.example.com"
 	testAppName                  = "test-app"
 	testAppVersion               = "v1.0.0"
@@ -1310,7 +1311,10 @@ func TestValidateDatabaseConditionalBehavior(t *testing.T) {
 		{
 			name: "connection_string_with_invalid_type",
 			config: DatabaseConfig{
-				ConnectionString: testConnectionString,
+				// Unrecognized scheme on purpose: a postgres:// DSN would be
+				// intercepted by ADR-050's conflict branch, leaving the
+				// validateDatabaseType call on this path with no failing test.
+				ConnectionString: testUnknownSchemeConnString,
 				Type:             "invalid",
 				Pool: PoolConfig{
 					Max: PoolMaxConfig{
@@ -1319,7 +1323,7 @@ func TestValidateDatabaseConditionalBehavior(t *testing.T) {
 				},
 			},
 			expectError:   true,
-			errorContains: databaseType,
+			errorContains: "'invalid' is not supported",
 		},
 		{
 			name: "connection_string_missing_max_conns_applies_default",
@@ -1510,6 +1514,84 @@ func TestValidateDatabaseWithConnectionStringEdgeCases(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateInfersDatabaseTypeFromConnectionString(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        DatabaseConfig
+		expectError   bool
+		errorContains string
+		expectedType  string
+	}{
+		{
+			name:         "postgres_scheme_infers_type",
+			config:       DatabaseConfig{ConnectionString: "postgres://user:pass@localhost:5432/db"},
+			expectedType: PostgreSQL,
+		},
+		{
+			name:         "postgresql_scheme_infers_type",
+			config:       DatabaseConfig{ConnectionString: testConnectionString},
+			expectedType: PostgreSQL,
+		},
+		{
+			name:         "oracle_scheme_infers_type",
+			config:       DatabaseConfig{ConnectionString: testOracleConnectionString},
+			expectedType: Oracle,
+		},
+		{
+			name:         "scheme_case_insensitive",
+			config:       DatabaseConfig{ConnectionString: "POSTGRES://user:pass@localhost:5432/db"},
+			expectedType: PostgreSQL,
+		},
+		{
+			name:         "unknown_scheme_keeps_empty_type_and_passes",
+			config:       DatabaseConfig{ConnectionString: testUnknownSchemeConnString},
+			expectedType: "",
+		},
+		{
+			name: "explicit_type_conflicting_with_scheme_fails",
+			config: DatabaseConfig{
+				Type:             Oracle,
+				ConnectionString: "postgres://user:pass@localhost:5432/db",
+			},
+			expectError:   true,
+			errorContains: "conflicts with the connectionstring scheme",
+		},
+		{
+			name: "explicit_matching_type_untouched",
+			config: DatabaseConfig{
+				Type:             PostgreSQL,
+				ConnectionString: "postgres://user:pass@localhost:5432/db",
+			},
+			expectedType: PostgreSQL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDatabase(&tt.config)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedType, tt.config.Type)
+		})
+	}
+}
+
+func TestValidateNamedDatabaseInfersTypeFromConnectionString(t *testing.T) {
+	databases := map[string]DatabaseConfig{
+		"reporting": {ConnectionString: testConnectionString},
+	}
+	mt := MultitenantConfig{Enabled: false}
+
+	err := validateNamedDatabases(databases, &mt)
+
+	require.NoError(t, err)
+	assert.Equal(t, PostgreSQL, databases["reporting"].Type)
 }
 
 func assertValidationError(t *testing.T, err error, errorContains string) {
@@ -2873,10 +2955,10 @@ func TestValidateOracleFields(t *testing.T) {
 				Host:     testOracleHost,
 				Port:     1521,
 				Username: "oracleuser",
-				// No Service.Name, SID, or Database
+				// No Service.Name, SID, or Database — and no connection string to supply one.
 			},
 			expectError:   true,
-			errorContains: oracleConnectionIdentifier,
+			errorContains: oracleConnectionIdentifier + " exactly one required",
 		},
 		{
 			name: "Oracle config with service name and SID",
@@ -3014,14 +3096,13 @@ func TestValidateOracleWithConnectionString(t *testing.T) {
 			errorContains: oracleConnectionIdentifier,
 		},
 		{
-			name: "Oracle with connection string but no identifiers",
+			name: "Oracle with connection string and no identifiers",
 			config: DatabaseConfig{
 				Type:             Oracle,
 				ConnectionString: testOracleConnectionString,
-				// No Service.Name, SID, or Database
+				// The DSN carries the identifier; buildOracleDSN ignores these fields.
 			},
-			expectError:   true,
-			errorContains: oracleConnectionIdentifier,
+			expectError: false,
 		},
 	}
 
@@ -3035,6 +3116,27 @@ func TestValidateOracleWithConnectionString(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateOracleConnectionStringNeedsNoIdentifier(t *testing.T) {
+	cfg := DatabaseConfig{ConnectionString: testOracleConnectionString}
+
+	require.NoError(t, validateDatabase(&cfg))
+
+	assert.Equal(t, Oracle, cfg.Type, "the oracle:// scheme must infer the type")
+	require.Empty(t, cfg.Oracle.Service.Name)
+	require.Empty(t, cfg.Oracle.Service.SID)
+	require.Empty(t, cfg.Database, "buildOracleDSN returns the connection string verbatim, so no identifier field is needed")
+}
+
+func TestValidateOracleWithoutConnectionStringStillNeedsIdentifier(t *testing.T) {
+	cfg := DatabaseConfig{Type: Oracle, Host: testOracleHost, Port: 1521, Username: "oracleuser"}
+
+	err := validateDatabase(&cfg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one required",
+		"without a DSN nothing else names the target, so the identifier stays mandatory")
 }
 
 // =============================================================================
@@ -4627,15 +4729,25 @@ func TestValidateOracleFieldsRejectsTLSMaterial(t *testing.T) {
 		{"cert", func(c *DatabaseConfig) { c.TLS.CertFile = "/etc/ssl/client.crt" }},
 		{"key", func(c *DatabaseConfig) { c.TLS.KeyFile = "/etc/ssl/client.key" }},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := &DatabaseConfig{Type: "oracle", Database: "PDB1"}
-			tc.mutate(cfg)
-			err := validateOracleFields(cfg)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "not supported for Oracle",
-				"Oracle TLS material must be rejected, not silently dropped (which leaves the connection unauthenticated)")
-		})
+	bases := []struct {
+		name string
+		cfg  DatabaseConfig
+	}{
+		{"identifier", DatabaseConfig{Type: "oracle", Database: "PDB1"}},
+		// A connection string waives the identifier requirement but never the TLS one.
+		{"connection_string", DatabaseConfig{Type: "oracle", ConnectionString: testOracleConnectionString}},
+	}
+	for _, base := range bases {
+		for _, tc := range cases {
+			t.Run(base.name+"_"+tc.name, func(t *testing.T) {
+				cfg := base.cfg
+				tc.mutate(&cfg)
+				err := validateOracleFields(&cfg)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "not supported for Oracle",
+					"Oracle TLS material must be rejected, not silently dropped (which leaves the connection unauthenticated)")
+			})
+		}
 	}
 }
 

--- a/database/oracle/connection.go
+++ b/database/oracle/connection.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"fmt"
 	"net"
+	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	go_ora "github.com/sijms/go-ora/v2"
@@ -112,13 +116,13 @@ func NewConnection(cfg *config.DatabaseConfig, log logger.Logger) (types.Interfa
 
 	db, err := openOracleConnection(dsn, cfg, log)
 	if err != nil {
-		return nil, err
+		return nil, redactDSNError(err, dsn)
 	}
 
 	configureConnectionPool(db, cfg)
 
 	if err := verifyConnection(db, log); err != nil {
-		return nil, err
+		return nil, redactDSNError(err, dsn)
 	}
 
 	logConnectionSuccess(log, cfg)
@@ -257,6 +261,139 @@ func buildOracleDSN(cfg *config.DatabaseConfig) string {
 	}
 
 	return go_ora.BuildUrl(cfg.Host, cfg.Port, serviceName, cfg.Username, cfg.Password, optsArg)
+}
+
+// redactionPlaceholder is the placeholder substituted for a DSN password, matching
+// pgx's redactPW so both vendors redact identically.
+const redactionPlaceholder = "xxxxx"
+
+// dsnRedactedError carries a sanitized message while keeping the original error
+// reachable through errors.Is / errors.As.
+type dsnRedactedError struct {
+	err error
+	msg string
+}
+
+func (e *dsnRedactedError) Error() string { return e.msg }
+func (e *dsnRedactedError) Unwrap() error { return e.err }
+
+// invalidDSNReason stands in for a net/url failure reason that quotes part of the DSN.
+const invalidDSNReason = "invalid DSN"
+
+// SECURITY: go-ora returns url.Parse's *url.Error unwrapped, and net/url renders the
+// whole raw URL with %q — so a DSN carrying inline credentials puts the password in a
+// startup error, hence in the log and the pod termination message. Mask every rendering
+// of the DSN before the error escapes NewConnection. Scheme, username and host survive
+// so an operator can still tell which connection failed; only the password is masked
+// (pgx's redactPW precedent).
+func redactDSNError(err error, dsn string) error {
+	msg := err.Error()
+	redacted := msg
+	// Rebuild the net/url rendering before masking the DSN in general: masking first
+	// would rewrite the URL inside that rendering, leaving nothing here to match.
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		redacted = maskURLError(redacted, urlErr)
+	}
+	redacted = maskDSNIn(redacted, dsn)
+	if redacted == msg {
+		return err
+	}
+	return &dsnRedactedError{err: err, msg: redacted}
+}
+
+// maskDSNIn replaces every rendering of dsn in msg with its masked form.
+func maskDSNIn(msg, dsn string) string {
+	masked := maskDSNPassword(dsn)
+	if masked == dsn {
+		return msg
+	}
+	// %q escapes non-printable bytes, so the DSN can appear either verbatim or quoted.
+	msg = strings.ReplaceAll(msg, dsn, masked)
+	return strings.ReplaceAll(msg, strconv.Quote(dsn), strconv.Quote(masked))
+}
+
+// SECURITY: net/url does not only render the URL — it also echoes the component it
+// rejected, and an unescaped '/', '?' or '#' in the password lands part of the password
+// where a port belongs ("invalid port \":pa\" after host"). Masking the URL alone leaves
+// that copy behind, so rebuild the whole rendering instead of scrubbing it. urlErr.URL
+// is what url.Parse actually saw — the DSN with any '#' fragment already stripped — so
+// it, not the DSN we built, is the string that reached the message.
+func maskURLError(msg string, urlErr *url.Error) string {
+	masked := maskDSNPassword(urlErr.URL)
+	if masked == urlErr.URL {
+		return msg
+	}
+	// net/url embeds URL-derived text only via %q, so a reason that quotes nothing
+	// cannot carry password material; anything else is dropped wholesale.
+	reason := invalidDSNReason
+	if urlErr.Err != nil && !strings.Contains(urlErr.Err.Error(), `"`) {
+		reason = urlErr.Err.Error()
+	}
+	return strings.ReplaceAll(msg, urlErr.Error(), fmt.Sprintf("%s %q: %s", urlErr.Op, masked, reason))
+}
+
+// maskDSNPassword masks the password of a URL-form DSN by scanning the string rather
+// than parsing it — the DSNs that leak are precisely the ones url.Parse rejects.
+// Non-URL DSNs (EZ-connect, TNS descriptors) and DSNs without a password pass through
+// unchanged: the leak is url.Parse's %q rendering of what it was handed, which only
+// fires for the URL form.
+func maskDSNPassword(dsn string) string {
+	const schemeSep = "://"
+	sep := strings.Index(dsn, schemeSep)
+	if sep == -1 {
+		return dsn
+	}
+	authority := sep + len(schemeSep)
+
+	rest := dsn[authority:]
+	end := strings.IndexAny(rest, "/?#")
+	if end == -1 {
+		end = len(rest)
+	}
+	// net/url splits userinfo at the last '@' of the authority, so an unescaped '@'
+	// inside the password stays part of the userinfo.
+	at := strings.LastIndex(rest[:end], "@")
+	if at == -1 {
+		// An unescaped '/', '?' or '#' in the password hides the '@' behind the
+		// authority terminator, and url.Parse drops everything from '#' on before it
+		// reports, so the '@' can be missing from the string entirely. Read the segment
+		// as userinfo only when it cannot be a host[:port] — that is exactly the shape
+		// url.Parse rejects, and so exactly the shape whose error echoes the DSN.
+		if looksLikeHostPort(rest[:end]) {
+			return dsn
+		}
+		if at = strings.LastIndex(rest, "@"); at == -1 {
+			at = len(rest)
+		}
+	}
+	// Everything after the first ':' is the password, so an unescaped ':' inside it
+	// is masked too.
+	colon := strings.Index(rest[:at], ":")
+	if colon == -1 {
+		return dsn
+	}
+
+	return dsn[:authority+colon+1] + redactionPlaceholder + dsn[authority+at:]
+}
+
+// looksLikeHostPort reports whether an authority segment is a plausible host[:port],
+// i.e. carries no credentials to mask. A true answer also means url.Parse accepts the
+// DSN, and an accepted DSN is never rendered into an error — so the ambiguous shape
+// "oracle://user:1234/secret@db" is left alone on purpose: masking it would buy nothing
+// and would mangle its mirror image, a passwordless DSN whose path holds an '@'.
+func looksLikeHostPort(authority string) bool {
+	if strings.HasPrefix(authority, "[") {
+		// Skip an IPv6 literal so only a trailing ":port" is examined; an unterminated
+		// literal yields index 0 and leaves the segment as it stands.
+		authority = authority[strings.LastIndex(authority, "]")+1:]
+	}
+	colon := strings.LastIndex(authority, ":")
+	if colon == -1 {
+		return true
+	}
+	port := authority[colon+1:]
+	return port != "" && strings.TrimLeft(port, "0123456789") == ""
 }
 
 // configureConnectionPool sets pool settings on the database connection.

--- a/database/oracle/connection_test.go
+++ b/database/oracle/connection_test.go
@@ -5,8 +5,11 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"net"
+	"net/url"
 	"regexp"
+	"strconv"
 	"testing"
 	"time"
 
@@ -227,6 +230,279 @@ func TestConnectionBasicMethodsWithSQLMock(t *testing.T) {
 func TestConnectionNewConnectionWithConnectionString(t *testing.T) {
 	cfg := createOracleConfig("connection_string", "oracle://user:pass@localhost:1521/XE")
 	testConnectionExpectedError(t, cfg)
+}
+
+// TestConnectionNewConnectionRedactsConnectionStringPassword pins the startup-error
+// leak: go-ora returns url.Parse's *url.Error unwrapped, and net/url renders the whole
+// raw URL (userinfo included) with %q. The DEL byte in the host is the url.Parse trigger.
+func TestConnectionNewConnectionRedactsConnectionStringPassword(t *testing.T) {
+	const password = "zqxvwmarmaladeplinth"
+	cfg := createOracleConfig("connection_string", "oracle://appuser:"+password+"@zonk\x7fhost:1521/XE")
+
+	_, err := NewConnection(cfg, dbtestlog.NewTestLogger())
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), password, "connection-string password leaked into the startup error")
+}
+
+// TestConnectionNewConnectionRedactsBuiltDSNPassword covers the other DSN source:
+// go_ora.BuildUrl embeds cfg.Password, so the same masking must apply there.
+func TestConnectionNewConnectionRedactsBuiltDSNPassword(t *testing.T) {
+	const password = "zqxvwtrellisfathom"
+	cfg := createOracleConfig("service_name", "XE")
+	cfg.Host = "zonk\x7fhost"
+	cfg.Password = password
+
+	_, err := NewConnection(cfg, dbtestlog.NewTestLogger())
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), password, "built-DSN password leaked into the startup error")
+	assert.Contains(t, err.Error(), "testuser", "username must stay visible so the failing connection is identifiable")
+	assert.Contains(t, err.Error(), "zonk", "host must stay visible so the failing connection is identifiable")
+}
+
+// TestConnectionNewConnectionRedactsDelimiterPasswords covers passwords carrying an
+// unescaped URL delimiter. Those hide the '@' behind the authority terminator, and
+// net/url then echoes the leading password segment a second time as the port it
+// rejected — so the assertion targets that segment, not just the whole password.
+func TestConnectionNewConnectionRedactsDelimiterPasswords(t *testing.T) {
+	const leadingSegment = "zqxvwmarrow"
+	tests := []struct {
+		name     string
+		password string
+	}{
+		{name: "password_with_slash", password: leadingSegment + "/plinth"},
+		{name: "password_with_question_mark", password: leadingSegment + "?plinth"},
+		{name: "password_with_hash", password: leadingSegment + "#plinth"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsn := "oracle://appuser:" + tt.password + "@host:1521/XE"
+			// Premise, checked before dialing: the delimiter makes url.Parse reject the
+			// authority, so NewConnection fails at parse and never resolves "host". A case
+			// that ever became parseable trips here instead of doing real network I/O.
+			_, parseErr := url.Parse(dsn)
+			require.Error(t, parseErr, "premise: url.Parse must reject the DSN before any connect attempt")
+
+			cfg := createOracleConfig("connection_string", dsn)
+
+			_, err := NewConnection(cfg, dbtestlog.NewTestLogger())
+
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), leadingSegment, "password leaked into the startup error")
+			assert.Contains(t, err.Error(), "appuser", "username must stay visible so the failing connection is identifiable")
+		})
+	}
+}
+
+func TestRedactDSNErrorPreservesErrorChain(t *testing.T) {
+	// Assembled from a variable so staticcheck (SA1007) does not constant-fold the
+	// deliberately invalid URL away.
+	host := "zonk\x7fhost"
+	dsn := "oracle://appuser:s3cr3t@" + host + ":1521/XE"
+	_, parseErr := url.Parse(dsn)
+	require.Error(t, parseErr)
+
+	err := redactDSNError(fmt.Errorf("%s: %w", oraclePingErrorMsg, parseErr), dsn)
+
+	assert.NotContains(t, err.Error(), "s3cr3t")
+	assert.Contains(t, err.Error(), "appuser")
+	// A net/url reason that quotes nothing carries no password material, so it survives.
+	assert.Contains(t, err.Error(), "invalid control character")
+
+	var urlErr *url.Error
+	require.ErrorAs(t, err, &urlErr, "wrapping must keep the original error reachable")
+	assert.Equal(t, dsn, urlErr.URL, "the unwrapped error still carries the raw DSN")
+}
+
+func TestRedactDSNErrorPassesOriginalThrough(t *testing.T) {
+	tests := []struct {
+		name string
+		dsn  string
+		err  error
+	}{
+		{name: "dsn_without_password", dsn: "oracle://host:1521/XE", err: errors.New("boom: oracle://host:1521/XE")},
+		{name: "message_omits_the_dsn", dsn: "oracle://appuser:s3cr3t@host:1521/XE", err: errors.New("context deadline exceeded")},
+		{
+			name: "url_error_without_password",
+			dsn:  "oracle://host:1521/XE",
+			err:  &url.Error{Op: "parse", URL: "oracle://host:1521/XE", Err: errors.New("boom")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Same(t, tt.err, redactDSNError(tt.err, tt.dsn), "nothing to mask must not allocate a wrapper")
+		})
+	}
+}
+
+// TestRedactDSNErrorHandlesURLErrorWithoutReason pins the nil guard: url.Error is a
+// plain struct, so a driver can hand one back with no wrapped reason at all.
+func TestRedactDSNErrorHandlesURLErrorWithoutReason(t *testing.T) {
+	const dsn = "oracle://appuser:zqxvwbarrowclasp@host:1521/XE"
+
+	err := redactDSNError(&url.Error{Op: "parse", URL: dsn}, dsn)
+
+	assert.NotContains(t, err.Error(), "zqxvwbarrowclasp")
+	assert.Contains(t, err.Error(), "appuser")
+}
+
+// TestNetURLErrorFormatUnchanged is a tripwire on the single stdlib assumption
+// maskURLError depends on: net/url renders url.Error as `%s %q: %s` over Op, URL, Err.
+// maskURLError replaces urlErr.Error() with a rebuild of that exact format, so a
+// format change makes the replacement silently stop matching and the password is
+// exposed again — a redaction that fails open. If this test ever fails, revisit
+// maskURLError before anything else.
+func TestNetURLErrorFormatUnchanged(t *testing.T) {
+	err := &url.Error{Op: "parse", URL: "x", Err: errors.New("boom")}
+
+	assert.Equal(t, `parse "x": boom`, err.Error())
+}
+
+// TestMaskDSNPasswordLeavesParseableAuthorityAlone pins the premise behind the
+// looksLikeHostPort guard, which is the whole reason these two DSNs are left unmasked:
+// url.Parse ACCEPTS both, so neither is ever rendered into an error. They are the same
+// shape read two ways — credentials in the first, host:port plus an '@' in the path in
+// the second — so masking one necessarily mangles the other, for no security gain.
+func TestMaskDSNPasswordLeavesParseableAuthorityAlone(t *testing.T) {
+	tests := []struct {
+		name string
+		dsn  string
+	}{
+		{name: "digit_password_segment_reads_as_a_real_port", dsn: "oracle://user:1234/secret@db"},
+		{name: "host_port_with_at_sign_in_path", dsn: "oracle://host:1521/XE@weird"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := url.Parse(tt.dsn)
+			require.NoError(t, err, "premise: url.Parse accepts it, so no error ever echoes this DSN")
+			assert.Equal(t, tt.dsn, maskDSNPassword(tt.dsn))
+		})
+	}
+}
+
+func TestMaskDSNPassword(t *testing.T) {
+	tests := []struct {
+		name string
+		dsn  string
+		want string
+	}{
+		{name: "empty_dsn", dsn: "", want: ""},
+		{name: "no_userinfo", dsn: "oracle://host:1521/XE", want: "oracle://host:1521/XE"},
+		{name: "user_only_no_colon", dsn: "oracle://appuser@host:1521/XE", want: "oracle://appuser@host:1521/XE"},
+		{name: "user_and_password", dsn: "oracle://appuser:s3cr3t@host:1521/XE", want: "oracle://appuser:xxxxx@host:1521/XE"},
+		{name: "empty_password", dsn: "oracle://appuser:@host:1521/XE", want: "oracle://appuser:xxxxx@host:1521/XE"},
+		{name: "password_with_at", dsn: "oracle://appuser:pa@ss@host:1521/XE", want: "oracle://appuser:xxxxx@host:1521/XE"},
+		{name: "password_with_colon", dsn: "oracle://appuser:pa:ss@host:1521/XE", want: "oracle://appuser:xxxxx@host:1521/XE"},
+		{name: "password_with_slash", dsn: "oracle://appuser:pa/ss@host:1521/XE", want: "oracle://appuser:xxxxx@host:1521/XE"},
+		{name: "password_with_question_mark", dsn: "oracle://appuser:pa?ss@host:1521/XE", want: "oracle://appuser:xxxxx@host:1521/XE"},
+		{name: "password_with_hash", dsn: "oracle://appuser:pa#ss@host:1521/XE", want: "oracle://appuser:xxxxx@host:1521/XE"},
+		// What url.Parse is handed once it drops the fragment: no '@' survives, so the
+		// userinfo is only recognizable by "appuser:pa" not being a valid host[:port].
+		{name: "fragment_truncated_userinfo", dsn: "oracle://appuser:pa", want: "oracle://appuser:xxxxx"},
+		// looksLikeHostPort rejects a non-numeric port, so this credential-free authority
+		// reads as userinfo and everything past "host:" is masked — including the "/XE"
+		// tail. Over-masking on purpose: the shape is one url.Parse rejects, so the DSN
+		// does reach an error message, and masking a DSN that holds no password is the
+		// safe direction. The accepted cost is that a plain port typo costs the operator
+		// the invalid-port text and the service path.
+		{name: "credential_free_authority_with_non_numeric_port", dsn: "oracle://host:abc/XE", want: "oracle://host:xxxxx"},
+		{name: "ipv6_host_with_port", dsn: "oracle://[::1]:1521/XE", want: "oracle://[::1]:1521/XE"},
+		{name: "ipv6_host_without_port", dsn: "oracle://[::1]/XE", want: "oracle://[::1]/XE"},
+		// A zero-compressed literal ends in the ':' the port scan looks for, so it is the
+		// only shape where skipping to the wrong side of the ']' changes the verdict.
+		{name: "ipv6_zero_compressed_host_without_port", dsn: "oracle://[::]/XE", want: "oracle://[::]/XE"},
+		// The scan tests each strings.Index result against -1, so index 0 must read as a
+		// hit. One case per sentinel: scheme, authority terminator, '@', ':'.
+		{name: "scheme_separator_at_index_zero", dsn: "://appuser:s3cr3t@host:1521/XE", want: "://appuser:xxxxx@host:1521/XE"},
+		{name: "authority_terminator_at_index_zero", dsn: "oracle:///user:pass@host", want: "oracle:///user:pass@host"},
+		{name: "at_sign_at_index_zero", dsn: "oracle://@host:1521/XE", want: "oracle://@host:1521/XE"},
+		{name: "empty_username_with_password", dsn: "oracle://:s3cr3t@host:1521/XE", want: "oracle://:xxxxx@host:1521/XE"},
+		{name: "query_options_preserved", dsn: "oracle://appuser:s3cr3t@host:1521/XE?SID=XE", want: "oracle://appuser:xxxxx@host:1521/XE?SID=XE"},
+		{name: "at_sign_only_in_path", dsn: "oracle://host:1521/XE@weird", want: "oracle://host:1521/XE@weird"},
+		{name: "scheme_without_authority", dsn: "oracle://", want: "oracle://"},
+		{name: "unparseable_host_still_masked", dsn: "oracle://appuser:s3cr3t@zonk\x7fhost:1521/XE", want: "oracle://appuser:xxxxx@zonk\x7fhost:1521/XE"},
+		{name: "ez_connect_not_a_url", dsn: "appuser/s3cr3t@host:1521/XE", want: "appuser/s3cr3t@host:1521/XE"},
+		{
+			name: "tns_descriptor_not_a_url",
+			dsn:  "(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=host)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=XE)))",
+			want: "(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=host)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=XE)))",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, maskDSNPassword(tt.dsn))
+		})
+	}
+}
+
+func TestLooksLikeHostPort(t *testing.T) {
+	tests := []struct {
+		name      string
+		authority string
+		want      bool
+	}{
+		{name: "bare_host", authority: "host", want: true},
+		{name: "host_with_numeric_port", authority: "host:1521", want: true},
+		{name: "userinfo_with_non_numeric_tail", authority: "user:pa", want: false},
+		{name: "bracketed_ipv6_without_port", authority: "[::1]", want: true},
+		// Skipping to the wrong side of the ']' leaves a ':' behind and turns the
+		// trailing "]" into the port.
+		{name: "zero_compressed_ipv6_without_port", authority: "[::]", want: true},
+		{name: "bracketed_ipv6_with_port", authority: "[2001:db8::1]:1521", want: true},
+		// LastIndex returns -1 for an unterminated literal, so the +1 slice is a no-op
+		// and the whole segment is examined: "db8" is not a port.
+		{name: "unterminated_ipv6_literal", authority: "[2001:db8", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, looksLikeHostPort(tt.authority))
+		})
+	}
+}
+
+// TestMaskDSNIn covers the seam directly: redactDSNError reaches it for every error,
+// but a *url.Error has already had its rendering rebuilt by maskURLError, so only a
+// non-url.Error carrying the raw DSN exercises the replacement here.
+func TestMaskDSNIn(t *testing.T) {
+	const password = "zqxvwgirdlespan"
+	// The DEL byte makes %q escape the DSN, so the quoted rendering is not a substring
+	// of the message and only the second replacement can reach it.
+	leaky := "oracle://appuser:" + password + "@zonk\x7fhost:1521/XE"
+	masked := "oracle://appuser:xxxxx@zonk\x7fhost:1521/XE"
+
+	tests := []struct {
+		name string
+		dsn  string
+		msg  string
+		want string
+	}{
+		{
+			name: "dsn_without_password_leaves_the_message_alone",
+			dsn:  "oracle://host:1521/XE",
+			msg:  `dial oracle://host:1521/XE: connection refused`,
+			want: `dial oracle://host:1521/XE: connection refused`,
+		},
+		{
+			name: "verbatim_and_quoted_renderings_both_masked",
+			dsn:  leaky,
+			msg:  "dial " + leaky + ": parse " + strconv.Quote(leaky) + ": bad",
+			want: "dial " + masked + ": parse " + strconv.Quote(masked) + ": bad",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := maskDSNIn(tt.msg, tt.dsn)
+			assert.Equal(t, tt.want, got)
+			assert.NotContains(t, got, password)
+		})
+	}
 }
 
 func TestConnectionNewConnectionWithServiceName(t *testing.T) {

--- a/wiki/adr_050_connectionstring_type_inference.md
+++ b/wiki/adr_050_connectionstring_type_inference.md
@@ -1,0 +1,115 @@
+# ADR-050: Infer `database.type` from the Connection-String Scheme, Fail Fast on What's Left Untyped
+
+**Status:** Accepted
+**Date:** 2026-08-05
+
+## Context
+
+A `database.connectionstring` with no `database.type` passes `config.Validate`
+today (`validateDatabaseWithConnectionString` only checks `Type` when it is
+non-empty) and then can never produce a connection: `database.NewConnection`
+dispatches solely on `cfg.Type` and errors with `unsupported database type: ""`
+at first use. Startup validation accepts a configuration that is guaranteed
+dead — the opposite of Fail Fast. Fixes #877.
+
+A hard `type` requirement was rejected: two working setups legitimately carry
+an empty `Type` alongside a connection string. The quiesce CLI path
+(`tools/migration/internal/commands/quiesce.go`) builds a PostgreSQL DSN and
+tolerates `Type == ""`. Consumers supplying `Options.DatabaseConnector` parse
+the DSN themselves and have no valid `Type` value to fake — only
+`postgresql`/`oracle` validate.
+
+## Decision
+
+**Infer at validation, fail fast at the builder — only for the built-in
+connector.**
+
+1. `config.validateDatabaseWithConnectionString` infers `Type` from a
+   recognized DSN scheme when `Type` is empty: `postgres://` / `postgresql://`
+   (pgx) → `postgresql`, `oracle://` (go-ora) → `oracle`. An explicit `Type`
+   that conflicts with the inferred scheme is a validation error naming
+   `database.type`. An unrecognized scheme is not an error at this layer —
+   whether an untyped DSN is fatal depends on who connects. The write-back
+   pattern is the one `validateDatabaseWithConnectionString` already uses for
+   pool/session defaults, so named databases and static-tenant entries pick
+   the inference up automatically through their existing persist-back paths.
+2. `app.Builder.ConfigureRuntimeHelpers` fails startup when any database path
+   (root, `databases.*`, and — only under `multitenant.enabled: true` —
+   `multitenant.tenants.*`) still carries a connection string with no resolved
+   type, but only when the built-in connector (`database.NewConnection`) would
+   be used. A caller-supplied `Options.DatabaseConnector` parses the DSN itself
+   and is exempt. The tenant gate mirrors `config.NewTenantStore`, which copies
+   static tenant entries only when multitenancy is enabled: koanf populates
+   `multitenant.tenants` from YAML regardless of the flag, so a leftover block
+   under a disabled flag is inert config that neither reaches inference nor
+   reaches a connector, and must not abort startup.
+
+3. `config.validateOracleFields` waives its identifier requirement when a
+   connection string is set. Inference makes Oracle's vendor-specific
+   validation run on a DSN-only config for the first time (an empty `Type` hit
+   `validateVendorSpecificFields`' `default` arm and skipped it), and that
+   validation demanded one of `oracle.service.name` / `oracle.service.sid` /
+   `database` — a field `buildOracleDSN` never reads, because it returns
+   `cfg.ConnectionString` verbatim. Requiring an identifier that is then
+   ignored would have made ADR-050 reject the very configuration it exists to
+   support. The waiver covers the missing-identifier check only: the
+   `count > 1` ambiguity error and the Oracle TLS rejection both still fire
+   alongside a connection string.
+
+`database/factory.go`'s dispatch and its error are unchanged: classification
+stays in the config/app layers, not the connector.
+
+## Alternatives considered
+
+- **Hard-require `type` whenever a connection string is set.** Rejected: it
+  breaks the quiesce CLI's tolerated-empty-`Type` PG path and forces every
+  custom-connector consumer to supply a `Type` value they have no use for and
+  that `validateDatabaseType` would reject.
+- **Infer only, no builder guard.** Rejected: an unrecognized scheme (or
+  future third vendor) still boots into a dead built-in connector — the
+  residue this ADR closes. Inference alone fixes the common case but not the
+  guarantee.
+- **Guard only, no inference.** Rejected: every working `postgres://`/`oracle://`
+  DSN would need its `Type` spelled out redundantly, which is exactly the
+  friction issue #877 flagged as the trap in the first place.
+
+## Consequences
+
+- **Breaking, in the surprising direction.** A connstring-only config with a
+  recognized scheme that used to boot and fail at first use now **connects**
+  — a deployment that "worked" only because its DB layer was never exercised
+  now dials a real database at startup pre-init.
+- A connstring with an unrecognized scheme and no type, on the built-in
+  connector, now **fails startup** instead of booting into a dead connection.
+- An explicit `database.type` that conflicts with the DSN scheme now fails
+  validation instead of silently taking the explicit value.
+- **Oracle validation is loosened, not tightened.** `oracle://user:pw@host:1521/XE`
+  with no `oracle.service.name`, `oracle.service.sid` or `database` now validates,
+  where `type: oracle` spelled out alongside the same DSN used to fail with
+  "oracle connection identifier exactly one required". Nothing that validated
+  before stops validating. `count > 1` still fires alongside a connection string:
+  no valid config needs two identifiers, and while all of them are inert in DSN
+  mode, an operator who set two has a broken mental model worth failing on.
+- Inference and the guard are two halves of one contract, and only
+  `config.Load` runs the first half — it is the sole caller of
+  `config.Validate`. A consumer handing `app.NewWithConfig` a hand-built
+  `*config.Config` gets the guard without the inference, so even a
+  `postgres://` DSN reaches it untyped and aborts startup. The guard's message
+  therefore reports the observed state ("connectionstring has no resolved
+  database type") rather than inferring a cause, so it stays true whether
+  inference ran and rejected the scheme or never ran at all. Such a config was
+  already dead for the root `database:` block (startup pre-init dispatched on
+  the empty `Type` and failed); the change is that `databases.*` entries, which
+  used to fail lazily on first use, now abort at startup too. Hand-built
+  configs must run `config.Validate` before `NewWithConfig`. The same shape
+  appears when `multitenant.enabled: true` is paired with
+  `source.type: dynamic` and a leftover static `multitenant.tenants` block:
+  `validateStaticTenantConfig` skips tenant validation for a dynamic source, so
+  those DSNs never reach inference either.
+- `Options.DatabaseConnector` consumers and the quiesce CLI's tolerated-empty
+  PG path are exempt from the builder guard, not from validation: `config.Validate`
+  is connector-blind, so a `type` contradicting the DSN scheme fails for them too.
+  The recognized-scheme list is deliberately closed to `postgresql`/`oracle`
+  (ADR-012); landing a third vendor would need both
+  `inferDatabaseTypeFromConnectionString` and the builder-guard message
+  extended in the same commit. See [migrations.md](migrations.md) `[C57.5]`.

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -847,6 +847,40 @@ also holds for probes the framework never constructs. See [migrations.md](migrat
 
 ---
 
+### [ADR-050: Infer `database.type` from the Connection-String Scheme, Fail Fast on What's Left Untyped](adr_050_connectionstring_type_inference.md)
+
+**Date:** 2026-08-05 | **Status:** Accepted
+
+A `database.connectionstring` with no `database.type` passed `config.Validate` and then
+could never connect: `database.NewConnection` dispatches solely on `Type` and errors
+`unsupported database type: ""` at first use — validation accepted a guaranteed-dead
+config. `validateDatabaseWithConnectionString` now infers `Type` from a recognized DSN
+scheme (`postgres://`/`postgresql://` → `postgresql`, `oracle://` → `oracle`) when `Type`
+is empty, and rejects an explicit `Type` that conflicts with the inferred scheme. An
+unrecognized scheme is not a validation error — whether it's fatal depends on who connects.
+`app.Builder.ConfigureRuntimeHelpers` closes that residue: it fails startup when the root
+`database:` block, a `databases.*` entry, or — only under `multitenant.enabled: true`, the
+same gate `config.NewTenantStore` uses — a `multitenant.tenants.*` entry still carries a
+connection string with no resolved type, but only for the built-in connector; a caller-supplied
+`Options.DatabaseConnector` parses the DSN itself and is exempt, as is the quiesce CLI's
+tolerated-empty-`Type` PostgreSQL path. Rejected: a hard `type` requirement (breaks both
+exemptions), inference without the builder guard (leaves the boots-then-fails residue for
+unrecognized schemes), and the guard without inference (forces redundant `type` on every
+working DSN). Because inference makes Oracle's vendor validation run on a DSN-only config
+for the first time, `validateOracleFields` waives its "exactly one of
+`oracle.service.name` / `oracle.service.sid` / `database`" requirement when a connection
+string is set — `buildOracleDSN` returns that string verbatim and never reads those fields.
+The `count > 1` ambiguity error and the Oracle TLS rejection are not waived.
+
+**Key Benefits:** A connstring-only config with a recognized scheme now connects instead of
+booting into a dead database — including `oracle://…` with no separate identifier field; an
+unrecognized scheme on the built-in connector fails fast
+at startup instead of at first query; a `type`/scheme conflict is caught at validation.
+Fixes [#877](https://github.com/gaborage/go-bricks/issues/877). See
+[migrations.md](migrations.md) `[C57.5]`.
+
+---
+
 ## ADR Lifecycle
 
 - **Proposed**: Under discussion, not yet implemented
@@ -856,7 +890,7 @@ also holds for probes the framework never constructs. See [migrations.md](migrat
 
 ### Numbering Policy
 
-ADR numbers (ADR-001 through ADR-048) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
+ADR numbers (ADR-001 through ADR-050) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
 
 ## Writing New ADRs
 

--- a/wiki/database.md
+++ b/wiki/database.md
@@ -284,6 +284,29 @@ Two consequences worth knowing:
   `app.DatabaseRequirer`; registration then aborts startup when the database is absent,
   instead of the service going green and serving errors.
 
+## Connection String Type Inference (ADR-050)
+
+A `connectionstring` alone used to pass validation and then never connect —
+`database.NewConnection` dispatches on `type`, so an untyped DSN failed only at first
+query. `config.Validate` now infers `type` from a recognized scheme when `type` is
+omitted: `postgres://`/`postgresql://` → `postgresql`, `oracle://` → `oracle`. An explicit
+`type` that conflicts with the inferred scheme is a validation error. Any other scheme
+passes validation with `type` left empty — the *effect* of an unrecognized scheme depends
+on the connector: the built-in one (`database.NewConnection`) fails startup with a
+`connectionstring has no resolved database type` error naming every affected path
+(`database`, `databases.<name>`, and — only under `multitenant.enabled: true` —
+`multitenant.tenants.<id>.database`); a caller-supplied `Options.DatabaseConnector` parses
+the DSN itself and is exempt.
+
+**An Oracle DSN needs no separate identifier.** `oracle://user:pw@host:1521/XE` alone is a
+complete config: `buildOracleDSN` returns the connection string verbatim, so
+`oracle.service.name`, `oracle.service.sid` and `database` are never consulted in that mode
+and none of them is required. Without a connection string the rule is unchanged — exactly
+one of the three, and zero or several is still a validation error. The Oracle TLS rejection
+is unconditional either way: `database.tls.cert`/`key`/`ca` fail validation even alongside a
+connection string, because tcps/wallet is not implemented and silently ignoring TLS material
+would leave the operator believing the connection is encrypted.
+
 ## Connection Pool Defaults
 
 | Setting | Default | Purpose |

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -39,7 +39,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E52  | v0.51.0 → v0.52.0 | compile-break | 4 | C52.1 | if you set `.Args` on any declaration in ≤v0.51.0, verify current broker state before upgrading |
 | E55  | v0.52.0 → v0.55.0 | additive (safe) | 3 | none | none |
 | E56  | v0.55.0 → v0.56.0 | compile-break (C56.6 only partially — see its gate) + silent-behavior default flip (C56.11) | 15 | C56.6 C56.9 | grep log-driven alerts, dashboards, and test assertions for card-data / `iban` / `otp` field names — their values render `***` after the bump (C56.3); expect a cold tenant's first messaging request to fail fast instead of blocking (C56.4); if you assemble config in Go, check for `forwardedclientcert.require` without `enabled` — that service was serving unauthenticated traffic and now returns 401 (C56.5); if one queue name is declared from two places, confirm the two shapes agree — a mismatch that used to be silently overwritten now fails startup (C56.7); if you call a JOSE-protected peer, check for payload-free requests of **any** method — `GET`/`HEAD`/`DELETE` as well as `POST`/`PUT`/`PATCH` — since none of them are sealed now and a peer demanding `application/jose` on every request will answer 415 (C56.8); `/ready`'s 200 body gains `cache` and `cache_stats` and, where a cache is configured, every poll now issues a Redis `PING`, so update any test, schema, or dashboard that pins its exact key set and expect a live cache outage to read `unhealthy` (C56.10); if you run with a top-level cache enabled (or supply an `Options.CacheConnector`, which is probed regardless of `cache.enabled`) and have never set `cache.critical`, that outage now also answers `503` and drains every replica from rotation at once — decide before the bump whether to keep the strict default (and set `readinessProbe.failureThreshold: 3`) or add `cache.critical: false` (C56.11); and if any alert or runbook parses the Redis address out of `/ready`'s `503` body, repoint it at the app log or `/_sys/health-debug` (C56.12); and a module that cannot work without a database can now declare `app.DatabaseRequirer` so an absent one aborts startup rather than booting green (C56.13); check every environment that sets any `database.*` identity field for a complete section, since a partial one now fails startup (C56.14); and re-point any alert asserting `/ready` returns 503 for a database-free or multi-tenant service — both now return 200 (C56.15) |
-| E57  | v0.56.0 → v0.57.0 | silent-behavior + breaking (C57.4 aborts startup) | 4 | none | if any alert, runbook, synthetic check, or contract test parses the driver error out of `/ready`'s database `503` body, repoint it at the app log or `<debug.pathprefix>/health-debug` (default `/_sys`) — the field is now the fixed string `database unavailable` (C57.1); and if you implement your own critical `app.Prober`, its `503` body now reads `<Name> unavailable` instead of its raw error, since sanitization became the default rather than an opt-in (C57.2); and if anything reads `db_stats.connections` out of `/ready`'s **200** body — a per-tenant pool dashboard, an activity alert, a test pinning the key set — repoint it at `<debug.pathprefix>/health-debug` or the OTel database metrics, because that array is gone from `/ready`; a repo-local grep alone will not find an out-of-repo dashboard (C57.3); and check every environment with `outbox.enabled: true` or `inbox.enabled: true` (outside per-tenant fan-out or a dynamic source) for a configured, reachable database whose ledger table exists — or whose `autocreatetable` can create it — because Init now aborts startup instead of booting green (C57.4) |
+| E57  | v0.56.0 → v0.57.0 | silent-behavior + breaking (C57.4, C57.5 abort startup) | 5 | none | if any alert, runbook, synthetic check, or contract test parses the driver error out of `/ready`'s database `503` body, repoint it at the app log or `<debug.pathprefix>/health-debug` (default `/_sys`) — the field is now the fixed string `database unavailable` (C57.1); and if you implement your own critical `app.Prober`, its `503` body now reads `<Name> unavailable` instead of its raw error, since sanitization became the default rather than an opt-in (C57.2); and if anything reads `db_stats.connections` out of `/ready`'s **200** body — a per-tenant pool dashboard, an activity alert, a test pinning the key set — repoint it at `<debug.pathprefix>/health-debug` or the OTel database metrics, because that array is gone from `/ready`; a repo-local grep alone will not find an out-of-repo dashboard (C57.3); and check every environment with `outbox.enabled: true` or `inbox.enabled: true` (outside per-tenant fan-out or a dynamic source) for a configured, reachable database whose ledger table exists — or whose `autocreatetable` can create it — because Init now aborts startup instead of booting green (C57.4); and check every `database.connectionstring` (root, `databases.*`, `multitenant.tenants.*`) with no `database.type` set — a recognized scheme (`postgres://`, `postgresql://`, `oracle://`) now infers its type and actually dials instead of booting into a dead connection, and an unrecognized scheme on the built-in connector now fails startup instead of failing at first query (C57.5) |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 - **`when: match`** → act only if `detect` returns ≥1 line (an API/arity/interface change, or a config key you set).
@@ -1178,7 +1178,14 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   `DELETE` but not `INSERT` still passes `Init` and fails at the first processed event. Per-tenant fan-out and `source.type: dynamic` deployments are
   unaffected — those resolve their database at runtime, not at `Init`. A custom dynamic
   `Options.ResourceSource` behind a *static* `source.type` is not among them: a module cannot see
-  that resource source, so such a deployment is probed (C57.4).
+  that resource source, so such a deployment is probed (C57.4). Separately, a
+  `database.connectionstring` with no `database.type` passed `config.Validate` and then
+  could never connect — `database.NewConnection` dispatches solely on `type` and errored
+  only at first query. `config.Validate` now infers `type` from a recognized DSN scheme
+  (`postgres://`/`postgresql://` → `postgresql`, `oracle://` → `oracle`) when `type` is
+  empty, and rejects an explicit `type` that conflicts with the inferred scheme. For the
+  built-in connector, any other scheme left untyped now fails startup instead of booting
+  into a dead database; a caller-supplied `Options.DatabaseConnector` is exempt (C57.5).
 - build-caught: none
 - exit: `go get github.com/gaborage/go-bricks@v0.57.0 && go mod tidy && go build ./... && go test ./...`
 
@@ -1422,6 +1429,111 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   off (or on, but the DDL fails); confirm a healthy environment still starts cleanly.
 - ref: wiki/outbox.md#startup-verification · `outbox/module.go` (`verifyStartupDatabase`) ·
   `inbox/module.go` (`verifyStartupDatabase`) · #876
+
+### [C57.5] `database.type` is inferred from a recognized connection-string scheme; an unrecognized one now fails startup on the built-in connector · breaking · when: match
+
+- detect: `git grep -n 'connectionstring' -- '*.yaml' '*.yml'` and
+  `git grep -nE 'DATABASE_CONNECTIONSTRING|DATABASES_.*_CONNECTIONSTRING|MULTITENANT_TENANTS_.*_CONNECTIONSTRING'`
+  across deployment manifests and env files for every `database.connectionstring` /
+  `databases.<name>.connectionstring` / `multitenant.tenants.<id>.database.connectionstring`
+  — **with or without** a sibling `type`. Match = one exists; check its scheme against the
+  recognized list (`postgres://`, `postgresql://`, `oracle://`), whether a sibling `type` is
+  set and agrees with that scheme, and whether the deployment uses the built-in connector (no
+  `Options.DatabaseConnector`). An entry with no `type` matters only on the built-in connector;
+  a `type` that contradicts the scheme matters on every connector.
+- scope: `config.validateDatabaseWithConnectionString` now infers `Type` from the DSN scheme
+  when `Type` is empty, and errors on an explicit `Type` that conflicts with the inferred
+  one. This applies everywhere `validateDatabase` runs: the root `database:` block, every
+  `databases.*` entry (write-back persists the inference the same way it already persists
+  pool/session defaults), and every static `multitenant.tenants.*.database` entry. Separately,
+  `app.Builder.ConfigureRuntimeHelpers` now fails startup when the root `database:` block, a
+  `databases.*` entry, or — **only under `multitenant.enabled: true`** — a
+  `multitenant.tenants.*.database` entry still carries a connection string with no resolved
+  type, but **only** when the built-in connector (`database.NewConnection`) would be used. A
+  tenants block left behind under `multitenant.enabled: false` is inert (koanf loads it from
+  YAML regardless of the flag, but neither validation nor `config.NewTenantStore` reads it)
+  and is deliberately not policed. A caller-supplied `Options.DatabaseConnector` parses the DSN
+  itself and is exempt from that startup guard — but from the guard only: `config.Validate` is
+  connector-blind, so a `type` that contradicts the DSN scheme fails on a custom connector too.
+  The quiesce CLI's tolerated-empty-`Type` PostgreSQL path
+  (`tools/migration/internal/commands/quiesce.go`) now arrives with `Type` already
+  inferred to `postgresql` and so is unaffected either way.
+  **Oracle only:** inference makes `validateOracleFields` run on a DSN-only config for the
+  first time (an empty `Type` used to skip vendor validation entirely), so that check is
+  relaxed in the same change — a connection string waives the "exactly one of
+  `oracle.service.name` / `oracle.service.sid` / `database`" requirement, because
+  `buildOracleDSN` returns the connection string verbatim and never reads those fields.
+  `oracle://user:pw@host:1521/XE` alone is therefore a complete config. Two Oracle checks are
+  **not** waived alongside a connection string: setting more than one identifier is still
+  "multiple identifiers configured", and `database.tls.cert`/`key`/`ca` are still rejected
+  (tcps/wallet is not implemented, so accepting them would imply an encryption that does not
+  exist).
+- gate: match = one of three outcomes. (1) A connstring with a recognized scheme and no
+  explicit `type` — this used to pass validation and then fail at first query with
+  `unsupported database type: ""`; it now infers the type and **actually connects**, which is
+  the surprising direction: a deployment that "worked" only because its database layer was
+  never exercised now dials a real database at startup pre-init. (2) A connstring with an
+  unrecognized scheme, no `type`, on the built-in connector — this also used to boot and fail
+  at first query; it now fails startup with an error naming every affected config path. (3) An
+  explicit `type` that conflicts with the DSN's scheme — this used to pass validation with the
+  explicit value taken as-is; it now fails validation, on every connector. A fourth outcome
+  needs no action, only awareness: an `oracle://` connection string with no identifier field
+  now validates, where `type: oracle` alongside the same DSN used to be rejected. That is a
+  relaxation — nothing that validated before stops validating. no-match = every
+  connection string either already carries a matching explicit `type`, or carries no `type`
+  while the deployment supplies its own `Options.DatabaseConnector`, or is one of the untyped
+  ones sitting under `multitenant.tenants` in a `multitenant.enabled: false` deployment, where
+  the whole block is inert.
+- before:
+
+  ```yaml
+  database:
+    connectionstring: postgres://app:pass@db.internal:5432/appdb
+  # no type — passed config.Validate, then every query hit
+  # "unsupported database type: \"\""
+  ```
+
+- after:
+
+  ```yaml
+  database:
+    connectionstring: postgres://app:pass@db.internal:5432/appdb
+  # type inferred to postgresql — the service now actually connects
+  ```
+
+  and, for an unrecognized scheme with no explicit `type`:
+
+  ```yaml
+  database:
+    connectionstring: sqlserver://app:pass@db.internal:1433/appdb
+  # built-in connector: Init now fails with
+  # "database configuration at [database]: connectionstring has no resolved database type; ..."
+  ```
+
+  and, for Oracle, where the DSN alone is now enough:
+
+  ```yaml
+  database:
+    connectionstring: oracle://app:pass@db.internal:1521/XEPDB1
+  # type inferred to oracle; no oracle.service.name / .sid / database needed —
+  # the DSN carries the identifier. Previously "type: oracle" plus this DSN failed
+  # with "oracle connection identifier exactly one required".
+  ```
+
+- apply: for outcome (1), confirm the target database is reachable and reviewed as a startup
+  dependency — it was previously inert, so pre-init now dials it for the first time. For
+  outcome (2), set `<path>.type` to `postgresql` or `oracle` explicitly (the schemes
+  `postgres://`, `postgresql://`, `oracle://` infer automatically and need no `type`), or
+  switch to a custom `Options.DatabaseConnector` if the scheme is neither vendor. For outcome
+  (3), fix the conflicting `type` or connection-string scheme — one of them is wrong.
+- verify: `go build ./... && go test ./...` exercises the inference and guard logic itself,
+  but no test can see your environment's config — start each affected environment and confirm
+  it now connects (outcome 1) or fails startup with a clear error naming the path (outcome 2)
+  instead of booting green.
+- ref: [ADR-050](adr_050_connectionstring_type_inference.md) ·
+  `config/validation.go` (`inferDatabaseTypeFromConnectionString`,
+  `validateDatabaseWithConnectionString`) · `app/app_builder.go`
+  (`untypedConnectionStringPaths`, `ConfigureRuntimeHelpers`) · #877
 
 ---
 


### PR DESCRIPTION
## What

A `database.connectionstring` with no `database.type` passed validation but
could never connect — `database.NewConnection` dispatches on `Type`. Validation
now infers the type from recognized DSN schemes; the builder fails startup for a
still-untyped DSN when the built-in connector would be used.

## Impact

A connstring-only config using `postgres://`, `postgresql://`, or `oracle://`
now **connects** instead of failing at first query — a service that "worked"
only because its database was never exercised now dials one at startup. An
unrecognized scheme with no `type`, on the built-in connector, now fails
startup. An explicit `type` contradicting the scheme now fails validation. Also
closes an Oracle credential leak this widens reach to: go-ora returns
`url.Parse`'s error unwrapped, so an inline DSN password reached the startup log.

## Verification

`make mutate` cannot reach the guard's `||` — gremlins leaves `INVERT_LOGICAL`
off. Hand-mutated instead: collapsing it to `if b.opts == nil` fails the
`DatabaseConnector`-nil test; dropping the `Multitenant.Enabled` gate fails the
disabled-tenants test.

Closes #877


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Database types are inferred from PostgreSQL and Oracle connection strings when not explicitly configured.
  * Startup validation detects unresolved types across primary, named, and enabled multi-tenant databases.
  * Custom database connectors remain exempt from built-in type validation.
  * Oracle connection-string-only configurations no longer require a separate identifier.
* **Bug Fixes**
  * Conflicting types and connection strings now produce clearer validation errors.
  * Oracle connection errors redact passwords while preserving diagnostic details.
* **Documentation**
  * Added guidance on connection-string inference, validation, startup behavior, and migration requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->