### PR TITLE
fix(cache): register the documented cache.manager.* metrics

### DIFF
--- a/cache/manager.go
+++ b/cache/manager.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
+	"github.com/gaborage/go-bricks/cache/internal/tracking"
 	"github.com/gaborage/go-bricks/config"
 	"github.com/gaborage/go-bricks/internal/resourcepool"
 )
@@ -80,8 +82,10 @@ type ReleaseFunc func()
 //
 //nolint:revive // CacheManager mirrors the database.DbManager / messaging.Manager naming
 type CacheManager struct {
-	pool      *resourcepool.Pool[Cache]
-	connector Connector
+	pool           *resourcepool.Pool[Cache]
+	connector      Connector
+	metricsCleanup func()
+	cleanupOnce    sync.Once
 }
 
 // ManagerConfig configures the cache manager's behavior.
@@ -127,6 +131,19 @@ func NewCacheManager(cfg ManagerConfig, connector Connector) (*CacheManager, err
 		pool:      pool,
 		connector: connector,
 	}
+
+	// wiki/cache.md documents these five cache.manager.* metrics; registering here
+	// is what makes that true.
+	m.metricsCleanup = tracking.RegisterManagerMetrics(func() tracking.ManagerMetricsStats {
+		s := m.Stats()
+		return tracking.ManagerMetricsStats{
+			ActiveCaches: s.ActiveCaches,
+			TotalCreated: s.TotalCreated,
+			Evictions:    s.Evictions,
+			IdleCleanups: s.IdleCleanups,
+			Errors:       s.Errors,
+		}
+	}, "")
 
 	// Start the background cleanup goroutine if an idle TTL is configured.
 	if cfg.IdleTTL > 0 {
@@ -195,6 +212,11 @@ func (m *CacheManager) Close() error {
 	if m.pool == nil {
 		return nil // zero-value manager: nothing to close
 	}
+	m.cleanupOnce.Do(func() {
+		if m.metricsCleanup != nil {
+			m.metricsCleanup()
+		}
+	})
 	return m.pool.Close()
 }
 

--- a/cache/manager_test.go
+++ b/cache/manager_test.go
@@ -11,8 +11,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/gaborage/go-bricks/cache"
+	"github.com/gaborage/go-bricks/cache/internal/tracking"
+	obtest "github.com/gaborage/go-bricks/observability/testing"
 )
 
 const (
@@ -1185,4 +1189,82 @@ func TestCacheManagerZeroValueMethodsAreSafe(t *testing.T) {
 	assert.Equal(t, cache.ManagerStats{}, m.Stats(), "zero-value Stats must report empty stats, not panic")
 
 	assert.NoError(t, m.Close(), "closing a never-initialized manager is a no-op")
+}
+
+const (
+	metricManagerActiveCaches = "cache.manager.active_caches"
+	metricManagerTotalCreated = "cache.manager.total_created"
+	metricManagerEvictions    = "cache.manager.evictions"
+	metricManagerIdleCleanups = "cache.manager.idle_cleanups"
+	metricManagerErrors       = "cache.manager.errors"
+)
+
+// setupManagerMetricsProvider installs a manual-reader MeterProvider globally and
+// clears the cache tracking package's memoized meter so the next
+// RegisterManagerMetrics call binds to it. Mirrors httpclient/client_test.go:1134.
+func setupManagerMetricsProvider(t *testing.T) *obtest.TestMeterProvider {
+	t.Helper()
+	prev := otel.GetMeterProvider()
+	mp := obtest.NewTestMeterProvider()
+	otel.SetMeterProvider(mp)
+	tracking.ResetForTesting()
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prev)
+		tracking.ResetForTesting()
+		require.NoError(t, mp.Shutdown(context.Background()))
+	})
+	return mp
+}
+
+func TestNewCacheManagerRegistersManagerMetrics(t *testing.T) {
+	mp := setupManagerMetricsProvider(t)
+
+	connector := func(_ context.Context, key string) (cache.Cache, error) {
+		return newMockCache(key), nil
+	}
+	mgr, err := cache.NewCacheManager(cache.DefaultManagerConfig(), connector)
+	require.NoError(t, err)
+	defer mgr.Close()
+
+	for _, tenant := range []string{tenantOne, tenantTwo, tenantThree} {
+		_, release, gerr := mgr.Get(context.Background(), tenant)
+		require.NoError(t, gerr)
+		release()
+	}
+
+	rm := mp.Collect(t)
+	obtest.AssertMetricValue(t, rm, metricManagerActiveCaches, int64(3))
+	obtest.AssertMetricValue(t, rm, metricManagerTotalCreated, int64(3))
+	obtest.AssertMetricValue(t, rm, metricManagerEvictions, int64(0))
+	obtest.AssertMetricValue(t, rm, metricManagerIdleCleanups, int64(0))
+	obtest.AssertMetricValue(t, rm, metricManagerErrors, int64(0))
+}
+
+func TestCacheManagerCloseUnregistersManagerMetrics(t *testing.T) {
+	mp := setupManagerMetricsProvider(t)
+
+	connector := func(_ context.Context, key string) (cache.Cache, error) {
+		return newMockCache(key), nil
+	}
+	mgr, err := cache.NewCacheManager(cache.DefaultManagerConfig(), connector)
+	require.NoError(t, err)
+
+	_, release, err := mgr.Get(context.Background(), tenantOne)
+	require.NoError(t, err)
+	release()
+
+	// Positive control: without this, the post-Close assertion below passes
+	// vacuously when nothing was ever registered.
+	obtest.AssertMetricValue(t, mp.Collect(t), metricManagerTotalCreated, int64(1))
+
+	require.NoError(t, mgr.Close())
+	require.NoError(t, mgr.Close()) // exactly-once: a second cleanup must not run
+
+	rm := mp.Collect(t)
+	if m := obtest.FindMetric(rm, metricManagerTotalCreated); m != nil {
+		sum, ok := m.Data.(metricdata.Sum[int64])
+		require.True(t, ok, "cache.manager.total_created should be Sum[int64]")
+		assert.Empty(t, sum.DataPoints,
+			"cache.manager.* must stop being observed after Close")
+	}
 }


### PR DESCRIPTION
## What
`wiki/cache.md` documents five `cache.manager.*` metrics, but `RegisterManagerMetrics` was never called outside its own package, so `CacheManager` emitted none of them. `NewCacheManager` now registers them against a live `Stats()` snapshot, and `Close()` unregisters them exactly once via `sync.Once`, mirroring the pattern already used by the PostgreSQL and Oracle connection pools.

## Impact
None. The change is additive-behavioral with no exported signature changes; existing callers of `NewCacheManager`/`Close` are unaffected.

## Verification
Hand-mutation on the registration call and on the `Close` guard both failed at the intended assertion (metric-not-found and stale-datapoint respectively), confirming both lines are load-bearing.
make mutate: deferred to a serial post-PR pass — hand-mutation table executed per plan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache metric lifecycle management to prevent stale metrics after a cache is closed.
  * Ensured metric cleanup occurs exactly once during shutdown.
  * Preserved expected behavior for zero-value cache managers.

* **Tests**
  * Added coverage for cache activity, creation, eviction, idle cleanup, errors, and metric deregistration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->