### PR TITLE
fix(mutatediff): exclude the integration-only containers package

### DIFF
--- a/scripts/mutatediff/diff.go
+++ b/scripts/mutatediff/diff.go
@@ -66,7 +66,10 @@ func mutationScope(changes map[string][]lineRange) map[string][]lineRange {
 		}
 		// scripts/ is excluded because gremlins v0.5.0 misverdicts this nested
 		// package main (wiki/testing.md#mutation-gate); its own unit tests are its net.
-		if strings.HasPrefix(file, "tools/") || strings.HasPrefix(file, "scripts/") || strings.Contains(file, "testdata/") {
+		// testing/containers/ is excluded because every file there is //go:build
+		// integration, so the package is empty under the default build and gremlins
+		// fails to gather coverage rather than reporting zero mutants.
+		if strings.HasPrefix(file, "tools/") || strings.HasPrefix(file, "scripts/") || strings.HasPrefix(file, "testing/containers/") || strings.Contains(file, "testdata/") {
 			continue
 		}
 		scoped[file] = ranges

--- a/scripts/mutatediff/diff_test.go
+++ b/scripts/mutatediff/diff_test.go
@@ -59,16 +59,19 @@ func TestParseUnifiedDiffSkipsPureDeletionHunks(t *testing.T) {
 
 func TestMutationScopeFiltersNonTargets(t *testing.T) {
 	in := map[string][]lineRange{
-		"config/injection.go":          {{Start: 1, End: 2}},
-		"config/injection_test.go":     {{Start: 1, End: 2}},
-		"tools/migration/main.go":      {{Start: 1, End: 2}},
-		"database/testdata/fixture.go": {{Start: 1, End: 2}},
-		"wiki/testing.md":              {{Start: 1, End: 2}},
-		"scripts/mutatediff/diff.go":   {{Start: 1, End: 2}},
+		"config/injection.go":            {{Start: 1, End: 2}},
+		"config/injection_test.go":       {{Start: 1, End: 2}},
+		"tools/migration/main.go":        {{Start: 1, End: 2}},
+		"database/testdata/fixture.go":   {{Start: 1, End: 2}},
+		"wiki/testing.md":                {{Start: 1, End: 2}},
+		"scripts/mutatediff/diff.go":     {{Start: 1, End: 2}},
+		"testing/containers/rabbitmq.go": {{Start: 1, End: 2}},
+		"testing/mocks/registry.go":      {{Start: 1, End: 2}},
 	}
 	got := mutationScope(in)
 	want := map[string][]lineRange{
-		"config/injection.go": {{Start: 1, End: 2}},
+		"config/injection.go":       {{Start: 1, End: 2}},
+		"testing/mocks/registry.go": {{Start: 1, End: 2}},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("mutationScope = %#v, want %#v", got, want)

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -505,7 +505,10 @@ no verdict and must stay visible. A run with outstanding timeouts does not repor
 "all mutants killed".
 
 Excluded from scope: `_test.go` files, `testdata/`, `tools/` (separate Go
-module), and `scripts/` (the wrapper itself — see the operational notes).
+module), `scripts/` (the wrapper itself — see the operational notes), and
+`testing/containers/` (every file there carries `//go:build integration`, so the
+package is empty under the default build and the engine fails to gather coverage
+rather than reporting zero mutants).
 Engine version is pinned via `GREMLINS_VERSION` in the Makefile;
 runtime knobs live in `.gremlins.yaml`. The nightly `Mutation Baseline`
 workflow runs every package except the excluded `scripts/` in advisory mode


### PR DESCRIPTION
## What

The mutation gate could not analyse `testing/containers/` at all. Every file there
carries `//go:build integration`, so under the default build the package is empty and
gremlins fails with `matched no packages` → `failed to gather coverage` rather than
reporting zero mutants. Any PR touching that directory therefore fails `make mutate`
for a tooling reason. It joins `tools/`, `scripts/` and `testdata/` on the exclusion list.

## Impact

None for consumers. `make mutate` stops failing on changes to the testcontainers
helpers. The exclusion is deliberately narrow — sibling packages like `testing/mocks/`
stay in scope, and a test asserts that.

## Verification

Removing the new clause makes the exclusion test fail with the containers file present
in the package list; `testing/mocks` stays included either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mutation testing now excludes container integration code, preventing unsupported files from being included in mutation analysis.
  * Updated filtering behavior to ensure only applicable source files are analyzed.

* **Documentation**
  * Documented the expanded mutation-testing exclusions and related coverage limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->