### PR TITLE
chore(docs): fix markdown structure across the tree

### DIFF
--- a/.claude/agents/project-conventions-reviewer.md
+++ b/.claude/agents/project-conventions-reviewer.md
@@ -10,6 +10,8 @@ tools: Read, Grep, Glob, Bash
 model: sonnet
 ---
 
+<!-- markdownlint-disable MD041 -->
+
 You are the GoBricks **project-conventions reviewer**. You audit a change set
 against this repository's documented, strictly-enforced conventions and return
 a single actionable findings list. You are read-only: you NEVER edit files.

--- a/.claude/commands/pr-review-fix.md
+++ b/.claude/commands/pr-review-fix.md
@@ -3,6 +3,7 @@
 Fix all review comments on a pull request in a single pass.
 
 ## Usage
+
 Provide a PR number or URL as argument. If omitted, uses the current branch's PR.
 
 ## Workflow
@@ -17,6 +18,7 @@ Provide a PR number or URL as argument. If omitted, uses the current branch's PR
 5. **Commit and push**: Create a single commit with a message summarizing all fixes, then push.
 
 ## Rules
+
 - NEVER push incremental fixes. All comments must be addressed in a single commit.
 - If `make check` fails after fixes, fix the issues and re-run until it passes.
 - If a review comment conflicts with another, flag it to the user before proceeding.

--- a/.claude/commands/security-audit.md
+++ b/.claude/commands/security-audit.md
@@ -30,6 +30,7 @@ Generated: {date}
 ```
 
 ## Severity Classification
+
 - **Critical**: Hardcoded secrets, SQL injection without sanitization, known CVEs with exploits
 - **High**: Missing input validation on public endpoints, raw-SQL escape hatch (`f.Raw` / `jf.Raw` / `database.Raw`) without `// SECURITY:` annotation
 - **Medium**: Missing validation tags, outdated dependencies with vulnerabilities

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ GoBricks is a **production-grade framework for building MVPs fast**. It provides
 - **Automation:** Makefile/Taskfile for common tasks, multi-platform CI/CD pipelines.
 - **Documentation:** Just enough for others to understand quickly, examples over exhaustive docs.
 
+<!-- markdownlint-disable-next-line MD036 -->
 **"Build it simple, build it strong, and refactor when it matters."**
 
 ## Code Quality
@@ -321,7 +322,6 @@ For dual-mode log routing, runtime metrics, custom-metric patterns, vendor authe
 
 > **Mental model:** GoBricks treats `context.Context` as the primary carrier of deadlines and cancellation. The framework configures timeouts at every external boundary — HTTP server, HTTP client, database pool, AMQP, Redis, observability exporter, startup — and lets those deadlines propagate. Inside business logic, **the default is to use the inherited deadline**: do not introduce new timeouts unless you have a specific reason to *shorten* what's already in flight.
 
-
 | Boundary | Config key | Default |
 | --- | --- | --- |
 | HTTP request handler (deadline on `c.Request().Context()`) | `server.timeout.middleware` | **5s** |
@@ -332,7 +332,6 @@ For dual-mode log routing, runtime metrics, custom-metric patterns, vendor authe
 | AMQP publish confirmation | `messaging.reconnect.connectiontimeout` | 30s |
 | Scheduler slow-job WARN / shutdown | `scheduler.timeout.slowjob`, `scheduler.timeout.shutdown` | 25s / 30s |
 | Observability export | `observability.trace.export.timeout`, `observability.metrics.export.timeout`, `observability.logs.export.timeout` | 10s when `observability.environment` is `development` (its default — **not** derived from `app.env`) or the signal's endpoint is `stdout`; 60s otherwise |
