### PR TITLE
fix(server): bind header slices of named string types

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -938,8 +938,8 @@ func (rb *RequestBinder) bindHeaderValue(c *echo.Context, headerName string, isS
 
 // bindHeaderStringSlice binds comma-separated header values to a string-kind slice field.
 // Parts are collected first so the slice can be built with SetString (which accepts any
-// String-Kind element type) instead of appending elements via reflect.Value.Append, which
-// rejects a plain string for a named element type like `type Scope string`.
+// String-Kind element type) instead of reflect.Append, which rejects a plain string for a
+// named element type like `type Scope string`.
 func (rb *RequestBinder) bindHeaderStringSlice(values []string, fieldValue reflect.Value) error {
 	parts := make([]string, 0, 8)
 	for _, raw := range values {

--- a/server/handler.go
+++ b/server/handler.go
@@ -936,16 +936,23 @@ func (rb *RequestBinder) bindHeaderValue(c *echo.Context, headerName string, isS
 	return nil
 }
 
-// bindHeaderStringSlice binds comma-separated header values to a []string field
+// bindHeaderStringSlice binds comma-separated header values to a string-kind slice field.
+// Parts are collected first so the slice can be built with SetString (which accepts any
+// String-Kind element type) instead of appending elements via reflect.Value.Append, which
+// rejects a plain string for a named element type like `type Scope string`.
 func (rb *RequestBinder) bindHeaderStringSlice(values []string, fieldValue reflect.Value) error {
-	slice := reflect.MakeSlice(fieldValue.Type(), 0, 8)
+	parts := make([]string, 0, 8)
 	for _, raw := range values {
 		for _, p := range strings.Split(raw, ",") {
 			p = strings.TrimSpace(p)
 			if p != "" {
-				slice = reflect.Append(slice, reflect.ValueOf(p))
+				parts = append(parts, p)
 			}
 		}
+	}
+	slice := reflect.MakeSlice(fieldValue.Type(), len(parts), len(parts))
+	for i, p := range parts {
+		slice.Index(i).SetString(p)
 	}
 	fieldValue.Set(slice)
 	return nil

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -3321,3 +3321,89 @@ func TestRequestAllocatorDefinedPointerType(t *testing.T) {
 	bound.Name = "bound"
 	assert.Equal(t, "bound", (*allocProbeRequest)(request).Name)
 }
+
+// auditScope is a named string type: its Kind is String, so isStringSliceType admits
+// []auditScope, but a plain `string` is NOT assignable to it in reflect's terms — which is
+// exactly what made bindHeaderStringSlice's reflect.Append panic before this fix.
+type auditScope string
+
+// namedSliceReq pins the named-element-type contract on both slice binders: the header one
+// (comma-split) and the query one (repeated params).
+type namedSliceReq struct {
+	Scopes      []auditScope `header:"X-Scopes"`
+	QueryScopes []auditScope `query:"scopes"`
+}
+
+// TestBindNamedStringSliceElementType pins that a slice whose element is a NAMED string type
+// binds from a header and from repeated query params, through both the precomputed-plan path
+// and the legacy reflect-per-request path. Before the fix the header cases panicked inside
+// reflect.Append, which middleware.Recover() turned into a per-request 500.
+func TestBindNamedStringSliceElementType(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(req *http.Request)
+		want  namedSliceReq
+	}{
+		{
+			name:  "named_type_header_comma_split",
+			setup: func(req *http.Request) { req.Header.Set("X-Scopes", "read, write") },
+			want:  namedSliceReq{Scopes: []auditScope{"read", "write"}},
+		},
+		{
+			name:  "named_type_repeated_query_params",
+			setup: func(req *http.Request) { req.URL.RawQuery = "scopes=read&scopes=write" },
+			want:  namedSliceReq{QueryScopes: []auditScope{"read", "write"}},
+		},
+		{
+			name:  "empty_and_whitespace_segments_dropped",
+			setup: func(req *http.Request) { req.Header.Set("X-Scopes", "a,, b ,") },
+			want:  namedSliceReq{Scopes: []auditScope{"a", "b"}},
+		},
+	}
+
+	plan := buildBindingPlan(reflect.TypeOf(namedSliceReq{}))
+	binder := NewRequestBinder()
+
+	newCtx := func(setup func(*http.Request)) *echo.Context {
+		e := echo.New()
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", http.NoBody)
+		setup(req)
+		return e.NewContext(req, httptest.NewRecorder())
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var planned namedSliceReq
+			require.NoError(t, binder.bindRequestPlanned(newCtx(tc.setup), &planned, plan))
+			assert.Equal(t, tc.want, planned, "planned path must bind the named element type")
+
+			var legacy namedSliceReq
+			require.NoError(t, binder.bindRequest(newCtx(tc.setup), &legacy))
+			assert.Equal(t, tc.want, legacy, "legacy and planned paths must agree")
+		})
+	}
+}
+
+// TestWrapHandlerNamedStringSliceHeaderReturns200 pins the user-visible symptom: a request
+// carrying the header reaches the handler and returns 200 instead of panicking. WrapHandler
+// installs no recover of its own, so a regression surfaces here as a panic in this test.
+func TestWrapHandlerNamedStringSliceHeaderReturns200(t *testing.T) {
+	e := echo.New()
+	e.Validator = NewValidator()
+	cfg := &config.Config{App: config.AppConfig{Env: "development"}}
+	binder := NewRequestBinder()
+
+	var seen namedSliceReq
+	h := WrapHandler(func(req namedSliceReq, _ HandlerContext) (namedSliceReq, IAPIError) {
+		seen = req
+		return req, nil
+	}, binder, cfg)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", http.NoBody)
+	req.Header.Set("X-Scopes", "read, write")
+	rec := httptest.NewRecorder()
+
+	require.NoError(t, h(e.NewContext(req, rec)))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []auditScope{"read", "write"}, seen.Scopes)
+}


### PR DESCRIPTION
## What
`bindHeaderStringSlice` appended plain `string` values via `reflect.Append`, which panics on any `[]Scope`-style named string element type; `middleware.Recover()` turned every such request into a 500. It now builds the slice with `SetString`, matching the already-correct query-param binder, so named string slice types bind instead of panicking.

## Impact
None. Existing `[]string` header binding behavior, including clearing the field on an empty header, is unchanged.

## Verification
Hand-mutation confirmed the fix and the query twin's regression pin each fail their targeted test when reverted to `reflect.Append`/`reflect.ValueOf`, attributing failure to the mutated binder. make mutate: deferred to a serial post-PR pass — hand-mutation table executed per plan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request binding for headers and repeated query parameters when using custom string types.
  * Improved handling of comma-separated values by trimming whitespace and ignoring empty entries.
  * Prevented runtime errors in supported request-handling scenarios.

* **Tests**
  * Added coverage for typed values, repeated parameters, and both binding paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->