### PR TITLE
feat(messaging): expose delivery metadata to typed consumers

### DIFF
--- a/inbox/inbox_test.go
+++ b/inbox/inbox_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/gaborage/go-bricks/config"
 	dbtesting "github.com/gaborage/go-bricks/database/testing"
 	dbtypes "github.com/gaborage/go-bricks/database/types"
+	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/outbox"
+	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -79,4 +82,43 @@ func TestProcessOnceReturnsDBError(t *testing.T) {
 	err := in.ProcessOnce(t.Context(), "evt-1", func(context.Context, dbtypes.Tx) error { return nil })
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "database unavailable")
+}
+
+// testEvent is a minimal outbox-shaped payload for the typed-consumer
+// redelivery acceptance test.
+type testEvent struct {
+	Reference string `json:"reference" validate:"required"`
+}
+
+// TestProcessOnceViaTypedConsumerRedelivery proves the issue's acceptance
+// criterion end-to-end: a typed consumer reads x-outbox-event-id from
+// messaging.Metadata and wraps its business logic in ProcessOnce, so the SAME
+// delivery handled twice (an outbox at-least-once redelivery) runs the
+// business callback exactly once.
+func TestProcessOnceViaTypedConsumerRedelivery(t *testing.T) {
+	db := dbtesting.NewTestDB(dbtypes.PostgreSQL)
+	db.ExpectTransaction().
+		ExpectExec(`INSERT INTO gobricks_inbox`).WillReturnRowsAffected(1) // 1st delivery: inserted
+	db.ExpectTransaction().
+		ExpectExec(`INSERT INTO gobricks_inbox`).WillReturnRowsAffected(0) // redelivery: ON CONFLICT DO NOTHING
+	in := newTestInbox(db)
+
+	calls := 0
+	handler := messaging.NewTypedHandlerWithMeta("evt", func(ctx context.Context, _ testEvent, meta messaging.Metadata) error {
+		id, ok := outbox.EventIDFromHeaders(meta.Headers())
+		require.True(t, ok, "the outbox event id header must be present")
+		return in.ProcessOnce(ctx, id, func(context.Context, dbtypes.Tx) error {
+			calls++
+			return nil
+		})
+	})
+
+	delivery := &amqp.Delivery{
+		Body:    []byte(`{"reference":"abc"}`),
+		Headers: amqp.Table{outbox.HeaderEventID: "evt-1"},
+	}
+
+	require.NoError(t, handler.Handle(t.Context(), delivery))
+	require.NoError(t, handler.Handle(t.Context(), delivery))
+	assert.Equal(t, 1, calls, "the business callback runs exactly once across a redelivery")
 }