-
 
 **The default pattern is to do nothing** — the request context already carries a 5s deadline, and every framework call propagates it. Shorten only when one sub-operation should fail fast (e.g., cap a cache lookup at 200–500ms so Redis hiccups don't burn the whole request budget). For fire-and-forget background work that must outlive the request, use `context.WithoutCancel(ctx)` to inherit values (trace ID, tenant ID) while severing cancellation — never `context.Background()`.
 
@@ -430,5 +429,3 @@ GoBricks breaks its own API surface when justified. Greenfield work uses the new
 - **.claude/tasks/** — Development task planning.
 - **llms.txt** — Quick reference examples for LLM code generation.
 - Tests alongside source files (`*_test.go`).
-
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Thank you for your interest in contributing to GoBricks! This document provides 
 ## Development Workflow
 
 ### Prerequisites
+
 - Go 1.26 or later
 - golangci-lint for linting
 - Make for build automation
@@ -19,15 +20,18 @@ Thank you for your interest in contributing to GoBricks! This document provides 
 ### Making Changes
 
 1. Create a new branch for your feature/fix:
+
    ```bash
    git checkout -b feature/your-feature-name
    ```
 
 2. Make your changes following the project conventions
 3. Run pre-commit checks:
+
    ```bash
    make check
    ```
+
    This runs formatting, linting, tests, alloc-stability guards, a vulnerability scan, gosec, and a go.mod/go.sum/go.work.sum tidiness check.
 
 ### Code Quality Standards

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Modern building blocks for Go microservices. GoBricks brings together configurat
 ---
 
 ## Table of Contents
+
 1. [Why GoBricks?](#why-gobricks)
 2. [Developer Resources](#developer-resources)
 3. [Feature Overview](#feature-overview)
@@ -38,6 +39,7 @@ Modern building blocks for Go microservices. GoBricks brings together configurat
 ---
 
 ## Why GoBricks?
+
 - **Production-ready defaults** for the boring-but-essential pieces (server, logging, configuration, tracing).
 - **Composable module system** that keeps HTTP, database, and messaging concerns organized.
 - **Mission-critical integrations** (PostgreSQL, Oracle, RabbitMQ, Flyway) with unified ergonomics.
@@ -49,16 +51,19 @@ Modern building blocks for Go microservices. GoBricks brings together configurat
 ## Developer Resources
 
 **For Contributors & Framework Developers:**
+
 - **[CLAUDE.md](CLAUDE.md)** - Comprehensive development guide with architecture, commands, testing, and workflows
 - **[llms.txt](llms.txt)** - Quick code examples optimized for LLMs and copy-paste development
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** - Coding standards, tooling, and contribution workflow
 
 **For Application Developers:**
+
 - **[go-bricks-demo-project](https://github.com/gaborage/go-bricks-demo-project)** - Complete working examples and patterns
 - **[MULTI_TENANT.md](MULTI_TENANT.md)** - Multi-tenant architecture and implementation guide
 - **[Go Reference](https://pkg.go.dev/github.com/gaborage/go-bricks)** - Complete API documentation
 
 **Quick Commands:**
+
 ```bash
 make check              # Pre-commit: fmt + lint + test + alloc guards + vuln scan + gosec
 make mutate             # Diff-scoped mutation gate (required before pushing)
@@ -72,6 +77,7 @@ go test -run TestName   # Run specific test
 ---
 
 ## Feature Overview
+
 - **Modular architecture** with explicit dependencies and lifecycle hooks
 - **Echo-based HTTP server** with typed handlers, standardized response envelopes, and raw response mode for legacy API migration
 - **Production-ready HTTP client** with retries, exponential backoff, W3C trace propagation, and interceptor chains
@@ -95,17 +101,20 @@ go test -run TestName   # Run specific test
 ## Quick Start
 
 ### Requirements
+
 - **Go 1.26** required
 - Modern Go toolchain with module support
 - Docker Desktop or Docker Engine (integration tests only)
 
 ### Install
+
 ```bash
 go mod init your-service
 go get github.com/gaborage/go-bricks@latest
 ```
 
 ### Bootstrap an application
+
 ```go
 // cmd/main.go
 package main
@@ -140,6 +149,7 @@ func main() {
 ```
 
 ### Configuration file
+
 ```yaml
 app:
   name: "my-service"
@@ -182,6 +192,7 @@ GoBricks loads defaults → `config.yaml` → `config.<env>.yaml` → environmen
 GoBricks uses Koanf for configuration management with layered loading: defaults → `config.yaml` → `config.<env>.yaml` → environment variables.
 
 ### Access Patterns
+
 ```go
 cfg, err := config.Load()
 if err != nil {
@@ -231,7 +242,9 @@ func (m *Module) Init(deps *ModuleDeps) error {
 **Supported types:** string, int, int64, float64, bool, time.Duration, []string (comma-separated via env/`default`, native sequence via YAML).
 
 ### Environment Variables
+
 Environment variables use uppercase with underscores and automatically map to dot notation:
+
 ```bash
 DATABASE_HOST=prod-db.company.com          # maps to database.host
 DATABASE_ORACLE_SERVICE_NAME=FREEPDB1      # maps to database.oracle.service.name
@@ -247,6 +260,7 @@ See the [config-injection example](https://github.com/gaborage/go-bricks-demo-pr
 Clear, actionable error messages for configuration and startup failures.
 
 ### Error Format
+
 ```text
 config_<category>: <field> <message> <action>
 ```
@@ -254,6 +268,7 @@ config_<category>: <field> <message> <action>
 **Categories**: `missing` (required field), `invalid` (bad value), `not_configured` (optional feature), `connection` (resource failure)
 
 ### Examples
+
 ```text
 config_missing: database.host required set DATABASE_HOST env var or add database.host to config.yaml
 
@@ -263,6 +278,7 @@ config_not_configured: messaging.broker.url (optional) to enable: set MESSAGING_
 ```
 
 ### Features
+
 - Dual paths: shows both env var and YAML path
 - Semantic distinction: differentiates missing, invalid, and optional
 - Multi-tenant context: includes tenant ID when applicable
@@ -273,6 +289,7 @@ config_not_configured: messaging.broker.url (optional) to enable: set MESSAGING_
 ## Modules and Application Structure
 
 ### Module interface
+
 ```go
 type Module interface {
     Name() string
@@ -298,6 +315,7 @@ type GlobalMiddlewareRegisterer interface {
 ```
 
 `ModuleDeps` injects shared services into every module:
+
 ```go
 type ModuleDeps struct {
     Logger        logger.Logger                                          // Structured logging
@@ -316,6 +334,7 @@ type ModuleDeps struct {
 ```
 
 ### Registering a module
+
 ```go
 func register(framework *app.App) error {
     return framework.RegisterModule(&users.Module{})
@@ -331,6 +350,7 @@ func register(framework *app.App) error {
 Echo v5-based server with typed handlers, standardized response envelopes, and comprehensive middleware (logging, recovery, rate limiting, CORS).
 
 ### Typed Handlers
+
 ```go
 func (h *Handler) createUser(req CreateReq, ctx server.HandlerContext) (server.Result[User], server.IAPIError) {
     user := h.svc.Create(req)
@@ -341,6 +361,7 @@ func (h *Handler) createUser(req CreateReq, ctx server.HandlerContext) (server.R
 Request structs use tags for binding/validation (`param`, `query`, `header`, `validate`). Responses follow consistent `{data:…, meta:…}` envelope structure. Use `server.WithRawResponse()` to bypass the envelope for legacy API migration (Strangler Fig pattern).
 
 ### Routing Configuration
+
 ```yaml
 server:
   path:
@@ -435,6 +456,7 @@ query := qb.Select("u.name", "p.bio").
 **JoinFilter Methods**: `EqColumn`, `NotEqColumn`, `LtColumn`, `LteColumn`, `GtColumn`, `GteColumn`, `Eq`, `NotEq`, `Lt`, `Lte`, `Gt`, `Gte`, `In`, `NotIn`, `Between`, `Like`, `Null`, `NotNull`, `And`, `Or`, `Raw`
 
 All methods automatically handle:
+
 - **Vendor-specific quoting** (Oracle reserved words like `NUMBER`, `DATE`)
 - **Placeholder formatting** (`$1` for PostgreSQL, `:1` for Oracle)
 - **Type safety** at compile time with refactor-friendly interfaces
@@ -464,10 +486,12 @@ query := qb.Select(cols.Cols("ID", "Name")). // []string flattened by Select
 **Benefits:** DRY (define columns once), type-safe (panics on typos), vendor-aware (auto-quotes Oracle reserved words), refactor-friendly, zero overhead after first use. See [CLAUDE.md](CLAUDE.md) for table aliases, INSERT patterns, and advanced examples.
 
 ### Database Support
+
 - **PostgreSQL**: `$1, $2` placeholders, pgx driver, advanced features
 - **Oracle**: `:1, :2` placeholders, reserved word quoting, service name/SID support, SEQUENCE objects, UDT registration
 
 ### Features
+
 - Connection pooling with production-safe defaults and health monitoring
 - Named databases for multi-database single-tenant setups (`deps.DBByName(ctx, "legacy")`)
 - Flyway integration for schema migrations (see below)
@@ -554,6 +578,7 @@ func (s *UserService) GetUser(ctx context.Context, id int64) (*User, error) {
 ```
 
 ### Key Features
+
 - **Type-Safe Serialization**: CBOR encoding with compile-time type safety
 - **Multi-Tenant Isolation**: Automatic tenant context resolution
 - **Lifecycle Management**: Lazy initialization, LRU eviction (max 100 tenants), idle cleanup (15m default)
@@ -711,6 +736,7 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 ```
 
 **Configuration:**
+
 ```yaml
 keystore:
   keys:
@@ -751,6 +777,7 @@ type CreateTokenResponse struct {
 ```
 
 **Key properties:**
+
 - **Bidirectional symmetry enforced** — request and response must both carry tags, or neither (registration-time check).
 - **Strict algorithm allowlist** — `RS256`/`PS256` for signing; `RSA-OAEP-256` + `A256GCM` for encryption. `alg=none`, `HS*`, and `RSA1_5` are rejected at parse time.
 - **Hybrid error envelope** — pre-trust failures (decrypt failed, signature invalid) emit a plaintext minimal `{code,message}` envelope so nothing leaks to unauthenticated peers; post-trust handler errors emit the standard `APIResponse` envelope, encrypted with the route's outbound policy.
@@ -766,12 +793,14 @@ Wire it by registering `keystore.NewModule()` **before** any module that declare
 Complete resource isolation with per-tenant database and messaging connections.
 
 ### Key Features
+
 - **Tenant Resolution**: Header, subdomain, path-segment, or composite (first-match chain) resolvers — plus custom strategies — all validated
 - **Resource Isolation**: Separate database/messaging connections per tenant
 - **Context Propagation**: Tenant ID flows automatically through all operations
 - **Declaration Replay**: Messaging infrastructure validated once, replayed per-tenant
 
 ### Quick Setup
+
 ```yaml
 multitenant:
   enabled: true
@@ -787,6 +816,7 @@ multitenant:
 Modules access tenant resources via `deps.DB(ctx)` and `deps.Messaging(ctx)`.
 
 ### Custom Integration
+
 Implement `app.TenantStore` to integrate with AWS Secrets Manager, HashiCorp Vault, or custom backends.
 
 See [MULTI_TENANT.md](MULTI_TENANT.md) for detailed architecture and [multitenant-aws example](https://github.com/gaborage/go-bricks-demo-project/tree/main/multitenant-aws) for implementation patterns.
@@ -891,7 +921,9 @@ See [MULTI_TENANT.md](MULTI_TENANT.md) for detailed architecture and [multitenan
 ## Examples
 
 ### Complete Working Examples
+
 Explore the [go-bricks-demo-project](https://github.com/gaborage/go-bricks-demo-project) repository:
+
 - `http/handlers` – typed HTTP handler module
 - `http/client` – fluent HTTP client with retries and interceptors
 - `oracle` – Oracle insert with reserved column quoting
@@ -901,7 +933,9 @@ Explore the [go-bricks-demo-project](https://github.com/gaborage/go-bricks-demo-
 - `multitenant-aws` – multi-tenant app with AWS Secrets Manager
 
 ### Quick Code Reference
+
 See **[llms.txt](llms.txt)** for copy-paste-ready code snippets covering:
+
 - Module system patterns
 - HTTP handlers (POST, GET, PUT, DELETE) and raw response mode
 - HTTP client with retries, interceptors, and W3C traces
@@ -922,10 +956,12 @@ See **[llms.txt](llms.txt)** for copy-paste-ready code snippets covering:
 Issues and pull requests are welcome!
 
 **Getting Started:**
+
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** - Coding standards, tooling, and workflow
 - **[CLAUDE.md](CLAUDE.md)** - Comprehensive development guide with architecture details, commands, and testing guidelines
 
 **Quick Setup:**
+
 ```bash
 go test ./...              # Run unit tests
 make check                 # Pre-commit checks (fmt, lint, test, alloc guards, vuln scan, gosec)
@@ -935,6 +971,7 @@ make test-integration      # Integration tests (Docker required)
 ---
 
 ## License
+
 MIT © [Contributors](LICENSE)
 
 ---

--- a/TESTING.md
+++ b/TESTING.md
@@ -457,6 +457,7 @@ func TestService_ConfigInjection(t *testing.T) {
 If you're currently using internal mock implementations, here's how to migrate:
 
 **Before (internal mocks):**
+
 ```go
 type MockDB struct {
     // custom implementation
@@ -469,6 +470,7 @@ func TestExample(t *testing.T) {
 ```
 
 **After (framework mocks):**
+
 ```go
 import "github.com/gaborage/go-bricks/testing/mocks"
 
@@ -481,6 +483,7 @@ func TestExample(t *testing.T) {
 ### From sqlmock to Framework Database Mocks
 
 **Before (sqlmock):**
+
 ```go
 db, mock, err := sqlmock.New()
 require.NoError(t, err)
@@ -490,6 +493,7 @@ mock.ExpectQuery("SELECT").WillReturnRows(rows)
 ```
 
 **After (framework mocks):**
+
 ```go
 mockDB := &mocks.MockDatabase{}
 rows := fixtures.NewMockRows([]string{"id", "name"}, [][]any{{1, "John"}})

--- a/docs/design/outbox-ops-surface.md
+++ b/docs/design/outbox-ops-surface.md
@@ -330,6 +330,7 @@ SELECT count(*) FROM <table> WHERE status = 'failed';   -- both vendors
 ## CIDR middleware reuse — recommendation
 
 **Options.**
+
 - **(a)** `outbox` imports `scheduler.CIDRMiddleware` directly. Works today (it is exported at
   `scheduler/cidr_middleware.go:23`), but couples `outbox → scheduler` for an HTTP concern —
   the outbox already depends on `scheduler` for the *relay job* (`outbox/relay.go:15`), yet
@@ -357,6 +358,7 @@ in ctx). `/_sys/job` never faced this because scheduler jobs are process-global 
 per-tenant DB rows (`listJobsHandler` reads `m.jobs`, `scheduler/api_handlers.go:38-56`).
 
 **Options.**
+
 - **(a) One tenant per call, addressed by a discriminator.** The tenant-resolution middleware
   already runs before handlers and puts the resolved tenant in ctx (the standard resolver
   header, e.g. `X-Tenant-ID`), so the handler just calls `deps.DB(ctx)` / the tenant's store

--- a/docs/superpowers/plans/2026-05-26-httpclient-tracing.md
+++ b/docs/superpowers/plans/2026-05-26-httpclient-tracing.md
@@ -1312,7 +1312,7 @@ git commit -m "test(httpclient): cover full retry-sequence span tree (#471)"
 
 - [ ] **Step 1: Locate the "## Metrics" section in `wiki/httpclient.md` and add a new "## Tracing" section AFTER the metrics section ends.**
 
-Find the end of the metrics section (look for the next `##` heading), then insert the following block immediately before it:
+Find the end of the metrics section (look for the next `## ` heading), then insert the following block immediately before it:
 
 ````markdown
 ## Tracing

--- a/docs/superpowers/plans/2026-05-26-httpclient-tracing.md
+++ b/docs/superpowers/plans/2026-05-26-httpclient-tracing.md
@@ -13,10 +13,12 @@
 ## File Structure
 
 **Created:**
+
 - `httpclient/internal/tracking/tracing.go` — `InitHTTPTracer`, `HTTPSpanInfo`, `StartHTTPClientSpan`, `EndHTTPClientSpan`, internal helpers.
 - `httpclient/internal/tracking/tracing_test.go` — unit tests for span emission, attributes, status mapping, name template, no-op behavior.
 
 **Modified:**
+
 - `httpclient/internal/tracking/testing.go` — add `ResetTracerForTesting()` alongside the existing `ResetMeterForTesting()`.
 - `httpclient/client.go` — wire parent + child spans in `Do` / `executeAttempt`; switch `ensureTraceContextHeaders` to propagator-based injection when a span is active.
 - `httpclient/client_test.go` — add integration test for full retry sequence (`5xx → 5xx → 2xx`) verifying parent/child relationship.
@@ -30,6 +32,7 @@
 ### Task 1: Scaffold `tracing.go` with lazy init + failing first test
 
 **Files:**
+
 - Create: `httpclient/internal/tracking/tracing.go`
 - Modify: `httpclient/internal/tracking/testing.go`
 - Create: `httpclient/internal/tracking/tracing_test.go`
@@ -210,6 +213,7 @@ git commit -m "feat(httpclient): scaffold OTel tracer + lazy init (#471)"
 ### Task 2: Span name template — method-only vs method+peer
 
 **Files:**
+
 - Modify: `httpclient/internal/tracking/tracing_test.go`
 - Modify: `httpclient/internal/tracking/tracing.go` (already covered, just add edge-case test)
 
@@ -294,6 +298,7 @@ git commit -m "test(httpclient): cover span name template variants (#471)"
 ### Task 3: Attribute set on StartHTTPClientSpan
 
 **Files:**
+
 - Modify: `httpclient/internal/tracking/tracing.go`
 - Modify: `httpclient/internal/tracking/tracing_test.go`
 
@@ -480,6 +485,7 @@ git commit -m "feat(httpclient): emit OTel HTTP client semconv attributes on spa
 ### Task 4: Status mapping in EndHTTPClientSpan (2xx/3xx/4xx unset, 5xx Error, transport RecordError)
 
 **Files:**
+
 - Modify: `httpclient/internal/tracking/tracing.go`
 - Modify: `httpclient/internal/tracking/tracing_test.go`
 
@@ -635,6 +641,7 @@ git commit -m "feat(httpclient): map HTTP status to OTel span status (#471)"
 ### Task 5: No-op behavior when no tracer provider
 
 **Files:**
+
 - Modify: `httpclient/internal/tracking/tracing_test.go`
 
 - [ ] **Step 1: Write the failing test**
@@ -690,6 +697,7 @@ git commit -m "test(httpclient): pin no-op tracer behavior for tracing seam (#47
 ### Task 6: Wire parent Do span into `client.Do`
 
 **Files:**
+
 - Modify: `httpclient/client.go`
 - Modify: `httpclient/client_test.go`
 
@@ -840,6 +848,7 @@ git commit -m "feat(httpclient): emit parent OTel span per logical Do call (#471
 ### Task 7: Wire child attempt span into `executeAttempt`
 
 **Files:**
+
 - Modify: `httpclient/client.go`
 - Modify: `httpclient/client_test.go`
 
@@ -986,6 +995,7 @@ Add this import at the top of `client.go`:
 > **Note:** `injectW3CTraceContext` is added in Task 8. For now, leave `c.ensureTraceContextHeaders(httpReq)` inside `applyHeaders` as it is — this means the parent header injection still happens once at applyHeaders-time. Task 8 replaces it with a propagator-aware version.
 
 Actually, to keep this task self-contained, **rename and adjust** the existing `ensureTraceContextHeaders` call:
+
 - In `applyHeaders`, remove the `c.ensureTraceContextHeaders(httpReq)` call.
 - Add `c.ensureTraceContextHeaders(httpReq)` (the existing function) immediately after the `c.applyHeaders(httpReq, req)` line inside `executeAttempt` is no longer needed — the call inside `applyHeaders` runs once per attempt anyway. Leave `applyHeaders` alone and DELETE the inline call I added in Step 3 above.
 
@@ -1031,6 +1041,7 @@ git commit -m "feat(httpclient): emit child attempt spans under Do span (#471)"
 ### Task 8: Replace `ensureTraceContextHeaders` with propagator injection when a span is active
 
 **Files:**
+
 - Modify: `httpclient/client.go`
 - Modify: `httpclient/client_test.go`
 
@@ -1193,6 +1204,7 @@ git commit -m "feat(httpclient): inject real traceparent via OTel propagator whe
 ### Task 9: Integration test for retry sequence (5xx → 5xx → 2xx)
 
 **Files:**
+
 - Modify: `httpclient/client_test.go`
 
 - [ ] **Step 1: Write the failing test**
@@ -1295,11 +1307,12 @@ git commit -m "test(httpclient): cover full retry-sequence span tree (#471)"
 ### Task 10: Documentation — wiki/httpclient.md Tracing section
 
 **Files:**
+
 - Modify: `wiki/httpclient.md`
 
 - [ ] **Step 1: Locate the "## Metrics" section in `wiki/httpclient.md` and add a new "## Tracing" section AFTER the metrics section ends.**
 
-Find the end of the metrics section (look for the next `## ` heading), then insert the following block immediately before it:
+Find the end of the metrics section (look for the next `##` heading), then insert the following block immediately before it:
 
 ````markdown
 ## Tracing
@@ -1394,6 +1407,7 @@ git commit -m "docs(httpclient): add Tracing section to wiki (#471)"
 ### Task 11: Documentation — wiki/observability.md, CLAUDE.md, llms.txt
 
 **Files:**
+
 - Modify: `wiki/observability.md`
 - Modify: `CLAUDE.md`
 - Modify: `llms.txt`
@@ -1443,6 +1457,7 @@ git commit -m "docs: reference httpclient tracing in observability/CLAUDE/llms.t
 ### Task 12: Run `make check-all` and fix any issues
 
 **Files:**
+
 - Possibly modify any of the above based on lint/test feedback.
 
 - [ ] **Step 1: Run the comprehensive checks**
@@ -1454,6 +1469,7 @@ make check-all
 - [ ] **Step 2: If anything fails, fix at the root cause (never bypass)**
 
 Common possibilities:
+
 - Lint may flag an unused `attemptCtx` in `executeAttempt` if propagator wiring uses `httpReq.WithContext(...)` only — handle by removing the local var.
 - `go vet` may flag missing argument names in the new `EndHTTPClientSpan` — apply Go-idiomatic naming.
 - Race detector may catch a tracerOnce race if `ResetTracerForTesting` is missing the mutex — verify it acquires `tracerInitMu`.
@@ -1478,6 +1494,7 @@ git commit -m "chore(httpclient): address make check-all feedback for tracing (#
 ## Self-review notes
 
 **Spec coverage:**
+
 - Q1 (one span per Do or per attempt): ✅ Task 6 (parent), Task 7 (child).
 - Q2 (span name template): ✅ Task 2.
 - Q3 (URL redaction): ✅ Task 3 (`url.path` only; no `url.full`).

--- a/docs/superpowers/plans/2026-06-02-scheduler-timezone.md
+++ b/docs/superpowers/plans/2026-06-02-scheduler-timezone.md
@@ -35,6 +35,7 @@
 ## Task 1: Config field, shared validation helper, and `Validate()` wiring
 
 **Files:**
+
 - Modify: `config/types.go` (`SchedulerConfig`, ~line 508)
 - Modify: `config/validation.go` (`Validate` ~line 102, `applyDatabaseTimezoneDefault` ~line 417)
 - Test: `config/validation_test.go` (append near the existing `TestApplyDatabaseTimezone*` tests, ~line 1796)
@@ -189,6 +190,7 @@ git commit -m "feat(scheduler): add and validate scheduler.timezone config key"
 ## Task 2: Apply the timezone to the gocron scheduler
 
 **Files:**
+
 - Modify: `scheduler/module.go` (`ensureSchedulerInitialized`, ~line 225)
 - Modify: `scheduler/test_helpers_test.go` (add `withTimezone`)
 - Test: `scheduler/module_test.go` (append)
@@ -404,6 +406,7 @@ git commit -m "feat(scheduler): apply configured timezone via gocron WithLocatio
 ## Task 3: Remove the dead `ScheduleConfiguration.Timezone` field
 
 **Files:**
+
 - Modify: `scheduler/schedule.go` (~lines 45-48)
 
 - [ ] **Step 1: Confirm the field is unreferenced**
@@ -441,6 +444,7 @@ git commit -m "refactor(scheduler): remove dead ScheduleConfiguration.Timezone f
 ## Task 4: Expose the active timezone in `GET /_sys/job`
 
 **Files:**
+
 - Modify: `scheduler/api_handlers.go` (`listJobsHandler`, ~line 62)
 - Test: `scheduler/api_handlers_test.go` (append)
 
@@ -501,6 +505,7 @@ git commit -m "feat(scheduler): expose active timezone in /_sys/job response"
 No behavior change — clarify that the `localTime` parameters are interpreted in the scheduler's configured zone.
 
 **Files:**
+
 - Modify: `app/module.go` (`JobRegistrar` interface, ~lines 47-62)
 - Modify: `scheduler/module.go` (`DailyAt`/`WeeklyAt`/`MonthlyAt` doc comments)
 
@@ -556,6 +561,7 @@ git commit -m "docs(scheduler): clarify localTime is in the configured timezone"
 ## Task 6: Documentation and ADR-023
 
 **Files:**
+
 - Create: `wiki/adr_023_scheduler_timezone.md`
 - Modify: `wiki/architecture_decisions.md`, `wiki/scheduler.md`, `wiki/migrations.md`, `CLAUDE.md`, `llms.txt`
 
@@ -724,6 +730,7 @@ Expected: PASS — fmt clean, lint clean, all tests pass with `-race`. Fix any i
 - [ ] **Step 2: Run the mandatory pre-push reviews**
 
 Per `CLAUDE.md` Workflow Rules, run both skills on the staged diff before pushing:
+
 - `/code-review` (reuse / quality / efficiency / correctness)
 - `/security-audit` (boundary validation, etc.)
 
@@ -738,6 +745,7 @@ Use the `superpowers:finishing-a-development-branch` skill to decide merge/PR. C
 ## Self-Review
 
 **Spec coverage** — every spec section maps to a task:
+
 - Config field + contract → Task 1 ✓
 - Shared validation helper (reuse `DefaultDatabaseTimezone`, no rename — confirmed cross-package referenced) → Task 1 ✓
 - Scheduler wiring via `WithLocation`, no per-schedule changes, sentinel/nil edges → Task 2 ✓

--- a/docs/superpowers/plans/2026-06-04-config-env-string-slice.md
+++ b/docs/superpowers/plans/2026-06-04-config-env-string-slice.md
@@ -26,6 +26,7 @@
 ## Task 1: Prefactor — isolate the decoder config (behavior-preserving)
 
 **Files:**
+
 - Modify: `config/config.go` (imports; `Load()` unmarshal call; new `buildDecoderConfig`)
 
 - [ ] **Step 1: Add imports**
@@ -101,6 +102,7 @@ git commit -m "refactor(config): extract buildDecoderConfig to control unmarshal
 ## Task 2: The fix — comma-split-and-trim decode hook (Unmarshal path)
 
 **Files:**
+
 - Create helper: `config/converters.go` (`splitAndTrimList`)
 - Modify: `config/config.go` (`stringToTrimmedSliceHookFunc`, add to chain)
 - Test: `config/config_test.go`
@@ -213,6 +215,7 @@ git commit -m "fix(config): split comma-separated env vars into []string fields 
 ## Task 3: Fail-fast on all-invalid security CIDR lists
 
 **Files:**
+
 - Modify: `config/validation.go` (`net` import; `validateCIDRList`; call sites in `validateScheduler`)
 - Test: `config/validation_test.go`
 
@@ -341,6 +344,7 @@ git commit -m "feat(config): fail startup when scheduler CIDR list has zero vali
 ## Task 4: `InjectInto` `[]string` support
 
 **Files:**
+
 - Modify: `config/converters.go` (`toStringSlice`)
 - Modify: `config/injection.go` (`reflect.Slice` arm; `assignStringSliceField`; doc comment)
 - Test: `config/injection_test.go`, `config/converters_test.go`
@@ -512,6 +516,7 @@ git commit -m "feat(config): support []string fields in InjectInto (#539)"
 ## Task 5: Documentation
 
 **Files:**
+
 - Modify: `CLAUDE.md` (Configuration Injection → Supported Types)
 - Modify: `llms.txt` (if it enumerates `InjectInto` supported types)
 
@@ -553,6 +558,7 @@ Run `/code-review` then `/security-audit` on the staged/branch diff; apply findi
 ```bash
 git push -u origin feature/config-env-string-slice
 ```
+
 Open PR titled `config: split comma-separated env vars for []string fields (#539)`, body referencing the issue, the four changes, and the fail-fast behavior note.
 
 ---

--- a/docs/superpowers/plans/2026-06-04-outbox-inbox-db-primitives.md
+++ b/docs/superpowers/plans/2026-06-04-outbox-inbox-db-primitives.md
@@ -9,6 +9,7 @@
 **Tech Stack:** Go 1.26, pgx/v5 (`pgconn`), sijms/go-ora/v2 (`network`), rabbitmq/amqp091-go, testify, `database/testing` (TestDB fluent mock), koanf config, release-please.
 
 **Conventions (apply to every PR):**
+
 - TDD: failing test → run (red) → implement → run (green) → `make check` → commit.
 - Commit trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
 - Conventional-Commit PR title IS the changelog entry (release-please owns `CHANGELOG.md`; never hand-edit it). Titles: `feat(scope): …` / `refactor(scope): …` / `fix(scope): …`.
@@ -23,6 +24,7 @@
 **PR title:** `refactor(database): extract shared SQL table-name validator to internal/sqlid`
 
 **Files:**
+
 - Create: `internal/sqlid/sqlid.go`
 - Create: `internal/sqlid/sqlid_test.go`
 - Modify: `outbox/store.go:13-44` (delegate `validateTableName` to `sqlid`, keep `outbox:` prefix)
@@ -132,6 +134,7 @@ func validateTableName(name string) error {
 ```
 
 Add `"github.com/gaborage/go-bricks/internal/sqlid"` to the import block; remove `"regexp"` and (if unused elsewhere in the file) `"strings"`.
+
 - [ ] **Step 2 — verify existing outbox tests still pass** (behavior preserved): `go test ./outbox/` → PASS. The existing `outbox/store_test.go` cases (`outbox$events`, `outbox#events` valid; dangerous rejected) must still pass; the error strings now read `outbox: table name …` (was `outbox: table name …` — confirm test assertions match; if a test asserts an exact old substring, update it minimally).
 - [ ] **Step 3 — `make check`** → PASS.
 - [ ] **Step 4 — commit:** `git add outbox/store.go outbox/*_test.go && git commit -m "refactor(outbox): use internal/sqlid for table-name validation"`
@@ -150,6 +153,7 @@ Add `"github.com/gaborage/go-bricks/internal/sqlid"` to the import block; remove
 **PR title:** `feat(database): add vendor-aware unique/FK/not-found error classifiers`
 
 **Files:**
+
 - Create: `database/errors.go`
 - Create: `database/errors_test.go`
 - Create: `database/errors_integration_test.go` (`//go:build integration`)
@@ -325,7 +329,7 @@ func ConstraintName(err error) (string, bool) {
 - [ ] **Step 2 — run:** `make test-integration` (Docker required) → PASS. If the local environment lacks Docker, note it in the PR and rely on CI's integration job.
 - [ ] **Step 3 — commit:** `git add database/errors_integration_test.go && git commit -m "test(database): integration coverage for unique-violation classifier (both vendors)"`
 
-### Task 2.3: open + babysit PR2 (same babysit loop as PR1).
+### Task 2.3: open + babysit PR2 (same babysit loop as PR1)
 
 ---
 
@@ -335,6 +339,7 @@ func ConstraintName(err error) (string, bool) {
 **PR title:** `feat(database): add WithTx/WithTxOptions transaction helpers`
 
 **Files:**
+
 - Modify: `database/internal/tracking/utils.go:114-125` (TrackDBOperation) and `:246-253` (createDBSpan)
 - Create: `database/internal/tracking/utils_test.go` additions (ErrTxDone downgrade test) — or extend existing
 - Create: `database/transaction.go`
@@ -367,7 +372,7 @@ func ConstraintName(err error) (string, bool) {
 	}
 ```
 
-  - createDBSpan record-error guard (currently lines 246-251):
+- createDBSpan record-error guard (currently lines 246-251):
 
 ```go
 	if err != nil {
@@ -380,6 +385,7 @@ func ConstraintName(err error) (string, bool) {
 ```
 
   (No new imports — `errors` and `database/sql` already imported.)
+
 - [ ] **Step 4 — run green** + `make check`.
 - [ ] **Step 5 — commit:** `git commit -am "fix(database): treat post-commit sql.ErrTxDone as benign in tracking (no ERROR log/span)"`
 
@@ -434,6 +440,7 @@ func TestWithTxRollsBackAndRepanics(t *testing.T) {
 ```
 
 (If `dbtesting` cannot satisfy a bare `ExpectTransaction()` with no exec on the rollback path, adjust to the TestDB's documented rollback expectation API — consult `database/testing/fake_tx.go` `IsRolledBack()`.)
+
 - [ ] **Step 2 — run red.**
 - [ ] **Step 3 — implement** `database/transaction.go`:
 
@@ -498,7 +505,7 @@ func WithTxOptions(ctx context.Context, db Interface, opts *sql.TxOptions, fn fu
 
 - [ ] Update the doc-comment examples in `outbox/outbox.go` and `database/types/transactor.go` to show `database.WithTx`; update `llms.txt` and `wiki/outbox.md`. Keep one manual Begin/Commit example for callers needing the tx handle outside a closure. Commit: `docs: show WithTx in transaction examples`.
 
-### Task 3.4: open + babysit PR3.
+### Task 3.4: open + babysit PR3
 
 ---
 
@@ -508,6 +515,7 @@ func WithTxOptions(ctx context.Context, db Interface, opts *sql.TxOptions, fn fu
 **PR title:** `feat(outbox): export x-outbox-event-id header name and EventIDFromHeaders getter`
 
 **Files:**
+
 - Create: `outbox/headers.go`
 - Create: `outbox/headers_test.go`
 - Modify: `outbox/relay.go:84-85` (reference the constants)
@@ -601,7 +609,7 @@ func EventIDFromHeaders(h amqp.Table) (string, bool) {
 - [ ] Update `outbox/relay_test.go:191,192,208`, `outbox/publisher_test.go:404` to reference `HeaderEventID`/`HeaderEventType`. Update `outbox/outbox.go:8` doc to mention `outbox.HeaderEventID` / `outbox.EventIDFromHeaders`.
 - [ ] `go test ./outbox/` → PASS; `make check` → PASS. Commit: `refactor(outbox): reference HeaderEventID/HeaderEventType constants at the relay`.
 
-### Task 4.3: open + babysit PR4.
+### Task 4.3: open + babysit PR4
 
 ---
 
@@ -611,6 +619,7 @@ func EventIDFromHeaders(h amqp.Table) (string, bool) {
 **PR title:** `feat(inbox): add durable consumer-side idempotency ledger (ProcessOnce)`
 
 **Files:**
+
 - Create: `inbox/store.go`, `inbox/store_postgres.go`, `inbox/store_oracle.go`
 - Create: `inbox/config.go`
 - Create: `inbox/cleanup.go`
@@ -887,6 +896,7 @@ var _ Store = (*oracleStore)(nil)
 ```
 
 NOTE on Oracle PK name: `pk_%s` consumes tableName once; if the table name is schema-qualified, the constraint name would contain a dot — guard by deriving the constraint suffix from the last segment, or document that schema-qualified inbox names are unsupported in v1 (simplest: require an unqualified `table_name` for inbox; validate in config). Decide during implementation; default to requiring unqualified inbox table names and asserting it in `validateConfig`.
+
 - [ ] **Tests** `inbox/store_postgres_test.go` / `inbox/store_oracle_test.go` mirror outbox store tests: `MarkProcessed` inserted=true (RowsAffected 1), duplicate inserted=false (PG RowsAffected 0; Oracle `WillReturnError` with a fabricated `*network.OracleError{ErrCode:1}` → inserted=false), `DeleteProcessed`, `CreateTable`. Conformance guards already in the store files.
 - [ ] `make check`. Commit: `feat(inbox): vendor-split ledger store (PG ON CONFLICT / Oracle catch unique violation)`.
 
@@ -1032,7 +1042,7 @@ func (c *Cleanup) Execute(ctx scheduler.JobContext) error {
 - [ ] `inbox/*_integration_test.go` (`//go:build integration`): same event id processed twice against PG and Oracle containers → fn runs once, second call is a no-op; verify PG path not poisoned and Oracle path survives. `make test-integration`.
 - [ ] Commit: `test(inbox): integration coverage for exactly-once across both vendors`.
 
-### Task 5.8: open + babysit PR5.
+### Task 5.8: open + babysit PR5
 
 ---
 

--- a/docs/superpowers/plans/2026-06-04-outbox-inbox-db-primitives.md
+++ b/docs/superpowers/plans/2026-06-04-outbox-inbox-db-primitives.md
@@ -372,7 +372,8 @@ func ConstraintName(err error) (string, bool) {
 	}
 ```
 
-- createDBSpan record-error guard (currently lines 246-251):
+<!-- markdownlint-disable-next-line MD007 -- nested under Step 3; the fenced block above breaks list continuation for the parser, so it reads the 2-space indent as stray -->
+  - createDBSpan record-error guard (currently lines 246-251):
 
 ```go
 	if err != nil {

--- a/docs/superpowers/plans/2026-06-05-config-key-flatsmush-rename.md
+++ b/docs/superpowers/plans/2026-06-05-config-key-flatsmush-rename.md
@@ -9,6 +9,7 @@
 **Tech Stack:** Go 1.26, koanf v2 (`koanf` struct tag), go-viper/mapstructure, testify, reflection.
 
 **Delivered as two self-contained PRs:**
+
 - **PR1** (this plan, Tasks 1–10): the rename + ADR + migration + tests + doc updates for the renamed keys.
 - **PR2** (Task 11, separate branch off `main` after PR1 merges): unrelated ride-along doc-drift fixes.
 
@@ -45,6 +46,7 @@ Each token is replaced in all five tag namespaces (`koanf`/`json`/`yaml`/`toml`/
 ### Task 1: No-underscore invariant test (the cornerstone guard)
 
 **Files:**
+
 - Create: `config/keyinvariant_test.go`
 
 - [ ] **Step 1: Write the failing test**
@@ -131,6 +133,7 @@ git commit -m "test(config): add no-underscore koanf-tag invariant (red)"
 ### Task 2: Env-reachability tests for renamed keys (red)
 
 **Files:**
+
 - Modify: `config/config_test.go` (append test)
 
 - [ ] **Step 1: Write the failing test** (uses the existing `clearEnvironmentVariables()` helper in `config_test.go` for env isolation)
@@ -174,6 +177,7 @@ git commit -m "test(config): assert env overrides reach renamed keys (red)"
 ### Task 3: Rename the 21 koanf tags + the one default key (green)
 
 **Files:**
+
 - Modify: `config/types.go`
 - Modify: `config/config.go` (loadDefaults: `keystore.secret_min_length` → `keystore.secretminlength`)
 
@@ -227,6 +231,7 @@ BREAKING: snake_case YAML/env keys no longer recognized. See ADR-024."
 ### Task 4: Fix pre-existing config tests that hardcode old keys
 
 **Files:**
+
 - Modify: `config/config_test.go`, `config/validation_test.go` (and any other failing `config/*_test.go`)
 
 - [ ] **Step 1: Identify failures**
@@ -252,6 +257,7 @@ git commit -m "test(config): update tests to renamed flat-smushed keys"
 ### Task 5: Update consistency strings (error messages + comments) and their tests
 
 **Files:**
+
 - Modify: `config/validation.go` (8 `NewValidationError("…reinit_delay"/…)` dotted key paths → smushed)
 - Modify: `outbox/config.go`, `inbox/config.go`, `cache/manager.go` (error-message strings naming the keys)
 - Modify: `keystore/keystore.go` (doc comment `secret_min_length: 32` → `secretminlength: 32`)
@@ -284,6 +290,7 @@ git commit -m "fix(config): align error messages and comments with renamed keys"
 ### Task 6: Update `config.example.yaml`
 
 **Files:**
+
 - Modify: `config.example.yaml`
 
 - [ ] **Step 1: Rename the keys** under `outbox:`, `inbox:`, and `log:` (lines ~112–139): `table_name`→`tablename`, `auto_create_table`→`autocreatetable`, `default_exchange`→`defaultexchange`, `poll_interval`→`pollinterval`, `batch_size`→`batchsize`, `max_retries`→`maxretries`, `retention_period`→`retentionperiod`, `sensitive_fields`→`sensitivefields`. (Leave the explanatory comment mentioning `password, api_key` — those are example sensitive field *values*, not config keys.)
@@ -305,6 +312,7 @@ git commit -m "docs(config): rename keys in config.example.yaml"
 ### Task 7: Update documentation references to the renamed keys
 
 **Files:**
+
 - Modify: `README.md`, `llms.txt`, `CLAUDE.md`, and the relevant `wiki/*.md` (`outbox.md`, `keystore.md`, `observability.md`, `cache.md`, `messaging.md`, others as found)
 
 - [ ] **Step 1: Enumerate exact references** (read-only) — distinguish our config keys from unrelated tokens (e.g. httpclient's own `connection_timeout`, DB columns). For each candidate file, confirm the match is one of the 21 config keys before editing:
@@ -330,6 +338,7 @@ git commit -m "docs: update config key references to flat-smushed names"
 ### Task 8: ADR-024 + migration table
 
 **Files:**
+
 - Create: `wiki/adr_024_config_key_flatsmush.md`
 - Modify: `wiki/architecture_decisions.md` (add ADR-024 to the index)
 - Modify: `wiki/migrations.md` (add a before→after rename table)
@@ -372,6 +381,7 @@ Expected: fmt + lint + tests pass, including `TestConfigKoanfTagsHaveNoUnderscor
 git push -u origin feature/config-key-flatsmush-rename
 ```
 
+<!-- markdownlint-disable-next-line MD033 -->
 - [ ] **Step 2: Open the PR** (`gh pr create`) — title `fix(config): rename underscored config keys to flat-smushed convention`; body: problem, the 21-key table, audit rationale (flat-smush is the standard; single-field structs are drift), BREAKING + ADR-024 link, "Closes #<finding issue if one exists>", and a note that Class 2 (InjectInto parity) is a deferred follow-up.
 
 - [ ] **Step 3: Babysit** — wait for CI; address CodeRabbit comments and SonarCloud NEW issues (fetch via `curl "https://sonarcloud.io/api/issues/search?componentKeys=gaborage_go-bricks&pullRequest=<N>&statuses=OPEN,CONFIRMED"`). Fix or document each skip in the commit. Push fixes. Re-check until quality gate green + reviews resolved.

--- a/docs/superpowers/plans/2026-06-30-hide-echo-types.md
+++ b/docs/superpowers/plans/2026-06-30-hide-echo-types.md
@@ -130,6 +130,7 @@ Run: `GOWORK=off go test ./server/... ./app/... ./scheduler/...` — Expected: a
 ## Self-Review
 
 **Spec coverage** — every spec section maps to a task:
+
 - §1 boundary types → Task 1 ✓; §2 HandlerContext → Task 1 ✓; §3 RouteRegistrar+seam → Tasks 1,2 ✓; §4 ServerRunner → Task 3 ✓; §5 app echo-free → Task 5 ✓; §6 scheduler → Task 6 ✓; §7 middleware class → Task 4 ✓; §8 test ctor → Task 1 ✓; §9 perf → Task 8 benchmarks ✓; Testing → Task 8 ✓; Docs → Task 9 ✓; gates → Task 10 ✓.
 
 **Panel resolutions covered:** benchmarks+invariant (Task 8) ✓; SetRequest/SetRequestContext (Task 1) ✓; constructor class Option A (Task 4) ✓; `Handler` rename + `RequestHeader` (Task 1) ✓; RealIP dropped + ClientIP denial log (Tasks 1,5) ✓; doc expansion + doc gate (Tasks 9,10) ✓.

--- a/docs/superpowers/plans/2026-07-26-mutation-gate-and-pbt.md
+++ b/docs/superpowers/plans/2026-07-26-mutation-gate-and-pbt.md
@@ -2,6 +2,8 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+<!-- MD028: separator keeps the two notes below as distinct blockquotes -->
+
 > **Historical record:** this document is the pre-execution blueprint plus
 > mid-execution patches. Its code blocks show what was planned at dispatch
 > time; the review gates (/simplify, /security-audit, CodeRabbit) refined the
@@ -34,11 +36,13 @@
 ### Task 1: Gremlins compatibility spike + pinned configuration
 
 **Files:**
+
 - Modify: `Makefile` (version pin block at top, near `GOVULNCHECK_VERSION`)
 - Modify: `.gitignore` (allowlist `.gremlins.yaml`)
 - Create: `.gremlins.yaml`
 
 **Interfaces:**
+
 - Produces: Makefile var `GREMLINS_VERSION`, a validated gremlins invocation shape (`unleash --output <file> <pkg>`), and a captured real report JSON used verbatim as the Task 3 fixture.
 
 - [ ] **Step 1: Verify gremlins runs on Go 1.26**
@@ -103,10 +107,12 @@ Save `/tmp/gremlins-config.json` — Task 3 pastes a trimmed excerpt of it as th
 ### Task 2: Wrapper diff parsing (`diff.go`)
 
 **Files:**
+
 - Create: `scripts/mutatediff/diff.go`
 - Create: `scripts/mutatediff/diff_test.go`
 
 **Interfaces:**
+
 - Produces (consumed by Tasks 3–4):
   - `type lineRange struct { Start, End int }` — half-open `[Start, End)` new-file line numbers
   - `func parseUnifiedDiff(diff string) map[string][]lineRange`
@@ -315,10 +321,12 @@ git log -1
 ### Task 3: Wrapper report judging (`report.go`)
 
 **Files:**
+
 - Create: `scripts/mutatediff/report.go`
 - Create: `scripts/mutatediff/report_test.go`
 
 **Interfaces:**
+
 - Consumes: `lineRange` from Task 2.
 - Produces (consumed by Task 4):
   - `type mutantVerdict struct { File string; Line int; Operator, Status string }`
@@ -491,10 +499,12 @@ git log -1
 ### Task 4: Wrapper orchestration + `make mutate` + live verification
 
 **Files:**
+
 - Create: `scripts/mutatediff/main.go`
 - Modify: `Makefile` (new `mutate` and `mutate-baseline` targets, after the `sec:` target)
 
 **Interfaces:**
+
 - Consumes: `parseUnifiedDiff`, `mutationScope`, `packagesOf`, `judge`, `lineRange`, `mutantVerdict` (Tasks 2–3).
 - Produces: `make mutate` (diff gate, exit 0 clean / 1 survivors / 2 tool error) and `make mutate-baseline` (full-repo run writing `gremlins-report.json`, used by Task 5).
 
@@ -631,9 +641,11 @@ git log -1
 ### Task 5: Nightly baseline workflow
 
 **Files:**
+
 - Create: `.github/workflows/mutation-nightly.yml`
 
 **Interfaces:**
+
 - Consumes: `make mutate-baseline` (Task 4), which writes `gremlins-report.json` at the repo root.
 
 - [ ] **Step 1: Write the workflow**
@@ -714,6 +726,7 @@ The cron cannot be exercised pre-merge; `workflow_dispatch` exists so it can be 
 ### Task 6: PR1 documentation
 
 **Files:**
+
 - Modify: `CLAUDE.md` (Quick Reference block + Workflow Rules bullet)
 - Modify: `wiki/testing.md` (new `## Mutation Gate` section at the end)
 
@@ -815,10 +828,12 @@ git checkout -b feature/property-based-suites
 ```
 
 **Files:**
+
 - Modify: `go.mod` / `go.sum` (root)
 - Create: `database/database_properties_test.go`
 
 **Interfaces:**
+
 - Consumes: `database.NewQueryBuilder(vendor string)`, consts `database.PostgreSQL` / `database.Oracle`, `qb.Filter() types.FilterFactory` (`Eq(column string, value any) types.Filter`, `And(filters ...types.Filter) types.Filter`), `qb.Select(...).From(...).Where(...).ToSQL() (string, []any, error)`.
 
 - [ ] **Step 1: Add the dependency**
@@ -952,9 +967,11 @@ git log -1
 ### Task 9: Config property suite
 
 **Files:**
+
 - Create: `config/config_properties_test.go`
 
 **Interfaces:**
+
 - Consumes: `Load() (*Config, error)`, `(*Config).InjectInto(target any) error`, test helper `clearEnvironmentVariables()` (already in `config` package tests).
 
 - [ ] **Step 1: Write the suite**
@@ -1090,9 +1107,11 @@ git log -1
 ### Task 10: JOSE property suite
 
 **Files:**
+
 - Create: `jose/jose_properties_test.go` (package `jose_test` — white-box would cycle through `jose/testing`, which imports `jose`)
 
 **Interfaces:**
+
 - Consumes: `jose.Seal(payload []byte, p *jose.Policy, r jose.KeyResolver) (string, error)`, `jose.Open(compact string, p *jose.Policy, r jose.KeyResolver) ([]byte, *jose.Claims, jose.OpenHeader, error)`, `josetest.NewBidirectionalFixture(t)` (fields `ClientOutbound`, `PeerInbound`, `Resolver`).
 
 - [ ] **Step 1: Write the suite**
@@ -1174,9 +1193,11 @@ git log -1
 ### Task 11: Multitenant resolver property suite
 
 **Files:**
+
 - Create: `multitenant/multitenant_properties_test.go` (package `multitenant`)
 
 **Interfaces:**
+
 - Consumes: `TenantResolver` interface (`ResolveTenant(ctx, *http.Request) (string, error)`), struct literals `&HeaderResolver{HeaderName}`, `&SubdomainResolver{RootDomain, TrustProxies}`, `&PathResolver{Segment, Prefix}`, `&CompositeResolver{Resolvers, TenantRegex}`.
 
 - [ ] **Step 1: Write the suite**
@@ -1287,6 +1308,7 @@ git log -1
 ### Task 12: PR2 documentation
 
 **Files:**
+
 - Modify: `wiki/testing.md` (new `## Property-Based Tests` section, after the Mutation Gate section from Task 6)
 
 - [ ] **Step 1: Append the section**

--- a/docs/superpowers/plans/2026-08-03-mutate-thermal-guardrails.md
+++ b/docs/superpowers/plans/2026-08-03-mutate-thermal-guardrails.md
@@ -37,10 +37,12 @@
 ### Task 1: Budget derivation and environment pinning
 
 **Files:**
+
 - Create: `scripts/mutatediff/throttle.go`
 - Test: `scripts/mutatediff/throttle_test.go`
 
 **Interfaces:**
+
 - Consumes: nothing from earlier tasks.
 - Produces:
   - `type throttle struct { cpu int; workers int; cooldown time.Duration; sleep func(time.Duration) }`
@@ -372,10 +374,12 @@ Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
 ### Task 2: Wire the budget into the gate
 
 **Files:**
+
 - Modify: `scripts/mutatediff/main.go:17-46` (flags and dispatch), `scripts/mutatediff/main.go:48-94` (`run`)
 - Modify: `scripts/mutatediff/main_test.go:11`, `scripts/mutatediff/main_test.go:77`
 
 **Interfaces:**
+
 - Consumes: `throttle`, `applyBudget`, `describeBudget` from Task 1.
 - Produces: `func run(ctx context.Context, engine, baseRef string, th throttle, out io.Writer) int` — the `workers int` parameter is replaced by the `throttle`, which carries it.
 
@@ -504,9 +508,11 @@ Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
 ### Task 3: Cool down between packages
 
 **Files:**
+
 - Modify: `scripts/mutatediff/main.go:82-92` (the package loop), `scripts/mutatediff/main.go:178-214` (`mutatePackage`)
 
 **Interfaces:**
+
 - Consumes: `shouldCool`, `throttle.coolDown` from Task 1; the `throttle`-taking `run` from Task 2.
 - Produces: `func mutatePackage(ctx context.Context, engineArgs []string, pkg, reportDir string, changed map[string][]lineRange, workers int, out io.Writer) (failures, warnings []mutantVerdict, ran bool, err error)` — the new third return reports whether the engine actually executed mutants for this package.
 
@@ -632,10 +638,12 @@ Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
 ### Task 4: Makefile knobs and documentation
 
 **Files:**
+
 - Modify: `Makefile:26-32` (the `MUTATE_*` knob block), `Makefile:126-127` (the `mutate` target)
 - Modify: `wiki/testing.md` (the knobs table under `## Mutation Gate`)
 
 **Interfaces:**
+
 - Consumes: the `-cpu` and `-cooldown` flags from Task 2.
 - Produces: `MUTATE_CPU` and `MUTATE_COOLDOWN` make variables.
 

--- a/docs/superpowers/specs/2026-05-26-httpclient-tracing-design.md
+++ b/docs/superpowers/specs/2026-05-26-httpclient-tracing-design.md
@@ -64,11 +64,13 @@ func ResetTracerForTesting()
 ### Wiring inside `client.go`
 
 `Do`:
+
 - After `validateRequest`, open the **parent "Do" span** via `StartHTTPClientSpan(ctx, &HTTPSpanInfo{Method, URL: parsedURL, PeerName})`.
 - `defer EndHTTPClientSpan(doSpan, finalStatus, finalErrType, finalRespBytes, finalErr)` — final values are captured by closure (or a small `final` struct updated by the loop).
 - The retry loop runs against the context that has the Do span attached, so each attempt span is its child.
 
 `executeAttempt`:
+
 - After `buildRequest` succeeds (so `httpReq.URL` is available), open the **child attempt span** via `StartHTTPClientSpan(attemptCtx, &HTTPSpanInfo{Method, URL: httpReq.URL, PeerName, ResendCount: attempt})`.
 - Move `applyHeaders → ensureTraceContextHeaders` to use `otel.GetTextMapPropagator().Inject(...)` *after* the attempt span starts, so the injected traceparent matches the attempt span's IDs.
 - Close the attempt span via `EndHTTPClientSpan(attemptSpan, statusCode, errType, respBytes, err)` after recording metrics — same lifecycle as the metric observation.

--- a/docs/superpowers/specs/2026-06-04-config-env-string-slice-design.md
+++ b/docs/superpowers/specs/2026-06-04-config-env-string-slice-design.md
@@ -120,6 +120,7 @@ if err := k.UnmarshalWithConf("", &cfg, koanf.UnmarshalConf{
 ```
 
 Notes:
+
 - koanf's default text hook (`textUnmarshalerHookFunc`) is unexported; we substitute the
   public `mapstructure.TextUnmarshallerHookFunc()`. Safe: the `Config` struct has **no**
   `[]byte`, custom string types, or `TextUnmarshaler` fields (verified), so the two behave
@@ -277,6 +278,7 @@ addition, nothing more.
 ## Testing (TDD order)
 
 **Step A — Fix tests first (red before Change 2):**
+
 - `config.Load()` with `SCHEDULER_SECURITY_CIDRALLOWLIST=10.0.0.0/8,192.168.0.0/16` → len 2, exact values.
 - `LOG_SENSITIVE_FIELDS=pan, cvv2 , otp` → `["pan","cvv2","otp"]` (trim + drop empties).
 - Single-element env still works (regression).
@@ -286,12 +288,14 @@ addition, nothing more.
 **Step B — Prefactor regression (Change 1):** full existing `config` suite green.
 
 **Step C — Fail-fast tests (Change 3):**
+
 - Non-empty all-invalid `cidrallowlist` via env → `Load()` errors naming `scheduler.security.cidrallowlist`.
 - Non-empty all-invalid `trustedproxies` → error naming the field.
 - Partial-invalid (≥1 valid) → no error.
 - Empty list → no error. Valid multi → no error.
 
 **Step D — `InjectInto` tests (Change 4):**
+
 - `[]string` field from env comma string → multi-element, trimmed.
 - From YAML sequence → multi-element.
 - From `default:"a,b,c"` tag → split.

--- a/docs/superpowers/specs/2026-06-04-outbox-inbox-db-primitives-design.md
+++ b/docs/superpowers/specs/2026-06-04-outbox-inbox-db-primitives-design.md
@@ -151,6 +151,7 @@ func WithTxOptions(ctx context.Context, db Interface, opts *sql.TxOptions, fn fu
 ```
 
 Contract:
+
 - `Begin`/`BeginTx` → `defer` closure: `recover()` → rollback → **re-panic**; else if `committed` skip;
   else rollback.
 - On `fn` error: rollback, return the **original `fn` error** (not the rollback error; join a rollback
@@ -233,7 +234,7 @@ return database.WithTx(ctx, db, func(ctx context.Context, tx dbtypes.Tx) error {
   `store_oracle.go` with vendor DDL **consts** (exported, so managed-migration shops can run them):
   - PG: `CREATE TABLE IF NOT EXISTS %s (tenant_id VARCHAR(255) NOT NULL DEFAULT '', event_id VARCHAR(255)
     NOT NULL, processed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(), PRIMARY KEY (tenant_id,event_id))`
-    + `CREATE INDEX IF NOT EXISTS idx_%s_processed ON %s (processed_at)`.
+    - `CREATE INDEX IF NOT EXISTS idx_%s_processed ON %s (processed_at)`.
   - Oracle: `VARCHAR2(255)`, `SYSTIMESTAMP`, no `IF NOT EXISTS` (tolerate ORA-00955 as warning),
     function-based index; mirror outbox's reserved-word handling.
 - `inbox/module.go`: copy `ensureStoreInitialized` (double-checked mutex, `switch db.DatabaseType()`,

--- a/docs/superpowers/specs/2026-06-05-config-key-flatsmush-rename-design.md
+++ b/docs/superpowers/specs/2026-06-05-config-key-flatsmush-rename-design.md
@@ -69,11 +69,13 @@ Renaming koanf keys breaks existing YAML/env using the snake_case form — old k
 ## Components / files
 
 **Core (behavioral):**
+
 - `config/types.go` — rename `koanf`/`json`/`yaml`/`toml`/`mapstructure` tags on the 21 fields.
 - `config/config.go` — `loadDefaults`: `keystore.secret_min_length` → `keystore.secretminlength` (the only underscored default key).
 - `config.example.yaml` — the outbox/inbox/log keys.
 
 **Consistency (strings that name the key, updated for accuracy):**
+
 - `config/validation.go` — `NewValidationError("messaging.reconnect.reinit_delay", …)` and the other dotted key paths (8 sites).
 - `outbox/config.go`, `inbox/config.go`, `cache/manager.go` — error-message strings (`poll_interval`, `batch_size`, `max_size`, …).
 - `keystore/keystore.go` — doc comment.
@@ -83,10 +85,12 @@ Renaming koanf keys breaks existing YAML/env using the snake_case form — old k
 **Governance:** `wiki/adr_024_*.md` (new) + `wiki/architecture_decisions.md` index + `wiki/migrations.md` entry.
 
 **Ride-along doc fixes** (independently misleading, found in the earlier audit):
+
 - `README.md:329-339` — wrong server-path env vars (`SERVER_BASE_PATH`→`SERVER_PATH_BASE`, `SERVER_HEALTH_ROUTE`→`SERVER_PATH_HEALTH`, `SERVER_READY_ROUTE`→`SERVER_PATH_READY`) + drifted YAML block shape; `:226` — soften the "auto-maps to dot notation" claim.
 - `.env.example` — `DATABASE_TYPE=postgres`→`postgresql`; verify-then-fix the 3 orphan `MULTITENANT_*` entries.
 
 **Explicit EXCLUSIONS** (false-positive tokens — do NOT rename):
+
 - `messaging/manager.go` `idle_ttl_seconds` (a metric/log field name).
 - `database/*` `table_name` etc. (SQL column names), and any other non-config use.
 - Implementation classifies each reference; `make check` + targeted tests catch mistakes.

--- a/docs/superpowers/specs/2026-06-16-lease-refcount-tenant-handles-design.md
+++ b/docs/superpowers/specs/2026-06-16-lease-refcount-tenant-handles-design.md
@@ -66,6 +66,7 @@ Each entry gains `refs int` and `detached bool` (guarded by the existing manager
 ### 3. `app/resource_provider.go`
 
 Each accessor calls the manager, then `leasescope.Register(ctx, release)`:
+
 - scope present → lease auto-released at the boundary;
 - no scope → `release()` immediately = today's behavior (non-leaking, **unprotected**), so
   uncovered paths (health/prewarm/startup probes, key `""`) never regress.

--- a/docs/superpowers/specs/2026-06-30-hide-echo-types-design.md
+++ b/docs/superpowers/specs/2026-06-30-hide-echo-types-design.md
@@ -183,7 +183,7 @@ func fromEchoMiddleware(em echo.MiddlewareFunc, cfg *config.Config) MiddlewareFu
 // public: func CORS(expose bool, env ...string) MiddlewareFunc { return fromEchoMiddleware(corsEcho(expose, env...), nil) }
 ```
 
-`SetupMiddlewares` calls the unexported `xxxEcho()` forms directly through `e.Use(...)` → **the default request path stays echo-native, zero baton** (the ADR-026 invariant, test-enforced). `SkipperFunc` becomes `func(r *http.Request) bool`; `CreateProbeSkipper` returns the flat form; internal echo `Skipper` configs adapt at the `SetupMiddlewares` seam. Severity escalation is the `HandlerContext.EscalateSeverity(level)` method. _(SkipperFunc→`*http.Request` and method-only EscalateSeverity were refined in Phase-3 code review.)_
+`SetupMiddlewares` calls the unexported `xxxEcho()` forms directly through `e.Use(...)` → **the default request path stays echo-native, zero baton** (the ADR-026 invariant, test-enforced). `SkipperFunc` becomes `func(r *http.Request) bool`; `CreateProbeSkipper` returns the flat form; internal echo `Skipper` configs adapt at the `SetupMiddlewares` seam. Severity escalation is the `HandlerContext.EscalateSeverity(level)` method. *(SkipperFunc→`*http.Request` and method-only EscalateSeverity were refined in Phase-3 code review.)*
 
 ### 8. Test support (exported, server package)
 

--- a/observability/README.md
+++ b/observability/README.md
@@ -110,6 +110,7 @@ observability:
 ```
 
 **Environment variables:**
+
 ```bash
 export OTEL_API_KEY="your-api-key-here"
 ```
@@ -367,11 +368,12 @@ observability:
 
 ### Connection Errors
 
-```
+```text
 Error: failed to initialize trace provider: failed to create trace exporter
 ```
 
 **Solutions:**
+
 - Verify endpoint is correct (hostname:port)
 - Check protocol matches endpoint (HTTP=4318, gRPC=4317)
 - Ensure firewall allows outbound connections

--- a/tools/migration/README.md
+++ b/tools/migration/README.md
@@ -7,6 +7,7 @@ go-bricks framework so the runtime engine and the CLI honor the same contract
 tenant, advisory-lock concurrency provided by Flyway natively).
 
 Deep dives:
+
 - [wiki/multi_tenant_migration.md](../../wiki/multi_tenant_migration.md) — full
   architecture, control-plane response shape, AWS Secrets Manager layout.
 - [wiki/migration_audit.md](../../wiki/migration_audit.md) — `migration.applied`

--- a/wiki/adr_001_enhanced_handler_system.md
+++ b/wiki/adr_001_enhanced_handler_system.md
@@ -7,6 +7,7 @@
 ## Problem Statement
 
 The original handler system required developers to:
+
 - Manually handle Echo context boilerplate (`c.JSON()`, `c.Bind()`, etc.)
 - Implement repetitive request binding and validation logic
 - Maintain inconsistent response formats across endpoints
@@ -19,6 +20,7 @@ This led to verbose code, inconsistent APIs, and reduced developer productivity.
 Implement an enhanced handler system with the following characteristics (updated to reflect current implementation):
 
 ### 1. **Type-Safe Handler Signature**
+
 - **Decision:** Adopt `func(request T, ctx HandlerContext) (response R, error IAPIError)` signature, with support for a typed `Result[R]` wrapper to control HTTP status and headers.
 - **Rationale:**
   - Focuses handlers on business logic rather than HTTP mechanics
@@ -28,6 +30,7 @@ Implement an enhanced handler system with the following characteristics (updated
 - **Trade-offs:** Breaking change for existing handlers, but significantly improves DX
 
 ### 2. **Generic Handler Wrapper Implementation**
+
 - **Decision:** Use Go generics for type-safe wrapper functions
 - **Rationale:**
   - Enables compile-time type checking
@@ -36,6 +39,7 @@ Implement an enhanced handler system with the following characteristics (updated
 - **Alternative Considered:** Interface{}-based approach with runtime reflection
 
 ### 3. **Comprehensive Request Binding Strategy**
+
 - **Decision:** Support multiple binding sources via struct tags
   - `param:"id"` for URL parameters
   - `query:"page"` for query parameters
@@ -53,7 +57,9 @@ Implement an enhanced handler system with the following characteristics (updated
 - **Trade-offs:** More complex implementation, but much cleaner usage
 
 ### 4. **Standardized Response Format**
+
 - **Decision:** Implement consistent JSON response envelope
+
   ```json
   {
     "data": {...},           // Success responses
@@ -64,6 +70,7 @@ Implement an enhanced handler system with the following characteristics (updated
     }
   }
   ```
+
 - **Rationale:**
   - Provides predictable API structure for consumers
   - Enables consistent error handling across all endpoints
@@ -76,6 +83,7 @@ Implement an enhanced handler system with the following characteristics (updated
   - `204 No Content` is supported via `server.NoContent()` and returns no body by design.
 
 ### 5. **Hierarchical Error System**
+
 - **Decision:** Implement `IAPIError` interface with predefined error types
   - `ValidationError`, `NotFoundError`, `ConflictError`, etc.
   - Environment-aware error details (dev vs production)
@@ -92,6 +100,7 @@ Implement an enhanced handler system with the following characteristics (updated
   - Error `details` are included only in development (`app.env=development|dev|local` — matched via `config.IsDevelopment()`; see ADR-022).
 
 ### 6. **Validation Integration Strategy**
+
 - **Decision:** Integrate `validator/v10` with automatic validation
 - **Rationale:**
   - Industry-standard validation library
@@ -106,10 +115,13 @@ Implement an enhanced handler system with the following characteristics (updated
   - Legacy ad-hoc validation formatting helpers were removed from the handler layer to avoid duplication.
 
 ### 7. **Module Interface Evolution**
+
 - **Decision:** Update Module interface to include HandlerRegistry parameter
+
   ```go
   RegisterRoutes(hr *HandlerRegistry, e *echo.Echo)
   ```
+
 - **Rationale:**
   - Provides access to enhanced handler registration
   - Maintains backward compatibility for Echo access
@@ -119,7 +131,9 @@ Implement an enhanced handler system with the following characteristics (updated
 - **Superseded in part by [ADR-002](adr_002_base_path_and_health_routes.md):** the second parameter is no longer the raw `*echo.Echo`; the current signature is `RegisterRoutes(hr *server.HandlerRegistry, r server.RouteRegistrar)`.
 
 ### 8. **Context Access Design**
+>
 > Superseded by [ADR-034](adr_034_echo_boundary_types.md) for the public boundary types — `HandlerContext` no longer exposes the underlying `echo.Context`; advanced access is via stdlib-typed accessors (`RequestContext()`, `Request()`, …).
+
 - **Decision:** Provide optional HandlerContext for advanced scenarios
 - **Rationale:**
   - Most handlers don't need direct request/response access
@@ -133,12 +147,14 @@ Implement an enhanced handler system with the following characteristics (updated
 ## Implementation Details
 
 ### Core Components
+
 - **`server/handler.go`**: Generic handler wrapper and registration system, `Result` helpers, request binder
 - **`server/errors.go`**: Predefined error types, `BaseAPIError` implements `error`
 - **`server/server.go`**: Unified `HTTPErrorHandler` that emits standard envelopes
 - **Updated Module System**: Enhanced interface with HandlerRegistry support
 
 ### Key Technical Decisions
+
 1. **Go Generics**: Leveraged for type-safe handler registration
 2. **Reflection**: Used minimally for request binding only
 3. **Middleware Integration**: Preserved existing middleware stack compatibility
@@ -147,6 +163,7 @@ Implement an enhanced handler system with the following characteristics (updated
 ## Consequences
 
 ### Positive
+
 - **Developer Experience**: Significant reduction in boilerplate code
 - **Type Safety**: Compile-time validation of request/response types
 - **Consistency**: Standardized response format across all APIs
@@ -154,11 +171,13 @@ Implement an enhanced handler system with the following characteristics (updated
 - **Error Handling**: Structured, consistent error responses
 
 ### Negative
+
 - **Breaking Change**: Existing handlers require migration
 - **Learning Curve**: Developers need to understand new patterns
 - **Complexity**: More sophisticated type system and error handling
 
 ### Neutral
+
 - **Performance**: Minimal impact due to compile-time optimization
 - **Dependencies**: Added `github.com/google/uuid` for trace ID generation
 

--- a/wiki/adr_002_base_path_and_health_routes.md
+++ b/wiki/adr_002_base_path_and_health_routes.md
@@ -14,6 +14,7 @@
 ## Context
 
 GoBricks applications often need to be deployed behind proxies, load balancers, or in containerized environments where:
+
 1. All application routes need a common prefix (e.g., `/api/v1`, `/service-name`)
 2. Health check endpoints need custom paths for infrastructure compatibility
 3. Different deployment environments require different routing configurations
@@ -42,6 +43,7 @@ We will implement configurable base paths and health routes through:
 ## Implementation Details
 
 ### Configuration Structure
+
 ```go
 type ServerConfig struct {
     // ... existing fields ...
@@ -72,7 +74,9 @@ type RouteRegistrar interface {
 ```
 
 ### Smart Path Handling
+
 The `routeGroup` implementation includes:
+
 - **Path Normalization**: Ensures consistent leading/trailing slash handling
 - **Duplication Prevention**: Detects and prevents double-prefixing when paths already contain base prefix
 - **Nested Group Support**: Proper prefix inheritance for complex routing scenarios
@@ -89,6 +93,7 @@ The `routeGroup` implementation includes:
 ## Configuration Examples
 
 ### Basic Configuration
+
 ```yaml
 server:
   path:
@@ -113,6 +118,7 @@ SERVER_PATH_READY="/readiness"
 ### Route Resolution Examples
 
 With `server.path.base: "/api/v1"`:
+
 - Module route `/users` → `/api/v1/users`
 - Health endpoint → `/api/v1/health` (or custom path)
 - Ready endpoint → `/api/v1/ready` (or custom path)
@@ -121,6 +127,7 @@ With `server.path.base: "/api/v1"`:
 ## Consequences
 
 ### Positive
+
 - **Enhanced Deployment Flexibility**: Single codebase works across multiple deployment scenarios
 - **Better Infrastructure Integration**: Health endpoints can be customized for specific load balancer requirements
 - **Improved Developer Experience**: Automatic base path inheritance eliminates manual prefix management
@@ -128,23 +135,27 @@ With `server.path.base: "/api/v1"`:
 - **Smart Path Logic**: Prevents common pitfalls like double-prefixing in complex routing scenarios
 
 ### Negative
+
 - **Increased Complexity**: Additional abstraction layer over Echo's routing
 - **Breaking Change**: Module interface signature changes (mitigated by interface compatibility)
 - **Configuration Overhead**: More configuration options to understand and manage
 
 ### Neutral
+
 - **Learning Curve**: Developers need to understand the new RouteRegistrar abstraction
 - **Testing Complexity**: Additional test scenarios for path resolution and nested groups
 
 ## Quality Assurance
 
 ### Testing Strategy
+
 - **Unit Tests**: Path normalization, configuration validation, route resolution
 - **Integration Tests**: End-to-end HTTP requests with various configurations
 - **Backward Compatibility Tests**: Verify existing functionality remains unchanged
 - **Edge Case Testing**: Double-prefixing prevention, nested groups, malformed paths
 
 ### Code Quality
+
 - **Linting**: All code passes golangci-lint with zero issues
 - **Race Detection**: Tests pass with `-race` flag
 - **Performance**: Zero overhead when base path is empty

--- a/wiki/adr_003_database_by_intent.md
+++ b/wiki/adr_003_database_by_intent.md
@@ -22,6 +22,7 @@ Implement "database by intent" configuration with the following principles:
 ## Implementation
 
 ### Configuration Changes
+
 - **Removed**: All database defaults from `loadDefaults()` in `config/config.go`
 - **Added**: `IsDatabaseConfigured(cfg *DatabaseConfig) bool` function in `config/validation.go`
 - **Logic**: Database enabled when `ConnectionString != ""` OR `Host != ""` OR `Type != ""`
@@ -30,11 +31,13 @@ Implement "database by intent" configuration with the following principles:
   rather than absence
 
 ### Validation Changes
+
 - **Before**: Database validation always required, caused failures for database-free apps
 - **After**: `validateDatabase()` returns early when `!IsDatabaseConfigured()`
 - **Consistency**: Shared logic between validation and runtime via `IsDatabaseConfigured()`
 
 ### Runtime Integration
+
 - **Historical**: The app builder checked `config.IsDatabaseConfigured(&cfg.Database)` directly
   (`app/app_builder.go`) to gate its startup connection probe. That check remains, but it is no
   longer where absence is decided — [ADR-047](adr_047_database_absence_vs_misconfiguration.md)
@@ -50,18 +53,21 @@ Implement "database by intent" configuration with the following principles:
 ## Consequences
 
 ### Positive
+
 - **Deterministic**: Configuration behavior is predictable and explicit
 - **Database-Free Support**: Applications can run without any database configuration
 - **Clear Intent**: Explicit configuration signals intentional database usage
 - **Reduced Confusion**: No ambiguity about database enablement
 
 ### Negative
+
 - **Breaking Change**: Applications relying on database defaults must update configuration
 - **More Explicit**: Requires intentional database configuration in all database-using applications
 
 ## Migration Impact
 
 Existing applications using database functionality must explicitly configure:
+
 - Connection string, OR
 - Host + type combination
 

--- a/wiki/adr_004_lazy_messaging_registry.md
+++ b/wiki/adr_004_lazy_messaging_registry.md
@@ -18,16 +18,19 @@ During the implementation of the multi-tenant architecture and the transition to
 ## Options Considered
 
 ### Option 1: Lazy Registry Creation (CHOSEN)
+
 - Initialize messaging registry only when first needed in `RegisterMessaging()`
 - Use singleflight protection to handle concurrent initialization
 - Keep registry self-contained and not dependent on external initialization
 
 ### Option 2: Eager Creation with Context
+
 - Require context parameter in `NewModuleRegistry(deps, ctx)`
 - Create registry immediately during construction
 - Break constructor signature compatibility
 
 ### Option 3: External Registry Management
+
 - Remove messaging registry from ModuleRegistry entirely
 - Require external code to create and pass registry to methods
 - Increase API surface and complexity for consumers
@@ -47,6 +50,7 @@ During the implementation of the multi-tenant architecture and the transition to
 ### Core Components
 
 **Lazy Initialization Method**:
+
 ```go
 func (r *ModuleRegistry) initializeMessagingRegistry(ctx context.Context) (*messaging.Registry, error) {
     result, err, _ := r.registryOnce.Do("messaging-registry", func() (any, error) {
@@ -72,6 +76,7 @@ func (r *ModuleRegistry) initializeMessagingRegistry(ctx context.Context) (*mess
 ```
 
 **Updated RegisterMessaging Method**:
+
 - Calls `initializeMessagingRegistry()` to ensure registry exists
 - Gracefully handles messaging unavailability by logging and continuing
 - Maintains all existing functionality once registry is created
@@ -86,6 +91,7 @@ func (r *ModuleRegistry) initializeMessagingRegistry(ctx context.Context) (*mess
 ## Consequences
 
 ### Positive
+
 - **Maintains Encapsulation**: Registry manages its own lifecycle without external dependencies
 - **Thread-Safe**: Concurrent calls to RegisterMessaging are safe
 - **Context-Aware**: Can properly resolve context-dependent messaging clients
@@ -93,11 +99,13 @@ func (r *ModuleRegistry) initializeMessagingRegistry(ctx context.Context) (*mess
 - **Future-Proof**: Architecture supports both single-tenant and multi-tenant modes
 
 ### Negative
+
 - **Deferred Errors**: Messaging configuration errors appear later during RegisterMessaging
 - **Additional Complexity**: Introduces singleflight dependency and lazy initialization pattern
 - **State Management**: Registry state becomes more complex with initialization tracking
 
 ### Neutral
+
 - **Performance**: Negligible impact, initialization happens once
 - **Memory**: Minimal additional memory for singleflight.Group
 - **Testing**: Tests needed updates but overall complexity remained similar

--- a/wiki/adr_005_type_safe_where_clauses.md
+++ b/wiki/adr_005_type_safe_where_clauses.md
@@ -18,6 +18,7 @@ SELECT id, "number" FROM accounts WHERE number = :1
 ```
 
 This issue occurred because:
+
 1. **Inconsistent Quoting**: SELECT clause properly quoted "number" but WHERE clause did not
 2. **Runtime Failures**: Errors only surfaced during query execution, not at compile time
 3. **Developer Confusion**: Inconsistent behavior between different SQL vendors
@@ -26,16 +27,19 @@ This issue occurred because:
 ## Options Considered
 
 ### Option 1: WHERE Clause Parser (Rejected)
+
 - Parse string-based WHERE clauses to identify and quote column names
 - Maintain backward compatibility with string-based API
 - **Rejected**: Complex implementation, potential parsing edge cases, runtime overhead
 
 ### Option 2: Enhanced Documentation (Rejected)
+
 - Improve documentation about Oracle quoting requirements
 - Provide more examples of correct usage
 - **Rejected**: Does not prevent the fundamental issue, relies on developer memory
 
 ### Option 3: Type-Safe WHERE Methods (CHOSEN)
+
 - Remove `.Where()` method entirely
 - Implement type-safe methods like `WhereEq()`, `WhereLt()`, etc.
 - Provide `WhereRaw()` escape hatch with clear documentation
@@ -46,12 +50,14 @@ This issue occurred because:
 **We chose Option 3: Type-Safe WHERE Methods** with the following implementation:
 
 ### Core Design Principles
+
 1. **Compile-Time Safety**: Prevent unquoted identifier issues at build time
 2. **Clear Responsibility**: Explicit methods vs. escape hatch with documented risks
 3. **Oracle-First**: Design that works reliably with Oracle's quoting requirements
 4. **Zero Ambiguity**: No possibility of accidentally bypassing safety mechanisms
 
 ### New SelectQueryBuilder API
+
 ```go
 // Type-safe methods (automatically handle quoting)
 .WhereEq(column, value)           // column = value
@@ -67,6 +73,7 @@ This issue occurred because:
 ```
 
 ### Architecture Changes
+
 1. **SelectQueryBuilder**: New wrapper around squirrel.SelectBuilder
 2. **Method Delegation**: All squirrel methods (Join, OrderBy, etc.) delegated through wrapper
 3. **Quoting Integration**: Type-safe methods use existing `qb.Eq()`, `qb.Lt()` infrastructure
@@ -77,6 +84,7 @@ This issue occurred because:
 ### Technical Components
 
 **Core Architecture**:
+
 ```go
 type SelectQueryBuilder struct {
     qb            *QueryBuilder
@@ -92,6 +100,7 @@ func (qb *QueryBuilder) Select(columns ...string) *SelectQueryBuilder {
 ```
 
 **Type-Safe WHERE Implementation**:
+
 ```go
 func (sqb *SelectQueryBuilder) WhereEq(column string, value any) *SelectQueryBuilder {
     sqb.selectBuilder = sqb.selectBuilder.Where(sqb.qb.Eq(column, value))
@@ -100,6 +109,7 @@ func (sqb *SelectQueryBuilder) WhereEq(column string, value any) *SelectQueryBui
 ```
 
 **Clear Escape Hatch Documentation**:
+
 ```go
 // WhereRaw adds a raw SQL WHERE condition to the query.
 //
@@ -112,6 +122,7 @@ func (sqb *SelectQueryBuilder) WhereRaw(condition string, args ...any) *SelectQu
 ```
 
 ### Testing Strategy
+
 1. **Comprehensive Oracle Tests**: All Oracle reserved words tested with type-safe methods
 2. **Original Bug Reproduction**: Specific test demonstrating the fix for the exact error
 3. **Escape Hatch Tests**: WhereRaw functionality with manual quoting examples
@@ -120,11 +131,13 @@ func (sqb *SelectQueryBuilder) WhereRaw(condition string, args ...any) *SelectQu
 ## Migration Strategy
 
 ### Breaking Change Implementation
+
 - **No Deprecation Period**: Immediate breaking change for compile-time safety
 - **Clear Error Messages**: Compilation errors guide developers to correct methods
 - **Comprehensive Examples**: Documentation shows exact replacements
 
 ### Migration Patterns
+
 ```go
 // OLD (no longer compiles)
 .Where("number = ?", value)
@@ -143,6 +156,7 @@ func (sqb *SelectQueryBuilder) WhereRaw(condition string, args ...any) *SelectQu
 ## Consequences
 
 ### Positive
+
 - **Eliminates Oracle Quoting Bugs**: Impossible to accidentally create unquoted WHERE clauses
 - **Compile-Time Safety**: Errors caught during build, not runtime
 - **Clear Responsibility Boundaries**: Type-safe methods vs. explicit escape hatch
@@ -151,12 +165,14 @@ func (sqb *SelectQueryBuilder) WhereRaw(condition string, args ...any) *SelectQu
 - **Self-Documenting Code**: Method names clearly indicate operation type
 
 ### Negative
+
 - **Breaking Change**: All existing `.Where()` usage requires migration
 - **Learning Curve**: Developers must learn new API methods
 - **Verbosity**: Some complex conditions require multiple method calls
 - **Migration Effort**: Existing codebases need comprehensive updates
 
 ### Neutral
+
 - **Performance**: No runtime impact, compile-time code generation
 - **Memory**: Minimal wrapper overhead
 - **Dependencies**: No new external dependencies required
@@ -164,12 +180,14 @@ func (sqb *SelectQueryBuilder) WhereRaw(condition string, args ...any) *SelectQu
 ## Quality Assurance
 
 ### Testing Coverage
+
 - **Oracle Reserved Words**: Comprehensive testing with 20+ reserved words
 - **All Operators**: Coverage for =, <>, <, <=, >, >=, IN, NOT IN, IS NULL
 - **Edge Cases**: Complex queries, nested conditions, function calls
 - **Regression**: Original bug scenario specifically tested and verified fixed
 
 ### Code Quality
+
 - **Type Safety**: Full Go type checking throughout query construction
 - **Documentation**: Extensive inline documentation with examples
 - **Error Handling**: Clear error messages for incorrect usage

--- a/wiki/adr_006_otlp_log_export.md
+++ b/wiki/adr_006_otlp_log_export.md
@@ -17,6 +17,7 @@ The GoBricks framework provided comprehensive OpenTelemetry integration for dist
 ## Options Considered
 
 ### Option 1: External Log Forwarder (Rejected)
+
 - Use external agents (Fluent Bit, Filebeat) to tail log files and forward to collectors
 - Keep framework focused only on stdout logging
 - **Rejected**:
@@ -26,6 +27,7 @@ The GoBricks framework provided comprehensive OpenTelemetry integration for dist
   - Harder to correlate with framework-generated traces
 
 ### Option 2: Hook-Based Logger Modification (Rejected)
+
 - Modify zerolog internals to add OpenTelemetry hooks
 - Fork or wrap zerolog with custom export logic
 - **Rejected**:
@@ -35,6 +37,7 @@ The GoBricks framework provided comprehensive OpenTelemetry integration for dist
   - Could break on upstream zerolog changes
 
 ### Option 3: io.Writer Bridge Pattern (CHOSEN)
+
 - Implement `io.Writer` that intercepts zerolog JSON output
 - Parse JSON and convert to OpenTelemetry log records
 - Leverage existing observability provider infrastructure
@@ -55,6 +58,7 @@ The GoBricks framework provided comprehensive OpenTelemetry integration for dist
 ### Architecture Components
 
 **1. Configuration Layer** (`observability/config.go`)
+
 ```go
 type LogsConfig struct {
     Enabled               *bool          // nil=default true when observability enabled
@@ -70,6 +74,7 @@ type LogsConfig struct {
 ```
 
 **Log Sampling Behavior** (via `DualModeLogProcessor`):
+
 - **Action logs** (`log.type="action"`): Always exported at 100% for request summaries
 - **Trace logs** (`log.type="trace"`):
   - ERROR/WARN: Always exported at 100%
@@ -77,6 +82,7 @@ type LogsConfig struct {
   - Sampling is deterministic per trace (all logs in same trace sampled together)
 
 **2. OTel Bridge** (`logger/otel_bridge.go`)
+
 ```go
 type OTelBridge struct {
     loggerProvider *sdklog.LoggerProvider
@@ -93,6 +99,7 @@ func (b *OTelBridge) Write(p []byte) (n int, err error) {
 ```
 
 **3. Logger Integration** (`logger/logger.go`)
+
 ```go
 func (l *ZeroLogger) WithOTelProvider(provider OTelProvider) *ZeroLogger {
     // Fail-fast validation: panic if pretty=true
@@ -119,6 +126,7 @@ func (l *ZeroLogger) WithOTelProvider(provider OTelProvider) *ZeroLogger {
 ```
 
 **4. Automatic Trace Correlation** (`logger/logger.go`)
+
 ```go
 func (l *ZeroLogger) WithContext(ctx any) Logger {
     // Phase 1: Check for explicit zerolog.Ctx() logger
@@ -140,6 +148,7 @@ func (l *ZeroLogger) WithContext(ctx any) Logger {
 ```
 
 **5. Bootstrap Integration** (`app/bootstrap.go`)
+
 ```go
 func (b *appBootstrap) dependencies() *dependencyBundle {
     obsProvider := b.initializeObservability()
@@ -201,7 +210,7 @@ func (p *DualModeLogProcessor) shouldSample(rec *sdklog.Record) bool {
 
 ### Integration Points
 
-```
+```text
 ┌─────────────────────────────────────────────────┐
 │         Application Bootstrap Flow              │
 │                                                 │
@@ -251,6 +260,7 @@ func (p *DualModeLogProcessor) shouldSample(rec *sdklog.Record) bool {
 ## Configuration Examples
 
 ### Development Configuration
+
 ```yaml
 observability:
   enabled: true
@@ -272,6 +282,7 @@ observability:
 ```
 
 ### Production Configuration
+
 ```yaml
 observability:
   enabled: true
@@ -295,6 +306,7 @@ observability:
 ```
 
 **Sampling Behavior:**
+
 - `samplingrate: 0.0` (default): Drop all INFO/DEBUG trace logs, keep ERROR/WARN
 - `samplingrate: 0.1`: Export 10% of INFO/DEBUG, all ERROR/WARN
 - `samplingrate: 1.0`: Export all trace logs (full visibility, higher volume)
@@ -332,15 +344,18 @@ observability:
 ### For Existing Applications
 
 **No Migration Required** for applications that:
+
 - Use JSON logging (`logger.pretty=false`)
 - Don't need OTLP log export
 
 **Optional Enablement** for applications wanting centralized logs:
+
 1. Add `observability.logs.enabled: true` to config
 2. Configure OTLP endpoint (or inherit from trace config)
 3. Logs automatically export to collector
 
 **Configuration Conflict** for applications using:
+
 - `logger.pretty=true` AND `observability.logs.enabled=true`
 - **Resolution**: Change `pretty: false` or disable `logs.enabled`
 - **Detection**: Fail-fast panic at startup with clear error message
@@ -387,6 +402,7 @@ observability:
 ## Observability Benefits in Practice
 
 ### Before (Fragmented)
+
 ```text
 Developer Workflow:
 1. Check application logs (stdout/files)
@@ -402,6 +418,7 @@ Challenges:
 ```
 
 ### After (Unified)
+
 ```text
 Developer Workflow:
 1. Open Grafana Explore

--- a/wiki/adr_007_struct_based_columns.md
+++ b/wiki/adr_007_struct_based_columns.md
@@ -26,6 +26,7 @@ qb.InsertWithColumns("users", "name", "email").Values(...)
 ```
 
 This led to:
+
 - **Code duplication**: Column names defined in structs, then hardcoded as strings
 - **Typo risk**: No compile-time validation of column references
 - **Oracle reserved words**: Manual quoting burden (`"LEVEL"`, `"NUMBER"`)
@@ -37,6 +38,7 @@ This led to:
 Implement struct-based column extraction using reflection with lazy caching, following these principles:
 
 ### 1. **Struct Tag-Based Column Definition**
+
 - **Decision:** Use `db:"column_name"` tags to define database columns on struct fields
 - **Rationale:**
   - Follows existing Go ecosystem conventions (GORM, sqlx)
@@ -46,6 +48,7 @@ Implement struct-based column extraction using reflection with lazy caching, fol
 - **Trade-offs:** Runtime reflection overhead, but mitigated by caching
 
 **API:**
+
 ```go
 type User struct {
     ID    int64  `db:"id"`
@@ -57,6 +60,7 @@ cols := qb.Columns(&User{})  // Extract and cache metadata
 ```
 
 ### 2. **Lazy Registry with Global Caching**
+
 - **Decision:** Parse struct tags on first use, cache forever per vendor
 - **Implementation:** `sync.Map` for lock-free cached reads after first parse
 - **Rationale:**
@@ -67,13 +71,15 @@ cols := qb.Columns(&User{})  // Extract and cache metadata
 - **Trade-offs:** First-use latency acceptable for development-time benefits
 
 **Performance:**
-```
+
+```text
 BenchmarkColumnRegistry_FirstUse-12     0.591 µs/op  (5 fields)
 BenchmarkColumnRegistry_CachedAccess-12 26.26 ns/op  (cached)
 BenchmarkColumnMetadata_Get-12          5.518 ns/op  (field lookup)
 ```
 
 ### 3. **Vendor-Aware Automatic Quoting**
+
 - **Decision:** Pre-compute vendor-specific quoting during struct parsing
 - **Rationale:**
   - **Oracle**: Reserved words (`NUMBER`, `LEVEL`, `SIZE`) quoted at parse time
@@ -83,6 +89,7 @@ BenchmarkColumnMetadata_Get-12          5.518 ns/op  (field lookup)
 - **Trade-offs:** Slightly more memory (cached quoted strings), significantly faster queries
 
 **Example:**
+
 ```go
 // Oracle
 cols := qb.Columns(&User{})
@@ -94,6 +101,7 @@ cols.Col("Level")  // Returns: "level" (no quoting needed)
 ```
 
 ### 4. **Explicit API Over Implicit Magic**
+
 - **Decision:** Fail-fast panics on invalid field names (not silent fallbacks)
 - **Rationale:**
   - Aligns with GoBricks "Explicit > Implicit" principle
@@ -103,6 +111,7 @@ cols.Col("Level")  // Returns: "level" (no quoting needed)
 - **Trade-offs:** Stricter API, but prevents subtle bugs
 
 **Error Handling:**
+
 ```go
 cols := qb.Columns(&User{})
 col := cols.Col("NonExistent")
@@ -125,6 +134,7 @@ col := cols.Col("NonExistent")
 - **Trade-offs:** Supports both patterns, but clean migration path
 
 ### 6. **Security-First Tag Validation**
+
 - **Decision:** Reject dangerous SQL patterns at parse time
 - **Implementation:**
   - Validate tags for `;`, `--`, `/*`, `*/` (SQL injection vectors)
@@ -140,7 +150,8 @@ col := cols.Col("NonExistent")
 ## Implementation
 
 **Package Structure:**
-```
+
+```text
 database/
 ├── internal/
 │   └── columns/
@@ -153,6 +164,7 @@ database/
 ```
 
 **Thread Safety:**
+
 - `sync.Map` for lock-free cached reads (read-heavy workload)
 - Double-checked locking for vendor cache creation
 - `LoadOrStore()` for atomic first-parse deduplication
@@ -161,6 +173,7 @@ database/
 ## Consequences
 
 **Positive:**
+
 - **DRY Principle**: Column names defined once in struct tags
 - **Type Safety**: Compile-time field name references (refactor-friendly)
 - **Oracle Safety**: Reserved words auto-quoted (eliminates manual quoting burden)
@@ -168,12 +181,14 @@ database/
 - **Backward Compatible**: Zero breaking changes, opt-in adoption
 
 **Negative:**
+
 - **Reflection Dependency**: First-use reflection (~0.6µs per struct type)
 - **Memory Overhead**: ~1-2KB per registered struct type (negligible at scale)
 - **INSERT Friction**: Requires type conversion `[]any` → `[]string` for `InsertWithColumns()`
   - Mitigated with helper: `toStrings := func(v []any) []string { ... }`
 
 **Neutral:**
+
 - **Breaking Change**: Added `Columns()` to `QueryBuilderInterface`
   - Impact: Mock implementations need update (testify mocks updated)
   - Mitigation: `make check-all` catches tool compatibility issues
@@ -181,12 +196,14 @@ database/
 ## Testing Strategy
 
 **Coverage:**
+
 - Unit tests: metadata, parser, registry (100% critical paths)
 - Integration tests: SELECT/INSERT/UPDATE/WHERE/JOIN across Oracle/PostgreSQL
 - Benchmarks: first-use parsing, cached access, concurrent safety
 - Security tests: tag validation, SQL injection prevention
 
 **CI/CD:**
+
 - `make check-all` validates framework + tool compatibility
 - Multi-platform (Ubuntu/Windows) × Go 1.26
 - SonarCloud: 80% coverage target maintained

--- a/wiki/adr_008_database_testing_interface_segregation.md
+++ b/wiki/adr_008_database_testing_interface_segregation.md
@@ -1,12 +1,15 @@
 # ADR-008: Database Testing with Interface Segregation
 
 ## Status
+
 Accepted (2025-01-10)
 
 > **Note (2026-05-12):** Code examples in this ADR were updated to reflect the S8179 rename (`GetDB` → `DB` field on `ModuleDeps`). The decision, rationale, and test-helper API surface are unchanged. The full rename table lives in [wiki/migrations.md](migrations.md).
 
 ## Context
+
 Application developers faced testing friction with `database.Interface` requiring ~25 methods across 4 wrapper types (Interface, Tx, Row, Statement). Testing required:
+
 - **30+ lines of sqlmock boilerplate** per test
 - **Mocking 13 methods** even when only using Query/QueryRow/Exec
 - **Manual sql.Rows construction** with complex sqlmock expectations
@@ -17,6 +20,7 @@ This violated YAGNI (mocking unused methods) and created hundreds of lines of te
 ## Decision
 
 ### 1. Interface Segregation
+
 Split `database.Interface` into focused sub-interfaces following Single Responsibility Principle:
 
 ```go
@@ -49,6 +53,7 @@ type Interface interface {
 Created comprehensive testing utilities following `observability/testing` patterns:
 
 **TestDB** - Fluent expectation-based mocking:
+
 ```go
 db := dbtest.NewTestDB(dbtypes.PostgreSQL).
     ExpectQuery("SELECT").
@@ -58,6 +63,7 @@ db := dbtest.NewTestDB(dbtypes.PostgreSQL).
 ```
 
 **RowSet** - Vendor-agnostic row builder:
+
 ```go
 rows := NewRowSet("id", "name", "email").
     AddRow(1, "Alice", "alice@example.com").
@@ -65,6 +71,7 @@ rows := NewRowSet("id", "name", "email").
 ```
 
 **TestTx** - Transaction testing with commit/rollback tracking:
+
 ```go
 tx := db.ExpectTransaction().
     ExpectExec("INSERT INTO orders").WillReturnRowsAffected(1).
@@ -75,6 +82,7 @@ AssertCommitted(t, tx)
 ```
 
 **TenantDBMap** - Multi-tenant testing support:
+
 ```go
 tenants := NewTenantDBMap()
 tenants.ForTenant("acme").ExpectQuery("SELECT").WillReturnRows(...)
@@ -86,6 +94,7 @@ deps := &app.ModuleDeps{
 ```
 
 **Assertion Helpers** - Clear test failures:
+
 ```go
 AssertQueryExecuted(t, db, "SELECT")
 AssertExecExecuted(t, db, "INSERT")
@@ -95,6 +104,7 @@ AssertTransactionCommitted(t, db)
 ## Consequences
 
 ### Positive
+
 - **73% less test boilerplate**: 30+ lines → 8 lines per test
 - **100% backward compatible**: All 32 test suites pass unchanged
 - **Honors SRP**: Separate Querier (execution) from Transactor (transactions)
@@ -104,11 +114,13 @@ AssertTransactionCommitted(t, db)
 - **Zero breaking changes**: Existing code unaffected
 
 ### Negative
+
 - **One more abstraction**: Developers must learn TestDB API (mitigated by clear examples in llms.txt)
 - **RowSet.toSQLRows() complexity**: Full multi-row support requires a `sql.DB`-backed connector (`newRowSetConnector`), adding internal complexity (resolved in final implementation)
 - **Intentional code duplication**: TestDB.Query and TestTx.Query share implementation (~65 lines each, marked with `//nolint:dupl`)
 
 ### Trade-offs Accepted
+
 - **Duplication over abstraction**: TestDB and TestTx implement similar Query/Exec logic separately to maintain clear separation of concerns and avoid premature abstraction
 - **Test fidelity vs speed**: In-memory fake sacrifices exact database behavior for instant feedback (0ms vs 2-5s testcontainers)
 - **Vendor-agnostic testing**: Most tests don't verify vendor-specific behavior (placeholder numbering, quoting) - integration tests cover this
@@ -116,20 +128,25 @@ AssertTransactionCommitted(t, db)
 ## Alternatives Considered
 
 ### 1. Keep Monolithic Interface
+
 **Rejected** - Violates SRP, makes testing unnecessarily complex
 
 ### 2. Use sqlmock Directly
+
 **Rejected** - Too verbose (~30 lines of setup), regex-based SQL matching error-prone
 
 ### 3. Split ModuleDeps (DB vs DBFull)
+
 **Rejected** - Violates SRP at wrong layer (ModuleDeps shouldn't have two database references)
 
 ### 4. Extract Shared Code to Helper Function
+
 **Rejected** - Premature abstraction for ~65 lines. TestDB and TestTx have different error messages ("unexpected query" vs "unexpected query in transaction") and logging contexts, making extraction add complexity without clear benefit.
 
 ## Implementation
 
 ### Files Created
+
 - `database/types/querier.go` - 4-method focused interface
 - `database/types/transactor.go` - Transaction management interface
 - `database/testing/fake_db.go` - TestDB with fluent API
@@ -140,9 +157,11 @@ AssertTransactionCommitted(t, db)
 - `database/testing/fake_db_test.go` - Comprehensive tests
 
 ### Files Modified
+
 - `database/types/interfaces.go` - Interface now embeds Querier + Transactor
 
 ### Quality Metrics
+
 - **Linter**: 0 issues (golangci-lint passes)
 - **Tests**: All 32 suites pass (including new database/testing tests)
 - **Coverage**: New package has comprehensive tests for all APIs
@@ -190,6 +209,7 @@ deps := &app.ModuleDeps{
 ```
 
 ## References
+
 - Similar pattern: `messaging.Client` (5 methods) vs `messaging.AMQPClient` (16 methods)
 - Inspiration: `observability/testing` package fluent API design
 - Related: [MULTI_TENANT.md](../MULTI_TENANT.md) - Multi-tenant patterns

--- a/wiki/adr_009_consumer_worker_pool_concurrency.md
+++ b/wiki/adr_009_consumer_worker_pool_concurrency.md
@@ -9,13 +9,15 @@
 GoBricks v0.16 and earlier processed AMQP messages sequentially (one at a time per consumer). This created severe throughput bottlenecks when handlers performed blocking I/O operations like database queries or HTTP calls:
 
 **Impact Examples:**
+
 - **100ms database query**: Maximum 10 messages/second per consumer
 - **500ms batch operation**: Maximum 2 messages/second per consumer
 - **CPU underutilization**: 1 thread per consumer, leaving 7-31 cores idle on modern servers
 - **Queue backlogs**: Messages piled up faster than they could be processed
 
 **Real-World Scenario:**
-```
+
+```text
 8-core production server
 Handler: 500ms (database query + business logic)
 Current throughput: 2 msg/sec
@@ -24,6 +26,7 @@ Queue depth: Constantly growing
 ```
 
 Users had no way to configure concurrency per consumer, forcing them to either:
+
 1. Accept poor throughput
 2. Run multiple service instances (wasteful resource usage)
 3. Implement custom worker pools in application code (error-prone)
@@ -33,7 +36,8 @@ Users had no way to configure concurrency per consumer, forcing them to either:
 ### Option 1: Application-Level Worker Pool (CHOSEN)
 
 **Architecture:**
-```
+
+```text
 handleMessages()
 ├─> Delivery channel (from RabbitMQ)
 ├─> Worker pool (N goroutines)
@@ -44,6 +48,7 @@ handleMessages()
 ```
 
 **Pros:**
+
 - ✅ Simple, idiomatic Go implementation (sync.WaitGroup + buffered channels)
 - ✅ Non-breaking with smart defaults (Workers=0 → auto-scales to NumCPU*4)
 - ✅ Flexible per-consumer tuning
@@ -51,6 +56,7 @@ handleMessages()
 - ✅ Natural backpressure via buffered channel
 
 **Cons:**
+
 - ⚠️ Requires thread-safe handlers (breaking change for existing code)
 - ⚠️ No message ordering guarantees with Workers>1
 
@@ -61,7 +67,8 @@ handleMessages()
 ### Option 2: Multiple RabbitMQ Consumers (Rejected)
 
 **Architecture:**
-```
+
+```text
 startSingleConsumer() - called N times for same queue
 ├─> Consumer 1: ConsumeFromQueue(tag="worker-1") → handleMessages()
 ├─> Consumer 2: ConsumeFromQueue(tag="worker-2") → handleMessages()
@@ -69,10 +76,12 @@ startSingleConsumer() - called N times for same queue
 ```
 
 **Pros:**
+
 - ✅ True RabbitMQ-level parallelism
 - ✅ Simpler code (no worker pool management)
 
 **Cons:**
+
 - ❌ Higher AMQP channel overhead (N channels per consumer declaration)
 - ❌ Less flexible prefetch distribution
 - ❌ Incompatible with exclusive consumers
@@ -87,10 +96,12 @@ startSingleConsumer() - called N times for same queue
 **Architecture:** No changes, users explicitly opt-in via configuration flag.
 
 **Pros:**
+
 - ✅ Fully backward compatible
 - ✅ No thread-safety requirements for existing handlers
 
 **Cons:**
+
 - ❌ Poor discoverability (users don't know feature exists)
 - ❌ Most users miss performance benefits
 - ❌ Framework should optimize by default (fail-fast philosophy)
@@ -104,9 +115,11 @@ startSingleConsumer() - called N times for same queue
 **Architecture:** Fixed default instead of CPU-based auto-scaling.
 
 **Pros:**
+
 - ✅ Predictable across environments
 
 **Cons:**
+
 - ❌ Too few on 32-core servers (underutilized)
 - ❌ Too many on 2-core laptops (oversubscribed)
 - ❌ Doesn't scale with hardware
@@ -128,6 +141,7 @@ startSingleConsumer() - called N times for same queue
 ### Why NumCPU × 4?
 
 The **4x multiplier** is standard for I/O-bound workloads:
+
 - While 1 worker waits on database/HTTP response, 3 others use CPU
 - Industry standard (Spring AMQP, Akka, etc. use similar patterns)
 - Balances throughput vs resource usage
@@ -135,6 +149,7 @@ The **4x multiplier** is standard for I/O-bound workloads:
 ### API Design
 
 **Configuration:**
+
 ```go
 type ConsumerOptions struct {
     Queue         string
@@ -147,6 +162,7 @@ type ConsumerOptions struct {
 ```
 
 **Examples:**
+
 ```go
 // Auto-scaling (default)
 decls.DeclareConsumer(&ConsumerOptions{
@@ -182,6 +198,7 @@ decls.DeclareConsumer(&ConsumerOptions{
 ### Worker Pool Architecture
 
 **Main Loop (Producer):**
+
 ```go
 jobs := make(chan *amqp.Delivery, workers*2)  // Buffered for backpressure
 
@@ -203,6 +220,7 @@ wg.Wait()
 ```
 
 **Worker (Consumer):**
+
 ```go
 func (r *Registry) worker(ctx context.Context, consumer *ConsumerDeclaration,
     jobs <-chan *amqp.Delivery, workerID int, wg *sync.WaitGroup) {
@@ -224,6 +242,7 @@ func (r *Registry) worker(ctx context.Context, consumer *ConsumerDeclaration,
 ### Resource Safeguards
 
 **Smart Defaults with Caps:**
+
 ```go
 func DeclareConsumer(opts *ConsumerOptions, queue *QueueDeclaration) {
     // Auto-scale workers
@@ -247,6 +266,7 @@ func DeclareConsumer(opts *ConsumerOptions, queue *QueueDeclaration) {
 ### Prefetch Configuration
 
 **Dynamic QoS:**
+
 ```go
 func (c *AMQPClientImpl) ConsumeFromQueue(ctx context.Context, options ConsumeOptions) {
     prefetchCount := options.PrefetchCount
@@ -267,61 +287,74 @@ func (c *AMQPClientImpl) ConsumeFromQueue(ctx context.Context, options ConsumeOp
 ### Positive
 
 ✅ **Massive Throughput Gains:**
+
 - 8-core machine, 100ms handler: **10 → 320 msg/sec (32x improvement)**
 - 32-core production server: **128 workers** automatically
 
 ✅ **Hardware Adaptive:**
+
 - Dev laptop (4 cores): 16 workers
 - Test server (8 cores): 32 workers
 - Production (32 cores): 128 workers
 
 ✅ **Better Resource Utilization:**
+
 - Multi-core CPUs fully engaged
 - Reduced service instance count needs
 
 ✅ **Flexible Configuration:**
+
 - Per-consumer tuning for different workload characteristics
 - Sequential processing still supported (Workers=1)
 
 ✅ **Production-Safe:**
+
 - Resource caps prevent goroutine/memory exhaustion
 - Graceful shutdown prevents message loss
 
 ### Negative
 
 ⚠️ **Breaking Change (v0.17.0):**
+
 - Default behavior changes from 1 → NumCPU*4 workers
 - Existing handlers MUST be thread-safe
 
 ⚠️ **Message Ordering Loss:**
+
 - Concurrent processing breaks sequential ordering
 - Applications requiring order MUST explicitly set Workers=1
 
 ⚠️ **Resource Requirements:**
+
 - Database connection pools must be sized appropriately:
   `MaxOpenConns >= NumCPU * 4 * NumConsumers`
 - Memory overhead: ~2KB per worker goroutine + prefetch buffer
 
 ⚠️ **Testing Requirements:**
+
 - All handlers must pass `go test -race`
 - Shared state requires synchronization (mutexes, atomic, channels)
 
 ### Mitigation Strategies
 
 **Thread-Safety:**
+
 - Document requirements prominently in CLAUDE.md and llms.txt
 - Recommend `go test -race` in CI pipelines
 - Provide clear examples of thread-safe patterns
 
 **Database Pools:**
+
 - Document sizing formula: `MaxOpenConns >= NumCPU * 4 * NumConsumers`
 - Add to troubleshooting guide
 
 **Message Ordering:**
+
 - Clear examples showing Workers=1 for sequential processing
 - Prominent documentation in configuration sections
 
 **Memory Management:**
+
 - PrefetchCount caps prevent unbounded growth
 - Buffer size tied to worker count (workers * 2)
 
@@ -350,12 +383,14 @@ func (c *AMQPClientImpl) ConsumeFromQueue(ctx context.Context, options ConsumeOp
 ### For Application Developers
 
 **1. Audit Handler Thread-Safety:**
+
 ```bash
 # Run race detector on all tests
 go test -race ./...
 ```
 
 **2. Size Database Pools:**
+
 ```go
 // Calculate required connections
 numCPU := runtime.NumCPU()
@@ -367,6 +402,7 @@ db.SetMaxIdleConns(maxConns / 2)
 ```
 
 **3. Identify Order-Dependent Consumers:**
+
 ```go
 // Set Workers=1 explicitly for ordering
 decls.DeclareConsumer(&ConsumerOptions{
@@ -379,6 +415,7 @@ decls.DeclareConsumer(&ConsumerOptions{
 ```
 
 **4. Test Concurrency:**
+
 ```go
 // Add concurrent test scenarios
 func TestHandlerConcurrency(t *testing.T) {
@@ -401,6 +438,7 @@ func TestHandlerConcurrency(t *testing.T) {
 ### Unit Tests
 
 **Added Tests:**
+
 - `TestAutoScaleWorkersDefault`: Verify Workers=0 → NumCPU*4
 - `TestExplicitWorkersOverride`: Verify explicit Workers/PrefetchCount honored
 - `TestSequentialProcessing`: Verify Workers=1 sequential behavior
@@ -411,11 +449,13 @@ func TestHandlerConcurrency(t *testing.T) {
 - `TestWorkerResourceCaps`: Verify resource safeguards
 
 **Benchmark:**
+
 - `BenchmarkSequentialVsConcurrent`: Compare Workers=1 vs Workers=4/8
 
 ### Integration Tests
 
 **Future Work:**
+
 - Testcontainers-based RabbitMQ integration tests
 - Verify prefetch behavior with real AMQP broker
 - Load testing with production-like message volumes

--- a/wiki/adr_010_panic_to_error_conversion.md
+++ b/wiki/adr_010_panic_to_error_conversion.md
@@ -14,6 +14,7 @@ GoBricks uses `panic()` for fail-fast validation in several internal APIs, follo
 4. **Consumer experience**: Library consumers receive stack traces instead of actionable error messages
 
 **Affected Patterns:**
+
 - Empty string validation (table names, expressions, aliases)
 - Nil checks (subqueries)
 - Parameter count validation (variadic alias arguments)
@@ -22,15 +23,18 @@ GoBricks uses `panic()` for fail-fast validation in several internal APIs, follo
 ## Options Considered
 
 ### Option 1: Mark as False Positives (NOSONAR)
+
 Keep existing panics, mark with NOSONAR comments.
 
 **Pros:** No breaking changes, maintains current behavior
 **Cons:** Doesn't improve reliability rating, existing NOSONAR comments not recognized
 
 ### Option 2: Convert to Error Returns (CHOSEN)
+
 Change function signatures to return errors instead of panicking.
 
 **Pros:**
+
 - ✅ Achieves reliability rating A
 - ✅ Follows Go idioms (explicit error handling)
 - ✅ Better consumer experience (actionable errors vs stack traces)
@@ -38,10 +42,12 @@ Change function signatures to return errors instead of panicking.
 - ✅ Improves testability (errors can be asserted, panics cannot)
 
 **Cons:**
+
 - ❌ Breaking API changes
 - ❌ Consumers must update call sites
 
 ### Option 3: Wrapper Functions
+
 Create new error-returning functions alongside panic variants.
 
 **Pros:** Non-breaking, gradual migration
@@ -49,9 +55,11 @@ Create new error-returning functions alongside panic variants.
 
 ## Decision
 
+<!-- markdownlint-disable-next-line MD036 -->
 **Option 2: Convert to Error Returns**
 
 This aligns with GoBricks manifesto principles:
+
 - **Explicit > Implicit**: Error returns make failure modes explicit
 - **Robustness**: Handle errors idiomatically, no silent failures
 - **Type Safety**: Compile-time error handling enforcement
@@ -86,6 +94,7 @@ type Tx interface {
 **Rationale:** This fixes S8242 (context-in-struct) by removing stored context from transactions. Context now flows through method parameters following Go idioms.
 
 **Migration:**
+
 ```go
 // Before
 tx, _ := db.Begin(ctx)
@@ -103,6 +112,7 @@ tx.Commit(ctx)
 ### Code Migration Examples
 
 **Before (panic-based):**
+
 ```go
 // Simple table reference
 table := dbtypes.Table("users")
@@ -118,6 +128,7 @@ types.ValidateSubquery(subquery)
 ```
 
 **After (error-returning):**
+
 ```go
 // Simple table reference
 table, err := dbtypes.Table("users")
@@ -227,6 +238,7 @@ The following S8242 (context-in-struct) patterns are **intentionally retained** 
 | `logger/context_test.go:17,59` | Table-driven tests | **Standard Go testing pattern**. Storing context in test struct for table-driven tests is universally accepted in Go testing. |
 
 **Why not refactored:**
+
 1. **Scheduler shutdown context**: Refactoring to channel-based shutdown would be complex and risky. The context-with-cancel pattern is idiomatic for service lifecycle management.
 2. **Job context embedding**: Changing to composition (storing `ctx` as field and delegating all methods) would add boilerplate without architectural benefit.
 3. **Test patterns**: Table-driven test patterns with context in struct are standard Go practice.

--- a/wiki/adr_011_redis_cache.md
+++ b/wiki/adr_011_redis_cache.md
@@ -10,6 +10,7 @@
 ## Problem Statement
 
 GoBricks applications require:
+
 1. **Query Result Caching**: Reduce database load by caching frequently accessed data
 2. **Distributed Locking**: Prevent duplicate processing across replicas (message deduplication, job coordination)
 3. **Multi-Tenant Isolation**: Separate cache namespaces per tenant
@@ -17,6 +18,7 @@ GoBricks applications require:
 5. **Observability**: Metrics for cache hits/misses, lock contention
 
 Without a first-class caching abstraction, developers face:
+
 - **Manual Redis Integration**: Each service reimplements connection pooling, serialization, error handling
 - **Inconsistent Patterns**: No standard approach for deduplication or distributed locking
 - **Missing Observability**: No unified metrics for cache performance
@@ -25,6 +27,7 @@ Without a first-class caching abstraction, developers face:
 ## Options Considered
 
 ### Option 1: In-Memory Cache Only (Rejected)
+
 - Use `sync.Map` or third-party Go caches (bigcache, freecache)
 - No distributed coordination needed
 - **Rejected**:
@@ -34,6 +37,7 @@ Without a first-class caching abstraction, developers face:
   - Limited to single-process applications
 
 ### Option 2: Generic Key-Value Interface (Rejected)
+
 - Abstract cache behind `Get(key)`, `Set(key, val)` interface
 - Support multiple backends (Redis, Memcached, DynamoDB)
 - **Rejected**:
@@ -43,6 +47,7 @@ Without a first-class caching abstraction, developers face:
   - Violates YAGNI principle
 
 ### Option 3: Redis-Specific with Abstract Interface (CHOSEN)
+
 - Define vendor-agnostic `Cache` interface
 - Implement Redis backend initially
 - Support future backends if needed (Memcached, Valkey)
@@ -53,6 +58,7 @@ Without a first-class caching abstraction, developers face:
 Implement **Redis as the first-class caching backend** with these architectural principles:
 
 ### 1. **Separate Package Structure**
+
 ```go
 cache/                      // Core interfaces and errors
 cache/redis/                // Redis implementation
@@ -60,11 +66,13 @@ cache/testing/              // Mock implementations for tests
 ```
 
 **Rationale:**
+
 - Follows `database/` package pattern (proven architecture)
 - Clear separation of concerns (interfaces vs implementations)
 - Easy to add alternate backends (e.g., `cache/memcached/`) in future
 
 ### 2. **Minimal Cache Interface**
+
 ```go
 type Cache interface {
     // Core operations
@@ -84,6 +92,7 @@ type Cache interface {
 ```
 
 **Rationale:**
+
 - **Byte-level API**: Serialization delegated to helper functions (separation of concerns)
 - **GetOrSet**: Atomic deduplication primitive (idempotency keys, message processing)
 - **CompareAndSet**: Distributed lock primitive (worker coordination, leader election)
@@ -94,9 +103,11 @@ type Cache interface {
 **Trade-offs:** Type-safe but couples cache to serialization logic; rejected for separation of concerns
 
 ### 3. **CBOR Serialization Standard**
+
 **Library:** `github.com/fxamacker/cbor/v2` (v2.9.0+)
 
 **Rationale:**
+
 - ✅ **RFC 8949 Internet Standard** (decades of cross-language compatibility)
 - ✅ **Actively maintained** (2025 releases, production-proven)
 - ✅ **Used by Kubernetes, Microsoft, IBM** (battle-tested)
@@ -117,6 +128,8 @@ type Cache interface {
 
 > **Note (2026-06-17):** `Get` now returns a `ReleaseFunc` alongside the handle, per the lease/refcount redesign in [ADR-032](adr_032_lease_refcount_tenant_handles.md). The signature below reflects the current interface.
 
+<!-- -->
+
 > **Note (2026-08-04):** The `Manager` interface below **no longer exists** — it was deleted in
 > [ADR-045](adr_045_no_producer_side_manager_interfaces.md). It was never implemented: the concrete
 > `*cache.CacheManager` returns a typed `ManagerStats` from `Stats()`, takes `key` rather than
@@ -134,17 +147,20 @@ type Manager interface {
 ```
 
 **Architecture:**
+
 - **LRU Eviction**: Limit max cached connections (prevent memory exhaustion)
 - **Singleflight**: Prevent thundering herd on cache miss (concurrent tenant requests)
 - **Idle Cleanup**: Background goroutine evicts idle connections (resource efficiency)
 - **Thread-Safe**: `sync.RWMutex` for concurrent access
 
 **Rationale:**
+
 - Follows proven `database.DbManager` pattern (as shipped, the type is the exported `*cache.CacheManager`; the `cache.Manager` interface named here was never implemented and was removed in [ADR-045](adr_045_no_producer_side_manager_interfaces.md))
 - Tenant isolation without manual key prefixing
 - Prevents connection pool exhaustion in high-cardinality tenant scenarios
 
 ### 5. **Fail-Fast Configuration Validation**
+
 ```yaml
 cache:
   enabled: true
@@ -158,16 +174,19 @@ cache:
 ```
 
 **Validation:**
+
 - Panic at startup if `enabled: true` but `host` missing (explicit > implicit)
 - Skip initialization if `enabled: false` (graceful degradation)
 - Environment variable override support (`CACHE_REDIS_PASSWORD`)
 
 **Rationale:**
+
 - Aligns with "Database by Intent" (ADR-003)
 - Deterministic behavior (same config → same result)
 - No silent failures or degraded modes
 
 ### 6. **ModuleDeps Extension (Breaking Change)**
+
 ```go
 type ModuleDeps struct {
     // ... existing fields
@@ -176,11 +195,13 @@ type ModuleDeps struct {
 ```
 
 **Impact:**
+
 - Minor breaking change (new field on struct)
 - Backward compatible: modules not using cache ignore new field
 - Function-based dependency (matches `DB`, `Messaging` pattern)
 
 **Rationale:**
+
 - Consistent API with existing multi-tenant dependencies
 - Context-aware resolution enables tenant isolation
 - Enables test mocking via dependency injection
@@ -188,6 +209,7 @@ type ModuleDeps struct {
 ## Implementation Details
 
 ### Phase 1: Core Interfaces (PR #1) ← **CURRENT**
+
 - **Files:** `cache/types.go`, `cache/errors.go`
 - **Deliverables:**
   - `Cache` interface definition
@@ -198,18 +220,21 @@ type ModuleDeps struct {
 - **Documentation:** This ADR draft
 
 ### Phase 2-9: Remaining Implementation
+
 See main implementation plan for details (CBOR serialization, Redis client, configuration, manager, app integration, observability, integration tests, documentation).
 
 ### Technical Decisions
 
-**1. Byte-Level Interface vs Generic Interface**
+#### 1. Byte-Level Interface vs Generic Interface
+
 - **Decision:** Use `[]byte` for Get/Set, separate serialization helpers
 - **Rationale:**
   - Clear separation: cache = storage, serialization = transformation
   - Supports future zero-copy optimizations
   - Generic helpers available for common use cases
 
-**2. GetOrSet Semantics**
+#### 2. GetOrSet Semantics
+
 - **Decision:** Return `(storedValue, wasSet, error)`
 - **Rationale:**
   - `wasSet=true`: Value was newly set (first-time processing)
@@ -217,14 +242,16 @@ See main implementation plan for details (CBOR serialization, Redis client, conf
   - `storedValue`: Always returns the value in cache (current or newly set)
   - Enables idempotency without separate Get+Set race
 
-**3. CompareAndSet Semantics**
+#### 3. CompareAndSet Semantics
+
 - **Decision:** Accept `nil` for `expectedValue` → SET NX semantics
 - **Rationale:**
   - `expectedValue=nil`: Set only if key doesn't exist (acquire lock)
   - `expectedValue!=nil`: Update only if current value matches (optimistic concurrency)
   - Covers both lock acquisition and CAS update patterns
 
-**4. Error Handling Strategy**
+#### 4. Error Handling Strategy
+
 - **Decision:** Sentinel errors for cache misses, structured errors for operations
 - **Rationale:**
   - `errors.Is(err, cache.ErrNotFound)` for cache miss detection
@@ -234,6 +261,7 @@ See main implementation plan for details (CBOR serialization, Redis client, conf
 ## Consequences
 
 ### Positive
+
 - **Unified Caching**: First-class cache abstraction across all modules
 - **Distributed Coordination**: Built-in primitives for locks and deduplication
 - **Multi-Tenant Ready**: Automatic tenant isolation via CacheManager
@@ -242,12 +270,14 @@ See main implementation plan for details (CBOR serialization, Redis client, conf
 - **Future-Proof**: Interface-based design supports alternate backends
 
 ### Negative
+
 - **Breaking Change**: `ModuleDeps` extension requires application updates
 - **Redis Dependency**: Requires Redis deployment in production
 - **Learning Curve**: Developers must understand GetOrSet/CAS semantics
 - **Cache Invalidation**: No built-in cache invalidation strategy (application responsibility)
 
 ### Neutral
+
 - **Performance**: Redis round-trip latency (~1-5ms local, ~10-50ms remote)
 - **Memory**: Minimal overhead (CBOR similar to MessagePack, ~30% smaller than JSON)
 - **Complexity**: ~1500 LOC across 9 PRs (similar to database abstraction)
@@ -255,11 +285,13 @@ See main implementation plan for details (CBOR serialization, Redis client, conf
 ## Migration Strategy
 
 ### For Existing Applications
+
 1. **No Cache**: Zero migration needed (cache is optional)
 2. **Manual Redis**: Gradual migration to `cache.Cache` interface
 3. **New Applications**: Use cache from day one
 
 ### Adoption Path
+
 ```go
 // Phase 1: Basic caching
 c, _ := deps.Cache(ctx)
@@ -291,6 +323,7 @@ defer c.Delete(ctx, lockKey)
 ## Quality Assurance
 
 ### Testing Strategy
+
 - **PR #1**: 100% error type coverage ✅
 - **PR #2-8**: 80%+ coverage per PR (SonarCloud enforced)
 - **Integration Tests**: Real Redis via testcontainers (PR #8)
@@ -298,6 +331,7 @@ defer c.Delete(ctx, lockKey)
 - **Multi-Platform CI**: Ubuntu/Windows × Go 1.26
 
 ### Success Metrics
+
 1. **Zero Regressions**: All existing tests pass unchanged
 2. **Coverage**: 80%+ maintained across all PRs
 3. **Performance**: <100ms P99 cache operations (local Redis)
@@ -329,6 +363,7 @@ defer c.Delete(ctx, lockKey)
 **Status:** All 9 PRs completed, feature production-ready
 
 **Code Quality Metrics:**
+
 - **Coverage:** 92.3% (cache + redis packages combined)
 - **Test Lines:** 2,144 total test lines across all packages
   - cache/errors_test.go: 232 lines (96.0% coverage)
@@ -341,6 +376,7 @@ defer c.Delete(ctx, lockKey)
 - **Linting:** Zero golangci-lint issues, follows all framework patterns
 
 **Completed PRs:**
+
 1. ✅ **Cache Interface & Errors** - Sentinel errors, structured errors, comprehensive tests
 2. ✅ **CBOR Serialization** - Type-safe generics, security limits, 100% coverage
 3. ✅ **Redis Client** - Atomic operations, connection pooling, health monitoring
@@ -352,11 +388,13 @@ defer c.Delete(ctx, lockKey)
 9. ✅ **Documentation** - llms.txt (400+ lines), README.md, CLAUDE.md, ADR finalized
 
 **Documentation Coverage:**
+
 - **llms.txt** (~1315 lines total): Multi-tenant patterns, CacheManager lifecycle, config injection, testing utilities, health checks, observability, performance metrics, comparison tables
 - **README.md**: Cache section added to TOC, Feature Overview, Quick Start config, dedicated Cache section with operations table
 - **CLAUDE.md**: Cache Architecture section (matches database/messaging depth), Core Components updated, Troubleshooting section added
 
 **Production-Ready Features:**
+
 - Type-safe CBOR serialization with compile-time guarantees
 - Multi-tenant isolation via separate Redis databases
 - Automatic lifecycle management (lazy init, LRU, idle cleanup)
@@ -365,14 +403,17 @@ defer c.Delete(ctx, lockKey)
 - Observability integration ready (traces, metrics, health endpoints)
 
 **Completed (PR #164):**
+
 - ✅ `cache/testing` package with MockCache and 20+ assertion helpers
 - ✅ End-to-end Redis integration tests (TTL expiration, atomic operation verification, concurrency)
 - ✅ Comprehensive benchmark suite (Redis + CBOR serialization)
 
 **Known Gaps (Future Work):**
+
 - Full observability metrics implementation (cache.hit, cache.miss counters)
 
 **Architectural Highlights:**
+
 - Follows "Explicit > Implicit" manifesto principle with function-based `deps.Cache(ctx)`
 - Lock-free close pattern prevents blocking operations during cache lifecycle events
 - Singleflight prevents duplicate cache creation under concurrent load

--- a/wiki/adr_012_remove_mongodb_support.md
+++ b/wiki/adr_012_remove_mongodb_support.md
@@ -10,14 +10,17 @@ GoBricks supported three database vendors: PostgreSQL, Oracle, and MongoDB. Mong
 ## Options Considered
 
 ### Option A: Keep MongoDB (Status Quo)
+
 - **Pros:** Feature parity, potential future use
 - **Cons:** Maintenance burden (~4,500 lines of unused code), additional dependency (`go.mongodb.org/mongo-driver/v2`), complexity in vendor-agnostic abstractions
 
 ### Option B: Deprecate MongoDB
+
 - **Pros:** Gradual migration path
 - **Cons:** Extended maintenance period, deprecation warnings add noise, no active users to migrate
 
 ### Option C: Remove MongoDB Entirely (Chosen)
+
 - **Pros:** Immediate reduction in complexity, smaller dependency tree, clearer framework scope
 - **Cons:** Breaking change for any hypothetical MongoDB users
 
@@ -28,6 +31,7 @@ Remove MongoDB support entirely with no deprecation period. The framework focuse
 ## Implementation Details
 
 ### Removed
+
 - `database/mongodb/` package (11 files, ~4,500 lines)
 - `internal/database/document_interface.go` (~430 lines of document-oriented interfaces)
 - `testing/containers/mongodb.go` (testcontainer helper)
@@ -39,6 +43,7 @@ Remove MongoDB support entirely with no deprecation period. The framework focuse
 - `go.mongodb.org/mongo-driver/v2` and `testcontainers-go/modules/mongodb` dependencies
 
 ### Unchanged
+
 - `database.Interface` — MongoDB implemented it but the interface itself is generic
 - `database/factory.go` — already only handled PostgreSQL and Oracle
 - All PostgreSQL and Oracle functionality
@@ -46,21 +51,25 @@ Remove MongoDB support entirely with no deprecation period. The framework focuse
 ## Consequences
 
 ### Positive
+
 - ~5,000 lines of code removed
 - Two fewer direct dependencies (`mongo-driver`, `testcontainers-go/modules/mongodb`)
 - Simplified vendor abstraction (no document vs. SQL interface split)
 - Faster CI (no MongoDB container pre-pull or integration tests)
 
 ### Negative
+
 - Breaking change for any applications using `database/mongodb` package
 - Breaking change for any applications using `DocumentInterface` type assertions
 
 ### Neutral
+
 - The `normalizeDBVendor` function in tracking still handles unknown vendors gracefully
 
 ## Migration Impact
 
 Applications using MongoDB with GoBricks must:
+
 1. Remove `database.type: mongodb` from configuration files
 2. Remove `DATABASE_MONGO_*` environment variables
 3. Replace `database/mongodb` imports with a direct MongoDB driver dependency

--- a/wiki/adr_013_interface_naming_conventions.md
+++ b/wiki/adr_013_interface_naming_conventions.md
@@ -25,12 +25,14 @@ Rename 6 interfaces to follow Go idiomatic naming:
 ## Implementation Details
 
 ### Changed
+
 - Interface definitions in their respective packages
 - All internal references (field types, parameters, type assertions, godoc)
 - Composite `app.TenantStore` interface embedding updated names
 - CLAUDE.md migration table added for downstream consumers
 
 ### Unchanged
+
 - `config.TenantStore` (struct, not an interface — different type)
 - `app.TenantStore` (composite interface name kept — it's the user-facing abstraction)
 - All method signatures on the interfaces remain identical
@@ -38,17 +40,20 @@ Rename 6 interfaces to follow Go idiomatic naming:
 ## Consequences
 
 ### Positive
+
 - Resolves 5 SonarCloud S8196 issues
 - Aligns with Go community naming conventions
 - More descriptive interface names improve code readability
 
 ### Negative
+
 - Breaking change for any code that references the old interface names
 - Downstream applications must update type assertions and variable declarations
 
 ## Migration Impact
 
 Applications referencing old interface names must update:
+
 1. `scheduler.Job` → `scheduler.Executor`
 2. `app.HealthProbe` → `app.Prober`
 3. `database.TenantStore` → `database.DBConfigProvider`

--- a/wiki/adr_015_echo_v5_migration.md
+++ b/wiki/adr_015_echo_v5_migration.md
@@ -10,6 +10,7 @@
 GoBricks uses Echo v4 as its HTTP framework foundation, deeply integrated across ~92 files spanning the server, app, and scheduler packages. Echo v5.0.0 was released January 18, 2026, with the latest stable release being v5.1.0 (March 31, 2026). The "critical API change window" for v5 closed on March 31, 2026, meaning the API surface is now stable.
 
 Echo v4 will only receive security and bug fixes until December 31, 2026. Continuing on v4 means:
+
 - No new features or improvements
 - Growing incompatibility with the Echo ecosystem (middleware, tooling)
 - The `otelecho` OpenTelemetry instrumentation package has no v5 support, blocking future OTel upgrades
@@ -17,6 +18,7 @@ Echo v4 will only receive security and bug fixes until December 31, 2026. Contin
 ## Decision
 
 Migrate from `echo/v4 v4.15.1` to `echo/v5 v5.1.0` and replace the OpenTelemetry instrumentation:
+
 - **Remove:** `go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.67.0`
 - **Add:** `github.com/labstack/echo-opentelemetry v0.0.2` (first-party Echo OTel middleware)
 
@@ -43,9 +45,11 @@ GoBricks' enhanced handler pattern (`server.GET/POST/etc.` with `HandlerFunc[T, 
 ## Key API Changes
 
 ### `echo.Context`: Interface to Struct Pointer
+
 The most pervasive change. `echo.Context` changes from an interface to a concrete struct, and all handler/middleware signatures use `*echo.Context`.
 
 ### `HTTPErrorHandler`: Parameter Order Reversed
+
 ```go
 // v4
 e.HTTPErrorHandler = func(err error, c echo.Context) { ... }
@@ -55,33 +59,41 @@ e.HTTPErrorHandler = func(c *echo.Context, err error) { ... }
 ```
 
 ### `echo.HTTPError.Message`: `interface{}` to `string`
+
 No longer requires type switching. `echo.NewHTTPError()` takes `(int, string)` instead of variadic `(int, ...interface{})`.
 
 ### `c.Response()`: `*echo.Response` to `http.ResponseWriter`
+
 Use `echo.UnwrapResponse(c.Response())` to access `.Committed` and `.Status` fields.
 
 ### Server Lifecycle: `StartServer()`/`Shutdown()` Removed
+
 Replaced by `echo.StartConfig` with context-based graceful shutdown.
 
 ### `NewContext`: Both Forms Available
+
 Echo v5 adds a standalone `echo.NewContext(req, rec, opts ...any)` package-level function (in `context.go`), where the `*Echo` instance can be passed as an optional variadic argument. The `e.NewContext(req, rec)` method on `*Echo` is retained unchanged. Either form works; the method form is used throughout this codebase.
 
 ### OpenTelemetry: `otelecho` to `echo-opentelemetry`
+
 The community `otelecho` package does not support Echo v5. The first-party `echo-opentelemetry` package provides equivalent functionality.
 
 ## Consequences
 
 ### Positive
+
 - Access to Echo v5 features: generic parameter extraction, type-safe context store, improved routing
 - First-party OpenTelemetry support from the Echo team
 - Better type safety with concrete struct pointer (compile-time errors instead of runtime)
 - Alignment with the Echo ecosystem going forward
 
 ### Negative
+
 - Breaking change for downstream users (import path + `HandlerContext.Echo` type)
 - `echo-opentelemetry` is v0.0.2 (young package), though it's maintained by the Echo team
 - `LegacyIPExtractor()` is a compatibility shim — should be replaced with proper trusted proxy configuration
 
 ### Neutral
+
 - `Echo.Logger` changed from custom interface to `*slog.Logger` — GoBricks uses zerolog, minimal impact
 - New v5 features (generic params, `ContextGet[T]`) available but not adopted in this migration to keep the diff focused

--- a/wiki/adr_018_multi_tenant_migration_cli.md
+++ b/wiki/adr_018_multi_tenant_migration_cli.md
@@ -171,6 +171,7 @@ returns the first error. Use `--continue-on-error` to override.
 ## Consequences
 
 **Pros:**
+
 - Multi-tenant fleets get a documented, repeatable migration story.
 - Library entry point lets the back-office reuse the same flow on tenant
   events without shelling out to the binary.
@@ -180,6 +181,7 @@ returns the first error. Use `--continue-on-error` to override.
   `aws-sdk-go-v2`.
 
 **Cons:**
+
 - The pre-defined HTTP contract is now a published API surface and changes
   must be backwards-compatible (versioned via `/v2/tenants` if ever needed).
 - Operators must provision AWS Secrets Manager entries with a documented JSON

--- a/wiki/adr_019_migration_audit_delivery.md
+++ b/wiki/adr_019_migration_audit_delivery.md
@@ -125,11 +125,13 @@ This list is part of the public API (additive changes only) so downstream alerti
 ## Consequences
 
 **Pros:**
+
 - Zero-config audit for the majority of adopters; durable audit for the compliance minority.
 - Audit events benefit from the same backend correlation as spans / metrics / logs in the OTel pipeline — operators can pivot from a span to an audit event and back in their existing tooling.
 - The `AuditRecorder` interface is small (one method) and stable; backwards-compatible additions to `AuditEvent` follow Go's struct-additive rules.
 
 **Cons:**
+
 - Two emission paths means schema discipline is essential: any change to `AuditEvent` must update OTel attribute mapping **and** sink contract. Mitigated by the single `AuditEvent` struct flowing into both paths.
 - The "sink-failure does not abort migration" semantics is a real trade-off. Customers requiring zero-loss audit must back their sink with a durable buffer; the framework does not retry on the sink's behalf. Documented in the operator wiki.
 - `ErrorClass` taxonomy must be maintained as Runner implementations grow. Adding a class is non-breaking; removing one is.

--- a/wiki/adr_020_oracle_integration_test_container_reuse.md
+++ b/wiki/adr_020_oracle_integration_test_container_reuse.md
@@ -61,6 +61,7 @@ We *will* apply this **as an interim safeguard** in the implementation PR — th
 testcontainers-go supports a `Reuse: true` flag that, combined with `Name`, lets multiple processes (or repeat runs) attach to the same running container. On a developer laptop this gives instant re-runs; in CI each fresh runner is a new VM so reuse provides no benefit there.
 
 Rejected because:
+
 - CI is where the flake hurts most, and reuse provides nothing on fresh runners.
 - The `Reuse` flag interacts oddly with testcontainers' Ryuk reaper — a reused container outlives the test session that "owned" it, and Ryuk's container-cleanup heuristics depend on session labels we'd need to manage by hand.
 - Containers persisting across test runs can mask state-leak bugs that a clean baseline would catch (e.g., a test that forgets to drop a sequence still passes the next run because the sequence already exists).

--- a/wiki/adr_032_lease_refcount_tenant_handles.md
+++ b/wiki/adr_032_lease_refcount_tenant_handles.md
@@ -89,6 +89,7 @@ release. See `wiki/migrations.md`. **No application-facing change:** `deps.DB/Ca
 `ResourceProvider` are unchanged.
 
 **Benefits:**
+
 - An in-use handle is **never** `Close()`d — the M3 eviction-while-in-use race is closed for every
   concurrent multi-tenant path (HTTP, consumers, jobs, outbox relay, inbox).
 - Leased entries can temporarily exceed `MaxSize` (they are detached, off-book) instead of being
@@ -98,6 +99,7 @@ release. See `wiki/migrations.md`. **No application-facing change:** `deps.DB/Ca
   with no retry storm.
 
 **Costs / limitations:**
+
 - A `refs++`/`refs--` per borrow under the manager mutex (negligible; already on the lock path).
 - Unscoped contexts are not protected (documented fallback). New framework entry points that
   borrow per-tenant handles concurrently should install a `leasescope.Scope` at their boundary.

--- a/wiki/adr_034_echo_boundary_types.md
+++ b/wiki/adr_034_echo_boundary_types.md
@@ -123,12 +123,14 @@ baton-free.
 ## Consequences
 
 **Positive:**
+
 - No `echo.*` symbol appears in any code an application developer writes, names, or imports; the consumer surface matches the database/cache/messaging precedent.
 - Downstream services are decoupled from Echo's concrete API and version — a future Echo bump is a `server/`-internal change.
 - The flat middleware shape is simpler than Echo's nested closure and is uniform across custom, framework, scheduler, and debug middleware.
 - Security improvement: no `RealIP()` accessor is exposed (it would graduate Echo's spoofable `LegacyIPExtractor` into the blessed path); the one internal consumer (the auth denial log) now uses `server.ClientIP(c.Request(), trustedNets)`, removing the spoofable IP from that log.
 
 **Negative:**
+
 - Breaking change for every consumer that touched the removed surface — mitigated by the compiler (each removed symbol fails the build), the `wiki/migrations.md` section, and the demo-project migration.
 - A custom-middleware route pays a bounded **+1 heap-alloc/request/middleware-layer** — the `func() error { return next(c) }` baton, structurally unavoidable under the locked flat shape (see Performance).
 

--- a/wiki/adr_035_route_template_path_params.md
+++ b/wiki/adr_035_route_template_path_params.md
@@ -111,6 +111,7 @@ stranded today — there is no public write channel that `Param()` or the
 ## Consequences
 
 **Positive:**
+
 - Purely additive: the `apidiff` gate stays green and the change ships in
   minor v0.46.0 as `feat(server):`, not `feat!:` — no migration for existing
   consumers.
@@ -121,6 +122,7 @@ stranded today — there is no public write channel that `Param()` or the
   boundary instead of being rediscovered by every consumer.
 
 **Negative:**
+
 - A future non-echo engine must support post-route path-parameter
   replacement — `SetPathParams` becomes part of the engine contract alongside
   the read accessors.

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -5,6 +5,7 @@ This document serves as an index to all architectural decisions made during the 
 ## Overview
 
 Architecture Decision Records help us:
+
 - Document **why** decisions were made, not just what was decided
 - Understand the context and trade-offs of past decisions
 - Onboard new developers with historical architectural context
@@ -450,7 +451,7 @@ migration.
 
 **Date:** 2026-06-30 | **Status:** Accepted
 
-> _Numbering note: ADR-033 is reserved for a concurrent change (outbox retry-count, PR #626) landing in parallel; this echo-boundary ADR took the next free number, 034._
+> *Numbering note: ADR-033 is reserved for a concurrent change (outbox retry-count, PR #626) landing in parallel; this echo-boundary ADR took the next free number, 034.*
 
 Resolves issue #623. Wraps every remaining `github.com/labstack/echo/v5` leak on the
 public surface behind go-bricks boundary types while Echo stays the unchanged engine

--- a/wiki/cache.md
+++ b/wiki/cache.md
@@ -7,12 +7,14 @@ GoBricks provides Redis-based caching with type-safe serialization, multi-tenant
 **Requires Redis 7.0+** because `GetOrSet` uses `SET … NX GET`, which Redis rejected as a syntax error before 7.0.0. The client fails construction when the server advertises an older version; because `CacheManager` builds clients lazily per tenant, a too-old server surfaces on the first request that touches the cache rather than at startup. The check is best-effort — it fails open when `INFO` is unavailable (ACL-restricted or redacted by a managed provider).
 
 **Core Components:**
+
 - **Redis Client**: Atomic operations (Get/Set/GetOrSet/CompareAndSet), connection pooling, health monitoring
 - **CacheManager**: Per-tenant cache lifecycle with lazy initialization, LRU eviction, idle cleanup, singleflight
 - **CBOR Serialization**: Type-safe encoding with security limits (max 10k array/map elements, max nesting depth 16)
 - **Multi-tenant integration**: Automatic tenant resolution from context via `deps.Cache(ctx)`
 
 **Lifecycle Management (CacheManager):**
+
 - **Lazy Initialization**: Cache created on first access per tenant (no upfront connections)
 - **LRU Eviction**: Oldest cache evicted when MaxSize exceeded (default: 100 tenants)
 - **Idle Cleanup**: Unused caches closed after IdleTTL (default: 15m, checked every 5m)
@@ -20,6 +22,7 @@ GoBricks provides Redis-based caching with type-safe serialization, multi-tenant
 - **Lock-Free Close**: Cache close operations don't block Get/Set/Delete operations
 
 **Performance Characteristics:**
+
 - **Latency**: <1ms for Get/Set (localhost), ~2ms for atomic operations (Lua scripts)
 - **Throughput**: 100k reads/sec, 80k writes/sec (single Redis instance)
 - **CBOR Serialization**: ~83ns/op marshal, ~167ns/op unmarshal (simple structs)
@@ -27,6 +30,7 @@ GoBricks provides Redis-based caching with type-safe serialization, multi-tenant
 - **Network Impact**: +0.5-1ms (same datacenter), +50-200ms (cross-region, not recommended)
 
 **Benchmark Results** (Apple M4 Pro, localhost Redis):
+
 | Operation | Performance | Allocations | Notes |
 |-----------|-------------|-------------|-------|
 | CBOR Marshal (simple) | ~83 ns/op | 96 B/op, 2 allocs | 12M ops/sec |
@@ -38,6 +42,7 @@ GoBricks provides Redis-based caching with type-safe serialization, multi-tenant
 *Redis benchmarks require:* `docker run -d -p 6379:6379 redis:7-alpine` then `go test -bench=BenchmarkRealRedis -benchmem -tags=integration ./cache/redis/`
 
 **Configuration Example:**
+
 ```yaml
 cache:
   enabled: true
@@ -57,6 +62,7 @@ cache:
 ```
 
 **Module Setup Pattern:**
+
 ```go
 type Module struct {
     svc *Service
@@ -111,6 +117,7 @@ func (s *Service) GetUser(ctx context.Context, id int64) (*User, error) {
 ```
 
 **Key Operations:**
+
 | Operation | Method | Use Case | Atomicity |
 |-----------|--------|----------|-----------|
 | Basic read | `Get(ctx, key)` | Query result caching | Single-key |
@@ -120,6 +127,7 @@ func (s *Service) GetUser(ctx context.Context, id int64) (*User, error) {
 | Type-safe store | `Marshal(v)` + `Set()` | Struct serialization | CBOR encoding |
 
 **Multi-Tenant Isolation:**
+
 - Each tenant gets separate Redis database (configurable per-tenant)
 - Cache instances managed by CacheManager with automatic lifecycle
 - Context propagation ensures tenant resolution via `deps.Cache(ctx)`
@@ -127,6 +135,7 @@ func (s *Service) GetUser(ctx context.Context, id int64) (*User, error) {
 
 **Observability Integration:**
 When `observability.enabled: true`, cache operations automatically emit:
+
 - **Metrics**: `db.client.operation.duration` (histogram, tagged with `error.type` on failure), `cache.hit`/`cache.miss` (counters), `cache.manager.active_caches`, `cache.manager.evictions`, `cache.manager.idle_cleanups`, `cache.manager.total_created`, `cache.manager.errors` — no distributed-tracing spans are emitted today
 - **Health**: A probe registered in the `/ready` probe set whenever the cache manager exists. It leases an instance from the manager (`cacheManager.Get(ctx, "")`) and then calls `Cache.Health(ctx)` on it — under the default connector that is one Redis `PING` on a warm poll and three round trips on a cold one (the construction-time `PING`, the `INFO` version check, then the probe's own `PING`); `Health` is connector-defined, so a custom `Options.CacheConnector` costs whatever its own implementation does, which need not touch the network. Its status is surfaced as the top-level `cache` and `cache_stats` keys in the `/ready` **200** body (a `503` carries only `status`, `cache` and `error`), and it fails `/ready` with `503` by default — `cache.critical: false` opts out and emits a startup WARN. See [Readiness](#readiness) below
 

--- a/wiki/database.md
+++ b/wiki/database.md
@@ -3,6 +3,7 @@
 Unified `database.Interface` supporting PostgreSQL and Oracle with vendor-specific SQL generation, type-safe WHERE clauses, performance tracking via OpenTelemetry, connection pooling, and health monitoring.
 
 **Package Structure:**
+
 - `database/types/` — Core interfaces
 - `database/internal/tracking/` — Performance metrics
 - `database/internal/builder/` — Query builder implementations
@@ -17,6 +18,7 @@ Unified `database.Interface` supporting PostgreSQL and Oracle with vendor-specif
 GoBricks supports accessing multiple databases in single-tenant mode, useful for legacy system migrations where applications need to access both old (e.g., Oracle) and new (e.g., PostgreSQL) databases.
 
 **Configuration:**
+
 ```yaml
 database:                # Default database (unchanged - backward compatible)
   type: postgresql
@@ -42,6 +44,7 @@ databases:               # Named databases — supports mixed vendors
 ```
 
 **Module Usage:**
+
 ```go
 func (m *Module) Init(deps *app.ModuleDeps) error {
     m.getDB = deps.DB              // Default database (unchanged)
@@ -65,6 +68,7 @@ func (h *Handler) MigrateLegacyData(ctx context.Context) error {
 ```
 
 **Key Features:**
+
 - Mixed vendor support per named database
 - Backward compatible: `deps.DB(ctx)` works exactly as before
 - Reuses infrastructure: same DbManager with LRU, connection pooling, idle cleanup
@@ -75,6 +79,7 @@ func (h *Handler) MigrateLegacyData(ctx context.Context) error {
 GoBricks eliminates column repetition through struct-based column management using `db:"column_name"` tags.
 
 **Benefits:**
+
 - **DRY:** Define columns once in struct tags, reference by field name
 - **Type Safety:** Compile-time field name validation (panics on typos)
 - **Vendor-Aware:** Automatic Oracle reserved word quoting
@@ -82,6 +87,7 @@ GoBricks eliminates column repetition through struct-based column management usi
 - **Refactor-Friendly:** Rename struct fields → compiler catches all query references
 
 **Quick Example:**
+
 ```go
 type User struct {
     ID    int64  `db:"id"`
@@ -106,6 +112,7 @@ qb.Update("users").
 ```
 
 **Service-Level Caching Pattern:**
+
 ```go
 type ProductService struct {
     qb   *database.QueryBuilder
@@ -321,6 +328,7 @@ would leave the operator believing the connection is encrypted.
 > **Idle defaults to max (changed in [ADR-025](adr_025_pool_idle_tracks_max.md)).** Earlier versions defaulted idle to a fixed `2`, which made the pool repeatedly open and close physical connections (TCP+TLS+auth) under sustained load. Idle now defaults to `pool.max.connections` so warm connections are reused. Set a lower `pool.idle.connections` explicitly only when you deliberately want idle connections released back to the database. See [migrations.md](migrations.md#connection-pool-idle-default--tracks-max-adr-025) for the footprint implications.
 
 **Cloud Provider Idle Timeouts:**
+
 | Provider | Component | Timeout |
 |----------|-----------|---------|
 | AWS | NAT Gateway/ALB | 350s |
@@ -329,6 +337,7 @@ would leave the operator believing the connection is encrypted.
 | On-prem | Firewalls | 60-300s |
 
 **Override defaults:**
+
 ```yaml
 database:
   pool:
@@ -461,6 +470,7 @@ case err != nil:
 | `database.timezone` | `UTC` | IANA timezone applied per session (PostgreSQL via pgx `RuntimeParams`, Oracle via `ALTER SESSION SET TIME_ZONE` on every new physical connection) |
 
 **Behavior:**
+
 - Unset / empty → defaulted to `UTC` at config validation
 - IANA name (`Asia/Tokyo`, `America/New_York`) → validated via `time.LoadLocation`, applied per-connection
 - `-` sentinel → opt-out; sessions inherit the database server's default (legacy behavior)

--- a/wiki/global_middleware.md
+++ b/wiki/global_middleware.md
@@ -71,7 +71,7 @@ framework-level exemption is the health/ready probes.
 
 Global middleware lands at the **innermost slot** of the root chain:
 
-```
+```text
 requestID → tenant resolution → logger → Recover → timeout → rate-limit → [GLOBAL MIDDLEWARE] → handler
 ```
 

--- a/wiki/handler_patterns.md
+++ b/wiki/handler_patterns.md
@@ -7,12 +7,14 @@ These are advanced HTTP handler patterns built on top of the basic Enhanced Hand
 The enhanced handler pattern supports both **value** and **pointer** types for requests and responses, allowing you to optimize for performance when handling large payloads.
 
 **When to Use Value Types (Default)**:
+
 - ✅ Small requests/responses (<1KB, ~10-15 simple fields)
 - ✅ No large embedded arrays or slices
 - ✅ Emphasizes immutability (idiomatic Go)
 - ✅ Examples: login credentials, ID lookups, simple CRUD operations
 
 **When to Use Pointer Types**:
+
 - ✅ Large requests/responses (>1KB)
 - ✅ File uploads (base64-encoded images, documents)
 - ✅ Bulk imports/exports (hundreds or thousands of records)
@@ -68,12 +70,14 @@ func (h *Handler) processBulk(req *BulkRequest, ctx server.HandlerContext) (Summ
 ```
 
 **Performance Impact**:
+
 - **Value types**: Small struct copy overhead (~nanoseconds for <1KB)
 - **Pointer types**: Zero copy overhead, just 8-byte pointer
 - **Rule of thumb**: Use pointers when struct size >1KB or contains large slices/arrays
 
 **Linter Configuration**:
 Configure `govet` to warn on large value copies:
+
 ```yaml
 # .golangci.yml  (add under the existing linters: block)
 linters:
@@ -100,6 +104,7 @@ server.GET(hr, e, "/v2/users/:id", h.getUser)
 ```
 
 **Handler returns the exact legacy shape:**
+
 ```go
 type LegacyUser struct {
     UserID   int64  `json:"userId"`

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -7,6 +7,7 @@ The `httpclient` package provides a production-ready outbound HTTP client built 
 The `httpclient` package provides a production-ready HTTP client with built-in observability and resilience.
 
 **Key Features:**
+
 - **Builder pattern**: Fluent configuration via `NewBuilder(logger).WithTimeout(...).Build()`, which returns `(Client, error)` — `Build` fails construction rather than silently building a client with a discarded transport (see [Transport composition](#transport-composition))
 - **W3C trace propagation**: Automatic `traceparent`/`tracestate` header injection
 - **Retry with backoff**: Exponential backoff with full jitter, configurable max retries

--- a/wiki/jose.md
+++ b/wiki/jose.md
@@ -7,6 +7,7 @@ The `jose` package provides nested JWE-of-JWS protection on HTTP request and res
 The `jose` package provides nested JWE-of-JWS protection on HTTP request and response bodies. Designed for **Visa Token Services**-style integrations and any partner API that requires sign-then-encrypt outbound and decrypt-then-verify inbound on every payload.
 
 **Key Features:**
+
 - **Struct-tag opt-in**: Add a `jose:` tag to a sentinel field on the request/response type — no per-route plumbing
 - **Bidirectional symmetry enforced**: both request and response must carry tags or neither (registration-time check)
 - **Strict algorithm allowlist**: `RS256`/`PS256` for signing; `RSA-OAEP-256` + `A256GCM` for encryption. `alg=none`, `HS*`, `RSA1_5`, and `ES256` are rejected at parse time. ECDSA support is gated on extending `keystore.KeyStore` to return ECDSA keys (tracked in [#347](https://github.com/gaborage/go-bricks/issues/347))
@@ -15,6 +16,7 @@ The `jose` package provides nested JWE-of-JWS protection on HTTP request and res
 - **Observability**: spans (`jose.decode_request`, `jose.encode_response`), failure counter (`jose.failures.total` by code/direction), duration histogram (`jose.operation.duration`)
 
 **Tag syntax:**
+
 ```go
 type CreateTokenRequest struct {
     _   struct{} `jose:"decrypt=our-signing,verify=visa-vts-verify"`
@@ -28,11 +30,13 @@ type CreateTokenResponse struct {
 ```
 
 **Tag keys (all kids are case-sensitive, charset `[A-Za-z0-9_-]+`):**
+
 - Request: `decrypt` (our private key), `verify` (peer public key)
 - Response: `sign` (our private key), `encrypt` (peer public key)
 - Optional everywhere: `sig_alg` (default `RS256`), `key_alg` (default `RSA-OAEP-256`), `enc` (default `A256GCM`), `cty` (default `application/json`)
 
 **Wiring:**
+
 ```yaml
 keystore:
   keys:
@@ -94,6 +98,7 @@ Vanilla `Result[R]` continues to seal raw `data` so VTS-style vendor-prescribed 
 **Replay protection**: the framework verifies the JWS signature and exposes verified claims via `jose.ClaimsFromContext(ctx)`. Applications enforce `iat`/`exp`/`jti` policies (Visa skew rules vary by product); `jose.CheckJTIReplay(ctx, recorder, claims, window)` provides the cache-backed `jti` half. `CheckJTIReplay` requires a non-empty `claims.Issuer` — iss-less token profiles must call `jose.CheckJTIReplayInNamespace(ctx, recorder, policy.VerifyKid, claims, window)` instead, so partners sharing no issuer don't collide on the same jti namespace.
 
 **Test utilities** (`jose/testing/`):
+
 - `GenerateTestKeyPair(t)` — 2048-bit RSA pair for fast tests
 - `NewTestResolver(map[string]any{kid: key})` — in-memory KeyResolver
 - `SealForTest(t, payload, policy, resolver)` — produce compact JWE for arrange step

--- a/wiki/keystore.md
+++ b/wiki/keystore.md
@@ -8,6 +8,7 @@ dev, a base64 env var / secrets-manager value in deployed environments, loaded
 once at startup and held read-only in memory.
 
 **Key Features:**
+
 - **One custody story** for asymmetric and symmetric material — no parallel,
   un-audited secret path, no deriving a MAC key off an RSA private key
 - **Per-entry RSA *or* secret**, never both — a mixed entry is a startup config

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -5,6 +5,7 @@ This document covers GoBricks' AMQP messaging subsystem in depth: declaration he
 ## Messaging Architecture
 
 AMQP-based messaging with **validate-once, replay-many** pattern:
+
 - Declarations validated upfront, replayed per-tenant for isolation
 - Automatic reconnection with exponential backoff
 - Context propagation for tenant IDs and tracing
@@ -14,6 +15,7 @@ AMQP-based messaging with **validate-once, replay-many** pattern:
 GoBricks provides production-safe defaults to reduce AMQP boilerplate (~50+ lines → ~15 lines):
 
 **Concise Declaration Pattern:**
+
 ```go
 exchange := decls.DeclareTopicExchange("issuance.events")
 queue := decls.DeclareQueue("issuance.events.queue")
@@ -31,6 +33,7 @@ decls.DeclareConsumer(&messaging.ConsumerOptions{
 ```
 
 **Production-Safe Defaults:**
+
 - Exchanges: `Durable: true`, `AutoDelete: false`, `Type: "topic"`
 - Queues: `Durable: true`, `AutoDelete: false`, `Exclusive: false`
 - Publishers: `Mandatory: false`, `Immediate: false`
@@ -56,7 +59,7 @@ Exchanges and bindings are unaffected: `RegisterExchange` still keeps the last d
 
 ## Consumer Registration Best Practices
 
-**CRITICAL: Deduplication Rules**
+### CRITICAL: Deduplication Rules
 
 GoBricks enforces **strict deduplication** to prevent message duplication bugs. Each unique `queue + consumer_tag + event_type` combination must be registered exactly once:
 
@@ -79,6 +82,7 @@ func (m *Module) DeclareMessaging(decls *messaging.Declarations) {
 ```
 
 **Common Mistakes:**
+
 - Registering consumers in loops or conditional blocks (creates duplicates)
 - Calling `app.RegisterModule()` multiple times for the same module
 - Module registration errors are unrecoverable - MUST use `log.Fatal(err)` to handle
@@ -167,6 +171,7 @@ messaging.DeclareTypedConsumerWithMeta(decls, &messaging.ConsumerOptions{
 **Behavior:** All handler errors → Message nacked WITHOUT requeue (message dropped). Prevents poison messages from blocking queues. Rich ERROR logs + OpenTelemetry metrics track all failures.
 
 **Panic Recovery:** Handler panics are automatically recovered and treated identically to errors:
+
 - Panic recovered with stack trace logging
 - Message nacked WITHOUT requeue (consistent with error policy)
 - Service continues processing other messages
@@ -174,6 +179,7 @@ messaging.DeclareTypedConsumerWithMeta(decls, &messaging.ConsumerOptions{
 - Other consumers remain unaffected (panic isolation)
 
 **Error Handling Pattern:**
+
 ```go
 func (h *Handler) Handle(ctx context.Context, delivery *amqp.Delivery) error {
     var order Order
@@ -260,6 +266,7 @@ via `x-death` count before parking permanently — remains future work; see
 GoBricks automatically configures `Workers = runtime.NumCPU() * 4` to handle blocking I/O operations (database queries, HTTP calls, file operations). The 4x multiplier ensures CPU utilization while threads wait on I/O.
 
 **Configuration:**
+
 ```go
 // Auto-scaling (default): Workers = NumCPU * 4, PrefetchCount = Workers * 10
 decls.DeclareConsumer(&messaging.ConsumerOptions{
@@ -291,28 +298,33 @@ decls.DeclareConsumer(&messaging.ConsumerOptions{
 ```
 
 **Thread-Safety Requirements:**
+
 - Handlers MUST be thread-safe (no shared mutable state without locks/atomic operations)
 - Database pools MUST be sized: `MaxOpenConns >= NumCPU * 4 * NumConsumers`
 - External APIs: Add semaphore for rate limit enforcement if needed
 - Test with `go test -race` to detect data races
 
 **Resource Safeguards:**
+
 - Workers capped at 200 per consumer (prevents goroutine explosion)
 - PrefetchCount capped at 1000 (prevents memory exhaustion)
 - Caps are applied silently (no warning is currently logged when a value is reduced)
 
 **Performance Impact (8-core machine, 100ms handler):**
+
 | Version | Workers | Throughput | Speedup |
 |---------|---------|------------|---------|
 | v0.16.x | 1 | 10 msg/sec | Baseline |
 | v0.17.0 | 32 | 320 msg/sec | **32x** |
 
 **When to Override Defaults:**
+
 - **Workers=1**: Message ordering required (events must be processed sequentially)
 - **Workers>NumCPU*4**: Very slow handlers (>1s per message) or high throughput needs
 - **Workers<NumCPU*4**: CPU-bound handlers (rare - most handlers are I/O-bound)
 
 **Observability:**
+
 - Startup logs include `workers` and `prefetch` counts
 - Each worker logs with `worker_id` for debugging
 - OpenTelemetry metrics track per-consumer throughput
@@ -397,8 +409,8 @@ headers are poison — see
 `NewAMQPClient` starts connecting asynchronously and returns immediately — `IsReady()` only flips
 true once the broker handshake and channel init finish. Before this pre-flight existed, the very
 first publish against a freshly created (or mid-reconnect) client failed instantly with
-`messaging.ErrNotConnected`, even though the client would have become ready a moment later (issue
-#655).
+`messaging.ErrNotConnected`, even though the client would have become ready a moment later
+(issue #655).
 
 `PublishToExchange` now runs a bounded, context-aware wait for readiness **before** entering the
 retry loop described above. The wait polls every 100ms (the same cadence

--- a/wiki/migration_roles.md
+++ b/wiki/migration_roles.md
@@ -64,6 +64,7 @@ opt-out flag. Re-running the same spec converges the setting; manual drift
 back on the next provisioning call.
 
 **Why it matters on both sides:**
+
 - **Migrator side.** Flyway's fallback when no schema is explicitly targeted
   resolves against the *connection's* current schema, which in turn is
   driven by the role's default `search_path`. Without this `ALTER ROLE`, a
@@ -180,6 +181,7 @@ see [multi_tenant_migration.md](multi_tenant_migration.md#aws-secrets-manager-co
 ```
 
 After provisioning:
+
 - The migration runner connects as `migrator` and applies Flyway migrations.
   All new tables are owned by `migrator`.
 - The running service connects as `tenant_a_app` and performs DML only. Any

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -7,16 +7,18 @@ Executable upgrade path for existing GoBricks apps, structured as one **hop per 
 ## How to use this runbook (agent protocol)
 
 **1 — Detect CURRENT version** from the consuming app's `go.mod`:
+
 ```sh
 go list -m -f '{{.Version}}{{if .Replace}} =>{{.Replace.Path}}{{end}}' github.com/gaborage/go-bricks
 ```
+
 A plain `vX.Y.Z` is your current node. `=>` a local path (dev `replace`) means the require line is not the running code — resolve the real version from that checkout: `git -C <path> describe --tags --abbrev=0`.
 
 **2 — Pick TARGET** = the version you're moving to (usually the newest node).
 
 **3 — Select the hop chain** on the Ladder: every edge strictly to the right of CURRENT, up to and including TARGET. Never apply an edge at/left of CURRENT.
 
-```
+```text
 v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0 ─E43─ v0.43.0 ─E44─ v0.44.0 ─E45─ v0.45.0 ─E49─ v0.49.0 ─E50─ v0.50.0 ─E51─ v0.51.0 ─E52─ v0.52.0 ─E55─ v0.55.0 ─E56─ v0.56.0 ─E57─ v0.57.0
 ```
 
@@ -42,6 +44,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E57  | v0.56.0 → v0.57.0 | silent-behavior + breaking (C57.4, C57.5, C57.6 abort startup) | 6 | none | if any alert, runbook, synthetic check, or contract test parses the driver error out of `/ready`'s database `503` body, repoint it at the app log or `<debug.pathprefix>/health-debug` (default `/_sys`) — the field is now the fixed string `database unavailable` (C57.1); and if you implement your own critical `app.Prober`, its `503` body now reads `<Name> unavailable` instead of its raw error, since sanitization became the default rather than an opt-in (C57.2); and if anything reads `db_stats.connections` out of `/ready`'s **200** body — a per-tenant pool dashboard, an activity alert, a test pinning the key set — repoint it at `<debug.pathprefix>/health-debug` or the OTel database metrics, because that array is gone from `/ready`; a repo-local grep alone will not find an out-of-repo dashboard (C57.3); and check every environment with `outbox.enabled: true` or `inbox.enabled: true` (outside per-tenant fan-out or a dynamic source) for a configured, reachable database whose ledger table exists — or whose `autocreatetable` can create it — because Init now aborts startup instead of booting green (C57.4); and check every `database.connectionstring` (root, `databases.*`, `multitenant.tenants.*`) with no `database.type` set — a recognized scheme (`postgres://`, `postgresql://`, `oracle://`) now infers its type and actually dials instead of booting into a dead connection, and an unrecognized scheme on the built-in connector now fails startup instead of failing at first query (C57.5); and check every environment for a database identity key delivered as an empty string (an empty `secretKeyRef`, `envsubst` over an unset variable) — that shape used to load silently as database-free and now aborts startup naming the key (C57.6) |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
+
 - **`when: match`** → act only if `detect` returns ≥1 line (an API/arity/interface change, or a config key you set).
 - **`when: no-match`** → act only if `detect` returns 0 lines. These are **default flips**: you are affected *precisely because the key is unset*, so the new default now governs you. A naive agent that greps, finds nothing, and concludes "not affected" is **wrong** for these — the miss is the actionable case.
 - Per class: **compile-break** atoms are build-driven — you may defer reading them and let `go build ./...` at the hop's `exit` enumerate them, then fix to green. **silent-behavior / silent-config** have no compiler safety net — you MUST run their `detect`. **additive-optional / no-consumer-action** — skip unless adopting the feature.
@@ -49,6 +52,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 > **Writing a `detect`: never use a PCRE escape in `git grep -E`.** Git's POSIX-ERE engine has no `\b`/`\s`/`\d`/`\w`; it strips the backslash and matches the bare letter, so `'Allow\b'` matches `Allowb` and not `Allow,`. The pattern still compiles and still exits cleanly — it just silently matches nothing, and step 4's `when: match` gate then reports "not affected" to every consumer. Use `[[:space:]]`, `[[:digit:]]`, `[[:alnum:]_]`, and `([^A-Za-z0-9_]|$)` for a trailing word boundary; `git grep -P` works only where git was built with PCRE. This applies to `git grep` only — a plain `grep -E` further down a pipe is GNU/BSD grep and handles `\b` fine.
 
 **5 — Execute, one of two modes:**
+
 - **WALK (default, safest):** for each edge left→right — run each atom's gate and apply/verify the actionable ones, then run the edge's `exit` line (build + test, then `go get @<node> && go mod tidy`). Don't advance until green. `go.mod` sits at a real released tag after every hop, so a failure bisects to one edge.
 - **DIRECT-JUMP (token-efficient over a wide range):** run every selected hop's `preflight` FIRST (these guard data hazards that are unrecoverable after the bump), then a single `go get @<TARGET> && go mod tidy`, let one `go build ./...` batch all compiler-caught edits, then run every silent atom's gate once. When two atoms touch the same config key/symbol across hops, apply only the later one. Fall back to WALK if a build break is hard to localize.
 
@@ -60,22 +64,27 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - exit: `go get github.com/gaborage/go-bricks@v0.40.0 && go mod tidy && go build ./... && go test ./...`
 
 ### [C40.1] Vendor-aware unique/FK/not-found error classifiers · additive-optional
+
 - note: New `database.IsUniqueViolation(err)`, `IsForeignKeyViolation(err)`, `IsNotFound(err)`, `ConstraintName(err)` classify pgx (SQLSTATE 23505/23503) and go-ora (ORA-00001/02291) errors via `errors.As` over the wrap chain — adopt to replace hand-rolled driver error-string matching (wrap driver errors with `%w`, not `%v`, for the chain to traverse). Purely additive; existing error handling is untouched.
 - ref: CHANGELOG 0.40.0 · #542 · database/errors.go
 
 ### [C40.2] database.WithTx / WithTxOptions transaction helpers · additive-optional
+
 - note: `database.WithTx(ctx, db, func(ctx, tx) error {...})` commits on nil, rolls back on error, and rolls back + re-panics on panic (committed-flag guard suppresses post-commit rollback noise); `WithTxOptions(ctx, db, *sql.TxOptions, fn)` adds isolation/read-only. Optional cleanup for the demo's manual `db.Begin`/`Commit`/`Rollback` blocks in `internal/modules/products/service/service.go`; manual tx code still compiles and runs unchanged.
 - ref: CHANGELOG 0.40.0 · #543 · database/transaction.go
 
 ### [C40.3] inbox ProcessOnce durable idempotency ledger · additive-optional
+
 - note: New `inbox` module — consumer-side complement to the outbox. Register `inbox.NewModule()` to get `deps.Inbox.ProcessOnce(ctx, eventID, func(ctx, tx) error {...})`, which records the id and runs the handler exactly once per id in one transaction (redelivery of a known id short-circuits, returns nil); the ledger table auto-creates on first use only when `inbox.autocreatetable: true` (opt-in; default false — otherwise you must provision the table yourself). No existing consumer breaks; adopt only for exactly-once handling.
 - ref: CHANGELOG 0.40.0 · #545 · inbox/inbox.go
 
 ### [C40.4] outbox exports x-outbox-event-id header + EventIDFromHeaders · additive-optional
+
 - note: `outbox.HeaderEventID` (`"x-outbox-event-id"`) and `outbox.EventIDFromHeaders(amqp.Table) (string, bool)` are now exported so consumers can pull the event id off AMQP delivery headers (normalizes string vs `[]byte`) to feed `inbox.ProcessOnce` or custom dedup. Optional correlation helper; nothing to change if you don't dedup consumer-side.
 - ref: CHANGELOG 0.40.0 · #544 · outbox/headers.go
 
 ### [C40.5] Comma-separated env vars now split into []string fields · silent-behavior · when: match
+
 - detect: `grep -rnE '^[A-Z][A-Z0-9_]*=[^=]*,' .env .env.example deploy k8s 2>/dev/null`
 - gate: match = you set an env var whose value contains a comma AND it binds to a `[]string` config field (e.g. `SCHEDULER_SECURITY_CIDRALLOWLIST`, `SCHEDULER_SECURITY_TRUSTEDPROXIES`) — it now decodes to multiple trimmed slice elements instead of one literal string; also, a non-empty `scheduler.security.cidrallowlist`/`trustedproxies` that resolves to zero valid CIDRs now FAILS startup instead of silently degrading to localhost-only. (This demo sets no such env vars → not affected.)
 - apply: Confirm each comma-containing env var was intended as a list; if a literal comma was meant for a scalar field, restructure the value so it no longer binds to a `[]string`.
@@ -83,6 +92,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: CHANGELOG 0.40.0 · #548 · config/converters.go
 
 ### [C40.6] outbox index names derived from table's last segment · silent-behavior · when: match
+
 - detect: `grep -rniE 'outbox:' -A6 config*.yaml | grep -iE 'tablename\s*:\s*\S+\.\S+'`
 - gate: match = your `outbox.tablename` is schema-qualified (e.g. `myschema.outbox`); generated index names now use only the last segment (`outbox`) so they are valid, un-dotted identifiers. (This demo uses `tablename: gobricks_outbox` — no dot → not affected.)
 - apply: None required; if migrating from an older run that created dotted/invalid index names, drop any stale duplicate index left by the old naming.
@@ -97,6 +107,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - exit: `go get github.com/gaborage/go-bricks@v0.40.1 && go mod tidy && go build ./... && go test ./...`
 
 ### [C401.1] ADR-024: 21 snake_case config keys renamed to flat-smushed · silent-config · when: match
+
 - detect: `git grep -nE '(^[[:space:]]*|\.)(max_size|idle_ttl|cleanup_interval|sensitive_fields|reinit_delay|resend_delay|connection_timeout|max_delay|max_cached|table_name|auto_create_table|default_exchange|poll_interval|batch_size|max_retries|retention_period|secret_min_length)[[:space:]]*:' -- '*.yaml' '*.yml'` (leaf-anchored so it matches BOTH nested and flat-dotted YAML — a `outbox\.table_name` dotted grep silently misses the nested `outbox:`→`table_name:` form the framework actually uses; also grep the UPPER_SNAKE env forms — `OUTBOX_TABLE_NAME`, `KEYSTORE_SECRET_MIN_LENGTH`, … — in deploy manifests)
 - gate: match = you set one of the 21 underscored keys, so on upgrade it stops binding and silently falls back to its default with NO error (e.g. `outbox.auto_create_table` → `false`, table never created; `outbox.default_exchange` → `""`, events never route; note keys with framework defaults like `outbox.batch_size` fall back to `100`, not zero). no-match = you use none of them (or already flat-smushed), unaffected.
 - apply: rename each YAML leaf AND env var to the underscore-free form per the 21-row table below (§ Config Keys — Flat-Smushed Rename (ADR-024)) — `outbox.table_name`→`outbox.tablename`, `OUTBOX_TABLE_NAME`→`OUTBOX_TABLENAME`, `keystore.secret_min_length`→`keystore.secretminlength`, etc. Go struct field names are unchanged.
@@ -104,6 +115,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: ADR-024 · #549 · wiki/adr_024_config_key_flatsmush.md
 
 ### [C401.2] Docs: corrected server-path env var names and .env.example orphans · no-consumer-action
+
 - note: Docs-only correction of the documented `server.path.*` env-var names and stale `.env.example` entries; no runtime or API change. Optionally cross-check that any `SERVER_PATH_*` vars in your `.env`/manifests match the corrected names (`grep -rniE 'server\.path|SERVER_PATH' .env* config*.yaml`).
 - ref: CHANGELOG 0.40.1 · #551
 
@@ -115,6 +127,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - exit: `go get github.com/gaborage/go-bricks@v0.41.0 && go mod tidy && go build ./... && go test ./...`
 
 ### [C41.1] server.gzip.minlength now defaults to 1024 bytes · silent-behavior · when: no-match
+
 - detect: `grep -rniE 'gzip\.minlength|SERVER_GZIP_MINLENGTH' config*.yaml etc/ deploy/`
 - gate: no-match = the new default now governs you, because the key is unset — responses smaller than 1024 bytes are now sent uncompressed (previously gzip compressed everything).
 - apply: Leave unset to keep the new (faster, less header overhead) behavior OR set `server.gzip.minlength: 0` to restore always-compress.
@@ -122,56 +135,72 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: ADR-026 · #559
 
 ### [C41.2] X-Response-Time header now opt-in; server.CORS() gains leading exposeResponseTime bool · compile-break · when: match
+
 - detect: `git grep -nE 'X-Response-Time|responsetime\.enabled|SERVER_RESPONSETIME_ENABLED|server\.CORS\('`
 - scope: The header is now OFF by default for ALL apps (silent): the `Timing` middleware is gated behind `server.responsetime.enabled` (default false), and CORS stops advertising it in `Access-Control-Expose-Headers`. Only DIRECT callers of `server.CORS(...)` hit the compile break — the standard `app.New()` bootstrap does not call it directly, but still loses the header. If a client/test reads `X-Response-Time`, set `server.responsetime.enabled: true` (or `SERVER_RESPONSETIME_ENABLED=true`). `X-Request-ID` / `traceparent` are unaffected.
 - before:
+
   ```go
   func CORS(envOverride ...string) echo.MiddlewareFunc
   // call site:
   e.Use(server.CORS(cfg.App.Env))
   ```
+
 - after:
+
   ```go
   func CORS(exposeResponseTime bool, envOverride ...string) echo.MiddlewareFunc
   // call site:
   e.Use(server.CORS(cfg.Server.ResponseTime.Enabled, cfg.App.Env))
   ```
+
 - verify: `go build ./...`
 - ref: ADR-026 · #563
 
 ### [C41.3] logger.LogEvent interface gained Enabled() bool · compile-break · when: match
+
 - detect: `git grep -nE 'logger\.LogEvent([^A-Za-z0-9_]|$)'`
 - scope: Any external type implementing `logger.LogEvent` (custom adapters, test doubles). The framework's own `LogEventAdapter` already implements it (delegating to zerolog's nil-safe `Event.Enabled()`); apps that only consume `deps.Logger` are unaffected.
 - before:
+
   ```go
   type stubEvent struct{ /* ... */ }
   func (e *stubEvent) Msg(string) {}
   // no Enabled() method
   ```
+
 - after:
+
   ```go
   type stubEvent struct{ /* ... */ }
   func (e *stubEvent) Msg(string) {}
   func (e *stubEvent) Enabled() bool { return true } // or delegate to the underlying event
   ```
+
 - verify: `go build ./...`
 - ref: ADR-026 · #559
 
 ### [C41.4] server.SetupMiddlewares gained explicit observabilityEnabled bool param · compile-break · when: match
+
 - detect: `git grep -nE 'SetupMiddlewares\('`
 - scope: Only direct callers of `server.SetupMiddlewares`. Apps using the normal `app`/server bootstrap are unaffected. The OTel HTTP middleware is now registered only when the flag is true (zero per-request span/metric overhead when observability is off).
 - before:
+
   ```go
   server.SetupMiddlewares(e, log, cfg, healthPath, readyPath)
   ```
+
 - after:
+
   ```go
   server.SetupMiddlewares(e, log, cfg, cfg.Bool("observability.enabled", false), healthPath, readyPath)
   ```
+
 - verify: `go build ./...`
 - ref: ADR-026 · #559
 
 ### [C41.5] DB spans/metrics gated on observability.enabled · silent-behavior · when: match
+
 - detect: `git grep -nE 'database\.NewQueryBuilder|database\.Open|SetObservabilityEnabled'`
 - gate: match = you use the `database` package. If you reach it via the `app.New()` bootstrap (this demo does), the gate is set AUTOMATICALLY from `observability.enabled` — no action. Only DIRECT-use apps (no framework bootstrap) now silently suppress DB spans/metrics until they opt in.
 - apply: For framework-bootstrapped apps do nothing OR, in a direct-use app that wants DB telemetry, call `database.SetObservabilityEnabled(true)` at startup.
@@ -179,6 +208,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: ADR-026 · #559
 
 ### [C41.6] Pool idle-connections default now tracks pool.max.connections (was fixed 2) · silent-behavior · when: no-match
+
 - detect: `grep -rniE 'pool\.idle\.connections|POOL_IDLE' config*.yaml etc/`
 - gate: no-match = the new default now governs you, because `database.pool.idle.connections` is unset — the pool now holds up to `pool.max.connections` (default 25) idle instead of 2 (still reaped after `pool.idle.time`, 5m). Fixed a 91% p95 latency regression from constant connection churn, but raises the steady-state server-side connection count ~12.5×.
 - apply: Do nothing to keep the new behavior (run the preflight budget check first) OR set `database.pool.idle.connections: 2` to restore the old cap; update any dashboard/alert keyed to idle==2.
@@ -186,6 +216,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: ADR-025 · #558
 
 ### [C41.7] Observability config keys flat-smushed (#554) — never bound from YAML before · silent-config · when: match
+
 - detect: `git grep -nE 'observability\.metrics\.histogram_aggregation|observability\.logs\.(disable_stdout|slow_request_threshold|sampling_rate)' -- '*.yaml' '*.yml'`
 - gate: match = you set one of the underscored keys. Unlike the ADR-024 rename, these keys NEVER bound from YAML, so your prior setting was silently the default all along — re-verify you actually want the value once it starts taking effect.
 - apply: Rename in YAML and env — `histogram_aggregation`→`histogramaggregation`, `disable_stdout`→`disablestdout`, `slow_request_threshold`→`slowrequestthreshold`, `sampling_rate`→`samplingrate` (env: `OBSERVABILITY_LOGS_SAMPLING_RATE`→`OBSERVABILITY_LOGS_SAMPLINGRATE`, etc.).
@@ -200,6 +231,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - exit: `go get github.com/gaborage/go-bricks@v0.42.0 && go mod tidy && go build ./... && go test ./...`
 
 ### [C42.1] `database.tls.cert/key/ca` now wired into drivers (PG verifies CA; Oracle rejects at startup) · silent-config · when: match
+
 - detect: `grep -rniE 'database\.tls\.(cert|key|ca)|DATABASE_TLS_(CERT|KEY|CA)' config*.yaml deploy/`
 - gate: match = you set one of these keys, so the driver now consumes it — PostgreSQL adds `sslrootcert`/`sslcert`/`sslkey` to the DSN and authenticates the server (a former `mode: require` + `ca:` connection was encrypted-but-unauthenticated and is now CA-verified); Oracle never implemented tcps/wallet so these keys are now rejected at startup validation.
 - apply: PostgreSQL — confirm the CA path and server certificate chain match, or the connection now fails where it previously succeeded unauthenticated. OR Oracle — remove `database.tls.cert`, `database.tls.key`, `database.tls.ca` (they were always no-ops and now fail validation; `database.tls.mode` alone still passes).
@@ -207,6 +239,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: ADR-027 · #582
 
 ### [C42.2] PostgreSQL `BuildUpsert` now binds update values (Oracle MERGE parity) · silent-behavior · when: match
+
 - detect: `git grep -nE 'BuildUpsert|EXCLUDED\.' -- '*.go'`
 - gate: match = you call `QueryBuilder.BuildUpsert` on PostgreSQL or assert on its SQL — the on-conflict clause changed from `SET "col" = EXCLUDED."col"` (which silently reused the *insert* value and ignored `updateColumns`) to `SET "col" = $N` (the caller's update value is bound, matching Oracle).
 - apply: update SQL-string assertions (`EXCLUDED."col"` → `$N`) OR, if you relied on updating to the inserted value, pass the same value in both `insertColumns` and `updateColumns` (result is then identical); calls that passed differing update values were silently wrong before and now apply the intended value — verify intent.
@@ -214,10 +247,12 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: ADR-028 · #583
 
 ### [C42.3] Graceful shutdown stops inbound work (server, consumers) before module teardown · no-consumer-action
+
 - note: `App.Shutdown` reordered to `server → consumers → modules → observability → manager cleanup → closers`, so in-flight handlers no longer run against already-torn-down modules; no code/config change. `messaging.Manager` gains an additive `StopConsumers()` (quiesce without closing). Only adjust if a module's `Shutdown()` implicitly relied on the HTTP server still serving or consumers still delivering — that was the buggy case the reorder fixes.
 - ref: ADR-029 · #585
 
 ### [C42.4] `APP_ENV` now selects the `config.<env>.yaml` overlay · silent-behavior · when: match
+
 - detect: `ls config.*.yaml 2>/dev/null; grep -rniE 'APP_ENV' deploy/`
 - gate: match = you set `APP_ENV` and ship a `config.<env>.yaml` — the overlay suffix was previously read from koanf before the env provider loaded, so the file was ignored (the suffix always came from `config.yaml`/defaults, usually `development`); `APP_ENV` now drives selection, so a formerly-ignored overlay is now loaded.
 - apply: review the now-active `config.<env>.yaml` for correctness in that environment; a malformed `APP_ENV` (not `^[a-z][a-z0-9-]{0,31}$`) is now rejected at startup with an `app.env` error instead of being interpolated into a filename.
@@ -225,6 +260,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: #578
 
 ### [C42.5] Migration `Config.DryRun` is now honored (downgrades migrate to Flyway validate) · silent-behavior · when: match
+
 - detect: `git grep -nE 'DryRun' -- '*.go'`
 - gate: match = a migration pipeline sets `DryRun=true` — it was documented and stamped into the `migration.applied` audit event but never consumed, so it actually ran a real schema-mutating migrate; it now downgrades to the Flyway `validate` verb (no schema change) and emits no `migration.applied` event.
 - apply: if a pipeline set `DryRun=true` but relied on it actually applying schema (contrary to the field's docs), remove `DryRun` or set it `false` for runs that must apply changes.
@@ -232,6 +268,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: #580
 
 ### [C42.6] Outbox/Inbox multi-tenant relay & cleanup fan-out; fail-fast on dynamic tenant source · silent-behavior · when: match
+
 - detect: `grep -rniE 'multitenant\.enabled\s*:\s*true|source\.type\s*:\s*dynamic|multitenant\.tenants' config*.yaml`
 - gate: match = you run multi-tenant with outbox/inbox — the relay/cleanup jobs ran from the scheduler's tenant-less context and could not resolve any tenant DB, so events accumulated and were never delivered and inbox ledgers were never pruned; jobs now fan out across static `multitenant.tenants`. For `source.type: dynamic`: outbox module Init fails, and inbox `RegisterJobs` fails when the scheduler is present.
 - apply: use static `multitenant.tenants` to get per-tenant delivery/cleanup OR, for a dynamic inbox, drop the scheduler to keep `ProcessOnce` without retention cleanup; a dynamic-multitenant app with outbox enabled now fails at startup instead of silently losing events.
@@ -239,6 +276,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: #581
 
 ### [C42.7] Debug/system endpoint IP allowlist now requires a trusted proxy (blocks XFF spoofing) · silent-config · when: match
+
 - detect: `grep -rniE 'debug\.(enabled|trustedproxies|ipwhitelist|allowlist)' config*.yaml`
 - gate: match = you gate debug/`_sys` endpoints by IP behind a proxy — the denial path now derives the client IP via the trusted-proxy-aware `server.ClientIP(...)` instead of echo's spoofable `c.RealIP()`, so an unconfigured proxy chain no longer honors a spoofable `X-Forwarded-For`.
 - apply: set `debug.trustedproxies` to your proxy CIDR(s) so the real client IP is derived from a trusted hop; an invalid CIDR entry now logs a startup WARN whenever debug endpoints are enabled.
@@ -246,6 +284,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: #576 · CHANGELOG 0.42.0
 
 ### [C42.8] httpclient redacts credentials/secrets from logged request URLs · silent-behavior · when: match
+
 - detect: `git grep -nE 'httpclient\.New|WithJOSE' -- '*.go'`
 - gate: match = you make outbound requests whose logs are scraped by a parser keyed on the full URL — logged request URLs now have userinfo credentials and secret query params redacted.
 - apply: none for behavior; adjust any log parser that expected the raw URL with credentials/secrets intact.
@@ -253,6 +292,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: #575 · CHANGELOG 0.42.0
 
 ### [C42.9] messaging publish-confirmation timeout applied; lazy consumers detached from request ctx; contiguous subquery placeholders · silent-behavior · when: match
+
 - detect: `grep -rniE 'messaging\.reconnect\.connectiontimeout' config*.yaml; git grep -niE 'Subquery' -- '*.go'`
 - gate: match = you set `messaging.reconnect.connectiontimeout`, start consumers lazily, or build subquery filters — three bug fixes: the configured `reconnect.connectiontimeout` now actually governs the AMQP client's per-publish broker ACK/NACK confirmation wait (the timeout waiting for a publish-confirm; it is NOT the connection-establishment timeout) (#571), lazily-started consumers no longer inherit/cancel with the triggering request context (#577), and subquery filter placeholders are now numbered contiguously (#579).
 - apply: none required; verify any tests asserting exact subquery placeholder indices.
@@ -267,6 +307,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - exit: `go get github.com/gaborage/go-bricks@v0.43.0 && go mod tidy && go build ./... && go test ./...`
 
 ### [C43.1] Query builder validates direct-string identifiers on all vendors · silent-behavior · when: match
+
 - detect: `git grep -nE '\.(From|OrderBy|GroupBy|JoinOn|LeftJoinOn|RightJoinOn|InnerJoinOn|CrossJoinOn|Set|SetMap)\('`
 - gate: match = you pass an SQL function/expression or dynamic identifier (e.g. `OrderBy("COUNT(*) DESC")`) as a plain string to one of these methods, so `ToSQL()` now returns an error instead of interpolating it. Bare/qualified columns, aliases (`"users u"`), `Table().As()`, and trailing `ASC`/`DESC`/`NULLS FIRST|LAST` still pass; user **values** through the Filter API were never affected.
 - apply: wrap function/expression identifiers in `qb.Expr(...)`/`qb.MustExpr(...)` — e.g. `OrderBy(qb.MustExpr("COUNT(*) DESC"))` — and keep bare column/table identifiers as-is
@@ -274,15 +315,19 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: ADR-031 · #604
 
 ### [C43.2] Per-tenant resource managers return a third ReleaseFunc value · compile-break · when: match
+
 - detect: `git grep -nE '(dbManager|cacheManager|messagingManager|DbManager|CacheManager)\.(Get|Publisher)\(|cache\.Manager([^A-Za-z0-9_]|$)'`
 - scope: only DIRECT callers of the raw managers (`database.DbManager.Get`, `messaging.Manager.Publisher`, `cache.CacheManager.Get`); standard apps on `deps.DB(ctx)`/`deps.Cache(ctx)`/`deps.Messaging(ctx)`/`deps.DBByName` and the `ResourceProvider` interface are unaffected — the framework leases/releases for you
 - before:
+
   ```go
   conn, err := dbManager.Get(ctx, tenantID)
   client, err := messagingManager.Publisher(ctx, tenantID)
   inst, err := cacheManager.Get(ctx, tenantID)
   ```
+
 - after:
+
   ```go
   conn, release, err := dbManager.Get(ctx, tenantID) // Get(ctx, key) (Interface, ReleaseFunc, error)
   if err != nil {
@@ -296,29 +341,36 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
   inst, release, err := cacheManager.Get(ctx, tenantID) // cache.CacheManager.Get(ctx, key): (Cache, ReleaseFunc, error)
   // ... defer release()  // on error the returned ReleaseFunc is nil — check err first
   ```
+
 - verify: `go build ./...`
 - ref: ADR-032 · #606/#607
 
 ### [C43.3] PoolKeepAliveConfig.Enabled changed from bool to *bool · compile-break · when: match
+
 - detect: `git grep -nE 'PoolKeepAliveConfig|KeepAlive\.Enabled'`
 - scope: code that constructs `config.PoolKeepAliveConfig` directly or reads `.Enabled` as a `bool` (e.g. tests, custom config wiring); YAML/env `database.pool.keepalive.enabled` binding is unchanged
 - before:
+
   ```go
   PoolKeepAliveConfig{Enabled: true}
   PoolKeepAliveConfig{Enabled: false}
   if cfg.Pool.KeepAlive.Enabled { ... }
   ```
+
 - after:
+
   ```go
   PoolKeepAliveConfig{Enabled: observability.BoolPtr(true)}
   PoolKeepAliveConfig{Enabled: observability.BoolPtr(false)}
   PoolKeepAliveConfig{}                          // nil → defaulted to enabled at validation
   if cfg.Pool.KeepAlive.IsEnabled() { ... }      // nil-safe reader (nil treated as disabled)
   ```
+
 - verify: `go build ./...`
 - ref: ADR-030 · #601
 
 ### [C43.4] Bare section-named env vars dropped before koanf unflatten; scalar-over-map merge guard · silent-behavior · when: match
+
 - detect: `env | grep -iE '^(DEBUG|CACHE|DATABASE|DATABASES|SERVER|APP|LOG|MESSAGING|MULTITENANT|SOURCE|SCHEDULER|OUTBOX|INBOX|KEYSTORE|OBSERVABILITY)=|=tcp://'`
 - gate: match = you set a bare section-named var (`DEBUG=1`, `CACHE=…`, `MULTITENANT=…`) or a K8s docker-link var (`SERVER_PORT=tcp://10.96.0.1:80`). The env loader has NO prefix filter — it still ingests EVERY process env var; what changed is that a bare var whose full key exactly equals a top-level section name is now dropped before koanf unflattens (previously it clobbered that section's map and crashed startup with `expected a map or struct, got string`), plus a scalar-over-map merge guard. Sub-keyed vars (`DEBUG_ENABLED`, `CACHE_REDIS_HOST`) AND all unrelated/app-specific vars still bind exactly as before; `custom` is deliberately NOT in the dropped set.
 - apply: none required for the common case — sub-keyed and app-specific vars are unaffected. Only remove or rename any BARE section-named var (or scalar that would overwrite a section map) that you relied on; `custom.*` settings continue to bind.
@@ -326,10 +378,12 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: #601
 
 ### [C43.5] App consumes validated startup-budget & manager-tuning keys; warns on under-provisioned pools · additive-optional
+
 - note: new startup-budget/manager-tuning config keys are now honored (#600) and evicted handles close outside the manager lock, emitting an under-provisioned-pool WARN at startup (#605); no action — optionally tune the new keys and heed the pool WARN.
 - ref: #600/#605 · CHANGELOG 0.43.0
 
 ### [C43.6] Oracle identifier quoting correction in query builder · silent-behavior · when: match
+
 - detect: `git grep -nE 'NewQueryBuilder\(database\.Oracle|database\.Oracle'`
 - gate: match = you build queries with the Oracle dialect and assert on the generated SQL string — Oracle identifier quoting is corrected (#603), so quoted-identifier expectations may shift. Runtime behavior needs no change.
 - apply: update any Oracle SQL-string assertions to the corrected quoting
@@ -344,10 +398,12 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - exit: `go get github.com/gaborage/go-bricks@v0.44.0 && go mod tidy && go build ./... && go test ./...`
 
 ### [C44.1] CI: actions/checkout bumped to v7 (framework-internal workflows only) · no-consumer-action
+
 - note: The BREAKING label on #609 is scoped to go-bricks' own GitHub Actions workflows, not to any Go symbol. Your app's `.github/workflows/*.yml` are independent — this demo's `ci.yml`/`security.yml` are unaffected. Only act if you literally copied go-bricks' workflow files: then bump `actions/checkout@v6`→`v7` yourself (`grep -rniE 'actions/checkout@v[0-9]' .github/workflows/`).
 - ref: #609 · CHANGELOG 0.44.0
 
 ### [C44.2] Transitive dependency bumps (amqp091-go v1.12.0, go-redis v9.21.0, echo/v5 v5.2.1, testcontainers v0.43.0) · no-consumer-action
+
 - note: These are pulled in automatically when you bump go-bricks; `go mod tidy` reconciles your `go.mod` (this demo already resolves `labstack/echo/v5 v5.2.1`, `amqp091-go v1.12.0`, `redis/go-redis/v9 v9.21.0`). No public API impact — verify only with `go build ./... && go test ./...`. Confirm with `go list -m all | grep -E 'amqp091-go|go-redis|labstack/echo|testcontainers'`.
 - ref: #616 · #598 · #612 · CHANGELOG 0.44.0
 
@@ -359,9 +415,11 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - exit: `go get github.com/gaborage/go-bricks@v0.45.0 && go mod tidy && go build ./... && go test ./...`
 
 ### [C45.1] Custom middleware: Echo nested closure → flat `server.MiddlewareFunc` · compile-break · when: match
+
 - detect: `git grep -nE 'echo\.(HandlerFunc|MiddlewareFunc)|func\([a-z]* \*?echo\.Context\)|next\(c\)'`
 - scope: apps that write their own middleware; standard `app.New()` bootstrap and typed handlers are unaffected.
 - before:
+
   ```go
   func Auth(next echo.HandlerFunc) echo.HandlerFunc {
       return func(c *echo.Context) error {
@@ -375,7 +433,9 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
       }
   }
   ```
+
 - after:
+
   ```go
   func Auth() server.MiddlewareFunc {
       return func(c server.HandlerContext, next func() error) error {
@@ -388,13 +448,16 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
       }
   }
   ```
+
 - verify: `go build ./...`
 - ref: ADR-034 · #627 · wiki/adr_034_echo_boundary_types.md
 
 ### [C45.2] `HandlerContext.Echo` removed → typed accessors · compile-break · when: match
+
 - detect: `git grep -nE 'ctx\.Echo|hctx\.Echo|\.Echo\.(Request|Response)'`
 - scope: handlers/middleware that reached through the removed `.Echo` field; use `RequestContext()`, `Request()`/`ResponseWriter()`, `Param`/`Query`/`RequestHeader`/`Get`/`Set`.
 - before:
+
   ```go
   func (h *Handler) getUser(req GetReq, ctx server.HandlerContext) (server.Result[User], server.IAPIError) {
       reqCtx := ctx.Echo.Request().Context()
@@ -402,7 +465,9 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
       // ...
   }
   ```
+
 - after:
+
   ```go
   func (h *Handler) getUser(req GetReq, ctx server.HandlerContext) (server.Result[User], server.IAPIError) {
       reqCtx := ctx.RequestContext()
@@ -410,14 +475,17 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
       // ...
   }
   ```
+
 - verify: `go build ./...`
 - note (restored in v0.46.0): three v0.44 capabilities had NO v0.45 substitute and are restored as typed accessors in v0.46.0 — `ctx.Echo.Path()` → `ctx.RouteTemplate()`, `ctx.Echo.PathValues()` → `ctx.PathParams()` (neutral `[]server.PathParam`, route-template order, defensive copy), `ctx.Echo.SetPathValues(...)` → `ctx.SetPathParams(...)`. Projects landing on v0.45 with any of these call sites should proceed to v0.46 rather than work around. SEMANTIC CHANGE for PathValues() migrants: the v0.44 slice was a LIVE view — in-place element writes reached `Param()` and `param:` binding; the v0.46 `PathParams()` slice is a defensive copy, so in-place mutation silently does nothing. Rewrite mutation sites to read → modify → `ctx.SetPathParams(modified)`. WARNING: do not substitute stdlib `ctx.Request().PathValue(name)` — under echo v5 it is ALWAYS empty (echo deliberately never populates stdlib path values); and `ctx.Request().Pattern`, while it currently carries the template, is unpromised engine behavior — use `RouteTemplate()`.
 - ref: ADR-034 · #627 · wiki/adr_034_echo_boundary_types.md
 
 ### [C45.3] `ServerRunner.Echo()` removed → `RootGroup()`/`ModuleGroup()`; `RegisterReadyHandler` retyped · compile-break · when: match
+
 - detect: `git grep -nE 'runner\.Echo\(\)|RegisterReadyHandler|scheduler\.CIDRMiddleware|e\.(GET|POST|Use)\('`
 - scope: apps that grabbed the raw `*echo.Echo` for `_sys`/debug routes or overrode readiness; `scheduler.CIDRMiddleware` now returns `server.MiddlewareFunc` (call site unchanged — only explicit `var` types).
 - before:
+
   ```go
   e := runner.Echo()
   e.Use(server.LoggerWithConfig(appLogger, cfg))
@@ -426,7 +494,9 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
       return c.JSON(http.StatusOK, map[string]string{"status": "ready"})
   })
   ```
+
 - after:
+
   ```go
   root := runner.RootGroup() // no basePath; ModuleGroup() applies basePath for app routes
   root.Use(server.LoggerWithConfig(appLogger, cfg))
@@ -435,67 +505,84 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
       return c.JSON(http.StatusOK, map[string]string{"status": "ready"})
   }) // pass nil to restore the built-in readiness check
   ```
+
 - verify: `go build ./...`
 - ref: ADR-034 · #627 · wiki/adr_034_echo_boundary_types.md
 
 ### [C45.4] Framework middleware constructors return `server.MiddlewareFunc`; `SkipperFunc` takes `*http.Request`; `EscalateSeverity` is a method · compile-break · when: match
+
 - detect: `git grep -nE 'echo\.MiddlewareFunc|server\.EscalateSeverity\(|SkipperFunc'`
 - scope: only code with explicit `echo.MiddlewareFunc` var types, a `SkipperFunc`, or the removed package-level `server.EscalateSeverity(c, level)`; plain `r.Use(server.CORS(...))` call sites are unchanged.
 - before:
+
   ```go
   var cors echo.MiddlewareFunc = server.CORS(exposeResponseTime, env)
   func skip(c *echo.Context) bool { return c.Path() == "/health" }
   // ... in a middleware:
   server.EscalateSeverity(c, zerolog.WarnLevel)
   ```
+
 - after:
+
   ```go
   var cors server.MiddlewareFunc = server.CORS(exposeResponseTime, env)
   func skip(r *http.Request) bool { return r.URL.Path == "/health" }
   // ... in a middleware (c is a server.HandlerContext):
   c.EscalateSeverity(zerolog.WarnLevel)
   ```
+
 - note: the skipper rewrite `c.Path() == "/health"` → `r.URL.Path == "/health"` swaps a route-template check for a concrete-URL check — equivalent ONLY for static routes. For parameterized routes (`/users/:id` matches `/users/42`, `/users/43`, …) the faithful migration target is the route template via `ctx.RouteTemplate()` (v0.46.0+, see the C45.2 note) — i.e. compare inside the middleware body, where the `server.HandlerContext` is available, instead of in the `*http.Request` skipper.
 - verify: `go build ./...`
 - ref: ADR-034 · #627 · wiki/adr_034_echo_boundary_types.md
 
 ### [C45.5] Tests build the context via `server.NewHandlerContextForTest` · compile-break · when: match
+
 - detect: `git grep -nE 'echo\.New\(\)\.NewContext|e\.NewContext\('`
 - scope: unit tests that hand-built an echo context to drive a handler; handlers are now `server.Handler`. `NewHandlerContextForTest` returns a `server.HandlerContext` (no `Bind` method) — replace any echo-context calls the test made, e.g. `echoCtx.Bind(&req)` → `json.NewDecoder(req.Body).Decode(&req)`. Echo remains a `go.mod` dependency (server/ uses it internally); it drops to `// indirect` only if you remove ALL direct echo references, including test-only constants like `echo.HeaderContentType`/`echo.MIMEApplicationJSON` — otherwise it stays a direct dep, which is fine.
 - before:
+
   ```go
   e := echo.New()
   c := e.NewContext(req, rec)
   err := handler.GetUser(c) // raw echo handler
   ```
+
 - after:
+
   ```go
   ctx := server.NewHandlerContextForTest(rec, req, cfg)
   err := handler.GetUser(ctx) // handler is now a server.Handler
   ```
+
 - verify: `go test ./...`
 - ref: ADR-034 · #627 · wiki/adr_034_echo_boundary_types.md
 
 ### [C45.6] Custom `outbox.Store`: `FetchPending` loses `maxRetries`; new `MarkDeadLettered` · compile-break · when: match
+
 - detect: `git grep -nE 'FetchPending|outbox\.Store|MarkDeadLettered'`
 - scope: only apps that implement a custom `outbox.Store`; apps using `deps.Outbox` / the built-in PostgreSQL & Oracle stores need no change.
 - before:
+
   ```go
   // FetchPending was retry_count-gated and took maxRetries:
   FetchPending(ctx context.Context, db dbtypes.Interface, batchSize, maxRetries int) ([]Record, error)
   // (no MarkDeadLettered method)
   ```
+
 - after:
+
   ```go
   // FetchPending is status-gated only (drops maxRetries):
   FetchPending(ctx context.Context, db dbtypes.Interface, batchSize int) ([]Record, error)
   // new terminal-parking method for poison events:
   MarkDeadLettered(ctx context.Context, db dbtypes.Interface, eventID, errMsg string) error
   ```
+
 - verify: `go build ./...`
 - ref: ADR-033 · #626 · wiki/adr_033_outbox_retry_count_status_parking.md
 
 ### [C45.7] `messaging.Publish`/`PublishToExchange` are now bounded — return `ErrPublishRetriesExhausted` · silent-behavior · when: match
+
 - detect: `git grep -nE 'PublishToExchange|\.Publish\(ctx|== context\.(Canceled|DeadlineExceeded)|ErrPublish'`
 - gate: match = you call `Publish`/`PublishToExchange` directly, so the old "blocks forever until ACK/shutdown" assumption is now wrong — after `messaging.reconnect.maxpublishattempts` (default 5) it returns `ErrPublishRetriesExhausted` wrapping the cause, and once at least one publish attempt has failed, cancel/deadline errors are *wrapped*, so an `err == context.Canceled` / `== context.DeadlineExceeded` comparison can silently stop matching (use `errors.Is`).
 - apply: Handle the returned error instead of assuming an infinite block (the durable path is the outbox, which retries next cycle) AND switch publish-error comparisons from `==` to `errors.Is(err, ...)`.
@@ -503,6 +590,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: ADR-033 · #626 · wiki/adr_033_outbox_retry_count_status_parking.md
 
 ### [C45.8] New config keys + startup validation (`maxpublishattempts`, `publishtimeout ≥ connectiontimeout`) · silent-config · when: no-match
+
 - detect: `grep -rniE 'messaging\.reconnect\.maxpublishattempts|outbox\.publishtimeout|messaging\.reconnect\.connectiontimeout' config*.yaml`
 - gate: no-match = the new defaults now govern you because the keys are unset — `messaging.reconnect.maxpublishattempts=5` and `outbox.publishtimeout=60s` apply automatically; harmless unless you later set `outbox.publishtimeout` below `messaging.reconnect.connectiontimeout`, which the outbox module now rejects at startup.
 - apply: Leave unset to accept the safe defaults, OR if you set `outbox.publishtimeout` keep it `>= messaging.reconnect.connectiontimeout`.
@@ -510,6 +598,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: ADR-033 · #626 · wiki/adr_033_outbox_retry_count_status_parking.md
 
 ### [C45.9] Status-driven parking → re-delivery surge of previously soft-parked outbox rows · silent-behavior · when: match
+
 - detect: `psql ... -c "SELECT count(*) FROM gobricks_outbox WHERE status='pending' AND retry_count >= <outbox.maxretries>;"` (run BEFORE upgrading)
 - gate: match = that count is > 0 — before ADR-033 those rows were retry_count-gated out and left silently `pending`; the new status-gated `FetchPending` fetches them, so on the first post-upgrade relay cycle they all re-publish in a burst (correct at-least-once un-sticking, but a surprising surge). No DB migration is needed (the `status` column / `'failed'` value already exist).
 - apply: Run the count query before upgrading, then either let idempotent consumers absorb the re-delivery OR delete the rows you intend to abandon; note `'failed'` rows now accumulate (`DeletePublished` purges only `'published'`) — monitor and prune.
@@ -524,6 +613,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - exit: `go get github.com/gaborage/go-bricks@v0.49.0 && go mod tidy && go build ./... && go test ./...`
 
 ### [C49.1] messaging.* defaults/validation now run without a root broker URL — outbox timeout guards armed in multi-tenant · silent-config · when: match
+
 - detect: `git grep -nE '(^[[:space:]]*|\.)(publishtimeout|connectiontimeout|readytimeout)[[:space:]]*:' -- '*.yaml' '*.yml'` (leaf-anchored so it matches BOTH the nested `outbox:`→`publishtimeout:` form and flat-dotted keys; also grep the env forms `OUTBOX_PUBLISHTIMEOUT`, `MESSAGING_RECONNECT_CONNECTIONTIMEOUT`, `MESSAGING_RECONNECT_READYTIMEOUT` in deploy manifests) — and check `messaging.*` keys for negative values (`git grep -nE ':[[:space:]]*-[0-9]' -- '*.yaml' '*.yml'`)
 - gate: match = (a) you run multi-tenant with the outbox module and set `outbox.publishtimeout` below the effective `messaging.reconnect.connectiontimeout` (default 30s) **or** `messaging.reconnect.readytimeout` (default 5s) — both guards were silently skipped in multi-tenant mode because those timeouts stayed 0 without a root broker URL, so the config booted and then risked the unbounded duplicate-delivery loop the checks exist to prevent; startup now rejects it by design (`outbox.publishtimeout` defaults to 60s, so leaving it unset = unaffected); or (b) any deployment mode without a root `messaging.broker.url` carries a negative `messaging.*` value — previously silently ignored, now a startup validation error naming the key.
 - apply: (a) raise `outbox.publishtimeout` to `>= max(messaging.reconnect.connectiontimeout, messaging.reconnect.readytimeout)` (with defaults: `>= 30s`); (b) delete or correct negative `messaging.*` values. Single-tenant deployments WITH a broker URL already had defaults and guards applied — nothing changes for them.
@@ -531,6 +621,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: #659 · config/validation.go: validateMessaging · wiki/outbox.md
 
 ### [C49.2] Single-tenant publisher IdleTTL default 10m → 1h; cold publishes wait for readiness · silent-behavior · when: no-match
+
 - detect: `git grep -nE '(^[[:space:]]*|\.)idlettl[[:space:]]*:' -- '*.yaml' '*.yml'` (also `MESSAGING_PUBLISHER_IDLETTL` in deploy manifests)
 - gate: no-match = you left `messaging.publisher.idlettl` unset in a single-tenant deployment, so the effective idle-eviction TTL rises from 10m to 1h (#660) — publishers for low-frequency publish cadences stay warm longer (the fix for the once-daily cold-publish failure class, #655). Multi-tenant default stays 10m; explicitly-set values are untouched. Independently, the first publish on a cold publisher now waits up to `messaging.reconnect.readytimeout` (default 5s) for client readiness instead of failing fast with `ErrNotConnected` (#656), and evictions/idle-cleanups now log at Info with `Stats()` counters (#657).
 - apply: none required; set `messaging.publisher.idlettl` explicitly if you relied on the 10m eviction cadence.
@@ -538,6 +629,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: #655 #656 #657 #660 · app/managers.go · messaging/amqp_client.go
 
 ### [C49.3] database.manager.* pool keys go live (maxsize/idlettl/cleanupinterval) · silent-config · when: match
+
 - detect: `git grep -nE '(^[[:space:]]*|\.)(maxsize|idlettl|cleanupinterval)[[:space:]]*:' -- '*.yaml' '*.yml'` then keep only hits under a `database:`/`databases:`/tenant `database:` block (leaf-anchored: matches nested and flat-dotted forms); also grep `DATABASE_MANAGER_` in deploy manifests
 - gate: match = you already carry `database.manager.*` keys or `DATABASE_MANAGER_*` env vars — inert (silently ignored) on v0.45–v0.48, they now bind: negative values abort startup naming the key, and a `manager` block under `databases.<name>` or `multitenant.tenants.<id>.database` is now rejected at startup (it was and remains non-functional — only the primary `database.manager.*` is honored). no-match = adopt-only: unset keys default to today's exact hardcoded behavior, byte-identical (single-tenant 10 / 1h / 5m; multi-tenant `maxsize` still scales to `multitenant.limits.tenants`, `idlettl` 30m, `cleanupinterval` 5m). The keys govern the single process-wide manager, which also caches named `databases.<name>` and per-tenant handles — count those when sizing `maxsize` (see wiki/database.md).
 - apply: delete stale/negative `database.manager.*` values and any `manager` block under named/tenant database entries; set the primary keys only to tune the pool.
@@ -545,6 +637,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: #658 · config/validation.go: applyDatabaseManagerDefaults · app/managers.go: BuildDatabaseOptions · wiki/database.md
 
 ### [C49.4] messaging.reconnect delay/backoff keys go live (delay/maxdelay/reinitdelay/resenddelay) · silent-config · when: match
+
 - detect: `git grep -nE '(^[[:space:]]*|\.)(delay|maxdelay|reinitdelay|resenddelay)[[:space:]]*:' -- '*.yaml' '*.yml'` then keep only hits under a `messaging:`→`reconnect:` block (leaf-anchored: matches nested and flat-dotted forms); also grep `MESSAGING_RECONNECT_DELAY`, `MESSAGING_RECONNECT_MAXDELAY`, `MESSAGING_RECONNECT_REINITDELAY`, `MESSAGING_RECONNECT_RESENDDELAY` in deploy manifests
 - gate: match = you already set one of `messaging.reconnect.{delay,maxdelay,reinitdelay,resenddelay}` — validated and defaulted since forever but silently ignored (the AMQP client used its own hardcoded 5s/60s/2s/5s), these values now take effect on upgrade. Know each knob's exact scope: `delay` is the full-jitter backoff base (each wait is uniform-random in `[0, min(delay·2^attempt, maxdelay))` — an upper bound, NOT a minimum spacing); `maxdelay` caps the connection-reconnect loop only (the consumer re-subscribe loop keeps its fixed 60s cap); `resenddelay` spaces channel-publish-error retries only (broker NACKs retry on a fixed 100ms backoff, confirmation timeouts retry immediately). Startup now also rejects inconsistent pairs: `maxdelay < delay` fails validation, and `outbox.publishtimeout < resenddelay` fails outbox Init (same class as the C45.8 guards). no-match = adopt-only: unset keys default to 5s/60s/2s/5s — byte-identical to the old hardcoded behavior.
 - apply: review any explicitly-set delay/backoff keys — a large previously-inert `delay`/`maxdelay` now stretches reconnect waits that interact with the publish retry budget (`readytimeout` 5s pre-flight × `maxpublishattempts` 5): confirm publish-side timeouts still cover your worst-case backoff. Fix any pair the new startup guards reject.
@@ -552,6 +645,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: #662 · config/validation.go: validateMessaging · messaging/amqp_client.go: WithReconnectDelay/WithReconnectMaxDelay/WithReinitDelay/WithResendDelay · outbox/module.go: validatePublishTimeout
 
 ### [C49.5] multi-tenant cache pool scales to tenant limit when maxsize unset · silent-behavior · when: no-match
+
 - detect: `git grep -nE '(^[[:space:]]*|\.)maxsize[[:space:]]*:' -- '*.yaml' '*.yml'` then keep only hits under a `cache:`→`manager:` block (leaf-anchored: matches nested and flat-dotted forms); also grep `CACHE_MANAGER_MAXSIZE` in deploy manifests
 - gate: no-match = you run multi-tenant (`multitenant.enabled: true`) with `cache.manager.maxsize` unset — the cache pool previously capped at a flat 100 and now scales to **`multitenant.limits.tenants`** (NOT your static tenant count; `limits.tenants` itself defaults to 100, so a >100-tenant fleet must also raise `multitenant.limits.tenants` or the cap — and the pool-below-tenant-count WARN — stays). match = your explicit positive value wins in both modes, but note the falsy-zero: an explicit `maxsize: 0` is indistinguishable from unset (previously coerced to 100, now scales in multi-tenant). Single-tenant unset still defaults to 100; negative is rejected in both modes.
 - apply: multi-tenant fleets above 100 tenants: confirm `multitenant.limits.tenants` covers your fleet (that is the value the pool now scales to). Set `cache.manager.maxsize` explicitly to pin a specific pool size; replace any explicit `maxsize: 0` with the intended positive value.
@@ -559,6 +653,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 - ref: #668 · config/validation.go: applyCacheManagerDefaults · app/managers.go: BuildCacheOptions
 
 ### [C49.6] unit-less numeric durations rejected at config decode (fail-fast) · silent-config · when: match
+
 - detect: `git grep -nE ':[[:space:]]*-?[0-9]+(\.[0-9]+)?([[:space:]]|$|#)' -- '*.yaml' '*.yml'` (tolerates trailing comments) then check each hit's field type — **treat every numeric-valued key as suspect until you've confirmed it is not `time.Duration`**. The regex over-matches genuine numerics (`server.port`, pool/connection counts, `maxsize`, retry counts) which are untouched, but do NOT assume thresholds/intervals are safe: `database.query.slow.threshold`, `database.pool.keepalive.interval`, `database.pool.idle.time`, `database.pool.lifetime.max`, `database.manager.idlettl`/`cleanupinterval`, `observability.metrics.export.interval`, and `app.startup.{timeout,database,messaging,cache,observability}` are all durations, alongside the obvious `timeout`/`delay`/`backoff` leaves. Also scan JSON tenant secrets (pool duration fields) and the tenants file passed to `go-bricks-migrate --source-config`. Env forms (`MESSAGING_RECONNECT_DELAY=300`) already failed pre-upgrade via `time.ParseDuration`'s missing-unit error; only numeric YAML/JSON/TOML leaked through.
 - gate: match = a config carries a non-zero bare number (or a boolean) on a `time.Duration` key (e.g. `delay: 300`) — previously coerced to that many **nanoseconds** by `WeaklyTypedInput` and silently booted (busy-loop tickers, microsecond TTLs, usually masked by runtime fallbacks), now aborts startup naming the value. Negative and float unit-less numerics are rejected the same way. An explicit `0` still means use-the-default (the framework `unset -> default` idiom, byte-identical to before). The guard covers all four decode seams: `config.Load`, the public `deps.Config.Unmarshal`, per-tenant JSON secrets (`migration.SecretsProvider`, now guarded), and the `go-bricks-migrate` CLI's `--source-config` tenants file — the last often lives in a separate ops/infra repo the detect grep never scans, so run it there too.
 - apply: add the unit suffix — `300` → `300s` (or `5m`, `1h30m`).
@@ -843,6 +938,7 @@ git grep -nE '^[[:space:]]*(defer|go)[[:space:]]+.*\.Build\(\)' -- '*.go'
 ```
 
 None of them is exhaustive — all three are line-oriented and blind to an import alias or an unusual layout — so treat them as probes, not proof; a `go/analysis`-based unused-result check (or `errcheck` configured for this symbol) is the only complete answer. Expect false positives in both directions: the first probe matches the terminating `Build()` line of *any* multi-line fluent chain, including one whose result is fully captured on the opening line and including builders that have nothing to do with `httpclient` (go-bricks' own `app.NewAppBuilder()` chain matches it). Read each hit rather than acting on the count: confirm it is an `httpclient` builder **and** that its result is genuinely discarded before touching it. Add an assignment plus real error handling only to the hits that clear both checks — editing a captured chain or an unrelated builder is a regression, not a migration. Once assignment-captured sites compile, a chain that previously logged a WARN now either builds successfully (composed) or returns a non-nil error (genuine discard) — confirm which one your chain hits.
+
 - ref: ADR-044 · `httpclient/client.go` (`Build`) · `httpclient/tls.go` (`WithTLSConfig`)
 
 ### [C56.7] Re-declaring one queue name merges instead of overwriting — an incompatible pair now fails startup · silent-behavior · when: match
@@ -867,10 +963,13 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
 - scope: only code that *names the interface type* — a parameter, field, local, type assertion, or a `var _ cache.Manager = ...` assertion. Callers of the concrete `*cache.CacheManager` are unaffected, as are apps on `deps.Cache(ctx)` / `ResourceProvider`. Nothing inside go-bricks ever implemented or consumed it, and `*CacheManager` never satisfied it either (its `Stats()` returns `ManagerStats`, not `map[string]any` — see `after`), so no in-tree assertion existed to break. A type in **your** module could still satisfy it, which is why this is a `match` gate and not a no-op
 - gate: match = the detect returns ≥1 line. no-match = no Go file names the type. Treat the grep as a probe, not proof — it is line-oriented and blind to an import alias or a dot-import (`import c ".../cache"` then `c.Manager`). the compiler is the authoritative answer for a compile-break atom, since it resolves references regardless of how the package was imported. Use `go build ./... && go test ./...` — `go build` alone skips `_test.go` files, so a test-only reference survives it; and either way the answer covers only the files your active build tags select
 - before:
+
   ```go
   func NewService(m cache.Manager) *Service { ... }
   ```
+
 - after:
+
   ```go
   // Depend on the concrete manager…
   func NewService(m *cache.CacheManager) *Service { ... }
@@ -883,6 +982,7 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
 
   func NewService(m cacheGetter) *Service { ... }
   ```
+
   Exactly one difference made `*CacheManager` unable to satisfy the deleted interface: `Stats()` returns `cache.ManagerStats`, where the interface demanded `map[string]any`. So if you wrote your own narrow interface, do not copy the old `Stats()` signature. Two further differences do **not** affect satisfaction but are worth knowing when you write that interface: the concrete `Get`'s second parameter is named `key`, not `tenantID` (parameter names never participate in satisfaction — it is the cache key, which is the tenant ID only in multi-tenant deployments), and `*CacheManager` also offers `Remove(key string) error`, which the interface never declared (extra methods are always fine)
 - verify: `go build ./... && go test ./...`
 - ref: ADR-045 · `cache/types.go` · `cache/manager.go` (`CacheManager`) · #862
@@ -1092,10 +1192,12 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   advisory: silence it by configuring a database, or ignore it on a service that is
   intentionally database-free. The three exempt modes above never emit it.
 - after:
+
   ```go
   // In the module that owns database-backed work:
   func (m *Module) RequiresDatabase() bool { return true }
   ```
+
 - verify: `go build ./... && go test ./...`
 - ref: `app/module.go` (`DatabaseRequirer`) · `app/module_registry.go` (`checkDatabaseRequirement`) · `app/bootstrap.go` (`rootDatabaseAbsent`, `warnIfDatabaseAbsent`) · #872
 
@@ -1105,12 +1207,15 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
 - scope: `config.IsDatabaseConfigured` widened from three fields (`connectionstring`, `host`, `type`) to every connection-identity field, adding `port`, `database`, `username`, `password`, and Oracle's `oracle.service.name` / `oracle.service.sid` (Oracle names its target with those rather than a database name). Any one of them now marks the section as intended, which routes it into `validateDatabase`. A config that set, say, `database.database` + `database.username` with no type or host used to load silently and then fail at first query; it now fails `config.Load` with `config_invalid: database.type '' is not supported`. Fields filled in by `applyDatabasePoolDefaults` (`timezone`, `pool.*`, `query.*`) are deliberately excluded, so the verdict is identical before and after defaulting — a defaulted config never reads as intent
 - gate: match = some environment sets a database identity field without completing the section (see the detect for what complete means). no-match = every environment either configures the database fully or sets no `database.*` identity field at all. Caveat: a field delivered as an *empty string* (an empty `secretKeyRef`, `envsubst` over an unset variable) still reads as absence — the predicate cannot distinguish it from an unset field
 - before:
+
   ```yaml
   database:
     database: appdb
     username: app        # loaded fine; failed at first query
   ```
+
 - after:
+
   ```yaml
   database:
     type: postgresql     # complete the section: type + host + port + username + target
@@ -1119,6 +1224,7 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
     database: appdb      # Oracle instead: oracle.service.name or oracle.service.sid
     username: app
   ```
+
   …or remove the `database:` block entirely if the service genuinely has no database. Partial is the one thing that is no longer accepted
 - verify: `config.Load()` succeeds for every environment you deploy
 - ref: ADR-047 · `config/validation.go` (`IsDatabaseConfigured`) · #872
@@ -1129,13 +1235,17 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
 - scope: three deployments change readiness. (1) A service with **no** `database:` block at all: `/ready` returned a permanent 503 with `unsupported database type: ` and now returns 200 with `database: "not_configured"`. (2) Every **static multi-tenant** deployment: the probe resolves the fixed `""` key, and validation rejects a root block alongside static tenants, so that key could never resolve and these were *also* permanently 503 even when every tenant was healthy — they now report a new `per_tenant` status. Note the consequence: where the `""` key does not resolve, multi-tenant `/ready` carries no database signal at all — no critical probe, no startup gate, no WARN. A multi-tenant deployment that *does* configure a root block (a shared-ledger control plane, `outbox.tenancy: shared`) is still probed and still gates readiness. (3) `/_debug/health` `overall_status` counts `not_configured`, `disabled`, and `per_tenant` as healthy, so it stops reporting `critical` for a service `/ready` calls ready. A configured-but-unreachable database is unchanged: still `critical: true`, still 503. `deps.DB(ctx)` on a database-free service now returns an error satisfying `config.IsNotConfigured`, and the spurious pre-warm WARN pair disappears
 - gate: match = you deploy a database-free or multi-tenant service, or you alert on `/ready` status codes. no-match = every service configures a root database
 - before:
+
   ```json
   {"database":"unhealthy","error":"failed to create database connection for key : unsupported database type:  (supported: postgresql, oracle)","status":"not ready"}
   ```
+
 - after:
+
   ```json
   {"status":"ready","database":"not_configured","db_stats":{"status":"not_configured"}}
   ```
+
   (database keys only — the body also carries `messaging`, `cache` and their stats per C56.10.)
   A rollout that was previously held back by a failing readiness gate will now proceed. If that 503 was load-bearing for you — i.e. the service genuinely needs a database — implement `app.DatabaseRequirer` (C56.13) so the absence aborts startup instead
 - verify: `curl -s -o /dev/null -w '%{http_code}' localhost:8080/ready`
@@ -1403,13 +1513,16 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   the table exists — or `autocreatetable` is on and its DDL succeeds — or the deployment is
   exempt.
 - before:
+
   ```yaml
   outbox:
     enabled: true
   # no database: block — the service booted green; the relay then logged a
   # poll-interval failure forever, captioned "database (optional)"
   ```
+
 - after:
+
   ```yaml
   database:
     type: postgresql
@@ -1422,6 +1535,7 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   # …and the outbox table must already exist (run migrations), or set
   # outbox.autocreatetable: true
   ```
+
 - verify: `go build ./... && go test ./...` exercises the probe logic itself, but no test can
   see your environment's config — start the service against each non-exempt environment and
   confirm it now exits non-zero (instead of logging a relay/cleanup failure once per interval)
@@ -1594,17 +1708,21 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   that bypasses `config.Load` (dynamic-source tenants, hand-built `Config`
   literals).
 - before:
+
   ```yaml
   database:
     host: ""   # e.g. from an empty secretKeyRef
   # loaded as database-free; /ready reported not_configured; first query failed
   ```
+
 - after:
+
   ```yaml
   database:
     host: ""   # config.Load now fails: "database identity field(s) delivered
                # empty: [database.host]"
   ```
+
   Fix by supplying a real value, or removing the key entirely if the service
   genuinely has no database — an absent section is unaffected.
 - verify: `config.Load()` succeeds for every environment you deploy; an
@@ -1616,7 +1734,7 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
 
 ---
 
-_The sections below are reference material: the two config-key rename lookup tables (linked from atoms C401.1 and C41.7), followed by pre-v0.39 changes retained for consumers upgrading from older releases._
+*The sections below are reference material: the two config-key rename lookup tables (linked from atoms C401.1 and C41.7), followed by pre-v0.39 changes retained for consumers upgrading from older releases.*
 
 ## Config Keys — Flat-Smushed Rename (ADR-024)
 
@@ -1684,6 +1802,7 @@ Per [SonarCloud rule S8179](https://rules.sonarsource.com/go/RSPEC-8179/), gette
 | `server.RouteRegistry` | `GetRoutes()` | `Routes()` |
 
 **Example:**
+
 ```go
 // OLD
 host := cfg.GetString("server.host", "0.0.0.0")
@@ -1719,6 +1838,7 @@ Per [ADR-017](adr_017_insert_query_builder.md), `qb.Insert*` constructors return
 | `qb.InsertFields(table, instance, fields...)` | `squirrel.InsertBuilder` | `types.InsertQueryBuilder` | `ToSQL()` |
 
 **Example:**
+
 ```go
 // OLD
 sql, args, err := qb.Insert("users").Columns("name").Values("Alice").ToSql()

--- a/wiki/multi_tenant_migration.md
+++ b/wiki/multi_tenant_migration.md
@@ -48,6 +48,7 @@ Authorization: Bearer <optional>
 ```
 
 Rules:
+
 - `id` is the only required field per tenant; extra fields are ignored.
 - Empty/absent `next_cursor` ends iteration.
 - `limit` is advisory; the CLI defaults to 100.

--- a/wiki/new_relic_otlp.md
+++ b/wiki/new_relic_otlp.md
@@ -110,6 +110,7 @@ trace:
 ## Attribute Limits
 
 New Relic enforces attribute limits on its ingest side, but be aware of:
+
 - **Maximum attributes per span/metric/log:** 255 attributes
 - **Maximum attribute value size:** 4095 bytes
 - **Truncation behavior:** GoBricks does not validate or truncate attributes before export — oversized or excess attributes may be silently dropped by New Relic, not by GoBricks

--- a/wiki/observability.md
+++ b/wiki/observability.md
@@ -15,6 +15,7 @@ GoBricks provides production-grade observability built on OpenTelemetry: distrib
 **Go Runtime Metrics:** Auto-exports memory, goroutines, CPU, scheduler latency, GC config when `observability.enabled: true`. Follows [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/runtime/go-metrics/)
 
 **Export Timeout Configuration:** GoBricks gates export timeouts on `observability.environment` and the signal's endpoint, balancing fail-fast feedback against network resilience:
+
 - **`observability.environment: development` (the default) or `endpoint: stdout`:** 10s (quick failure detection for debugging)
 - **Any other environment with a network endpoint:** 60s (accommodates network latency, TLS handshake, batch transmission)
 - **⚠️ `observability.environment` is not derived from `app.env`.** It is an independent key defaulting to `development`, so a service running `app.env: production` against a remote OTLP collector keeps the 10s default until you set `observability.environment` explicitly.
@@ -22,6 +23,7 @@ GoBricks provides production-grade observability built on OpenTelemetry: distrib
 - **Why 60s?** Real-world production scenarios involve cross-region latency, TLS negotiation, and 512-span batch transmission to remote OTLP endpoints
 
 **Dual-Mode Logging:** `DualModeLogProcessor` routes logs by `log.type`:
+
 - **Action logs** (`log.type="action"`): Always exported at 100% (request summaries)
 - **Trace logs** (`log.type="trace"`): ERROR/WARN always exported, INFO/DEBUG sampled by `samplingrate`
 - Configure via `observability.logs.samplingrate` (0.0-1.0, default 0.0 drops INFO/DEBUG)
@@ -30,6 +32,7 @@ GoBricks provides production-grade observability built on OpenTelemetry: distrib
 **Request Logging:** HTTP requests track severity escalation via `requestLogContext`. Automatic escalation from status codes (4xx→WARN, 5xx→ERROR). Explicit: `c.EscalateSeverity(zerolog.WarnLevel)` (the `HandlerContext` method). Configure `observability.logs.slowrequestthreshold` for slow request detection.
 
 **Testing:** Use `observability/testing` package:
+
 ```go
 tp := obtest.NewTestTraceProvider()
 spans := tp.Exporter.GetSpans()
@@ -39,6 +42,7 @@ mp := obtest.NewTestMeterProvider()
 rm := mp.Collect(t)
 obtest.AssertMetricExists(t, rm, "my.counter")
 ```
+
 Span helpers: `AssertSpanName`, `AssertSpanAttribute`, `AssertSpanStatus`, `AssertSpanStatusDescription`, `AssertSpanError`, plus `NewSpanCollector(t, exporter)` for filtering. Metric helpers: `AssertMetricExists`, `AssertMetricValue`, `AssertMetricCount`, `AssertMetricDescription`, `FindMetric`, `GetMetricSumValue`, `GetMetricHistogramCount`. There is no in-memory log exporter today — capture zerolog output via an `io.Writer` sink for action/trace log assertions.
 
 **Debug Mode:** Set `GOBRICKS_DEBUG=true` for `[OBSERVABILITY]` logs (provider init, exporter setup, span lifecycle)
@@ -87,6 +91,7 @@ No Go code changes. The framework reads `cfg.Log.SensitiveFields` during `Builde
 **Seam 2 — `app.Options.LoggerFilterConfig` (full replacement, code-level):**
 
 Use this when YAML can't express what you need:
+
 - Custom `MaskValue` (e.g., `[REDACTED]`, `<hidden>`, vendor-specific).
 - Opting out of every default field (testing, deterministic-output fixtures).
 - Composing the list at startup from a secret manager, feature flag, or remote config.
@@ -155,19 +160,23 @@ Field-name masking is *one* layer. A complete PCI-DSS 3.3/3.4/3.5 posture combin
 GoBricks exposes `MeterProvider` via `ModuleDeps` for creating application-specific metrics. When `observability.enabled: false`, a no-op provider is used with zero overhead.
 
 **Available in ModuleDeps:**
+
 - `deps.MeterProvider` - OpenTelemetry MeterProvider for creating custom instruments
 
 **Helper Functions (observability/metrics.go):**
+
 - `CreateCounter(meter, name, description)` - Monotonically increasing values (requests, errors)
 - `CreateHistogram(meter, name, description)` - Distributions (latency, size)
 - `CreateUpDownCounter(meter, name, description)` - Values that increase/decrease (connections, queue depth)
 
 **Pattern:**
+
 1. Store `MeterProvider` in module struct
 2. Create instruments in `Init()` (one-time, cached)
 3. Record values in business logic with attributes
 
 **Quick Example:**
+
 ```go
 type OrderModule struct {
     meterProvider metric.MeterProvider
@@ -207,6 +216,7 @@ func (s *OrderService) CreateOrder(ctx context.Context, req CreateOrderRequest) 
 | `Int64ObservableGauge` | Current state via callback | Memory usage, pool size |
 
 **Best Practices:**
+
 - Pre-create instruments in `Init()` for performance (avoid per-request creation)
 - Use semantic naming: `<namespace>.<entity>.<measurement>` (e.g., `orders.processing.duration`)
 - Add attributes for dimensions: `status`, `tenant_id`, `operation_type`
@@ -248,6 +258,7 @@ GoBricks supports all New Relic OTLP optimizations: gzip compression (~70% bandw
 | `http` | `https://host:port/path` | `https://otlp.nr-data.net:4318/v1/traces` |
 
 **Common Mistakes:**
+
 - `https://otlp.nr-data.net:4317` with `protocol: grpc` → ERROR
 - `otlp.nr-data.net:4317` with `protocol: grpc` → Correct
 

--- a/wiki/observability_headers_auth.md
+++ b/wiki/observability_headers_auth.md
@@ -44,6 +44,7 @@ The actual secret lives in the deployment environment (Kubernetes Secret, AWS Se
 ## Security Best Practices
 
 1. **Never hardcode secrets in YAML.** Always use `${VAR}` references for credentials, even in non-production configs.
+
    ```yaml
    # SAFE
    api-key: ${NEW_RELIC_API_KEY}

--- a/wiki/outbox.md
+++ b/wiki/outbox.md
@@ -7,6 +7,7 @@ This document covers GoBricks' built-in Transactional Outbox: the components tha
 GoBricks provides a built-in **Transactional Outbox** for reliable event publishing. It solves the dual-write problem: events are written to an outbox table in the **same database transaction** as business data, then reliably delivered to the message broker by a background relay.
 
 **Core Components:**
+
 - **Publisher**: Writes events to the outbox table within a database transaction
 - **Relay**: Background poller (scheduler job) that publishes pending events to AMQP
 - **Cleanup**: Scheduled job that removes published events after retention period
@@ -15,6 +16,7 @@ GoBricks provides a built-in **Transactional Outbox** for reliable event publish
 **Delivery Guarantee:** At-least-once. Consumers MUST be idempotent. Use the `x-outbox-event-id` header for deduplication.
 
 **Module Setup:**
+
 ```go
 for _, m := range []app.Module{
     scheduler.NewModule(), // Required: relay runs as a scheduled job
@@ -35,6 +37,7 @@ func (m *Module) Init(deps *app.ModuleDeps) error {
 ```
 
 **Business Logic Pattern (atomic write + event):**
+
 ```go
 func (s *OrderService) CreateOrder(ctx context.Context, req CreateOrderReq) error {
     db, err := s.getDB(ctx)
@@ -65,6 +68,7 @@ func (s *OrderService) CreateOrder(ctx context.Context, req CreateOrderReq) erro
 ```
 
 **How It Works:**
+
 1. `Publish()` writes an `OutboxRecord` to the outbox table within the caller's transaction
 2. The **relay job** (`outbox-relay` via scheduler) polls for pending events every `pollinterval`
 3. Each pending event is published to the target AMQP exchange with `x-outbox-event-id` header

--- a/wiki/scheduler.md
+++ b/wiki/scheduler.md
@@ -7,6 +7,7 @@ The `scheduler` package provides gocron-based job scheduling integrated with the
 The `scheduler` package provides gocron-based job scheduling integrated with the GoBricks module system.
 
 **Key Features:**
+
 - **Lazy initialization**: Scheduler created only when first job is registered
 - **Overlapping prevention**: Mutex-based lock per job (skips trigger if already running)
 - **Panic recovery**: Automatic recovery with stack trace logging and metrics
@@ -14,6 +15,7 @@ The `scheduler` package provides gocron-based job scheduling integrated with the
 - **OpenTelemetry**: Counter, histogram, and panic tracking per job
 
 **Executor Interface:**
+
 ```go
 type Executor interface {
     Execute(ctx JobContext) error
@@ -23,6 +25,7 @@ type Executor interface {
 ```
 
 **Registration via ModuleDeps:**
+
 ```go
 // mustParseTime parses "HH:MM" and panics on error — acceptable in init paths
 // where a malformed literal is a programmer bug that must crash at startup.

--- a/wiki/startup_defaults.md
+++ b/wiki/startup_defaults.md
@@ -15,11 +15,13 @@ GoBricks applies component-specific startup timeouts for graceful initialization
 | `app.startup.observability` | 15s | OTLP endpoint connection (higher for TLS handshake) |
 
 **Fallback Hierarchy:**
+
 1. Explicit component value (e.g., `app.startup.database: 15s`) → preserved
 2. Global timeout (if set): `app.startup.timeout: 30s` → applied to all unset components
 3. Per-component default (shown in table) → used when neither is set
 
 **Example - Global fallback:**
+
 ```yaml
 app:
   startup:
@@ -27,6 +29,7 @@ app:
 ```
 
 **Override defaults** in `config.yaml`:
+
 ```yaml
 app:
   startup:
@@ -97,6 +100,7 @@ Attribution is by **registration order** (`module.Name()`), covering both typed 
 Startup fails when two registrations claim the same **exact method + full path**. The echo engine is constructed with `AllowOverwritingRoute: true`, so without this check the second registration silently wins and the first module's handler is dead on arrival — no error, no warning, unless the shadowed route happens to be exercised. This closes that gap at the framework's own registration seam (`server.RouteRegistrar`), covering both typed (`server.GET/POST`) and raw (`RouteRegistrar.Add`) routes, plus anything registered through nested `Group()`s.
 
 **Coverage notes:**
+
 - `health`/`ready` probes register directly on the HTTP engine (not through `RouteRegistrar` — same seam note as route logging above), but `server.New` records their method+path pairs in the conflict tracker explicitly, so a module claiming `GET /health` (or the configured probe paths) fails startup like any other collision.
 - Param-name-differing route templates (e.g. `/users/:id` vs `/users/:uid`) are **excluded** — these are distinct strings and are not detected as duplicates, even though they collide in echo's radix tree at request time; echo's own behavior governs there.
 

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -4,6 +4,7 @@ This document covers the GoBricks testing conventions and the dedicated testing 
 
 ## Test Naming Conventions
 
+<!-- markdownlint-disable-next-line MD036 -->
 **MANDATORY: Use camelCase for ALL test function names**
 
 ```go
@@ -19,6 +20,7 @@ func TestQueryBuilder_with_complex_joins(t *testing.T) { }
 ```
 
 **Table-Driven Test Naming:**
+
 ```go
 // ✅ CORRECT
 func TestFilterEq(t *testing.T) {
@@ -38,6 +40,7 @@ func Test_Filter_Eq(t *testing.T) { }
 ```
 
 **Rationale:**
+
 - **Consistency:** GoBricks enforces camelCase across the entire codebase
 - **Go Idioms:** Test function names are regular Go identifiers (prefer camelCase)
 - **Tooling:** Some tools parse test names assuming camelCase convention
@@ -46,6 +49,7 @@ func Test_Filter_Eq(t *testing.T) { }
 **Exception:** Test case descriptions in table-driven tests use snake_case for readability (e.g., `name: "with_invalid_credentials"`)
 
 ## Testing Strategy
+
 - **Unit tests:** testify, `database/testing` (DB mocking), `cache/testing` (cache mocking), `outbox/testing` (outbox mocking), httptest (server), fake adapters (messaging)
 - **Integration tests:** testcontainers, `-tags=integration` flag
 - **Race detection:** All tests run with `-race` in CI
@@ -56,6 +60,7 @@ func Test_Filter_Eq(t *testing.T) { }
 GoBricks provides `database/testing` package for easy database mocking without sqlmock complexity (**73% less boilerplate**).
 
 **Simple Query Test:**
+
 ```go
 import dbtest "github.com/gaborage/go-bricks/database/testing"
 
@@ -85,6 +90,7 @@ func TestProductServiceFindActive(t *testing.T) {
 ```
 
 **Transaction Testing:**
+
 ```go
 db := dbtest.NewTestDB(dbtypes.PostgreSQL)
 tx := db.ExpectTransaction().
@@ -98,6 +104,7 @@ dbtest.AssertCommitted(t, tx)
 ```
 
 **Multi-Tenant Testing:**
+
 ```go
 tenants := dbtest.NewTenantDBMap()
 tenants.ForTenant("acme").ExpectQuery("SELECT").WillReturnRows(...)
@@ -112,6 +119,7 @@ result, err := svc.Process(ctx)  // Uses acme's TestDB
 ```
 
 **Key Features:**
+
 - Fluent expectation API (ExpectQuery/ExpectExec)
 - Multi-tenant support via TenantDBMap
 - Transaction tracking (commit/rollback assertions)
@@ -125,6 +133,7 @@ See [database/testing](../database/testing/) package and llms.txt's "Database Te
 GoBricks provides `cache/testing` package for easy cache mocking without Redis dependencies (**similar to database/testing pattern**).
 
 **Simple Cache Test:**
+
 ```go
 import cachetest "github.com/gaborage/go-bricks/cache/testing"
 
@@ -146,6 +155,7 @@ func TestUserServiceCaching(t *testing.T) {
 ```
 
 **Configurable Failures:**
+
 ```go
 mockCache := cachetest.NewMockCache().
     WithGetFailure(cache.ErrClosed)
@@ -159,6 +169,7 @@ cachetest.AssertOperationCount(t, mockCache, "Get", 1)
 ```
 
 **Multi-Tenant Testing:**
+
 ```go
 tenantCaches := map[string]*cachetest.MockCache{
     "acme":   cachetest.NewMockCache(),
@@ -177,6 +188,7 @@ result, err := svc.Process(acmeCtx)  // Uses acme's MockCache
 ```
 
 **Key Features:**
+
 - Fluent configuration API (`WithGetFailure`, `WithDelay`, `WithCloseCallback`)
 - Operation tracking (Get/Set/Delete/GetOrSet/CompareAndSet counts)
 - 17 assertion helpers (`AssertCacheHit`, `AssertOperationCount`, `AssertValue`)
@@ -190,6 +202,7 @@ See [cache/testing](../cache/testing/) package for full API documentation and th
 GoBricks provides `outbox/testing` package for mocking outbox operations in unit tests.
 
 **Simple Test:**
+
 ```go
 import outboxtest "github.com/gaborage/go-bricks/outbox/testing"
 
@@ -211,6 +224,7 @@ func TestOrderServiceCreateOrder(t *testing.T) {
 ```
 
 **Configurable Failures:**
+
 ```go
 mockOutbox := outboxtest.NewMockOutbox().
     WithError(fmt.Errorf("outbox unavailable"))
@@ -221,6 +235,7 @@ assert.Error(t, err)
 ```
 
 **Key Features:**
+
 - Fluent configuration API (`WithError`)
 - Event tracking (type, aggregate ID, payload, exchange)
 - Assertion helpers (`AssertEventPublished`, `AssertEventCount`, `AssertEventWithAggregate`, `AssertNoEvents`)
@@ -282,6 +297,7 @@ a `server.Server` and drive it with `httptest` / `ServeHTTP` instead.
 **Prerequisites:** Docker Desktop or Docker Engine running
 
 **Run Integration Tests:**
+
 ```bash
 make test-integration           # All integration tests
 make test-coverage-integration  # With coverage
@@ -290,6 +306,7 @@ make test-coverage-integration  # With coverage
 **Build Tag Isolation:** Integration tests use `//go:build integration` - testcontainers dependencies only compiled with `-tags=integration`
 
 **Writing Integration Tests:**
+
 ```go
 //go:build integration
 

--- a/wiki/troubleshooting.md
+++ b/wiki/troubleshooting.md
@@ -86,6 +86,7 @@ Currently this is a documented developer convenience: TestMain always spins up a
 ```
 
 **Override defaults for aggressive environments (e.g., strict firewall):**
+
 ```yaml
 database:
   pool:
@@ -99,6 +100,7 @@ database:
 ```
 
 **On-premises with no NAT/firewall concerns, opt-out of recycling:**
+
 ```yaml
 database:
   pool:
@@ -163,7 +165,7 @@ database:
 
 ### gRPC error: "frame header looked like an HTTP/1.1 header" (New Relic)
 
-```
+```text
 ERROR: rpc error: code = Unavailable desc = connection error: desc = "error reading server preface:
        http2: failed reading the frame payload: http2: frame too large, note that the frame header
        looked like an HTTP/1.1 header"
@@ -172,11 +174,13 @@ ERROR: rpc error: code = Unavailable desc = connection error: desc = "error read
 **Root cause:** gRPC client connecting to HTTP endpoint (port mismatch).
 
 **Solutions:**
+
 1. Using port 4318 with `protocol: grpc` → WRONG (4318 is HTTP port). Change endpoint to `otlp.nr-data.net:4317` (gRPC port).
 2. Using `https://` scheme with gRPC protocol → WRONG (gRPC doesn't accept scheme). Use `otlp.nr-data.net:4317` (no `https://`).
 3. Missing TLS configuration → Check `insecure: false` (New Relic requires TLS).
 
 **Correct New Relic gRPC config:**
+
 ```yaml
 observability:
   trace:
@@ -189,6 +193,7 @@ observability:
 ```
 
 **HTTP endpoint format:**
+
 - HTTP requires `https://` or `http://` scheme: `https://otlp.nr-data.net:4318/v1/traces`
 - gRPC requires NO scheme, just `host:port`: `otlp.nr-data.net:4317`
 
@@ -265,6 +270,7 @@ observability:
 ```
 
 **Diagnostic commands:**
+
 ```bash
 grep "Starting message consumers" logs/app.log
 grep "Multiple consumers registered for same queue" logs/app.log


### PR DESCRIPTION
## What

Markdown across the tree had 8,203 markdownlint violations in 108 of 111 tracked files. This fixes the structural ones so a gate can land on a clean tree; the gate itself is the follow-up PR, so nothing here can fail CI on its own. 825 violations cleared mechanically via `markdownlint-cli2 --fix` (blank lines around lists, headings, fences), 26 by hand (code-fence language tags, emphasis-vs-heading calls, blockquote separation).

## Impact

None for consumers. Two living docs changed outline: `wiki/adr_011_redis_cache.md` and `wiki/messaging.md` gained real headings where bold lines were acting as section headers. `wiki/messaging.md` also had a genuine defect — a wrapped line was rendering as an H1 reading `# 655).` — which is now repaired prose.

## Verification

Zero prose was reworded and no code sample altered; every changed file was diffed to confirm it. Two content regressions the mechanical pass introduced (MD038 stripping load-bearing trailing spaces from a documented SECURITY annotation prefix and from an error literal) were caught and reverted — that rule is disabled in the follow-up's config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved Markdown formatting and readability across guides, reference materials, architecture records, specifications, and implementation plans.
  - Added clearer spacing around headings, lists, examples, code blocks, and navigation sections.
  - Clarified documented migration considerations and consumer-facing consequences for boundary changes.
  - Improved syntax highlighting for selected documentation examples.
- **Chores**
  - Added Markdown linting exceptions where needed to support valid document structure.
  - Corrected minor list formatting and emphasis inconsistencies.
  - No functional behavior, APIs, configuration, or documented procedures were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->