### PR TITLE
fix(logger)!: reserve resource-identity namespaces in OTel bridge

### DIFF
--- a/logger/otel_bridge.go
+++ b/logger/otel_bridge.go
@@ -4,14 +4,45 @@ import (
 	"context"
 	"encoding/json"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
 	"go.opentelemetry.io/otel/trace"
+)
+
+// Reserved resource-identity attribute namespaces (OTel semantic conventions).
+// Caller log fields matching these are remapped under callerAttrPrefix so a log
+// call can never shadow the provider's resource identity at record level, where
+// record attributes deliberately win over resource attributes on collision (#915).
+// log.type is intentionally NOT reserved: dual-mode routing depends on callers
+// (e.g. request middleware) setting it. Only top-level keys are guarded: nested
+// map values flatten under their parent key and cannot collide with bare
+// resource keys.
+const (
+	reservedServicePrefix      = "service."
+	reservedTelemetrySDKPrefix = "telemetry.sdk."
+	// Same semconv constant observability/provider.go stamps on the resource,
+	// so the guard and the resource cannot drift apart on this key.
+	reservedDeploymentEnvKey = string(semconv.DeploymentEnvironmentNameKey)
+
+	// callerAttrPrefix relocates colliding caller fields
+	// (e.g. service.name -> app.service.name), preserving the value.
+	callerAttrPrefix = "app."
+
+	// maxRemapWarnKeysLen bounds the key list carried by the one-time remap
+	// WARN; field names are caller-influenced and must not grow the record.
+	maxRemapWarnKeysLen = 256
+
+	// logTypeAttrKey routes records through dual-mode processing
+	// (observability.DualModeLogProcessor); deliberately caller-settable.
+	logTypeAttrKey = "log.type"
 )
 
 // OTelBridge converts zerolog JSON output to OpenTelemetry log records.
@@ -19,6 +50,7 @@ import (
 type OTelBridge struct {
 	loggerProvider *sdklog.LoggerProvider
 	logger         log.Logger
+	remapWarnOnce  sync.Once
 }
 
 // NewOTelBridge creates a new bridge that converts zerolog logs to OTel log records.
@@ -49,16 +81,55 @@ func (b *OTelBridge) Write(p []byte) (n int, err error) {
 		return len(p), nil
 	}
 
-	rec, ctx := buildLogRecord(entry)
+	rec, ctx, remapped := buildLogRecord(entry)
 	b.logger.Emit(ctx, rec)
+
+	if len(remapped) > 0 {
+		b.remapWarnOnce.Do(func() {
+			b.emitRemapWarning(ctx, remapped)
+		})
+	}
 
 	return len(p), nil
 }
 
