### PR TITLE
fix(httpclient)!: validate JOSE policies at Build time

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -369,7 +369,14 @@ func (b *Builder) normalizeJOSE() error {
 		return nil
 	}
 	if b.joseConfig.Resolver == nil && (b.joseConfig.Outbound != nil || b.joseConfig.Inbound != nil) {
-		return errors.New("a Resolver is required when Outbound or Inbound is set")
+		// Mirrors Seal's nil-resolver guard so every Build JOSE failure is a
+		// *jose.Error, as the package doc and wiki promise.
+		return &jose.Error{
+			Sentinel: jose.ErrKeyResolution,
+			Code:     "JOSE_KEYSTORE_UNAVAILABLE",
+			Status:   500,
+			Message:  "a Resolver is required when Outbound or Inbound is set",
+		}
 	}
 	outbound, err := normalizedJOSEPolicy(b.joseConfig.Outbound)
 	if err != nil {

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -337,16 +337,26 @@ type JOSEConfig struct {
 // missing for the policy's direction, or a nil Resolver fails construction rather
 // than every request. Kids are NOT resolved at Build time: a resolver may be backed
 // by lazily-loaded key material, so an unknown kid still surfaces per request.
+//
+// Calling this twice does not stack two JOSE layers: the last call wins outright,
+// as it does for the base-transport slot. The body is sealed exactly once, with the
+// config from the final call — including its nil fields.
 func (b *Builder) WithJOSE(cfg JOSEConfig) *Builder {
+	// The closure below reads b.joseConfig, so registering a second layer would seal
+	// an already-sealed body — a JWE nested inside a JWE — instead of replacing the
+	// first. Register once; every call still overwrites the config.
+	needsLayer := b.joseConfig == nil
 	b.joseConfig = &cfg
-	b.addTransportWrapper(layerBodyTransform, func(inner nethttp.RoundTripper) nethttp.RoundTripper {
-		return &JOSETransport{
-			Inner:    inner,
-			Outbound: b.joseConfig.Outbound,
-			Inbound:  b.joseConfig.Inbound,
-			Resolver: b.joseConfig.Resolver,
-		}
-	})
+	if needsLayer {
+		b.addTransportWrapper(layerBodyTransform, func(inner nethttp.RoundTripper) nethttp.RoundTripper {
+			return &JOSETransport{
+				Inner:    inner,
+				Outbound: b.joseConfig.Outbound,
+				Inbound:  b.joseConfig.Inbound,
+				Resolver: b.joseConfig.Resolver,
+			}
+		})
+	}
 	return b
 }
 

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -84,6 +84,10 @@ type Builder struct {
 	// silently losing a client certificate or a caller's RoundTripper is not.
 	baseSlot      baseSource
 	displacedBase baseSource
+	// joseConfig holds WithJOSE's material. The wrapper closure cannot be inspected,
+	// so Build reads it from here to normalize and validate the policies before
+	// resolveTransport builds the JOSETransport from it.
+	joseConfig *JOSEConfig
 }
 
 // transportLayer orders RoundTripper wrappers independently of the order the
@@ -327,16 +331,72 @@ type JOSEConfig struct {
 // Per-attempt freshness: because httpclient retries by re-running the request build
 // loop, each retry produces a freshly-sealed payload — useful for protocols that
 // require unique iat/jti claims per attempt.
+//
+// Validation: Build fills each non-nil policy's unset algorithms from the jose
+// package defaults and runs Policy.Validate, so a disallowed algorithm, a kid
+// missing for the policy's direction, or a nil Resolver fails construction rather
+// than every request. Kids are NOT resolved at Build time: a resolver may be backed
+// by lazily-loaded key material, so an unknown kid still surfaces per request.
 func (b *Builder) WithJOSE(cfg JOSEConfig) *Builder {
+	b.joseConfig = &cfg
 	b.addTransportWrapper(layerBodyTransform, func(inner nethttp.RoundTripper) nethttp.RoundTripper {
 		return &JOSETransport{
 			Inner:    inner,
-			Outbound: cfg.Outbound,
-			Inbound:  cfg.Inbound,
-			Resolver: cfg.Resolver,
+			Outbound: b.joseConfig.Outbound,
+			Inbound:  b.joseConfig.Inbound,
+			Resolver: b.joseConfig.Resolver,
 		}
 	})
 	return b
+}
+
+// normalizeJOSE replaces the configured policies with normalized, validated copies.
+// It runs on b.joseConfig, which WithJOSE already populated from its own by-value
+// parameter, so the caller's JOSEConfig and jose.Policy values are never mutated.
+// A nil policy stays nil: one-directional protection is legitimate.
+func (b *Builder) normalizeJOSE() error {
+	if b.joseConfig == nil {
+		return nil
+	}
+	if b.joseConfig.Resolver == nil && (b.joseConfig.Outbound != nil || b.joseConfig.Inbound != nil) {
+		return errors.New("a Resolver is required when Outbound or Inbound is set")
+	}
+	outbound, err := normalizedJOSEPolicy(b.joseConfig.Outbound)
+	if err != nil {
+		return err
+	}
+	inbound, err := normalizedJOSEPolicy(b.joseConfig.Inbound)
+	if err != nil {
+		return err
+	}
+	b.joseConfig.Outbound, b.joseConfig.Inbound = outbound, inbound
+	return nil
+}
+
+// normalizedJOSEPolicy returns a validated copy of p with unset algorithms filled from
+// the jose package defaults. Defaults must be applied before Validate: a zero SigAlg is
+// not in the allowlist, so an otherwise-valid policy that omits algorithms would fail.
+func normalizedJOSEPolicy(p *jose.Policy) (*jose.Policy, error) {
+	if p == nil {
+		return nil, nil
+	}
+	cp := *p
+	if cp.SigAlg == "" {
+		cp.SigAlg = jose.DefaultSigAlg
+	}
+	if cp.KeyAlg == "" {
+		cp.KeyAlg = jose.DefaultKeyAlg
+	}
+	if cp.Enc == "" {
+		cp.Enc = jose.DefaultEnc
+	}
+	if cp.Cty == "" {
+		cp.Cty = jose.DefaultCty
+	}
+	if err := cp.Validate(); err != nil {
+		return nil, err
+	}
+	return &cp, nil
 }
 
 // addTransportWrapper registers a RoundTripper layer applied at Build time.
@@ -437,7 +497,9 @@ var ErrUnsafeTransportComposition = errors.New("unsafe transport composition")
 
 // Build creates the REST client. It returns an error wrapping
 // ErrUnsafeTransportComposition on a base-transport-slot displacement —
-// see ADR-044 for scope (what counts, what doesn't).
+// see ADR-044 for scope (what counts, what doesn't). A WithJOSE policy that
+// fails jose.Policy.Validate is reported on a separate error path that carries
+// the underlying *jose.Error (match it with errors.As), not that sentinel.
 func (b *Builder) Build() (Client, error) {
 	if b == nil || b.config == nil || isNilLogger(b.logger) {
 		panic("httpclient: Build requires a Builder created by NewBuilder") // NOSONAR: Fail-fast on invalid initialization (manifesto: configuration errors crash at startup)
@@ -459,6 +521,12 @@ func (b *Builder) Build() (Client, error) {
 			c.Timeout = cfg.Timeout
 		}
 		httpClient = &c
+	}
+
+	// Before resolveTransport: the wrapper closure reads b.joseConfig, so the
+	// JOSETransport must be built from the normalized policies, not the raw ones.
+	if err := b.normalizeJOSE(); err != nil {
+		return nil, fmt.Errorf("httpclient: invalid JOSE policy: %w", err)
 	}
 
 	rt := b.resolveTransport()

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -2684,6 +2684,9 @@ type capturingRoundTripper struct {
 
 func (c *capturingRoundTripper) RoundTrip(req *nethttp.Request) (*nethttp.Response, error) {
 	if req.Body != nil {
+		// A RoundTripper owns the request body once it reads it — close it on every
+		// path, the same obligation addTransportWrapper documents for real layers.
+		defer req.Body.Close()
 		raw, err := io.ReadAll(req.Body)
 		if err != nil {
 			return nil, err
@@ -2837,7 +2840,11 @@ func TestBuildRejectsJOSEWithoutResolver(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := NewBuilder(log).WithTransport(&stubRoundTripper{name: "base"}).WithJOSE(tc.cfg).Build()
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "Resolver is required")
+			require.ErrorIs(t, err, jose.ErrKeyResolution)
+
+			var jerr *jose.Error
+			require.ErrorAs(t, err, &jerr, "every Build JOSE failure must be matchable as a *jose.Error")
+			assert.Equal(t, "JOSE_KEYSTORE_UNAVAILABLE", jerr.Code)
 		})
 	}
 

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -2778,6 +2778,46 @@ func TestBuildAppliesJOSEDefaultsToZeroValuePolicy(t *testing.T) {
 	assert.Equal(t, string(jose.DefaultSigAlg), hdr.JWS.Alg, "an unset SigAlg must land on the package default")
 	assert.Equal(t, string(jose.DefaultKeyAlg), hdr.JWE.Alg)
 	assert.Equal(t, string(jose.DefaultEnc), hdr.JWE.Enc)
+	// Asserted explicitly because nothing else here would notice: Policy.Validate
+	// ignores Cty, and Open's cty check is permissive by design — it accepts a token
+	// that declares no cty at all, so an undefaulted Cty would reach the wire silently.
+	assert.Equal(t, jose.DefaultCty, hdr.JWS.Cty, "an unset Cty must land on the package default")
+}
+
+// The mirror of the defaulting above: a Cty the caller set explicitly must survive
+// Build untouched. Cty is the one normalized field Policy.Validate never inspects,
+// so only the emitted header can show which way the default went.
+func TestBuildKeepsExplicitJOSECty(t *testing.T) {
+	const customCty = "application/vnd.test+json"
+
+	log := createTestLogger()
+	f := jositest.NewBidirectionalFixture(t)
+	inner := &capturingRoundTripper{}
+
+	outbound := outboundKidsOnly(f)
+	outbound.Cty = customCty
+
+	built, err := NewBuilder(log).
+		WithTransport(inner).
+		WithJOSE(JOSEConfig{Outbound: outbound, Resolver: f.Resolver}).
+		Build()
+	require.NoError(t, err)
+
+	_, err = built.Post(context.Background(), &Request{
+		URL:  "http://example.invalid/tokens",
+		Body: []byte(`{"hello":"world"}`),
+	})
+	require.NoError(t, err)
+
+	// The peer declares the same cty, so a clobbered one is rejected outright
+	// (JOSE_CTY_REJECTED) as well as being visible in the header below.
+	peerInbound := *f.PeerInbound
+	peerInbound.Cty = customCty
+
+	plaintext, _, hdr, err := jose.Open(inner.body, &peerInbound, f.Resolver)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"hello":"world"}`, string(plaintext))
+	assert.Equal(t, customCty, hdr.JWS.Cty, "an explicitly-set Cty must not be overwritten by the default")
 }
 
 // A nil Resolver used to fail per-request as JOSE_KEYSTORE_UNAVAILABLE.

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	nethttp "net/http"
 	"net/http/httptest"
@@ -27,6 +28,8 @@ import (
 	obtest "github.com/gaborage/go-bricks/observability/testing"
 
 	"github.com/gaborage/go-bricks/httpclient/internal/tracking"
+	"github.com/gaborage/go-bricks/jose"
+	jositest "github.com/gaborage/go-bricks/jose/testing"
 	"github.com/gaborage/go-bricks/logger"
 )
 
@@ -2670,4 +2673,163 @@ func TestNewBuilderAndBuildRejectNilLogger(t *testing.T) {
 			_, _ = b.Build()
 		})
 	})
+}
+
+// capturingRoundTripper records the body and Content-Type the chain actually put on
+// the wire, then answers 200 with plaintext JSON.
+type capturingRoundTripper struct {
+	body        string
+	contentType string
+}
+
+func (c *capturingRoundTripper) RoundTrip(req *nethttp.Request) (*nethttp.Response, error) {
+	if req.Body != nil {
+		raw, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		c.body = string(raw)
+	}
+	c.contentType = req.Header.Get(testContentTypeHdr)
+	return &nethttp.Response{
+		StatusCode: nethttp.StatusOK,
+		Header:     nethttp.Header{testContentTypeHdr: []string{testJSONType}},
+		Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+		Request:    req,
+	}, nil
+}
+
+// outboundKidsOnly is an outbound policy carrying only the two kids — every algorithm
+// left at its zero value, the shape Build must fill from the jose package defaults.
+func outboundKidsOnly(f *jositest.BidirectionalFixture) *jose.Policy {
+	return &jose.Policy{
+		Direction:  jose.DirectionOutbound,
+		SignKid:    f.ClientOutbound.SignKid,
+		EncryptKid: f.ClientOutbound.EncryptKid,
+	}
+}
+
+// A policy whose algorithms sit outside the jose allowlist used to seal every request
+// and fail per-request in production. Build now refuses it, the ADR-044 posture.
+func TestBuildRejectsJOSEPolicyWithDisallowedAlgorithm(t *testing.T) {
+	log := createTestLogger()
+	f := jositest.NewBidirectionalFixture(t)
+
+	cases := []struct {
+		name    string
+		mutate  func(p *jose.Policy)
+		wantAlg string
+	}{
+		{name: "symmetric_signature", mutate: func(p *jose.Policy) { p.SigAlg = "HS256" }, wantAlg: "HS256"},
+		{name: "pkcs1v15_key_wrapping", mutate: func(p *jose.Policy) { p.KeyAlg = "RSA1_5" }, wantAlg: "RSA1_5"},
+		{name: "non_aead_content_encryption", mutate: func(p *jose.Policy) { p.Enc = "A256CBC-HS512" }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := outboundKidsOnly(f)
+			tc.mutate(policy)
+
+			_, err := NewBuilder(log).
+				WithTransport(&stubRoundTripper{name: "base"}).
+				WithJOSE(JOSEConfig{Outbound: policy, Resolver: f.Resolver}).
+				Build()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid JOSE policy")
+			assert.NotErrorIs(t, err, ErrUnsafeTransportComposition,
+				"a policy failure is its own error path, not a transport-slot displacement")
+
+			var jerr *jose.Error
+			require.ErrorAs(t, err, &jerr)
+			require.ErrorIs(t, err, jose.ErrAlgorithmDisallowed)
+			assert.Equal(t, "JOSE_ALGORITHM_DISALLOWED", jerr.Code)
+			if tc.wantAlg != "" {
+				assert.Equal(t, tc.wantAlg, jerr.Alg)
+			}
+		})
+	}
+}
+
+// A policy that names only its kids must build and seal: Build fills the algorithms
+// from the jose defaults, exactly as the server's tag parser does.
+func TestBuildAppliesJOSEDefaultsToZeroValuePolicy(t *testing.T) {
+	log := createTestLogger()
+	f := jositest.NewBidirectionalFixture(t)
+	inner := &capturingRoundTripper{}
+
+	built, err := NewBuilder(log).
+		WithTransport(inner).
+		WithJOSE(JOSEConfig{Outbound: outboundKidsOnly(f), Resolver: f.Resolver}).
+		Build()
+	require.NoError(t, err)
+
+	resp, err := built.Post(context.Background(), &Request{
+		URL:  "http://example.invalid/tokens",
+		Body: []byte(`{"hello":"world"}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, nethttp.StatusOK, resp.StatusCode)
+
+	assert.Equal(t, jose.ContentType, inner.contentType, "the defaulted policy must still seal the body")
+	plaintext, _, hdr, err := jose.Open(inner.body, f.PeerInbound, f.Resolver)
+	require.NoError(t, err, "the sealed payload must parse under the peer's inbound policy")
+	assert.JSONEq(t, `{"hello":"world"}`, string(plaintext))
+	assert.Equal(t, string(jose.DefaultSigAlg), hdr.JWS.Alg, "an unset SigAlg must land on the package default")
+	assert.Equal(t, string(jose.DefaultKeyAlg), hdr.JWE.Alg)
+	assert.Equal(t, string(jose.DefaultEnc), hdr.JWE.Enc)
+}
+
+// A nil Resolver used to fail per-request as JOSE_KEYSTORE_UNAVAILABLE.
+func TestBuildRejectsJOSEWithoutResolver(t *testing.T) {
+	log := createTestLogger()
+	f := jositest.NewBidirectionalFixture(t)
+
+	cases := []struct {
+		name string
+		cfg  JOSEConfig
+	}{
+		{name: "outbound_without_resolver", cfg: JOSEConfig{Outbound: f.ClientOutbound}},
+		{name: "inbound_without_resolver", cfg: JOSEConfig{Inbound: f.ClientInbound}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewBuilder(log).WithTransport(&stubRoundTripper{name: "base"}).WithJOSE(tc.cfg).Build()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "Resolver is required")
+		})
+	}
+
+	t.Run("no_policy_needs_no_resolver", func(t *testing.T) {
+		_, err := NewBuilder(log).WithTransport(&stubRoundTripper{name: "base"}).WithJOSE(JOSEConfig{}).Build()
+		require.NoError(t, err, "an all-nil JOSEConfig registers an inert layer and must still build")
+	})
+}
+
+// Build normalizes copies: the caller may reuse its jose.Policy across builders, so
+// defaulting must not write algorithms back into the struct it was handed.
+func TestBuildDoesNotMutateCallerJOSEPolicy(t *testing.T) {
+	log := createTestLogger()
+	f := jositest.NewBidirectionalFixture(t)
+
+	caller := outboundKidsOnly(f)
+	before := *caller
+	cfg := JOSEConfig{Outbound: caller, Resolver: f.Resolver}
+
+	built, err := NewBuilder(log).WithTransport(&capturingRoundTripper{}).WithJOSE(cfg).Build()
+	require.NoError(t, err)
+
+	assert.Equal(t, before, *caller, "Build must normalize a copy, never the caller's policy")
+	assert.Empty(t, string(caller.SigAlg), "the caller's unset algorithm must stay unset")
+	assert.Same(t, caller, cfg.Outbound, "the caller's JOSEConfig must not be repointed either")
+
+	// The normalized copy is what reached the transport — proving the copy is not a
+	// discarded intermediate the request path bypasses.
+	clientImpl, ok := built.(*client)
+	require.True(t, ok)
+	joseTransport, ok := clientImpl.httpClient.Transport.(*JOSETransport)
+	require.True(t, ok)
+	assert.NotSame(t, caller, joseTransport.Outbound)
+	assert.Equal(t, jose.DefaultSigAlg, joseTransport.Outbound.SigAlg)
 }

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -2833,3 +2833,43 @@ func TestBuildDoesNotMutateCallerJOSEPolicy(t *testing.T) {
 	assert.NotSame(t, caller, joseTransport.Outbound)
 	assert.Equal(t, jose.DefaultSigAlg, joseTransport.Outbound.SigAlg)
 }
+
+// Two WithJOSE calls must not stack two body-transform layers: the wrapper closure
+// reads the builder's config, so a second layer would seal the first layer's JWE
+// again. Last call wins, and the body is sealed exactly once.
+func TestWithJOSECalledTwiceSealsOnce(t *testing.T) {
+	log := createTestLogger()
+	// Two fixtures reuse the same kid names but hold different keys, so which config
+	// sealed the body is decided by whose resolver can open it.
+	first := jositest.NewBidirectionalFixture(t)
+	last := jositest.NewBidirectionalFixture(t)
+	inner := &capturingRoundTripper{}
+
+	built, err := NewBuilder(log).
+		WithTransport(inner).
+		WithJOSE(JOSEConfig{Outbound: first.ClientOutbound, Inbound: first.ClientInbound, Resolver: first.Resolver}).
+		WithJOSE(JOSEConfig{Outbound: last.ClientOutbound, Resolver: last.Resolver}).
+		Build()
+	require.NoError(t, err)
+
+	clientImpl, ok := built.(*client)
+	require.True(t, ok)
+	joseTransport, ok := clientImpl.httpClient.Transport.(*JOSETransport)
+	require.True(t, ok)
+	assert.Same(t, inner, joseTransport.Inner,
+		"the single JOSE layer must sit directly on the base transport, not on a second JOSE layer")
+	assert.Nil(t, joseTransport.Inbound,
+		"the last call wins outright, including the Inbound policy it did not carry")
+
+	_, err = built.Post(context.Background(), &Request{
+		URL:  "http://example.invalid/tokens",
+		Body: []byte(`{"hello":"world"}`),
+	})
+	require.NoError(t, err)
+
+	// Double sealing would yield the inner compact JWE here, not the payload — and
+	// only the last config's peer can decrypt at all.
+	plaintext, _, _, err := jose.Open(inner.body, last.PeerInbound, last.Resolver)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"hello":"world"}`, string(plaintext))
+}

--- a/jose/sealer.go
+++ b/jose/sealer.go
@@ -10,7 +10,9 @@ import (
 //
 // On failure, returns an *Error. Pre-flight guard failures (Status 500) use Code
 // JOSE_POLICY_DIRECTION_MISMATCH (nil or wrong-direction policy) or JOSE_KEYSTORE_UNAVAILABLE
-// (nil resolver); sign/encrypt failures (Status 500) use JOSE_OUTBOUND_FAILED. Key-resolution
+// (nil resolver), or JOSE_ALGORITHM_DISALLOWED when an algorithm is outside the allowlist
+// (unset Status, which callers map to 500);
+// sign/encrypt failures (Status 500) use JOSE_OUTBOUND_FAILED. Key-resolution
 // failures propagate the resolver's *Error verbatim (e.g. JOSE_KID_UNKNOWN), whose Status is
 // resolver-defined. The Cause field carries the underlying detail for logging.
 func Seal(payload []byte, p *Policy, r KeyResolver) (string, error) {
@@ -29,6 +31,13 @@ func Seal(payload []byte, p *Policy, r KeyResolver) (string, error) {
 			Status:   500,
 			Message:  "Seal called without a KeyResolver",
 		}
+	}
+	// Defense in depth: Open threads the allowlists into the parser, but the outbound
+	// algorithms are handed to the crypto adapter verbatim. Both live callers (the tag
+	// scanner, httpclient's Build) normalize and validate first, so an empty algorithm
+	// reaching here is a policy that skipped that path and must fail closed.
+	if err := p.validateAlgorithms(); err != nil {
+		return "", err
 	}
 
 	signKey, err := r.PrivateKey(p.SignKid)

--- a/jose/sealer_opener_test.go
+++ b/jose/sealer_opener_test.go
@@ -292,3 +292,33 @@ func TestOpenAcceptsMatchingCty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, custom, hdr.JWS.Cty)
 }
+
+// Open threads the allowlists into the parser; Seal handed its algorithms to the crypto
+// adapter verbatim, so a hand-built policy could emit a JWE wrapped with an algorithm the
+// framework's own floor excludes. Defense in depth for callers that skip Policy.Validate.
+func TestSealRejectsDisallowedKeyAlgorithm(t *testing.T) {
+	f := newTestFixture(t)
+
+	cases := []struct {
+		name   string
+		mutate func(p *Policy)
+	}{
+		{name: "pkcs1v15_key_wrapping", mutate: func(p *Policy) { p.KeyAlg = "RSA1_5" }},
+		{name: "symmetric_signature", mutate: func(p *Policy) { p.SigAlg = "HS256" }},
+		{name: "non_aead_content_encryption", mutate: func(p *Policy) { p.Enc = "A256CBC-HS512" }},
+		{name: "unset_algorithms", mutate: func(p *Policy) { p.SigAlg, p.KeyAlg, p.Enc = "", "", "" }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := *f.outbound
+			tc.mutate(&p)
+
+			compact, err := Seal([]byte(`{"pan":"4111111111111111"}`), &p, f.resolver)
+			require.Error(t, err)
+			assert.Empty(t, compact, "no token may be emitted for a disallowed algorithm")
+			require.ErrorIs(t, err, ErrAlgorithmDisallowed)
+			requireJOSEErrorCode(t, err, codeAlgorithmDisallowed)
+		})
+	}
+}

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -89,6 +89,23 @@ if err != nil {
 }
 ```
 
+#### JOSE policy validation at `Build()`
+
+`Build()` also validates the `WithJOSE` policies, which the server's tag scanner has
+always done at route registration. Each non-nil policy gets its unset algorithms
+filled from the `jose` package defaults (`RS256`, `RSA-OAEP-256`, `A256GCM`,
+`application/json`) and is then run through `jose.Policy.Validate`, so a disallowed
+algorithm, a kid missing for the policy's direction, or a `Resolver` left nil while
+a policy is set now fails construction instead of failing every request with
+`JOSE_OUTBOUND_FAILED`. Validation runs on **copies** — a `jose.Policy` you reuse
+across builders is never mutated. The error is its own path, not
+`ErrUnsafeTransportComposition` (whose meaning stays transport-slot composition):
+match the wrapped `*jose.Error` with `errors.As`, or its sentinel with `errors.Is`.
+
+Kids are **not** resolved at `Build()`. A `KeyResolver` may be backed by key material
+loaded lazily, and resolving eagerly would force that load at construction — so an
+unknown kid still surfaces per request as `JOSE_KID_UNKNOWN`.
+
 ### Mutual TLS (client certificates)
 
 `NewClientTLSConfig` turns declarative certificate material into a hardened

--- a/wiki/httpclient.md
+++ b/wiki/httpclient.md
@@ -96,11 +96,12 @@ always done at route registration. Each non-nil policy gets its unset algorithms
 filled from the `jose` package defaults (`RS256`, `RSA-OAEP-256`, `A256GCM`,
 `application/json`) and is then run through `jose.Policy.Validate`, so a disallowed
 algorithm, a kid missing for the policy's direction, or a `Resolver` left nil while
-a policy is set now fails construction instead of failing every request with
-`JOSE_OUTBOUND_FAILED`. Validation runs on **copies** — a `jose.Policy` you reuse
-across builders is never mutated. The error is its own path, not
-`ErrUnsafeTransportComposition` (whose meaning stays transport-slot composition):
-match the wrapped `*jose.Error` with `errors.As`, or its sentinel with `errors.Is`.
+a policy is set now fails construction instead of failing every request. Validation
+runs on **copies** — a `jose.Policy` you reuse across builders is never mutated. The
+error is its own path, not `ErrUnsafeTransportComposition` (whose meaning stays
+transport-slot composition): every one of these — the nil `Resolver` included, which
+reports `JOSE_KEYSTORE_UNAVAILABLE` — wraps a `*jose.Error`, so match it with
+`errors.As`, or its sentinel with `errors.Is`.
 
 Kids are **not** resolved at `Build()`. A `KeyResolver` may be backed by key material
 loaded lazily, and resolving eagerly would force that load at construction — so an

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -1916,7 +1916,8 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   per-client escape hatch. To distinguish this failure from a transport-slot
   displacement, match the error rather than its text: it wraps `*jose.Error`
   (`errors.As`) and its sentinel (`errors.Is(err, jose.ErrAlgorithmDisallowed)`,
-  `jose.ErrPolicyMismatch`), and it is **not** `httpclient.ErrUnsafeTransportComposition`.
+  `jose.ErrPolicyMismatch`, or `jose.ErrKeyResolution` for the nil `Resolver`), and it
+  is **not** `httpclient.ErrUnsafeTransportComposition`.
 - verify: every `WithJOSE` client constructs at startup — `Build()` returns a nil
   error — and a request through it still round-trips against the peer. A client that
   previously sealed with `RSA1_5` will fail construction until the algorithm is

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -41,7 +41,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E52 | v0.51.0 → v0.52.0 | compile-break | 4 | C52.1 | if you set `.Args` on any declaration in ≤v0.51.0, verify current broker state before upgrading |
 | E55 | v0.52.0 → v0.55.0 | additive (safe) | 3 | none | none |
 | E56 | v0.55.0 → v0.56.0 | compile-break (C56.6 only partially — see its gate) + silent-behavior default flip (C56.11) | 15 | C56.6 C56.9 | grep log-driven alerts, dashboards, and test assertions for card-data / `iban` / `otp` field names — their values render `***` after the bump (C56.3); expect a cold tenant's first messaging request to fail fast instead of blocking (C56.4); if you assemble config in Go, check for `forwardedclientcert.require` without `enabled` — that service was serving unauthenticated traffic and now returns 401 (C56.5); if one queue name is declared from two places, confirm the two shapes agree — a mismatch that used to be silently overwritten now fails startup (C56.7); if you call a JOSE-protected peer, check for payload-free requests of **any** method — `GET`/`HEAD`/`DELETE` as well as `POST`/`PUT`/`PATCH` — since none of them are sealed now and a peer demanding `application/jose` on every request will answer 415 (C56.8); `/ready`'s 200 body gains `cache` and `cache_stats` and, where a cache is configured, every poll now issues a Redis `PING`, so update any test, schema, or dashboard that pins its exact key set and expect a live cache outage to read `unhealthy` (C56.10); if you run with a top-level cache enabled (or supply an `Options.CacheConnector`, which is probed regardless of `cache.enabled`) and have never set `cache.critical`, that outage now also answers `503` and drains every replica from rotation at once — decide before the bump whether to keep the strict default (and set `readinessProbe.failureThreshold: 3`) or add `cache.critical: false` (C56.11); and if any alert or runbook parses the Redis address out of `/ready`'s `503` body, repoint it at the app log or `/_sys/health-debug` (C56.12); and a module that cannot work without a database can now declare `app.DatabaseRequirer` so an absent one aborts startup rather than booting green (C56.13); check every environment that sets any `database.*` identity field for a complete section, since a partial one now fails startup (C56.14); and re-point any alert asserting `/ready` returns 503 for a database-free or multi-tenant service — both now return 200 (C56.15) |
