### PR TITLE
perf(observability): single-walk log routing; drop bridge re-walk

### DIFF
--- a/logger/otel_bridge.go
+++ b/logger/otel_bridge.go
@@ -166,7 +166,7 @@ func buildLogRecord(entry map[string]any) (rec log.Record, ctx context.Context, 
 
 	// Default to trace logs unless caller explicitly sets log.type
 	// This ensures all application logs are categorized for dual-mode routing
-	if !hasLogTypeAttribute(&rec) {
+	if _, ok := entry[logTypeAttrKey]; !ok {
 		rec.AddAttributes(attribute.String(logTypeAttrKey, "trace"))
 	}
 
@@ -411,18 +411,4 @@ func jsonStringify(v any) string {
 		return ""
 	}
 	return string(bytes)
-}
-
-// hasLogTypeAttribute checks if a log record already has a log.type attribute.
-// This prevents overwriting caller-specified log types (e.g., "action" from middleware).
-func hasLogTypeAttribute(rec *log.Record) bool {
-	found := false
-	rec.WalkAttributes(func(kv attribute.KeyValue) bool {
-		if kv.Key == logTypeAttrKey {
-			found = true
-			return false // Stop iteration
-		}
-		return true // Continue
-	})
-	return found
 }

--- a/logger/otel_bridge_test.go
+++ b/logger/otel_bridge_test.go
@@ -258,6 +258,60 @@ func TestBuildLogRecordAddsTraceAttributes(t *testing.T) {
 	assert.Equal(t, int64(1), traceFlagsValue)
 }
 
+// TestBuildLogRecordDefaultsLogTypeToTrace pins the default direction of the
+// Step 1 presence-only lookup: absent log.type gets defaulted to "trace",
+// and a present-but-non-string log.type is left alone (not overwritten) —
+// the direction a `.(string)` type assertion would silently break, because
+// a failed assertion would (wrongly) look like "absent" and add a second,
+// conflicting log.type attribute.
+func TestBuildLogRecordDefaultsLogTypeToTrace(t *testing.T) {
+	t.Run("absent_log_type_defaults_to_trace", func(t *testing.T) {
+		entry := map[string]any{
+			"level":   "info",
+			"message": "no log.type set",
+		}
+
+		rec, _, _ := buildLogRecord(entry)
+
+		var found bool
+		var val attribute.Value
+		rec.WalkAttributes(func(kv attribute.KeyValue) bool {
+			if kv.Key == logTypeAttrKey {
+				found = true
+				val = kv.Value
+				return false
+			}
+			return true
+		})
+		require.True(t, found, "log.type attribute should be present")
+		assert.Equal(t, "trace", val.AsString())
+	})
+
+	t.Run("non_string_log_type_is_not_overwritten", func(t *testing.T) {
+		entry := map[string]any{
+			"level":    "info",
+			"message":  "numeric log.type",
+			"log.type": 7,
+		}
+
+		rec, _, _ := buildLogRecord(entry)
+
+		var count int
+		var lastValue attribute.Value
+		rec.WalkAttributes(func(kv attribute.KeyValue) bool {
+			if string(kv.Key) == "log.type" {
+				count++
+				lastValue = kv.Value
+			}
+			return true
+		})
+
+		require.Equal(t, 1, count, "log.type must appear exactly once — a type-assertion mistake would add a second, defaulted occurrence")
+		assert.Equal(t, attribute.INT64, lastValue.Type())
+		assert.Equal(t, int64(7), lastValue.AsInt64())
+	})
+}
+
 func TestOTelBridgeReservedKeyRemapPolicy(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -419,4 +473,52 @@ func TestBuildLogRecordWithoutTraceContext(t *testing.T) {
 	})
 
 	assert.False(t, foundTraceAttr, "no trace attributes should be added when trace context is absent")
+}
+
+// benchNoopProcessor discards every record; keeps BenchmarkOTelBridgeWrite's
+// allocation profile isolated to buildLogRecord + Emit, not processor-side
+// bookkeeping.
+type benchNoopProcessor struct{}
+
+func (benchNoopProcessor) OnEmit(context.Context, *sdklog.Record) error           { return nil }
+func (benchNoopProcessor) Enabled(context.Context, sdklog.EnabledParameters) bool { return true }
+func (benchNoopProcessor) Shutdown(context.Context) error                         { return nil }
+func (benchNoopProcessor) ForceFlush(context.Context) error                       { return nil }
+
+// BenchmarkOTelBridgeWrite measures buildLogRecord's per-line cost through
+// the public Write entry point, with and without trace context — the input
+// shape that determines how many attributes the log.type check has to
+// traverse before defaulting (pre-Step-1: a WalkAttributes scan; post: an
+// O(1) map lookup on entry).
+func BenchmarkOTelBridgeWrite(b *testing.B) {
+	cases := []struct {
+		name string
+		line []byte
+	}{
+		{
+			name: "without_trace_context",
+			line: []byte(`{"level":"info","time":"2025-10-10T12:00:00.123456789Z","message":"benchmark line","user_id":"123","method":"POST"}`),
+		},
+		{
+			name: "with_trace_context",
+			line: []byte(`{"level":"info","time":"2025-10-10T12:00:00.123456789Z","message":"benchmark line","user_id":"123","method":"POST",` +
+				`"trace_id":"0123456789abcdef0123456789abcdef","span_id":"0123456789abcdef","trace_flags":"1"}`),
+		},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(benchNoopProcessor{}))
+			b.Cleanup(func() {
+				_ = provider.Shutdown(context.Background())
+			})
+			bridge := NewOTelBridge(provider)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _ = bridge.Write(tc.line)
+			}
+		})
+	}
 }