-func buildLogRecord(entry map[string]any) (log.Record, context.Context) {
-	var rec log.Record
+// emitRemapWarning emits a WARN naming the remapped keys, once per bridge
+// instance (the framework wires a single bridge per process).
+// It builds the record directly and emits via b.logger — never through zerolog
+// (the bridge sits inside zerolog's writer chain; logging through it recurses).
+// Because it bypasses the SensitiveDataFilter it carries key names only, never
+// field values.
+func (b *OTelBridge) emitRemapWarning(ctx context.Context, remapped []string) {
+	sort.Strings(remapped)
+	keys := strings.Join(remapped, ",")
+	// Unconditional bound: ToValidUTF8 repairs a rune split by the byte cut and
+	// returns the string unchanged when nothing was cut.
+	keys = strings.ToValidUTF8(keys[:min(len(keys), maxRemapWarnKeysLen)], "")
 
-	ctx := context.Background()
+	var rec log.Record
+	rec.SetTimestamp(time.Now())
+	rec.SetSeverity(log.SeverityWarn)
+	rec.SetSeverityText(LevelWarn)
+	rec.SetBody(attribute.StringValue(
+		"log fields shadow reserved resource attribute namespaces; remapped with \"" + callerAttrPrefix + "\" prefix"))
+	rec.AddAttributes(
+		attribute.String("reserved.keys", keys),
+		attribute.String(logTypeAttrKey, "trace"),
+	)
+	b.logger.Emit(ctx, rec)
+}
+
+// isReservedAttrKey reports whether a caller field key would shadow the
+// provider's resource identity. Trailing dots in the prefixes are load-bearing:
+// bare "service", "servicex", or "deployment.environment" must not match.
+func isReservedAttrKey(k string) bool {
+	return strings.HasPrefix(k, reservedServicePrefix) ||
+		strings.HasPrefix(k, reservedTelemetrySDKPrefix) ||
+		k == reservedDeploymentEnvKey
+}
+
+func buildLogRecord(entry map[string]any) (rec log.Record, ctx context.Context, remapped []string) {
+	ctx = context.Background()
 	var traceIDStr, spanIDStr string
 	var traceFlags trace.TraceFlags
 	hasTraceContext := false
@@ -80,7 +151,7 @@ func buildLogRecord(entry map[string]any) (log.Record, context.Context) {
 	applyTimestamp(&rec, entry)
 	applySeverity(&rec, entry)
 	applyBody(&rec, entry)
-	applyAttributes(&rec, entry)
+	remapped = applyAttributes(&rec, entry)
 
 	// Add trace correlation attributes if available
 	// - String format (trace_id, span_id) enables text-based queries
@@ -96,10 +167,10 @@ func buildLogRecord(entry map[string]any) (log.Record, context.Context) {
 	// Default to trace logs unless caller explicitly sets log.type
 	// This ensures all application logs are categorized for dual-mode routing
 	if !hasLogTypeAttribute(&rec) {
-		rec.AddAttributes(attribute.String("log.type", "trace"))
+		rec.AddAttributes(attribute.String(logTypeAttrKey, "trace"))
 	}
 
-	return rec, ctx
+	return rec, ctx, remapped
 }
 
 func applyTimestamp(rec *log.Record, entry map[string]any) {
@@ -131,12 +202,20 @@ func applyBody(rec *log.Record, entry map[string]any) {
 	}
 }
 
-func applyAttributes(rec *log.Record, entry map[string]any) {
+// applyAttributes copies entry fields onto the record and returns the original
+// names of any keys remapped out of the reserved resource namespaces (nil in
+// the common no-collision case).
+func applyAttributes(rec *log.Record, entry map[string]any) (remapped []string) {
 	attrs := make([]attribute.KeyValue, 0, len(entry))
 	for k, v := range entry {
 		// Skip fields handled elsewhere
 		if k == "time" || k == fieldLevel || k == fieldMessage || k == "msg" {
 			continue
+		}
+
+		if isReservedAttrKey(k) {
+			remapped = append(remapped, k)
+			k = callerAttrPrefix + k
 		}
 
 		attrs = append(attrs, attribute.KeyValue{
@@ -147,6 +226,7 @@ func applyAttributes(rec *log.Record, entry map[string]any) {
 	if len(attrs) > 0 {
 		rec.AddAttributes(attrs...)
 	}
+	return remapped
 }
 
 func extractSpanContext(entry map[string]any) (trace.SpanContext, bool) {
@@ -338,7 +418,7 @@ func jsonStringify(v interface{}) string {
 func hasLogTypeAttribute(rec *log.Record) bool {
 	found := false
 	rec.WalkAttributes(func(kv attribute.KeyValue) bool {
-		if kv.Key == "log.type" {
+		if kv.Key == logTypeAttrKey {
 			found = true
 			return false // Stop iteration
 		}

--- a/logger/otel_bridge_test.go
+++ b/logger/otel_bridge_test.go
@@ -49,7 +49,7 @@ func newCaptureBridge(t *testing.T) (*OTelBridge, *captureProcessor) {
 	proc := &captureProcessor{}
 	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(proc))
 	t.Cleanup(func() {
-		_ = provider.Shutdown(context.Background())
+		require.NoError(t, provider.Shutdown(context.Background()))
 	})
 	bridge := NewOTelBridge(provider)
 	require.NotNil(t, bridge)

--- a/logger/otel_bridge_test.go
+++ b/logger/otel_bridge_test.go
@@ -2,6 +2,11 @@ package logger
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +16,81 @@ import (
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// captureProcessor records every emitted log record for assertions.
+type captureProcessor struct {
+	mu      sync.Mutex
+	records []sdklog.Record
+}
+
+func (p *captureProcessor) OnEmit(_ context.Context, rec *sdklog.Record) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.records = append(p.records, rec.Clone())
+	return nil
+}
+
+//nolint:gocritic // hugeParam: EnabledParameters passed by value per OTel SDK interface contract
+func (p *captureProcessor) Enabled(_ context.Context, _ sdklog.EnabledParameters) bool {
+	return true
+}
+
+func (p *captureProcessor) Shutdown(_ context.Context) error   { return nil }
+func (p *captureProcessor) ForceFlush(_ context.Context) error { return nil }
+
+func (p *captureProcessor) snapshot() []sdklog.Record {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]sdklog.Record(nil), p.records...)
+}
+
+func newCaptureBridge(t *testing.T) (*OTelBridge, *captureProcessor) {
+	t.Helper()
+	proc := &captureProcessor{}
+	provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(proc))
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+	})
+	bridge := NewOTelBridge(provider)
+	require.NotNil(t, bridge)
+	return bridge, proc
+}
+
+// dataRecord returns the first record NOT emitted at WARN severity, so tests
+// don't depend on the data-before-WARN emission order.
+func dataRecord(records []sdklog.Record) (sdklog.Record, bool) {
+	for i := range records {
+		if records[i].Severity() != log.SeverityWarn {
+			return records[i], true
+		}
+	}
+	return sdklog.Record{}, false
+}
+
+// warnRecords filters the records emitted at WARN severity (the remap WARN).
+func warnRecords(records []sdklog.Record) []sdklog.Record {
+	var warns []sdklog.Record
+	for i := range records {
+		if records[i].Severity() == log.SeverityWarn {
+			warns = append(warns, records[i])
+		}
+	}
+	return warns
+}
+
+func recordAttrValue(rec *sdklog.Record, key string) (attribute.Value, bool) {
+	var val attribute.Value
+	found := false
+	rec.WalkAttributes(func(kv attribute.KeyValue) bool {
+		if string(kv.Key) == key {
+			val = kv.Value
+			found = true
+			return false
+		}
+		return true
+	})
+	return val, found
+}
 
 // TestOTelBridge_ValidJSON tests parsing of valid zerolog JSON output
 func TestOTelBridgeValidJSON(t *testing.T) {
@@ -105,7 +185,7 @@ func TestBuildLogRecordWithTraceFields(t *testing.T) {
 		"message":  "hello",
 	}
 
-	_, ctx := buildLogRecord(entry)
+	_, ctx, _ := buildLogRecord(entry)
 
 	spanCtx := trace.SpanContextFromContext(ctx)
 	require.True(t, spanCtx.IsValid(), "span context should be valid when trace_id/span_id are present")
@@ -119,7 +199,7 @@ func TestBuildLogRecordWithTraceParentFallback(t *testing.T) {
 		"message":     "hello",
 	}
 
-	_, ctx := buildLogRecord(entry)
+	_, ctx, _ := buildLogRecord(entry)
 
 	spanCtx := trace.SpanContextFromContext(ctx)
 	require.True(t, spanCtx.IsValid(), "span context should be derived from traceparent")
@@ -137,7 +217,7 @@ func TestBuildLogRecordAddsTraceAttributes(t *testing.T) {
 		"level":       "info",
 	}
 
-	rec, ctx := buildLogRecord(entry)
+	rec, ctx, _ := buildLogRecord(entry)
 
 	// Verify context has span context
 	spanCtx := trace.SpanContextFromContext(ctx)
@@ -178,13 +258,151 @@ func TestBuildLogRecordAddsTraceAttributes(t *testing.T) {
 	assert.Equal(t, int64(1), traceFlagsValue)
 }
 
+func TestOTelBridgeReservedKeyRemapPolicy(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		value     string
+		wantRemap bool
+	}{
+		{name: "service_name_remapped", key: "service.name", value: "spoofed-svc", wantRemap: true},
+		{name: "service_instance_id_remapped", key: "service.instance.id", value: "spoofed-instance", wantRemap: true},
+		{name: "telemetry_sdk_name_remapped", key: "telemetry.sdk.name", value: "spoofed-sdk", wantRemap: true},
+		{name: "deployment_environment_name_remapped", key: "deployment.environment.name", value: "spoofed-env", wantRemap: true},
+		{name: "bare_service_verbatim", key: "service", value: "v", wantRemap: false},
+		{name: "servicex_verbatim", key: "servicex", value: "v", wantRemap: false},
+		{name: "services_count_verbatim", key: "services.count", value: "v", wantRemap: false},
+		{name: "telemetry_sdkx_verbatim", key: "telemetry.sdkx", value: "v", wantRemap: false},
+		{name: "deployment_environment_verbatim", key: "deployment.environment", value: "v", wantRemap: false},
+		{name: "deployment_environment_namex_verbatim", key: "deployment.environment.namex", value: "v", wantRemap: false},
+		{name: "log_type_stays_caller_settable", key: "log.type", value: "action", wantRemap: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bridge, proc := newCaptureBridge(t)
+
+			line := fmt.Sprintf(`{"level":"info","message":"m",%q:%q}`, tt.key, tt.value)
+			_, err := bridge.Write([]byte(line))
+			require.NoError(t, err)
+
+			records := proc.snapshot()
+			require.NotEmpty(t, records)
+			rec, foundData := dataRecord(records)
+			require.True(t, foundData, "data record should be present")
+
+			wantKey, forbiddenKey := tt.key, "app."+tt.key
+			if tt.wantRemap {
+				wantKey, forbiddenKey = "app."+tt.key, tt.key
+			}
+
+			val, found := recordAttrValue(&rec, wantKey)
+			require.True(t, found, "key %s should be present", wantKey)
+			assert.Equal(t, tt.value, val.AsString(), "value must be preserved under %s", wantKey)
+
+			_, present := recordAttrValue(&rec, forbiddenKey)
+			assert.False(t, present, "key %s must not be present", forbiddenKey)
+		})
+	}
+}
+
+func TestOTelBridgeWarnsOnceOnReservedKeyRemap(t *testing.T) {
+	bridge, proc := newCaptureBridge(t)
+
+	colliding := []byte(`{"level":"info","message":"m","service.name":"evil-svc"}`)
+	clean := []byte(`{"level":"info","message":"clean"}`)
+
+	for i := 0; i < 2; i++ {
+		_, err := bridge.Write(colliding)
+		require.NoError(t, err)
+	}
+	_, err := bridge.Write(clean)
+	require.NoError(t, err)
+
+	records := proc.snapshot()
+	require.Len(t, records, 4, "3 data records + exactly 1 WARN")
+
+	warns := warnRecords(records)
+	require.Len(t, warns, 1, "remap WARN must fire exactly once per bridge instance")
+
+	warn := warns[0]
+	keys, found := recordAttrValue(&warn, "reserved.keys")
+	require.True(t, found, "WARN must name the offending keys")
+	assert.Contains(t, keys.AsString(), "service.name")
+	assert.NotContains(t, keys.AsString(), "evil-svc", "WARN must never carry the field value (bypasses SensitiveDataFilter)")
+	assert.NotContains(t, warn.Body().AsString(), "evil-svc")
+
+	logType, found := recordAttrValue(&warn, "log.type")
+	require.True(t, found, "WARN must be routable by dual-mode processing")
+	assert.Equal(t, "trace", logType.AsString())
+}
+
+func TestOTelBridgeRemapWarnTruncatesKeyList(t *testing.T) {
+	bridge, proc := newCaptureBridge(t)
+
+	entry := map[string]any{"level": "info", "message": "m"}
+	for i := 0; i < 10; i++ {
+		entry[fmt.Sprintf("service.padding.%02d.%s", i, strings.Repeat("k", 40))] = "v"
+	}
+	line, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	_, err = bridge.Write(line)
+	require.NoError(t, err)
+
+	warns := warnRecords(proc.snapshot())
+	require.Len(t, warns, 1, "remap WARN expected")
+
+	keys, found := recordAttrValue(&warns[0], "reserved.keys")
+	require.True(t, found)
+	assert.LessOrEqual(t, len(keys.AsString()), maxRemapWarnKeysLen,
+		"caller-influenced key list must be length-bounded on the WARN record")
+	assert.Contains(t, keys.AsString(), "service.padding.00.")
+}
+
+func TestOTelBridgeNoWarnWithoutCollision(t *testing.T) {
+	bridge, proc := newCaptureBridge(t)
+
+	_, err := bridge.Write([]byte(`{"level":"info","message":"m","user_id":"123"}`))
+	require.NoError(t, err)
+
+	assert.Empty(t, warnRecords(proc.snapshot()), "clean writes must not emit the remap WARN")
+}
+
+func TestOTelBridgeConcurrentRemapWarnsOnce(t *testing.T) {
+	bridge, proc := newCaptureBridge(t)
+
+	const goroutines = 8
+	const writesPerGoroutine = 5
+
+	var wg sync.WaitGroup
+	var writeErrs atomic.Int32
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < writesPerGoroutine; i++ {
+				if _, err := bridge.Write([]byte(`{"level":"info","message":"m","service.name":"evil"}`)); err != nil {
+					writeErrs.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	require.Zero(t, writeErrs.Load(), "no Write may fail under concurrency")
+
+	records := proc.snapshot()
+	require.Len(t, records, goroutines*writesPerGoroutine+1, "all data records plus exactly one WARN")
+	assert.Len(t, warnRecords(records), 1)
+}
+
 func TestBuildLogRecordWithoutTraceContext(t *testing.T) {
 	entry := map[string]any{
 		"message": "test message without trace",
 		"level":   "info",
 	}
 
-	rec, ctx := buildLogRecord(entry)
+	rec, ctx, _ := buildLogRecord(entry)
 
 	// Verify context has no span context
 	spanCtx := trace.SpanContextFromContext(ctx)

--- a/observability/resource_exporter_test.go
+++ b/observability/resource_exporter_test.go
@@ -381,7 +381,7 @@ func exportThroughBridge(t *testing.T, res *resource.Resource, line string) []sd
 	enriched := newResourceAttributeExporter(wrapped, res)
 	logProvider := sdklog.NewLoggerProvider(sdklog.WithProcessor(sdklog.NewSimpleProcessor(enriched)))
 	t.Cleanup(func() {
-		_ = logProvider.Shutdown(context.Background())
+		require.NoError(t, logProvider.Shutdown(context.Background()))
 	})
 
 	bridge := logger.NewOTelBridge(logProvider)

--- a/observability/resource_exporter_test.go
+++ b/observability/resource_exporter_test.go
@@ -13,6 +13,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/log/logtest"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
+
+	"github.com/gaborage/go-bricks/logger"
 )
 
 // Keyed off semconv rather than literals so the fixtures track the keys provider.go
@@ -350,6 +352,94 @@ func BenchmarkResourceAttributeExporterEnrichWithResource(b *testing.B) {
 			for b.Loop() {
 				_ = enricher.enrichWithResource(&rec)
 			}
+		})
+	}
+}
+
+func identityTestResource(t *testing.T) *resource.Resource {
+	t.Helper()
+	p := &provider{
+		config: Config{
+			Service: ServiceConfig{
+				Name:    "real-svc",
+				Version: "1.2.3",
+			},
+			Environment: "production",
+		},
+	}
+	res, err := p.createResource(context.Background())
+	require.NoError(t, err)
+	return res
+}
+
+// exportThroughBridge runs one zerolog JSON line through the real OTel bridge
+// and a resource-enriching exporter, returning the records a backend would see.
+func exportThroughBridge(t *testing.T, res *resource.Resource, line string) []sdklog.Record {
+	t.Helper()
+
+	wrapped := &fakeLogExporter{}
+	enriched := newResourceAttributeExporter(wrapped, res)
+	logProvider := sdklog.NewLoggerProvider(sdklog.WithProcessor(sdklog.NewSimpleProcessor(enriched)))
+	t.Cleanup(func() {
+		_ = logProvider.Shutdown(context.Background())
+	})
+
+	bridge := logger.NewOTelBridge(logProvider)
+	require.NotNil(t, bridge)
+
+	_, err := bridge.Write([]byte(line))
+	require.NoError(t, err)
+	require.NoError(t, logProvider.ForceFlush(context.Background()))
+
+	var records []sdklog.Record
+	for _, batch := range wrapped.batches {
+		records = append(records, batch...)
+	}
+	return records
+}
+
+// The composed invariant behind the bridge's reserved-namespace remap (#915):
+// because the bridge frees the reserved key, this exporter's record-over-resource
+// precedence backfills the framework's true identity, while the caller's value
+// survives under the app. prefix.
+func TestResourceEnrichmentRestoresIdentityAfterBridgeRemap(t *testing.T) {
+	res := identityTestResource(t)
+
+	records := exportThroughBridge(t, res, `{"level":"info","message":"m","service.name":"spoofed-svc"}`)
+	require.NotEmpty(t, records)
+	attrs := collectAttrs(&records[0])
+
+	require.Contains(t, attrs, serviceNameKey, "resource identity must be backfilled on the exported record")
+	assert.Equal(t, attribute.StringValue("real-svc"), attrs[serviceNameKey],
+		"the exported service.name must be the resource's, not the caller's")
+
+	require.Contains(t, attrs, attribute.Key("app.service.name"), "the caller's field must survive under the app. prefix")
+	assert.Equal(t, attribute.StringValue("spoofed-svc"), attrs[attribute.Key("app.service.name")])
+}
+
+// Drift guard: every identity key the real resource carries must be protected
+// by the bridge's reserved-namespace guard. A new resource attribute added in
+// createResource (or a semconv rename) that the bridge does not cover fails
+// here instead of silently reopening the #915 shadowing hole.
+func TestBridgeGuardCoversEveryResourceIdentityKey(t *testing.T) {
+	res := identityTestResource(t)
+
+	for _, kv := range res.Attributes() {
+		key := string(kv.Key)
+		t.Run(key, func(t *testing.T) {
+			line := fmt.Sprintf(`{"level":"info","message":"m",%q:"spoofed"}`, key)
+			records := exportThroughBridge(t, res, line)
+			require.NotEmpty(t, records)
+			attrs := collectAttrs(&records[0])
+
+			require.Contains(t, attrs, kv.Key, "identity key %s must reach the backend", key)
+			assert.NotEqual(t, attribute.StringValue("spoofed"), attrs[kv.Key],
+				"resource identity key %s is spoofable at record level — extend the bridge's reserved namespaces", key)
+
+			remapped := attribute.Key("app." + key)
+			require.Contains(t, attrs, remapped,
+				"the caller's value for %s must be preserved under the app. prefix, not dropped", key)
+			assert.Equal(t, attribute.StringValue("spoofed"), attrs[remapped])
 		})
 	}
 }

--- a/wiki/adr_055_reserved_log_attribute_namespaces.md
+++ b/wiki/adr_055_reserved_log_attribute_namespaces.md
@@ -1,0 +1,89 @@
+# ADR-055: Reserve resource-identity namespaces in the OTel log bridge
+
+- **Status**: Accepted
+- **Date**: 2026-08-07
+- **Related**: #915 (the finding), #873 (the `/security-audit` pass that surfaced it)
+
+## Context
+
+`logger/otel_bridge.go` copies every zerolog field key verbatim into a log record
+attribute, skipping only `time`, `level`, `message` and `msg`. Nothing reserved the
+OTel semantic-convention identity namespace, so a log call could set a record
+attribute that shadows the service's own identity:
+
+```go
+logger.Info().Str("service.name", "payments-core").Msg("hello")
+```
+
+The spoof survives enrichment by design: `resourceAttributeExporter.enrichWithResource`
+gives record attributes precedence over resource attributes on a key collision. That
+precedence is load-bearing — it is what keeps a caller-set `log.type` from being
+clobbered, which is how dual-mode routing works — so the spoofed value was
+deliberately protected from correction. The authoritative resource-level
+`service.name` in the OTLP `ResourceLogs` envelope was never spoofable; the exposure
+is backends that flatten record attributes over resource attributes in search and
+dashboards, where the record-level duplicate wins.
+
+The fix belongs at the bridge — the boundary where caller-supplied field names become
+attributes — not at the exporter, whose precedence must not change. The open question
+was what to do with a colliding field: drop it, prefix it, and/or warn.
+
+## Decision
+
+**Remap colliding top-level keys under the `app.` prefix, and emit a one-time WARN.**
+
+The reserved set mirrors what the provider's resource actually carries:
+
+- `service.*` (prefix)
+- `telemetry.sdk.*` (prefix)
+- `deployment.environment.name` (exact)
+
+`log.type` is intentionally not reserved — middleware sets it to `"action"` and
+dual-mode routing depends on it.
+
+A four-lens review (operator, framework philosophy, implementation risk, security)
+settled the policy 3–1 for prefixing over dropping and 3–1 for warning over silence:
+
+- **Prefix over drop.** The rename is self-evidencing on every affected record —
+  `app.service.name` sits next to the attributes an operator is already reading —
+  while a drop destroys the caller's data and, in the spoof case, the forensic
+  evidence of the attempt. The value survives for the one legitimate collision shape
+  (fields about a *downstream* service, e.g. `service.latency`). The envelope-meta
+  precedent (`timestamp`/`traceId` dropped with WARN in `server/handler.go`) does not
+  transfer: those values are framework-provided either way, so nothing is lost there.
+- **WARN over silence.** A silent rename breaks saved queries keyed on the original
+  name with no signal — the manifesto's "no degradation without signal". The WARN is
+  emitted **directly via the bridge's `log.Logger`**, never through zerolog: the
+  bridge sits inside zerolog's writer chain, so logging through it would recurse. It
+  therefore bypasses the `SensitiveDataFilter` and carries key names only, never
+  field values, with the joined key list length-bounded.
+- **Global `sync.Once`, not a per-key map.** Field names are caller-influenced, so a
+  per-key dedup map is an unbounded allocation under `service.<random>` churn. The
+  per-record prefix carries the per-key evidence; the WARN only needs to exist once
+  per bridge instance (one bridge per process in practice).
+
+Scope is deliberately top-level keys only: nested map values flatten under their
+parent key (`ctx.service.name`) and cannot collide with bare resource keys.
+
+## Consequences
+
+**Positive.** Record-level identity spoofing is neutralized for every backend,
+including those that flatten record attributes over resource attributes. The
+no-collision hot path stays allocation-free (two `strings.HasPrefix` plus one
+equality per key).
+
+**Negative.** Behavioral break for any consumer legitimately logging top-level
+fields inside the reserved namespaces — their dashboards and queries see the `app.`-
+prefixed key instead. `[C58.4]` in [migrations.md](migrations.md) records the rename.
+`app.*` keys remain caller-supplied and unauthenticated; they must never be treated
+as service identity.
+
+**Neutral.** The exporter's record-over-resource precedence is untouched. The
+resource-level identity was correct before and after.
+
+## References
+
+- #915 — the finding
+- `logger/otel_bridge.go` — guard, remap, and WARN emission
+- `observability/resource_exporter.go` — the precedence that stays
+- [migrations.md](migrations.md) `[C58.4]`

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -1023,6 +1023,31 @@ enough that no manager exists to probe. Fixes
 
 ---
 
+### [ADR-055: Reserve Resource-Identity Namespaces in the OTel Log Bridge](adr_055_reserved_log_attribute_namespaces.md)
+
+**Date:** 2026-08-07 | **Status:** Accepted
+
+The OTel log bridge copied every zerolog field key verbatim into record attributes, and the
+resource-attribute exporter deliberately lets record attributes win over resource attributes on
+collision (that precedence keeps a caller-set `log.type` authoritative for dual-mode routing) — so
+a log call could set a record-level `service.name` that shadows the service's identity on backends
+that flatten record attributes over resource attributes. The bridge now reserves `service.*`,
+`telemetry.sdk.*`, and `deployment.environment.name` at the boundary where field names become
+attributes: a colliding top-level key is remapped under the `app.` prefix with its value preserved,
+and the first remap per bridge instance (one bridge per process in practice) emits a one-time WARN
+naming the keys (never the values — the WARN bypasses zerolog, and therefore the
+`SensitiveDataFilter`, to avoid writer-chain recursion). Dropping the field was rejected as
+anti-forensic and data-destroying; a per-key WARN dedup map was rejected as an unbounded allocation
+under caller-influenced key churn. `log.type` stays caller-settable; the exporter's precedence and
+the resource-level identity are untouched.
+
+**Key Benefits:** Record-level identity spoofing neutralized for every backend; the no-collision
+hot path stays allocation-free; the remap is self-evidencing per record. Fixes
+[#915](https://github.com/gaborage/go-bricks/issues/915). See
+[migrations.md](migrations.md) `[C58.4]`.
+
+---
+
 ## ADR Lifecycle
 
 - **Proposed**: Under discussion, not yet implemented
@@ -1032,7 +1057,7 @@ enough that no manager exists to probe. Fixes
 
 ### Numbering Policy
 
-ADR numbers (ADR-001 through ADR-054) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
+ADR numbers (ADR-001 through ADR-055) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
 
 ## Writing New ADRs
 

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -42,7 +42,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E55 | v0.52.0 → v0.55.0 | additive (safe) | 3 | none | none |
 | E56 | v0.55.0 → v0.56.0 | compile-break (C56.6 only partially — see its gate) + silent-behavior default flip (C56.11) | 15 | C56.6 C56.9 | grep log-driven alerts, dashboards, and test assertions for card-data / `iban` / `otp` field names — their values render `***` after the bump (C56.3); expect a cold tenant's first messaging request to fail fast instead of blocking (C56.4); if you assemble config in Go, check for `forwardedclientcert.require` without `enabled` — that service was serving unauthenticated traffic and now returns 401 (C56.5); if one queue name is declared from two places, confirm the two shapes agree — a mismatch that used to be silently overwritten now fails startup (C56.7); if you call a JOSE-protected peer, check for payload-free requests of **any** method — `GET`/`HEAD`/`DELETE` as well as `POST`/`PUT`/`PATCH` — since none of them are sealed now and a peer demanding `application/jose` on every request will answer 415 (C56.8); `/ready`'s 200 body gains `cache` and `cache_stats` and, where a cache is configured, every poll now issues a Redis `PING`, so update any test, schema, or dashboard that pins its exact key set and expect a live cache outage to read `unhealthy` (C56.10); if you run with a top-level cache enabled (or supply an `Options.CacheConnector`, which is probed regardless of `cache.enabled`) and have never set `cache.critical`, that outage now also answers `503` and drains every replica from rotation at once — decide before the bump whether to keep the strict default (and set `readinessProbe.failureThreshold: 3`) or add `cache.critical: false` (C56.11); and if any alert or runbook parses the Redis address out of `/ready`'s `503` body, repoint it at the app log or `/_sys/health-debug` (C56.12); and a module that cannot work without a database can now declare `app.DatabaseRequirer` so an absent one aborts startup rather than booting green (C56.13); check every environment that sets any `database.*` identity field for a complete section, since a partial one now fails startup (C56.14); and re-point any alert asserting `/ready` returns 503 for a database-free or multi-tenant service — both now return 200 (C56.15) |
 | E57 | v0.56.0 → v0.57.0 | silent-behavior + breaking (C57.4, C57.5, C57.6, C57.7, C57.8 abort startup; C57.9 fails `httpclient` construction) | 9 | C57.7 (only partially — a direct call still compiles; see its scope) | if any alert, runbook, synthetic check, or contract test parses the driver error out of `/ready`'s database `503` body, repoint it at the app log or `<debug.pathprefix>/health-debug` (default `/_sys`) — the field is now the fixed string `database unavailable` (C57.1); and if you implement your own critical `app.Prober`, its `503` body now reads `<Name> unavailable` instead of its raw error, since sanitization became the default rather than an opt-in (C57.2); and if anything reads `db_stats.connections` out of `/ready`'s **200** body — a per-tenant pool dashboard, an activity alert, a test pinning the key set — repoint it at `<debug.pathprefix>/health-debug` or the OTel database metrics, because that array is gone from `/ready`; a repo-local grep alone will not find an out-of-repo dashboard (C57.3); and check every environment with `outbox.enabled: true` or `inbox.enabled: true` (outside per-tenant fan-out or a dynamic source) for a configured, reachable database whose ledger table exists — or whose `autocreatetable` can create it — because Init now aborts startup instead of booting green (C57.4); and check every `database.connectionstring` (root, `databases.*`, `multitenant.tenants.*`) with no `database.type` set — a recognized scheme (`postgres://`, `postgresql://`, `oracle://`) now infers its type and actually dials instead of booting into a dead connection, and an unrecognized scheme on the built-in connector now fails startup instead of failing at first query (C57.5); and check every environment for a database identity key delivered as an empty string (an empty `secretKeyRef`, `envsubst` over an unset variable) — that shape used to load silently as database-free and now aborts startup naming the key (C57.6); and check every environment for `debug.enabled: true` (`DEBUG_ENABLED=true`) with at least one `debug.endpoints.*` flag on, an empty `debug.allowedips` and no `debug.bearertoken` — all four required, and that service refuses to start after the bump; and if you assemble config in Go, check for a `Debug` block with `Enabled: true` and any endpoint flag but no `AllowedIPs` — that path never received the loopback default, so the refusal is reachable there by omission; grep shortlists, booting in staging decides (C57.7); and check every **single-tenant** service that declares AMQP consumers for a broker that is reachable, accepts its credentials, and accepts its declarations at boot, because a consumer bootstrap failure now aborts startup instead of logging one WARN and serving HTTP while consuming nothing forever — publisher-only and messaging-free services are unaffected (C57.8); and read every `WithJOSE` policy and direct `jose.Seal` call for an explicitly-set algorithm outside the allowlist — `KeyAlg: RSA1_5` or a non-AEAD `Enc` sealed successfully before and now fails `Build()` at startup, while a policy that named no algorithms at all takes the package defaults and starts working instead of failing every request (C57.9) |
-| E58 | v0.57.0 → v0.58.0 | compile-break + breaking (C58.3 aborts startup) | 3 | C58.1 C58.2 C58.3 | check every environment for a **negative** `cache.manager.maxsize` or `cache.manager.idlettl`, and — in multi-tenant mode with `cache.manager.maxsize` unset — a negative `multitenant.limits.tenants`, which becomes the pool size. Under `cache.enabled: false` such a value used to be inert and now aborts startup (C58.3) |
+| E58 | v0.57.0 → v0.58.0 | compile-break + breaking (C58.3 aborts startup) + behavior (C58.4) | 4 | C58.1 C58.2 C58.3 | check every environment for a **negative** `cache.manager.maxsize` or `cache.manager.idlettl`, and — in multi-tenant mode with `cache.manager.maxsize` unset — a negative `multitenant.limits.tenants`, which becomes the pool size. Under `cache.enabled: false` such a value used to be inert and now aborts startup (C58.3); and if any dashboard, alert, or saved query reads OTLP-exported log records by a `service.*`, `telemetry.sdk.*`, or `deployment.environment.name` **record** attribute your code sets as a log field, re-key it to the `app.`-prefixed name (C58.4) |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 
@@ -1928,7 +1928,7 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   `jose/sealer.go` (`Seal`) · `jose/policy.go` (`validateAlgorithms`) ·
   [wiki/httpclient.md](httpclient.md#jose-policy-validation-at-build)
 
-## E58 · v0.57.0 → v0.58.0 — dead exported surface removed + a cache that cannot be constructed aborts startup
+## E58 · v0.57.0 → v0.58.0 — dead exported surface removed + a cache that cannot be constructed aborts startup + reserved log attribute namespaces
 
 - gist: Two clusters of dead exported symbols leave the public API, both carrying a comment
   that asserted a use they never had. `jose.PolicyRegistry` goes with its constructor and its
@@ -1956,13 +1956,20 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   got none, and joined the rotation. It now returns `(*cache.CacheManager, error)`,
   `dependencies` propagates it, and `Builder.ResolveDependencies` records it, so startup aborts.
   Reaching the cache is unaffected: an unreachable Redis at boot still only WARNs
-  (C58.3, ADR-054).
+  (C58.3, ADR-054). Separately, the OTel log bridge now reserves the resource-identity
+  attribute namespaces: a top-level log field keyed `service.*`, `telemetry.sdk.*`, or
+  `deployment.environment.name` is remapped under the `app.` prefix in OTLP-exported log
+  records (value preserved, one-time WARN), so a log call can no longer shadow the service's
+  identity at record level (C58.4).
 - build-caught: C58.1 C58.2 C58.3
 - preflight: check every environment for a **negative** `cache.manager.maxsize` or
   `cache.manager.idlettl`, and — in multi-tenant mode where `cache.manager.maxsize` is unset —
   a negative `multitenant.limits.tenants`, which `BuildCacheOptions` substitutes as the pool
   size. Under `cache.enabled: false` such a value used to be inert and now aborts startup
-  (C58.3)
+  (C58.3). For C58.4, grep for reserved-key literals (see its detect) and hand-review any code
+  path that ranges a map into log fields — dynamic keys escape every grep, and the bridge's
+  runtime WARN only exists after the bump, so it is post-upgrade confirmation, not preflight
+  evidence; when such paths exist, smoke-test in staging before relying on the old key names
 - exit: `go get github.com/gaborage/go-bricks@v0.58.0 && go mod tidy && go build ./... && go test ./...`
 
 ### [C58.1] `jose.PolicyRegistry` and its constructor and methods are removed · compile-break · when: match
@@ -2056,6 +2063,27 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   If a negative was reaching for "unbounded", it never meant that — `cache.NewCacheManager` has always rejected it. Omit the key instead: an unset `maxsize` takes the mode default (`multitenant.limits.tenants` in multi-tenant mode, the built-in single-tenant default otherwise). Running without a cache is still supported and still silent — that is `cache.enabled: false` with no stale tuning values under it
 - verify: the service starts. On the refused config it now exits during startup with `create cache manager with maxsize=-1 idlettl=15m0s (from cache.manager.*, or multitenant.limits.tenants where maxsize is unset in multi-tenant mode): maxsize cannot be negative` rather than logging `Failed to create cache manager, cache will be disabled` and serving traffic. The error reports the **resolved** values rather than only the key names, because a third input can produce them: in multi-tenant mode an unset `cache.manager.maxsize` takes `multitenant.limits.tenants`, so a negative there lands here too — `validateMultitenantLimits` clamps it for `config.Load`, leaving that shape reachable on the same `app.NewWithConfig` path as the rest of this atom
 - ref: [ADR-054](adr_054_cache_construction_fails_startup.md) · #861 · `app/managers.go` (`CreateCacheManager`, `BuildCacheOptions`) · `app/bootstrap.go` (`dependencies`) · `app/app_builder.go` (`ResolveDependencies`) · `config/validation.go` (`validateCache`, `applyCacheManagerDefaults`) · `cache/manager.go` (`NewCacheManager`)
+
+### [C58.4] Log fields in resource-identity namespaces are remapped under `app.` in OTLP log records · behavior · when: match
+
+- detect: `` git grep -nE '["`](service|telemetry[.]sdk)[.][^"`[:space:]]*["`]' -- '*.go' `` and `` git grep -nE '["`]deployment[.]environment[.]name["`]' -- '*.go' `` — key-literal based across both Go string-literal forms (quoted and raw) with any non-space suffix, so it catches every zerolog constructor (`Str`, `Uint`, `Dur`, `Time`, `RawJSON`, …) and keys like `service.1` at the cost of some non-log noise. Fields built dynamically (ranging a caller- or tenant-influenced map into log fields) escape any literal grep — hand-review those call sites; the runtime WARN record confirms only after the bump
+- scope: the OTel log bridge only — the boundary where zerolog field names become OTLP record attributes. A top-level field keyed with the `service.` or `telemetry.sdk.` prefix, or exactly `deployment.environment.name`, reaches the backend as `app.<original key>` with its value preserved; the first remap per bridge instance (one bridge per process in practice) also emits a WARN record (`reserved.keys` names the offending keys, never values). The raw zerolog stream (stdout/file JSON, console output) is **unchanged** — only OTLP-exported records are affected. `log.type` stays caller-settable; nested map values are untouched (they flatten under their parent key); the resource-level identity was never spoofable and does not change
+- gate: match = a detect hit, or any code path that ranges caller/tenant-influenced keys into log fields. no-match = nothing to do
+- before:
+
+  ```text
+  record attribute: service.name = "downstream-svc"   (shadows identity on flattening backends)
+  ```
+
+- after:
+
+  ```text
+  record attribute: app.service.name = "downstream-svc"   (+ one-time WARN naming service.name)
+  ```
+
+  Re-key dashboards, alerts, and saved queries reading the old record attribute to the `app.`-prefixed name — or rename the field at the call site out of the reserved namespace (for a downstream peer, semconv's `peer.service` is the conventional home). Never treat `app.*` as service identity: it is caller-supplied and unauthenticated
+- verify: with `observability.logs.enabled: true`, log a field keyed `service.name` and confirm the backend shows `app.service.name` plus the WARN record; `go test ./...`
+- ref: [ADR-055](adr_055_reserved_log_attribute_namespaces.md) · #915 · `logger/otel_bridge.go`
 
 ---
 

--- a/wiki/observability.md
+++ b/wiki/observability.md
@@ -29,6 +29,8 @@ GoBricks provides production-grade observability built on OpenTelemetry: distrib
 - Configure via `observability.logs.samplingrate` (0.0-1.0, default 0.0 drops INFO/DEBUG)
 - Sampling is deterministic per trace (all logs in same trace sampled together)
 
+**Reserved log attribute namespaces:** record attributes deliberately win over resource attributes on key collision (that precedence is what keeps a caller-set `log.type` authoritative), so the OTel bridge reserves the resource-identity namespaces at the boundary where zerolog field names become record attributes. A top-level log field whose key starts with `service.` or `telemetry.sdk.`, or equals `deployment.environment.name`, is remapped under the `app.` prefix with its value preserved (`service.name` → `app.service.name`), and the first remap per bridge instance (one bridge per process in practice) emits a one-time WARN record (`reserved.keys` names the offending keys — never their values). `log.type` is intentionally not reserved. `app.*` keys are caller-supplied and unauthenticated — never treat them as service identity. Nested map values are not remapped: they flatten under their parent key and cannot collide with bare resource keys. See [ADR-055](adr_055_reserved_log_attribute_namespaces.md).
+
 **Request Logging:** HTTP requests track severity escalation via `requestLogContext`. Automatic escalation from status codes (4xx→WARN, 5xx→ERROR). Explicit: `c.EscalateSeverity(zerolog.WarnLevel)` (the `HandlerContext` method). Configure `observability.logs.slowrequestthreshold` for slow request detection.
 
 **Testing:** Use `observability/testing` package:


### PR DESCRIPTION
## What

A zerolog field keyed `service.*`, `telemetry.sdk.*`, or `deployment.environment.name` landed verbatim as an OTLP record attribute and shadowed the service's identity on backends that flatten record attributes over resource attributes — the exporter's record-over-resource precedence is load-bearing for `log.type`, so the spoof was protected. The bridge now remaps such top-level fields under the `app.` prefix (value preserved) and emits a one-time WARN naming the keys, never the values.

Closes #915

## Impact

Dashboards or queries keyed on caller-set record-level reserved names must re-key to `app.<key>`; raw zerolog output is unchanged and `log.type` stays caller-settable. ADR-055 and migrations.md C58.4 document the break.

## Verification

Diff-scoped mutation gate passed (all changed-line mutants killed). A drift test walks every real resource attribute through the live bridge, so a future identity key the guard misses fails the build. CodeRabbit CLI ran clean through the penultimate revision; the final one-line truncation restructure is covered by this PR's bot review (CLI rate-limited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Protected OpenTelemetry resource identity attributes from being overwritten by log fields.
  * Conflicting top-level fields are preserved under an `app.` prefix.
  * A value-free warning is emitted once when remapping occurs.
  * The caller-defined `log.type` remains supported.

* **Documentation**
  * Added guidance for reserved attribute namespaces, migration steps, and preflight checks.

* **Breaking Changes**
  * Cache creation now reports startup errors instead of silently disabling the cache.
  * Removed legacy policy-registry APIs and test timeout constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->