### PR TITLE
fix(config)!: a delivered-but-empty database identity field fails startup

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -881,12 +881,11 @@ func clearEnvironmentVariables() {
 }
 
 func TestLoadDatabaseDisabled(t *testing.T) {
+	clearEnvironmentVariables()
 	defer clearEnvironmentVariables()
+	t.Chdir(t.TempDir())
 
-	// Explicitly disable database by clearing defaults
-	os.Setenv("DATABASE_HOST", "")
-	os.Setenv("DATABASE_TYPE", "")
-
+	// A genuinely absent database section (no identity key set at all) loads fine.
 	cfg, err := Load()
 	require.NoError(t, err) // Should NOT fail validation now
 	require.NotNil(t, cfg)
@@ -1079,14 +1078,12 @@ func TestLoadUnitlessNumericDurationEnvVarStillFails(t *testing.T) {
 // The core conditional validation functionality works as intended
 
 func TestLoadDatabaseDisabledByDefault(t *testing.T) {
+	clearEnvironmentVariables()
 	defer clearEnvironmentVariables()
+	t.Chdir(t.TempDir())
 
-	// Don't set any database environment variables
-	// The defaults will have host="localhost" and type="postgresql", so database will be enabled
-	// To test truly disabled, we need to override the defaults
-	os.Setenv("DATABASE_HOST", "")
-	os.Setenv("DATABASE_TYPE", "")
-
+	// loadDefaults registers no database.* keys, so a Load with no database
+	// environment variables and no config.yaml leaves the section genuinely absent.
 	cfg, err := Load()
 	require.NoError(t, err)
 	require.NotNil(t, cfg)

--- a/config/validation.go
+++ b/config/validation.go
@@ -175,6 +175,10 @@ func Validate(cfg *Config) error {
 		return fmt.Errorf("scheduler config: %w", err)
 	}
 
+	if err := validateNoDeliveredEmptyDatabase(cfg); err != nil {
+		return fmt.Errorf("database config: %w", err)
+	}
+
 	if err := validateMultitenant(&cfg.Multitenant, &cfg.Database, &cfg.Messaging, &cfg.Source); err != nil {
 		return fmt.Errorf("multitenant config: %w", err)
 	}
@@ -387,6 +391,83 @@ func validateServerTLSMaterial(fileField, valueField, file, value string) error 
 	}
 }
 
+// identityKeyHost and identityKeyPort name recurring identity-key suffixes as
+// constants (goconst: both bare literals recur elsewhere in the package's
+// test fixtures).
+const (
+	identityKeyHost = "host"
+	identityKeyPort = "port"
+)
+
+// databaseIdentityKeys mirrors IsDatabaseConfigured's field set — the koanf
+// key suffixes whose PRESENCE marks a database section as delivered. Keep the
+// two in lockstep; TestDatabaseIdentityKeysMatchPredicate pins it.
+var databaseIdentityKeys = []string{
+	"connectionstring", "type", identityKeyHost, identityKeyPort, fieldDatabase,
+	"username", "password", "oracle.service.name", "oracle.service.sid",
+}
+
+// deliveredEmptyDatabaseKeys returns every identity key present in the loaded
+// configuration under base while the decoded section carries zero identity
+// values — the "delivered but empty" shape ADR-047 could not see (ADR-051).
+// All of them, not just the first: the error promises "field(s)", and an
+// operator who clears only the one key named would hit the same abort again.
+// Nil means the section is either genuinely absent or carries a real value
+// (later validators own that).
+func deliveredEmptyDatabaseKeys(cfg *Config, base string, db *DatabaseConfig) []string {
+	if IsDatabaseConfigured(db) {
+		return nil
+	}
+	var keys []string
+	for _, k := range databaseIdentityKeys {
+		key := base + "." + k
+		if cfg.Exists(key) {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
+// validateNoDeliveredEmptyDatabase fails startup when any database section —
+// root, named, or static-tenant — was delivered with only empty identity
+// fields. Tenant sections are walked only when multitenancy is enabled (see
+// below). Inert for hand-built Config literals (no koanf instance) and for
+// dynamic-source tenant configs (never in koanf). Offending paths are
+// collected sorted so the startup error is deterministic.
+func validateNoDeliveredEmptyDatabase(cfg *Config) error {
+	var offending []string
+	collect := func(base string, db *DatabaseConfig) {
+		offending = append(offending, deliveredEmptyDatabaseKeys(cfg, base, db)...)
+	}
+	collect(fieldDatabase, &cfg.Database)
+	for name := range cfg.Databases {
+		db := cfg.Databases[name]
+		collect("databases."+name, &db)
+	}
+	// Koanf populates Multitenant.Tenants from YAML regardless of the enabled flag,
+	// but a leftover block is inert in single-tenant mode: TenantStore skips it
+	// (config/tenant_store.go), ManagerConfigBuilder does not count it
+	// (app/bootstrap.go), and validateMultitenant returns before reaching it.
+	// Walking it anyway would abort startup over config no deployment consumes.
+	if cfg.Multitenant.Enabled {
+		for id := range cfg.Multitenant.Tenants {
+			t := cfg.Multitenant.Tenants[id]
+			collect("multitenant.tenants."+id+".database", &t.Database)
+		}
+	}
+	if len(offending) == 0 {
+		return nil
+	}
+	slices.Sort(offending)
+	return &ConfigError{
+		Category: errCategoryInvalid,
+		Field:    offending[0],
+		Message:  fmt.Sprintf("database identity field(s) delivered empty: %v", offending),
+		Action: "set real values (empty secretKeyRef / unset envsubst variable?) or remove the keys entirely — " +
+			"an absent database section is the supported database-free posture (ADR-047, ADR-051)",
+	}
+}
+
 // IsDatabaseConfigured reports whether a database is intentionally configured
 // (ADR-003, ADR-047).
 //
@@ -399,10 +480,14 @@ func validateServerTLSMaterial(fileField, valueField, file, value string) error 
 // Fields that applyDatabasePoolDefaults fills in (timezone, pool, query) are
 // deliberately excluded, so the verdict is identical before and after defaulting.
 //
-// Known limit: a field delivered as an EMPTY string is indistinguishable from an
-// unset one here (an empty secretKeyRef, envsubst over an unset variable). That shape
-// still reads as absence. TLS material is likewise excluded — it identifies no
-// database on its own.
+// A field delivered as an EMPTY string (an empty secretKeyRef, envsubst over an
+// unset variable) is indistinguishable from an unset one here and reads as
+// absence — but that shape is now caught at Load time by
+// validateNoDeliveredEmptyDatabase (ADR-051), which consults koanf key presence
+// rather than decoded values. The remaining blind spots are hand-built Config
+// values (no koanf instance to consult) and dynamic-source tenant configs
+// (resolved from a remote store, never koanf). TLS material is likewise
+// excluded from this predicate — it identifies no database on its own.
 func IsDatabaseConfigured(cfg *DatabaseConfig) bool {
 	return cfg.ConnectionString != "" ||
 		cfg.Type != "" ||

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -1,7 +1,10 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -5240,4 +5243,214 @@ func TestApplyDatabasePoolDefaultsNilConfig(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "configuration is nil")
+}
+
+// loadDeliveredEmptyFixture stages one TestValidateNoDeliveredEmptyDatabaseViaLoad
+// case — a scratch working directory holding yaml (when non-empty) plus env — and
+// returns Load()'s results from inside it. t.Cleanup rather than defer, so the
+// environment is cleared at subtest end from within a helper.
+func loadDeliveredEmptyFixture(t *testing.T, yaml string, env map[string]string) (*Config, error) {
+	t.Helper()
+	clearEnvironmentVariables()
+	t.Cleanup(clearEnvironmentVariables)
+
+	dir := t.TempDir()
+	if yaml != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, testConfigFileYAML), []byte(yaml), 0o600))
+	}
+	t.Chdir(dir)
+
+	for k, v := range env {
+		t.Setenv(k, v)
+	}
+	return Load()
+}
+
+// assertDeliveredEmptyError checks a rendered startup error against one case's
+// expectations. wantOrdered pins the sorted-path contract: each entry must appear
+// strictly before the next.
+func assertDeliveredEmptyError(t *testing.T, got string, wantContains, wantNotContain, wantOrdered []string) {
+	t.Helper()
+	for _, s := range wantContains {
+		assert.Contains(t, got, s)
+	}
+	for _, s := range wantNotContain {
+		assert.NotContains(t, got, s)
+	}
+	for i := 1; i < len(wantOrdered); i++ {
+		prev, cur := strings.Index(got, wantOrdered[i-1]), strings.Index(got, wantOrdered[i])
+		assert.Less(t, prev, cur, "%s must be reported before %s", wantOrdered[i-1], wantOrdered[i])
+	}
+}
+
+// TestValidateNoDeliveredEmptyDatabaseViaLoad drives validateNoDeliveredEmptyDatabase
+// through the real Load() path (env + YAML), since the koanf presence semantics it
+// relies on cannot be exercised through a hand-built Config literal (see
+// TestValidateNoDeliveredEmptyDatabaseInertForLiteral for that guarantee instead).
+func TestValidateNoDeliveredEmptyDatabaseViaLoad(t *testing.T) {
+	tests := []struct {
+		name           string
+		env            map[string]string
+		yaml           string
+		wantErr        bool
+		wantContains   []string
+		wantNotContain []string
+		// wantOrdered pins the sorted-path contract: each entry must appear
+		// strictly before the next in the rendered error.
+		wantOrdered []string
+	}{
+		{
+			name:         "env_delivered_empty_host_fails",
+			env:          map[string]string{"DATABASE_HOST": ""},
+			wantErr:      true,
+			wantContains: []string{"delivered empty", "database.host"},
+		},
+		{
+			name:         "yaml_bare_host_key_fails",
+			yaml:         "database:\n  host:\n",
+			wantErr:      true,
+			wantContains: []string{"database.host"},
+		},
+		{
+			name: "empty_database_block_is_absence",
+			yaml: "database: {}\n",
+		},
+		{
+			name: "absent_section_is_absence",
+		},
+		{
+			name: "real_value_bypasses",
+			env: map[string]string{
+				"DATABASE_TYPE":      PostgreSQL,
+				"DATABASE_HOST":      "db.internal",
+				"DATABASE_PORT":      "5432",
+				testDatabaseDatabase: "testdb",
+				testDatabaseUsername: "testuser",
+			},
+		},
+		{
+			name:         "named_database_empty_host_fails",
+			yaml:         "databases:\n  reporting:\n    host:\n",
+			wantErr:      true,
+			wantContains: []string{"databases.reporting.host"},
+		},
+		{
+			name: "tenant_database_empty_username_fails",
+			yaml: "multitenant:\n  enabled: true\n  resolver:\n    type: header\n  tenants:\n" +
+				"    acme:\n      database:\n        username:\n",
+			wantErr:        true,
+			wantContains:   []string{"multitenant.tenants.acme.database.username"},
+			wantNotContain: []string{"configuration required"},
+		},
+		{
+			name:         "multiple_offenders_listed",
+			yaml:         "databases:\n  alpha:\n    host:\n  beta:\n    host:\n",
+			wantErr:      true,
+			wantContains: []string{"databases.alpha.host", "databases.beta.host"},
+			wantOrdered:  []string{"databases.alpha.host", "databases.beta.host"},
+		},
+		{
+			// Every empty key in one section is named, not just the first: an
+			// operator who cleared only the first would hit the same abort again.
+			// The keys are chosen so databaseIdentityKeys order (type before host)
+			// contradicts sorted order — wantOrdered therefore pins slices.Sort,
+			// not the traversal order it happens to share elsewhere.
+			name:         "all_empty_keys_in_one_section_listed",
+			yaml:         "database:\n  type:\n  host:\n  username:\n",
+			wantErr:      true,
+			wantContains: []string{"database.type", "database.host", "database.username"},
+			wantOrdered:  []string{"database.host", "database.type", "database.username"},
+		},
+		{
+			// Koanf populates Multitenant.Tenants from YAML regardless of the enabled
+			// flag, but TenantStore, ManagerConfigBuilder and validateMultitenant all
+			// ignore the block in single-tenant mode — so a leftover tenants section is
+			// inert, and aborting startup over it would be a false abort on a config
+			// that runs today.
+			name: "disabled_multitenancy_leftover_tenant_ignored",
+			yaml: "multitenant:\n  enabled: false\n  tenants:\n" +
+				"    acme:\n      database:\n        username:\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := loadDeliveredEmptyFixture(t, tc.yaml, tc.env)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, cfg)
+				assertDeliveredEmptyError(t, err.Error(), tc.wantContains, tc.wantNotContain, tc.wantOrdered)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+		})
+	}
+}
+
+// TestValidateNoDeliveredEmptyDatabaseInertForLiteral pins the Exists nil-safety the
+// whole design leans on: a hand-built Config (no koanf instance) never trips the
+// validator, regardless of how empty its Database section is. Calling Validate(&Config{})
+// instead would fail earlier at validateApp on the empty app name, never reaching this
+// validator, so the function is called directly.
+func TestValidateNoDeliveredEmptyDatabaseInertForLiteral(t *testing.T) {
+	cfg := &Config{}
+	assert.NoError(t, validateNoDeliveredEmptyDatabase(cfg))
+}
+
+// TestLoadDefaultsCarryNoDatabaseIdentityKeys pins the enabling invariant this whole
+// design rests on (config/config.go's loadDefaults registers no database.* keys): if a
+// default is ever added for one of these keys, every deployment would read as
+// "delivered" and this test fails.
+func TestLoadDefaultsCarryNoDatabaseIdentityKeys(t *testing.T) {
+	clearEnvironmentVariables()
+	defer clearEnvironmentVariables()
+	t.Chdir(t.TempDir())
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	for _, k := range databaseIdentityKeys {
+		assert.False(t, cfg.Exists("database."+k), "database.%s must not be a registered default", k)
+	}
+}
+
+// TestDatabaseIdentityKeysMatchPredicate pins the one direction it can enforce
+// automatically: every entry in databaseIdentityKeys corresponds to a DatabaseConfig
+// field that IsDatabaseConfigured recognizes. The reverse direction — a field added to
+// IsDatabaseConfigured but never to the list — is not detectable by iterating the list;
+// the length assertion below is the tripwire for that direction.
+func TestDatabaseIdentityKeysMatchPredicate(t *testing.T) {
+	// grew IsDatabaseConfigured? grow this list first, then this number.
+	require.Len(t, databaseIdentityKeys, 9)
+
+	for _, key := range databaseIdentityKeys {
+		t.Run(key, func(t *testing.T) {
+			cfg := DatabaseConfig{}
+			switch key {
+			case "connectionstring":
+				cfg.ConnectionString = testConnectionString
+			case "type":
+				cfg.Type = PostgreSQL
+			case "host":
+				cfg.Host = "db.internal"
+			case "port":
+				cfg.Port = 5432
+			case "database":
+				cfg.Database = "appdb"
+			case "username":
+				cfg.Username = "app"
+			case "password":
+				cfg.Password = "s3cretpw"
+			case "oracle.service.name":
+				cfg.Oracle.Service.Name = "ORCLPDB1"
+			case "oracle.service.sid":
+				cfg.Oracle.Service.SID = "ORCL"
+			default:
+				t.Fatalf("databaseIdentityKeys entry %q has no mapping in this test — add one, and check IsDatabaseConfigured too", key)
+			}
+			assert.True(t, IsDatabaseConfigured(&cfg))
+		})
+	}
 }

