### PR TITLE
fix(server)!: remove unreferenced Test*Timeout constants

### DIFF
--- a/server/constants.go
+++ b/server/constants.go
@@ -68,21 +68,3 @@ const (
 	// DefaultAPITimeout is the maximum duration for external API calls.
 	DefaultAPITimeout = 30 * time.Second
 )
-
-// Test-Specific Timeouts
-//
-// These constants are used exclusively in test files for simulating
-// timeout scenarios and synchronization.
-
-const (
-	// TestShortTimeout is a very short timeout for testing timeout behavior.
-	// Used in handler tests to verify proper timeout error handling.
-	TestShortTimeout = 100 * time.Millisecond
-
-	// TestMediumTimeout is a moderate timeout for async operations in tests.
-	TestMediumTimeout = 1 * time.Second
-
-	// TestLongTimeout is a generous timeout for slow operations in tests.
-	// Used when testing complex handlers or integration scenarios.
-	TestLongTimeout = 5 * time.Second
-)

--- a/wiki/adr_053_remove_server_test_timeout_constants.md
+++ b/wiki/adr_053_remove_server_test_timeout_constants.md
@@ -1,0 +1,67 @@
+# ADR-053: Delete `server`'s exported test-timeout constants
+
+- **Status**: Accepted
+- **Date**: 2026-08-07
+- **Related**: [ADR-052](adr_052_remove_jose_policy_registry.md) (the same disposition, same hop)
+
+## Context
+
+`server/constants.go` declared three exported constants under a section header asserting a
+use that never existed:
+
+```go
+// Test-Specific Timeouts
+//
+// These constants are used exclusively in test files for simulating
+// timeout scenarios and synchronization.
+
+const (
+	TestShortTimeout  = 100 * time.Millisecond
+	TestMediumTimeout = 1 * time.Second
+	TestLongTimeout   = 5 * time.Second
+)
+```
+
+Nothing in the repository referenced them — zero hits outside their own declaration, in
+production or test code, for their whole life. The header was not describing a convention that
+had lapsed; it was describing one that was never adopted.
+
+They are also an odd thing for a framework to export at all. `server` is a `go get`-consumed
+package, and test-timing values carry no framework semantics: no production code read them, so
+their values constrained nothing.
+
+## Decision
+
+**Delete all three.**
+
+**Adopt them instead**, replacing the ad-hoc literals in `server`'s own tests, was the
+alternative worth taking seriously — it would make the header true with no API change. Counted
+first, as the issue asked: 14 occurrences of `100 * time.Millisecond`, 10 of `1 * time.Second`,
+3 of `5 * time.Second`. But most of the `1 * time.Second` hits are `SlowRequestThreshold`
+values, which is a *threshold*, not a timeout, and several of the `100ms` hits are rate-limiter
+refill sleeps. Substituting `TestMediumTimeout` there would name the value after something it
+is not, making the tests less legible in exchange for retiring an issue. Where the vocabulary is
+genuinely wanted, an unexported constant in the test file is the better home.
+
+**Deprecate in place** was rejected for the reason the manifesto gives: obsolete exported paths
+are removed, not shimmed.
+
+## Consequences
+
+**Positive.** Three exported symbols leave the public surface along with a comment that
+asserted a convention the codebase never followed.
+
+**Negative.** This is apidiff-INCOMPATIBLE. Consumer impact is plausibly zero — test-timing
+constants exported from a framework's `server` package are an unlikely dependency — but that
+cannot be proven from inside this repo, so it pays the breaking-change ceremony like any other.
+Replacement is a literal or a constant in the consumer's own test package; `[C58.2]` in
+[migrations.md](migrations.md) records the three values.
+
+**Neutral.** Nothing behavioural changes. No framework code ever read these, so the only
+possible effect is on whether code naming them compiles.
+
+## References
+
+- #818 — the report, from the `doc-drift` audit at `bb43eb1`
+- `server/constants.go`
+- [migrations.md](migrations.md) `[C58.2]`

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -938,6 +938,30 @@ Fixes [#880](https://github.com/gaborage/go-bricks/issues/880). See
 
 ---
 
+### [ADR-053: Delete `server`'s Exported Test-Timeout Constants](adr_053_remove_server_test_timeout_constants.md)
+
+**Date:** 2026-08-07 | **Status:** Accepted
+
+`server/constants.go` exported `TestShortTimeout` (100ms), `TestMediumTimeout` (1s) and
+`TestLongTimeout` (5s) under a header asserting they "are used exclusively in test files for
+simulating timeout scenarios and synchronization". Nothing in the repository referenced them, in
+production or test code, for their whole life — the header described a convention that was never
+adopted rather than one that lapsed. Adopting them was counted before being rejected: 14
+occurrences of `100 * time.Millisecond`, 10 of `1 * time.Second`, 3 of `5 * time.Second`, but most
+of the one-second hits are `SlowRequestThreshold` values (a threshold, not a timeout) and several
+100ms hits are rate-limiter refill sleeps, so substituting a shared constant would name each value
+after something it is not. Deprecating in place was rejected as the compatibility shim the
+manifesto forbids. Where a shared test vocabulary is genuinely wanted, an unexported constant in
+the test file is the right home — a framework exporting test-timing values constrains nothing,
+since no production code ever read them.
+
+**Key Benefits:** Three exported symbols leave the public surface along with a comment asserting a
+convention the codebase never followed; nothing behavioural changes, since no framework code read
+these values. Fixes [#818](https://github.com/gaborage/go-bricks/issues/818). See
+[migrations.md](migrations.md) `[C58.2]`.
+
+---
+
 ## ADR Lifecycle
 
 - **Proposed**: Under discussion, not yet implemented
@@ -947,7 +971,7 @@ Fixes [#880](https://github.com/gaborage/go-bricks/issues/880). See
 
 ### Numbering Policy
 
-ADR numbers (ADR-001 through ADR-051) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
+ADR numbers (ADR-001 through ADR-053) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
 
 ## Writing New ADRs
 

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -19,7 +19,7 @@ A plain `vX.Y.Z` is your current node. `=>` a local path (dev `replace`) means t
 **3 — Select the hop chain** on the Ladder: every edge strictly to the right of CURRENT, up to and including TARGET. Never apply an edge at/left of CURRENT.
 
 ```text
-v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0 ─E43─ v0.43.0 ─E44─ v0.44.0 ─E45─ v0.45.0 ─E49─ v0.49.0 ─E50─ v0.50.0 ─E51─ v0.51.0 ─E52─ v0.52.0 ─E55─ v0.55.0 ─E56─ v0.56.0 ─E57─ v0.57.0
+v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0 ─E43─ v0.43.0 ─E44─ v0.44.0 ─E45─ v0.45.0 ─E49─ v0.49.0 ─E50─ v0.50.0 ─E51─ v0.51.0 ─E52─ v0.52.0 ─E55─ v0.55.0 ─E56─ v0.56.0 ─E57─ v0.57.0 ─E58─ v0.58.0
 ```
 
 > v0.46.0–v0.48.0 shipped additive-only changes (route template/path-param accessors, raw-route descriptors, module-contributed global middleware — adopt-only, no migration atoms), so E49 is the next hop after v0.45.0 and applies when crossing from any of v0.45.0–v0.48.0 to v0.49.0.
@@ -42,6 +42,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E55 | v0.52.0 → v0.55.0 | additive (safe) | 3 | none | none |
 | E56 | v0.55.0 → v0.56.0 | compile-break (C56.6 only partially — see its gate) + silent-behavior default flip (C56.11) | 15 | C56.6 C56.9 | grep log-driven alerts, dashboards, and test assertions for card-data / `iban` / `otp` field names — their values render `***` after the bump (C56.3); expect a cold tenant's first messaging request to fail fast instead of blocking (C56.4); if you assemble config in Go, check for `forwardedclientcert.require` without `enabled` — that service was serving unauthenticated traffic and now returns 401 (C56.5); if one queue name is declared from two places, confirm the two shapes agree — a mismatch that used to be silently overwritten now fails startup (C56.7); if you call a JOSE-protected peer, check for payload-free requests of **any** method — `GET`/`HEAD`/`DELETE` as well as `POST`/`PUT`/`PATCH` — since none of them are sealed now and a peer demanding `application/jose` on every request will answer 415 (C56.8); `/ready`'s 200 body gains `cache` and `cache_stats` and, where a cache is configured, every poll now issues a Redis `PING`, so update any test, schema, or dashboard that pins its exact key set and expect a live cache outage to read `unhealthy` (C56.10); if you run with a top-level cache enabled (or supply an `Options.CacheConnector`, which is probed regardless of `cache.enabled`) and have never set `cache.critical`, that outage now also answers `503` and drains every replica from rotation at once — decide before the bump whether to keep the strict default (and set `readinessProbe.failureThreshold: 3`) or add `cache.critical: false` (C56.11); and if any alert or runbook parses the Redis address out of `/ready`'s `503` body, repoint it at the app log or `/_sys/health-debug` (C56.12); and a module that cannot work without a database can now declare `app.DatabaseRequirer` so an absent one aborts startup rather than booting green (C56.13); check every environment that sets any `database.*` identity field for a complete section, since a partial one now fails startup (C56.14); and re-point any alert asserting `/ready` returns 503 for a database-free or multi-tenant service — both now return 200 (C56.15) |
 | E57 | v0.56.0 → v0.57.0 | silent-behavior + breaking (C57.4, C57.5, C57.6, C57.7, C57.8 abort startup; C57.9 fails `httpclient` construction) | 9 | C57.7 (only partially — a direct call still compiles; see its scope) | if any alert, runbook, synthetic check, or contract test parses the driver error out of `/ready`'s database `503` body, repoint it at the app log or `<debug.pathprefix>/health-debug` (default `/_sys`) — the field is now the fixed string `database unavailable` (C57.1); and if you implement your own critical `app.Prober`, its `503` body now reads `<Name> unavailable` instead of its raw error, since sanitization became the default rather than an opt-in (C57.2); and if anything reads `db_stats.connections` out of `/ready`'s **200** body — a per-tenant pool dashboard, an activity alert, a test pinning the key set — repoint it at `<debug.pathprefix>/health-debug` or the OTel database metrics, because that array is gone from `/ready`; a repo-local grep alone will not find an out-of-repo dashboard (C57.3); and check every environment with `outbox.enabled: true` or `inbox.enabled: true` (outside per-tenant fan-out or a dynamic source) for a configured, reachable database whose ledger table exists — or whose `autocreatetable` can create it — because Init now aborts startup instead of booting green (C57.4); and check every `database.connectionstring` (root, `databases.*`, `multitenant.tenants.*`) with no `database.type` set — a recognized scheme (`postgres://`, `postgresql://`, `oracle://`) now infers its type and actually dials instead of booting into a dead connection, and an unrecognized scheme on the built-in connector now fails startup instead of failing at first query (C57.5); and check every environment for a database identity key delivered as an empty string (an empty `secretKeyRef`, `envsubst` over an unset variable) — that shape used to load silently as database-free and now aborts startup naming the key (C57.6); and check every environment for `debug.enabled: true` (`DEBUG_ENABLED=true`) with at least one `debug.endpoints.*` flag on, an empty `debug.allowedips` and no `debug.bearertoken` — all four required, and that service refuses to start after the bump; and if you assemble config in Go, check for a `Debug` block with `Enabled: true` and any endpoint flag but no `AllowedIPs` — that path never received the loopback default, so the refusal is reachable there by omission; grep shortlists, booting in staging decides (C57.7); and check every **single-tenant** service that declares AMQP consumers for a broker that is reachable, accepts its credentials, and accepts its declarations at boot, because a consumer bootstrap failure now aborts startup instead of logging one WARN and serving HTTP while consuming nothing forever — publisher-only and messaging-free services are unaffected (C57.8); and read every `WithJOSE` policy and direct `jose.Seal` call for an explicitly-set algorithm outside the allowlist — `KeyAlg: RSA1_5` or a non-AEAD `Enc` sealed successfully before and now fails `Build()` at startup, while a policy that named no algorithms at all takes the package defaults and starts working instead of failing every request (C57.9) |
+| E58 | v0.57.0 → v0.58.0 | compile-break | 1 | C58.2 | none |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 
@@ -1926,6 +1927,38 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   `httpclient/client.go` (`WithJOSE`, `normalizeJOSE`, `normalizedJOSEPolicy`) ·
   `jose/sealer.go` (`Seal`) · `jose/policy.go` (`validateAlgorithms`) ·
   [wiki/httpclient.md](httpclient.md#jose-policy-validation-at-build)
+
+## E58 · v0.57.0 → v0.58.0 — dead exported surface removed
+
+- gist: `server.TestShortTimeout`, `TestMediumTimeout` and `TestLongTimeout` leave the public
+  API. The three exported `time.Duration` constants were declared under a header asserting
+  they are "used exclusively in test files" and were referenced by nothing in the framework,
+  production or test, for their whole life. No framework code ever read them, so removing
+  them changes no behaviour — only whether code naming them compiles (C58.2).
+- build-caught: C58.2
+- preflight: none
+- exit: `go get github.com/gaborage/go-bricks@v0.58.0 && go mod tidy && go build ./... && go test ./...`
+
+### [C58.2] `server.TestShortTimeout`, `TestMediumTimeout` and `TestLongTimeout` are removed · compile-break · when: match
+
+- detect: `git grep -nE 'Test(Short|Medium|Long)Timeout' -- '*.go'`. As everywhere in this runbook, keep the pattern free of `\b`/`\s`/`\w` — `git grep -E` has no PCRE escapes, so a pattern carrying one silently matches nothing and the gate reports "not affected"
+- scope: three exported `time.Duration` constants in `server/constants.go` — `TestShortTimeout` (100ms), `TestMediumTimeout` (1s), `TestLongTimeout` (5s). No framework code ever read them, so nothing changes behaviourally; only code that names them stops compiling. The `Default*Timeout` constants in the same file (`DefaultReadTimeout`, `DefaultWriteTimeout`, `DefaultIdleTimeout`, `DefaultShutdownTimeout`, `DefaultAPITimeout`) are untouched
+- gate: match = the detect returns ≥1 line. no-match = no Go file names any of the three
+- before:
+
+  ```go
+  ctx, cancel := context.WithTimeout(context.Background(), server.TestShortTimeout)
+  ```
+
+- after:
+
+  ```go
+  ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+  ```
+
+  Or keep the vocabulary as constants in your own test package — `const testShortTimeout = 100 * time.Millisecond` — which is where test-timing values belong. The three removed values were 100ms, 1s and 5s respectively
+- verify: `go build ./... && go test ./...`
+- ref: [ADR-053](adr_053_remove_server_test_timeout_constants.md) · #818 · `server/constants.go`
 
 ---
 


### PR DESCRIPTION
## What

`server.TestShortTimeout`, `TestMediumTimeout` and `TestLongTimeout` sat under a header claiming they are "used exclusively in test files" and were referenced by nothing in the repository — production or test — for their whole life. They are deleted.

## Impact

Breaking — three constants leave the public API; replace with a literal or a constant in your own test package (the values were 100ms, 1s, 5s). Adopting them in `server`'s own tests was rejected: the nearest literals are `SlowRequestThreshold` values, which are thresholds rather than timeouts. See `wiki/migrations.md` `[C58.2]`.

## Verification

CI gates only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the migration guide for version 0.58.0.
  * Documented the removal of exported test timeout constants and recommended defining equivalent local values where needed.

* **Refactor**
  * Removed test-only timeout constants.
  * Production timeout behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->