### PR TITLE
chore(lint): enable revive defaults and drop dead exclusions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -179,16 +179,6 @@ linters:
       - linters:
           - zerologlint
         path: logger/adapter\.go
-      # Intentional "testing" subpackages for test utilities (imported with aliases)
-      - linters:
-          - revive
-        path: "(cache|database|observability)/testing/|^testing/"
-        text: "var-naming: avoid package names"
-      # trace package intentionally named to match its domain
-      - linters:
-          - revive
-        path: "trace/"
-        text: "var-naming: avoid package names"
       # cmd/seal-payload is the only file set that imports BOTH go-jose/v4 (whose
       # package name is `jose`) and github.com/gaborage/go-bricks/jose. One of
       # them must be aliased away, and the go-bricks package is the dominant one

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,35 +114,15 @@ linters:
       string-format: false
     revive:
       confidence: 0
-      # Declaring `rules` REPLACES revive's default set rather than extending it,
-      # so every rule golangci-lint enables by default is re-listed below before
-      # the additions. An unknown rule name only logs `level=error` and still
-      # exits 0, so a typo here silently disables a rule — keep names exact.
+      # Declaring `rules` REPLACES revive's default set rather than extending it.
+      # `enable-default-rules` restores the defaults, so only the additions need
+      # listing. This is behavior-identical to re-declaring the 23 default names:
+      # golangci-lint's own default list is a verbatim copy of revive's, and both
+      # spellings resolve to the same 40-rule set. An unknown rule name only logs
+      # `level=error` and still exits 0, so a typo below silently disables a rule —
+      # keep names exact.
+      enable-default-rules: true
       rules:
-        # Default set — re-declared to preserve current behavior.
-        - name: blank-imports
-        - name: context-as-argument
-        - name: context-keys-type
-        - name: dot-imports
-        - name: empty-block
-        - name: error-naming
-        - name: error-return
-        - name: error-strings
-        - name: errorf
-        - name: exported
-        - name: increment-decrement
-        - name: indent-error-flow
-        - name: package-comments
-        - name: range
-        - name: receiver-naming
-        - name: redefines-builtin-id
-        - name: superfluous-else
-        - name: time-naming
-        - name: unexported-return
-        - name: unreachable-code
-        - name: unused-parameter
-        - name: var-declaration
-        - name: var-naming
         # Additions from the uber-go style guide. Each measured 0 findings
         # against the tree, so they ratchet current behavior without a sweep.
         - name: atomic                  # non-atomic assignment to an atomic value

