### PR TITLE
perf(mutatediff): cache clean per-package mutation results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ MUTATE_WORKERS ?= 2
 # Any time.ParseDuration string; 0 disables. It does nothing inside a single long
 # package — for those, speeding up the slowest tests is the lever.
 MUTATE_COOLDOWN ?= 30s
+# Set to any non-empty value to bypass the result cache and re-mutate every
+# package in the diff. The cache only ever stores a package whose changed lines
+# came back entirely clean, so this is a debugging lever, not a correctness one.
+MUTATE_NO_CACHE ?=
 # Default target
 help: ## Show this help message
 	@echo "Available targets:"
@@ -127,6 +131,7 @@ clean: ## Clean build cache and test artifacts
 	go clean -cache -testcache
 	rm -f coverage.out coverage-integration.out coverage.html coverage.func
 	rm -f *.test
+	rm -rf .mutatediff-cache
 
 # `sec` is not redundant with `lint`: golangci-lint's gosec runs under the
 # common-false-positives preset, so classes like G304 are suppressed there and
@@ -152,7 +157,7 @@ sec: ## Run gosec security scanner (pinned; identical to CI)
 	go run github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION) -exclude=G103,G104 ./...
 
 mutate: ## Diff-scoped mutation gate: mutants on changed lines vs origin/main must die (see wiki/testing.md#mutation-gate)
-	go run ./scripts/mutatediff -engine "$(GREMLINS_CMD)" -workers "$(MUTATE_WORKERS)" -cpu "$(MUTATE_CPU)" -cooldown "$(MUTATE_COOLDOWN)"
+	go run ./scripts/mutatediff -engine "$(GREMLINS_CMD)" -workers "$(MUTATE_WORKERS)" -cpu "$(MUTATE_CPU)" -cooldown "$(MUTATE_COOLDOWN)" $(if $(MUTATE_NO_CACHE),-no-cache,)
 
 # One gremlins process per package: a single full-repo process with 4 workers
 # exhausted a 4-vCPU/16GB hosted runner ~25 min in (runner shutdown signal).