-| E57 | v0.56.0 → v0.57.0 | silent-behavior + breaking (C57.4, C57.5, C57.6, C57.7, C57.8 abort startup) | 8 | C57.7 (only partially — a direct call still compiles; see its scope) | if any alert, runbook, synthetic check, or contract test parses the driver error out of `/ready`'s database `503` body, repoint it at the app log or `<debug.pathprefix>/health-debug` (default `/_sys`) — the field is now the fixed string `database unavailable` (C57.1); and if you implement your own critical `app.Prober`, its `503` body now reads `<Name> unavailable` instead of its raw error, since sanitization became the default rather than an opt-in (C57.2); and if anything reads `db_stats.connections` out of `/ready`'s **200** body — a per-tenant pool dashboard, an activity alert, a test pinning the key set — repoint it at `<debug.pathprefix>/health-debug` or the OTel database metrics, because that array is gone from `/ready`; a repo-local grep alone will not find an out-of-repo dashboard (C57.3); and check every environment with `outbox.enabled: true` or `inbox.enabled: true` (outside per-tenant fan-out or a dynamic source) for a configured, reachable database whose ledger table exists — or whose `autocreatetable` can create it — because Init now aborts startup instead of booting green (C57.4); and check every `database.connectionstring` (root, `databases.*`, `multitenant.tenants.*`) with no `database.type` set — a recognized scheme (`postgres://`, `postgresql://`, `oracle://`) now infers its type and actually dials instead of booting into a dead connection, and an unrecognized scheme on the built-in connector now fails startup instead of failing at first query (C57.5); and check every environment for a database identity key delivered as an empty string (an empty `secretKeyRef`, `envsubst` over an unset variable) — that shape used to load silently as database-free and now aborts startup naming the key (C57.6); and check every environment for `debug.enabled: true` (`DEBUG_ENABLED=true`) with at least one `debug.endpoints.*` flag on, an empty `debug.allowedips` and no `debug.bearertoken` — all four required, and that service refuses to start after the bump; and if you assemble config in Go, check for a `Debug` block with `Enabled: true` and any endpoint flag but no `AllowedIPs` — that path never received the loopback default, so the refusal is reachable there by omission; grep shortlists, booting in staging decides (C57.7); and check every **single-tenant** service that declares AMQP consumers for a broker that is reachable, accepts its credentials, and accepts its declarations at boot, because a consumer bootstrap failure now aborts startup instead of logging one WARN and serving HTTP while consuming nothing forever — publisher-only and messaging-free services are unaffected (C57.8) |
+| E57 | v0.56.0 → v0.57.0 | silent-behavior + breaking (C57.4, C57.5, C57.6, C57.7, C57.8 abort startup; C57.9 fails `httpclient` construction) | 9 | C57.7 (only partially — a direct call still compiles; see its scope) | if any alert, runbook, synthetic check, or contract test parses the driver error out of `/ready`'s database `503` body, repoint it at the app log or `<debug.pathprefix>/health-debug` (default `/_sys`) — the field is now the fixed string `database unavailable` (C57.1); and if you implement your own critical `app.Prober`, its `503` body now reads `<Name> unavailable` instead of its raw error, since sanitization became the default rather than an opt-in (C57.2); and if anything reads `db_stats.connections` out of `/ready`'s **200** body — a per-tenant pool dashboard, an activity alert, a test pinning the key set — repoint it at `<debug.pathprefix>/health-debug` or the OTel database metrics, because that array is gone from `/ready`; a repo-local grep alone will not find an out-of-repo dashboard (C57.3); and check every environment with `outbox.enabled: true` or `inbox.enabled: true` (outside per-tenant fan-out or a dynamic source) for a configured, reachable database whose ledger table exists — or whose `autocreatetable` can create it — because Init now aborts startup instead of booting green (C57.4); and check every `database.connectionstring` (root, `databases.*`, `multitenant.tenants.*`) with no `database.type` set — a recognized scheme (`postgres://`, `postgresql://`, `oracle://`) now infers its type and actually dials instead of booting into a dead connection, and an unrecognized scheme on the built-in connector now fails startup instead of failing at first query (C57.5); and check every environment for a database identity key delivered as an empty string (an empty `secretKeyRef`, `envsubst` over an unset variable) — that shape used to load silently as database-free and now aborts startup naming the key (C57.6); and check every environment for `debug.enabled: true` (`DEBUG_ENABLED=true`) with at least one `debug.endpoints.*` flag on, an empty `debug.allowedips` and no `debug.bearertoken` — all four required, and that service refuses to start after the bump; and if you assemble config in Go, check for a `Debug` block with `Enabled: true` and any endpoint flag but no `AllowedIPs` — that path never received the loopback default, so the refusal is reachable there by omission; grep shortlists, booting in staging decides (C57.7); and check every **single-tenant** service that declares AMQP consumers for a broker that is reachable, accepts its credentials, and accepts its declarations at boot, because a consumer bootstrap failure now aborts startup instead of logging one WARN and serving HTTP while consuming nothing forever — publisher-only and messaging-free services are unaffected (C57.8); and read every `WithJOSE` policy and direct `jose.Seal` call for an explicitly-set algorithm outside the allowlist — `KeyAlg: RSA1_5` or a non-AEAD `Enc` sealed successfully before and now fails `Build()` at startup, while a policy that named no algorithms at all takes the package defaults and starts working instead of failing every request (C57.9) |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 
@@ -1306,6 +1306,15 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   (it is what declares exchanges, queues, and bindings), so publisher-only services — and
   every service with no messaging configured, which reaches the same call with an empty
   declaration set and an unresolvable broker URL — keep warn-and-continue (C57.8).
