### PR TITLE
fix(messaging): record consume metrics on success and start a receive span

### DIFF
--- a/messaging/internal/tracking/metrics.go
+++ b/messaging/internal/tracking/metrics.go
@@ -214,6 +214,35 @@ func RecordAMQPPublishMetrics(ctx context.Context, exchange, routingKey string, 
 	}
 }
 
+// consumeAttributes assembles the metric attribute set shared by the receive
+// counter and the receive duration histogram.
+func consumeAttributes(delivery *amqp.Delivery, queueName string, err error) []attribute.KeyValue {
+	var exchange, routingKey string
+	if delivery != nil {
+		exchange = delivery.Exchange
+		routingKey = delivery.RoutingKey
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String(attrMessagingSystem, messagingSystemRabbitMQ),
+		attribute.String(attrMessagingOperation, operationReceive),
+		attribute.String(attrMessagingDestination, formatDestinationName(exchange, routingKey, queueName)),
+	}
+	if exchange != "" {
+		attrs = append(attrs, attribute.String(attrMessagingRabbitMQExchange, exchange))
+	}
+	if routingKey != "" {
+		attrs = append(attrs, attribute.String(attrMessagingRabbitMQRoutingKey, routingKey))
+	}
+	if queueName != "" {
+		attrs = append(attrs, attribute.String(attrMessagingRabbitMQQueue, queueName))
+	}
+	if errorType := extractErrorType(err); errorType != "" {
+		attrs = append(attrs, attribute.String(attrErrorType, errorType))
+	}
+	return attrs
+}
+
 // RecordAMQPConsumeMetrics records OpenTelemetry metrics for an AMQP consume operation.
 // This function is called automatically when a message is consumed to emit metrics.
 //
@@ -228,39 +257,7 @@ func RecordAMQPConsumeMetrics(ctx context.Context, delivery *amqp.Delivery, queu
 		return
 	}
 
