### PR TITLE
fix(migration): guard tenant-source redirects and cap response reads

### DIFF
--- a/migration/source/http/source.go
+++ b/migration/source/http/source.go
@@ -39,13 +39,25 @@ const DefaultTimeout = 30 * time.Second
 // set at one million tenants — well past any realistic fleet size.
 const maxPages = 10000
 
+// maxRedirects mirrors net/http's default redirect cap, which a custom
+// CheckRedirect replaces wholesale (see net/http.defaultCheckRedirect).
+const maxRedirects = 10
+
+// DefaultMaxResponseBytes caps a single page response when
+// Options.MaxResponseBytes is unset. 4 MiB is far past any real page: a page
+// carries at most PageLimit tenant IDs, and even 1000 UUIDs is ~40 KB.
+// Spelled as a plain literal rather than 4 << 20 so the mutation gate cannot
+// generate a bitwise-shift mutant on a line no test could distinguish.
+const DefaultMaxResponseBytes int64 = 4194304 // 4 MiB
+
 // Options configures TenantSource.
 type Options struct {
 	// BearerToken is sent in the Authorization header when non-empty.
 	BearerToken string
 
 	// Client overrides the default HTTP client. When nil, a client with a
-	// DefaultTimeout is used.
+	// DefaultTimeout is used. A caller-supplied CheckRedirect is honored as-is
+	// and replaces the source's scheme/host redirect guard.
 	Client *stdhttp.Client
 
 	// PageLimit is sent as the ?limit= query parameter on each request.
@@ -55,8 +67,14 @@ type Options struct {
 	// AllowInsecureScheme opts in to accepting `http://` base URLs. By default
 	// New() rejects plaintext schemes so an operator-supplied bearer token is
 	// never transmitted in clear text. Set this to true only for LocalStack,
-	// dev loops, or internal-only tooling on private networks.
+	// dev loops, or internal-only tooling on private networks. It additionally
+	// permits redirects that downgrade to `http://`.
 	AllowInsecureScheme bool
+
+	// MaxResponseBytes caps how many bytes are read from a single page
+	// response before the read fails with ErrResponseTooLarge. When 0 or
+	// negative, DefaultMaxResponseBytes is used.
+	MaxResponseBytes int64
 }
 
 // ErrInsecureScheme is returned by New when the supplied base URL uses a
@@ -67,12 +85,17 @@ var ErrInsecureScheme = errors.New("migration/source/http: http:// scheme requir
 // scheme other than http or https.
 var ErrUnsupportedScheme = errors.New("migration/source/http: unsupported URL scheme (expected http or https)")
 
+// ErrResponseTooLarge is returned when one page response exceeds
+// Options.MaxResponseBytes (DefaultMaxResponseBytes when unset).
+var ErrResponseTooLarge = errors.New("migration/source/http: control-plane response exceeded the configured maximum")
+
 // TenantSource implements migration.TenantLister against an HTTP control-plane API.
 type TenantSource struct {
-	baseURL     *url.URL
-	bearerToken string
-	client      *stdhttp.Client
-	pageLimit   int
+	baseURL          *url.URL
+	bearerToken      string
+	client           *stdhttp.Client
+	pageLimit        int
+	maxResponseBytes int64
 }
 
 // New constructs a TenantSource. baseURL must be parseable; the /tenants
@@ -105,18 +128,51 @@ func New(baseURL string, opts Options) (*TenantSource, error) {
 	if client == nil {
 		client = &stdhttp.Client{Timeout: DefaultTimeout}
 	}
+	client = redirectGuard(client, u.Host, opts.AllowInsecureScheme)
 
 	limit := opts.PageLimit
 	if limit <= 0 {
 		limit = DefaultPageLimit
 	}
 
+	maxBytes := opts.MaxResponseBytes
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxResponseBytes
+	}
+
 	return &TenantSource{
-		baseURL:     u,
-		bearerToken: opts.BearerToken,
-		client:      client,
-		pageLimit:   limit,
+		baseURL:          u,
+		bearerToken:      opts.BearerToken,
+		client:           client,
+		pageLimit:        limit,
+		maxResponseBytes: maxBytes,
 	}, nil
+}
+
+// redirectGuard returns client unchanged when the caller installed its own
+// CheckRedirect, and otherwise a shallow copy carrying a policy that refuses
+// any redirect which downgrades to http:// or leaves the base host — net/http
+// forwards Authorization on both (it compares hosts only, never the scheme).
+func redirectGuard(client *stdhttp.Client, baseHost string, allowInsecure bool) *stdhttp.Client {
+	if client.CheckRedirect != nil {
+		return client
+	}
+	// Shallow-copy: New must never mutate a client the caller may reuse
+	// (same rule as httpclient/client.go:531-539).
+	c := *client
+	c.CheckRedirect = func(req *stdhttp.Request, via []*stdhttp.Request) error {
+		if len(via) >= maxRedirects {
+			return errors.New("stopped after 10 redirects")
+		}
+		if req.URL.Scheme == "http" && !allowInsecure {
+			return fmt.Errorf("%w: redirect to %q downgrades to http", ErrInsecureScheme, req.URL.Redacted())
+		}
+		if req.URL.Host != baseHost {
+			return fmt.Errorf("control-plane redirected off-host to %q; refusing to follow", req.URL.Redacted())
+		}
+		return nil
+	}
+	return &c
 }
 
 // envelope mirrors the go-bricks server.APIResponse shape (see server/handler.go).
@@ -214,8 +270,15 @@ func (s *TenantSource) fetchPage(ctx context.Context, cursor string) (*envelopeD
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	// nil ResponseWriter is deliberate — the close signal is gated on an
+	// unexported net/http method nothing here can satisfy (same as
+	// server/jose.go:316-319 and httpclient/jose_transport.go:217).
+	body, err := io.ReadAll(stdhttp.MaxBytesReader(nil, resp.Body, s.maxResponseBytes))
 	if err != nil {
+		var maxErr *stdhttp.MaxBytesError
+		if errors.As(err, &maxErr) {
+			return nil, fmt.Errorf("%w (%d bytes)", ErrResponseTooLarge, s.maxResponseBytes)
+		}
 		return nil, fmt.Errorf("read control-plane response: %w", err)
 	}
 

--- a/migration/source/http/source_test.go
+++ b/migration/source/http/source_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -250,6 +251,113 @@ func TestHTTPTenantSourceSkipsEmptyIDs(t *testing.T) {
 	got, err := src.ListTenants(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, []string{"good", "also-good"}, got)
+}
+
+func TestHTTPTenantSourceRefusesSchemeDowngradeRedirect(t *testing.T) {
+	srv := httptest.NewTLSServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		stdhttp.Redirect(w, r, "http://"+r.Host+"/tenants", stdhttp.StatusFound)
+	}))
+	defer srv.Close()
+
+	hc := srv.Client() // trusts the test cert; its CheckRedirect is nil, so the guard installs
+	src, err := New(srv.URL, Options{Client: hc})
+	require.NoError(t, err)
+
+	_, err = src.ListTenants(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInsecureScheme) // must be the scheme branch, not the host branch
+	assert.Nil(t, hc.CheckRedirect, "New must not mutate the caller's client")
+}
+
+func TestHTTPTenantSourceRefusesOffHostRedirect(t *testing.T) {
+	srv := httptest.NewTLSServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		stdhttp.Redirect(w, r, "https://other-host.invalid/tenants", stdhttp.StatusFound)
+	}))
+	defer srv.Close()
+
+	hc := srv.Client()
+	src, err := New(srv.URL, Options{Client: hc})
+	require.NoError(t, err)
+
+	_, err = src.ListTenants(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "off-host")
+	assert.NotErrorIs(t, err, ErrInsecureScheme)
+}
+
+func TestHTTPTenantSourceHonorsCallerCheckRedirect(t *testing.T) {
+	plainSrv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+		writeJSON(w, stdhttp.StatusOK, writeEnvelope{
+			Data: map[string]any{
+				"tenants":     []map[string]string{{"id": "t1"}},
+				"next_cursor": "",
+			},
+			Meta: map[string]any{},
+		})
+	}))
+	defer plainSrv.Close()
+
+	tlsSrv := httptest.NewTLSServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		stdhttp.Redirect(w, r, plainSrv.URL+"/tenants", stdhttp.StatusFound)
+	}))
+	defer tlsSrv.Close()
+
+	hc := tlsSrv.Client()
+	hc.CheckRedirect = func(*stdhttp.Request, []*stdhttp.Request) error { return nil }
+
+	src, err := New(tlsSrv.URL, Options{Client: hc})
+	require.NoError(t, err)
+
+	got, err := src.ListTenants(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"t1"}, got)
+}
+
+func TestHTTPTenantSourceStopsAfterTenRedirects(t *testing.T) {
+	var hits int32
+	srv := httptest.NewTLSServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		atomic.AddInt32(&hits, 1)
+		stdhttp.Redirect(w, r, "https://"+r.Host+"/tenants", stdhttp.StatusFound)
+	}))
+	defer srv.Close()
+
+	hc := srv.Client()
+	src, err := New(srv.URL, Options{Client: hc})
+	require.NoError(t, err)
+
+	_, err = src.ListTenants(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stopped after 10 redirects")
+	assert.Equal(t, int32(10), atomic.LoadInt32(&hits))
+}
+
+func TestHTTPTenantSourceRejectsOversizedResponse(t *testing.T) {
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+		_, _ = w.Write(bytes.Repeat([]byte("a"), 1025))
+	}))
+	defer srv.Close()
+
+	src, err := New(srv.URL, Options{AllowInsecureScheme: true, MaxResponseBytes: 1024})
+	require.NoError(t, err)
+
+	_, err = src.ListTenants(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrResponseTooLarge)
+}
+
+func TestHTTPTenantSourceAcceptsResponseAtLimit(t *testing.T) {
+	const body = `{"data":{"tenants":[{"id":"t1"}],"next_cursor":""},"meta":{}}`
+	srv := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	src, err := New(srv.URL, Options{AllowInsecureScheme: true, MaxResponseBytes: int64(len(body))})
+	require.NoError(t, err)
+
+	got, err := src.ListTenants(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"t1"}, got)
 }
 
 func writeJSON(w stdhttp.ResponseWriter, status int, body any) {

--- a/migration/source/http/source_test.go
+++ b/migration/source/http/source_test.go
@@ -255,7 +255,7 @@ func TestHTTPTenantSourceSkipsEmptyIDs(t *testing.T) {
 
 func TestHTTPTenantSourceRefusesSchemeDowngradeRedirect(t *testing.T) {
 	srv := httptest.NewTLSServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
-		stdhttp.Redirect(w, r, "http://"+r.Host+"/tenants", stdhttp.StatusFound)
+		stdhttp.Redirect(w, r, "http://"+r.Host+"/tenants", stdhttp.StatusFound) // NOSONAR: test fixture simulates the redirect attack redirectGuard must refuse (S5146 targets production handlers)
 	}))
 	defer srv.Close()
 