--- a/wiki/adr_047_database_absence_vs_misconfiguration.md
+++ b/wiki/adr_047_database_absence_vs_misconfiguration.md
@@ -130,13 +130,17 @@ second-guess a caller-supplied resolver.
   a module supplies that missing intent; a startup WARN is the backstop for
   modules that do not. Neither reaches multi-tenant mode, which
   `rootDatabaseAbsent` exempts.
-- **The widened predicate does not catch every partial delivery.** Three shapes
-  still read as absence and boot green:
-  - **Identity fields delivered but empty** (`DATABASE_HOST=""` from an empty
-    `secretKeyRef`, `envsubst` over an unset variable, an empty mounted file). The
-    predicate sees a zero value and cannot tell "set to empty" from "never set".
-    This is a more common Kubernetes failure than a wholly unmounted secret, and
-    it is the one shape this design cannot see.
+- **At the time of ADR-047, the widened predicate did not catch every partial
+  delivery.** The shape it most conspicuously missed — **identity fields
+  delivered but empty** (`DATABASE_HOST=""` from an empty `secretKeyRef`,
+  `envsubst` over an unset variable, an empty mounted file), where the predicate
+  sees a zero value and cannot tell "set to empty" from "never set", a more
+  common Kubernetes failure than a wholly unmounted secret — is closed by
+  **[ADR-051](adr_051_delivered_empty_database_identity.md)**, which rejects a
+  delivered-but-empty identity key during `Load` by checking koanf key presence
+  instead of decoded values; configs carrying no koanf instance (hand-built
+  `Config` literals, dynamic-source tenant configs) stay outside its reach.
+  What the predicate still does not catch:
   - **TLS material alone** (`database.tls.*`) — deliberately excluded, because it
     identifies no database. Note the inverse hazard, which predates this ADR: a
     ConfigMap-provides-`host`/`type` + Secret-provides-TLS split whose TLS secret

