### PR TITLE
ci: build the migrate CLI against its pinned go-bricks

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -686,15 +686,30 @@ jobs:
           cache-dependency-path: tools/migration/go.sum
 
       - name: Download dependencies
+        # Every step below runs in tools/migration, which the go command resolves
+        # THROUGH go.work — silently substituting framework HEAD for the
+        # `github.com/gaborage/go-bricks` version this module actually pins. That
+        # is not what `go install .../cmd/go-bricks-migrate@vX` ships, so without
+        # GOWORK=off this job validates a binary no consumer ever gets, and a
+        # breaking framework change plus a stale pin merges green. GOWORK=off
+        # takes the workspace — and go.work.sum with it — out of the path, so
+        # download/build/validate all resolve against tools/migration/go.mod.
+        # Same reasoning as lint-framework's GOWORK env, adapted.
+        env:
+          GOWORK: "off"
         run: go mod download
 
       - name: Build and validate CLI (Unix)
         if: matrix.os != 'windows-latest'
+        env:
+          GOWORK: "off"   # build the pinned graph, not the workspace union
         run: make validate-cli
 
       - name: Build and validate CLI (Windows)
         if: matrix.os == 'windows-latest'
         shell: powershell
+        env:
+          GOWORK: "off"   # build the pinned graph, not the workspace union
         run: |
           go build -ldflags "-X main.version=dev" -o go-bricks-migrate.exe ./cmd/go-bricks-migrate
           ./go-bricks-migrate.exe version


### PR DESCRIPTION
## What
`tools/migration` pins `github.com/gaborage/go-bricks v0.58.0`, but CI's `migrate-tool-build` job ran inside `go.work`, so it silently compiled the CLI against framework HEAD instead of the pinned version — never exercising the build consumers actually get via `go install`. This adds `GOWORK: "off"` to the job's three module-resolving steps, mirroring the existing `lint-framework` precedent.

## Impact
None. CI-only change; no consumer-facing API or build output changes.

## Verification
Consumer-shape `GOWORK=off go build ./...` and `go vet ./...` in `tools/migration` both exit 0 at the pinned version, confirmed by hand before this diff. `make mutate` on this YAML-only diff has no mutatable changed lines and is a deliberate no-op, not a pass: make mutate: deferred to a serial post-PR pass — hand-mutation table executed per plan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration-tool dependency resolution during builds and CLI validation across Unix and Windows environments.
  * Increased consistency and reliability of automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->