@@ -317,7 +317,7 @@ func TestHTTPTenantSourceStopsAfterTenRedirects(t *testing.T) {
 	var hits int32
 	srv := httptest.NewTLSServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 		atomic.AddInt32(&hits, 1)
-		stdhttp.Redirect(w, r, "https://"+r.Host+"/tenants", stdhttp.StatusFound)
+		stdhttp.Redirect(w, r, "https://"+r.Host+"/tenants", stdhttp.StatusFound) // NOSONAR: test fixture simulates the redirect attack redirectGuard must refuse (S5146 targets production handlers)
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
## What

The multi-tenant HTTP config source followed redirects with the Bearer header attached (Go strips Authorization only cross-host, never on same-host scheme downgrade) and read response bodies unbounded; a redirect guard now refuses scheme-downgrade and off-host hops (honoring any caller-supplied CheckRedirect), and reads are capped via http.MaxBytesReader.

## Impact

Responses over the new default 4 MiB cap now fail with ErrResponseTooLarge; deployments serving larger tenant pages set the new Options.MaxResponseBytes. Redirects that downgrade scheme or leave the host now fail instead of leaking the token.

## Verification

All 7 hand-mutations killed with attributed assertions (e.g. the redirect-cap boundary mutant fails the exact-10 hit-count assertion, independently replayed by a reviewer); make mutate non-vacuous — 7 mutants on changed lines, all killed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Blocked redirects to different hosts and insecure HTTP redirects from HTTPS by default.
  * Preserved custom redirect policies and limited redirect chains to ten hops.

* **Bug Fixes**
  * Added response-size protection with a configurable 4 MiB default limit.
  * Oversized responses now return a clear error, while responses at the configured limit remain accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->