--- a/wiki/linting.md
+++ b/wiki/linting.md
@@ -64,8 +64,8 @@ Recheck your own exclusions periodically: an exclusion that matches on message `
 matching when the linter rewords the message, and it fails **silently** in either
 direction. GoBricks carried two `text: "var-naming: avoid package names"` stanzas that were
 dead from revive v1.15.0 onward, when that check moved to a separate rule and the wording
-changed. Nothing was being suppressed, and nothing said so — deleting them changed no
-findings. Prefer scoping by `path` and `linters` over matching message text.
+changed. Those two stanzas were suppressing nothing, and nothing said so — deleting them
+changed no findings. Prefer scoping by `path` and `linters` over matching message text.
 
 Keep the `presets` list (`comments`, `common-false-positives`, `legacy`,
 `std-error-handling`) — those are generic.
@@ -170,8 +170,8 @@ linters:
 This is what GoBricks does. It previously re-declared all 23 defaults above its additions,
 which worked but meant deleting one line lost a rule silently. The two spellings are
 equivalent at v2.12.2 — golangci-lint's default list is a verbatim copy of revive's, and
-both resolve to the same rule set — so the flag is strictly safer. It cannot be combined
-with `enable-all-rules`.
+both resolve to the same rule set — so the flag is safer against accidental omissions. It
+cannot be combined with `enable-all-rules`.
 
 Because of all three, a reading of "0 findings" is ambiguous between *no violations*, *the
 rule never ran*, and *another linter claimed the line*. Prove a rule fires by planting a

--- a/wiki/linting.md
+++ b/wiki/linting.md
@@ -58,7 +58,7 @@ Pick the order that moves you *toward* your existing convention, not away from i
 
 Every entry under `linters.exclusions.rules` is a GoBricks path and means nothing in your
 repo — `logger/adapter.go` (zerologlint), `^cmd/seal-payload/` (an importas carve-out), and
-a few `_test.go` scopings. Delete them all and add your own as findings justify.
+a few rules scoped to `_test.go`. Delete them all and add your own as findings justify.
 
 Recheck your own exclusions periodically: an exclusion that matches on message `text` stops
 matching when the linter rewords the message, and it fails **silently** in either

--- a/wiki/linting.md
+++ b/wiki/linting.md
@@ -57,9 +57,15 @@ Pick the order that moves you *toward* your existing convention, not away from i
 ### 2. Delete the framework-only exclusions
 
 Every entry under `linters.exclusions.rules` is a GoBricks path and means nothing in your
-repo — `logger/adapter.go` (zerologlint), `(cache|database|observability)/testing/` and
-`trace/` (revive var-naming), `^cmd/seal-payload/` (an importas carve-out). Delete them all
-and add your own as findings justify.
+repo — `logger/adapter.go` (zerologlint), `^cmd/seal-payload/` (an importas carve-out), and
+a few `_test.go` scopings. Delete them all and add your own as findings justify.
+
+Recheck your own exclusions periodically: an exclusion that matches on message `text` stops
+matching when the linter rewords the message, and it fails **silently** in either
+direction. GoBricks carried two `text: "var-naming: avoid package names"` stanzas that were
+dead from revive v1.15.0 onward, when that check moved to a separate rule and the wording
+changed. Nothing was being suppressed, and nothing said so — deleting them changed no
+findings. Prefer scoping by `path` and `linters` over matching message text.
 
 Keep the `presets` list (`comments`, `common-false-positives`, `legacy`,
 `std-error-handling`) — those are generic.
@@ -148,9 +154,9 @@ golangci-lint run ./... 2>&1 | grep -E 'level=error|cannot find rule'
 ```
 
 **`revive.rules` REPLACES the default set** when `enable-default-rules` is omitted. It does
-not extend it, so declaring any rule silently drops every default you did not re-list.
-GoBricks re-declares all 23 above its additions for that reason. The alternative is
-`enable-default-rules: true`, which keeps the defaults without re-declaration:
+not extend it, so declaring any rule silently drops every default you did not re-list —
+with no warning, because a missing rule and a passing rule both report nothing. Set
+`enable-default-rules: true` and list only your additions:
 
 ```yaml
 linters:
@@ -161,7 +167,11 @@ linters:
         - name: early-return       # additions only
 ```
 
-That is the shorter path for a new config. It cannot be combined with `enable-all-rules`.
+This is what GoBricks does. It previously re-declared all 23 defaults above its additions,
+which worked but meant deleting one line lost a rule silently. The two spellings are
+equivalent at v2.12.2 — golangci-lint's default list is a verbatim copy of revive's, and
+both resolve to the same rule set — so the flag is strictly safer. It cannot be combined
+with `enable-all-rules`.
 
 Because of all three, a reading of "0 findings" is ambiguous between *no violations*, *the
 rule never ran*, and *another linter claimed the line*. Prove a rule fires by planting a


### PR DESCRIPTION
## What

`.golangci.yml` re-declared golangci-lint's 23 default revive rules, because declaring
`rules` replaces the default set rather than extending it. `enable-default-rules: true`
restores them, so only the 17 uber-go additions need listing — and deleting one line can no
longer silently drop a rule. Also removes two `var-naming` exclusions that stopped matching
at revive v1.15.0, and updates `wiki/linting.md` for both.

## Impact

None — behavior-identical. In v2.12.2 the same `defaultRules` slice backs both the implicit
default and `enable-default-rules`, and it is a verbatim copy of revive v1.15.0's list.
Consumers following `wiki/linting.md` now get the flag rather than a 23-line transcription.

## Verification

Resolved-config dumps differ in exactly one field (`EnableDefaultRules`), same 40 rules with
identical arguments. With exclusion presets stripped so the comparison is non-vacuous, the
full repo yields the same 166 issues (88 revive) under both, matched issue-for-issue. The
deleted exclusions suppressed nothing — removing them leaves the repo at 0 findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated static analysis settings to use the standard rule set while preserving custom checks.
  * Removed outdated naming exclusions.

* **Documentation**
  * Clarified how default rules and message-text exclusions work.
  * Added guidance for scoping rules by path and linter.
  * Documented compatibility considerations when combining default rules with all available rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->