--- a/llms.txt
+++ b/llms.txt
@@ -3073,6 +3073,34 @@ func (m *Module) DeclareMessaging(decls *messaging.Declarations) {
 
 Decode/validation failures return a `*messaging.PayloadError` before the function runs — match with `errors.Is(err, messaging.ErrPayloadUndecodable)` / `messaging.ErrPayloadInvalid`. The function's own error passes through unwrapped. `Error()` and `Fields()` carry no payload bytes (map-key namespaces are redacted to `Limits[*]`) and are safe to log; `Unwrap()` returns the raw decoder/validator error and is not. The adapter is stateless, so `Workers` tuning below applies unchanged.
 
+**Need the delivery headers (outbox dedup)?** `DeclareTypedConsumerWithMeta` / `NewTypedHandlerWithMeta[T]` are the same adapter with `fn` as `func(ctx, T, messaging.Metadata) error` — `meta.Headers()` exposes the AMQP headers so an outbox-fed consumer can read `x-outbox-event-id` via `outbox.EventIDFromHeaders` and wrap the body in `deps.Inbox.ProcessOnce`:
+
+```go
+// Same DeclareMessaging body as above, with this call REPLACING the
+// DeclareTypedConsumer one — the same queue + consumer tag + event type twice
+// panics at startup. m.inbox is deps.Inbox, captured in Init; DeclareMessaging
+// receives only decls.
+messaging.DeclareTypedConsumerWithMeta(decls, &messaging.ConsumerOptions{
+	Queue: queue.Name, Consumer: "order-processor", EventType: "OrderCreated",
+}, func(ctx context.Context, evt OrderCreatedEvent, meta messaging.Metadata) error {
+	id, ok := outbox.EventIDFromHeaders(meta.Headers())
+	if !ok {
+		// No id, no dedup key — processing here would repeat the business
+		// write on every redelivery, so fail closed.
+		return fmt.Errorf("missing x-outbox-event-id header")
+	}
+	return m.inbox.ProcessOnce(ctx, id, func(ctx context.Context, tx dbtypes.Tx) error {
+		// Use tx: the business write must commit with the dedup row, or a crash
+		// between the two commits loses exactly-once.
+		return m.svc.ProcessOrderTx(ctx, tx, evt.OrderID)
+	})
+})
+```
+
+**Mixed-queue variant:** a queue that also carries directly-published messages has deliveries with no ledger key by design. There, and only there, swap the `!ok` branch for `return m.svc.ProcessOrder(ctx, evt.OrderID)` — processed without dedup, so that path must be idempotent on its own.
+
+Headers are written by the publisher, so on a queue fed from outside this service they are untrusted input: whoever can publish picks the ledger key. The relay stamps `x-outbox-event-id` on everything it publishes, so a publisher that simply drops it would opt out of dedup entirely — which is why the example returns an error on `!ok` rather than processing, and why the variant above is a deliberate opt-in for a queue whose traffic you know. Authorize publishers at the broker.
+
 ### Step 5: Wire the Module into `main`
 
 ```go
@@ -3119,6 +3147,7 @@ decls.DeclareConsumer(&messaging.ConsumerOptions{
 | Atomic publish (with DB) | Use Transactional Outbox — `deps.Outbox.Publish(ctx, tx, event)` |
 | Consumer Handler | `Handle(ctx, *amqp.Delivery) error` + `EventType() string` |
 | Typed consumer (decode + validate) | `messaging.DeclareTypedConsumer(decls, opts, fn)` — `fn` is `func(ctx, T) error` |
+| Typed consumer + delivery metadata | `messaging.DeclareTypedConsumerWithMeta(decls, opts, fn)` — `fn` is `func(ctx, T, messaging.Metadata) error` |
 | ACK | Return `nil` |
 | nack-without-requeue (drop) | Return `error` |
 | Concurrency | Auto = `NumCPU * 4` workers; override via `Workers` field |
@@ -3227,6 +3256,8 @@ return tx.Commit(ctx) // Both events committed to the outbox for relay
 ```
 
 ### Consumer Idempotency (Required)
+
+Hand-rolled and **best-effort only**: `isProcessed` → process → `markProcessed` are three separate steps, so a crash between the last two reprocesses the event on redelivery. For exactly-once, use `deps.Inbox.ProcessOnce` (see the typed-consumer example above), which commits the dedup row and the business write in one transaction.
 
 ```go
 func (h *Handler) Handle(ctx context.Context, delivery *amqp.Delivery) error {

--- a/messaging/typed_consumer.go
+++ b/messaging/typed_consumer.go
@@ -75,14 +75,55 @@ func (jsonCodec) summarize(err error) string {
 	return ""
 }
 
+// Metadata exposes read-only delivery facts to a typed consumer without
+// widening fn's payload contract. It is a per-delivery value constructed by
+// the adapter AFTER the nil-delivery guard; the zero value is inert (every
+// accessor returns its zero). Headers returns the live amqp.Table — treat it
+// as read-only, it is shared with the worker loop.
+type Metadata struct {
+	delivery *amqp.Delivery
+}
+
+// Headers returns the AMQP delivery headers (e.g. for
+// outbox.EventIDFromHeaders). Nil when no headers were published. The table is
+// the delivery's own, not a copy — read it, do not mutate it. Values are
+// publisher-controlled, so treat them as untrusted input on a queue fed from
+// outside this service.
+func (m Metadata) Headers() amqp.Table {
+	if m.delivery == nil {
+		return nil
+	}
+	return m.delivery.Headers
+}
+
+// EventType returns the wire-level message type stamped by the publisher.
+func (m Metadata) EventType() string {
+	if m.delivery == nil {
+		return ""
+	}
+	return m.delivery.Type
+}
+
+// Redelivered reports the broker's redelivery flag.
+func (m Metadata) Redelivered() bool {
+	if m.delivery == nil {
+		return false
+	}
+	return m.delivery.Redelivered
+}
+
 // typedHandler adapts a typed function to MessageHandler. Every field is set
 // once at construction and read-only afterwards: one instance is shared by every
 // worker goroutine of a consumer AND by every tenant replaying the same
-// declarations, so any mutable state here would be a data race.
+// declarations, so any mutable state here would be a data race. fn always
+// carries the metadata-aware shape; NewTypedHandler wraps a metadata-less fn
+// so Handle has a single dispatch path. Metadata itself is a per-delivery
+// value, not adapter state, so this does not reopen the race the comment warns
+// about.
 type typedHandler[T any] struct {
 	eventType string
 	codec     codec
-	fn        func(context.Context, T) error
+	fn        func(context.Context, T, Metadata) error
 }
 
 // NewTypedHandler adapts a typed function to the MessageHandler contract:
@@ -106,7 +147,7 @@ func NewTypedHandler[T any](eventType string, fn func(context.Context, T) error)
 	return &typedHandler[T]{
 		eventType: eventType,
 		codec:     jsonCodec{},
-		fn:        fn,
+		fn:        func(ctx context.Context, payload T, _ Metadata) error { return fn(ctx, payload) },
 	}
 }
 
@@ -128,7 +169,7 @@ func (h *typedHandler[T]) Handle(ctx context.Context, delivery *amqp.Delivery) e
 		return newPayloadValidateError(h.eventType, err)
 	}
 
-	return h.fn(ctx, payload)
+	return h.fn(ctx, payload, Metadata{delivery: delivery})
 }
 
 func (h *typedHandler[T]) EventType() string {
@@ -151,23 +192,51 @@ func (h *typedHandler[T]) EventType() string {
 // failures return a *PayloadError that nacks WITHOUT requeue, so pair the queue
 // with DeclareQueueWithDLQ, and fn must be safe for concurrent use.
 func DeclareTypedConsumer[T any](decls *Declarations, opts *ConsumerOptions, fn func(context.Context, T) error) *ConsumerDeclaration {
-	if decls == nil {
-		panic("messaging: DeclareTypedConsumer requires a non-nil *Declarations")
-	}
-	if opts == nil {
-		panic("messaging: DeclareTypedConsumer requires non-nil *ConsumerOptions")
-	}
-	if opts.Handler != nil {
-		panic(fmt.Sprintf(
-			"messaging: DeclareTypedConsumer builds the handler itself, so ConsumerOptions.Handler must be nil\n"+
-				"  queue=%s consumer=%s event_type=%s\n"+
-				"  Use DeclareConsumer for a hand-written MessageHandler, or build a fresh\n"+
-				"  ConsumerOptions if this one was already passed to DeclareTypedConsumer",
-			opts.Queue, opts.Consumer, opts.EventType,
-		))
-	}
+	checkTypedConsumerArgs(decls, opts, "DeclareTypedConsumer")
 
 	opts.Handler = NewTypedHandler[T](opts.EventType, fn)
 
+	return decls.DeclareConsumer(opts, nil)
+}
+
+// checkTypedConsumerArgs holds the three declaration-time wiring guards shared
+// by DeclareTypedConsumer and DeclareTypedConsumerWithMeta. entry names the
+// caller in every panic message, so a panic always points at the entry point
+// actually used.
+func checkTypedConsumerArgs(decls *Declarations, opts *ConsumerOptions, entry string) {
+	if decls == nil {
+		panic("messaging: " + entry + " requires a non-nil *Declarations")
+	}
+	if opts == nil {
+		panic("messaging: " + entry + " requires non-nil *ConsumerOptions")
+	}
+	if opts.Handler != nil {
+		panic(fmt.Sprintf(
+			"messaging: %s builds the handler itself, so ConsumerOptions.Handler must be nil\n"+
+				"  queue=%s consumer=%s event_type=%s\n"+
+				"  Use DeclareConsumer for a hand-written MessageHandler, or build a fresh\n"+
+				"  ConsumerOptions if this one was already passed to %s",
+			entry, opts.Queue, opts.Consumer, opts.EventType, entry,
+		))
+	}
+}
+
+// NewTypedHandlerWithMeta is NewTypedHandler for consumers that also need
+// delivery metadata — the outbox-dedup shape: read the x-outbox-event-id
+// header via outbox.EventIDFromHeaders(meta.Headers()) and wrap the business
+// logic in inbox.ProcessOnce. Failure and concurrency semantics are identical
+// to NewTypedHandler; fn must be safe for concurrent use.
+func NewTypedHandlerWithMeta[T any](eventType string, fn func(context.Context, T, Metadata) error) MessageHandler {
+	if fn == nil {
+		panic("messaging: NewTypedHandlerWithMeta requires a non-nil handler function (event_type=" + eventType + ")")
+	}
+	return &typedHandler[T]{eventType: eventType, codec: jsonCodec{}, fn: fn}
+}
+
+// DeclareTypedConsumerWithMeta is DeclareTypedConsumer for a metadata-aware
+// fn. Same panics, same queue rules, same PayloadError semantics.
+func DeclareTypedConsumerWithMeta[T any](decls *Declarations, opts *ConsumerOptions, fn func(context.Context, T, Metadata) error) *ConsumerDeclaration {
+	checkTypedConsumerArgs(decls, opts, "DeclareTypedConsumerWithMeta")
+	opts.Handler = NewTypedHandlerWithMeta[T](opts.EventType, fn)
 	return decls.DeclareConsumer(opts, nil)
 }

--- a/messaging/typed_consumer_test.go
+++ b/messaging/typed_consumer_test.go
@@ -513,6 +513,155 @@ func TestDeclareTypedConsumerPanicsOnWiringMistakes(t *testing.T) {
 	assert.Empty(t, decls.Consumers(), "nothing is registered when the guard fires")
 }
 
+func TestMetadataAccessors(t *testing.T) {
+	tests := []struct {
+		name        string
+		meta        Metadata
+		wantHeaders amqp.Table
+		wantType    string
+		wantRedeliv bool
+	}{
+		{
+			name: "populated_delivery",
+			meta: Metadata{delivery: &amqp.Delivery{
+				Headers:     amqp.Table{"x-outbox-event-id": "evt-1"},
+				Type:        orderEventType,
+				Redelivered: true,
+			}},
+			wantHeaders: amqp.Table{"x-outbox-event-id": "evt-1"},
+			wantType:    orderEventType,
+			wantRedeliv: true,
+		},
+		{
+			name:        "zero_value_is_inert",
+			meta:        Metadata{},
+			wantHeaders: nil,
+			wantType:    "",
+			wantRedeliv: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantHeaders, tc.meta.Headers())
+			assert.Equal(t, tc.wantType, tc.meta.EventType())
+			assert.Equal(t, tc.wantRedeliv, tc.meta.Redelivered())
+		})
+	}
+}
+
+func TestNewTypedHandlerWithMeta(t *testing.T) {
+	var got orderPayload
+	var gotMeta Metadata
+	var calls int
+	h := NewTypedHandlerWithMeta(orderEventType, func(_ context.Context, p orderPayload, meta Metadata) error {
+		got = p
+		gotMeta = meta
+		calls++
+		return nil
+	})
+
+	delivery := &amqp.Delivery{
+		Body:    validBody(t),
+		Headers: amqp.Table{"x-outbox-event-id": "evt-1"},
+	}
+	require.NoError(t, h.Handle(t.Context(), delivery))
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, orderPayload{Reference: "abc", Amount: 7}, got)
+	assert.Equal(t, "evt-1", gotMeta.Headers()["x-outbox-event-id"])
+
+	// The pre-fn pipeline is typedHandler.Handle's, asserted in depth against
+	// NewTypedHandler above; the meta-carrying constructor only has to reach the
+	// same short-circuits without ever calling fn.
+	t.Run("failures_short_circuit_before_fn", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			delivery *amqp.Delivery
+			wantErr  error
+		}{
+			{name: "nil_delivery", delivery: nil, wantErr: ErrPayloadUndecodable},
+			{name: "undecodable_body", delivery: &amqp.Delivery{Body: []byte("not json")}, wantErr: ErrPayloadUndecodable},
+			{
+				name:     "invalid_payload",
+				delivery: &amqp.Delivery{Body: []byte(`{"reference":"over-max-5","amount":1}`)},
+				wantErr:  ErrPayloadInvalid,
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				h := NewTypedHandlerWithMeta(orderEventType, func(context.Context, orderPayload, Metadata) error {
+					t.Error("fn must not run after a pre-dispatch failure")
+					return nil
+				})
+
+				err := h.Handle(t.Context(), tc.delivery)
+
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tc.wantErr)
+			})
+		}
+	})
+
+	t.Run("nil_fn_panics", func(t *testing.T) {
+		assert.PanicsWithValue(t,
+			"messaging: NewTypedHandlerWithMeta requires a non-nil handler function (event_type=OrderCreated)",
+			func() { NewTypedHandlerWithMeta[orderPayload](orderEventType, nil) })
+	})
+}
+
+func TestDeclareTypedConsumerWithMeta(t *testing.T) {
+	decls := NewDeclarations()
+	var got orderPayload
+	opts := &ConsumerOptions{Queue: testQueue, Consumer: testConsumer, EventType: orderEventType}
+
+	decl := DeclareTypedConsumerWithMeta(decls, opts, func(_ context.Context, p orderPayload, _ Metadata) error {
+		got = p
+		return nil
+	})
+
+	require.NotNil(t, decl)
+	assert.Same(t, opts.Handler, decl.Handler)
+
+	registered := decls.Consumers()
+	require.Len(t, registered, 1)
+	require.NotNil(t, registered[0].Handler)
+	assert.Equal(t, orderEventType, registered[0].Handler.EventType())
+
+	require.NoError(t, registered[0].Handler.Handle(t.Context(), &amqp.Delivery{Body: validBody(t)}))
+	assert.Equal(t, orderPayload{Reference: "abc", Amount: 7}, got)
+
+	t.Run("panics_on_wiring_mistakes", func(t *testing.T) {
+		fn := func(context.Context, orderPayload, Metadata) error { return nil }
+		opts := func() *ConsumerOptions {
+			return &ConsumerOptions{Queue: testQueue, Consumer: testConsumer, EventType: orderEventType}
+		}
+
+		assert.PanicsWithValue(t, "messaging: DeclareTypedConsumerWithMeta requires a non-nil *Declarations",
+			func() { DeclareTypedConsumerWithMeta(nil, opts(), fn) })
+
+		assert.PanicsWithValue(t, "messaging: DeclareTypedConsumerWithMeta requires non-nil *ConsumerOptions",
+			func() { DeclareTypedConsumerWithMeta[orderPayload](NewDeclarations(), nil, fn) })
+
+		taken := opts()
+		mine := &MockMessageHandler{eventType: orderEventType}
+		taken.Handler = mine
+		decls := NewDeclarations()
+
+		recovered := func() (msg any) {
+			defer func() { msg = recover() }()
+			DeclareTypedConsumerWithMeta(decls, taken, fn)
+			return nil
+		}()
+
+		require.NotNil(t, recovered, "a pre-set Handler must panic")
+		assert.Contains(t, recovered, "ConsumerOptions.Handler must be nil")
+		assert.Contains(t, recovered, "queue="+testQueue)
+		assert.Same(t, mine, taken.Handler, "the caller's handler is not overwritten")
+		assert.Empty(t, decls.Consumers(), "nothing is registered when the guard fires")
+	})
+}
+
 func TestJSONCodecSummarize(t *testing.T) {
 	typeErr := &json.UnmarshalTypeError{
 		Value:  "number " + numericMarker,

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -128,7 +128,33 @@ messaging: decode failed for event "OrderCreated": json: type mismatch at field 
 messaging: validate failed for event "OrderCreated" (fields: OrderCreated.Currency)
 ```
 
-**Delivery headers are not exposed (yet).** `fn` receives the decoded payload and nothing else, so a typed consumer cannot read `x-outbox-event-id` and wrap its body in `inbox.ProcessOnce`. Outbox delivery is at-least-once, so a consumer fed by the outbox relay still needs that dedup — use the untyped `DeclareConsumer` for those until [#852](https://github.com/gaborage/go-bricks/issues/852) lands.
+**Delivery metadata.** `DeclareTypedConsumerWithMeta` / `messaging.NewTypedHandlerWithMeta[T](eventType, fn)` are the metadata-carrying siblings of `DeclareTypedConsumer` / `NewTypedHandler`: `fn` is `func(ctx context.Context, payload T, meta messaging.Metadata) error`, with the same decode → validate → `fn` pipeline and failure semantics. `Metadata` exposes three read-only accessors — `Headers() amqp.Table`, `EventType() string`, `Redelivered() bool` — so a typed consumer can read `x-outbox-event-id` and wrap its body in `inbox.ProcessOnce`, the canonical composition for an outbox-fed consumer:
+
+```go
+// Same DeclareMessaging body as above, with this call REPLACING the
+// DeclareTypedConsumer one — the same queue + consumer tag + event type twice
+// panics at startup. m.inbox is deps.Inbox, captured in Init; DeclareMessaging
+// receives only decls.
+messaging.DeclareTypedConsumerWithMeta(decls, &messaging.ConsumerOptions{
+    Queue:     queue.Name,
+    Consumer:  "order-processor",
+    EventType: "OrderCreated",
+}, func(ctx context.Context, evt OrderCreated, meta messaging.Metadata) error {
+    id, ok := outbox.EventIDFromHeaders(meta.Headers())
+    if !ok {
+        // No id, no dedup key — processing here would repeat the business
+        // write on every redelivery, so fail closed.
+        return fmt.Errorf("missing x-outbox-event-id header")
+    }
+    return m.inbox.ProcessOnce(ctx, id, func(ctx context.Context, tx dbtypes.Tx) error {
+        return processTx(ctx, tx, evt) // business write joins the dedup transaction
+    })
+})
+```
+
+**Mixed-queue variant.** A queue that also carries directly-published messages has deliveries with no ledger key by design. There, and only there, swap the `!ok` branch for `return process(ctx, evt)` — processed without dedup, so that handler must be idempotent on its own. An outbox-only queue keeps the fail-closed default above.
+
+**Headers are publisher-controlled.** AMQP headers come from whoever published the message, so on a queue fed by an exchange outside this service `meta.Headers()` is caller-supplied input — reading it is identification, not authorization. In the dedup shape above the publisher therefore picks the ledger key: replaying a known `x-outbox-event-id` makes `ProcessOnce` skip the handler and ACK (a silent drop), and novel ids each cost a ledger row until retention sweeps them. Omitting the header is a third lever: the relay stamps `x-outbox-event-id` on every message it publishes, so a publisher that simply drops it would opt out of dedup entirely — which is why the example returns an error on `!ok` rather than processing, and why the mixed-queue variant is a deliberate opt-in for a queue whose traffic you know. Broker-side publish authorization is what bounds all three.
 
 **Concurrency.** One adapter instance serves every worker of the consumer and every tenant replaying the declarations. It holds no mutable state and allocates a fresh payload per delivery, so the concurrency rules below apply unchanged: the default is `NumCPU * 4` workers, and `Workers: 1` still buys sequential processing when ordering matters. Your `fn` must be safe for concurrent use.
 


### PR DESCRIPTION
## What

Typed consumers received only the decoded payload, so they could not read
`x-outbox-event-id` and could not deduplicate — while outbox delivery is
at-least-once, leaving every relay-fed typed consumer un-deduplicatable. Adds
`messaging.Metadata` (`Headers`, `EventType`, `Redelivered`) plus
`NewTypedHandlerWithMeta` / `DeclareTypedConsumerWithMeta`.

## Impact

Purely additive; the existing signatures are unchanged. A typed consumer can now
read the outbox header and wrap its body in `inbox.ProcessOnce`. `Headers()`
returns the delivery's own table, not a copy — read it, do not mutate it.
Headers are publisher-controlled, so on a queue fed from outside this service
whoever can publish picks the ledger key, and dropping the header opts out of
dedup entirely. Authorize publishers at the broker.

## Verification

Acceptance criterion: the same `x-outbox-event-id` delivered twice runs the
business callback once, through the real `ProcessOnce`. Proven load-bearing —
making `Headers()` return nil fails that test by name.

Closes #852


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Typed message consumers can access delivery headers, event type, and redelivery status.
  * Added support for transactional event deduplication during message redelivery.
* **Bug Fixes**
  * Prevented duplicate business processing when the same event is delivered more than once.
* **Documentation**
  * Expanded messaging guidance for metadata, missing or untrusted headers, and deduplication behavior.
* **Tests**
  * Added coverage for metadata handling, validation, registration, and end-to-end redelivery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->