+  Lastly, `httpclient.Builder.Build()` extends its ADR-044 fail-closed posture to JOSE:
+  it fills a policy's unset algorithms from the `jose` defaults and runs
+  `jose.Policy.Validate` — the check the server's tag scanner has always run at
+  registration — so a disallowed algorithm, direction-mismatched kids, or a nil
+  `Resolver` fails construction rather than every request. `jose.Seal` now runs the
+  allowlist itself as well, closing the gap where an httpclient-built policy could emit
+  a JWE wrapped with `RSA1_5` or a non-AEAD content encryption — shapes go-jose sealed
+  happily, below the framework's own floor. Kid *resolution* stays per-request, so a
+  lazily-loaded keystore is not forced open at construction (C57.9).
 - build-caught: none
 - exit: `go get github.com/gaborage/go-bricks@v0.57.0 && go mod tidy && go build ./... && go test ./...`
 
@@ -1825,6 +1834,97 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   restart backoff is configured, or start the broker first.
 - ref: `app/messaging_setup.go` (`PrepareRuntimeConsumers`) · `app/lifecycle.go`
   (`prepareMessagingConsumers`, `assertMessagingConfiguredIfDeclared`)
+
+### [C57.9] `httpclient.Build` validates JOSE policies; `jose.Seal` enforces the algorithm allowlist · breaking · when: match
+
+- detect: `git grep -n 'WithJOSE(' -- '*.go'` for the builder call sites and
+  `git grep -n 'jose\.Seal(' -- '*.go'` for direct sealing, then read the
+  `*jose.Policy` each one is handed. You are looking for three shapes:
+  an explicitly-set `SigAlg`, `KeyAlg`, or `Enc` outside the allowlist
+  (`RS256`/`PS256`; `RSA-OAEP-256`; `A256GCM`) — `git grep -nE
+  'SigAlg:|KeyAlg:|Enc:' -- '*.go'` enumerates the assignments; kids that do
+  not match the policy's `Direction` (an outbound policy carrying
+  `DecryptKid`/`VerifyKid`, or missing `SignKid`/`EncryptKid`); and a
+  `JOSEConfig` whose `Resolver` is nil while `Outbound` or `Inbound` is set.
+  All three greps are line-oriented and blind to an import alias or a policy
+  built field-by-field across statements, so treat them as probes: the
+  authoritative answer is that `Build()` now returns the error, at startup,
+  for every affected client.
+- scope: `Build` normalizes each non-nil policy — unset `SigAlg`/`KeyAlg`/`Enc`/`Cty`
+  take the `jose` package defaults — and then runs `jose.Policy.Validate`, the same
+  check the server's struct-tag scanner has always run at route registration.
+  Normalization happens on **copies**, so a `jose.Policy` shared across builders is
+  never mutated. **The two call-site classes are not affected alike.** Through
+  `WithJOSE` you get both halves — unset algorithms take the package defaults, and only
+  a genuinely invalid policy fails, at `Build()`, before the process serves traffic. A
+  **direct** `jose.Seal` caller gets the check without the defaults: `Seal` now runs the
+  allowlist itself before touching the crypto adapter, so an explicitly-set disallowed
+  algorithm that used to seal successfully returns `JOSE_ALGORITHM_DISALLOWED` at
+  runtime, and a policy that left its algorithms unset now fails the same way rather
+  than on whatever go-jose made of an empty `alg`. **Kid *resolution* is
+  deliberately not part of this**: a `KeyResolver` may be backed by lazily-loaded key
+  material, so an unknown kid still fails per request as `JOSE_KID_UNKNOWN`.
+- gate: match = a policy you hand to `WithJOSE` or `jose.Seal` explicitly names an
+  algorithm outside the allowlist, or sets kids that contradict its `Direction`, or
+  you call `WithJOSE` with a policy and no `Resolver`. The consequential case is
+  `KeyAlg: RSA1_5` or a non-AEAD `Enc`: those **worked** before — go-jose sealed them
+  and the peer accepted them — so the client is emitting tokens below the framework's
+  floor today and stops building after the bump. no-match = your policies come from
+  the defaults or `jose/testing`'s fixtures, or they set no algorithms at all *and*
+  reach the wire through `WithJOSE`. A policy that named **no** algorithms is strictly
+  better off on that path — it used to reach the crypto adapter with an empty `alg` and
+  fail every request with `JOSE_OUTBOUND_FAILED`, and now takes the package defaults and
+  works — but the same policy handed to `jose.Seal` **directly** is a match, because
+  nothing defaults it there and it now fails as `JOSE_ALGORITHM_DISALLOWED`.
+  A disallowed *signature* algorithm (`HS256`) is likewise not a regression in
+  outcome — it already failed every request — only in timing.
+- before:
+
+  ```go
+  // Built fine; every request failed, or (RSA1_5) succeeded below the algorithm floor.
+  client, err := httpclient.NewBuilder(logger).
+      WithTransport(base).
+      WithJOSE(httpclient.JOSEConfig{
+          Outbound: &jose.Policy{
+              Direction: jose.DirectionOutbound,
+              SignKid:   "our-signing", EncryptKid: "visa-vts-encrypt",
+              KeyAlg:    "RSA1_5",
+          },
+          Resolver: resolver,
+      }).Build()
+  ```
+
+- after:
+
+  ```go
+  // err: "httpclient: invalid JOSE policy: JOSE_ALGORITHM_DISALLOWED:
+  //       key-wrapping algorithm not in allowlist"
+  //
+  // Drop the field to take the default (RSA-OAEP-256):
+  Outbound: &jose.Policy{
+      Direction: jose.DirectionOutbound,
+      SignKid:   "our-signing", EncryptKid: "visa-vts-encrypt",
+  },
+  ```
+
+- apply: remove the disallowed algorithm and let the default apply, or fix the kids
+  for the policy's direction, or pass the `Resolver` you were relying on the transport
+  to have. Do not work around it by constructing the `JOSETransport` struct directly —
+  `jose.Seal` enforces the allowlist too, so that path fails at the same point without
+  the startup signal. A peer that genuinely requires `RSA1_5` needs the allowlist
+  widened in `jose/algorithms.go` with the padding-oracle risk argued in an ADR, not a
+  per-client escape hatch. To distinguish this failure from a transport-slot
+  displacement, match the error rather than its text: it wraps `*jose.Error`
+  (`errors.As`) and its sentinel (`errors.Is(err, jose.ErrAlgorithmDisallowed)`,
+  `jose.ErrPolicyMismatch`), and it is **not** `httpclient.ErrUnsafeTransportComposition`.
+- verify: every `WithJOSE` client constructs at startup — `Build()` returns a nil
+  error — and a request through it still round-trips against the peer. A client that
+  previously sealed with `RSA1_5` will fail construction until the algorithm is
+  changed; confirm with the peer that it accepts `RSA-OAEP-256` before deploying.
+- ref: ADR-044 (the fail-closed `Build` posture this extends) ·
+  `httpclient/client.go` (`WithJOSE`, `normalizeJOSE`, `normalizedJOSEPolicy`) ·
+  `jose/sealer.go` (`Seal`) · `jose/policy.go` (`validateAlgorithms`) ·
+  [wiki/httpclient.md](httpclient.md#jose-policy-validation-at-build)
 
 ---
 


### PR DESCRIPTION
## What

httpclient JOSE policies were never validated: mistakes surfaced as per-request `JOSE_OUTBOUND_FAILED`, and `jose.Seal` handed algorithms to the crypto adapter verbatim, so an httpclient-built policy could emit JWEs below the framework's floor (`RSA1_5`, non-AEAD `Enc` sealed successfully — reproduced under hand-mutation). `Build()` now fills unset algorithms from the jose defaults and runs `Policy.Validate`; `Seal` enforces the allowlist itself; a repeated `WithJOSE` no longer stacks wrappers — last call wins, body sealed exactly once.

## Impact

Migration atom `[C57.8]` (breaking): invalid `WithJOSE` policies fail `Build()` at startup; direct `jose.Seal` callers with disallowed or unset algorithms now get `JOSE_ALGORITHM_DISALLOWED` at runtime. Zero-value algorithms on the httpclient path keep working via defaults. Kid resolution stays per-request.

## Verification

Three hand-mutations (Seal allowlist, Build normalization, wrapper guard) each failed only their own tests; double-seal reproduced (inner JWE returned) then guarded. Diff-scoped mutation gate green. Local CodeRabbit pass 1: two findings, both fixed here; pass 2 hit the free-tier throttle — the PR bot review covers the final diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