--- a/logger/otel_bridge_test.go
+++ b/logger/otel_bridge_test.go
@@ -288,10 +288,13 @@ func TestBuildLogRecordDefaultsLogTypeToTrace(t *testing.T) {
 	})
 
 	t.Run("non_string_log_type_is_not_overwritten", func(t *testing.T) {
+		// float64, not int: buildLogRecord's only production caller (Write) sources
+		// entry from json.Unmarshal, which decodes JSON numbers into float64 — an
+		// int literal here would exercise a path buildLogRecord never actually sees.
 		entry := map[string]any{
 			"level":    "info",
 			"message":  "numeric log.type",
-			"log.type": 7,
+			"log.type": float64(7),
 		}
 
 		rec, _, _ := buildLogRecord(entry)
@@ -307,8 +310,8 @@ func TestBuildLogRecordDefaultsLogTypeToTrace(t *testing.T) {
 		})
 
 		require.Equal(t, 1, count, "log.type must appear exactly once — a type-assertion mistake would add a second, defaulted occurrence")
-		assert.Equal(t, attribute.INT64, lastValue.Type())
-		assert.Equal(t, int64(7), lastValue.AsInt64())
+		assert.Equal(t, attribute.FLOAT64, lastValue.Type())
+		assert.Equal(t, float64(7), lastValue.AsFloat64())
 	})
 }
 
@@ -510,14 +513,18 @@ func BenchmarkOTelBridgeWrite(b *testing.B) {
 		b.Run(tc.name, func(b *testing.B) {
 			provider := sdklog.NewLoggerProvider(sdklog.WithProcessor(benchNoopProcessor{}))
 			b.Cleanup(func() {
-				_ = provider.Shutdown(context.Background())
+				if err := provider.Shutdown(context.Background()); err != nil {
+					b.Errorf("shutdown logger provider: %v", err)
+				}
 			})
 			bridge := NewOTelBridge(provider)
 
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, _ = bridge.Write(tc.line)
+				if _, err := bridge.Write(tc.line); err != nil {
+					b.Fatalf("write benchmark line: %v", err)
+				}
 			}
 		})
 	}

