### PR TITLE
perf(messaging/httpclient/database): guard debug log sites and fold SQL prefix matching

### DIFF
--- a/database/internal/tracking/metrics.go
+++ b/database/internal/tracking/metrics.go
@@ -292,31 +292,29 @@ func extractTableName(query string) string {
 	}
 
 	// Try each pattern based on query type
-	queryUpper := strings.ToUpper(query)
-
 	// SELECT queries
-	if strings.HasPrefix(queryUpper, "SELECT") {
+	if hasPrefixFold(query, "SELECT") {
 		if table := tryExtractTable(selectTableRegex, query); table != "" {
 			return table
 		}
 	}
 
 	// INSERT queries
-	if strings.HasPrefix(queryUpper, "INSERT") {
+	if hasPrefixFold(query, "INSERT") {
 		if table := tryExtractTable(insertTableRegex, query); table != "" {
 			return table
 		}
 	}
 
 	// UPDATE queries
-	if strings.HasPrefix(queryUpper, "UPDATE") {
+	if hasPrefixFold(query, "UPDATE") {
 		if table := tryExtractTable(updateTableRegex, query); table != "" {
 			return table
 		}
 	}
 
 	// DELETE queries
-	if strings.HasPrefix(queryUpper, "DELETE") {
+	if hasPrefixFold(query, "DELETE") {
 		if table := tryExtractTable(deleteTableRegex, query); table != "" {
 			return table
 		}

--- a/database/internal/tracking/metrics_test.go
+++ b/database/internal/tracking/metrics_test.go
@@ -424,6 +424,23 @@ func TestExtractTableName(t *testing.T) {
 			query:         "SELECT * FROM (SELECT id FROM users) AS subquery",
 			expectedTable: "users", // Extracts from main FROM clause
 		},
+
+		// Fold-boundary and mixed-case verb coverage (plan 118).
+		{
+			name:          "select_mixed_case",
+			query:         "SeLeCt * FrOm users",
+			expectedTable: "users",
+		},
+		{
+			name:          "insert_mixed_case",
+			query:         "InSeRt InTo users (name) VALUES ('x')",
+			expectedTable: "users",
+		},
+		{
+			name:          "select_keyword_only",
+			query:         "SELECT",
+			expectedTable: unknownTable,
+		},
 	}
 
 	for _, tt := range tests {

--- a/database/internal/tracking/metrics_test.go
+++ b/database/internal/tracking/metrics_test.go
@@ -936,3 +936,14 @@ func TestRegisterConnectionPoolMetricsSemconvNames(t *testing.T) {
 	assert.Nil(t, obtest.FindMetric(rm, "db.client.connection.pending_count"),
 		"legacy pending_count metric must not be emitted")
 }
+
+// BenchmarkExtractTableName measures extractTableName's per-call allocations.
+// Baseline (pre-fold, whole-query strings.ToUpper) recorded in the plan 118 PR
+// body; re-run after the hasPrefixFold rewrite to confirm allocs/op decreased.
+func BenchmarkExtractTableName(b *testing.B) {
+	const q = "SELECT u.id, u.name, u.email FROM users u JOIN orders o ON u.id = o.user_id WHERE u.tenant_id = $1 AND o.created_at > $2 ORDER BY o.created_at DESC LIMIT 50"
+	b.ReportAllocs()
+	for b.Loop() {
+		extractTableName(q)
+	}
+}

--- a/database/internal/tracking/otel_test.go
+++ b/database/internal/tracking/otel_test.go
@@ -201,6 +201,16 @@ func TestExtractDBOperation(t *testing.T) {
 		{"  select  * from users", "select"}, // Leading whitespace
 		{"", "query"},                        // Empty query
 		{"UNKNOWN_COMMAND", "query"},         // Unknown command
+
+		// Fold-boundary and lowercase special-op equivalence (plan 118).
+		{"PREPARE:", "prepare"},
+		{"SEL", "query"},
+		{"begin", "begin"},
+		{"begin_tx", "begin"},
+		{"commit", "commit"},
+		{"rollback", "rollback"},
+		{"create_migration_table", "create_table"},
+		{"prepare: select 1", "prepare"},
 	}
 
 	for _, tt := range tests {

--- a/database/internal/tracking/otel_test.go
+++ b/database/internal/tracking/otel_test.go
@@ -203,14 +203,14 @@ func TestExtractDBOperation(t *testing.T) {
 		{"UNKNOWN_COMMAND", "query"},         // Unknown command
 
 		// Fold-boundary and lowercase special-op equivalence (plan 118).
-		{"PREPARE:", "prepare"},
+		{"PREPARE:", sqlOpLowerPrepare},
 		{"SEL", "query"},
 		{"begin", "begin"},
 		{"begin_tx", "begin"},
 		{"commit", "commit"},
-		{"rollback", "rollback"},
+		{"rollback", sqlOpLowerRollback},
 		{"create_migration_table", "create_table"},
-		{"prepare: select 1", "prepare"},
+		{"prepare: select 1", sqlOpLowerPrepare},
 	}
 
 	for _, tt := range tests {

--- a/database/internal/tracking/otel_test.go
+++ b/database/internal/tracking/otel_test.go
@@ -211,6 +211,7 @@ func TestExtractDBOperation(t *testing.T) {
 		{"rollback", sqlOpLowerRollback},
 		{"create_migration_table", "create_table"},
 		{"prepare: select 1", sqlOpLowerPrepare},
+		{"BEGIN TRANSACTION", "query"}, // multi-word BEGIN variant: exact-match special-case misses, falls to default
 	}
 
 	for _, tt := range tests {

--- a/database/internal/tracking/utils.go
+++ b/database/internal/tracking/utils.go
@@ -364,6 +364,26 @@ func appendDBErrorType(event logger.LogEvent, driverErr error) logger.LogEvent {
 	return event.Str("error_type", dbErrorClass(driverErr))
 }
 
+// hasPrefixFold reports whether s begins with prefix, comparing ASCII letters
+// case-insensitively, without allocating. prefix must be an ASCII literal.
+// This is narrower than the removed whole-string upper-case-and-compare
+// approach: when the first len(prefix) bytes of s are not all ASCII the fold
+// cannot match, so a query opening with a non-ASCII rune degrades to the
+// "unknown"/"query" default instead of matching. SQL keywords are ASCII, so
+// no real query is affected.
+func hasPrefixFold(s, prefix string) bool {
+	if len(s) < len(prefix) {
+		return false
+	}
+	return strings.EqualFold(s[:len(prefix)], prefix)
+}
+
+// equalFoldASCII reports whether s equals keyword under the same ASCII-only
+// fold as hasPrefixFold, without allocating. keyword must be an ASCII literal.
+func equalFoldASCII(s, keyword string) bool {
+	return len(s) == len(keyword) && hasPrefixFold(s, keyword)
+}
+
 // extractDBOperation determines the database operation name from the given SQL query.
 // It returns a lowercase operation such as "select", "insert", "update", "delete",
 // "create", "drop", "alter", or "truncate". If the query is empty or the first token
@@ -379,21 +399,20 @@ func extractDBOperation(query string) string {
 
 	// Handle special operations
 	q = strings.TrimSuffix(q, ";")
-	upper := strings.ToUpper(q)
 
 	// Handle PREPARE: prefix
-	if strings.HasPrefix(upper, "PREPARE:") {
+	if hasPrefixFold(q, "PREPARE:") {
 		return "prepare"
 	}
 
-	switch upper {
-	case sqlOpBegin, "BEGIN_TX":
+	switch {
+	case equalFoldASCII(q, sqlOpBegin), equalFoldASCII(q, "BEGIN_TX"):
 		return sqlOpLowerBegin
-	case sqlOpCommit:
+	case equalFoldASCII(q, sqlOpCommit):
 		return sqlOpLowerCommit
-	case sqlOpRollback:
+	case equalFoldASCII(q, sqlOpRollback):
 		return "rollback"
-	case "CREATE_MIGRATION_TABLE":
+	case equalFoldASCII(q, "CREATE_MIGRATION_TABLE"):
 		return sqlOpLowerCreateTable
 	}
 

--- a/database/internal/tracking/utils.go
+++ b/database/internal/tracking/utils.go
@@ -61,6 +61,8 @@ const (
 	sqlOpLowerUpdate      = "update"
 	sqlOpLowerDelete      = "delete"
 	sqlOpLowerCreateTable = "create_table"
+	sqlOpLowerPrepare     = "prepare"
+	sqlOpLowerRollback    = "rollback"
 
 	// OpenTelemetry instrumentation constants
 	dbTracerName      = "go-bricks/database"
@@ -402,7 +404,7 @@ func extractDBOperation(query string) string {
 
 	// Handle PREPARE: prefix
 	if hasPrefixFold(q, "PREPARE:") {
-		return "prepare"
+		return sqlOpLowerPrepare
 	}
 
 	switch {
@@ -411,7 +413,7 @@ func extractDBOperation(query string) string {
 	case equalFoldASCII(q, sqlOpCommit):
 		return sqlOpLowerCommit
 	case equalFoldASCII(q, sqlOpRollback):
-		return "rollback"
+		return sqlOpLowerRollback
 	case equalFoldASCII(q, "CREATE_MIGRATION_TABLE"):
 		return sqlOpLowerCreateTable
 	}

--- a/database/internal/tracking/utils.go
+++ b/database/internal/tracking/utils.go
@@ -377,7 +377,22 @@ func hasPrefixFold(s, prefix string) bool {
 	if len(s) < len(prefix) {
 		return false
 	}
-	return strings.EqualFold(s[:len(prefix)], prefix)
+	for i := range prefix {
+		left, right := s[i], prefix[i]
+		if left >= 0x80 || right >= 0x80 {
+			return false
+		}
+		if 'A' <= left && left <= 'Z' {
+			left += 'a' - 'A'
+		}
+		if 'A' <= right && right <= 'Z' {
+			right += 'a' - 'A'
+		}
+		if left != right {
+			return false
+		}
+	}
+	return true
 }
 
 // equalFoldASCII reports whether s equals keyword under the same ASCII-only

--- a/database/internal/tracking/utils.go
+++ b/database/internal/tracking/utils.go
@@ -379,7 +379,11 @@ func hasPrefixFold(s, prefix string) bool {
 	}
 	for i := range prefix {
 		left, right := s[i], prefix[i]
-		if left >= 0x80 || right >= 0x80 {
+		// Only left needs the explicit reject: right never folds outside ASCII
+		// (the 'A'-'Z' shift below stays under 0x80), so a non-ASCII right can
+		// never equal a folded left and the mismatch check below already
+		// returns false for it.
+		if left >= 0x80 {
 			return false
 		}
 		if 'A' <= left && left <= 'Z' {

--- a/database/internal/tracking/utils_test.go
+++ b/database/internal/tracking/utils_test.go
@@ -887,3 +887,15 @@ func TestCreateDBSpanIgnoresErrNoRowsAndTxDone(t *testing.T) {
 		}
 	}
 }
+
+// BenchmarkExtractDBOperation measures extractDBOperation's per-call
+// allocations. Baseline (pre-fold, whole-query strings.ToUpper) recorded in
+// the plan 118 PR body; re-run after the hasPrefixFold/equalFoldASCII rewrite
+// to confirm allocs/op decreased.
+func BenchmarkExtractDBOperation(b *testing.B) {
+	const q = "SELECT u.id, u.name, u.email FROM users u JOIN orders o ON u.id = o.user_id WHERE u.tenant_id = $1 AND o.created_at > $2 ORDER BY o.created_at DESC LIMIT 50"
+	b.ReportAllocs()
+	for b.Loop() {
+		extractDBOperation(q)
+	}
+}

--- a/database/internal/tracking/utils_test.go
+++ b/database/internal/tracking/utils_test.go
@@ -941,6 +941,28 @@ func TestHasPrefixFoldNarrowsOnNonASCII(t *testing.T) {
 	}
 }
 
+// TestHasPrefixFoldRejectsExactBoundaryByte pins the >= 0x80 boundary (as opposed
+// to > 0x80) introduced by the byte-wise ASCII fold: a byte of exactly 0x80 — the
+// first non-ASCII value — must reject the match on its own, whether it leads the
+// query or sits mid-prefix, not just byte values above it. equalFoldASCII is
+// exercised too since it delegates to hasPrefixFold and both fixtures happen to
+// match the compared keyword's length.
+func TestHasPrefixFoldRejectsExactBoundaryByte(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{name: "boundary_byte_leading", query: "\x80ELECT"},
+		{name: "boundary_byte_mid_prefix", query: "S\x80LECT"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.False(t, hasPrefixFold(tt.query, "SELECT"))
+			assert.False(t, equalFoldASCII(tt.query, "SELECT"))
+		})
+	}
+}
+
 // TestEqualFoldASCII covers the whole-string fold, including length mismatch
 // in both directions.
 func TestEqualFoldASCII(t *testing.T) {

--- a/database/internal/tracking/utils_test.go
+++ b/database/internal/tracking/utils_test.go
@@ -899,3 +899,66 @@ func BenchmarkExtractDBOperation(b *testing.B) {
 		extractDBOperation(q)
 	}
 }
+
+// TestHasPrefixFoldMatchesUpperPrefixOnASCII is a differential test against the
+// removed strings.ToUpper(s) + strings.HasPrefix path, over an ASCII corpus.
+func TestHasPrefixFoldMatchesUpperPrefixOnASCII(t *testing.T) {
+	keywords := []string{"SELECT", "INSERT", "UPDATE", "DELETE", "PREPARE:"}
+	queries := []string{
+		"", "S", "SEL", "SELECT", "select", "SeLeCt", "SELECTED x",
+		"SELECT * FROM users", "select * from products",
+		"INSERT INTO users (name) VALUES ($1)", "insert into products (name) values ('x')",
+		"UPDATE users SET name = $1", "update products set price = 1",
+		"DELETE FROM users WHERE id = $1", "delete from products where x = true",
+		"PREPARE:", "PREPARE: SELECT 1", "prepare: select 1",
+		"BEGIN", "COMMIT", "CREATE_MIGRATION_TABLE", "   select 1",
+	}
+	for _, q := range queries {
+		for _, kw := range keywords {
+			want := strings.HasPrefix(strings.ToUpper(q), kw)
+			assert.Equal(t, want, hasPrefixFold(q, kw), "query=%q keyword=%q", q, kw)
+		}
+	}
+}
+
+// TestHasPrefixFoldNarrowsOnNonASCII pins the documented ASCII-only narrowing
+// (see hasPrefixFold's doc comment) so it is not "fixed" later: a query whose
+// leading bytes are not all ASCII cannot match, unlike the removed
+// strings.ToUpper Unicode-folding path.
+func TestHasPrefixFoldNarrowsOnNonASCII(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{name: "long_s_select", query: "ſelect * from users"},
+		{name: "dotless_i_insert", query: "ınsert into users values (1)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.False(t, hasPrefixFold(tt.query, "SELECT"))
+			assert.False(t, hasPrefixFold(tt.query, "INSERT"))
+		})
+	}
+}
+
+// TestEqualFoldASCII covers the whole-string fold, including length mismatch
+// in both directions.
+func TestEqualFoldASCII(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want bool
+	}{
+		{name: "exact_match", s: "BEGIN", want: true},
+		{name: "lowercase_match", s: "begin", want: true},
+		{name: "mixed_case_match", s: "BeGiN", want: true},
+		{name: "longer_no_match", s: "BEGINX", want: false},
+		{name: "shorter_no_match", s: "BEGI", want: false},
+		{name: "different_no_match", s: "COMMIT", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, equalFoldASCII(tt.s, "BEGIN"))
+		})
+	}
+}

--- a/database/internal/tracking/utils_test.go
+++ b/database/internal/tracking/utils_test.go
@@ -963,6 +963,28 @@ func TestHasPrefixFoldRejectsExactBoundaryByte(t *testing.T) {
 	}
 }
 
+// TestHasPrefixFoldRejectsIdenticalNonASCIIByte guards the reject itself, not
+// just its downstream effect: when s and prefix carry the SAME raw byte >= 0x80,
+// no ASCII fold ever touches it, so without the explicit check the two bytes
+// would compare equal and wrongly report a match. The fixtures above (query
+// non-ASCII, prefix plain ASCII) can't expose this — the trailing byte-mismatch
+// check already returns false whenever exactly one side is non-ASCII, masking a
+// weakened check; only an identical non-ASCII byte on both sides isolates it.
+func TestHasPrefixFoldRejectsIdenticalNonASCIIByte(t *testing.T) {
+	assert.False(t, hasPrefixFold("\x80", "\x80"))
+	assert.False(t, equalFoldASCII("\x80", "\x80"))
+}
+
+// TestHasPrefixFoldFoldsAtZBoundary pins 'Z' as the fold range's upper edge (not
+// narrower): both sides carry 'Z', in same- and mixed-case pairings, so a version
+// that stopped folding just that endpoint left it unfolded and mismatched
+// against the other side's lowercase.
+func TestHasPrefixFoldFoldsAtZBoundary(t *testing.T) {
+	assert.True(t, hasPrefixFold("Z", "Z"))
+	assert.True(t, hasPrefixFold("Z", "z"))
+	assert.True(t, hasPrefixFold("z", "Z"))
+}
+
 // TestEqualFoldASCII covers the whole-string fold, including length mismatch
 // in both directions.
 func TestEqualFoldASCII(t *testing.T) {

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -1449,17 +1449,21 @@ func (c *client) logRequest(httpReq *nethttp.Request, body []byte, traceID strin
 
 	// Optional debug payload logging, gated by config
 	if c.config != nil && c.config.LogPayloads {
-		dbg := c.logger.Debug().
-			Str("direction", "outbound").
-			Str("method", httpReq.Method).
-			Str("url", redactURLForLog(httpReq.URL)).
-			Str("request_id", traceID)
-		if len(httpReq.Header) > 0 {
-			// Headers go through logger filter to mask sensitive keys/values
-			dbg = dbg.Interface("headers", httpReq.Header)
+		// Skip field building when the debug event is dropped: this block otherwise
+		// pays a reflective filter walk over the header map (and, here, a second
+		// redactURLForLog). DEBUG is below WarnLevel, so the adapter's
+		// Msg -> trackSeverity hook is a no-op and skipping Msg is safe.
+		if dbg := c.logger.Debug(); dbg.Enabled() {
+			dbg = dbg.Str("direction", "outbound").
+				Str("method", httpReq.Method).
+				Str("url", redactURLForLog(httpReq.URL)).
+				Str("request_id", traceID)
+			if len(httpReq.Header) > 0 {
+				dbg = dbg.Interface("headers", httpReq.Header)
+			}
+			dbg = c.appendBodyPreview(dbg, body, httpReq.Header.Get(headerContentType))
+			dbg.Msg("REST client request")
 		}
-		dbg = c.appendBodyPreview(dbg, body, httpReq.Header.Get(headerContentType))
-		dbg.Msg("REST client request")
 	}
 }
 
@@ -1480,18 +1484,19 @@ func (c *client) logResponse(resp *Response, traceID string) {
 
 	// Optional debug payload logging, gated by config
 	if c.config != nil && c.config.LogPayloads {
-		dbg := c.logger.Debug().
-			Str("direction", "inbound").
-			Int("status", resp.StatusCode).
-			Dur("elapsed", resp.Stats.ElapsedTime).
-			Int64("call_count", resp.Stats.CallCount).
-			Str("request_id", traceID)
-		dbg = c.appendBodyPreview(dbg, resp.Body, resp.Headers.Get(headerContentType))
-		// Response headers go through logger filter to mask sensitive keys/values
-		if len(resp.Headers) > 0 {
-			dbg = dbg.Interface("headers", resp.Headers)
+		// Same guard as logRequest.
+		if dbg := c.logger.Debug(); dbg.Enabled() {
+			dbg = dbg.Str("direction", "inbound").
+				Int("status", resp.StatusCode).
+				Dur("elapsed", resp.Stats.ElapsedTime).
+				Int64("call_count", resp.Stats.CallCount).
+				Str("request_id", traceID)
+			dbg = c.appendBodyPreview(dbg, resp.Body, resp.Headers.Get(headerContentType))
+			if len(resp.Headers) > 0 {
+				dbg = dbg.Interface("headers", resp.Headers)
+			}
+			dbg.Msg("REST client response")
 		}
-		dbg.Msg("REST client response")
 	}
 }
 

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -1459,6 +1459,7 @@ func (c *client) logRequest(httpReq *nethttp.Request, body []byte, traceID strin
 				Str("url", redactURLForLog(httpReq.URL)).
 				Str("request_id", traceID)
 			if len(httpReq.Header) > 0 {
+				// Headers go through logger filter to mask sensitive keys/values
 				dbg = dbg.Interface("headers", httpReq.Header)
 			}
 			dbg = c.appendBodyPreview(dbg, body, httpReq.Header.Get(headerContentType))
@@ -1493,6 +1494,7 @@ func (c *client) logResponse(resp *Response, traceID string) {
 				Str("request_id", traceID)
 			dbg = c.appendBodyPreview(dbg, resp.Body, resp.Headers.Get(headerContentType))
 			if len(resp.Headers) > 0 {
+				// Response headers go through logger filter to mask sensitive keys/values
 				dbg = dbg.Interface("headers", resp.Headers)
 			}
 			dbg.Msg("REST client response")

--- a/httpclient/logging_test.go
+++ b/httpclient/logging_test.go
@@ -919,3 +919,56 @@ func TestClientLogResponseSkipsPayloadFieldBuildWhenDebugDisabled(t *testing.T) 
 
 	assert.Len(t, fakeLog.eventsByLevel("info"), 1, "the INFO line is unaffected by the debug guard")
 }
+
+// TestClientLogRequestSkipsHeadersFieldWhenEmpty verifies the logRequest
+// header guard on the enabled debug path: with an empty, non-nil Header (as
+// produced by http.NewRequestWithContext), the "headers" field is never
+// added to the debug event. Pins the len(httpReq.Header) > 0 boundary against
+// a >= 0 mutant, which is always true and would add the field even though
+// there are no headers.
+func TestClientLogRequestSkipsHeadersFieldWhenEmpty(t *testing.T) {
+	fakeLog := &fakeLogger{}
+	c := &client{
+		logger: fakeLog,
+		config: &Config{LogPayloads: true, MaxPayloadLogBytes: 512},
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.example.com/status", http.NoBody)
+	require.NoError(t, err)
+
+	c.logRequest(req, nil, "trace-empty-headers")
+
+	debugEvents := fakeLog.eventsByLevel("debug")
+	require.Len(t, debugEvents, 1)
+	assert.NotContains(t, debugEvents[0].fields, "headers")
+}
+
+// TestClientLogResponseSkipsHeadersFieldWhenEmpty verifies the logResponse
+// header guard on the enabled debug path: with Headers set to an empty,
+// non-nil http.Header, the "headers" field is never added to the debug
+// event. Pins the len(resp.Headers) > 0 boundary against a >= 0 mutant,
+// which is always true and would add the field even though there are no
+// headers.
+func TestClientLogResponseSkipsHeadersFieldWhenEmpty(t *testing.T) {
+	fakeLog := &fakeLogger{}
+	c := &client{
+		logger: fakeLog,
+		config: &Config{LogPayloads: true, MaxPayloadLogBytes: 512},
+	}
+
+	response := &Response{
+		StatusCode: 200,
+		Body:       nil,
+		Headers:    http.Header{},
+		Stats: Stats{
+			ElapsedTime: 10 * time.Millisecond,
+			CallCount:   1,
+		},
+	}
+
+	c.logResponse(response, "trace-empty-headers")
+
+	debugEvents := fakeLog.eventsByLevel("debug")
+	require.Len(t, debugEvents, 1)
+	assert.NotContains(t, debugEvents[0].fields, "headers")
+}

--- a/httpclient/logging_test.go
+++ b/httpclient/logging_test.go
@@ -88,11 +88,21 @@ func (e *fakeLogEvent) Bool(key string, value bool) logger.LogEvent {
 	return e
 }
 
-func (e *fakeLogEvent) Enabled() bool { return true }
+// Enabled reports false only for a debug event handed out while debugDisabled
+// is set — every other level, and every existing test (zero value = enabled),
+// keeps the prior hardcoded-true behavior.
+func (e *fakeLogEvent) Enabled() bool {
+	if e.level == "debug" && e.logger.debugDisabled {
+		return false
+	}
+	return true
+}
 
 // fakeLogger implements logger.Logger for testing
 type fakeLogger struct {
-	events []loggedEvent
+	events        []loggedEvent
+	debugDisabled bool          // zero value = enabled, matching every existing test
+	lastDebug     *fakeLogEvent // last event handed out by Debug(), for disabled-path assertions
 }
 
 type loggedEvent struct {
@@ -118,11 +128,13 @@ func (l *fakeLogger) Error() logger.LogEvent {
 }
 
 func (l *fakeLogger) Debug() logger.LogEvent {
-	return &fakeLogEvent{
+	e := &fakeLogEvent{
 		logger: l,
 		level:  "debug",
 		fields: make(map[string]any),
 	}
+	l.lastDebug = e
+	return e
 }
 
 func (l *fakeLogger) Warn() logger.LogEvent {
@@ -852,4 +864,58 @@ func TestIsJSONContentTypeEdgeCases(t *testing.T) {
 			t.Errorf("isJSONContentType(%q) = %v, want %v", tc.ct, got, tc.want)
 		}
 	}
+}
+
+// TestClientLogRequestSkipsPayloadFieldBuildWhenDebugDisabled verifies the
+// logRequest guard: when the debug event is disabled, the header/body-preview
+// field chain (and the second redactURLForLog call) is never built, and the
+// INFO line is unaffected.
+func TestClientLogRequestSkipsPayloadFieldBuildWhenDebugDisabled(t *testing.T) {
+	fakeLog := &fakeLogger{debugDisabled: true}
+	c := &client{
+		logger: fakeLog,
+		config: &Config{LogPayloads: true, MaxPayloadLogBytes: 512},
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://api.example.com/users", http.NoBody)
+	assert.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer token")
+	req.Header.Set(testContentTypeHeader, testContentType)
+
+	body := []byte(`{"name": "test user"}`)
+	c.logRequest(req, body, "trace-123")
+
+	assert.Empty(t, fakeLog.eventsByLevel("debug"), "guard deleted: a debug line was emitted for a dropped event")
+	require.NotNil(t, fakeLog.lastDebug, "Debug() was never called")
+	assert.Empty(t, fakeLog.lastDebug.fields, "guard deleted: debug fields were built for a dropped event")
+
+	assert.Len(t, fakeLog.eventsByLevel("info"), 1, "the INFO line is unaffected by the debug guard")
+}
+
+// TestClientLogResponseSkipsPayloadFieldBuildWhenDebugDisabled verifies the
+// logResponse guard: when the debug event is disabled, the body-preview/header
+// field chain is never built, and the INFO line is unaffected.
+func TestClientLogResponseSkipsPayloadFieldBuildWhenDebugDisabled(t *testing.T) {
+	fakeLog := &fakeLogger{debugDisabled: true}
+	c := &client{
+		logger: fakeLog,
+		config: &Config{LogPayloads: true, MaxPayloadLogBytes: 512},
+	}
+
+	response := &Response{
+		StatusCode: 200,
+		Body:       []byte(`{"id": 1}`),
+		Headers:    http.Header{testContentTypeHeader: []string{testContentType}, "Set-Cookie": []string{"session=abc"}},
+		Stats: Stats{
+			ElapsedTime: 250 * time.Millisecond,
+			CallCount:   5,
+		},
+	}
+	c.logResponse(response, "trace-123")
+
+	assert.Empty(t, fakeLog.eventsByLevel("debug"), "guard deleted: a debug line was emitted for a dropped event")
+	require.NotNil(t, fakeLog.lastDebug, "Debug() was never called")
+	assert.Empty(t, fakeLog.lastDebug.fields, "guard deleted: debug fields were built for a dropped event")
+
+	assert.Len(t, fakeLog.eventsByLevel("info"), 1, "the INFO line is unaffected by the debug guard")
 }

--- a/messaging/registry.go
+++ b/messaging/registry.go
@@ -698,14 +698,18 @@ func (r *Registry) processMessage(ctx context.Context, consumer *ConsumerDeclara
 		}
 	}()
 
-	contextLog.Debug().
-		Str("correlation_id", traceID).
-		Str("message_id", delivery.MessageId).
-		Str("routing_key", delivery.RoutingKey).
-		Str("exchange", delivery.Exchange).
-		Uint64("delivery_tag", delivery.DeliveryTag).
-		Int("body_size", len(delivery.Body)).
-		Msg("Processing message")
+	// Skip the per-field sensitive-data scan when the debug event is dropped.
+	// DEBUG is below WarnLevel, so the adapter's Msg -> trackSeverity hook is a
+	// no-op and skipping Msg on the disabled path changes nothing.
+	if dbg := contextLog.Debug(); dbg.Enabled() {
+		dbg.Str("correlation_id", traceID).
+			Str("message_id", delivery.MessageId).
+			Str("routing_key", delivery.RoutingKey).
+			Str("exchange", delivery.Exchange).
+			Uint64("delivery_tag", delivery.DeliveryTag).
+			Int("body_size", len(delivery.Body)).
+			Msg("Processing message")
+	}
 
 	err := consumer.Handler.Handle(msgCtx, delivery)
 	processingTime := time.Since(startTime)

--- a/messaging/registry_test.go
+++ b/messaging/registry_test.go
@@ -2575,6 +2575,14 @@ type recordingLogger struct {
 	mu     *sync.Mutex
 	lines  *[]recordedLine
 	fields [][2]string // context-level fields carried by this logger
+	// debugDisabled, when set, makes every event handed out by Debug() report
+	// Enabled() == false. Zero value = enabled, matching every pre-existing test.
+	debugDisabled bool
+	// lastDebug is the most recent event Debug() handed out, so a disabled-path
+	// test can assert no fields were built on it: the Step 1 guard skips the
+	// whole setter chain (including Msg) when disabled, so no line is ever
+	// recorded to assert against instead.
+	lastDebug *recordingEvent
 }
 
 func newRecordingLogger() *recordingLogger {
@@ -2616,24 +2624,31 @@ func (l *recordingLogger) WithFields(f map[string]any) gobrickslogger.Logger {
 	for _, k := range keys {
 		merged = append(merged, [2]string{k, fmt.Sprint(f[k])})
 	}
-	return &recordingLogger{mu: l.mu, lines: l.lines, fields: merged}
+	return &recordingLogger{mu: l.mu, lines: l.lines, fields: merged, debugDisabled: l.debugDisabled}
 }
 
-func (l *recordingLogger) Info() gobrickslogger.LogEvent  { return l.event() }
-func (l *recordingLogger) Error() gobrickslogger.LogEvent { return l.event() }
-func (l *recordingLogger) Debug() gobrickslogger.LogEvent { return l.event() }
-func (l *recordingLogger) Warn() gobrickslogger.LogEvent  { return l.event() }
-func (l *recordingLogger) Fatal() gobrickslogger.LogEvent { return l.event() }
+func (l *recordingLogger) Info() gobrickslogger.LogEvent  { return l.event(false) }
+func (l *recordingLogger) Error() gobrickslogger.LogEvent { return l.event(false) }
+func (l *recordingLogger) Warn() gobrickslogger.LogEvent  { return l.event(false) }
+func (l *recordingLogger) Fatal() gobrickslogger.LogEvent { return l.event(false) }
 
-func (l *recordingLogger) event() gobrickslogger.LogEvent {
+// Debug additionally tracks the event it hands out in lastDebug (see field doc).
+func (l *recordingLogger) Debug() gobrickslogger.LogEvent {
+	e := l.event(l.debugDisabled)
+	l.lastDebug = e
+	return e
+}
+
+func (l *recordingLogger) event(disabled bool) *recordingEvent {
 	pairs := make([][2]string, len(l.fields), len(l.fields)+8)
 	copy(pairs, l.fields)
-	return &recordingEvent{l: l, pairs: pairs}
+	return &recordingEvent{l: l, pairs: pairs, enabled: !disabled}
 }
 
 type recordingEvent struct {
-	l     *recordingLogger
-	pairs [][2]string
+	l       *recordingLogger
+	pairs   [][2]string
+	enabled bool
 }
 
 func (e *recordingEvent) add(k string, v any) gobrickslogger.LogEvent {
@@ -2651,7 +2666,7 @@ func (e *recordingEvent) Bytes(k string, v []byte) gobrickslogger.LogEvent {
 	return e.add(k, string(v))
 }
 func (e *recordingEvent) Bool(k string, v bool) gobrickslogger.LogEvent { return e.add(k, v) }
-func (e *recordingEvent) Enabled() bool                                 { return true }
+func (e *recordingEvent) Enabled() bool                                 { return e.enabled }
 
 func (e *recordingEvent) Err(err error) gobrickslogger.LogEvent {
 	if err != nil {
@@ -2906,4 +2921,86 @@ func TestRegistryProcessMessagePerDeliveryLoggerAllocs(t *testing.T) {
 	// 47.0, AFTER = 38.0 allocs/op — fails the old per-delivery WithFields
 	// layer, passes the new per-event stamps with headroom.
 	assert.Less(t, avg, 42.0, "the per-delivery WithFields layer is back")
+}
+
+// TestRegistryProcessMessageLogsDebugFieldsWhenEnabled proves the Step 1 guard
+// is transparent when the debug event is enabled: the exact field set and
+// values the live chain sets must still reach the "Processing message" line,
+// in order.
+func TestRegistryProcessMessageLogsDebugFieldsWhenEnabled(t *testing.T) {
+	const wantTraceID = "req-118-enabled"
+	registry := NewRegistry(&simpleMockAMQPClient{}, &stubLogger{})
+
+	handler := &countingTestHandler{}
+	consumer := &ConsumerDeclaration{
+		Queue:     testQueueName,
+		EventType: testEventType,
+		Handler:   handler,
+		AutoAck:   false,
+	}
+
+	acker := &mockAcknowledger{}
+	delivery := &amqp.Delivery{
+		MessageId:    testMessageID,
+		RoutingKey:   testRoutingKey,
+		Exchange:     testExchangeName,
+		DeliveryTag:  123,
+		Body:         []byte(testMessageBody),
+		Headers:      amqp.Table{gobrickstrace.HeaderXRequestID: wantTraceID},
+		Acknowledger: acker,
+	}
+
+	rec := newRecordingLogger()
+	registry.processMessage(context.Background(), consumer, delivery, rec)
+
+	debugLine := rec.Line(t, "Processing message")
+	assert.Equal(t, [][2]string{
+		{"correlation_id", wantTraceID},
+		{"message_id", testMessageID},
+		{"routing_key", testRoutingKey},
+		{"exchange", testExchangeName},
+		{"delivery_tag", "123"},
+		{"body_size", fmt.Sprint(len(testMessageBody))},
+	}, debugLine.Pairs)
+}
+
+// TestRegistryProcessMessageSkipsDebugFieldBuildWhenDisabled proves the Step 1
+// guard suppresses field building on the disabled path: no fields are set on
+// the debug event and no "Processing message" line is emitted, while the INFO
+// success line is unaffected (the guard did not swallow the rest of the
+// function).
+func TestRegistryProcessMessageSkipsDebugFieldBuildWhenDisabled(t *testing.T) {
+	registry := NewRegistry(&simpleMockAMQPClient{}, &stubLogger{})
+
+	handler := &countingTestHandler{}
+	consumer := &ConsumerDeclaration{
+		Queue:     testQueueName,
+		EventType: testEventType,
+		Handler:   handler,
+		AutoAck:   false,
+	}
+
+	acker := &mockAcknowledger{}
+	delivery := &amqp.Delivery{
+		MessageId:    testMessageID,
+		RoutingKey:   testRoutingKey,
+		Exchange:     testExchangeName,
+		DeliveryTag:  123,
+		Body:         []byte(testMessageBody),
+		Headers:      amqp.Table{},
+		Acknowledger: acker,
+	}
+
+	rec := newRecordingLogger()
+	rec.debugDisabled = true
+	registry.processMessage(context.Background(), consumer, delivery, rec)
+
+	require.NotNil(t, rec.lastDebug, "Debug() was never called")
+	assert.Empty(t, rec.lastDebug.pairs, "guard deleted: debug fields were built for a dropped event")
+	for _, ln := range rec.Lines() {
+		assert.NotEqual(t, "Processing message", ln.Msg, "guard deleted: Msg was called on a disabled debug event")
+	}
+
+	infoLine := rec.Line(t, "Message processed successfully")
+	assert.NotEmpty(t, infoLine.Pairs)
 }

--- a/messaging/registry_test.go
+++ b/messaging/registry_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -2960,7 +2961,7 @@ func TestRegistryProcessMessageLogsDebugFieldsWhenEnabled(t *testing.T) {
 		{"routing_key", testRoutingKey},
 		{"exchange", testExchangeName},
 		{"delivery_tag", "123"},
-		{"body_size", fmt.Sprint(len(testMessageBody))},
+		{"body_size", strconv.Itoa(len(testMessageBody))},
 	}, debugLine.Pairs)
 }
 


### PR DESCRIPTION
## What

Hot-path debug log sites in `messaging/registry.go` and `httpclient/client.go` built their field payloads — including a reflective header-map walk — even when debug was disabled, and SQL operation/table extraction in `database/internal/tracking` upper-cased the whole query to test a few prefixes. `Enabled()` guards now skip disabled-path field building at all three sites, and an ASCII prefix-fold/equal-fold pair replaces the whole-string `ToUpper`.

## Impact

None. Enabled-path log output is byte-identical; extraction is deliberately ASCII-strict, pinned by a differential test against the removed `ToUpper` path.

## Verification

`BenchmarkExtractTableName` and `BenchmarkExtractDBOperation` dropped 193→32 B/op and 616→456 B/op, one fewer allocation each. `make mutate` was non-vacuous: all 7 changed-line mutants died, including two boundary mutants from re-indenting pre-existing header conditions into the guards, pinned by new empty-header absence tests. A 6-row hand-mutation table attributes each guard deletion to a failing test/assertion; two rows were independently replayed by the reviewer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary processing when debug logging is disabled for HTTP requests, responses, and message processing.
  * Improved SQL operation and table detection efficiency while preserving existing behavior.

* **Bug Fixes**
  * Improved recognition of mixed-case SQL statements and transaction commands.
  * Avoided empty header fields in HTTP debug logs.

* **Tests**
  * Added coverage for case-insensitive SQL parsing, transaction detection, and debug logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->