### PR TITLE
test(server): pin URL-over-body binding precedence as a tested contract

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -749,7 +749,8 @@ func wrapHandlerWithJOSE[T any, R any](
 // legacy per-request-reflecting path, kept alive as requestProcessor.process's fallback
 // for non-struct T (F26): bindStructFields's NumField() call panics at request time for
 // non-struct types, and that panic must stay exactly there. Struct T never reaches this
-// path — it uses bindRequestPlanned instead.
+// path — it uses bindRequestPlanned instead. It binds body-then-tags in the same order,
+// so the source-precedence note on bindRequestPlanned applies here too.
 func (rb *RequestBinder) bindRequest(c *echo.Context, target any) error {
 	targetValue := reflect.ValueOf(target).Elem()
 	targetType := targetValue.Type()
@@ -766,6 +767,11 @@ func (rb *RequestBinder) bindRequest(c *echo.Context, target any) error {
 // bindRequestPlanned binds request data using a precomputed binding plan (buildBindingPlan),
 // avoiding per-request struct-tag reflection. When plan is empty — the common case, e.g. a
 // JSON-body-only struct — only bindJSONBody runs.
+//
+// Source precedence is load-bearing and tested (TestRequestBinderPrecedence*): the JSON body
+// binds first, then param/query/header overlay on top, so a non-empty URL value wins over a
+// conflicting body value for a dual-tagged field. This overlay is deliberate — echo's own
+// binder binds the body last and would otherwise let the body win. Do not reorder or drop it.
 func (rb *RequestBinder) bindRequestPlanned(c *echo.Context, target any, plan []boundField) error {
 	if err := rb.bindJSONBody(c, target); err != nil {
 		return err

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -345,6 +345,85 @@ func TestRequestBinderPrecedenceEmptyPathSegmentKeepsBody(t *testing.T) {
 	assert.Equal(t, 999, seen.ID, "empty path param does not overwrite, so the body value survives")
 }
 
+// TestRequestBinderPrecedenceEmptyQueryParamKeepsBody covers a present-but-empty query
+// key (?limit=), which is distinct from the absent key covered above: bindQueryValue
+// guards on the VALUE being non-empty, so both cases leave the body value in place.
+func TestRequestBinderPrecedenceEmptyQueryParamKeepsBody(t *testing.T) {
+	e := echo.New()
+	e.Validator = NewValidator()
+	binder := NewRequestBinder()
+	cfg := &config.Config{App: config.AppConfig{Env: "development"}}
+
+	var seen numericRequest
+	h := WrapHandler(func(req numericRequest, _ HandlerContext) (numericRequest, IAPIError) {
+		seen = req
+		return req, nil
+	}, binder, cfg)
+
+	// `limit` is present but empty; the body supplies 999. Body value survives.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x?limit=", strings.NewReader(`{"limit":999}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h(c))
+	assert.Equal(t, uint16(999), seen.Limit, "an empty query value must not clobber the body value")
+}
+
+// TestRequestBinderPrecedenceAbsentHeaderKeepsBody pins the header side of the guard:
+// bindHeaderValue returns early when the header is absent, so the body value survives.
+func TestRequestBinderPrecedenceAbsentHeaderKeepsBody(t *testing.T) {
+	e := echo.New()
+	e.Validator = NewValidator()
+	binder := NewRequestBinder()
+	cfg := &config.Config{App: config.AppConfig{Env: "development"}}
+
+	var seen advancedBindReq
+	h := WrapHandler(func(req advancedBindReq, _ HandlerContext) (advancedBindReq, IAPIError) {
+		seen = req
+		return req, nil
+	}, binder, cfg)
+
+	// No X-Items header at all; the body supplies headerVals. Body value survives.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", strings.NewReader(`{"id":1,"headerVals":["from-body"]}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h(c))
+	assert.Equal(t, []string{"from-body"}, seen.HeaderVals, "an absent header must not clobber the body value")
+}
+
+// TestRequestBinderPrecedenceEmptyHeaderClearsSliceField pins the one place the overlay
+// does NOT fall back to the body. Header and query guards differ in shape: bindQueryValue
+// guards on the value, but bindHeaderValue guards on Header.Values being EMPTY — and a
+// present-but-empty header yields [""], which is length 1. That reaches
+// bindHeaderStringSlice, which parses no non-empty parts and still Sets the result, so the
+// []string field is cleared rather than left holding the body value. Pinned, not endorsed:
+// changing it is a behavior change and belongs in its own PR.
+func TestRequestBinderPrecedenceEmptyHeaderClearsSliceField(t *testing.T) {
+	e := echo.New()
+	e.Validator = NewValidator()
+	binder := NewRequestBinder()
+	cfg := &config.Config{App: config.AppConfig{Env: "development"}}
+
+	var seen advancedBindReq
+	h := WrapHandler(func(req advancedBindReq, _ HandlerContext) (advancedBindReq, IAPIError) {
+		seen = req
+		return req, nil
+	}, binder, cfg)
+
+	// X-Items present but empty; the body supplies headerVals. The field is cleared.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", strings.NewReader(`{"id":1,"headerVals":["from-body"]}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Set("X-Items", "")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h(c))
+	assert.Empty(t, seen.HeaderVals, "a present-but-empty header clears the field instead of preserving the body value")
+}
+
 func TestRequestBinderBindsUnsignedAndFloatValues(t *testing.T) {
 	e := echo.New()
 	v := NewValidator()

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -196,6 +196,155 @@ func TestRequestBinderAdvancedBinding(t *testing.T) {
 	assert.Equal(t, time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), got.When.UTC())
 }
 
+// TestRequestBinderPrecedencePathParamOverridesBody locks in that a path param
+// overwrites a conflicting JSON body value for a field tagged with both `param`
+// and `json`. echo's own binder would let the body win on POST (it binds the
+// body last); go-bricks' post-body param overlay is what makes the URL win.
+// See wiki/handler_patterns.md#binding-source-precedence.
+func TestRequestBinderPrecedencePathParamOverridesBody(t *testing.T) {
+	e := echo.New()
+	v := NewValidator()
+	e.Validator = v
+	binder := NewRequestBinder()
+	cfg := &config.Config{App: config.AppConfig{Env: "development"}}
+
+	var seen advancedBindReq
+	handler := func(req advancedBindReq, _ HandlerContext) (advancedBindReq, IAPIError) {
+		seen = req
+		return req, nil
+	}
+	h := WrapHandler(handler, binder, cfg)
+
+	// Body says id=999; URL path says id=5. URL must win.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/users/5", strings.NewReader(`{"id":999}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "id", Value: "5"}})
+
+	require.NoError(t, h(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 5, seen.ID, "path param must override JSON body value")
+}
+
+// TestRequestBinderPrecedenceQueryParamOverridesBody locks in that a present
+// query param overwrites a conflicting JSON body value. GET is the interesting
+// method here: echo binds query params before the body for the GET family, so
+// inside c.Bind the body clobbers the query value — go-bricks' overlay is what
+// restores it. See wiki/handler_patterns.md#binding-source-precedence.
+func TestRequestBinderPrecedenceQueryParamOverridesBody(t *testing.T) {
+	e := echo.New()
+	v := NewValidator()
+	e.Validator = v
+	binder := NewRequestBinder()
+	cfg := &config.Config{App: config.AppConfig{Env: "development"}}
+
+	var seen numericRequest
+	handler := func(req numericRequest, _ HandlerContext) (numericRequest, IAPIError) {
+		seen = req
+		return req, nil
+	}
+	h := WrapHandler(handler, binder, cfg)
+
+	// Body says limit=999; query says limit=10. Query must win.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x?limit=10", strings.NewReader(`{"limit":999}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h(c))
+	assert.Equal(t, uint16(10), seen.Limit, "present query param must override JSON body value")
+}
+
+// TestRequestBinderPrecedenceHeaderOverridesBody locks in the third overlay
+// source: a present header overwrites a conflicting JSON body value. echo binds
+// no headers at all in DefaultBinder.Bind, so this arm exists only in go-bricks'
+// overlay loop.
+func TestRequestBinderPrecedenceHeaderOverridesBody(t *testing.T) {
+	e := echo.New()
+	v := NewValidator()
+	e.Validator = v
+	binder := NewRequestBinder()
+	cfg := &config.Config{App: config.AppConfig{Env: "development"}}
+
+	var seen advancedBindReq
+	handler := func(req advancedBindReq, _ HandlerContext) (advancedBindReq, IAPIError) {
+		seen = req
+		return req, nil
+	}
+	h := WrapHandler(handler, binder, cfg)
+
+	// Body says headerVals=["from-body"] and id=999; header and path must win.
+	body := `{"id":999,"headerVals":["from-body"]}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/items/3", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Set("X-Items", "a, b")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "id", Value: "3"}})
+
+	require.NoError(t, h(c))
+	assert.Equal(t, []string{"a", "b"}, seen.HeaderVals, "present header must override JSON body value")
+	assert.Equal(t, 3, seen.ID, "path param must override JSON body value")
+}
+
+// TestRequestBinderPrecedenceAbsentQueryParamKeepsBody documents the boundary of
+// the contract: the URL overlay only overwrites when the URL value is non-empty,
+// so an absent query param leaves the JSON body value in place. A change that
+// made URL-wins unconditional would break this test.
+func TestRequestBinderPrecedenceAbsentQueryParamKeepsBody(t *testing.T) {
+	e := echo.New()
+	v := NewValidator()
+	e.Validator = v
+	binder := NewRequestBinder()
+	cfg := &config.Config{App: config.AppConfig{Env: "development"}}
+
+	var seen numericRequest
+	handler := func(req numericRequest, _ HandlerContext) (numericRequest, IAPIError) {
+		seen = req
+		return req, nil
+	}
+	h := WrapHandler(handler, binder, cfg)
+
+	// No `limit` query param; body supplies limit=999. Body value survives.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", strings.NewReader(`{"limit":999}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h(c))
+	assert.Equal(t, uint16(999), seen.Limit, "absent query param must not clobber the body value")
+}
+
+// TestRequestBinderPrecedenceEmptyPathSegmentKeepsBody pins the sharp edge of the
+// "only when present" qualifier, and is the reason a dual-tagged identifier is not a
+// security control on its own. An empty path segment still MATCHES the route, so
+// c.Param returns "", the overlay's non-empty guard skips the field, and the JSON body
+// value survives. This test routes through the real router (not SetPathValues) because
+// that is the only way the empty-segment match arises.
+// See wiki/handler_patterns.md#binding-source-precedence.
+func TestRequestBinderPrecedenceEmptyPathSegmentKeepsBody(t *testing.T) {
+	e := echo.New()
+	e.Validator = NewValidator()
+	binder := NewRequestBinder()
+	cfg := &config.Config{App: config.AppConfig{Env: "development"}}
+
+	var seen advancedBindReq
+	h := WrapHandler(func(req advancedBindReq, _ HandlerContext) (advancedBindReq, IAPIError) {
+		seen = req
+		return req, nil
+	}, binder, cfg)
+	e.POST("/users/:id/detail", h)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/users//detail", strings.NewReader(`{"id":999}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "an empty path segment still matches the route")
+	assert.Equal(t, 999, seen.ID, "empty path param does not overwrite, so the body value survives")
+}
+
 func TestRequestBinderBindsUnsignedAndFloatValues(t *testing.T) {
 	e := echo.New()
 	v := NewValidator()

--- a/wiki/handler_patterns.md
+++ b/wiki/handler_patterns.md
@@ -281,3 +281,34 @@ func PromoteCardID(c server.HandlerContext, next func() error) error {
 ```
 
 **Trust caveat:** injected params pass through verbatim — no duplicate- or empty-name validation — and reach `param:"x"` binding in downstream handlers. Treat them with the same trust as their source value: a promoted query param is still user input, so keep the usual `validate:` tags on the bound request struct.
+
+## Binding source precedence
+
+When a request struct field carries more than one binding tag — for example a
+field tagged both `json:"id"` and `param:"id"` — the framework binds the **JSON
+body first, then overlays path param, query, and header**. A **present** URL or
+header value therefore wins over a conflicting body value:
+
+- A **path param** overrides the body whenever the matched segment is non-empty,
+  which is the ordinary case. It is **not** an absolute guarantee: an empty
+  segment still matches, so `POST /cards//status` against `/cards/:cardId/status`
+  binds `cardId` as `""`, the overlay skips it, and the body's value survives.
+- A **query param** or **header** overrides the body only when present; an absent
+  or empty one leaves the body value in place.
+- `SetPathParams()` (above) feeds the same overlay, so a path parameter injected
+  by middleware also beats the body.
+
+This holds on every method, including POST/PUT/PATCH. It is not the underlying
+engine's default — echo's binder binds the body *last* — so the framework runs
+its own overlay pass afterwards to guarantee it.
+
+**For a security-sensitive identifier, do not lean on this ordering — give the
+field only its URL tag.** Dropping the `json` tag makes "the body cannot set
+this" a local, checkable property of the struct, instead of a consequence of
+binder ordering plus the shape of the incoming path. Dual-tagging a tenant or
+resource ID leaves the empty-segment case above open. This precedence is a
+tested contract (`TestRequestBinderPrecedence*` in `server/handler_test.go`).
+
+[ADR-001](adr_001_enhanced_handler_system.md) records the ordering as the original
+design decision; the "only when present" qualifier above refines its wording, which
+says later sources overwrite earlier ones without noting the guard.

--- a/wiki/handler_patterns.md
+++ b/wiki/handler_patterns.md
@@ -293,8 +293,12 @@ header value therefore wins over a conflicting body value:
   which is the ordinary case. It is **not** an absolute guarantee: an empty
   segment still matches, so `POST /cards//status` against `/cards/:cardId/status`
   binds `cardId` as `""`, the overlay skips it, and the body's value survives.
-- A **query param** or **header** overrides the body only when present; an absent
-  or empty one leaves the body value in place.
+- A **query param** overrides the body only when its value is non-empty. Both an
+  absent key and a present-but-empty one (`?limit=`) leave the body value in place.
+- A **header** guards on the header being absent, not on its value being empty —
+  a different shape. An absent header leaves the body value in place, but a
+  **present-but-empty** header still binds: for a `[]string` field it parses no
+  entries and clears the field rather than falling back to the body.
 - `SetPathParams()` (above) feeds the same overlay, so a path parameter injected
   by middleware also beats the body.
 


### PR DESCRIPTION
## What

The request binder overlays path param, query, and header on top of the JSON body, so a present URL value beats a conflicting body value for a field carrying both a `json` tag and a URL tag. Nothing tested it, and it is not the engine's default — echo binds the body last, so go-bricks' post-body overlay is the whole mechanism. ADR-001 recorded the ordering but stated it without the guard that the overlay only fires when the value is present.

## Impact

None at runtime — the only `server/handler.go` edits are doc comments. One consumer-facing correction: a dual-tagged identifier is **not** a mass-assignment control on its own. An empty path segment still matches its route, so `POST /cards//status` against `/cards/:cardId/status` binds `cardId` as `""` and the body's value survives. Give a security-sensitive identifier only its URL tag.

## Verification

The tests bite: disabling the overlay turns the path, query, and header cases red with the body's values and leaves the guard cases green. The empty-segment case was confirmed against the real router, not reasoned about.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Behavior**
  - Clarified request-binding precedence when fields are supplied by multiple sources.
  - JSON body values are applied first, then present path, query, and header values override conflicting values.
  - Empty path segments and absent or empty query values preserve body data; present-but-empty headers can clear slice fields.

- **Documentation**
  - Added guidance covering binding behavior across HTTP methods, including security considerations for URL-only identifiers.

- **Tests**
  - Added coverage for source precedence and boundary cases involving empty or absent URL and header inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->