--- a/scripts/mutatediff/cache.go
+++ b/scripts/mutatediff/cache.go
@@ -1,0 +1,550 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+// The result cache remembers packages whose mutants on changed lines were ALL
+// judged clean, so amending a one-line fix on a 22-package branch re-mutates the
+// package that moved instead of all 22. Every rule below exists because this is a
+// gate: a false pass costs far more than a slow run, so the cache is built to be
+// wrong only in the direction of doing work twice.
+//
+//  1. PASS only, and only a *fully* clean pass. A survivor is never stored, and
+//     neither is a NOT COVERED or TIMED OUT mutant or a vacuous package. A
+//     timeout is indeterminate and load-dependent (timeout.go), so caching one
+//     would let a laptop under thermal load mint a permanent pass for a mutant
+//     that was never evaluated. Refusing every non-clean verdict also means a
+//     hit contributes nothing to the report, so the final verdict lines read
+//     exactly as they would have without the cache.
+//  2. The key covers everything that can change a verdict: the package, the
+//     content of every .go file (test files included — the package's own tests
+//     are what kill its mutants) in the package subtree the engine mutates AND
+//     in its transitive first-party dependency closure, testdata/ under those
+//     dirs, the pinned engine command (which carries its version), the engine
+//     config that selects the mutator set, the module pins, and the toolchain
+//     and platform the verdict was produced on.
+//  3. The judged line set is compared, not hashed. A cached pass proves only
+//     that mutants on the lines judged *at cache time* died, so a run that would
+//     judge a line the cached run did not is a MISS. See rangesCovered.
+//  4. Every error, absence, or ambiguity is a miss. Nothing in this file can
+//     turn a package that should run into one that does not.
+//  5. Entries carry cacheSchema and are ignored when it differs, so a future
+//     format change cannot be misread as a pass.
+const (
+	// cacheSchema is folded into the key AND stored in the entry. Bump it
+	// whenever the entry format changes or a cached PASS starts meaning
+	// something different.
+	cacheSchema = 1
+	// cacheDirName sits at the repo root. The repo's .gitignore is an allowlist
+	// ("ignore everything, then un-ignore"), so this path is ignored without an
+	// entry of its own — and must stay that way. cache_test.go pins it.
+	cacheDirName = ".mutatediff-cache"
+	// cacheTTL bounds how long an entry is trusted and how large the directory
+	// grows. The key already covers every input that decides a verdict, so this
+	// is hygiene rather than a correctness lever.
+	cacheTTL = 30 * 24 * time.Hour
+)
+
+// cacheEntry is the on-disk record of one package's clean verdict. Key is stored
+// inside the file that is named after it, so a truncated write, a stale filename,
+// or a hand-edited file reads as a miss instead of as a pass for some other
+// input set.
+type cacheEntry struct {
+	Schema  int                    `json:"schema"`
+	Key     string                 `json:"key"`
+	Package string                 `json:"package"`
+	Ranges  map[string][]lineRange `json:"ranges"`
+	Stored  time.Time              `json:"stored"`
+}
+
+// resultCache is nil when caching is off or could not be initialized. Every
+// method tolerates a nil receiver, so the caller never branches on it: a
+// disabled cache simply never hits and never stores.
+type resultCache struct {
+	root   string
+	dir    string
+	static string
+	graph  *packageGraph
+	// keys memoizes each package's key from the lookup, so store can detect a
+	// working tree that moved while the engine was running.
+	keys map[string]string
+}
+
+// newResultCache builds the fingerprinting machinery once per run. Any failure
+// returns nil — a run without a cache, never a run that skips on a guess.
+func newResultCache(ctx context.Context, engine, callerGoflags string, out io.Writer) *resultCache {
+	root, err := repoRoot()
+	if err != nil {
+		fmt.Fprintf(out, "WARN: result cache disabled (%v)\n", err)
+		return nil
+	}
+	graph, err := loadPackageGraph(ctx, root)
+	if err != nil {
+		fmt.Fprintf(out, "WARN: result cache disabled (%v)\n", err)
+		return nil
+	}
+	static, err := staticFingerprint(root, engine, callerGoflags)
+	if err != nil {
+		fmt.Fprintf(out, "WARN: result cache disabled (%v)\n", err)
+		return nil
+	}
+	dir := filepath.Join(root, cacheDirName)
+	pruneCache(dir)
+	return &resultCache{root: root, dir: dir, static: static, graph: graph, keys: map[string]string{}}
+}
+
+// repoRoot resolves symlinks because `go list` reports resolved directories:
+// on macOS a /var/folders working directory would otherwise never be a prefix of
+// the /private/var/folders paths it prints, and every package would look external.
+func repoRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("working directory: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(wd)
+	if err != nil {
+		return "", fmt.Errorf("resolve working directory: %w", err)
+	}
+	return resolved, nil
+}
+
+// hit reports whether pkg's mutants on the lines this run would judge have
+// already been judged clean under identical inputs.
+func (c *resultCache) hit(pkg string, changed map[string][]lineRange, out io.Writer) bool {
+	if c == nil {
+		return false
+	}
+	key, err := c.keyFor(pkg)
+	if err != nil {
+		fmt.Fprintf(out, "WARN: could not fingerprint %s for the result cache (%v) — running it\n", pkg, err)
+		return false
+	}
+	c.keys[pkg] = key
+	entry, err := readCacheEntry(filepath.Join(c.dir, key+".json"))
+	if err != nil {
+		return false
+	}
+	if entry.Schema != cacheSchema || entry.Key != key || entry.Package != pkg {
+		return false
+	}
+	// A negative age is a clock that moved, which is exactly the ambiguity rule
+	// 4 says to resolve by running the package.
+	if age := time.Since(entry.Stored); age < 0 || age > cacheTTL {
+		return false
+	}
+	return rangesCovered(scopedRanges(pkg, changed), entry.Ranges)
+}
+
+// store records a clean verdict. The caller decides what "clean" means; store's
+// own job is to refuse a write whose inputs no longer match the ones hit looked
+// up, because the engine reads the working tree and that tree can move under it.
+func (c *resultCache) store(pkg string, changed map[string][]lineRange, out io.Writer) {
+	if c == nil {
+		return
+	}
+	key, err := c.keyFor(pkg)
+	if err != nil {
+		return
+	}
+	if prev, ok := c.keys[pkg]; !ok || prev != key {
+		fmt.Fprintf(out, "WARN: %s changed while it was being mutated — not caching the result\n", pkg)
+		return
+	}
+	entry := cacheEntry{
+		Schema:  cacheSchema,
+		Key:     key,
+		Package: pkg,
+		Ranges:  scopedRanges(pkg, changed),
+		Stored:  time.Now().UTC(),
+	}
+	if writeErr := writeCacheEntry(c.dir, key, entry); writeErr != nil {
+		fmt.Fprintf(out, "WARN: could not cache the result for %s: %v\n", pkg, writeErr)
+	}
+}
+
+// keyFor hashes every input that can change pkg's verdict. It deliberately does
+// NOT include the worker count, the CPU budget, or the timeout ceiling: those
+// move timings only, and a run with any timing-sensitive verdict (TIMED OUT, or
+// a vacuous package) is never stored in the first place.
+func (c *resultCache) keyFor(pkg string) (string, error) {
+	dirs, err := c.graph.closureDirs(pkgDirOf(pkg))
+	if err != nil {
+		return "", err
+	}
+	h := sha256.New()
+	fmt.Fprintf(h, "mutatediff\x00schema=%d\x00pkg=%s\x00static=%s\n", cacheSchema, pkg, c.static)
+	for _, d := range dirs {
+		fmt.Fprintf(h, "dir=%s\n", d)
+		if dirErr := hashPackageDir(h, c.root, d); dirErr != nil {
+			return "", dirErr
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// staticFingerprint folds in what lives outside the package graph: the pinned
+// engine command (its @version is part of the string), the toolchain and target
+// platform that compiled the mutants, the caller's GOFLAGS — which can carry
+// -tags and so decide which files exist at all — and the repo-level files that
+// select the mutator set and pin every dependency version.
+func staticFingerprint(root, engine, callerGoflags string) (string, error) {
+	h := sha256.New()
+	fmt.Fprintf(h, "schema=%d\n", cacheSchema)
+	fmt.Fprintf(h, "engine=%s\n", engine)
+	fmt.Fprintf(h, "toolchain=%s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(h, "goflags=%s\n", callerGoflags)
+	for _, name := range []string{"go.mod", "go.sum", "go.work", "go.work.sum", ".gremlins.yaml"} {
+		if err := hashOptionalFile(h, filepath.Join(root, name), name); err != nil {
+			return "", err
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// scopedRanges narrows the repo-wide changed-line map to the files this
+// package's engine run can judge. It mirrors changedMutants' own selector: that
+// function resolves a report entry to pkgDir + file_name, so the reachable set
+// is exactly the files under pkgDir — the whole repo when pkgDir is ".".
+func scopedRanges(pkg string, changed map[string][]lineRange) map[string][]lineRange {
+	dir := pkgDirOf(pkg)
+	prefix := ""
+	if dir != "." {
+		prefix = dir + "/"
+	}
+	scoped := map[string][]lineRange{}
+	for file, ranges := range changed {
+		if strings.HasPrefix(file, prefix) {
+			scoped[file] = ranges
+		}
+	}
+	return scoped
+}
+
+// rangesCovered is rule 3. A cached pass is evidence about the lines it judged
+// and nothing else, so every line this run would judge must already be inside
+// the cached run's ranges. An exact match or a narrower set hits; one extra line
+// — a widened hunk, a file the cached run never saw — misses.
+//
+// The line-by-line walk is deliberate over interval arithmetic: hunks are small,
+// and "is every line I am about to judge inside a line that was judged" is the
+// property, stated as the property.
+func rangesCovered(now, cached map[string][]lineRange) bool {
+	for file, ranges := range now {
+		judged, ok := cached[file]
+		if !ok {
+			return false
+		}
+		for _, r := range ranges {
+			for line := r.Start; line < r.End; line++ {
+				if !inRanges(line, judged) {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+// pkgDirOf converts the engine's package argument ("." or "./config") into the
+// repo-relative directory the rest of this file keys off.
+func pkgDirOf(pkg string) string {
+	dir := strings.TrimSuffix(strings.TrimPrefix(pkg, "./"), "/")
+	if dir == "" {
+		return "."
+	}
+	return dir
+}
+
+// ---- package graph ----
+
+// listedPackage is the slice of `go list` output the cache reads.
+type listedPackage struct {
+	ImportPath string   `json:"ImportPath"`
+	Dir        string   `json:"Dir"`
+	Deps       []string `json:"Deps"`
+}
+
+// packageGraph indexes one `go list -deps -test ./...` so every package's
+// first-party dependency closure resolves without shelling out again per package.
+type packageGraph struct {
+	// dirOf maps an import path to its repo-relative directory, or "" for a
+	// package outside the repo. Presence is what matters: an import path absent
+	// from this map is an unresolvable dependency, which fails the key.
+	dirOf map[string]string
+	// depsOf is `go list`'s transitive dependency list, already flattened.
+	depsOf map[string][]string
+	// inDir groups import paths by directory; one directory holds the package
+	// and the synthetic test packages `go list -test` emits for it.
+	inDir map[string][]string
+	// dirs is inDir's key set, sorted, for subtree prefix scans.
+	dirs []string
+}
+
+// loadPackageGraph lists the module with test dependencies included. -test is
+// what makes a test-only import (a fake, a fixture package) part of the closure:
+// it changes what the package's own tests do, and the package's own tests are
+// what decide whether a mutant lives.
+//
+// Load failures cannot hide a change, which is why -e is not needed. A package
+// `go list` cannot parse keeps its directory in the listing but loses its Deps,
+// so it drops out of its dependents' closures — that changes their keys and
+// forces a miss instead of masking the edit. A dependency that vanishes from the
+// listing altogether is rejected outright by closureDirs. The command itself
+// fails only when the module cannot be resolved at all, and that disables the
+// cache for the whole run.
+func loadPackageGraph(ctx context.Context, root string) (*packageGraph, error) {
+	cmd := exec.CommandContext(ctx, "go", "list", "-deps", "-test", "-json=ImportPath,Dir,Deps", "./...")
+	cmd.Dir = root
+	raw, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("go list for the result cache: %w", err)
+	}
+	g := &packageGraph{
+		dirOf:  map[string]string{},
+		depsOf: map[string][]string{},
+		inDir:  map[string][]string{},
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	for {
+		var p listedPackage
+		if decErr := dec.Decode(&p); errors.Is(decErr, io.EOF) {
+			break
+		} else if decErr != nil {
+			return nil, fmt.Errorf("parse go list output: %w", decErr)
+		}
+		if p.Dir == "" {
+			// Unresolvable: leave it out of dirOf so any dependent fails its key.
+			continue
+		}
+		rel := relativeDir(root, p.Dir)
+		g.dirOf[p.ImportPath] = rel
+		g.depsOf[p.ImportPath] = p.Deps
+		if rel != "" {
+			g.inDir[rel] = append(g.inDir[rel], p.ImportPath)
+		}
+	}
+	for d := range g.inDir {
+		g.dirs = append(g.dirs, d)
+	}
+	sort.Strings(g.dirs)
+	if len(g.dirs) == 0 {
+		return nil, errors.New("go list produced no first-party packages")
+	}
+	return g, nil
+}
+
+// relativeDir returns dir relative to root in slash form, or "" when dir is
+// outside the repo (the standard library, the module cache).
+func relativeDir(root, dir string) string {
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		resolved = dir
+	}
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil {
+		return ""
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return ""
+	}
+	return rel
+}
+
+// closureDirs returns every repo-relative directory whose contents can change
+// pkgDir's verdict: the whole subtree the engine mutates (gremlins mutates
+// recursively from the directory it is pointed at), plus the first-party
+// transitive dependency closure of every package in that subtree. The closure
+// matters because a mutant in X is killed by X's tests, but X's *behavior*
+// changes when a package X imports changes.
+func (g *packageGraph) closureDirs(pkgDir string) ([]string, error) {
+	targets := g.subtree(pkgDir)
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("no Go package listed under %q", pkgDir)
+	}
+	set := map[string]bool{}
+	for _, importPath := range targets {
+		set[g.dirOf[importPath]] = true
+		for _, dep := range g.depsOf[importPath] {
+			dir, ok := g.dirOf[dep]
+			if !ok {
+				return nil, fmt.Errorf("dependency %q of %q is missing from the package listing", dep, importPath)
+			}
+			if dir != "" {
+				set[dir] = true
+			}
+		}
+	}
+	delete(set, "")
+	dirs := make([]string, 0, len(set))
+	for d := range set {
+		dirs = append(dirs, d)
+	}
+	sort.Strings(dirs)
+	return dirs, nil
+}
+
+// subtree lists every import path declared at or below pkgDir. "." is the whole
+// repo, which is what pointing the engine at the root directory would mutate.
+func (g *packageGraph) subtree(pkgDir string) []string {
+	var out []string
+	for _, d := range g.dirs {
+		if pkgDir == "." || d == pkgDir || strings.HasPrefix(d, pkgDir+"/") {
+			out = append(out, g.inDir[d]...)
+		}
+	}
+	return out
+}
+
+// ---- hashing ----
+
+// hashPackageDir folds one directory's verdict-deciding inputs into h: every .go
+// file in it, and everything under its testdata/. Test files are included
+// because they are what kills mutants; testdata is included because a golden
+// file decides an outcome exactly as source does. Build-excluded .go files are
+// hashed too — over-invalidation costs a re-run, under-invalidation costs the gate.
+func hashPackageDir(h io.Writer, root, relDir string) error {
+	dir := filepath.Join(root, filepath.FromSlash(relDir))
+	entries, err := os.ReadDir(dir) // sorted by name, so the digest is order-stable
+	if err != nil {
+		return fmt.Errorf("read %s: %w", relDir, err)
+	}
+	for _, e := range entries {
+		switch {
+		case e.IsDir():
+			if e.Name() != "testdata" {
+				continue
+			}
+			if walkErr := hashTree(h, filepath.Join(dir, e.Name()), path.Join(relDir, e.Name())); walkErr != nil {
+				return walkErr
+			}
+		case strings.HasSuffix(e.Name(), ".go"):
+			if fileErr := hashFile(h, filepath.Join(dir, e.Name()), path.Join(relDir, e.Name())); fileErr != nil {
+				return fileErr
+			}
+		}
+	}
+	return nil
+}
+
+// hashTree folds a whole directory tree in. WalkDir walks lexically, so the
+// digest does not depend on filesystem ordering.
+func hashTree(h io.Writer, absRoot, label string) error {
+	return filepath.WalkDir(absRoot, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(absRoot, p)
+		if relErr != nil {
+			return relErr
+		}
+		return hashFile(h, p, path.Join(label, filepath.ToSlash(rel)))
+	})
+}
+
+// hashOptionalFile folds a repo-level file in, recording its absence explicitly
+// so "no go.work" and "an empty go.work" are different keys.
+func hashOptionalFile(h io.Writer, abs, label string) error {
+	err := hashFile(h, abs, label)
+	if errors.Is(err, fs.ErrNotExist) {
+		fmt.Fprintf(h, "%s absent\n", label)
+		return nil
+	}
+	return err
+}
+
+// hashFile writes "<label> <sha256>" into h. Digesting per file rather than
+// streaming raw bytes keeps the path and the content unambiguously separated,
+// so renaming a file cannot produce the same digest as editing it.
+func hashFile(h io.Writer, abs, label string) error {
+	f, err := os.Open(abs) // #nosec G304 -- paths come from `go list` output under the repo root, not user input
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	fileHash := sha256.New()
+	if _, copyErr := io.Copy(fileHash, f); copyErr != nil {
+		return copyErr
+	}
+	fmt.Fprintf(h, "%s %x\n", label, fileHash.Sum(nil))
+	return nil
+}
+
+// ---- storage ----
+
+func readCacheEntry(p string) (cacheEntry, error) {
+	raw, err := os.ReadFile(p) // #nosec G304 -- <cache dir>/<hex key>.json, both derived in-process
+	if err != nil {
+		return cacheEntry{}, err
+	}
+	var e cacheEntry
+	if unmarshalErr := json.Unmarshal(raw, &e); unmarshalErr != nil {
+		return cacheEntry{}, unmarshalErr
+	}
+	return e, nil
+}
+
+// writeCacheEntry writes through a temp file and renames, so an interrupted run
+// leaves either the previous entry or none — never a half-written one that a
+// later run would have to parse.
+func writeCacheEntry(dir, key string, e cacheEntry) error {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	raw, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, "entry-*.tmp")
+	if err != nil {
+		return err
+	}
+	name := tmp.Name()
+	if _, writeErr := tmp.Write(raw); writeErr != nil {
+		_ = tmp.Close()
+		_ = os.Remove(name)
+		return writeErr
+	}
+	if closeErr := tmp.Close(); closeErr != nil {
+		_ = os.Remove(name)
+		return closeErr
+	}
+	return os.Rename(name, filepath.Join(dir, key+".json"))
+}
+
+// pruneCache drops entries past the TTL. Best effort by design: a failure here
+// costs disk, never correctness.
+func pruneCache(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-cacheTTL)
+	for _, e := range entries {
+		info, infoErr := e.Info()
+		if infoErr != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(dir, e.Name()))
+	}
+}

--- a/scripts/mutatediff/cache.go
+++ b/scripts/mutatediff/cache.go
@@ -90,7 +90,7 @@ type resultCache struct {
 // newResultCache builds the fingerprinting machinery once per run. Any failure
 // returns nil — a run without a cache, never a run that skips on a guess.
 func newResultCache(ctx context.Context, engine, callerGoflags string, out io.Writer) *resultCache {
-	root, err := repoRoot()
+	root, err := repoRoot(ctx)
 	if err != nil {
 		fmt.Fprintf(out, "WARN: result cache disabled (%v)\n", err)
 		return nil
@@ -110,17 +110,23 @@ func newResultCache(ctx context.Context, engine, callerGoflags string, out io.Wr
 	return &resultCache{root: root, dir: dir, static: static, graph: graph, keys: map[string]string{}}
 }
 
-// repoRoot resolves symlinks because `go list` reports resolved directories:
-// on macOS a /var/folders working directory would otherwise never be a prefix of
-// the /private/var/folders paths it prints, and every package would look external.
-func repoRoot() (string, error) {
-	wd, err := os.Getwd()
+// repoRoot is the git top-level rather than the working directory, because the
+// changed-line map this cache is keyed against comes from `git diff`, whose
+// paths are repo-root relative. A root taken from the invocation directory would
+// put package dirs and changed files in two different path spaces, and would
+// also scatter one cache directory per directory the tool is run from.
+//
+// Symlinks are resolved because `go list` reports resolved directories: on macOS
+// a /var/folders root would otherwise never be a prefix of the
+// /private/var/folders paths it prints, and every package would look external.
+func repoRoot(ctx context.Context) (string, error) {
+	top, err := gitOutput(ctx, "rev-parse", "--show-toplevel")
 	if err != nil {
-		return "", fmt.Errorf("working directory: %w", err)
+		return "", err
 	}
-	resolved, err := filepath.EvalSymlinks(wd)
+	resolved, err := filepath.EvalSymlinks(top)
 	if err != nil {
-		return "", fmt.Errorf("resolve working directory: %w", err)
+		return "", fmt.Errorf("resolve repository root: %w", err)
 	}
 	return resolved, nil
 }
@@ -312,9 +318,17 @@ type packageGraph struct {
 func loadPackageGraph(ctx context.Context, root string) (*packageGraph, error) {
 	cmd := exec.CommandContext(ctx, "go", "list", "-deps", "-test", "-json=ImportPath,Dir,Deps", "./...")
 	cmd.Dir = root
+	// Without this, the WARN in newResultCache — the one diagnostic a developer
+	// gets when the cache turns itself off — reads only "exit status 1".
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	raw, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("go list for the result cache: %w", err)
+		detail := strings.TrimSpace(stderr.String())
+		if detail != "" {
+			detail = ": " + detail
+		}
+		return nil, fmt.Errorf("go list for the result cache: %w%s", err, detail)
 	}
 	g := &packageGraph{
 		dirOf:  map[string]string{},

--- a/scripts/mutatediff/cache_test.go
+++ b/scripts/mutatediff/cache_test.go
@@ -1,0 +1,589 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	appPkg     = "./app"
+	appSource  = "app/app.go"
+	appTest    = "app/app_test.go"
+	libSource  = "lib/lib.go"
+	testEngine = "go run example.com/engine@v1.0.0"
+)
+
+// moduleFiles is a compilable two-package module: app depends on lib, so a
+// change to lib must invalidate app's cached verdict even though app's own files
+// are untouched.
+func moduleFiles() map[string]string {
+	return map[string]string{
+		"go.mod":                 "module example.com/m\n\ngo 1.24\n",
+		libSource:                "package lib\n\n// Double returns n doubled.\nfunc Double(n int) int { return n * 2 }\n",
+		appSource:                "package app\n\nimport \"example.com/m/lib\"\n\n// Quad returns n quadrupled.\nfunc Quad(n int) int { return lib.Double(lib.Double(n)) }\n",
+		appTest:                  "package app\n\nimport \"testing\"\n\nfunc TestQuad(t *testing.T) {\n\tif Quad(2) != 8 {\n\t\tt.Fatal(\"quad\")\n\t}\n}\n",
+		"app/testdata/gold.json": "{\"want\":8}\n",
+	}
+}
+
+// cacheFixture is one simulated `make mutate` invocation over a throwaway
+// module. reload rebuilds the cache the way a *second* invocation would: fresh
+// package graph, fresh fingerprint, same directory on disk.
+type cacheFixture struct {
+	root    string
+	engine  string
+	changed map[string][]lineRange
+	cache   *resultCache
+	out     *bytes.Buffer
+}
+
+func newCacheFixture(t *testing.T) *cacheFixture {
+	t.Helper()
+	// Deterministic module resolution: an inherited GOWORK pointing at the
+	// go-bricks workspace would reject a module living in the temp directory.
+	t.Setenv("GOWORK", "off")
+	t.Setenv("GOFLAGS", "")
+	root := writeModule(t, moduleFiles())
+	t.Chdir(root)
+	f := &cacheFixture{
+		root:   root,
+		engine: testEngine,
+		changed: map[string][]lineRange{
+			appSource: {{Start: 5, End: 9}},
+		},
+		out: &bytes.Buffer{},
+	}
+	f.reload(t)
+	return f
+}
+
+func writeModule(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	for name, body := range files {
+		writeFile(t, root, name, body)
+	}
+	return root
+}
+
+func writeFile(t *testing.T, root, rel, body string) {
+	t.Helper()
+	p := filepath.Join(root, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o750))
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o600))
+}
+
+func (f *cacheFixture) reload(t *testing.T) {
+	t.Helper()
+	f.out.Reset()
+	f.cache = newResultCache(t.Context(), f.engine, "", f.out)
+	require.NotNil(t, f.cache, "cache init failed: %s", f.out.String())
+}
+
+// entryPath returns the single stored entry, failing loudly when the count is
+// not one — a test that silently found zero entries would assert nothing.
+func (f *cacheFixture) entryPath(t *testing.T) string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(f.root, cacheDirName, "*.json"))
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	return matches[0]
+}
+
+func TestResultCacheMissesUntilStoredThenHits(t *testing.T) {
+	f := newCacheFixture(t)
+	require.False(t, f.cache.hit(appPkg, f.changed, f.out), "an empty cache must never hit")
+	f.cache.store(appPkg, f.changed, f.out)
+	f.reload(t)
+	require.True(t, f.cache.hit(appPkg, f.changed, f.out), "identical inputs must hit: %s", f.out.String())
+}
+
+// TestResultCacheInvalidation is the gate's real contract: every input that can
+// change a verdict must move the key, and every doubt must resolve to a miss.
+func TestResultCacheInvalidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(t *testing.T, f *cacheFixture)
+		wantHit bool
+	}{
+		{
+			name:    "untouched_tree_hits",
+			mutate:  func(*testing.T, *cacheFixture) {},
+			wantHit: true,
+		},
+		{
+			name: "changed_package_source_misses",
+			mutate: func(t *testing.T, f *cacheFixture) {
+				writeFile(t, f.root, appSource, "package app\n\nimport \"example.com/m/lib\"\n\n// Quad returns n quadrupled.\nfunc Quad(n int) int { return lib.Double(n) * 2 }\n")
+			},
+		},
+		{
+			name: "changed_package_test_misses",
+			mutate: func(t *testing.T, f *cacheFixture) {
+				writeFile(t, f.root, appTest, "package app\n\nimport \"testing\"\n\nfunc TestQuad(t *testing.T) {\n\tif Quad(3) != 12 {\n\t\tt.Fatal(\"quad\")\n\t}\n}\n")
+			},
+		},
+		{
+			name: "changed_dependency_misses",
+			mutate: func(t *testing.T, f *cacheFixture) {
+				writeFile(t, f.root, libSource, "package lib\n\n// Double returns n doubled.\nfunc Double(n int) int { return n + n }\n")
+			},
+		},
+		{
+			// `go list` reports a package it cannot parse without a Deps list
+			// rather than failing, so this pins that the edit still moves the key.
+			name: "unparsable_dependency_misses",
+			mutate: func(t *testing.T, f *cacheFixture) {
+				writeFile(t, f.root, libSource, "package lib\n\nthis is not go\n")
+			},
+		},
+		{
+			name: "new_file_in_dependency_misses",
+			mutate: func(t *testing.T, f *cacheFixture) {
+				writeFile(t, f.root, "lib/helper.go", "package lib\n\n// Triple returns n tripled.\nfunc Triple(n int) int { return n * 3 }\n")
+			},
+		},
+		{
+			name: "changed_testdata_misses",
+			mutate: func(t *testing.T, f *cacheFixture) {
+				writeFile(t, f.root, "app/testdata/gold.json", "{\"want\":12}\n")
+			},
+		},
+		{
+			name: "changed_go_mod_misses",
+			mutate: func(t *testing.T, f *cacheFixture) {
+				writeFile(t, f.root, "go.mod", "module example.com/m\n\ngo 1.24\n\n// pin bumped\n")
+			},
+		},
+		{
+			name: "new_engine_config_misses",
+			mutate: func(t *testing.T, f *cacheFixture) {
+				writeFile(t, f.root, ".gremlins.yaml", "unleash:\n  workers: 4\n")
+			},
+		},
+		{
+			name: "changed_engine_version_misses",
+			mutate: func(_ *testing.T, f *cacheFixture) {
+				f.engine = "go run example.com/engine@v1.1.0"
+			},
+		},
+		{
+			name: "widened_line_range_misses",
+			mutate: func(_ *testing.T, f *cacheFixture) {
+				f.changed[appSource] = []lineRange{{Start: 5, End: 12}}
+			},
+		},
+		{
+			name: "narrowed_line_range_hits",
+			mutate: func(_ *testing.T, f *cacheFixture) {
+				f.changed[appSource] = []lineRange{{Start: 6, End: 8}}
+			},
+			wantHit: true,
+		},
+		{
+			name: "newly_changed_file_in_package_misses",
+			mutate: func(_ *testing.T, f *cacheFixture) {
+				f.changed["app/extra.go"] = []lineRange{{Start: 1, End: 2}}
+			},
+		},
+		{
+			name: "newly_changed_file_outside_package_hits",
+			mutate: func(_ *testing.T, f *cacheFixture) {
+				// ./app's engine run can only judge files under app/, so a change
+				// elsewhere is ./lib's problem, not a reason to re-run ./app.
+				f.changed[libSource] = []lineRange{{Start: 4, End: 5}}
+			},
+			wantHit: true,
+		},
+		{
+			name: "corrupt_entry_misses",
+			mutate: func(t *testing.T, f *cacheFixture) {
+				require.NoError(t, os.WriteFile(f.entryPath(t), []byte("{not json"), 0o600))
+			},
+		},
+		{
+			name: "truncated_entry_misses",
+			mutate: func(t *testing.T, f *cacheFixture) {
+				require.NoError(t, os.WriteFile(f.entryPath(t), nil, 0o600))
+			},
+		},
+		{
+			name:   "schema_mismatch_misses",
+			mutate: rewriteEntry(func(e *cacheEntry) { e.Schema = cacheSchema + 1 }),
+		},
+		{
+			name:   "key_mismatch_misses",
+			mutate: rewriteEntry(func(e *cacheEntry) { e.Key = "not-the-key" }),
+		},
+		{
+			name:   "package_mismatch_misses",
+			mutate: rewriteEntry(func(e *cacheEntry) { e.Package = "./somewhere-else" }),
+		},
+		{
+			name:   "expired_entry_misses",
+			mutate: rewriteEntry(func(e *cacheEntry) { e.Stored = time.Now().Add(-cacheTTL - time.Hour) }),
+		},
+		{
+			name:   "future_dated_entry_misses",
+			mutate: rewriteEntry(func(e *cacheEntry) { e.Stored = time.Now().Add(24 * time.Hour) }),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newCacheFixture(t)
+			require.False(t, f.cache.hit(appPkg, f.changed, f.out))
+			f.cache.store(appPkg, f.changed, f.out)
+			require.FileExists(t, f.entryPath(t))
+
+			tt.mutate(t, f)
+			f.reload(t)
+
+			assert.Equal(t, tt.wantHit, f.cache.hit(appPkg, f.changed, f.out), "output: %s", f.out.String())
+		})
+	}
+}
+
+// rewriteEntry edits the stored entry in place, which is how a schema bump, a
+// filename collision, or a stale clock reaches the lookup.
+func rewriteEntry(edit func(*cacheEntry)) func(*testing.T, *cacheFixture) {
+	return func(t *testing.T, f *cacheFixture) {
+		t.Helper()
+		p := f.entryPath(t)
+		raw, err := os.ReadFile(p) // #nosec G304 -- test-owned temp path
+		require.NoError(t, err)
+		var e cacheEntry
+		require.NoError(t, json.Unmarshal(raw, &e))
+		edit(&e)
+		updated, err := json.Marshal(e)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(p, updated, 0o600))
+	}
+}
+
+// TestResultCacheDisablesItselfOnAnUnlistableTree pins rule 4 at the widest
+// seam: if the package graph cannot be built, there is no cache at all rather
+// than a cache with silent holes in its dependency closure.
+func TestResultCacheDisablesItselfOnAnUnlistableTree(t *testing.T) {
+	t.Setenv("GOWORK", "off")
+	t.Setenv("GOFLAGS", "")
+	files := moduleFiles()
+	delete(files, "go.mod") // no module: `go list ./...` cannot resolve anything
+	t.Chdir(writeModule(t, files))
+
+	var out bytes.Buffer
+	cache := newResultCache(t.Context(), testEngine, "", &out)
+	require.Nil(t, cache, "a tree go list cannot resolve must not produce a cache")
+	assert.Contains(t, out.String(), "result cache disabled")
+	assert.False(t, cache.hit(appPkg, map[string][]lineRange{}, &out), "a disabled cache must never hit")
+}
+
+// TestStoreRefusesAResultWhoseSourcesMovedMidRun covers the window the engine
+// itself opens: it reads the working tree while it runs, so a verdict produced
+// against sources that have since changed belongs to neither state.
+func TestStoreRefusesAResultWhoseSourcesMovedMidRun(t *testing.T) {
+	f := newCacheFixture(t)
+	require.False(t, f.cache.hit(appPkg, f.changed, f.out))
+
+	writeFile(t, f.root, appSource, "package app\n\nimport \"example.com/m/lib\"\n\n// Quad returns n quadrupled.\nfunc Quad(n int) int { return lib.Double(n) + lib.Double(n) }\n")
+	f.out.Reset()
+	f.cache.store(appPkg, f.changed, f.out)
+
+	assert.Contains(t, f.out.String(), "changed while it was being mutated")
+	matches, err := filepath.Glob(filepath.Join(f.root, cacheDirName, "*.json"))
+	require.NoError(t, err)
+	assert.Empty(t, matches, "no entry may be written for a tree that moved")
+}
+
+// TestMutateAllSkipsTheEngineOnACacheHit is the end-to-end proof that a hit
+// really replaces work: the engine here is `false`, which fails on any
+// invocation, so the run can only succeed by never reaching it.
+func TestMutateAllSkipsTheEngineOnACacheHit(t *testing.T) {
+	f := newCacheFixture(t)
+	require.False(t, f.cache.hit(appPkg, f.changed, f.out))
+	f.cache.store(appPkg, f.changed, f.out)
+	f.reload(t)
+
+	var out bytes.Buffer
+	gr := &gateRun{
+		engineArgs: []string{"false"},
+		reportDir:  t.TempDir(),
+		changed:    f.changed,
+		workers:    1,
+		cache:      f.cache,
+		out:        &out,
+	}
+	v, err := gr.mutateAll(t.Context(), []string{appPkg})
+	require.NoError(t, err, "the engine must not have been invoked; output: %s", out.String())
+	assert.Contains(t, out.String(), "./app cached PASS (skipped)")
+	assert.Empty(t, v.failures)
+	assert.Empty(t, v.warnings)
+	assert.Empty(t, v.unjudged)
+
+	// The inverse pins that the skip is what saved it: without a cache the same
+	// package reaches the failing engine.
+	gr.cache = nil
+	_, err = gr.mutateAll(t.Context(), []string{appPkg})
+	require.Error(t, err, "an uncached package must still reach the engine")
+}
+
+func TestNilResultCacheIsInert(t *testing.T) {
+	var out bytes.Buffer
+	var cache *resultCache
+	assert.False(t, cache.hit(appPkg, map[string][]lineRange{}, &out))
+	assert.NotPanics(t, func() { cache.store(appPkg, map[string][]lineRange{}, &out) })
+	assert.Empty(t, out.String())
+}
+
+func TestRangesCoveredEnforcesSubsetRule(t *testing.T) {
+	tests := []struct {
+		name   string
+		now    map[string][]lineRange
+		cached map[string][]lineRange
+		want   bool
+	}{
+		{
+			name:   "exact_match_hits",
+			now:    map[string][]lineRange{"a.go": {{Start: 10, End: 14}}},
+			cached: map[string][]lineRange{"a.go": {{Start: 10, End: 14}}},
+			want:   true,
+		},
+		{
+			name:   "strict_subset_hits",
+			now:    map[string][]lineRange{"a.go": {{Start: 11, End: 13}}},
+			cached: map[string][]lineRange{"a.go": {{Start: 10, End: 14}}},
+			want:   true,
+		},
+		{
+			name:   "subset_spanning_two_cached_ranges_hits",
+			now:    map[string][]lineRange{"a.go": {{Start: 10, End: 11}, {Start: 20, End: 21}}},
+			cached: map[string][]lineRange{"a.go": {{Start: 10, End: 14}, {Start: 18, End: 22}}},
+			want:   true,
+		},
+		{
+			name:   "widened_line_range_misses",
+			now:    map[string][]lineRange{"a.go": {{Start: 10, End: 15}}},
+			cached: map[string][]lineRange{"a.go": {{Start: 10, End: 14}}},
+		},
+		{
+			name:   "range_shifted_by_one_line_misses",
+			now:    map[string][]lineRange{"a.go": {{Start: 9, End: 13}}},
+			cached: map[string][]lineRange{"a.go": {{Start: 10, End: 14}}},
+		},
+		{
+			name:   "gap_between_cached_ranges_misses",
+			now:    map[string][]lineRange{"a.go": {{Start: 10, End: 20}}},
+			cached: map[string][]lineRange{"a.go": {{Start: 10, End: 14}, {Start: 15, End: 20}}},
+		},
+		{
+			name:   "unjudged_file_misses",
+			now:    map[string][]lineRange{"a.go": {{Start: 10, End: 11}}, "b.go": {{Start: 1, End: 2}}},
+			cached: map[string][]lineRange{"a.go": {{Start: 10, End: 14}}},
+		},
+		{
+			name:   "extra_cached_file_still_hits",
+			now:    map[string][]lineRange{"a.go": {{Start: 10, End: 11}}},
+			cached: map[string][]lineRange{"a.go": {{Start: 10, End: 14}}, "b.go": {{Start: 1, End: 9}}},
+			want:   true,
+		},
+		{
+			name:   "nothing_to_judge_hits",
+			now:    map[string][]lineRange{},
+			cached: map[string][]lineRange{"a.go": {{Start: 10, End: 14}}},
+			want:   true,
+		},
+		{
+			name: "empty_cache_misses",
+			now:  map[string][]lineRange{"a.go": {{Start: 10, End: 11}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, rangesCovered(tt.now, tt.cached))
+		})
+	}
+}
+
+func TestScopedRangesSelectsThePackageSubtree(t *testing.T) {
+	changed := map[string][]lineRange{
+		"database/factory.go":     {{Start: 1, End: 2}},
+		"database/types/spec.go":  {{Start: 3, End: 4}},
+		"databaseutil/helper.go":  {{Start: 5, End: 6}},
+		"config/injection.go":     {{Start: 7, End: 8}},
+		"root.go":                 {{Start: 9, End: 10}},
+		"database/types/more.go":  {{Start: 11, End: 12}},
+		"databases/decoy/file.go": {{Start: 13, End: 14}},
+	}
+	tests := []struct {
+		name string
+		pkg  string
+		want []string
+	}{
+		{
+			name: "package_takes_its_whole_subtree",
+			pkg:  "./database",
+			// databaseutil and databases share a prefix but not a directory:
+			// the trailing separator is what keeps them out.
+			want: []string{"database/factory.go", "database/types/more.go", "database/types/spec.go"},
+		},
+		{
+			name: "subpackage_takes_only_its_own_files",
+			pkg:  "./database/types",
+			want: []string{"database/types/more.go", "database/types/spec.go"},
+		},
+		{
+			name: "root_package_takes_everything",
+			pkg:  ".",
+			want: []string{
+				"config/injection.go", "database/factory.go", "database/types/more.go",
+				"database/types/spec.go", "databaseutil/helper.go", "databases/decoy/file.go", "root.go",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scopedRanges(tt.pkg, changed)
+			files := make([]string, 0, len(got))
+			for f := range got {
+				files = append(files, f)
+			}
+			assert.ElementsMatch(t, tt.want, files)
+		})
+	}
+}
+
+func TestPkgDirOfNormalizesEngineArguments(t *testing.T) {
+	tests := []struct {
+		name string
+		pkg  string
+		want string
+	}{
+		{name: "dot_stays_dot", pkg: ".", want: "."},
+		{name: "dot_slash_prefix_stripped", pkg: "./config", want: "config"},
+		{name: "nested_package", pkg: "./database/types", want: "database/types"},
+		{name: "trailing_slash_stripped", pkg: "./config/", want: "config"},
+		{name: "bare_dot_slash_is_root", pkg: "./", want: "."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, pkgDirOf(tt.pkg))
+		})
+	}
+}
+
+func testGraph() *packageGraph {
+	return &packageGraph{
+		dirOf: map[string]string{
+			"example.com/m/app":     "app",
+			"example.com/m/app/sub": "app/sub",
+			"example.com/m/lib":     "lib",
+			"example.com/m/unused":  "unused",
+			"fmt":                   "",
+		},
+		depsOf: map[string][]string{
+			"example.com/m/app":     {"example.com/m/lib", "fmt"},
+			"example.com/m/app/sub": {"fmt"},
+			"example.com/m/lib":     {"fmt"},
+			"example.com/m/unused":  {"fmt"},
+		},
+		inDir: map[string][]string{
+			"app":     {"example.com/m/app"},
+			"app/sub": {"example.com/m/app/sub"},
+			"lib":     {"example.com/m/lib"},
+			"unused":  {"example.com/m/unused"},
+		},
+		dirs: []string{"app", "app/sub", "lib", "unused"},
+	}
+}
+
+func TestClosureDirsCoversSubtreeAndFirstPartyDeps(t *testing.T) {
+	tests := []struct {
+		name string
+		pkg  string
+		want []string
+	}{
+		{
+			name: "subtree_plus_dependencies",
+			pkg:  "app",
+			// app/sub because the engine mutates the whole subtree it is pointed
+			// at; lib because app's behavior changes when lib does. Stdlib and
+			// unrelated first-party packages stay out.
+			want: []string{"app", "app/sub", "lib"},
+		},
+		{name: "leaf_package", pkg: "lib", want: []string{"lib"}},
+		{name: "root_covers_the_module", pkg: ".", want: []string{"app", "app/sub", "lib", "unused"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := testGraph().closureDirs(tt.pkg)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClosureDirsFailsClosedOnAnIncompleteGraph(t *testing.T) {
+	t.Run("unlisted_dependency", func(t *testing.T) {
+		g := testGraph()
+		g.depsOf["example.com/m/app"] = []string{"example.com/m/vanished"}
+		_, err := g.closureDirs("app")
+		require.ErrorContains(t, err, "missing from the package listing")
+	})
+	t.Run("unknown_package_directory", func(t *testing.T) {
+		_, err := testGraph().closureDirs("nowhere")
+		require.ErrorContains(t, err, "no Go package listed")
+	})
+}
+
+// TestCacheDirIsGitIgnored guards the one thing a reviewer cannot see in a diff:
+// the allowlist .gitignore ignores this path today only because nothing
+// un-ignores it, and an added allowlist entry would start committing the cache.
+func TestCacheDirIsGitIgnored(t *testing.T) {
+	repoRootDir := filepath.Join("..", "..")
+	if _, err := os.Stat(filepath.Join(repoRootDir, ".gitignore")); err != nil {
+		t.Skip("not running inside the repository checkout")
+	}
+	cmd := exec.CommandContext(t.Context(), "git", "check-ignore", "-q", cacheDirName+"/deadbeef.json")
+	cmd.Dir = repoRootDir
+	err := cmd.Run()
+	require.NoError(t, err, "%s/ must be git-ignored; `git check-ignore` said otherwise", cacheDirName)
+}
+
+func TestHashPackageDirDistinguishesContentAndLayout(t *testing.T) {
+	root := writeModule(t, map[string]string{
+		"pkg/a.go":                 "package pkg\n",
+		"pkg/a_test.go":            "package pkg\n",
+		"pkg/testdata/golden.json": "{}\n",
+		"pkg/notes.txt":            "ignored\n",
+	})
+	digest := func(t *testing.T) string {
+		t.Helper()
+		var b strings.Builder
+		require.NoError(t, hashPackageDir(&b, root, "pkg"))
+		return b.String()
+	}
+
+	base := digest(t)
+
+	writeFile(t, root, "pkg/notes.txt", "still ignored, differently\n")
+	assert.Equal(t, base, digest(t), "a non-Go, non-testdata file must not invalidate")
+
+	writeFile(t, root, "pkg/a_test.go", "package pkg\n\n// touched\n")
+	afterTest := digest(t)
+	assert.NotEqual(t, base, afterTest, "a test file decides whether a mutant dies")
+
+	writeFile(t, root, "pkg/testdata/golden.json", "{\"v\":1}\n")
+	assert.NotEqual(t, afterTest, digest(t), "a golden file decides outcomes like source does")
+}

--- a/scripts/mutatediff/cache_test.go
+++ b/scripts/mutatediff/cache_test.go
@@ -66,10 +66,19 @@ func newCacheFixture(t *testing.T) *cacheFixture {
 	return f
 }
 
+// writeModule builds a throwaway module that is also its own git repository,
+// because repoRoot asks git for the top level. The `git init` is what keeps
+// TestResultCacheDisablesItselfOnAnUnlistableTree honest — without it the cache
+// would be nil because the root never resolved, and that test would pass without
+// reaching the `go list` seam it claims to pin — and it stops a TMPDIR nested in
+// a real checkout from resolving to that checkout instead.
 func writeModule(t *testing.T, files map[string]string) string {
 	t.Helper()
 	root, err := filepath.EvalSymlinks(t.TempDir())
 	require.NoError(t, err)
+	init := exec.CommandContext(t.Context(), "git", "init")
+	init.Dir = root
+	require.NoError(t, init.Run())
 	for name, body := range files {
 		writeFile(t, root, name, body)
 	}
@@ -285,7 +294,29 @@ func TestResultCacheDisablesItselfOnAnUnlistableTree(t *testing.T) {
 	cache := newResultCache(t.Context(), testEngine, "", &out)
 	require.Nil(t, cache, "a tree go list cannot resolve must not produce a cache")
 	assert.Contains(t, out.String(), "result cache disabled")
+	// Attribution: the disable must come from the `go list` seam this test names,
+	// not from an earlier step failing for its own reasons. The second assertion
+	// is what proves go list's stderr survives into the WARN — without capturing
+	// it the message ends at "exit status 1" and diagnoses nothing.
+	assert.Contains(t, out.String(), "go list for the result cache")
+	assert.Contains(t, out.String(), "main module", "go list's own diagnostic must reach the WARN")
 	assert.False(t, cache.hit(appPkg, map[string][]lineRange{}, &out), "a disabled cache must never hit")
+}
+
+// TestResultCacheRootsAtTheRepositoryTopLevel pins the path space. The changed
+// -line map is built from `git diff`, whose paths are repo-root relative, so the
+// root must be the git top level no matter which directory the tool ran from.
+func TestResultCacheRootsAtTheRepositoryTopLevel(t *testing.T) {
+	t.Setenv("GOWORK", "off")
+	t.Setenv("GOFLAGS", "")
+	root := writeModule(t, moduleFiles())
+	t.Chdir(filepath.Join(root, "app"))
+
+	var out bytes.Buffer
+	cache := newResultCache(t.Context(), testEngine, "", &out)
+	require.NotNil(t, cache, "cache init failed: %s", out.String())
+	assert.Equal(t, root, cache.root, "the root must be the repository top level, not the working directory")
+	assert.Equal(t, filepath.Join(root, cacheDirName), cache.dir, "one cache directory at the top level, not one per invocation directory")
 }
 
 // TestStoreRefusesAResultWhoseSourcesMovedMidRun covers the window the engine

--- a/scripts/mutatediff/diff.go
+++ b/scripts/mutatediff/diff.go
@@ -11,10 +11,12 @@ import (
 	"strings"
 )
 
-// lineRange is a half-open [Start, End) range of new-file line numbers.
+// lineRange is a half-open [Start, End) range of new-file line numbers. The
+// json tags are load-bearing: cache.go persists these ranges, and a cached
+// entry that decoded to zero values would look like "nothing was judged".
 type lineRange struct {
-	Start int
-	End   int
+	Start int `json:"start"`
+	End   int `json:"end"`
 }
 
 var hunkRe = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)

--- a/scripts/mutatediff/main.go
+++ b/scripts/mutatediff/main.go
@@ -23,6 +23,7 @@ func main() {
 	workers := flag.Int("workers", 0, "engine workers; each is a concurrent `go test`. 0 inherits .gremlins.yaml")
 	cpu := flag.Int("cpu", 0, "whole-run core budget divided across workers; 0 leaves the machine default")
 	cooldown := flag.Duration("cooldown", 0, "pause between packages so the machine sheds heat; 0 disables")
+	noCache := flag.Bool("no-cache", false, "ignore and do not write the result cache; re-run every package in the diff")
 	flag.Parse()
 
 	// 0 is the documented opt-out for both guardrails, so a negative value is a
@@ -48,13 +49,13 @@ func main() {
 		fmt.Fprintln(os.Stderr, "mutatediff: -engine is required")
 		code = 2
 	default:
-		code = run(ctx, *engine, *base, throttle{cpu: *cpu, workers: *workers, cooldown: *cooldown}, os.Stdout)
+		code = run(ctx, *engine, *base, throttle{cpu: *cpu, workers: *workers, cooldown: *cooldown}, !*noCache, os.Stdout)
 	}
 	stop()
 	os.Exit(code)
 }
 
-func run(ctx context.Context, engine, baseRef string, th throttle, out io.Writer) int {
+func run(ctx context.Context, engine, baseRef string, th throttle, useCache bool, out io.Writer) int {
 	engineArgs := strings.Fields(engine)
 	if len(engineArgs) == 0 {
 		return fail("engine command is blank")
@@ -82,6 +83,9 @@ func run(ctx context.Context, engine, baseRef string, th throttle, out io.Writer
 		fmt.Fprintln(out, "mutatediff: no mutatable changes vs merge-base")
 		return 0
 	}
+	// Snapshotted before apply rewrites it: the cache key covers the GOFLAGS the
+	// caller chose (which can carry -tags), not the -p this process adds.
+	callerGoflags := os.Getenv(goflagsEnv)
 	// After the no-op return: a gate with nothing to do must not leave the
 	// caller's GOFLAGS rewritten.
 	b := computeBudget(th.cpu, th.workers)
@@ -94,28 +98,87 @@ func run(ctx context.Context, engine, baseRef string, th throttle, out io.Writer
 		return fail("%v", err)
 	}
 	defer os.RemoveAll(reportDir)
-	var failures, warnings, unjudged []mutantVerdict
-	pkgs := packagesOf(changed)
+	gr := &gateRun{
+		engineArgs: engineArgs,
+		reportDir:  reportDir,
+		changed:    changed,
+		workers:    b.workers,
+		th:         th,
+		cache:      resolveCache(ctx, useCache, engine, callerGoflags, out),
+		out:        out,
+	}
+	v, gateErr := gr.mutateAll(ctx, packagesOf(changed))
+	if gateErr != nil {
+		return fail("%v", gateErr)
+	}
+	return reportVerdict(v.failures, v.warnings, v.unjudged, out)
+}
+
+// resolveCache keeps the disabled path visible in the transcript: a cached run
+// and an uncached one must never be confused for each other, in either direction.
+func resolveCache(ctx context.Context, useCache bool, engine, callerGoflags string, out io.Writer) *resultCache {
+	if !useCache {
+		fmt.Fprintln(out, "mutatediff: result cache disabled (-no-cache) — every package in the diff will run")
+		return nil
+	}
+	return newResultCache(ctx, engine, callerGoflags, out)
+}
+
+// verdictSet is one run's accumulated judgment, split the way reportVerdict
+// consumes it.
+type verdictSet struct {
+	failures []mutantVerdict
+	warnings []mutantVerdict
+	unjudged []mutantVerdict
+}
+
+// gateRun is the per-run state the package loop threads through.
+type gateRun struct {
+	engineArgs []string
+	reportDir  string
+	changed    map[string][]lineRange
+	workers    int
+	th         throttle
+	cache      *resultCache
+	out        io.Writer
+}
+
+// mutateAll walks the changed packages, consulting the result cache before each
+// one and populating it only from a package whose changed lines came back
+// entirely clean. "Entirely" is the load-bearing word: a survivor fails the
+// gate, and a NOT COVERED or TIMED OUT mutant or a vacuous package would have to
+// be replayed for the report to stay honest — so none of them are stored, and a
+// hit therefore contributes nothing at all to the verdict.
+func (r *gateRun) mutateAll(ctx context.Context, pkgs []string) (verdictSet, error) {
+	var v verdictSet
 	for i, pkg := range pkgs {
-		f, w, ran, mErr := mutatePackage(ctx, engineArgs, pkg, reportDir, changed, b.workers, out)
-		if mErr != nil {
-			return fail("%v", mErr)
+		if r.cache.hit(pkg, r.changed, r.out) {
+			fmt.Fprintf(r.out, "mutatediff: %s cached PASS (skipped)\n", pkg)
+			continue
 		}
-		failures = append(failures, f...)
-		warnings = append(warnings, w...)
-		if vacuousPkg(pkg, reportDir, out) {
-			unjudged = append(unjudged, mutantVerdict{File: pkg})
+		f, w, ran, mErr := mutatePackage(ctx, r.engineArgs, pkg, r.reportDir, r.changed, r.workers, r.out)
+		if mErr != nil {
+			return verdictSet{}, mErr
+		}
+		v.failures = append(v.failures, f...)
+		v.warnings = append(v.warnings, w...)
+		isVacuous := vacuousPkg(pkg, r.reportDir, r.out)
+		if isVacuous {
+			v.unjudged = append(v.unjudged, mutantVerdict{File: pkg})
+		}
+		if len(f) == 0 && len(w) == 0 && !isVacuous {
+			r.cache.store(pkg, r.changed, r.out)
 		}
 		if shouldCool(ran, i, len(pkgs)) {
 			// A cooldown cut short means the run was canceled, not that the next
 			// package is ready: reporting a verdict over packages that never ran
 			// would call an interrupted gate clean.
-			if coolErr := th.coolDown(ctx, out); coolErr != nil {
-				return fail("canceled during cooldown: %v", coolErr)
+			if coolErr := r.th.coolDown(ctx, r.out); coolErr != nil {
+				return verdictSet{}, fmt.Errorf("canceled during cooldown: %w", coolErr)
 			}
 		}
 	}
-	return reportVerdict(failures, warnings, unjudged, out)
+	return v, nil
 }
 
 // reportVerdict prints every result and returns the process exit code. Vacuous

--- a/scripts/mutatediff/main_test.go
+++ b/scripts/mutatediff/main_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestRunNoOpDiffExitsCleanWithoutEngine(t *testing.T) {
 	var buf bytes.Buffer
-	if got := run(t.Context(), "false", "HEAD", throttle{}, &buf); got != 0 {
+	if got := run(t.Context(), "false", "HEAD", throttle{}, false, &buf); got != 0 {
 		t.Fatalf("run = %d, want 0; output: %s", got, buf.String())
 	}
 	if !strings.Contains(buf.String(), "no mutatable changes") {
@@ -75,7 +75,7 @@ func TestReportVerdictCleanSweepOnlyWhenFullyJudged(t *testing.T) {
 
 func TestRunBlankEngineFailsFast(t *testing.T) {
 	var buf bytes.Buffer
-	if got := run(t.Context(), "   ", "HEAD", throttle{}, &buf); got != 2 {
+	if got := run(t.Context(), "   ", "HEAD", throttle{}, false, &buf); got != 2 {
 		t.Fatalf("run = %d, want 2 for whitespace-only engine", got)
 	}
 }
@@ -86,7 +86,7 @@ func TestRunNoOpDiffLeavesEnvironmentAlone(t *testing.T) {
 	t.Setenv("GOFLAGS", "-mod=mod")
 	t.Setenv("GOMAXPROCS", "sentinel")
 	var buf bytes.Buffer
-	if got := run(t.Context(), "false", "HEAD", throttle{cpu: 4, workers: 2}, &buf); got != 0 {
+	if got := run(t.Context(), "false", "HEAD", throttle{cpu: 4, workers: 2}, false, &buf); got != 0 {
 		t.Fatalf("run = %d, want 0; output: %s", got, buf.String())
 	}
 	if got := os.Getenv("GOFLAGS"); got != "-mod=mod" {

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -370,6 +370,7 @@ Knobs (all `?=`, so the environment overrides):
 | `MUTATE_BASELINE_WORKERS` | 2 | Same as `MUTATE_WORKERS`, for the nightly baseline; also bounds peak memory. Unbudgeted — CI runs at full speed. |
 | `MUTATE_CEILING_FLOOR` | 30s | Minimum per-mutant ceiling (any `time.ParseDuration` string). |
 | `MUTATE_FALLBACK_COEFFICIENT` | 600 | Used only when a package's coefficient cannot be computed. |
+| `MUTATE_NO_CACHE` | *(empty)* | Any non-empty value bypasses the result cache below and re-mutates every package in the diff. |
 
 The budget is applied once, on `mutatediff`'s own environment, so gremlins, its
 coverage pass, `measureSuite`'s timing passes, and every mutant's `go test` all
@@ -382,6 +383,56 @@ mutants run unbudgeted.
 The cooldown gives no relief inside a single package — `mutatediff` drives
 gremlins once per package and cannot interrupt its internal mutant loop. For a
 package that dominates a run, speeding up its slowest tests remains the lever.
+
+### Result cache
+
+The gate used to have no memory: every invocation re-ran every package in the
+branch diff, so amending a one-line fix on a wide branch re-mutated everything
+at a full gremlins run plus that package's whole test suite each.
+`scripts/mutatediff/cache.go` remembers packages that came back clean, in
+`.mutatediff-cache/` at the repo root (git-ignored by the allowlist
+`.gitignore`, and removed by `make clean`). Every skip prints
+`mutatediff: <pkg> cached PASS (skipped)`, so a cached run is never mistakable
+for one that did the work. `MUTATE_NO_CACHE=1` bypasses it entirely.
+
+Because this is a gate, the cache is built to be wrong only in the direction of
+doing work twice:
+
+- **PASS only, and only a *fully* clean pass.** A surviving mutant is never
+  stored — and neither is a `NOT COVERED` or `TIMED OUT` one, nor a vacuous
+  package. A timeout is indeterminate and load-dependent, so freezing one into
+  the cache would let a machine under thermal load mint a permanent pass for a
+  mutant that was never evaluated. Refusing every non-clean verdict also keeps
+  the report honest: a hit contributes nothing to it, so the final verdict lines
+  read exactly as they would have without the cache.
+- **The key covers everything that can change a verdict.** The package; the
+  content of every `.go` file — test files included, since the package's own
+  tests are what kill its mutants — and everything under `testdata/`, both in
+  the subtree the engine mutates *and* in its transitive first-party dependency
+  closure (a mutant in X is killed by X's tests, but X's *behavior* changes when
+  a package it imports changes); the pinned engine command, whose `@version` is
+  part of the string; `.gremlins.yaml`, which selects the mutator set; `go.mod`
+  / `go.sum` / `go.work` / `go.work.sum`; the Go toolchain, `GOOS`/`GOARCH`, and
+  the caller's `GOFLAGS`, which can carry `-tags` and decide which files compile
+  at all. The closure comes from one `go list -deps -test ./...` per run.
+- **The judged line set is compared, not hashed.** A cached pass proves only
+  that mutants on the lines judged *at cache time* died. An exact match or a
+  narrower set hits; one extra line — a widened hunk, a file the cached run
+  never saw — misses. This is the subtlest way to mint a false pass, so it is
+  checked line by line rather than by interval arithmetic.
+- **Every doubt is a miss.** A read error, a parse error, a schema mismatch, a
+  clock that moved, a dependency missing from the package listing, a module
+  `go list` cannot resolve: all of them run the package. Nothing in the cache
+  can turn a package that should run into one that does not.
+- **Entries carry a schema version** and are ignored when it differs.
+
+Deliberately *not* in the key: `MUTATE_WORKERS`, `MUTATE_CPU`, and
+`MUTATE_CEILING_FLOOR`. Those move timings only, and any run with a
+timing-sensitive verdict is refused by the first rule before it can be stored.
+
+A hub package is not a leaf. Touching `logger/` on a 12-package diff correctly
+re-ran the nine packages that import it and kept the three that do not — the
+dependency-closure rule doing its job, not a cache miss to debug.
 
 ### Timeout ceiling
 


### PR DESCRIPTION
## What

`mutatediff` had no memory: every invocation re-ran every package in the branch
diff, so amending one line on a 22-package branch re-mutated all 22. It now caches
clean per-package results, keyed on the package's own `.go` files (tests included),
its transitive first-party dependency closure, `testdata/`, the pinned engine
command, `.gremlins.yaml`, module files, toolchain/`GOFLAGS`, and a schema version.

## Impact

None for consumers — dev tooling only. `make mutate` gains a cache under a
gitignored path; `MUTATE_NO_CACHE=1` opts out. A cached skip prints its own line,
so a warm run is never mistaken for one that did the work.

## Verification

Only clean results are stored: survivors, `NOT COVERED`, and `TIMED OUT` are never
cached, so a load-induced timeout cannot mint a permanent pass. A cached pass is
reused only when every line the current run would judge was judged before —
stored and compared, not hashed — so a widened range misses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mutation-testing runs now cache clean package results, allowing unchanged packages to be skipped on later runs.
  * Cache entries automatically expire or invalidate when relevant source, dependencies, configuration, or toolchain details change.
  * Added an option to disable result caching when needed.

* **Documentation**
  * Added guidance for controlling the cache, invalidation behavior, safety rules, and dependency handling.

* **Chores**
  * The cleanup command now removes cached mutation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->