### PR TITLE
test(outbox,messaging): pin shared-resolver guard halves and Metadata pairing

### DIFF
--- a/messaging/typed_consumer_test.go
+++ b/messaging/typed_consumer_test.go
@@ -662,6 +662,70 @@ func TestDeclareTypedConsumerWithMeta(t *testing.T) {
 	})
 }
 
+// TestNewTypedHandlerWithMetaKeepsMetadataPairedUnderConcurrency pins that
+// Metadata stays paired with its own delivery under concurrent Handle calls on
+// one shared typedHandler instance. Reference is capped at 5 chars
+// (validate:"max=5"), so the per-goroutine marker must stay short or every
+// delivery fails validation before fn runs and the pairing assertion never
+// executes.
+func TestNewTypedHandlerWithMetaKeepsMetadataPairedUnderConcurrency(t *testing.T) {
+	const goroutines = 24
+
+	var mismatches atomic.Int64
+	var calls atomic.Int64
+	h := NewTypedHandlerWithMeta(orderEventType, func(_ context.Context, p orderPayload, meta Metadata) error {
+		calls.Add(1)
+		if meta.Headers()["x-check"] != p.Reference {
+			t.Errorf("metadata mismatch: got header %v for payload %+v", meta.Headers()["x-check"], p)
+			mismatches.Add(1)
+		}
+		return nil
+	})
+
+	ctx := t.Context()
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			marker := fmt.Sprintf("r%02d", i)
+			body, err := json.Marshal(orderPayload{Reference: marker, Amount: 1})
+			if err != nil {
+				t.Errorf("marshal payload: %v", err)
+				return
+			}
+			delivery := &amqp.Delivery{
+				Body:    body,
+				Headers: amqp.Table{"x-check": marker},
+			}
+			if err := h.Handle(ctx, delivery); err != nil {
+				t.Errorf("delivery %s failed: %v", marker, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(0), mismatches.Load(), "Metadata must stay paired with its own delivery")
+	assert.Equal(t, int64(goroutines), calls.Load(), "fn must run for every delivery, or the pairing assertion passes vacuously")
+}
+
+// TestNewTypedHandlerWithMetaNilHeaders pins that a delivery with nil Headers
+// survives Handle as a nil amqp.Table via Metadata.Headers() — the shape
+// outbox.EventIDFromHeaders must tolerate.
+func TestNewTypedHandlerWithMetaNilHeaders(t *testing.T) {
+	var calls int
+	var gotMeta Metadata
+	h := NewTypedHandlerWithMeta(orderEventType, func(_ context.Context, _ orderPayload, meta Metadata) error {
+		calls++
+		gotMeta = meta
+		return nil
+	})
+
+	require.NoError(t, h.Handle(t.Context(), &amqp.Delivery{Body: validBody(t)}))
+	assert.Equal(t, 1, calls)
+	assert.Nil(t, gotMeta.Headers())
+}
+
 func TestJSONCodecSummarize(t *testing.T) {
 	typeErr := &json.UnmarshalTypeError{
 		Value:  "number " + numericMarker,

--- a/outbox/module_test.go
+++ b/outbox/module_test.go
@@ -637,7 +637,7 @@ func TestModuleInitSharedTenancyRequiresInjectedResolvers(t *testing.T) {
 }
 
 // TestModuleInitSharedTenancyRequiresMessagingResolver pins the m.sharedMsg == nil
-// half of the module.go:158 guard: a nil DB resolver alone must not satisfy it.
+// half of the module.go:158 guard: a nil messaging resolver alone must not satisfy it.
 func TestModuleInitSharedTenancyRequiresMessagingResolver(t *testing.T) {
 	m := NewModule()
 	m.SetSharedResolvers(stubSharedDB, nil)
@@ -654,7 +654,7 @@ func TestModuleInitSharedTenancyRequiresMessagingResolver(t *testing.T) {
 }
 
 // TestModuleInitSharedTenancyRequiresDatabaseResolver pins the m.sharedDB == nil
-// half of the module.go:158 guard: a nil messaging resolver alone must not satisfy it.
+// half of the module.go:158 guard: a nil database resolver alone must not satisfy it.
 func TestModuleInitSharedTenancyRequiresDatabaseResolver(t *testing.T) {
 	m := NewModule()
 	m.SetSharedResolvers(nil, stubSharedMsg)

--- a/outbox/module_test.go
+++ b/outbox/module_test.go
@@ -636,6 +636,40 @@ func TestModuleInitSharedTenancyRequiresInjectedResolvers(t *testing.T) {
 		"a module constructed without SetSharedResolvers must be told how to fix it")
 }
 
+// TestModuleInitSharedTenancyRequiresMessagingResolver pins the m.sharedMsg == nil
+// half of the module.go:158 guard: a nil DB resolver alone must not satisfy it.
+func TestModuleInitSharedTenancyRequiresMessagingResolver(t *testing.T) {
+	m := NewModule()
+	m.SetSharedResolvers(stubSharedDB, nil)
+	deps := sharedTenancyDeps(&config.Config{
+		Outbox:      config.OutboxConfig{Enabled: true, Tenancy: config.TenancyShared},
+		Multitenant: config.MultitenantConfig{Enabled: true},
+		Source:      config.SourceConfig{Type: config.SourceTypeDynamic},
+	})
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "app.RegisterModule",
+		"a nil messaging resolver alone must still trip the guard")
+}
+
+// TestModuleInitSharedTenancyRequiresDatabaseResolver pins the m.sharedDB == nil
+// half of the module.go:158 guard: a nil messaging resolver alone must not satisfy it.
+func TestModuleInitSharedTenancyRequiresDatabaseResolver(t *testing.T) {
+	m := NewModule()
+	m.SetSharedResolvers(nil, stubSharedMsg)
+	deps := sharedTenancyDeps(&config.Config{
+		Outbox:      config.OutboxConfig{Enabled: true, Tenancy: config.TenancyShared},
+		Multitenant: config.MultitenantConfig{Enabled: true},
+		Source:      config.SourceConfig{Type: config.SourceTypeDynamic},
+	})
+
+	err := m.Init(deps)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "app.RegisterModule",
+		"a nil database resolver alone must still trip the guard")
+}
+
 func TestModuleInitSharedTenancyRejectsStaticTenants(t *testing.T) {
 	m := NewModule()
 	m.SetSharedResolvers(stubSharedDB, stubSharedMsg)


### PR DESCRIPTION
## What
The outbox shared-resolver guard's `||` and the typed-consumer `Metadata` per-delivery pairing were unpinned: gremlins never generates `||` mutants, and a wrong-pointer Metadata hoist is invisible to `-race`. Four new tests now pin each guard half independently and confirm `Metadata` stays paired with its own delivery under 24-goroutine concurrency, plus nil-headers survival through `Handle`.

## Impact
None. Test-only change; no production code, config, or public API is touched.

## Verification
Three hand-mutations were applied and reverted, each failing exactly its intended test and no other: the `sharedDB`-only and `sharedMsg`-only guard mutants, and a `sync.Once`-hoisted Metadata mutant (23/24 mismatches, no race report). make mutate: deferred to a serial post-PR pass — hand-mutation table executed per plan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for concurrent message handling to ensure payloads remain correctly paired with metadata.
  - Added validation for messages with missing headers.
  - Added checks to ensure shared-tenancy setup reports clear guidance when required messaging or database configuration is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->