### PR TITLE
docs(wiki): add consumer lint-config guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ go test -bench=.        # Run benchmarks
 
 - Architecture: [database.md](wiki/database.md) · [cache.md](wiki/cache.md) · [messaging.md](wiki/messaging.md) · [outbox.md](wiki/outbox.md) · [scheduler.md](wiki/scheduler.md) · [httpclient.md](wiki/httpclient.md) · [jose.md](wiki/jose.md) · [keystore.md](wiki/keystore.md) · [observability.md](wiki/observability.md) · [multi_tenant_resolvers.md](wiki/multi_tenant_resolvers.md)
 - Patterns: [handler_patterns.md](wiki/handler_patterns.md) · [context_deadlines.md](wiki/context_deadlines.md) · [global_middleware.md](wiki/global_middleware.md) · [testing.md](wiki/testing.md)
-- Reference: [troubleshooting.md](wiki/troubleshooting.md) · [migrations.md](wiki/migrations.md) (breaking changes) · [startup_defaults.md](wiki/startup_defaults.md)
+- Reference: [troubleshooting.md](wiki/troubleshooting.md) · [migrations.md](wiki/migrations.md) (breaking changes) · [startup_defaults.md](wiki/startup_defaults.md) · [linting.md](wiki/linting.md) (consumer lint config)
 - ADRs: [wiki/architecture_decisions.md](wiki/architecture_decisions.md), files `wiki/adr_NNN_*.md`
 - Vendor docs: [observability_headers_auth.md](wiki/observability_headers_auth.md) · [new_relic_otlp.md](wiki/new_relic_otlp.md) · [otel_collector.md](wiki/otel_collector.md)
 