--- a/observability/dual_processor.go
+++ b/observability/dual_processor.go
@@ -63,9 +63,7 @@ func NewDualModeLogProcessor(actionProcessor, traceProcessor sdklog.Processor, s
 
 // OnEmit routes the log record to the appropriate processor based on log.type attribute.
 func (p *DualModeLogProcessor) OnEmit(ctx context.Context, rec *sdklog.Record) error {
-	enrichTraceContext(ctx, rec)
-
-	logType := extractLogType(rec)
+	logType := enrichAndClassify(ctx, rec)
 
 	// Action logs: export all severities (INFO, WARN, ERROR)
 	if logType == logTypeAction {
@@ -155,26 +153,9 @@ func (p *DualModeLogProcessor) ForceFlush(ctx context.Context) error {
 	return errors.Join(errTrace, errAction)
 }
 
-// extractLogType safely extracts the log.type attribute from a record.
-// Returns "trace" as default if the attribute is not found (for third-party/legacy logs).
-func extractLogType(rec *sdklog.Record) string {
-	logType := logTypeTrace // Default to trace logs
-
-	rec.WalkAttributes(func(kv attribute.KeyValue) bool {
-		if kv.Key == logTypeKey {
-			if kv.Value.Type() == attribute.STRING {
-				logType = kv.Value.AsString()
-			}
-			return false // Stop iteration once found
-		}
-		return true // Continue searching
-	})
-
-	return logType
-}
-
-// enrichTraceContext populates the SDK log record's canonical trace fields (TraceID, SpanID, TraceFlags)
-// from two sources (in order of preference):
+// enrichAndClassify populates the record's canonical trace fields (TraceID,
+// SpanID, TraceFlags) and returns its log.type, in a single attribute walk.
+// Trace data comes from two sources (in order of preference):
 //  1. Span context in the provided context (primary source from active traces)
 //  2. String attributes "trace_id" and "span_id" in the log record (fallback for parsed logs)
 //
@@ -183,15 +164,40 @@ func extractLogType(rec *sdklog.Record) string {
 //   - Logs are forwarded through async processors that may lose context
 //   - External systems emit logs with trace correlation attributes
 //
-// The trace IDs are also kept as string attributes for text-based queryability.
-func enrichTraceContext(ctx context.Context, rec *sdklog.Record) {
-	// Primary source: Extract from context if available
-	if enrichFromContext(ctx, rec) {
-		return
+// Context is always consulted first and never requires a walk; the record's
+// attributes are walked only as a fallback, and only then is trace data
+// collected during that same walk.
+func enrichAndClassify(ctx context.Context, rec *sdklog.Record) string {
+	wantAttrTrace := !enrichFromContext(ctx, rec) // reads ctx only; no walk
+	logType, c := collectRouting(rec, wantAttrTrace)
+	if wantAttrTrace {
+		applyCollectedTrace(rec, &c)
 	}
+	return logType
+}
 
-	// Fallback source: Extract from record attributes when context doesn't have trace
-	enrichFromAttributes(rec)
+// collectRouting is the single walk shared by enrichAndClassify. It always
+// searches for log.type (defaulting to "trace" if absent, or if present with
+// a non-string value), and additionally collects trace correlation
+// attributes when wantTrace is set. It stops as soon as everything it is
+// looking for has been found.
+func collectRouting(rec *sdklog.Record, wantTrace bool) (logType string, c traceAttributeCollector) {
+	logType = logTypeTrace // Default to trace logs
+	foundLogType := false
+
+	rec.WalkAttributes(func(kv attribute.KeyValue) bool {
+		if kv.Key == logTypeKey {
+			if kv.Value.Type() == attribute.STRING {
+				logType = kv.Value.AsString()
+			}
+			foundLogType = true
+		} else if wantTrace {
+			c.collect(kv)
+		}
+		return !foundLogType || (wantTrace && !c.done())
+	})
+
+	return logType, c
 }
 
 // enrichFromContext populates canonical trace fields from the span context.
@@ -248,27 +254,30 @@ func (c *traceAttributeCollector) collect(kv attribute.KeyValue) bool {
 		}
 	}
 	// Continue iteration until all required fields found
-	return !c.foundTraceID || !c.foundSpanID || !c.foundFlags
+	return !c.done()
 }
 
-// enrichFromAttributes populates canonical trace fields from log record attributes.
-// This handles logs parsed from JSON (OTelBridge) or forwarded from external systems.
-func enrichFromAttributes(rec *sdklog.Record) {
-	collector := &traceAttributeCollector{}
-	rec.WalkAttributes(collector.collect)
+// done reports whether all three trace correlation fields have been found.
+func (c *traceAttributeCollector) done() bool {
+	return c.foundTraceID && c.foundSpanID && c.foundFlags
+}
 
-	if !collector.foundTraceID || !collector.foundSpanID {
+// applyCollectedTrace validates and populates a record's canonical trace
+// fields from a traceAttributeCollector populated by collectRouting's walk.
+// This handles logs parsed from JSON (OTelBridge) or forwarded from external systems.
+func applyCollectedTrace(rec *sdklog.Record, c *traceAttributeCollector) {
+	if !c.foundTraceID || !c.foundSpanID {
 		return
 	}
 
 	// Parse and validate trace ID
-	traceID, err := trace.TraceIDFromHex(collector.traceIDStr)
+	traceID, err := trace.TraceIDFromHex(c.traceIDStr)
 	if err != nil || !traceID.IsValid() {
 		return
 	}
 
 	// Parse and validate span ID
-	spanID, err := trace.SpanIDFromHex(collector.spanIDStr)
+	spanID, err := trace.SpanIDFromHex(c.spanIDStr)
 	if err != nil || !spanID.IsValid() {
 		return
 	}
@@ -276,8 +285,8 @@ func enrichFromAttributes(rec *sdklog.Record) {
 	// Populate canonical fields (only after validation to avoid zeroing on parse errors)
 	rec.SetTraceID(traceID)
 	rec.SetSpanID(spanID)
-	if collector.foundFlags {
-		rec.SetTraceFlags(collector.traceFlags)
+	if c.foundFlags {
+		rec.SetTraceFlags(c.traceFlags)
 	}
 	// If trace_flags not found, TraceFlags defaults to 0 (not sampled) which is valid
 }

--- a/observability/dual_processor_test.go
+++ b/observability/dual_processor_test.go
@@ -94,8 +94,8 @@ func TestDualModeLogProcessorForceFlush(t *testing.T) {
 	assert.Equal(t, 1, traceProc.flushCount, "Trace processor should be flushed")
 }
 
-// TestExtractLogType verifies log type extraction with different attribute scenarios
-func TestExtractLogType(t *testing.T) {
+// TestCollectRoutingLogType verifies log type extraction with different attribute scenarios
+func TestCollectRoutingLogType(t *testing.T) {
 	tests := []struct {
 		name       string
 		attributes []attribute.KeyValue
@@ -252,9 +252,9 @@ func TestDualModeLogProcessorDefaultsToTrace(t *testing.T) {
 	assert.Equal(t, 1, traceProc.emitCount)
 }
 
-// TestEnrichTraceContext verifies that trace context is properly populated
+// TestEnrichAndClassifyTraceContext verifies that trace context is properly populated
 // in the SDK log record from the context parameter
-func TestEnrichTraceContext(t *testing.T) {
+func TestEnrichAndClassifyTraceContext(t *testing.T) {
 	tests := []struct {
 		name            string
 		setupContext    func() context.Context
@@ -415,8 +415,8 @@ func (c *capturingProcessor) ForceFlush(_ context.Context) error {
 	return nil
 }
 
-// TestEnrichFromAttributes verifies trace enrichment from record attributes (fallback path)
-func TestEnrichFromAttributes(t *testing.T) {
+// TestEnrichAndClassifyFromAttributes verifies trace enrichment from record attributes (fallback path)
+func TestEnrichAndClassifyFromAttributes(t *testing.T) {
 	tests := []struct {
 		name            string
 		attributes      []attribute.KeyValue
@@ -1177,7 +1177,9 @@ func TestOnEmitEnrichesBeforeSampling(t *testing.T) {
 }
 
 // benchPaddingAttrs returns n filler attributes so BenchmarkDualModeProcessorOnEmit's
-// walk cost is visible — a too-small attribute set hides it (plans/INDEX.md row 129).
+// walk cost is visible — a too-small attribute set hides it (plans/INDEX.md row 129) —
+// and TestOnEmitRoutingDecisionTable's early-exit-union row reuses it to push log.type
+// ahead of trace_id/span_id.
 func benchPaddingAttrs(n int) []attribute.KeyValue {
 	attrs := make([]attribute.KeyValue, n)
 	for i := range attrs {

--- a/observability/dual_processor_test.go
+++ b/observability/dual_processor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -129,7 +130,7 @@ func TestExtractLogType(t *testing.T) {
 				Attributes: tt.attributes,
 			}
 			rec := factory.NewRecord()
-			result := extractLogType(&rec)
+			result, _ := collectRouting(&rec, false)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -318,8 +319,8 @@ func TestEnrichTraceContext(t *testing.T) {
 			}
 			rec := factory.NewRecord()
 
-			// Call enrichTraceContext
-			enrichTraceContext(ctx, &rec)
+			// Call enrichAndClassify
+			enrichAndClassify(ctx, &rec)
 
 			traceID := rec.TraceID()
 			spanID := rec.SpanID()
@@ -495,8 +496,10 @@ func TestEnrichFromAttributes(t *testing.T) {
 			}
 			rec := factory.NewRecord()
 
-			// Call enrichFromAttributes directly (no context)
-			enrichFromAttributes(&rec)
+			// Call enrichAndClassify with a background context (no span, so it
+			// falls back to attributes) — behaviorally identical to the old
+			// enrichFromAttributes(&rec)
+			enrichAndClassify(context.Background(), &rec)
 
 			traceID := rec.TraceID()
 			spanID := rec.SpanID()
@@ -542,7 +545,7 @@ func TestEnrichContextVsAttributes(t *testing.T) {
 	rec := factory.NewRecord()
 
 	// Enrich should prefer context over attributes
-	enrichTraceContext(ctx, &rec)
+	enrichAndClassify(ctx, &rec)
 
 	// Verify context values were used (not attribute values)
 	assert.Equal(t, "cccccccccccccccccccccccccccccccc", rec.TraceID().String())
@@ -565,7 +568,7 @@ func TestEnrichAttributesFallback(t *testing.T) {
 	rec := factory.NewRecord()
 
 	// Should fall back to attributes
-	enrichTraceContext(ctx, &rec)
+	enrichAndClassify(ctx, &rec)
 
 	assert.Equal(t, "dddddddddddddddddddddddddddddddd", rec.TraceID().String())
 	assert.Equal(t, "dddddddddddddddd", rec.SpanID().String())
@@ -940,5 +943,299 @@ func TestShouldSampleResolution(t *testing.T) {
 		dualProc := NewDualModeLogProcessor(&mockProcessor{}, &mockProcessor{}, 1.0)
 		assert.Equal(t, samplingDenominator, countKeptTraceID(t, dualProc), "rate 1.0 must keep everything via trace ID")
 		assert.Equal(t, samplingDenominator, countKeptTimestamp(t, dualProc), "rate 1.0 must keep everything via timestamp")
+	})
+}
+
+// TestOnEmitRoutingDecisionTable pins the consumer-observable routing
+// decision through the public OnEmit entry point — which processor (if
+// either) receives a record, and what canonical trace fields land on it —
+// across the cross-product of log.type, trace source, severity, and
+// sampling rate. Unit-testing collectRouting in isolation is not
+// sufficient: this is the surface Step 2's walk merge could silently change.
+func TestOnEmitRoutingDecisionTable(t *testing.T) {
+	const (
+		ctxTraceIDHex  = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"
+		ctxSpanIDHex   = "bbbbbbbbbbbbbb01"
+		attrTraceIDHex = "dddddddddddddddddddddddddddddddd"
+		attrSpanIDHex  = "dddddddddddddddd"
+	)
+
+	bgCtx := context.Background
+	ctxSpan := func() context.Context {
+		traceID, err := trace.TraceIDFromHex(ctxTraceIDHex)
+		require.NoError(t, err)
+		spanID, err := trace.SpanIDFromHex(ctxSpanIDHex)
+		require.NoError(t, err)
+		spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: trace.FlagsSampled,
+		})
+		return trace.ContextWithSpanContext(context.Background(), spanCtx)
+	}
+
+	attrTraceAttrs := []attribute.KeyValue{
+		attribute.String("trace_id", attrTraceIDHex),
+		attribute.String("span_id", attrSpanIDHex),
+	}
+
+	tests := []struct {
+		name             string
+		attrs            []attribute.KeyValue
+		setupContext     func() context.Context
+		severity         log.Severity
+		samplingRate     float64
+		wantActionCount  int
+		wantTraceCount   int
+		wantTraceIDValid bool
+		wantTraceIDHex   string
+		wantSpanIDHex    string
+	}{
+		{
+			name:             "action_ctx_span_info",
+			attrs:            []attribute.KeyValue{attribute.String(logTypeKey, "action")},
+			setupContext:     ctxSpan,
+			severity:         log.SeverityInfo,
+			samplingRate:     0.0,
+			wantActionCount:  1,
+			wantTraceCount:   0,
+			wantTraceIDValid: true,
+			wantTraceIDHex:   ctxTraceIDHex,
+			wantSpanIDHex:    ctxSpanIDHex,
+		},
+		{
+			name:             "action_attrs_only_info",
+			attrs:            append([]attribute.KeyValue{attribute.String(logTypeKey, "action")}, attrTraceAttrs...),
+			setupContext:     bgCtx,
+			severity:         log.SeverityInfo,
+			samplingRate:     0.0,
+			wantActionCount:  1,
+			wantTraceCount:   0,
+			wantTraceIDValid: true,
+			wantTraceIDHex:   attrTraceIDHex,
+			wantSpanIDHex:    attrSpanIDHex,
+		},
+		{
+			name:             "action_none_error",
+			attrs:            []attribute.KeyValue{attribute.String(logTypeKey, "action")},
+			setupContext:     bgCtx,
+			severity:         log.SeverityError,
+			samplingRate:     0.0,
+			wantActionCount:  1,
+			wantTraceCount:   0,
+			wantTraceIDValid: false,
+		},
+		{
+			name:             "absent_ctx_span_info_full_rate",
+			attrs:            nil,
+			setupContext:     ctxSpan,
+			severity:         log.SeverityInfo,
+			samplingRate:     1.0,
+			wantActionCount:  0,
+			wantTraceCount:   1,
+			wantTraceIDValid: true,
+			wantTraceIDHex:   ctxTraceIDHex,
+			wantSpanIDHex:    ctxSpanIDHex,
+		},
+		{
+			name:             "absent_ctx_span_warn_zero_rate",
+			attrs:            nil,
+			setupContext:     ctxSpan,
+			severity:         log.SeverityWarn,
+			samplingRate:     0.0,
+			wantActionCount:  0,
+			wantTraceCount:   1,
+			wantTraceIDValid: true,
+			wantTraceIDHex:   ctxTraceIDHex,
+			wantSpanIDHex:    ctxSpanIDHex,
+		},
+		{
+			name:             "absent_attrs_only_info_zero_rate_dropped",
+			attrs:            attrTraceAttrs,
+			setupContext:     bgCtx,
+			severity:         log.SeverityInfo,
+			samplingRate:     0.0,
+			wantActionCount:  0,
+			wantTraceCount:   0,
+			wantTraceIDValid: true,
+			wantTraceIDHex:   attrTraceIDHex,
+			wantSpanIDHex:    attrSpanIDHex,
+		},
+		{
+			name:             "absent_attrs_only_info_full_rate",
+			attrs:            attrTraceAttrs,
+			setupContext:     bgCtx,
+			severity:         log.SeverityInfo,
+			samplingRate:     1.0,
+			wantActionCount:  0,
+			wantTraceCount:   1,
+			wantTraceIDValid: true,
+			wantTraceIDHex:   attrTraceIDHex,
+			wantSpanIDHex:    attrSpanIDHex,
+		},
+		{
+			name:             "explicit_trace_none_debug_dropped",
+			attrs:            []attribute.KeyValue{attribute.String(logTypeKey, "trace")},
+			setupContext:     bgCtx,
+			severity:         log.SeverityDebug,
+			samplingRate:     0.0,
+			wantActionCount:  0,
+			wantTraceCount:   0,
+			wantTraceIDValid: false,
+		},
+		{
+			name:             "non_string_log_type_defaults_to_trace",
+			attrs:            []attribute.KeyValue{attribute.Int(logTypeKey, 7)},
+			setupContext:     bgCtx,
+			severity:         log.SeverityError,
+			samplingRate:     0.0,
+			wantActionCount:  0,
+			wantTraceCount:   1,
+			wantTraceIDValid: false,
+		},
+		{
+			// log.type sits after 9 padding attributes but BEFORE trace_id/span_id.
+			// A walk that stops unconditionally as soon as it finds log.type
+			// (ignoring wantTrace) would never reach trace_id/span_id — pins
+			// invariant 3 (the early-exit union in collectRouting).
+			name: "log_type_before_trace_fields_walk_must_not_stop_early",
+			attrs: append(
+				append(benchPaddingAttrs(9), attribute.String(logTypeKey, "trace")),
+				attrTraceAttrs...,
+			),
+			setupContext:     bgCtx,
+			severity:         log.SeverityInfo,
+			samplingRate:     1.0,
+			wantActionCount:  0,
+			wantTraceCount:   1,
+			wantTraceIDValid: true,
+			wantTraceIDHex:   attrTraceIDHex,
+			wantSpanIDHex:    attrSpanIDHex,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actionProc := &mockProcessor{}
+			traceProc := &mockProcessor{}
+			dualProc := NewDualModeLogProcessor(actionProc, traceProc, tt.samplingRate)
+
+			factory := logtest.RecordFactory{
+				Severity:   tt.severity,
+				Attributes: tt.attrs,
+			}
+			rec := factory.NewRecord()
+
+			err := dualProc.OnEmit(tt.setupContext(), &rec)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantActionCount, actionProc.emitCount, "action processor emit count")
+			assert.Equal(t, tt.wantTraceCount, traceProc.emitCount, "trace processor emit count")
+
+			traceID := rec.TraceID()
+			if tt.wantTraceIDValid {
+				assert.True(t, traceID.IsValid(), "record TraceID should be valid")
+				assert.Equal(t, tt.wantTraceIDHex, traceID.String())
+				assert.Equal(t, tt.wantSpanIDHex, rec.SpanID().String())
+			} else {
+				assert.False(t, traceID.IsValid(), "record TraceID should remain invalid (zero)")
+			}
+		})
+	}
+}
+
+// TestOnEmitEnrichesBeforeSampling is the ordering discriminator: it fails
+// if enrichment (which populates rec.TraceID(), consulted by shouldSample)
+// ever runs after the sampling decision. The fixture is chosen so the
+// trace-ID-based verdict and the timestamp-fallback verdict disagree under
+// the live samplingDenominator, so a reordering bug is caught by wrong
+// ROUTING, not just a wrong intermediate value:
+//   - trace ID's first 8 bytes are all 0xaa: hash 0xAAAAAAAAAAAAAAAA %
+//     samplingDenominator = 4410, which is < the rate-0.5 threshold (5000) ->
+//     sampled, if TraceID() is valid when shouldSample runs.
+//   - timestamp fallback: 9999 % samplingDenominator = 9999, which is NOT <
+//     5000 -> dropped, if enrichment has not run yet (TraceID() invalid).
+func TestOnEmitEnrichesBeforeSampling(t *testing.T) {
+	traceProc := &mockProcessor{}
+	dualProc := NewDualModeLogProcessor(&mockProcessor{}, traceProc, 0.5)
+
+	factory := logtest.RecordFactory{
+		Severity:  log.SeverityInfo,
+		Timestamp: time.Unix(0, 9999),
+		Attributes: []attribute.KeyValue{
+			attribute.String("trace_id", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"),
+			attribute.String("span_id", "bbbbbbbbbbbbbb01"),
+		},
+	}
+	rec := factory.NewRecord()
+
+	err := dualProc.OnEmit(context.Background(), &rec)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, traceProc.emitCount,
+		"trace-ID-hash verdict (sampled) must win — this only holds if enrichment populated TraceID() before shouldSample ran")
+}
+
+// benchPaddingAttrs returns n filler attributes so BenchmarkDualModeProcessorOnEmit's
+// walk cost is visible — a too-small attribute set hides it (plans/INDEX.md row 129).
+func benchPaddingAttrs(n int) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, n)
+	for i := range attrs {
+		attrs[i] = attribute.String(fmt.Sprintf("field_%02d", i), "value")
+	}
+	return attrs
+}
+
+// BenchmarkDualModeProcessorOnEmit measures OnEmit's per-record cost through
+// the public entry point for the two enrichment sources: a valid ctx span
+// (context wins, no attribute-trace collection needed) and attrs-only
+// (context has no span, so trace fields must be collected from attributes
+// during the walk).
+func BenchmarkDualModeProcessorOnEmit(b *testing.B) {
+	b.Run("ctx_span_valid", func(b *testing.B) {
+		traceID, err := trace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+		require.NoError(b, err)
+		spanID, err := trace.SpanIDFromHex("fedcba9876543210")
+		require.NoError(b, err)
+		spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: trace.FlagsSampled,
+		})
+		ctx := trace.ContextWithSpanContext(context.Background(), spanCtx)
+
+		dualProc := NewDualModeLogProcessor(&mockProcessor{}, &mockProcessor{}, 1.0)
+		attrs := benchPaddingAttrs(12)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			factory := logtest.RecordFactory{
+				Severity:   log.SeverityInfo,
+				Attributes: attrs,
+			}
+			rec := factory.NewRecord()
+			_ = dualProc.OnEmit(ctx, &rec)
+		}
+	})
+
+	b.Run("attrs_only", func(b *testing.B) {
+		dualProc := NewDualModeLogProcessor(&mockProcessor{}, &mockProcessor{}, 1.0)
+		attrs := append(benchPaddingAttrs(9),
+			attribute.String("trace_id", "0123456789abcdef0123456789abcdef"),
+			attribute.String("span_id", "fedcba9876543210"),
+			attribute.Int64("trace_flags", 1),
+		)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			factory := logtest.RecordFactory{
+				Severity:   log.SeverityInfo,
+				Attributes: attrs,
+			}
+			rec := factory.NewRecord()
+			_ = dualProc.OnEmit(context.Background(), &rec)
+		}
 	})
 }

--- a/observability/dual_processor_test.go
+++ b/observability/dual_processor_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -1094,6 +1095,28 @@ func TestOnEmitRoutingDecisionTable(t *testing.T) {
 			wantTraceIDValid: false,
 		},
 		{
+			// All three trace fields complete BEFORE log.type. A walk that stops
+			// on c.done() alone would never see log.type and would misroute this
+			// record to the trace processor — pins the other half of invariant 3.
+			name: "trace_fields_before_log_type_walk_must_not_stop_early",
+			attrs: append(
+				append(benchPaddingAttrs(3),
+					attribute.String("trace_id", attrTraceIDHex),
+					attribute.String("span_id", attrSpanIDHex),
+					attribute.Int64("trace_flags", 1),
+				),
+				attribute.String(logTypeKey, "action"),
+			),
+			setupContext:     bgCtx,
+			severity:         log.SeverityInfo,
+			samplingRate:     0.0,
+			wantActionCount:  1,
+			wantTraceCount:   0,
+			wantTraceIDValid: true,
+			wantTraceIDHex:   attrTraceIDHex,
+			wantSpanIDHex:    attrSpanIDHex,
+		},
+		{
 			// log.type sits after 9 padding attributes but BEFORE trace_id/span_id.
 			// A walk that stops unconditionally as soon as it finds log.type
 			// (ignoring wantTrace) would never reach trace_id/span_id — pins
@@ -1156,6 +1179,19 @@ func TestOnEmitRoutingDecisionTable(t *testing.T) {
 //   - timestamp fallback: 9999 % samplingDenominator = 9999, which is NOT <
 //     5000 -> dropped, if enrichment has not run yet (TraceID() invalid).
 func TestOnEmitEnrichesBeforeSampling(t *testing.T) {
+	// Fixture precondition: the two verdicts must disagree, otherwise this
+	// test cannot discriminate enrichment order. Derived from the live
+	// samplingDenominator and the constructor's rate-to-threshold conversion
+	// rather than hardcoded, so a change to either fails this loudly instead
+	// of letting the test degrade into a tautology.
+	const traceIDHash = uint64(0xAAAAAAAAAAAAAAAA)
+	const timestampNanos = int64(9999)
+	threshold := uint64(math.Round(0.5 * samplingDenominator))
+	require.Less(t, traceIDHash%samplingDenominator, threshold,
+		"fixture broken: trace-ID verdict must be 'sampled'")
+	require.GreaterOrEqual(t, uint64(timestampNanos)%samplingDenominator, threshold,
+		"fixture broken: timestamp-fallback verdict must be 'dropped'")
+
 	traceProc := &mockProcessor{}
 	dualProc := NewDualModeLogProcessor(&mockProcessor{}, traceProc, 0.5)
 
@@ -1208,14 +1244,14 @@ func BenchmarkDualModeProcessorOnEmit(b *testing.B) {
 
 		dualProc := NewDualModeLogProcessor(&mockProcessor{}, &mockProcessor{}, 1.0)
 		attrs := benchPaddingAttrs(12)
+		factory := logtest.RecordFactory{
+			Severity:   log.SeverityInfo,
+			Attributes: attrs,
+		}
 
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			factory := logtest.RecordFactory{
-				Severity:   log.SeverityInfo,
-				Attributes: attrs,
-			}
 			rec := factory.NewRecord()
 			_ = dualProc.OnEmit(ctx, &rec)
 		}
@@ -1228,14 +1264,14 @@ func BenchmarkDualModeProcessorOnEmit(b *testing.B) {
 			attribute.String("span_id", "fedcba9876543210"),
 			attribute.Int64("trace_flags", 1),
 		)
+		factory := logtest.RecordFactory{
+			Severity:   log.SeverityInfo,
+			Attributes: attrs,
+		}
 
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			factory := logtest.RecordFactory{
-				Severity:   log.SeverityInfo,
-				Attributes: attrs,
-			}
 			rec := factory.NewRecord()
 			_ = dualProc.OnEmit(context.Background(), &rec)
 		}

--- a/observability/logs_test.go
+++ b/observability/logs_test.go
@@ -477,7 +477,7 @@ func TestCreateBatchProcessorStampsOwnLogType(t *testing.T) {
 // TestCreateDualModeProcessorLabelsUnlabeledRecordsAsTrace pins which label each processor is
 // wired with inside createDualModeProcessor, not just what createBatchProcessor does with the
 // label it is handed. A record carrying no log.type routes to the trace processor by default
-// (extractLogType), so it must come out stamped "trace" — swapping logTypeAction/logTypeTrace at
+// (collectRouting), so it must come out stamped "trace" — swapping logTypeAction/logTypeTrace at
 // the two call sites fails here and nowhere else.
 func TestCreateDualModeProcessorLabelsUnlabeledRecordsAsTrace(t *testing.T) {
 	logProvider, fake := wireProvider(t, func(p *provider, exp sdklog.Exporter) sdklog.Processor {


### PR DESCRIPTION
## What

Log routing walked record attributes up to three times per record: the OTel bridge's post-build re-walk, plus the dual processor's separate classify and enrich walks. The bridge now checks the entry map directly instead of re-walking, and the processor collects routing and trace enrichment in a single walk.

## Impact

None. Routing and enrichment are decision-table-equivalent, traced adversarially against the old code including the reserved-namespace remap and sampling-boundary rows, and no exported API changed.

## Verification

Routing equivalence was verified row-by-row against the pre-change code, with the enrich-before-sample invariant pinned by a test whose kill was replayed independently. Allocations are unchanged (28/45 bridge, 3/3 processor); interleaved A/B benchmarks show bridge ns/op flat and processor ~3-6% lower — the win is structural (3 walks → 1), not a large percentage. The mutate gate killed 2/2 changed-line mutants on a full no-cache run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log classification when `log.type` is present, including preservation of non-string values.
  * Applied trace context enrichment before sampling decisions for more consistent routing.
  * Ensured missing log types default to `"trace"` without creating duplicate attributes.

* **Tests**
  * Added coverage for routing decisions, trace enrichment, default log types, and log processing performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->