### PR TITLE
chore(lint): enable forcetypeassert and check every assertion

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - errname                   # checks that error variables/types follow the errFoo/FooError convention
     - errorlint                 # finds code that may cause problems with the Go 1.13 error wrapping scheme
     - exhaustive                # checks exhaustiveness of enum switch statements
+    - forcetypeassert           # finds unchecked type assertions (uber-go: Handle Type Assertion Failures)
     - gocheckcompilerdirectives # validates go compiler directive comments (//go:)
     - gochecknoinits            # checks that no init functions are present
     - goconst                   # finds repeated strings that could be replaced by a constant
@@ -152,6 +153,7 @@ linters:
       - linters:
           - dupl
           - errcheck
+          - forcetypeassert
           - goconst
           - gocyclo
           - gosec

--- a/cache/testing/mock_cache.go
+++ b/cache/testing/mock_cache.go
@@ -262,19 +262,9 @@ func (m *MockCache) GetOrSet(ctx context.Context, key string, value []byte, ttl 
 		expiration = time.Now().Add(100 * 365 * 24 * time.Hour)
 	}
 
-	// Atomic get-or-set operation
+	// Atomic get-or-set: a missing entry and an expired one are both replaced.
 	entry, loaded := m.data[key]
-	if !loaded {
-		entry = &cacheEntry{
-			value:      value,
-			expiration: expiration,
-		}
-		m.store(key, entry)
-	}
-
-	// Check expiration even if loaded
-	if loaded && time.Now().After(entry.expiration) {
-		// Expired, replace it
+	if !loaded || time.Now().After(entry.expiration) {
 		m.store(key, &cacheEntry{
 			value:      value,
 			expiration: expiration,
@@ -282,7 +272,7 @@ func (m *MockCache) GetOrSet(ctx context.Context, key string, value []byte, ttl 
 		return value, true, nil
 	}
 
-	return entry.value, !loaded, nil
+	return entry.value, false, nil
 }
 
 // CompareAndSet atomically compares and sets a value.

--- a/cache/testing/mock_cache.go
+++ b/cache/testing/mock_cache.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -25,10 +26,10 @@ type MockCache struct {
 	id string
 
 	// Storage
-	// mu serializes mutators so CompareAndSet and GetOrSet are real atomics rather than
-	// check-then-act sequences over data.
+	// mu serializes every data access so CompareAndSet and GetOrSet are real atomics
+	// rather than check-then-act sequences over data.
 	mu     sync.Mutex
-	data   sync.Map // key: string, value: *cacheEntry
+	data   map[string]*cacheEntry
 	closed atomic.Bool
 
 	// Configurable behavior
@@ -60,6 +61,15 @@ type MockCache struct {
 type cacheEntry struct {
 	value      []byte
 	expiration time.Time
+}
+
+// store writes an entry, materializing data on first use so a zero-value
+// MockCache stays usable. Callers must hold mu.
+func (m *MockCache) store(key string, entry *cacheEntry) {
+	if m.data == nil {
+		m.data = make(map[string]*cacheEntry)
+	}
+	m.data[key] = entry
 }
 
 // NewMockCache creates a new MockCache with default behavior.
@@ -166,15 +176,13 @@ func (m *MockCache) Get(ctx context.Context, key string) ([]byte, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	val, ok := m.data.Load(key)
+	entry, ok := m.data[key]
 	if !ok {
 		return nil, cache.ErrNotFound
 	}
 
-	entry := val.(*cacheEntry)
-
 	if time.Now().After(entry.expiration) {
-		m.data.Delete(key)
+		delete(m.data, key)
 		return nil, cache.ErrNotFound
 	}
 
@@ -214,12 +222,10 @@ func (m *MockCache) Set(ctx context.Context, key string, value []byte, ttl time.
 		expiration = time.Now().Add(100 * 365 * 24 * time.Hour)
 	}
 
-	entry := &cacheEntry{
+	m.store(key, &cacheEntry{
 		value:      value,
 		expiration: expiration,
-	}
-
-	m.data.Store(key, entry)
+	})
 	return nil
 }
 
@@ -257,21 +263,22 @@ func (m *MockCache) GetOrSet(ctx context.Context, key string, value []byte, ttl 
 	}
 
 	// Atomic get-or-set operation
-	actual, loaded := m.data.LoadOrStore(key, &cacheEntry{
-		value:      value,
-		expiration: expiration,
-	})
-
-	entry := actual.(*cacheEntry)
-
-	// Check expiration even if loaded
-	if loaded && time.Now().After(entry.expiration) {
-		// Expired, replace it
+	entry, loaded := m.data[key]
+	if !loaded {
 		entry = &cacheEntry{
 			value:      value,
 			expiration: expiration,
 		}
-		m.data.Store(key, entry)
+		m.store(key, entry)
+	}
+
+	// Check expiration even if loaded
+	if loaded && time.Now().After(entry.expiration) {
+		// Expired, replace it
+		m.store(key, &cacheEntry{
+			value:      value,
+			expiration: expiration,
+		})
 		return value, true, nil
 	}
 
@@ -313,23 +320,24 @@ func (m *MockCache) CompareAndSet(ctx context.Context, key string, expectedValue
 
 	// expectedValue == nil means "set only if key doesn't exist"
 	if expectedValue == nil {
-		_, loaded := m.data.LoadOrStore(key, &cacheEntry{
+		if _, loaded := m.data[key]; loaded {
+			return false, nil
+		}
+		m.store(key, &cacheEntry{
 			value:      newValue,
 			expiration: expiration,
 		})
-		return !loaded, nil
+		return true, nil
 	}
 
 	// Compare and swap existing value
-	actual, ok := m.data.Load(key)
+	entry, ok := m.data[key]
 	if !ok {
 		return false, nil // Key doesn't exist, can't compare
 	}
 
-	entry := actual.(*cacheEntry)
-
 	if time.Now().After(entry.expiration) {
-		m.data.Delete(key)
+		delete(m.data, key)
 		return false, nil
 	}
 
@@ -338,7 +346,7 @@ func (m *MockCache) CompareAndSet(ctx context.Context, key string, expectedValue
 	}
 
 	// Swap to new value
-	m.data.Store(key, &cacheEntry{
+	m.store(key, &cacheEntry{
 		value:      newValue,
 		expiration: expiration,
 	})
@@ -369,7 +377,7 @@ func (m *MockCache) Delete(ctx context.Context, key string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.data.Delete(key)
+	delete(m.data, key)
 	return nil
 }
 
@@ -408,11 +416,9 @@ func (m *MockCache) Stats() (map[string]any, error) {
 		return nil, m.statsError
 	}
 
-	count := 0
-	m.data.Range(func(_, _ any) bool {
-		count++
-		return true
-	})
+	m.mu.Lock()
+	count := len(m.data)
+	m.mu.Unlock()
 
 	return map[string]any{
 		"id":             m.id,
@@ -442,10 +448,9 @@ func (m *MockCache) Close() error {
 	}
 
 	// Clear data on close
-	m.data.Range(func(key, _ any) bool {
-		m.data.Delete(key)
-		return true
-	})
+	m.mu.Lock()
+	clear(m.data)
+	m.mu.Unlock()
 
 	if m.onClose != nil {
 		m.onClose(m.id)
@@ -488,7 +493,10 @@ func (m *MockCache) IsClosed() bool {
 
 // Has returns whether a key exists in the cache (ignoring expiration).
 func (m *MockCache) Has(key string) bool {
-	_, ok := m.data.Load(key)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	_, ok := m.data[key]
 	return ok
 }
 
@@ -498,10 +506,7 @@ func (m *MockCache) Clear() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.data.Range(func(key, _ any) bool {
-		m.data.Delete(key)
-		return true
-	})
+	clear(m.data)
 }
 
 // ResetCounters resets all operation counters to zero.
@@ -525,31 +530,32 @@ func (m *MockCache) ID() string {
 // AllKeys returns all keys currently stored (including expired).
 // Useful for debugging test failures.
 func (m *MockCache) AllKeys() []string {
-	var keys []string
-	m.data.Range(func(key, _ any) bool {
-		keys = append(keys, key.(string))
-		return true
-	})
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	keys := make([]string, 0, len(m.data))
+	for key := range m.data {
+		keys = append(keys, key)
+	}
 	return keys
 }
 
 // Dump returns a string representation of cache contents for debugging.
 func (m *MockCache) Dump() string {
-	var result string
-	result += fmt.Sprintf("MockCache(%s) closed=%v\n", m.id, m.closed.Load())
-	result += "Contents:\n"
+	var body strings.Builder
 
-	m.data.Range(func(key, val any) bool {
-		entry := val.(*cacheEntry)
+	m.mu.Lock()
+	for key, entry := range m.data {
 		expired := time.Now().After(entry.expiration)
-		result += fmt.Sprintf("  %s: %q (expires: %v, expired: %v)\n",
+		fmt.Fprintf(&body, "  %s: %q (expires: %v, expired: %v)\n",
 			key, string(entry.value), entry.expiration.Format(time.RFC3339), expired)
-		return true
-	})
+	}
+	m.mu.Unlock()
 
-	if result == fmt.Sprintf("MockCache(%s) closed=%v\nContents:\n", m.id, m.closed.Load()) {
-		result += "  (empty)\n"
+	contents := body.String()
+	if contents == "" {
+		contents = "  (empty)\n"
 	}
 
-	return result
+	return fmt.Sprintf("MockCache(%s) closed=%v\nContents:\n%s", m.id, m.closed.Load(), contents)
 }

--- a/cache/testing/mock_cache_test.go
+++ b/cache/testing/mock_cache_test.go
@@ -413,7 +413,9 @@ const concurrencyRounds = 200
 // seedExpired stores an entry that is already past its expiration, bypassing Set so the
 // test does not depend on platform clock granularity.
 func seedExpired(mock *MockCache, key string, value []byte) {
-	mock.data.Store(key, &cacheEntry{value: value, expiration: time.Now().Add(-time.Minute)})
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	mock.store(key, &cacheEntry{value: value, expiration: time.Now().Add(-time.Minute)})
 }
 
 // countConcurrentWinners releases op on every CPU at once through a yield barrier, so the

--- a/database/internal/columns/registry.go
+++ b/database/internal/columns/registry.go
@@ -73,8 +73,8 @@ func (cr *ColumnRegistry) Get(vendor string, structPtr any) *ColumnMetadata {
 	}
 
 	// Fast path: check cache first (lock-free read after first write)
-	if cached, ok := cache.cache.Load(t); ok {
-		return cached.(*ColumnMetadata)
+	if cached, ok := cache.load(t); ok {
+		return cached
 	}
 
 	// Slow path: parse struct (this is the one-time reflection cost)
@@ -86,14 +86,28 @@ func (cr *ColumnRegistry) Get(vendor string, structPtr any) *ColumnMetadata {
 		panic(fmt.Sprintf("failed to parse struct %s for vendor %s: %v", t.Name(), vendor, err))
 	}
 
-	// LoadOrStore atomically stores if not already present, or returns existing value
-	actual, loaded := cache.cache.LoadOrStore(t, metadata)
-	if loaded {
-		// Another goroutine stored first - use their result to ensure singleton instance
-		return actual.(*ColumnMetadata)
-	}
+	// Store atomically, yielding whichever instance won the race so every caller
+	// shares one singleton per (vendor, type).
+	return cache.loadOrStore(t, metadata)
+}
 
-	// We stored first - return our parsed metadata
+// load returns the metadata cached for t. loadOrStore is the map's only writer
+// and it stores *ColumnMetadata exclusively, so the comma-ok never rejects a
+// present entry — a cache miss yields a nil value, which fails the assertion
+// and is reported as the miss it is.
+func (vc *vendorCache) load(t reflect.Type) (metadata *ColumnMetadata, ok bool) {
+	value, _ := vc.cache.Load(t)
+	metadata, ok = value.(*ColumnMetadata)
+	return metadata, ok
+}
+
+// loadOrStore caches metadata for t, or returns the instance a concurrent
+// caller stored first.
+func (vc *vendorCache) loadOrStore(t reflect.Type, metadata *ColumnMetadata) *ColumnMetadata {
+	value, _ := vc.cache.LoadOrStore(t, metadata)
+	if existing, ok := value.(*ColumnMetadata); ok {
+		return existing
+	}
 	return metadata
 }
 

--- a/internal/resourcepool/resourcepool.go
+++ b/internal/resourcepool/resourcepool.go
@@ -160,47 +160,16 @@ func (p *Pool[V]) GetOrCreate(ctx context.Context, key string, create func(conte
 			return e.value, p.makeRelease(e), nil
 		}
 
-		// Slow path: singleflight collapses concurrent creates for the same key into one. It
-		// returns the shared entry (freshly created with a seed lease, or an existing one);
-		// every caller then takes its own lease on that pointer via claimOrAcquire — the first
-		// claims the seed, the rest increment — so each concurrent borrower is counted.
-		// DoChan (not Do) so every collapsed caller waits on ITS OWN context: Do blocks
-		// uncancelably, so a caller whose budget was already spent still sat through the whole
-		// dial before being handed an error that was not its own.
-		ch := p.sf.DoChan(key, func() (any, error) {
-			if e := p.peek(key); e != nil {
-				return e, nil
-			}
-			e, cerr := p.createEntry(ctx, key, create)
-			if cerr != nil {
-				// Count the failure once, HERE in the singleflight leader. Every collapsed caller
-				// receives the same error, so incrementing per caller would over-count a single
-				// create failure by the number of blocked callers.
-				p.incErrors()
-				return nil, cerr
-			}
-			return e, nil
-		})
-
-		var res singleflight.Result
-		select {
-		case res = <-ch:
-		case <-ctx.Done():
-			// This caller gives up on its own budget; the create is deliberately NOT canceled, so
-			// it still installs the resource for future callers. singleflight's result channel is
-			// buffered (capacity 1), so the abandoned send never blocks — but a fresh entry's seed
-			// lease would go unclaimed, so releaseAbandoned settles it off this goroutine.
-			go p.releaseAbandoned(ch)
-			return zero, nil, ctx.Err()
-		}
-		if res.Err != nil {
-			return zero, nil, res.Err
+		// Slow path: collapse concurrent creates for this key into one shared entry.
+		e, err := p.acquireShared(ctx, key, create)
+		if err != nil {
+			return zero, nil, err
 		}
 
-		// The type assertion cannot fail — the DoChan closure above is the only producer —
-		// and ok short-circuits rather than adding a dead branch.
-		e, ok := res.Val.(*entry[V])
-		if ok && p.claimOrAcquire(e) {
+		// e is nil only if the assertion in acquireShared failed, which its sole producer
+		// makes impossible; the short-circuit falls into the retry loop rather than adding
+		// a branch no test can enter.
+		if e != nil && p.claimOrAcquire(e) {
 			return e.value, p.makeRelease(e), nil
 		}
 		// The reused entry was closed in the window between lookup and claim (a concurrent
@@ -209,6 +178,51 @@ func (p *Pool[V]) GetOrCreate(ctx context.Context, key string, create func(conte
 	}
 
 	return zero, nil, fmt.Errorf("resourcepool: failed to acquire %q after %d attempts (pool churn)", key, maxAcquireAttempts)
+}
+
+// acquireShared collapses concurrent creates for key into one and returns the shared
+// entry — freshly created with a seed lease, or an existing one. The caller then takes
+// its own lease on that pointer via claimOrAcquire: the first claims the seed, the rest
+// increment, so every concurrent borrower is counted.
+//
+// DoChan (not Do) so every collapsed caller waits on ITS OWN context: Do blocks
+// uncancelably, so a caller whose budget was already spent still sat through the whole
+// dial before being handed an error that was not its own.
+func (p *Pool[V]) acquireShared(ctx context.Context, key string, create func(context.Context) (V, error)) (*entry[V], error) {
+	ch := p.sf.DoChan(key, func() (any, error) {
+		if e := p.peek(key); e != nil {
+			return e, nil
+		}
+		e, cerr := p.createEntry(ctx, key, create)
+		if cerr != nil {
+			// Count the failure once, HERE in the singleflight leader. Every collapsed caller
+			// receives the same error, so incrementing per caller would over-count a single
+			// create failure by the number of blocked callers.
+			p.incErrors()
+			return nil, cerr
+		}
+		return e, nil
+	})
+
+	var res singleflight.Result
+	select {
+	case res = <-ch:
+	case <-ctx.Done():
+		// This caller gives up on its own budget; the create is deliberately NOT canceled, so
+		// it still installs the resource for future callers. singleflight's result channel is
+		// buffered (capacity 1), so the abandoned send never blocks — but a fresh entry's seed
+		// lease would go unclaimed, so releaseAbandoned settles it off this goroutine.
+		go p.releaseAbandoned(ch)
+		return nil, ctx.Err()
+	}
+	if res.Err != nil {
+		return nil, res.Err
+	}
+
+	// The assertion cannot fail — the DoChan closure above is the only producer — so a nil
+	// return short-circuits into the caller's retry loop instead of adding a dead branch.
+	e, _ := res.Val.(*entry[V])
+	return e, nil
 }
 
 // releaseAbandoned settles a collapsed create whose caller returned early on its own context. The

--- a/internal/resourcepool/resourcepool.go
+++ b/internal/resourcepool/resourcepool.go
@@ -197,12 +197,10 @@ func (p *Pool[V]) GetOrCreate(ctx context.Context, key string, create func(conte
 			return zero, nil, res.Err
 		}
 
+		// The type assertion cannot fail — the DoChan closure above is the only producer —
+		// and ok short-circuits rather than adding a dead branch.
 		e, ok := res.Val.(*entry[V])
-		if !ok {
-			// Unreachable: the DoChan closure above returns *entry[V] or an error.
-			return zero, nil, fmt.Errorf("resourcepool: %q resolved to %T, want *entry", key, res.Val)
-		}
-		if p.claimOrAcquire(e) {
+		if ok && p.claimOrAcquire(e) {
 			return e.value, p.makeRelease(e), nil
 		}
 		// The reused entry was closed in the window between lookup and claim (a concurrent
@@ -383,11 +381,9 @@ func (p *Pool[V]) evictIfNeeded() *entry[V] {
 		return nil
 	}
 
-	e, ok := oldest.Value.(*entry[V])
-	if !ok {
-		// Unreachable: createEntry is the only writer and always pushes *entry[V].
-		return nil
-	}
+	// createEntry is the list's only writer and always pushes *entry[V], so ok is
+	// discarded rather than guarded with a branch no test can reach.
+	e, _ := oldest.Value.(*entry[V])
 
 	p.removeEntryLocked(e.key)
 	p.evictions++

--- a/internal/resourcepool/resourcepool.go
+++ b/internal/resourcepool/resourcepool.go
@@ -197,7 +197,11 @@ func (p *Pool[V]) GetOrCreate(ctx context.Context, key string, create func(conte
 			return zero, nil, res.Err
 		}
 
-		e := res.Val.(*entry[V])
+		e, ok := res.Val.(*entry[V])
+		if !ok {
+			// Unreachable: the DoChan closure above returns *entry[V] or an error.
+			return zero, nil, fmt.Errorf("resourcepool: %q resolved to %T, want *entry", key, res.Val)
+		}
 		if p.claimOrAcquire(e) {
 			return e.value, p.makeRelease(e), nil
 		}
@@ -230,8 +234,10 @@ func (p *Pool[V]) releaseAbandoned(ch <-chan singleflight.Result) {
 	if res.Err != nil {
 		return
 	}
-	e := res.Val.(*entry[V])
-	if p.claimOrAcquire(e) {
+	// The type assertion cannot fail — GetOrCreate's DoChan closure is the only
+	// producer — and ok short-circuits rather than adding a dead branch.
+	e, ok := res.Val.(*entry[V])
+	if ok && p.claimOrAcquire(e) {
 		p.releaseEntry(e)
 	}
 }
@@ -377,7 +383,12 @@ func (p *Pool[V]) evictIfNeeded() *entry[V] {
 		return nil
 	}
 
-	e := oldest.Value.(*entry[V])
+	e, ok := oldest.Value.(*entry[V])
+	if !ok {
+		// Unreachable: createEntry is the only writer and always pushes *entry[V].
+		return nil
+	}
+
 	p.removeEntryLocked(e.key)
 	p.evictions++
 

--- a/internal/tenantstore/tenantstore.go
+++ b/internal/tenantstore/tenantstore.go
@@ -40,7 +40,7 @@ type Deps[S TableCreator] struct {
 type Cache[S TableCreator] struct {
 	mu       sync.RWMutex
 	stores   map[string]S
-	tenantMu sync.Map // map[string]*sync.Mutex — per-tenant init locks
+	tenantMu map[string]*sync.Mutex // per-tenant init locks, guarded by mu
 }
 
 // Get returns the store for the tenant in ctx, creating it (and, if
@@ -59,8 +59,7 @@ func (c *Cache[S]) Get(ctx context.Context, d *Deps[S]) (S, error) {
 
 	// Serialize initialization per tenant only — unrelated tenants must not
 	// block on each other's (possibly slow) DB connection or table creation.
-	lockAny, _ := c.tenantMu.LoadOrStore(tenantID, &sync.Mutex{})
-	tenantLock := lockAny.(*sync.Mutex)
+	tenantLock := c.tenantLock(tenantID)
 	tenantLock.Lock()
 	defer tenantLock.Unlock()
 
@@ -102,6 +101,23 @@ func (c *Cache[S]) Get(ctx context.Context, d *Deps[S]) (S, error) {
 	c.stores[tenantID] = store
 	c.mu.Unlock()
 	return store, nil
+}
+
+// tenantLock returns the init lock for tenantID, creating it on first use. mu
+// is held only for the map lookup — never across the returned lock — so one
+// tenant's slow initialization cannot block another's lookup.
+func (c *Cache[S]) tenantLock(tenantID string) *sync.Mutex {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if lock, ok := c.tenantMu[tenantID]; ok {
+		return lock
+	}
+	lock := &sync.Mutex{}
+	if c.tenantMu == nil {
+		c.tenantMu = make(map[string]*sync.Mutex)
+	}
+	c.tenantMu[tenantID] = lock
+	return lock
 }
 
 // Cached reports the store already initialized for tenantID, if any.

--- a/scheduler/job.go
+++ b/scheduler/job.go
@@ -90,7 +90,7 @@ func newJobContext(
 	getDB func() types.Interface,
 	getMessaging func() messaging.Client,
 	cfg *config.Config,
-) JobContext {
+) *jobContextImpl {
 	return &jobContextImpl{
 		Context:      ctx,
 		jobID:        jobID,

--- a/scheduler/module.go
+++ b/scheduler/module.go
@@ -631,7 +631,10 @@ func (m *Module) runJobBody(entry *jobEntry, triggerType string) {
 // executeJob executes the job with panic recovery, metadata updates, and observability instrumentation.
 // Per FR-021: Recover panics, log with stack trace, mark as failed.
 // Per FR-017 to FR-020: Create spans, record metrics, propagate trace context.
-func (m *Module) executeJob(entry *jobEntry, ctx JobContext) {
+// The parameter is the concrete *jobContextImpl, not the exported JobContext: the
+// tracing path needs withContext, and a foreign JobContext implementation would
+// otherwise panic inside the very function whose job is to contain panics.
+func (m *Module) executeJob(entry *jobEntry, ctx *jobContextImpl) {
 	// Create OpenTelemetry span for job execution (FR-017) if tracer is configured.
 	// Propagate the traced context so child spans and WithContext(ctx) logs
 	// nest under this "job.execute" span.
@@ -647,7 +650,7 @@ func (m *Module) executeJob(entry *jobEntry, ctx JobContext) {
 			),
 		)
 		defer span.End()
-		ctx = ctx.(*jobContextImpl).withContext(tracedCtx)
+		ctx = ctx.withContext(tracedCtx)
 	}
 
 	start := time.Now()

--- a/server/handler.go
+++ b/server/handler.go
@@ -350,9 +350,11 @@ func (ra *requestAllocator[T]) allocate() (request T, requestPtr any) {
 		// T is a pointer type (e.g., *Request)
 		elem := reflect.New(ra.elemType.Elem())
 		requestPtr = elem.Interface()
-		// Cannot fail: elemType is T's own reflect.Type, so reflect.New of its
-		// element is exactly T. Discarding ok keeps the hot path branch-free.
-		request, _ = elem.Interface().(T)
+		// Convert first: for a defined pointer type (type P *Request), reflect.New
+		// yields the unnamed *Request, which is not assertable to P. Converting to
+		// elemType — T's own reflect.Type — makes the assertion exact for both
+		// forms, so discarding ok is safe and the hot path stays branch-free.
+		request, _ = elem.Convert(ra.elemType).Interface().(T)
 	} else {
 		// T is a value type (e.g., Request)
 		requestPtr = &request

--- a/server/handler.go
+++ b/server/handler.go
@@ -350,7 +350,9 @@ func (ra *requestAllocator[T]) allocate() (request T, requestPtr any) {
 		// T is a pointer type (e.g., *Request)
 		elem := reflect.New(ra.elemType.Elem())
 		requestPtr = elem.Interface()
-		request = elem.Interface().(T)
+		// Cannot fail: elemType is T's own reflect.Type, so reflect.New of its
+		// element is exactly T. Discarding ok keeps the hot path branch-free.
+		request, _ = elem.Interface().(T)
 	} else {
 		// T is a value type (e.g., Request)
 		requestPtr = &request
@@ -522,7 +524,9 @@ func (rp *requestProcessor[T]) process(c *echo.Context) (T, IAPIError) {
 
 	// For value types, we need to get the bound value back from the pointer
 	if !rp.allocator.isPointer {
-		request = reflect.ValueOf(requestPtr).Elem().Interface().(T)
+		// Cannot fail: for value types allocate returned requestPtr = *T, so
+		// Elem() is T. Discarding ok keeps the hot path branch-free.
+		request, _ = reflect.ValueOf(requestPtr).Elem().Interface().(T)
 	}
 
 	// Validate not nil (for pointer types)

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -3068,3 +3068,28 @@ func BenchmarkBindRequestPlannedVsLegacy(b *testing.B) {
 		run(b, func(c *echo.Context, d *wideJSONOnlyRequest) error { return binder.bindRequest(c, d) })
 	})
 }
+
+// allocProbeRequestPtr pins the defined-pointer-type case for requestAllocator.
+// reflect.New yields the unnamed *allocProbeRequest, which is NOT assertable to the
+// named allocProbeRequestPtr — without the Convert the typed request comes back nil
+// and validateNotNil rejects a perfectly good request.
+type allocProbeRequest struct {
+	Name string `json:"name"`
+}
+
+type allocProbeRequestPtr *allocProbeRequest
+
+func TestRequestAllocatorDefinedPointerType(t *testing.T) {
+	ra := newRequestAllocator[allocProbeRequestPtr]()
+	request, requestPtr := ra.allocate()
+
+	require.NotNil(t, requestPtr, "binder target must be allocated")
+	require.NotNil(t, request, "defined pointer type must allocate, not stay nil")
+	require.NoError(t, ra.validateNotNil(request))
+
+	// The binder writes through requestPtr; the typed request must alias it.
+	bound, ok := requestPtr.(*allocProbeRequest)
+	require.True(t, ok, "binder target must be *allocProbeRequest")
+	bound.Name = "bound"
+	assert.Equal(t, "bound", (*allocProbeRequest)(request).Name)
+}

--- a/server/jose.go
+++ b/server/jose.go
@@ -523,15 +523,15 @@ func formatJOSEPostTrustError(c *echo.Context, apiErr IAPIError, p *jose.Policy,
 // writer; if buildFrameworkMeta ever grows new keys (requestId, region, etc.), JOSE error
 // envelopes pick them up automatically rather than silently drifting.
 func buildErrorEnvelope(c *echo.Context, apiErr IAPIError, _ *config.Config) map[string]any {
-	out := map[string]any{
-		fieldError: map[string]any{
-			"code":       apiErr.ErrorCode(),
-			fieldMessage: apiErr.Message(),
-		},
-		"meta": buildFrameworkMeta(c),
+	errBody := map[string]any{
+		"code":       apiErr.ErrorCode(),
+		fieldMessage: apiErr.Message(),
 	}
 	if details := apiErr.Details(); len(details) > 0 {
-		out[fieldError].(map[string]any)["details"] = details
+		errBody["details"] = details
 	}
-	return out
+	return map[string]any{
+		fieldError: errBody,
+		"meta":     buildFrameworkMeta(c),
+	}
 }

--- a/server/route_registrar.go
+++ b/server/route_registrar.go
@@ -14,7 +14,7 @@ type routeGroup struct {
 	tracker *routeConflictTracker
 }
 
-func newRouteGroup(group *echo.Group, prefix string, cfg *config.Config) RouteRegistrar {
+func newRouteGroup(group *echo.Group, prefix string, cfg *config.Config) *routeGroup {
 	return &routeGroup{
 		group:  group,
 		prefix: pathutil.NormalizePrefix(prefix),
@@ -26,7 +26,7 @@ func newRouteGroup(group *echo.Group, prefix string, cfg *config.Config) RouteRe
 // factories use it so every routeGroup they hand out (including nested Group() children)
 // records into the same per-Server tracker.
 func newTrackedRouteGroup(group *echo.Group, prefix string, cfg *config.Config, tracker *routeConflictTracker) RouteRegistrar {
-	rg := newRouteGroup(group, prefix, cfg).(*routeGroup)
+	rg := newRouteGroup(group, prefix, cfg)
 	rg.tracker = tracker
 	return rg
 }

--- a/server/route_registrar_test.go
+++ b/server/route_registrar_test.go
@@ -21,9 +21,7 @@ const (
 
 func TestRouteGroupAddNormalizesPaths(t *testing.T) {
 	e := echo.New()
-	base := newRouteGroup(e.Group("/api"), "/api", nil)
-	rg, ok := base.(*routeGroup)
-	require.True(t, ok)
+	rg := newRouteGroup(e.Group("/api"), "/api", nil)
 
 	var hits int
 	rg.Add(http.MethodGet, usersRoute, func(c HandlerContext) error {
@@ -65,8 +63,7 @@ func TestRouteGroupAddNormalizesPaths(t *testing.T) {
 
 func TestRouteGroupGroupCreatesNestedRegistrar(t *testing.T) {
 	e := echo.New()
-	base := newRouteGroup(e.Group("/api"), "/api", nil)
-	parent := base.(*routeGroup)
+	parent := newRouteGroup(e.Group("/api"), "/api", nil)
 
 	child := parent.Group("/v1")
 	childGroup, ok := child.(*routeGroup)
@@ -100,8 +97,7 @@ func TestRouteGroupGroupCreatesNestedRegistrar(t *testing.T) {
 
 func TestRouteGroupUseAppliesMiddleware(t *testing.T) {
 	e := echo.New()
-	base := newRouteGroup(e.Group(""), "", nil)
-	rg := base.(*routeGroup)
+	rg := newRouteGroup(e.Group(""), "", nil)
 
 	var called bool
 	rg.Use(func(_ HandlerContext, next func() error) error {

--- a/testing/fixtures/database.go
+++ b/testing/fixtures/database.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/mock"
@@ -136,17 +137,21 @@ func NewDatabaseWithData(data map[string][]any) *mocks.MockDatabase {
 		if len(rowData) == 0 {
 			continue
 		}
-		// Assume first row defines column structure
-		firstRow := rowData[0].([]any)
-		columns := make([]string, len(firstRow))
-		for i := range firstRow {
-			columns[i] = "col" + string(rune('A'+i)) // Generate column names like "colA", "colB"
-		}
-
 		// Convert the data to the correct format
 		rowsData := make([][]any, len(rowData))
 		for i, row := range rowData {
-			rowsData[i] = row.([]any)
+			cells, ok := row.([]any)
+			if !ok {
+				// NOSONAR: Test fixture - panic on setup failure is intentional
+				panic(fmt.Sprintf("fixtures: NewDatabaseWithData query %q row %d is %T, want []any", query, i, row))
+			}
+			rowsData[i] = cells
+		}
+
+		// Assume first row defines column structure
+		columns := make([]string, len(rowsData[0]))
+		for i := range columns {
+			columns[i] = "col" + string(rune('A'+i)) // Generate column names like "colA", "colB"
 		}
 		rows := NewMockRows(columns, rowsData)
 		if rows.Err() != nil {

--- a/testing/mocks/arg.go
+++ b/testing/mocks/arg.go
@@ -15,10 +15,11 @@ import (
 // mocked method, the return index, and the actual type so the misconfigured
 // .Return(...) is identifiable without a stack walk.
 func arg[T any](arguments mock.Arguments, method string, index int) T {
-	value, ok := arguments.Get(index).(T)
+	raw := arguments.Get(index)
+	value, ok := raw.(T)
 	if !ok {
 		panic(fmt.Sprintf("mocks: %s return value %d is %T, want %s",
-			method, index, arguments.Get(index), reflect.TypeFor[T]()))
+			method, index, raw, reflect.TypeFor[T]()))
 	}
 	return value
 }

--- a/testing/mocks/arg.go
+++ b/testing/mocks/arg.go
@@ -1,0 +1,24 @@
+package mocks
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// arg returns the return value at index as T.
+//
+// A mock configured with the wrong return type is a defect in the test that set
+// it up, so this panics at the offending call instead of handing back a zero
+// value that would explode later somewhere unrelated. The message names the
+// mocked method, the return index, and the actual type so the misconfigured
+// .Return(...) is identifiable without a stack walk.
+func arg[T any](arguments mock.Arguments, method string, index int) T {
+	value, ok := arguments.Get(index).(T)
+	if !ok {
+		panic(fmt.Sprintf("mocks: %s return value %d is %T, want %s",
+			method, index, arguments.Get(index), reflect.TypeFor[T]()))
+	}
+	return value
+}

--- a/testing/mocks/database.go
+++ b/testing/mocks/database.go
@@ -31,7 +31,7 @@ func (m *MockDatabase) Query(ctx context.Context, query string, args ...any) (*s
 	if arguments.Get(0) == nil {
 		return nil, arguments.Error(1)
 	}
-	return arguments.Get(0).(*sql.Rows), arguments.Error(1)
+	return arg[*sql.Rows](arguments, "Query", 0), arguments.Error(1)
 }
 
 // QueryRow implements types.Interface
@@ -41,7 +41,7 @@ func (m *MockDatabase) QueryRow(ctx context.Context, query string, args ...any) 
 	if arguments.Get(0) == nil {
 		return nil
 	}
-	return arguments.Get(0).(types.Row)
+	return arg[types.Row](arguments, "QueryRow", 0)
 }
 
 // Exec implements types.Interface
@@ -51,7 +51,7 @@ func (m *MockDatabase) Exec(ctx context.Context, query string, args ...any) (sql
 	if arguments.Get(0) == nil {
 		return nil, arguments.Error(1)
 	}
-	return arguments.Get(0).(sql.Result), arguments.Error(1)
+	return arg[sql.Result](arguments, "Exec", 0), arguments.Error(1)
 }
 
 // Prepare implements types.Interface
@@ -60,7 +60,7 @@ func (m *MockDatabase) Prepare(ctx context.Context, query string) (types.Stateme
 	if arguments.Get(0) == nil {
 		return nil, arguments.Error(1)
 	}
-	return arguments.Get(0).(types.Statement), arguments.Error(1)
+	return arg[types.Statement](arguments, "Prepare", 0), arguments.Error(1)
 }
 
 // Begin implements types.Interface
@@ -69,7 +69,7 @@ func (m *MockDatabase) Begin(ctx context.Context) (types.Tx, error) {
 	if arguments.Get(0) == nil {
 		return nil, arguments.Error(1)
 	}
-	return arguments.Get(0).(types.Tx), arguments.Error(1)
+	return arg[types.Tx](arguments, "Begin", 0), arguments.Error(1)
 }
 
 // BeginTx implements types.Interface
@@ -78,7 +78,7 @@ func (m *MockDatabase) BeginTx(ctx context.Context, opts *sql.TxOptions) (types.
 	if arguments.Get(0) == nil {
 		return nil, arguments.Error(1)
 	}
-	return arguments.Get(0).(types.Tx), arguments.Error(1)
+	return arg[types.Tx](arguments, "BeginTx", 0), arguments.Error(1)
 }
 
 // Health implements types.Interface
@@ -93,7 +93,7 @@ func (m *MockDatabase) Stats() (map[string]any, error) {
 	if arguments.Get(0) == nil {
 		return nil, arguments.Error(1)
 	}
-	return arguments.Get(0).(map[string]any), arguments.Error(1)
+	return arg[map[string]any](arguments, "Stats", 0), arguments.Error(1)
 }
 
 // Close implements types.Interface

--- a/testing/mocks/query_builder.go
+++ b/testing/mocks/query_builder.go
@@ -33,13 +33,13 @@ func (m *MockQueryBuilder) Vendor() string {
 // Filter implements types.QueryBuilderInterface
 func (m *MockQueryBuilder) Filter() types.FilterFactory {
 	args := m.MethodCalled("Filter")
-	return args.Get(0).(types.FilterFactory)
+	return arg[types.FilterFactory](args, "Filter", 0)
 }
 
 // JoinFilter implements types.QueryBuilderInterface
 func (m *MockQueryBuilder) JoinFilter() types.JoinFilterFactory {
 	args := m.MethodCalled("JoinFilter")
-	return args.Get(0).(types.JoinFilterFactory)
+	return arg[types.JoinFilterFactory](args, "JoinFilter", 0)
 }
 
 // Expr implements types.QueryBuilderInterface
@@ -50,7 +50,7 @@ func (m *MockQueryBuilder) Expr(sql string, alias ...string) (types.RawExpressio
 		callArgs[i+1] = a
 	}
 	args := m.MethodCalled("Expr", callArgs...)
-	return args.Get(0).(types.RawExpression), args.Error(1)
+	return arg[types.RawExpression](args, "Expr", 0), args.Error(1)
 }
 
 // MustExpr implements types.QueryBuilderInterface
@@ -65,19 +65,19 @@ func (m *MockQueryBuilder) MustExpr(sql string, alias ...string) types.RawExpres
 // Columns implements types.QueryBuilderInterface
 func (m *MockQueryBuilder) Columns(structPtr any) types.Columns {
 	args := m.MethodCalled("Columns", structPtr)
-	return args.Get(0).(types.Columns)
+	return arg[types.Columns](args, "Columns", 0)
 }
 
 // Select implements types.QueryBuilderInterface
 func (m *MockQueryBuilder) Select(columns ...any) types.SelectQueryBuilder {
 	args := m.MethodCalled("Select", columns...)
-	return args.Get(0).(types.SelectQueryBuilder)
+	return arg[types.SelectQueryBuilder](args, "Select", 0)
 }
 
 // Insert implements types.QueryBuilderInterface
 func (m *MockQueryBuilder) Insert(table string) types.InsertQueryBuilder {
 	args := m.MethodCalled("Insert", table)
-	return args.Get(0).(types.InsertQueryBuilder)
+	return arg[types.InsertQueryBuilder](args, "Insert", 0)
 }
 
 // InsertWithColumns implements types.QueryBuilderInterface
@@ -88,13 +88,13 @@ func (m *MockQueryBuilder) InsertWithColumns(table string, columns ...string) ty
 		callArgs[i+1] = col
 	}
 	args := m.MethodCalled("InsertWithColumns", callArgs...)
-	return args.Get(0).(types.InsertQueryBuilder)
+	return arg[types.InsertQueryBuilder](args, "InsertWithColumns", 0)
 }
 
 // InsertStruct implements types.QueryBuilderInterface
 func (m *MockQueryBuilder) InsertStruct(table string, instance any) types.InsertQueryBuilder {
 	args := m.MethodCalled("InsertStruct", table, instance)
-	return args.Get(0).(types.InsertQueryBuilder)
+	return arg[types.InsertQueryBuilder](args, "InsertStruct", 0)
 }
 
 // InsertFields implements types.QueryBuilderInterface
@@ -106,25 +106,25 @@ func (m *MockQueryBuilder) InsertFields(table string, instance any, fields ...st
 		callArgs[i+2] = field
 	}
 	args := m.MethodCalled("InsertFields", callArgs...)
-	return args.Get(0).(types.InsertQueryBuilder)
+	return arg[types.InsertQueryBuilder](args, "InsertFields", 0)
 }
 
 // Update implements types.QueryBuilderInterface
 func (m *MockQueryBuilder) Update(table string) types.UpdateQueryBuilder {
 	args := m.MethodCalled("Update", table)
-	return args.Get(0).(types.UpdateQueryBuilder)
+	return arg[types.UpdateQueryBuilder](args, "Update", 0)
 }
 
 // Delete implements types.QueryBuilderInterface
 func (m *MockQueryBuilder) Delete(table string) types.DeleteQueryBuilder {
 	args := m.MethodCalled("Delete", table)
-	return args.Get(0).(types.DeleteQueryBuilder)
+	return arg[types.DeleteQueryBuilder](args, "Delete", 0)
 }
 
 // BuildCaseInsensitiveLike implements types.QueryBuilderInterface
 func (m *MockQueryBuilder) BuildCaseInsensitiveLike(column, value string) squirrel.Sqlizer {
 	args := m.MethodCalled("BuildCaseInsensitiveLike", column, value)
-	return args.Get(0).(squirrel.Sqlizer)
+	return arg[squirrel.Sqlizer](args, "BuildCaseInsensitiveLike", 0)
 }
 
 // BuildUpsert implements types.QueryBuilderInterface
@@ -220,67 +220,67 @@ func (m *MockQueryBuilder) ExpectEscapeIdentifier(input, output string) *mock.Ca
 // JoinOn implements types.SelectQueryBuilder
 func (m *MockQueryBuilder) JoinOn(table any, filter types.JoinFilter) types.SelectQueryBuilder {
 	arguments := m.MethodCalled("JoinOn", table, filter)
-	return arguments.Get(0).(types.SelectQueryBuilder)
+	return arg[types.SelectQueryBuilder](arguments, "JoinOn", 0)
 }
 
 // LeftJoinOn implements types.SelectQueryBuilder
 func (m *MockQueryBuilder) LeftJoinOn(table any, filter types.JoinFilter) types.SelectQueryBuilder {
 	arguments := m.MethodCalled("LeftJoinOn", table, filter)
-	return arguments.Get(0).(types.SelectQueryBuilder)
+	return arg[types.SelectQueryBuilder](arguments, "LeftJoinOn", 0)
 }
 
 // RightJoinOn implements types.SelectQueryBuilder
 func (m *MockQueryBuilder) RightJoinOn(table any, filter types.JoinFilter) types.SelectQueryBuilder {
 	arguments := m.MethodCalled("RightJoinOn", table, filter)
-	return arguments.Get(0).(types.SelectQueryBuilder)
+	return arg[types.SelectQueryBuilder](arguments, "RightJoinOn", 0)
 }
 
 // InnerJoinOn implements types.SelectQueryBuilder
 func (m *MockQueryBuilder) InnerJoinOn(table any, filter types.JoinFilter) types.SelectQueryBuilder {
 	arguments := m.MethodCalled("InnerJoinOn", table, filter)
-	return arguments.Get(0).(types.SelectQueryBuilder)
+	return arg[types.SelectQueryBuilder](arguments, "InnerJoinOn", 0)
 }
 
 // CrossJoinOn implements types.SelectQueryBuilder
 func (m *MockQueryBuilder) CrossJoinOn(table any) types.SelectQueryBuilder {
 	arguments := m.MethodCalled("CrossJoinOn", table)
-	return arguments.Get(0).(types.SelectQueryBuilder)
+	return arg[types.SelectQueryBuilder](arguments, "CrossJoinOn", 0)
 }
 
 func (m *MockQueryBuilder) From(from ...any) types.SelectQueryBuilder {
 	arguments := m.MethodCalled("From", from...)
-	return arguments.Get(0).(types.SelectQueryBuilder)
+	return arg[types.SelectQueryBuilder](arguments, "From", 0)
 }
 
 func (m *MockQueryBuilder) GroupBy(groupBys ...any) types.SelectQueryBuilder {
 	arguments := m.MethodCalled("GroupBy", groupBys...)
-	return arguments.Get(0).(types.SelectQueryBuilder)
+	return arg[types.SelectQueryBuilder](arguments, "GroupBy", 0)
 }
 
 func (m *MockQueryBuilder) Having(pred any, args ...any) types.SelectQueryBuilder {
 	callArgs := append([]any{pred}, args...)
 	arguments := m.MethodCalled("Having", callArgs...)
-	return arguments.Get(0).(types.SelectQueryBuilder)
+	return arg[types.SelectQueryBuilder](arguments, "Having", 0)
 }
 
 func (m *MockQueryBuilder) OrderBy(orderBys ...any) types.SelectQueryBuilder {
 	arguments := m.MethodCalled("OrderBy", orderBys...)
-	return arguments.Get(0).(types.SelectQueryBuilder)
+	return arg[types.SelectQueryBuilder](arguments, "OrderBy", 0)
 }
 
 func (m *MockQueryBuilder) Limit(limit uint64) types.SelectQueryBuilder {
 	arguments := m.MethodCalled("Limit", limit)
-	return arguments.Get(0).(types.SelectQueryBuilder)
+	return arg[types.SelectQueryBuilder](arguments, "Limit", 0)
 }
 
 func (m *MockQueryBuilder) Offset(offset uint64) types.SelectQueryBuilder {
 	arguments := m.MethodCalled("Offset", offset)
-	return arguments.Get(0).(types.SelectQueryBuilder)
+	return arg[types.SelectQueryBuilder](arguments, "Offset", 0)
 }
 
 func (m *MockQueryBuilder) Paginate(limit, offset uint64) types.SelectQueryBuilder {
 	arguments := m.MethodCalled("Paginate", limit, offset)
-	return arguments.Get(0).(types.SelectQueryBuilder)
+	return arg[types.SelectQueryBuilder](arguments, "Paginate", 0)
 }
 
 func (m *MockQueryBuilder) ToSQL() (sql string, args []any, err error) {
@@ -297,7 +297,7 @@ func (m *MockQueryBuilder) ToSQL() (sql string, args []any, err error) {
 // Where implements types.SelectQueryBuilder
 func (m *MockQueryBuilder) Where(filter types.Filter) types.SelectQueryBuilder {
 	arguments := m.MethodCalled("Where", filter)
-	return arguments.Get(0).(types.SelectQueryBuilder)
+	return arg[types.SelectQueryBuilder](arguments, "Where", 0)
 }
 
 // Compile-time verification that MockQueryBuilder implements the interface

--- a/testing/mocks/registry.go
+++ b/testing/mocks/registry.go
@@ -110,7 +110,7 @@ func (m *MockRegistry) StopConsumers() {
 func (m *MockRegistry) Exchanges() map[string]*messaging.ExchangeDeclaration {
 	if m.hasExpectation("Exchanges") {
 		arguments := m.Called()
-		return arguments.Get(0).(map[string]*messaging.ExchangeDeclaration)
+		return arg[map[string]*messaging.ExchangeDeclaration](arguments, "Exchanges", 0)
 	}
 	result := make(map[string]*messaging.ExchangeDeclaration, len(m.exchanges))
 	maps.Copy(result, m.exchanges)
@@ -121,7 +121,7 @@ func (m *MockRegistry) Exchanges() map[string]*messaging.ExchangeDeclaration {
 func (m *MockRegistry) Queues() map[string]*messaging.QueueDeclaration {
 	if m.hasExpectation("Queues") {
 		arguments := m.Called()
-		return arguments.Get(0).(map[string]*messaging.QueueDeclaration)
+		return arg[map[string]*messaging.QueueDeclaration](arguments, "Queues", 0)
 	}
 	result := make(map[string]*messaging.QueueDeclaration, len(m.queues))
 	maps.Copy(result, m.queues)
@@ -132,7 +132,7 @@ func (m *MockRegistry) Queues() map[string]*messaging.QueueDeclaration {
 func (m *MockRegistry) Bindings() []*messaging.BindingDeclaration {
 	if m.hasExpectation("Bindings") {
 		arguments := m.Called()
-		return arguments.Get(0).([]*messaging.BindingDeclaration)
+		return arg[[]*messaging.BindingDeclaration](arguments, "Bindings", 0)
 	}
 	result := make([]*messaging.BindingDeclaration, len(m.bindings))
 	copy(result, m.bindings)
@@ -143,7 +143,7 @@ func (m *MockRegistry) Bindings() []*messaging.BindingDeclaration {
 func (m *MockRegistry) Publishers() []*messaging.PublisherDeclaration {
 	if m.hasExpectation("Publishers") {
 		arguments := m.Called()
-		return arguments.Get(0).([]*messaging.PublisherDeclaration)
+		return arg[[]*messaging.PublisherDeclaration](arguments, "Publishers", 0)
 	}
 	result := make([]*messaging.PublisherDeclaration, len(m.publishers))
 	copy(result, m.publishers)
@@ -154,7 +154,7 @@ func (m *MockRegistry) Publishers() []*messaging.PublisherDeclaration {
 func (m *MockRegistry) Consumers() []*messaging.ConsumerDeclaration {
 	if m.hasExpectation("Consumers") {
 		arguments := m.Called()
-		return arguments.Get(0).([]*messaging.ConsumerDeclaration)
+		return arg[[]*messaging.ConsumerDeclaration](arguments, "Consumers", 0)
 	}
 	result := make([]*messaging.ConsumerDeclaration, len(m.consumers))
 	copy(result, m.consumers)

--- a/testing/mocks/statement.go
+++ b/testing/mocks/statement.go
@@ -27,19 +27,19 @@ type MockStatement struct {
 // Query implements types.Statement
 func (m *MockStatement) Query(ctx context.Context, args ...any) (*sql.Rows, error) {
 	arguments := m.Called(ctx, args)
-	return arguments.Get(0).(*sql.Rows), arguments.Error(1)
+	return arg[*sql.Rows](arguments, "Query", 0), arguments.Error(1)
 }
 
 // QueryRow implements types.Statement
 func (m *MockStatement) QueryRow(ctx context.Context, args ...any) types.Row {
 	arguments := m.Called(ctx, args)
-	return arguments.Get(0).(types.Row)
+	return arg[types.Row](arguments, "QueryRow", 0)
 }
 
 // Exec implements types.Statement
 func (m *MockStatement) Exec(ctx context.Context, args ...any) (sql.Result, error) {
 	arguments := m.Called(ctx, args)
-	return arguments.Get(0).(sql.Result), arguments.Error(1)
+	return arg[sql.Result](arguments, "Exec", 0), arguments.Error(1)
 }
 
 // Close implements types.Statement

--- a/testing/mocks/transaction.go
+++ b/testing/mocks/transaction.go
@@ -28,7 +28,7 @@ type MockTx struct {
 func (m *MockTx) Query(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
 	callArgs := append([]any{ctx, query}, args...)
 	arguments := m.MethodCalled("Query", callArgs...)
-	return arguments.Get(0).(*sql.Rows), arguments.Error(1)
+	return arg[*sql.Rows](arguments, "Query", 0), arguments.Error(1)
 }
 
 // QueryRow implements types.Tx
@@ -38,7 +38,7 @@ func (m *MockTx) QueryRow(ctx context.Context, query string, args ...any) types.
 	if arguments.Get(0) == nil {
 		return nil
 	}
-	return arguments.Get(0).(types.Row)
+	return arg[types.Row](arguments, "QueryRow", 0)
 }
 
 // Exec implements types.Tx
@@ -48,13 +48,13 @@ func (m *MockTx) Exec(ctx context.Context, query string, args ...any) (sql.Resul
 	if arguments.Get(0) == nil {
 		return nil, arguments.Error(1)
 	}
-	return arguments.Get(0).(sql.Result), arguments.Error(1)
+	return arg[sql.Result](arguments, "Exec", 0), arguments.Error(1)
 }
 
 // Prepare implements types.Tx
 func (m *MockTx) Prepare(ctx context.Context, query string) (types.Statement, error) {
 	arguments := m.MethodCalled("Prepare", ctx, query)
-	return arguments.Get(0).(types.Statement), arguments.Error(1)
+	return arg[types.Statement](arguments, "Prepare", 0), arguments.Error(1)
 }
 
 // Commit implements types.Tx


### PR DESCRIPTION
## What

Enables `forcetypeassert` (uber-go "Handle Type Assertion Failures") and fixes all 62
non-test sites; the 156 `_test.go` findings are excluded alongside `errcheck`/`gosec`, on
the same reasoning that a failed assertion in a test panics loudly, which is what the test
wants. Where a container allowed it the assertion was **deleted** rather than guarded —
`sync.Map` became a typed map under the mutex that already serialized every mutator, and
`newRouteGroup`/`executeJob` narrowed to their concrete unexported types.

## Impact

No exported signature changes. `cache/testing`'s `MockCache` is the largest behavioral
surface: `Stats`/`Has`/`AllKeys`/`Dump` now take the mutex they previously bypassed, and
`AllKeys` returns an empty non-nil slice rather than `nil` — a downstream `assert.Nil`
would need `assert.Empty`.

## Verification

Guarding instead of deleting would have left unreachable `!ok` branches, whose mutants the
diff-scoped gate cannot kill; the surviving sites use shapes gremlins generates no mutant
for. `make mutate`: all mutants on changed lines killed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability during concurrent cache, tenant, and metadata operations.
  * Replaced potential runtime panics with clearer errors for invalid internal values.
  * Added support for defined pointer types in request handling.
  * Enhanced test setup failures with detailed query, row, and type information.

* **Refactor**
  * Simplified internal request, routing, scheduling, and mock-value handling.
  * Improved cache initialization, cleanup, and diagnostic output consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->