--- a/wiki/linting.md
+++ b/wiki/linting.md
@@ -1,0 +1,173 @@
+# Linting (Deep Dive)
+
+This document is for teams building services **with** GoBricks who want the framework's
+lint posture in their own repository. It explains what GoBricks enforces, gives a
+consumer-ready `.golangci.yml`, and — more usefully — records which linters were measured
+and **rejected**, so you do not re-litigate decisions that were already tested against a
+real GoBricks codebase.
+
+The enforcement target is the [uber-go style guide](https://github.com/uber-go/guide/blob/master/style.md).
+There is no single tool for it; coverage is assembled from ~45 `golangci-lint` linters, an
+explicit `revive` rule set, and the `formatters:` block.
+
+## There is no config inheritance
+
+`golangci-lint` v2 has **no `extends` and no `include`**. Adding one fails schema
+validation:
+
+```console
+$ golangci-lint config verify -c probe.yml
+jsonschema: "" does not validate with "/additionalProperties":
+additional properties 'extends' not allowed
+```
+
+Within a single repository, a sub-module with no config of its own walks **up** to the
+nearest `.golangci.yml` (this is how `tools/migration` inherits GoBricks' root config).
+Across repositories there is no mechanism at all — you copy the file. Plan for that: a copy
+is a fork, and it will drift.
+
+## Adopting the config
+
+Start from GoBricks' [`.golangci.yml`](../.golangci.yml) and make three edits.
+
+### 1. Substitute the `gci` prefix
+
+```yaml
+formatters:
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/your-org/your-service)   # <- your module path
+```
+
+**Do not copy the section order blindly.** GoBricks uses `standard, default, prefix(...)`
+because that already matched its dominant convention: switching to the plain
+`standard, default` default would rewrite 197 files, merging third-party imports back into
+the first-party block. Measure your own tree before choosing:
+
+```bash
+# how many files would each order rewrite?
+golangci-lint fmt --diff ./... | grep -c '^--- '
+```
+
+Pick the order that moves you *toward* your existing convention, not away from it.
+
+### 2. Delete the framework-only exclusions
+
+Every entry under `linters.exclusions.rules` is a GoBricks path and means nothing in your
+repo — `logger/adapter.go` (zerologlint), `(cache|database|observability)/testing/` and
+`trace/` (revive var-naming), `^cmd/seal-payload/` (an importas carve-out). Delete them all
+and add your own as findings justify.
+
+Keep the `presets` list (`comments`, `common-false-positives`, `legacy`,
+`std-error-handling`) — those are generic.
+
+### 3. Trim the `importas` map
+
+Two entries are worth keeping, because consumers import these packages too:
+
+```yaml
+importas:
+  alias:
+    - pkg: github.com/gaborage/go-bricks/database/testing
+      alias: dbtesting
+    - pkg: github.com/gaborage/go-bricks/jose/testing
+      alias: jositest
+```
+
+Leave `no-unaliased` and `no-extra-aliases` **off**. Either one turns a handful of alias
+fixes into a repo-wide sweep with no style-guide mandate behind it.
+
+## Framework settings you probably want to loosen
+
+GoBricks holds itself to a stricter standard than it expects of applications built on it
+(80% coverage, production-grade stability; see the Developer Manifesto in `CLAUDE.md`).
+These three are calibrated for a framework:
+
+| Setting | GoBricks | Consider for a service |
+| --- | --- | --- |
+| `dupl.threshold` | 100 | 150+, or drop `dupl` — handler/test symmetry trips it |
+| `gocyclo.min-complexity` | 15 | 15–20; raise before adding `//nolint` |
+| `lll.line-length` | 215 | whatever your editor is set to |
+
+## Linters measured and rejected
+
+These were each measured against the GoBricks tree and deliberately **not** adopted. The
+counts are GoBricks' — re-measure against yours — but the *reasons* mostly transfer,
+because they follow from patterns the framework encourages.
+
+| Linter | Findings | Why not |
+| --- | --- | --- |
+| `ireturn` | 663 | Fights the framework's design. `database.Interface`, `messaging.AMQPClient`, and `cache.Cache` are returned as interfaces on purpose — that is the vendor-agnosticism principle. Your service will inherit those signatures. |
+| `err113` | 662 | Flags every `fmt.Errorf` without a sentinel. Defensible in a library with a stable error surface; punishing in service code. |
+| `wrapcheck` | 321 | Directly contradicts "wrap once at boundaries". Adopting it means wrapping at every call depth. |
+| `revive: unused-receiver` | 302 | Pure style, no guide backing. |
+| `revive: struct-tag` | 24 | False-positives the jose `_ struct{}` marker idiom and any runtime-registered custom validator (`validate:"mcc_code"`). |
+| `revive: datarace` | 3 | All false positives — a syntactic check that cannot see mutex protection. `go test -race` covers the class soundly. |
+| `predeclared` | 0 | Redundant with revive's `redefines-builtin-id`, which is already in the default set. |
+| `gochecknoglobals` | 106 | Sentinel errors and `sync.Pool` instances are legitimate globals. |
+| `mnd` | 156 | Magic-number detection is noisy against HTTP status codes and durations. |
+
+`go-ruleguard` (via `gocritic`) was also evaluated. It **works**, and it is the only way to
+express guide rules no linter covers ("Channel Size is One or None"). It was rejected for
+GoBricks because it requires a real `go.mod` dependency on `github.com/quasilyte/go-ruleguard/dsl`,
+which for a public library lands in every consumer's module graph. **In a service, that
+objection does not apply** — if you want executable house rules, ruleguard is a reasonable
+choice for you even though it was wrong for us. Two things to know: the rules-file path is
+resolved relative to the working directory (sub-modules break), and `failOn: dsl` is
+mandatory or a rules file that fails to load is silently empty.
+
+## Measuring before you adopt
+
+Do not trust the counts above, or any single run. Three traps, all of which produced wrong
+numbers during GoBricks' own adoption:
+
+**`issues.uniq-by-line` defaults to `true`.** Only the first issue per line is reported, so
+enabling many linters at once *undercounts* each one. `perfsprint` measured 44 in a
+combined run and 149 alone — `err113` and `wrapcheck` were claiming the same
+`fmt.Errorf` lines. Measure one linter at a time:
+
+```bash
+golangci-lint run --enable-only=<linter> --uniq-by-line=false ./...
+```
+
+**An unknown `revive` rule name exits 0.** It logs `level=error ... cannot find rule: <name>`
+and the run still succeeds, so a typo silently disables a rule while CI stays green. Grep
+for it:
+
+```bash
+golangci-lint run ./... 2>&1 | grep -E 'level=error|cannot find rule'
+```
+
+**`revive.rules` REPLACES the default set.** It does not extend it. If you declare any
+rules, you must re-declare every default you still want — GoBricks' config lists all 23
+above its additions for exactly this reason. Dropping one removes enforcement with no
+signal.
+
+Because of all three, a reading of "0 findings" is ambiguous between *no violations*, *the
+rule never ran*, and *another linter claimed the line*. Prove a rule fires by planting a
+deliberate violation in a throwaway package before believing a zero.
+
+## The formatters block
+
+In v2, formatters are **not** linters. Putting `gofumpt` under `linters.enable` is a hard
+error (`can't load config: gofumpt is a formatter`); they belong in a top-level
+`formatters:` block. Two consequences:
+
+- `golangci-lint run` reports formatter output as ordinary issues
+  (`File is not properly formatted (gci)`), so the config and the reformat must land in the
+  same commit or CI goes red immediately.
+- `go fmt` cannot fix `gofumpt`/`gci` findings. If your `fmt` target runs `go fmt` and your
+  `check` target is `fmt lint ...`, it will reformat and then fail lint anyway. Point `fmt`
+  at `golangci-lint fmt`.
+
+`golangci-lint fmt` walks **files**, while `run` loads **packages** — so `fmt` reaches
+build-tagged files (`//go:build integration`) that `run` never sees. If you have
+build-tagged code, `fmt` is the only thing keeping it formatted.
+
+## Related
+
+- [testing.md](testing.md) — test conventions the linters assume (camelCase test names)
+- [architecture_decisions.md](architecture_decisions.md) — ADR index

--- a/wiki/linting.md
+++ b/wiki/linting.md
@@ -69,12 +69,14 @@ Keep the `presets` list (`comments`, `common-false-positives`, `legacy`,
 Two entries are worth keeping, because consumers import these packages too:
 
 ```yaml
-importas:
-  alias:
-    - pkg: github.com/gaborage/go-bricks/database/testing
-      alias: dbtesting
-    - pkg: github.com/gaborage/go-bricks/jose/testing
-      alias: jositest
+linters:
+  settings:
+    importas:
+      alias:
+        - pkg: github.com/gaborage/go-bricks/database/testing
+          alias: dbtesting
+        - pkg: github.com/gaborage/go-bricks/jose/testing
+          alias: jositest
 ```
 
 Leave `no-unaliased` and `no-extra-aliases` **off**. Either one turns a handful of alias
@@ -150,10 +152,12 @@ GoBricks re-declares all 23 above its additions for that reason. The alternative
 `enable-default-rules: true`, which keeps the defaults without re-declaration:
 
 ```yaml
-revive:
-  enable-default-rules: true   # keep the golint-equivalent set
-  rules:
-    - name: early-return       # additions only
+linters:
+  settings:
+    revive:
+      enable-default-rules: true   # keep the golint-equivalent set
+      rules:
+        - name: early-return       # additions only
 ```
 
 That is the shorter path for a new config. It cannot be combined with `enable-all-rules`.

--- a/wiki/linting.md
+++ b/wiki/linting.md
@@ -135,7 +135,8 @@ combined run and 149 alone — `err113` and `wrapcheck` were claiming the same
 `fmt.Errorf` lines. Measure one linter at a time:
 
 ```bash
-golangci-lint run --enable-only=<linter> --uniq-by-line=false ./...
+LINTER=perfsprint   # one candidate at a time
+golangci-lint run --enable-only="$LINTER" --uniq-by-line=false ./...
 ```
 
 **An unknown `revive` rule name exits 0.** It logs `level=error ... cannot find rule: <name>`

--- a/wiki/linting.md
+++ b/wiki/linting.md
@@ -105,7 +105,7 @@ because they follow from patterns the framework encourages.
 | `wrapcheck` | 321 | Directly contradicts "wrap once at boundaries". Adopting it means wrapping at every call depth. |
 | `revive: unused-receiver` | 302 | Pure style, no guide backing. |
 | `revive: struct-tag` | 24 | False-positives the jose `_ struct{}` marker idiom and any runtime-registered custom validator (`validate:"mcc_code"`). |
-| `revive: datarace` | 3 | All false positives — a syntactic check that cannot see mutex protection. `go test -race` covers the class soundly. |
+| `revive: datarace` | 3 | All false positives — a syntactic check that cannot see mutex protection. `go test -race` is the better tool, but it detects races only on paths a test actually executes and does not prove their absence. |
 | `predeclared` | 0 | Redundant with revive's `redefines-builtin-id`, which is already in the default set. |
 | `gochecknoglobals` | 106 | Sentinel errors and `sync.Pool` instances are legitimate globals. |
 | `mnd` | 156 | Magic-number detection is noisy against HTTP status codes and durations. |
@@ -116,8 +116,11 @@ GoBricks because it requires a real `go.mod` dependency on `github.com/quasilyte
 which for a public library lands in every consumer's module graph. **In a service, that
 objection does not apply** — if you want executable house rules, ruleguard is a reasonable
 choice for you even though it was wrong for us. Two things to know: the rules-file path is
-resolved relative to the working directory (sub-modules break), and `failOn: dsl` is
-mandatory or a rules file that fails to load is silently empty.
+resolved relative to the working directory (sub-modules break), and you must set
+`failOn: dsl,import` (or `all`) or a rules file that fails to load is silently empty.
+`failOn: dsl` alone is not enough — it catches DSL syntax errors but still logs-and-skips
+when an import cannot be resolved, which is the most likely failure since the rules file
+must import `.../go-ruleguard/dsl`.
 
 ## Measuring before you adopt
 
@@ -141,10 +144,19 @@ for it:
 golangci-lint run ./... 2>&1 | grep -E 'level=error|cannot find rule'
 ```
 
-**`revive.rules` REPLACES the default set.** It does not extend it. If you declare any
-rules, you must re-declare every default you still want — GoBricks' config lists all 23
-above its additions for exactly this reason. Dropping one removes enforcement with no
-signal.
+**`revive.rules` REPLACES the default set** when `enable-default-rules` is omitted. It does
+not extend it, so declaring any rule silently drops every default you did not re-list.
+GoBricks re-declares all 23 above its additions for that reason. The alternative is
+`enable-default-rules: true`, which keeps the defaults without re-declaration:
+
+```yaml
+revive:
+  enable-default-rules: true   # keep the golint-equivalent set
+  rules:
+    - name: early-return       # additions only
+```
+
+That is the shorter path for a new config. It cannot be combined with `enable-all-rules`.
 
 Because of all three, a reading of "0 findings" is ambiguous between *no violations*, *the
 rule never ran*, and *another linter claimed the line*. Prove a rule fires by planting a
@@ -163,9 +175,12 @@ error (`can't load config: gofumpt is a formatter`); they belong in a top-level
   `check` target is `fmt lint ...`, it will reformat and then fail lint anyway. Point `fmt`
   at `golangci-lint fmt`.
 
-`golangci-lint fmt` walks **files**, while `run` loads **packages** — so `fmt` reaches
-build-tagged files (`//go:build integration`) that `run` never sees. If you have
-build-tagged code, `fmt` is the only thing keeping it formatted.
+`golangci-lint fmt` walks **files**, while `run` loads **packages** under the build tags it
+was invoked with. So `fmt` reaches build-tagged files (`//go:build integration`)
+unconditionally, whereas `run` sees them only when passed a matching
+`--build-tags=integration`. GoBricks' `make lint` and CI jobs do not pass it, so `fmt` is
+the only thing keeping those files formatted here — check your own invocations before
+assuming the same.
 
 ## Related
 


### PR DESCRIPTION
## What

Services built on GoBricks cannot inherit its lint posture — golangci-lint v2 has no
`extends` and no `include`, so the only option is copying `.golangci.yml`. `wiki/linting.md`
covers that copy: which parts are portable, the three required edits (gci prefix, delete the
framework-only exclusions, trim the importas map), and which thresholds are calibrated for a
framework rather than a service.

## Impact

None — documentation only, plus one line in CLAUDE.md's wiki index. Consumers get the nine
measured-and-rejected linters with reasons (`ireturn` and `wrapcheck` fight this framework's
interface-returning API specifically), and one reversed verdict: `go-ruleguard` was rejected
here to keep a lint-only dependency out of consumers' module graphs, which is not a reason
that applies to *their* repos.

## Verification

Commands in the page were run, not composed: the naive `gci` order reproduces 197 rewritten
files, independently matching the count already cited in `.golangci.yml`'s section-order
rationale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive linting guide covering configuration, formatting, framework-specific settings, validation practices, and customization.
  * Added the linting guide to the Quick Reference documentation list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->