--- a/wiki/adr_051_delivered_empty_database_identity.md
+++ b/wiki/adr_051_delivered_empty_database_identity.md
@@ -1,0 +1,102 @@
+# ADR-051: A Delivered-but-Empty Database Identity Field Fails Startup
+
+**Status:** Accepted
+**Date:** 2026-08-06
+
+## Context
+
+`config.IsDatabaseConfigured` (ADR-047) infers intent from decoded VALUES: any
+non-empty identity field marks a database section as configured. It cannot
+distinguish a field that was never set from one delivered as an empty string —
+an empty `secretKeyRef`, `envsubst` over an unset variable, a templated file
+rendering blank, or `DATABASE_HOST=""` written by a deployment tool. That shape
+reads as absence: the service boots, `/ready` reports `not_configured` (200),
+and the first query fails. ADR-047's own Consequences section named this as
+the one shape its widened predicate could not see. Fixes #880.
+
+The issue's original design proposed changing `IsDatabaseConfigured`'s
+signature across its six call sites so it could consult koanf directly. That
+turned out to be unnecessary: `config.Load` already stores the koanf instance
+on `cfg.k` *before* calling `Validate`, and `Config.Exists` is nil-safe. A
+validator living inside `Validate` can consult key presence without touching
+the predicate's signature or any of its callers at all.
+
+## Decision
+
+**Presence-of-identity-KEY plus zero identity VALUES fails startup.**
+
+`validateNoDeliveredEmptyDatabase` runs inside `config.Validate`, immediately
+before `validateMultitenant`. For each database-bearing section — root
+`database`, each `databases.<name>`, and, **only when
+`multitenant.enabled: true`**, each static `multitenant.tenants.<id>.database`
+— it first applies `IsDatabaseConfigured`;
+a section with any real value short-circuits (later validators own that path
+unchanged). Only when the decoded section is empty does it walk
+`databaseIdentityKeys` (the same nine suffixes `IsDatabaseConfigured` checks)
+and ask `cfg.Exists(section + "." + key)`. Every present key fails startup, and
+all of them are named — the message promises "field(s)", and an operator who
+cleared only the first would hit the same abort again. Offenders across all
+sections are collected and reported together, sorted for determinism.
+
+Placement is load-bearing: `validateMultitenantTenants` already rejects an
+unconfigured tenant database with a generic "configuration required" message.
+Running before `validateMultitenant` means a delivered-empty tenant section
+gets the precise key path instead of the generic message — specific beats
+generic. The validator's own logic has no dependency on any earlier
+validation having run: identity fields are decoded values, never mutated by
+defaulting.
+
+The tenant gate is not cosmetic. Koanf populates `Multitenant.Tenants` from
+YAML regardless of the enabled flag, but a leftover block is inert in
+single-tenant mode — `TenantStore` skips it (`config/tenant_store.go`),
+`ManagerConfigBuilder` does not count it (`app/bootstrap.go`), and
+`validateMultitenant` returns before reaching it. Walking it unconditionally
+would abort startup over config no deployment consumes.
+
+Two shapes remain deliberately out of reach, both pre-existing
+`IsDatabaseConfigured` blind spots this change does not touch:
+
+1. **Hand-built `Config` values.** No koanf instance means `Exists` returns
+   `false` for every key, so the validator is inert by construction — the
+   design leans on this for the many struct-literal tests scattered across the
+   suite, not just the new ones.
+2. **Dynamic-source tenant configs.** Resolved from a remote store at
+   request time, never routed through `config.Load`'s koanf instance.
+
+## Alternatives considered
+
+- **The issue's original six-call-site signature change.** Rejected: strictly
+  more churn (every `IsDatabaseConfigured` caller now needs a `*Config` in
+  scope) for the identical verdict the `Validate`-level seam already reaches
+  with zero signature changes.
+- **Classify inside `database.NewConnection`.** Rejected for the same reason
+  ADR-047 rejected it there: key-blind, and it would turn a loud startup
+  misconfiguration into a service that boots and fails at first query.
+
+## Consequences
+
+- **Breaking, and deliberately loud about it.** An ambient empty value for one
+  of the nine identity keys — `DATABASE_HOST=""` from a CI fixture, a Helm
+  chart default, a leftover override — now aborts startup instead of loading
+  as database-free. The scope is narrower than "any `DATABASE_*`": it fires
+  only when nothing else in that section carries a real value (an empty
+  `DATABASE_HOST` beside a populated `DATABASE_TYPE` still falls to ADR-047's
+  partial-section check), and non-identity keys — `database.tls.*`, pool,
+  query — are excluded here exactly as they are from `IsDatabaseConfigured`.
+  That is the point: an operator who intended "no database" should remove the
+  key, not set it to empty.
+- The residual blind spots (hand-built `Config` literals, dynamic-source
+  tenant configs) are unchanged from ADR-047 and remain the honest limit of
+  what a `Validate`-time, koanf-backed check can see.
+- `IsDatabaseConfigured`'s signature, logic, and all six existing call sites
+  are untouched — this is additive at the `Validate` level only.
+
+## References
+
+- `config/validation.go` — `validateNoDeliveredEmptyDatabase`,
+  `deliveredEmptyDatabaseKeys`, `databaseIdentityKeys`, `IsDatabaseConfigured`
+- `config/config.go` — `Load` (koanf instance stored before `Validate`),
+  `loadDefaults` (registers no `database.*`/`databases.*` keys)
+- [ADR-047](adr_047_database_absence_vs_misconfiguration.md) — the predicate
+  this closes a gap in
+- See [migrations.md](migrations.md) `[C57.6]`.

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -881,6 +881,37 @@ Fixes [#877](https://github.com/gaborage/go-bricks/issues/877). See
 
 ---
 
+### [ADR-051: A Delivered-but-Empty Database Identity Field Fails Startup](adr_051_delivered_empty_database_identity.md)
+
+**Date:** 2026-08-06 | **Status:** Accepted
+
+`config.IsDatabaseConfigured` (ADR-047) infers intent from decoded values, so an identity
+field delivered as an empty string — an empty `secretKeyRef`, `envsubst` over an unset
+variable, `DATABASE_HOST=""` — is indistinguishable from one never set and reads as
+absence: the service boots, `/ready` reports `not_configured`, and the first query fails.
+`validateNoDeliveredEmptyDatabase` now runs inside `config.Validate`, immediately before
+`validateMultitenant`, and consults the koanf instance `config.Load` already stores on
+`cfg.k` before validating: for the root `database` section, each `databases.<name>`, and —
+only when `multitenant.enabled: true` — each static `multitenant.tenants.<id>.database`, a
+section that decodes as unconfigured but has any identity key present in koanf fails startup
+naming every such key. A leftover `tenants:` block under disabled multitenancy stays inert, matching
+`TenantStore` and `ManagerConfigBuilder`, which both ignore it. Sections with real
+values short-circuit via `IsDatabaseConfigured` unchanged. Placement before
+`validateMultitenant` means a delivered-empty tenant section gets the precise key path
+instead of `validateMultitenantTenants`'s generic "configuration required" message. The
+issue's original six-call-site `IsDatabaseConfigured` signature change was rejected as
+strictly more churn for the identical verdict. Hand-built `Config` literals (no koanf
+instance) and dynamic-source tenant configs (never routed through koanf) remain out of
+reach, unchanged from ADR-047.
+
+**Key Benefits:** A partially-injected Kubernetes secret now fails loudly at startup
+instead of silently booting as database-free; `IsDatabaseConfigured`'s signature and all
+six existing call sites are untouched — the fix is additive at the `Validate` level only.
+Fixes [#880](https://github.com/gaborage/go-bricks/issues/880). See
+[migrations.md](migrations.md) `[C57.6]`.
+
+---
+
 ## ADR Lifecycle
 
 - **Proposed**: Under discussion, not yet implemented
@@ -890,7 +921,7 @@ Fixes [#877](https://github.com/gaborage/go-bricks/issues/877). See
 
 ### Numbering Policy
 
-ADR numbers (ADR-001 through ADR-050) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
+ADR numbers (ADR-001 through ADR-051) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
 
 ## Writing New ADRs
 

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -39,7 +39,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E52  | v0.51.0 → v0.52.0 | compile-break | 4 | C52.1 | if you set `.Args` on any declaration in ≤v0.51.0, verify current broker state before upgrading |
 | E55  | v0.52.0 → v0.55.0 | additive (safe) | 3 | none | none |
 | E56  | v0.55.0 → v0.56.0 | compile-break (C56.6 only partially — see its gate) + silent-behavior default flip (C56.11) | 15 | C56.6 C56.9 | grep log-driven alerts, dashboards, and test assertions for card-data / `iban` / `otp` field names — their values render `***` after the bump (C56.3); expect a cold tenant's first messaging request to fail fast instead of blocking (C56.4); if you assemble config in Go, check for `forwardedclientcert.require` without `enabled` — that service was serving unauthenticated traffic and now returns 401 (C56.5); if one queue name is declared from two places, confirm the two shapes agree — a mismatch that used to be silently overwritten now fails startup (C56.7); if you call a JOSE-protected peer, check for payload-free requests of **any** method — `GET`/`HEAD`/`DELETE` as well as `POST`/`PUT`/`PATCH` — since none of them are sealed now and a peer demanding `application/jose` on every request will answer 415 (C56.8); `/ready`'s 200 body gains `cache` and `cache_stats` and, where a cache is configured, every poll now issues a Redis `PING`, so update any test, schema, or dashboard that pins its exact key set and expect a live cache outage to read `unhealthy` (C56.10); if you run with a top-level cache enabled (or supply an `Options.CacheConnector`, which is probed regardless of `cache.enabled`) and have never set `cache.critical`, that outage now also answers `503` and drains every replica from rotation at once — decide before the bump whether to keep the strict default (and set `readinessProbe.failureThreshold: 3`) or add `cache.critical: false` (C56.11); and if any alert or runbook parses the Redis address out of `/ready`'s `503` body, repoint it at the app log or `/_sys/health-debug` (C56.12); and a module that cannot work without a database can now declare `app.DatabaseRequirer` so an absent one aborts startup rather than booting green (C56.13); check every environment that sets any `database.*` identity field for a complete section, since a partial one now fails startup (C56.14); and re-point any alert asserting `/ready` returns 503 for a database-free or multi-tenant service — both now return 200 (C56.15) |
-| E57  | v0.56.0 → v0.57.0 | silent-behavior + breaking (C57.4, C57.5 abort startup) | 5 | none | if any alert, runbook, synthetic check, or contract test parses the driver error out of `/ready`'s database `503` body, repoint it at the app log or `<debug.pathprefix>/health-debug` (default `/_sys`) — the field is now the fixed string `database unavailable` (C57.1); and if you implement your own critical `app.Prober`, its `503` body now reads `<Name> unavailable` instead of its raw error, since sanitization became the default rather than an opt-in (C57.2); and if anything reads `db_stats.connections` out of `/ready`'s **200** body — a per-tenant pool dashboard, an activity alert, a test pinning the key set — repoint it at `<debug.pathprefix>/health-debug` or the OTel database metrics, because that array is gone from `/ready`; a repo-local grep alone will not find an out-of-repo dashboard (C57.3); and check every environment with `outbox.enabled: true` or `inbox.enabled: true` (outside per-tenant fan-out or a dynamic source) for a configured, reachable database whose ledger table exists — or whose `autocreatetable` can create it — because Init now aborts startup instead of booting green (C57.4); and check every `database.connectionstring` (root, `databases.*`, `multitenant.tenants.*`) with no `database.type` set — a recognized scheme (`postgres://`, `postgresql://`, `oracle://`) now infers its type and actually dials instead of booting into a dead connection, and an unrecognized scheme on the built-in connector now fails startup instead of failing at first query (C57.5) |
+| E57  | v0.56.0 → v0.57.0 | silent-behavior + breaking (C57.4, C57.5, C57.6 abort startup) | 6 | none | if any alert, runbook, synthetic check, or contract test parses the driver error out of `/ready`'s database `503` body, repoint it at the app log or `<debug.pathprefix>/health-debug` (default `/_sys`) — the field is now the fixed string `database unavailable` (C57.1); and if you implement your own critical `app.Prober`, its `503` body now reads `<Name> unavailable` instead of its raw error, since sanitization became the default rather than an opt-in (C57.2); and if anything reads `db_stats.connections` out of `/ready`'s **200** body — a per-tenant pool dashboard, an activity alert, a test pinning the key set — repoint it at `<debug.pathprefix>/health-debug` or the OTel database metrics, because that array is gone from `/ready`; a repo-local grep alone will not find an out-of-repo dashboard (C57.3); and check every environment with `outbox.enabled: true` or `inbox.enabled: true` (outside per-tenant fan-out or a dynamic source) for a configured, reachable database whose ledger table exists — or whose `autocreatetable` can create it — because Init now aborts startup instead of booting green (C57.4); and check every `database.connectionstring` (root, `databases.*`, `multitenant.tenants.*`) with no `database.type` set — a recognized scheme (`postgres://`, `postgresql://`, `oracle://`) now infers its type and actually dials instead of booting into a dead connection, and an unrecognized scheme on the built-in connector now fails startup instead of failing at first query (C57.5); and check every environment for a database identity key delivered as an empty string (an empty `secretKeyRef`, `envsubst` over an unset variable) — that shape used to load silently as database-free and now aborts startup naming the key (C57.6) |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 - **`when: match`** → act only if `detect` returns ≥1 line (an API/arity/interface change, or a config key you set).
@@ -1534,6 +1534,85 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   `config/validation.go` (`inferDatabaseTypeFromConnectionString`,
   `validateDatabaseWithConnectionString`) · `app/app_builder.go`
   (`untypedConnectionStringPaths`, `ConfigureRuntimeHelpers`) · #877
+
+---
+
+### [C57.6] A database identity field delivered as an empty string now fails startup · breaking · when: match
+
+- detect: `git grep -nE "(MULTITENANT_TENANTS_[A-Z0-9_]+_)?DATABASE(S_[A-Z0-9_]+)?_(TYPE|HOST|PORT|DATABASE|USERNAME|PASSWORD|CONNECTIONSTRING|ORACLE_SERVICE_(NAME|SID))=(\"\"|'')?$"`
+  across env files and deployment manifests for any identity var set to an
+  empty value — the optional prefix covers the per-tenant namespace, which
+  `config.Load` maps to `multitenant.tenants.<id>.database.*` like any other
+  key — and
+  `git grep -nE "(host|type|port|database|username|password|connectionstring):[[:space:]]*(\"\"|''|null|~)?[[:space:]]*$"`
+  under `database:`, `databases.*`, and `multitenant.tenants.*.database` blocks
+  in YAML for a key that is bare **or** set to an explicit empty scalar: `""`,
+  `''`, `null`, and `~` all decode to the empty string and all abort startup, so
+  a bare-key-only pattern would miss the very shape the `before:` block below
+  shows. Use `[[:space:]]`, not `\s`: `git grep -E`
+  is POSIX ERE and silently drops the backslash, so `\s*` degrades to "zero or
+  more literal `s`" — it would miss a key with trailing whitespace and match
+  `weird:sss`. C56.14 named this exact shape as its one
+  blind spot: a field delivered empty (an empty `secretKeyRef`, `envsubst` over
+  an unset variable) reads as absence and the predicate cannot tell it from a
+  field never set. Both greps are repo-local and `config.Load` ingests **every**
+  process environment variable, so also check the rendered environment your
+  deployment actually runs with — a CI runner's exported vars, a base image
+  `ENV`, a `docker run -e DATABASE_HOST` with no value, an operator's shell
+  profile. None of those live in the tree, and each one now aborts startup.
+  Both greps are also line-oriented, which bounds them to flat YAML keys and
+  shell-style assignments; two shapes need a manual pass. The YAML pattern omits
+  `oracle.service.name` and `oracle.service.sid` deliberately — the env pattern
+  covers them, but in YAML they nest four deep under `database.oracle.service`
+  and their leaves, `name:` and `sid:`, are among the commonest keys in the
+  format, so folding them into the alternation above matches every unrelated
+  `name:` in reach. Locate the block instead, with
+  `git grep -nE "^[[:space:]]*oracle:[[:space:]]*$"`, and read its two leaves.
+  And a structured manifest carries the key and its value on separate lines
+  (`- name: DATABASE_HOST` then `value: ""`), which no line-oriented pattern can
+  correlate — nor can any repo grep see a `secretKeyRef` / `configMapKeyRef`
+  whose referenced secret is the empty thing. Check those by eye, the same way
+  `[C57.3]` sends you outside the repo for its dashboards.
+- scope: `config.Validate` gains `validateNoDeliveredEmptyDatabase`, which runs
+  before `validateMultitenant` and consults the koanf instance `config.Load`
+  already stores on `cfg.k`, not just the decoded `DatabaseConfig` values. For
+  the root `database` section, each `databases.<name>`, and each static
+  `multitenant.tenants.<id>.database`, a section that `IsDatabaseConfigured`
+  reports as unconfigured but that has ANY identity key present in the loaded
+  configuration now fails startup, naming every offending key path so one boot
+  surfaces the whole set.
+  Tenant sections are walked only when `multitenant.enabled: true`, so a
+  leftover `tenants:` block in a single-tenant deployment stays inert.
+  `IsDatabaseConfigured`'s signature and its six existing call sites are
+  unchanged; hand-built `Config` values (no koanf instance) and dynamic-source
+  tenant configs (never routed through koanf) are unaffected.
+- gate: match = some environment sets a database identity key to an empty
+  value with no other identity field completing the section. no-match = every
+  environment either configures the section fully, sets no identity key at
+  all, the empty key sits under `multitenant.tenants.*` with
+  `multitenant.enabled: false`, or the empty key belongs to a config source
+  that bypasses `config.Load` (dynamic-source tenants, hand-built `Config`
+  literals).
+- before:
+  ```yaml
+  database:
+    host: ""   # e.g. from an empty secretKeyRef
+  # loaded as database-free; /ready reported not_configured; first query failed
+  ```
+- after:
+  ```yaml
+  database:
+    host: ""   # config.Load now fails: "database identity field(s) delivered
+               # empty: [database.host]"
+  ```
+  Fix by supplying a real value, or removing the key entirely if the service
+  genuinely has no database — an absent section is unaffected.
+- verify: `config.Load()` succeeds for every environment you deploy; an
+  environment relying on an empty `DATABASE_*` var as its "no database" signal
+  must switch to leaving the var unset.
+- ref: [ADR-051](adr_051_delivered_empty_database_identity.md) ·
+  `config/validation.go` (`validateNoDeliveredEmptyDatabase`,
+  `deliveredEmptyDatabaseKeys`, `databaseIdentityKeys`) · C56.14 · #880
 
 ---
 


### PR DESCRIPTION
## What

A database identity field delivered but **empty** — an empty `secretKeyRef`,
`envsubst` over an unset variable, `DATABASE_HOST=""` — was indistinguishable
from one never set, so the service booted, `/ready` reported 200
`not_configured`, and the first query failed. `Validate` now consults koanf key
presence and fails startup when a section has an identity key present but every
identity value empty.

## Impact

Breaking for configs that were already dead. A section delivered with only empty
identity values now aborts startup naming every offending key path; a genuinely
absent section keeps the supported database-free posture. `config.Load` ingests
every process environment variable, so an ambient `DATABASE_*=""` in a CI runner
or base image aborts too — a repo-local grep will not find it. Hand-built
`Config` literals and dynamic-source tenant configs stay value-judged.

## Verification

No mutation operator covers statement order, so the placement before
`validateMultitenant` was hand-proven: moving it later makes the tenant case
report the generic "configuration required" instead of the precise key.

Closes #880


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Applications now fail at startup when database identity settings are supplied but left empty, preventing misconfiguration from being mistaken for a database-free setup.
  * Validation covers root, named, and enabled multi-tenant database configurations and reports all affected settings clearly.
  * Disabled multi-tenant configuration leftovers remain ignored.

* **Documentation**
  * Added guidance for diagnosing and remediating empty database identity settings from environment and YAML configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->