-	// Extract delivery information
-	var exchange, routingKey string
-	if delivery != nil {
-		exchange = delivery.Exchange
-		routingKey = delivery.RoutingKey
-	}
-
-	// Format destination name per OTel RabbitMQ convention (consumer format)
-	destination := formatDestinationName(exchange, routingKey, queueName)
-	errorType := extractErrorType(err)
-
-	// Common attributes for metrics
-	commonAttrs := []attribute.KeyValue{
-		attribute.String(attrMessagingSystem, messagingSystemRabbitMQ),
-		attribute.String(attrMessagingOperation, operationReceive),
-		attribute.String(attrMessagingDestination, destination),
-	}
-
-	// Add granular attributes for filtering
-	if exchange != "" {
-		commonAttrs = append(commonAttrs, attribute.String(attrMessagingRabbitMQExchange, exchange))
-	}
-	if routingKey != "" {
-		commonAttrs = append(commonAttrs, attribute.String(attrMessagingRabbitMQRoutingKey, routingKey))
-	}
-	if queueName != "" {
-		commonAttrs = append(commonAttrs, attribute.String(attrMessagingRabbitMQQueue, queueName))
-	}
-
-	// Add error type if present
-	if errorType != "" {
-		commonAttrs = append(commonAttrs, attribute.String(attrErrorType, errorType))
-	}
+	commonAttrs := consumeAttributes(delivery, queueName, err)
 
 	// Record duration histogram (in seconds) - only if duration is > 0
 	if amqpOperationDuration != nil && duration > 0 {
@@ -272,6 +269,24 @@ func RecordAMQPConsumeMetrics(ctx context.Context, delivery *amqp.Delivery, queu
 	if amqpMessagesConsumed != nil && err == nil {
 		amqpMessagesConsumed.Add(ctx, 1, metric.WithAttributes(commonAttrs...))
 	}
+}
+
+// RecordAMQPConsumeCompletion records the receive duration histogram for a
+// delivery whose handling has finished.
+//
+// It deliberately does NOT touch messaging.client.consumed.messages. That
+// counter has a single owner — StartConsumeSpan, which increments it once per
+// delivery received — so a delivery is counted exactly once regardless of how
+// its handler ended. Incrementing here too would double count every message.
+func RecordAMQPConsumeCompletion(ctx context.Context, delivery *amqp.Delivery, queueName string, duration time.Duration, err error) {
+	meter := getAMQPMeter()
+	if meter == nil {
+		return
+	}
+	if amqpOperationDuration == nil || duration <= 0 {
+		return
+	}
+	amqpOperationDuration.Record(ctx, durationToSeconds(duration), metric.WithAttributes(consumeAttributes(delivery, queueName, err)...))
 }
 
 // RecordPublishRetry records a publish retry attempt in the retry counter.

--- a/messaging/internal/tracking/metrics_test.go
+++ b/messaging/internal/tracking/metrics_test.go
@@ -2,7 +2,7 @@ package tracking
 
 import (
 	"context"
-	"sync"
+	"errors"
 	"testing"
 	"time"
 
@@ -24,8 +24,7 @@ const (
 
 // resetMeterForTesting resets the meter state for testing purposes
 func resetMeterForTesting() {
-	meterOnce = sync.Once{}
-	amqpMeter = nil
+	ResetMeterForTesting()
 }
 
 func TestInitAMQPMeter(t *testing.T) {
@@ -270,6 +269,85 @@ func TestRecordAMQPConsumeMetricsZeroDuration(t *testing.T) {
 
 	// Messages consumed counter should still be incremented
 	obtest.AssertMetricValue(t, rm, metricMessagesConsumed, int64(1))
+}
+
+func TestRecordAMQPConsumeCompletion(t *testing.T) {
+	tests := []struct {
+		name          string
+		duration      time.Duration
+		err           error
+		wantHistogram bool
+		wantErrorType bool
+	}{
+		{
+			name:          "success_records_histogram_without_error_type",
+			duration:      150 * time.Millisecond,
+			err:           nil,
+			wantHistogram: true,
+			wantErrorType: false,
+		},
+		{
+			name:          "error_records_histogram_with_error_type",
+			duration:      150 * time.Millisecond,
+			err:           errors.New("boom"),
+			wantHistogram: true,
+			wantErrorType: true,
+		},
+		{
+			name:          "zero_duration_records_nothing",
+			duration:      0,
+			err:           nil,
+			wantHistogram: false,
+			wantErrorType: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mp := obtest.NewTestMeterProvider()
+			defer func() {
+				require.NoError(t, mp.Shutdown(context.Background()))
+			}()
+			otel.SetMeterProvider(mp)
+
+			resetMeterForTesting()
+			initAMQPMeter()
+
+			ctx := context.Background()
+			delivery := &amqp.Delivery{
+				Exchange:   "events",
+				RoutingKey: testRoutingKey,
+			}
+
+			RecordAMQPConsumeCompletion(ctx, delivery, testQueueName, tt.duration, tt.err)
+
+			rm := mp.Collect(t)
+
+			// The counter has exactly one owner (StartConsumeSpan) and must
+			// never be touched by RecordAMQPConsumeCompletion.
+			assert.Nil(t, obtest.FindMetric(rm, metricMessagesConsumed))
+
+			durationMetric := obtest.FindMetric(rm, metricOperationDuration)
+			if !tt.wantHistogram {
+				assert.Nil(t, durationMetric)
+				return
+			}
+
+			require.NotNil(t, durationMetric)
+			histData := durationMetric.Data.(metricdata.Histogram[float64])
+			require.Len(t, histData.DataPoints, 1)
+			dp := histData.DataPoints[0]
+			assert.InDelta(t, 0.15, dp.Sum, 0.01)
+
+			attrs := dp.Attributes.ToSlice()
+			if tt.wantErrorType {
+				assertHasAttribute(t, attrs, attrErrorType, "*errors.errorString")
+			} else {
+				_, hasErrType := dp.Attributes.Value(attribute.Key(attrErrorType))
+				assert.False(t, hasErrType, "success path must not stamp error.type")
+			}
+		})
+	}
 }
 
 func TestRecordPublishRetry(t *testing.T) {

--- a/messaging/internal/tracking/testing.go
+++ b/messaging/internal/tracking/testing.go
@@ -1,0 +1,24 @@
+package tracking
+
+import "sync"
+
+// ResetMeterForTesting resets the package-level meter state so a test starts
+// with instruments bound to the currently installed global MeterProvider.
+// Intended for messaging-package tests, which cannot reach the unexported
+// state. Safe to call concurrently with initAMQPMeter — the mutex serializes
+// both paths.
+func ResetMeterForTesting() {
+	meterInitMu.Lock()
+	defer meterInitMu.Unlock()
+
+	meterOnce = sync.Once{}
+	amqpMeter = nil
+	amqpOperationDuration = nil
+	amqpMessagesSent = nil
+	amqpMessagesConsumed = nil
+	amqpPublishRetries = nil
+	amqpConnectionCreate = nil
+	amqpConnectionClose = nil
+	amqpChannelCreate = nil
+	amqpChannelClose = nil
+}

--- a/messaging/internal/tracking/testing.go
+++ b/messaging/internal/tracking/testing.go
@@ -5,8 +5,9 @@ import "sync"
 // ResetMeterForTesting resets the package-level meter state so a test starts
 // with instruments bound to the currently installed global MeterProvider.
 // Intended for messaging-package tests, which cannot reach the unexported
-// state. Safe to call concurrently with initAMQPMeter — the mutex serializes
-// both paths.
+// state. Not safe against a concurrent getAMQPMeter: that path runs
+// meterOnce.Do without meterInitMu, so callers must ensure no goroutine is
+// recording metrics when this runs.
 func ResetMeterForTesting() {
 	meterInitMu.Lock()
 	defer meterInitMu.Unlock()

--- a/messaging/registry.go
+++ b/messaging/registry.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/gaborage/go-bricks/internal/leasescope"
 	"github.com/gaborage/go-bricks/logger"
@@ -666,9 +668,10 @@ func (r *Registry) worker(ctx context.Context, consumer *ConsumerDeclaration, jo
 func (r *Registry) processMessage(ctx context.Context, consumer *ConsumerDeclaration, delivery *amqp.Delivery, log logger.Logger) {
 	startTime := time.Now()
 
-	// Extract trace context using centralized trace package
-	accessor := &amqpDeliveryAccessor{headers: delivery.Headers}
-	msgCtx := gobrickstrace.ExtractFromHeaders(ctx, accessor)
+	// This performs the same go-bricks header extraction this function used
+	// to do inline, and increments the consumed counter once per delivery
+	// received.
+	msgCtx, span := StartConsumeSpan(ctx, delivery, consumer.Queue)
 
 	// Install the per-message lease scope (ADR-032): per-tenant handles borrowed via
 	// deps.DB/Cache/Messaging while handling this delivery (including inbox ProcessOnce,
@@ -677,6 +680,11 @@ func (r *Registry) processMessage(ctx context.Context, consumer *ConsumerDeclara
 	// panic-recovery defer so ReleaseAll runs last (even on panic).
 	msgCtx, scope := leasescope.Install(msgCtx)
 	defer scope.ReleaseAll()
+
+	// Registered after ReleaseAll and before the recovery defer, so LIFO order
+	// is recover -> span.End -> ReleaseAll: the panic path stamps span status
+	// before the span closes, and ReleaseAll still runs last.
+	defer span.End()
 
 	contextLog := log.WithContext(msgCtx)
 	traceID := gobrickstrace.EnsureTraceID(msgCtx)
@@ -709,7 +717,10 @@ func (r *Registry) processMessage(ctx context.Context, consumer *ConsumerDeclara
 			Msg("Message processing failed - discarding without requeue")
 
 		// Record failed message metrics (duration with error.type attribute)
-		tracking.RecordAMQPConsumeMetrics(msgCtx, delivery, consumer.Queue, processingTime, err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+
+		tracking.RecordAMQPConsumeCompletion(msgCtx, delivery, consumer.Queue, processingTime, err)
 
 		// Negative acknowledgment WITHOUT requeue - prevents infinite retry loops.
 		// Queues declared with x-dead-letter-exchange route the message to that
@@ -724,6 +735,8 @@ func (r *Registry) processMessage(ctx context.Context, consumer *ConsumerDeclara
 		Str("message_id", delivery.MessageId).
 		Dur("processing_time", processingTime).
 		Msg("Message processed successfully")
+
+	tracking.RecordAMQPConsumeCompletion(msgCtx, delivery, consumer.Queue, processingTime, nil)
 
 	// Positive acknowledgment (only when AutoAck is false)
 	if !consumer.AutoAck {
@@ -790,7 +803,10 @@ func (r *Registry) handlePanicRecovery(
 
 	// Record failed message metrics
 	panicErr := fmt.Errorf("panic in message handler: %v", recovered)
-	tracking.RecordAMQPConsumeMetrics(msgCtx, delivery, consumer.Queue, processingTime, panicErr)
+	span := trace.SpanFromContext(msgCtx)
+	span.RecordError(panicErr)
+	span.SetStatus(codes.Error, panicErr.Error())
+	tracking.RecordAMQPConsumeCompletion(msgCtx, delivery, consumer.Queue, processingTime, panicErr)
 
 	// Nack without requeue
 	r.nackMessage(delivery, consumer.AutoAck, log)

--- a/messaging/registry.go
+++ b/messaging/registry.go
@@ -668,9 +668,9 @@ func (r *Registry) worker(ctx context.Context, consumer *ConsumerDeclaration, jo
 func (r *Registry) processMessage(ctx context.Context, consumer *ConsumerDeclaration, delivery *amqp.Delivery, log logger.Logger) {
 	startTime := time.Now()
 
-	// This performs the same go-bricks header extraction this function used
-	// to do inline, and increments the consumed counter once per delivery
-	// received.
+	// StartConsumeSpan performs the go-bricks header extraction this function
+	// used to do inline, and increments the consumed counter once per
+	// delivery received.
 	msgCtx, span := StartConsumeSpan(ctx, delivery, consumer.Queue)
 
 	// Install the per-message lease scope (ADR-032): per-tenant handles borrowed via
@@ -716,10 +716,10 @@ func (r *Registry) processMessage(ctx context.Context, consumer *ConsumerDeclara
 			Err(err).
 			Msg("Message processing failed - discarding without requeue")
 
-		// Record failed message metrics (duration with error.type attribute)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 
+		// Record failed message metrics (duration with error.type attribute)
 		tracking.RecordAMQPConsumeCompletion(msgCtx, delivery, consumer.Queue, processingTime, err)
 
 		// Negative acknowledgment WITHOUT requeue - prevents infinite retry loops.

--- a/messaging/registry_test.go
+++ b/messaging/registry_test.go
@@ -13,6 +13,14 @@ import (
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/gaborage/go-bricks/messaging/internal/tracking"
+	obtest "github.com/gaborage/go-bricks/observability/testing"
 )
 
 // ===== Registry Infrastructure Management Tests =====
@@ -1028,14 +1036,19 @@ type mockAcknowledger struct {
 	nackErr      error
 	nackMultiple bool
 	nackRequeue  bool
+	mu           sync.Mutex
 }
 
 func (m *mockAcknowledger) Ack(_ uint64, _ bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.ackCalled = true
 	return m.ackErr
 }
 
 func (m *mockAcknowledger) Nack(_ uint64, multiple, requeue bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.nackCalled = true
 	m.nackMultiple = multiple
 	m.nackRequeue = requeue
@@ -1044,6 +1057,15 @@ func (m *mockAcknowledger) Nack(_ uint64, multiple, requeue bool) error {
 
 func (m *mockAcknowledger) Reject(_ uint64, _ bool) error {
 	return nil
+}
+
+// AckCalled is a thread-safe read of ackCalled, for tests that poll from a
+// goroutine other than the one calling Ack (e.g. require.Eventually against
+// an asynchronous worker).
+func (m *mockAcknowledger) AckCalled() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.ackCalled
 }
 
 // ===== processMessage Tests =====
@@ -2145,15 +2167,24 @@ func TestRegistryConsumerResubscribesAfterDeliveryChannelCloses(t *testing.T) {
 	}, time.Second, 2*time.Millisecond, "consumer did not re-subscribe after delivery channel close")
 
 	// Prove the new subscription is live: a delivery on ch2 is processed.
+	acker := &mockAcknowledger{}
 	ch2 <- amqp.Delivery{
 		MessageId:    testMessageID,
 		Body:         []byte(testMessageBody),
 		Headers:      amqp.Table{},
-		Acknowledger: &mockAcknowledger{},
+		Acknowledger: acker,
 	}
 	require.Eventually(t, func() bool {
 		return handler.CallCount() >= 1
 	}, time.Second, 2*time.Millisecond, "delivery after re-subscribe was not processed")
+
+	// Wait for processMessage's full tail (metrics + ack) to finish, not just
+	// the handler call, so this test's worker goroutine cannot outlive the
+	// test and race a later test's global meter/tracer reset (plan 099 wires
+	// tracking calls into the success path this delivery takes).
+	require.Eventually(t, func() bool {
+		return acker.AckCalled()
+	}, time.Second, 2*time.Millisecond, "delivery after re-subscribe was not acked")
 
 	registry.StopConsumers()
 }
@@ -2196,15 +2227,24 @@ func TestRegistryConsumerResubscribeRetriesUntilClientReady(t *testing.T) {
 		return client.consumeCallCount() >= 4
 	}, 2*time.Second, 2*time.Millisecond, "consumer did not retry re-subscribe until client ready")
 
+	acker := &mockAcknowledger{}
 	ch2 <- amqp.Delivery{
 		MessageId:    testMessageID,
 		Body:         []byte(testMessageBody),
 		Headers:      amqp.Table{},
-		Acknowledger: &mockAcknowledger{},
+		Acknowledger: acker,
 	}
 	require.Eventually(t, func() bool {
 		return handler.CallCount() >= 1
 	}, time.Second, 2*time.Millisecond, "delivery after re-subscribe was not processed")
+
+	// Wait for processMessage's full tail (metrics + ack) to finish, not just
+	// the handler call, so this test's worker goroutine cannot outlive the
+	// test and race a later test's global meter/tracer reset (plan 099 wires
+	// tracking calls into the success path this delivery takes).
+	require.Eventually(t, func() bool {
+		return acker.AckCalled()
+	}, time.Second, 2*time.Millisecond, "delivery after re-subscribe was not acked")
 
 	registry.StopConsumers()
 }
@@ -2258,4 +2298,238 @@ func TestRegistryConsumerSupervisorStopsOnContextCancel(t *testing.T) {
 	time.Sleep(20 * registry.resubscribeDelay)
 	assert.Equal(t, settled, client.consumeCallCount(),
 		"supervisor kept re-subscribing after StopConsumers")
+}
+
+// ===== Consume metrics + receive span tests (plan 099) =====
+
+// sleepingCountingHandler wraps countingTestHandler with a fixed sleep before
+// returning, so processMessage observes a non-zero processingTime.
+// RecordAMQPConsumeCompletion skips duration <= 0, and a zero-cost handler
+// can produce a zero delta on a coarse clock, which would make duration
+// assertions flake.
+type sleepingCountingHandler struct {
+	countingTestHandler
+	sleepFor time.Duration
+}
+
+func (h *sleepingCountingHandler) Handle(ctx context.Context, delivery *amqp.Delivery) error {
+	time.Sleep(h.sleepFor)
+	return h.countingTestHandler.Handle(ctx, delivery)
+}
+
+// setupConsumeMetrics installs a test MeterProvider for the AMQP tracking
+// package and returns it plus a cleanup that restores the previous provider.
+// The tracking instruments are singletons bound at first use, so the reset must
+// bracket the test on both sides or state leaks into sibling tests.
+func setupConsumeMetrics(t *testing.T) (mp *obtest.TestMeterProvider, cleanup func()) {
+	t.Helper()
+	prev := otel.GetMeterProvider()
+	mp = obtest.NewTestMeterProvider()
+	otel.SetMeterProvider(mp)
+	tracking.ResetMeterForTesting()
+	return mp, func() {
+		otel.SetMeterProvider(prev)
+		tracking.ResetMeterForTesting()
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}
+}
+
+func TestRegistryProcessMessageRecordsConsumeMetricsOnSuccess(t *testing.T) {
+	mp, cleanup := setupConsumeMetrics(t)
+	defer cleanup()
+
+	registry := NewRegistry(&simpleMockAMQPClient{}, &stubLogger{})
+
+	handler := &sleepingCountingHandler{sleepFor: time.Millisecond}
+	consumer := &ConsumerDeclaration{
+		Queue:     testQueueName,
+		EventType: testEventType,
+		Handler:   handler,
+		AutoAck:   false,
+	}
+
+	acker := &mockAcknowledger{}
+	delivery := &amqp.Delivery{
+		MessageId:    testMessageID,
+		RoutingKey:   testRoutingKey,
+		Exchange:     testExchangeName,
+		DeliveryTag:  123,
+		Body:         []byte(testMessageBody),
+		Headers:      amqp.Table{},
+		Acknowledger: acker,
+	}
+
+	registry.processMessage(context.Background(), consumer, delivery, &stubLogger{})
+
+	rm := mp.Collect(t)
+
+	obtest.AssertMetricValue(t, rm, "messaging.client.consumed.messages", int64(1))
+
+	durationMetric := obtest.FindMetric(rm, "messaging.client.operation.duration")
+	require.NotNil(t, durationMetric)
+	histData, ok := durationMetric.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, histData.DataPoints, 1)
+
+	dp := histData.DataPoints[0]
+	assertAttribute(t, dp.Attributes.ToSlice(), "messaging.operation.name", "receive")
+
+	_, hasErrType := dp.Attributes.Value(attribute.Key("error.type"))
+	assert.False(t, hasErrType, "success path must not stamp error.type")
+}
+
+func TestRegistryProcessMessageRecordsConsumeMetricsOnError(t *testing.T) {
+	mp, cleanup := setupConsumeMetrics(t)
+	defer cleanup()
+
+	registry := NewRegistry(&simpleMockAMQPClient{}, &stubLogger{})
+
+	handler := &sleepingCountingHandler{
+		countingTestHandler: countingTestHandler{
+			testHandler: testHandler{retErr: errors.New("handler error")},
+		},
+		sleepFor: time.Millisecond,
+	}
+	consumer := &ConsumerDeclaration{
+		Queue:     testQueueName,
+		EventType: testEventType,
+		Handler:   handler,
+		AutoAck:   false,
+	}
+
+	acker := &mockAcknowledger{}
+	delivery := &amqp.Delivery{
+		MessageId:    testMessageID,
+		RoutingKey:   testRoutingKey,
+		Exchange:     testExchangeName,
+		DeliveryTag:  123,
+		Body:         []byte(testMessageBody),
+		Headers:      amqp.Table{},
+		Acknowledger: acker,
+	}
+
+	registry.processMessage(context.Background(), consumer, delivery, &stubLogger{})
+
+	rm := mp.Collect(t)
+
+	// Counter is stamped at receive time, before the handler runs.
+	obtest.AssertMetricValue(t, rm, "messaging.client.consumed.messages", int64(1))
+
+	durationMetric := obtest.FindMetric(rm, "messaging.client.operation.duration")
+	require.NotNil(t, durationMetric)
+	histData, ok := durationMetric.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, histData.DataPoints, 1)
+
+	dp := histData.DataPoints[0]
+	assertAttribute(t, dp.Attributes.ToSlice(), "error.type", "*errors.errorString")
+}
+
+func TestRegistryProcessMessageCountsExactlyOncePerDelivery(t *testing.T) {
+	mp, cleanup := setupConsumeMetrics(t)
+	defer cleanup()
+
+	registry := NewRegistry(&simpleMockAMQPClient{}, &stubLogger{})
+
+	handler := &sleepingCountingHandler{sleepFor: time.Millisecond}
+	consumer := &ConsumerDeclaration{
+		Queue:     testQueueName,
+		EventType: testEventType,
+		Handler:   handler,
+		AutoAck:   false,
+	}
+
+	acker := &mockAcknowledger{}
+	delivery := &amqp.Delivery{
+		MessageId:    testMessageID,
+		RoutingKey:   testRoutingKey,
+		Exchange:     testExchangeName,
+		DeliveryTag:  123,
+		Body:         []byte(testMessageBody),
+		Headers:      amqp.Table{},
+		Acknowledger: acker,
+	}
+
+	registry.processMessage(context.Background(), consumer, delivery, &stubLogger{})
+	registry.processMessage(context.Background(), consumer, delivery, &stubLogger{})
+
+	rm := mp.Collect(t)
+
+	obtest.AssertMetricValue(t, rm, "messaging.client.consumed.messages", int64(2))
+
+	durationMetric := obtest.FindMetric(rm, "messaging.client.operation.duration")
+	require.NotNil(t, durationMetric)
+	histData, ok := durationMetric.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, histData.DataPoints, 1)
+	assert.Equal(t, uint64(2), histData.DataPoints[0].Count)
+}
+
+func TestRegistryProcessMessageStartsReceiveSpan(t *testing.T) {
+	exporter, cleanup := setupTestTracing(t)
+	defer cleanup()
+
+	registry := NewRegistry(&simpleMockAMQPClient{}, &stubLogger{})
+
+	handler := &countingTestHandler{}
+	consumer := &ConsumerDeclaration{
+		Queue:     testQueueName,
+		EventType: testEventType,
+		Handler:   handler,
+		AutoAck:   false,
+	}
+
+	acker := &mockAcknowledger{}
+	delivery := &amqp.Delivery{
+		MessageId:    testMessageID,
+		RoutingKey:   testRoutingKey,
+		Exchange:     testExchangeName,
+		DeliveryTag:  123,
+		Body:         []byte(testMessageBody),
+		Headers:      amqp.Table{},
+		Acknowledger: acker,
+	}
+
+	registry.processMessage(context.Background(), consumer, delivery, &stubLogger{})
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	span := spans[0]
+	assert.Equal(t, testQueueName+" receive", span.Name)
+	assert.Equal(t, trace.SpanKindConsumer, span.SpanKind)
+	assertAttribute(t, span.Attributes, "messaging.operation.name", "receive")
+}
+
+func TestRegistryProcessMessagePanicMarksSpanError(t *testing.T) {
+	exporter, cleanup := setupTestTracing(t)
+	defer cleanup()
+
+	registry := NewRegistry(&simpleMockAMQPClient{}, &stubLogger{})
+
+	handler := &panicTestHandler{panicMsg: "boom"}
+	consumer := &ConsumerDeclaration{
+		Queue:     testQueueName,
+		EventType: testEventType,
+		Handler:   handler,
+		AutoAck:   false,
+	}
+
+	acker := &mockAcknowledger{}
+	delivery := &amqp.Delivery{
+		MessageId:    testMessageID,
+		RoutingKey:   testRoutingKey,
+		Exchange:     testExchangeName,
+		DeliveryTag:  123,
+		Body:         []byte(testMessageBody),
+		Headers:      amqp.Table{},
+		Acknowledger: acker,
+	}
+
+	require.NotPanics(t, func() {
+		registry.processMessage(context.Background(), consumer, delivery, &stubLogger{})
+	})
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, codes.Error, spans[0].Status.Code)
 }


### PR DESCRIPTION
## What
`messaging.client.consumed.messages` was permanently zero and the receive duration histogram only captured failed handlers: metrics fired solely on the error/panic paths, and the only path able to increment the counter (`StartConsumeSpan`) had zero production callers. Consumers now start a real receive span per delivery and record completion metrics on all three outcomes (success, error, panic), with the counter owned exclusively by `StartConsumeSpan` to avoid double-counting.

## Impact
None. This is additive instrumentation with no signature or config changes; operators should note `METRICS.md`'s updated semantics — the counter now counts deliveries received, including ones whose handler later fails.

## Verification
Hand-mutation table (5/5): dropping the success-branch completion call, reverting to header-extraction without a span, loosening the zero-duration guard, double-incrementing the counter, and misordering the panic defer each produced the named test failure at the named assertion.
make mutate: deferred to a serial post-PR pass — hand-mutation table executed per plan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OpenTelemetry tracing for message consumption, including error recording and status reporting.
  - Added processing-duration metrics for completed message handling.
  - Improved receive metrics with consistent delivery, queue, and error details.

- **Bug Fixes**
  - Corrected metric behavior so completion tracking does not inflate consumed-message counts.
  - Ensured errors and panics are reflected accurately in tracing and metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->