### PR TITLE
fix(cache): clamp sub-millisecond CompareAndSet TTLs to 1ms

### DIFF
--- a/cache/redis/client.go
+++ b/cache/redis/client.go
@@ -272,6 +272,8 @@ func (c *Client) GetOrSet(ctx context.Context, key string, value []byte, ttl tim
 // expectedValue — including an empty slice — is a real compare-and-swap, so an absent key
 // fails the comparison.
 // Uses Lua script for atomicity.
+// A ttl of 0 stores the key without expiration; any positive ttl below 1ms is
+// raised to 1ms, matching what go-redis does for Set and GetOrSet.
 func (c *Client) CompareAndSet(ctx context.Context, key string, expectedValue, newValue []byte, ttl time.Duration) (bool, error) {
 	if c.closed.Load() {
 		return false, cache.ErrClosed
@@ -293,8 +295,15 @@ func (c *Client) CompareAndSet(ctx context.Context, key string, expectedValue, n
 
 	start := time.Now()
 
+	// A positive TTL below 1ms truncates to 0, which the script reads as
+	// "no expiry" — clamp it so only ttl == 0 produces a persistent key.
+	ttlMs := ttl.Milliseconds()
+	if ttl > 0 && ttlMs == 0 {
+		ttlMs = 1
+	}
+
 	// Execute Lua script
-	result, err := c.client.Eval(ctx, casScript, []string{key}, expected, newValue, ttl.Milliseconds(), mode).Int()
+	result, err := c.client.Eval(ctx, casScript, []string{key}, expected, newValue, ttlMs, mode).Int()
 
 	duration := time.Since(start)
 	tracking.RecordCacheOperation(ctx, tracking.OpCompareAndSet, duration, false, err, c.namespace(ctx))

--- a/cache/redis/client_test.go
+++ b/cache/redis/client_test.go
@@ -708,3 +708,66 @@ func TestNewClientRejectsOldRedis(t *testing.T) {
 		defer client.Close()
 	})
 }
+
+// TestCompareAndSetTTLClamp pins the TTL conversion at CompareAndSet's Eval
+// site. The pre-existing TestClientCompareAndSet/ZeroTTL_NoExpiration subtest
+// asserts only that the call succeeds, so it cannot distinguish "no expiry"
+// from "1ms expiry"; these cases assert the stored TTL itself.
+func TestCompareAndSetTTLClamp(t *testing.T) {
+	tests := []struct {
+		name        string
+		ttl         time.Duration
+		expectedTTL time.Duration
+	}{
+		{name: "sub_millisecond_ttl_clamps_to_one_millisecond", ttl: 500 * time.Microsecond, expectedTTL: time.Millisecond},
+		{name: "zero_ttl_means_no_expiry", ttl: 0, expectedTTL: 0},
+		{name: "millisecond_ttl_is_unchanged", ttl: 5 * time.Millisecond, expectedTTL: 5 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, mr := setupTestRedis(t)
+			defer client.Close()
+
+			ctx := context.Background()
+			success, err := client.CompareAndSet(ctx, testKey1, nil, []byte(testWorker), tt.ttl)
+			require.NoError(t, err)
+			require.True(t, success)
+			require.True(t, mr.Exists(testKey1))
+
+			// miniredis reports 0 for "no TTL set" (direct.go: TTL godoc).
+			assert.Equal(t, tt.expectedTTL, mr.TTL(testKey1))
+		})
+	}
+}
+
+// TestCompareAndSetSubMillisecondTTLExpires proves the clamped key actually
+// goes away rather than merely carrying a TTL field.
+func TestCompareAndSetSubMillisecondTTLExpires(t *testing.T) {
+	client, mr := setupTestRedis(t)
+	defer client.Close()
+
+	ctx := context.Background()
+	success, err := client.CompareAndSet(ctx, testKey1, nil, []byte(testWorker), 500*time.Microsecond)
+	require.NoError(t, err)
+	require.True(t, success)
+	require.True(t, mr.Exists(testKey1))
+
+	mr.FastForward(2 * time.Millisecond)
+	assert.False(t, mr.Exists(testKey1))
+}
+
+// TestCompareAndSetCASModeSubMillisecondTTLClamps covers the script's second
+// SET branch: the table above only exercises the nx (acquire-if-absent) path.
+func TestCompareAndSetCASModeSubMillisecondTTLClamps(t *testing.T) {
+	client, mr := setupTestRedis(t)
+	defer client.Close()
+
+	require.NoError(t, mr.Set(testKey1, testExistingValue))
+
+	ctx := context.Background()
+	success, err := client.CompareAndSet(ctx, testKey1, []byte(testExistingValue), []byte(testNewValue), 500*time.Microsecond)
+	require.NoError(t, err)
+	require.True(t, success)
+	assert.Equal(t, time.Millisecond, mr.TTL(testKey1))
+}


### PR DESCRIPTION
## What

`CompareAndSet` passed `ttl.Milliseconds()` straight to its Lua script, so any `0 < ttl < 1ms` truncated to `0`, which the script reads as "no expiration" — turning the documented distributed-lock primitive into a permanent lock on a crashed holder. `Set`/`GetOrSet` already round sub-millisecond TTLs up to 1ms via go-redis; `CompareAndSet` now clamps the same way, so `ttl == 0` still means no expiry and any `ttl > 0` always expires.

## Impact

None. No exported symbol changed; behavior is corrected only in the previously-broken `0 < ttl < 1ms` range, and `ttl == 0` is untouched (atom `[C581.1]` still holds).

## Verification

Step 3 hand-mutation confirmed all three named mutations on the clamp conditional (`ttl > 0` → `ttl >= 0`, `ttlMs == 0` → `ttlMs != 0`, deleting the `if` block) break their named tests. gremlins sweep: deferred to the orchestrator's serial post-PR pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Redis key expiration for positive TTLs shorter than one millisecond.
  * Ensured zero TTL continues to create keys without expiration.
  * Preserved expected expiration behavior for TTLs specified in milliseconds.
  * Improved compare-and-set updates involving short expiration periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->