### PR TITLE
fix(database): keep the PostgreSQL DSN out of ParseConfig startup errors

### DIFF
--- a/database/postgresql/connection.go
+++ b/database/postgresql/connection.go
@@ -132,6 +132,13 @@ func buildPostgresDSN(cfg *config.DatabaseConfig) string {
 	return strings.Join(parts, " ")
 }
 
+// parseConfigError reports a DSN parse failure without rendering the DSN, while
+// keeping pgx's error reachable through errors.Is / errors.As.
+type parseConfigError struct{ err error }
+
+func (e *parseConfigError) Error() string { return "failed to parse PostgreSQL config" }
+func (e *parseConfigError) Unwrap() error { return e.err }
+
 // NewConnection creates and configures a PostgreSQL Connection using cfg and log.
 // It validates cfg, builds or uses the provided DSN, sets pool options, ensures connectivity with a ping, logs success, and returns the wrapped Connection or an error.
 func NewConnection(cfg *config.DatabaseConfig, log logger.Logger) (types.Interface, error) {
@@ -147,7 +154,17 @@ func NewConnection(cfg *config.DatabaseConfig, log logger.Logger) (types.Interfa
 
 	pgxConfig, err := pgx.ParseConfig(dsn)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse PostgreSQL config: %w", err)
+		// SECURITY: pgx's ParseConfigError.Error() renders the whole DSN and redacts the
+		// password with regexes that a quote-bearing password escapes, so neither the
+		// returned error nor the log may carry its text. Identity comes from cfg fields
+		// we control; the original stays reachable via errors.As for a caller that wants
+		// ParseConfigError.ConnString.
+		log.Error().
+			Str("host", cfg.Host).
+			Int("port", cfg.Port).
+			Str("database", cfg.Database).
+			Msg("Failed to parse PostgreSQL configuration")
+		return nil, &parseConfigError{err: err}
 	}
 
 	// Apply session-level timezone via pgx RuntimeParams. Empty Timezone is

--- a/database/postgresql/connection_test.go
+++ b/database/postgresql/connection_test.go
@@ -12,6 +12,7 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -437,6 +438,53 @@ func TestConnectionNewConnectionInvalidConfig(t *testing.T) {
 	// Should fail at config parsing stage
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse PostgreSQL config")
+}
+
+func TestConnectionNewConnectionParseErrorOmitsConnectionStringPassword(t *testing.T) {
+	const password = `zqxvw'plinth marmalade`
+	cfg := &config.DatabaseConfig{
+		ConnectionString: `host=zqxvwhost port=notanumber user=zqxvwuser password='zqxvw\'plinth marmalade' dbname=zqxvwdb`,
+	}
+
+	// Premise, so the NotContains below cannot pass vacuously.
+	require.Contains(t, cfg.ConnectionString, "marmalade")
+
+	_, err := NewConnection(cfg, dbtestlog.NewTestLogger())
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "marmalade", "password fragment leaked into the startup error")
+	assert.NotContains(t, err.Error(), password)
+	assert.Contains(t, err.Error(), "failed to parse PostgreSQL config")
+}
+
+func TestConnectionNewConnectionParseErrorOmitsBuiltDSNPassword(t *testing.T) {
+	const password = `zqxvw'plinth marmalade`
+	cfg := &config.DatabaseConfig{
+		Host: "zqxvwhost", Port: 5432, Username: "zqxvwuser",
+		Password: password, Database: "zqxvwdb",
+	}
+	cfg.TLS.Mode = "zqxvwbogusmode"
+
+	// Non-vacuity: prove the value really is in the DSN handed to pgx.
+	require.Contains(t, buildPostgresDSN(cfg), "marmalade")
+
+	_, err := NewConnection(cfg, dbtestlog.NewTestLogger())
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "marmalade", "password fragment leaked into the startup error")
+	assert.NotContains(t, err.Error(), password)
+}
+
+func TestConnectionNewConnectionParseErrorPreservesChain(t *testing.T) {
+	cfg := &config.DatabaseConfig{
+		ConnectionString: `host=zqxvwhost port=notanumber user=zqxvwuser password='zqxvw\'plinth marmalade' dbname=zqxvwdb`,
+	}
+
+	_, err := NewConnection(cfg, dbtestlog.NewTestLogger())
+
+	require.Error(t, err)
+	var pgErr *pgconn.ParseConfigError
+	require.True(t, errors.As(err, &pgErr), "pgx error must stay reachable via errors.As")
 }
 
 func TestStatementQueryAndQueryRow(t *testing.T) {


### PR DESCRIPTION
## What
`postgresql.NewConnection` wrapped `pgx.ParseConfig`'s error verbatim with `%w`, which renders the whole DSN via pgx's regex-based `redactPW`; a password containing a single quote (e.g. `zqxvw'plinth marmalade`) escapes that regex and leaves a password fragment in the startup error and log. `ParseConfig` failures now return a `parseConfigError` that keeps the static, already-documented `"failed to parse PostgreSQL config"` prefix, logs only host/port/database, and preserves the original error via `Unwrap()` so `errors.Is`/`errors.As` still reach `pgconn.ParseConfigError`. This brings PostgreSQL to parity with Oracle's existing redaction (#896).

## Impact
None. The error string prefix and the `errors.Is`/`errors.As` chain are unchanged for consumers; only the leaked DSN/password fragment is removed. No new exported symbols.

## Verification
Hand-mutation confirmed both defenses bite: reverting to `fmt.Errorf("...: %w", err)` fails the `marmalade` `NotContains` assertions in `TestConnectionNewConnectionParseErrorOmitsConnectionStringPassword` and `TestConnectionNewConnectionParseErrorOmitsBuiltDSNPassword` (connection_test.go); changing `Unwrap()` to return `nil` fails `TestConnectionNewConnectionParseErrorPreservesChain` while the other two stay green. gremlins sweep: deferred to the orchestrator's serial post-PR pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL configuration errors no longer expose database passwords or full connection strings in logs or error messages.
  * Connection details now provide only safe diagnostic information, such as host, port, and database.
  * Underlying PostgreSQL parse errors remain available for error handling and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->