### PR TITLE
fix(config): reject NaN trace sampling rate

### DIFF
--- a/observability/config.go
+++ b/observability/config.go
@@ -2,6 +2,7 @@ package observability
 
 import (
 	"maps"
+	"math"
 	"strings"
 	"time"
 )
@@ -648,7 +649,7 @@ func (c *Config) validateTraceConfig() error {
 	// Validate sample rate if explicitly set
 	if c.Trace.Sample.Rate != nil {
 		rate := *c.Trace.Sample.Rate
-		if rate < 0.0 || rate > 1.0 {
+		if math.IsNaN(rate) || rate < 0.0 || rate > 1.0 {
 			return ErrInvalidSampleRate
 		}
 	}

--- a/observability/config_test.go
+++ b/observability/config_test.go
@@ -1,6 +1,7 @@
 package observability
 
 import (
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -92,6 +93,21 @@ func TestConfigValidate(t *testing.T) {
 				Trace: TraceConfig{
 					Sample: SampleConfig{
 						Rate: Float64Ptr(1.1),
+					},
+				},
+			},
+			wantErr: ErrInvalidSampleRate,
+		},
+		{
+			name: "nan_rate_rejected",
+			config: Config{
+				Enabled: true,
+				Service: ServiceConfig{
+					Name: testServiceName,
+				},
+				Trace: TraceConfig{
+					Sample: SampleConfig{
+						Rate: Float64Ptr(math.NaN()),
 					},
 				},
 			},


### PR DESCRIPTION
## What

NaN passed the trace sampling-rate range check — both comparisons false — reaching sampling math with implementation-defined results; validation now rejects NaN explicitly, mirroring the logs-side fix.

## Impact

A config that somehow injected NaN now fails startup validation instead of sampling unpredictably; None otherwise.

## Verification

Mirrored byte-for-byte from the #949-reviewed logs-side guard; NaN table case asserts the exact error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace sampling configuration validation to reject invalid “Not a Number” values.
  * Prevented invalid sampling rates from being accepted, ensuring rates remain within the supported 0.0–1.0 range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->