### PR TITLE
feat(messaging): add the native stream consumption manager

### DIFF
--- a/messaging/internal/tracking/metrics.go
+++ b/messaging/internal/tracking/metrics.go
@@ -289,6 +289,40 @@ func RecordAMQPConsumeCompletion(ctx context.Context, delivery *amqp.Delivery, q
 	amqpOperationDuration.Record(ctx, durationToSeconds(duration), metric.WithAttributes(consumeAttributes(delivery, queueName, err)...))
 }
 
+// RecordStreamConsume records the metrics for one native stream-protocol
+// delivery, reusing the AMQP instruments so both messaging lanes report under
+// the same names.
+//
+// Unlike the AMQP lane — where StartConsumeSpan counts the delivery at receive
+// time and RecordAMQPConsumeCompletion only times it — a stream delivery is
+// recorded exactly once, after its handler returned. The consumed counter
+// therefore increments regardless of the handler outcome (the message WAS
+// consumed from the stream); error.type separates the failures.
+func RecordStreamConsume(ctx context.Context, streamName string, duration time.Duration, err error) {
+	meter := getAMQPMeter()
+	if meter == nil {
+		return
+	}
+
+	attrs := make([]attribute.KeyValue, 0, 4)
+	attrs = append(attrs,
+		attribute.String(attrMessagingSystem, messagingSystemRabbitMQ),
+		attribute.String(attrMessagingOperation, operationReceive),
+		attribute.String(attrMessagingDestination, streamName),
+	)
+	if errorType := extractErrorType(err); errorType != "" {
+		attrs = append(attrs, attribute.String(attrErrorType, errorType))
+	}
+	attrSet := metric.WithAttributes(attrs...)
+
+	if amqpOperationDuration != nil && duration > 0 {
+		amqpOperationDuration.Record(ctx, durationToSeconds(duration), attrSet)
+	}
+	if amqpMessagesConsumed != nil {
+		amqpMessagesConsumed.Add(ctx, 1, attrSet)
+	}
+}
+
 // RecordPublishRetry records a publish retry attempt in the retry counter.
 // This is called each time a publish operation is retried due to NACK, timeout, or error.
 //

--- a/messaging/internal/tracking/metrics_test.go
+++ b/messaging/internal/tracking/metrics_test.go
@@ -20,6 +20,7 @@ const (
 	testExchange   = "test.exchange"
 	testRoutingKey = "test.key"
 	testQueueName  = "test-queue"
+	testStreamName = "test-stream"
 )
 
 // resetMeterForTesting resets the meter state for testing purposes
@@ -525,4 +526,86 @@ func assertHasAttribute(t *testing.T, attrs []attribute.KeyValue, key, expectedV
 		}
 	}
 	t.Errorf("Attribute %s not found", key)
+}
+
+func TestRecordStreamConsumeSuccess(t *testing.T) {
+	mp := obtest.NewTestMeterProvider()
+	defer func() {
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}()
+	otel.SetMeterProvider(mp)
+
+	resetMeterForTesting()
+	initAMQPMeter()
+
+	RecordStreamConsume(context.Background(), testStreamName, 15*time.Millisecond, nil)
+
+	rm := mp.Collect(t)
+
+	obtest.AssertMetricExists(t, rm, metricOperationDuration)
+	durationMetric := obtest.FindMetric(rm, metricOperationDuration)
+	require.NotNil(t, durationMetric)
+
+	histData := durationMetric.Data.(metricdata.Histogram[float64])
+	require.NotEmpty(t, histData.DataPoints)
+	attrs := histData.DataPoints[0].Attributes.ToSlice()
+
+	assertHasAttribute(t, attrs, attrMessagingSystem, messagingSystemRabbitMQ)
+	assertHasAttribute(t, attrs, attrMessagingOperation, operationReceive)
+	assertHasAttribute(t, attrs, attrMessagingDestination, testStreamName)
+	assertAttributeAbsent(t, attrs, attrErrorType)
+
+	obtest.AssertMetricValue(t, rm, metricMessagesConsumed, int64(1))
+}
+
+func TestRecordStreamConsumeFailureCarriesErrorType(t *testing.T) {
+	mp := obtest.NewTestMeterProvider()
+	defer func() {
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}()
+	otel.SetMeterProvider(mp)
+
+	resetMeterForTesting()
+	initAMQPMeter()
+
+	RecordStreamConsume(context.Background(), testStreamName, 5*time.Millisecond, errors.New("handler failed"))
+
+	rm := mp.Collect(t)
+
+	durationMetric := obtest.FindMetric(rm, metricOperationDuration)
+	require.NotNil(t, durationMetric)
+	histData := durationMetric.Data.(metricdata.Histogram[float64])
+	require.NotEmpty(t, histData.DataPoints)
+	assertHasAttribute(t, histData.DataPoints[0].Attributes.ToSlice(), attrErrorType, "*errors.errorString")
+
+	// The message was consumed from the stream regardless of how its handler ended.
+	obtest.AssertMetricValue(t, rm, metricMessagesConsumed, int64(1))
+}
+
+func TestRecordStreamConsumeZeroDurationSkipsHistogram(t *testing.T) {
+	mp := obtest.NewTestMeterProvider()
+	defer func() {
+		require.NoError(t, mp.Shutdown(context.Background()))
+	}()
+	otel.SetMeterProvider(mp)
+
+	resetMeterForTesting()
+	initAMQPMeter()
+
+	RecordStreamConsume(context.Background(), testStreamName, 0, nil)
+
+	rm := mp.Collect(t)
+
+	assert.Nil(t, obtest.FindMetric(rm, metricOperationDuration), "zero duration records no histogram sample")
+	obtest.AssertMetricValue(t, rm, metricMessagesConsumed, int64(1))
+}
+
+// assertAttributeAbsent asserts that no attribute with the given key was recorded.
+func assertAttributeAbsent(t *testing.T, attrs []attribute.KeyValue, key string) {
+	t.Helper()
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			t.Errorf("Attribute %s should be absent, got %q", key, attr.Value.AsString())
+		}
+	}
 }

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -1,0 +1,416 @@
+package streams
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/ha"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
+	"go.opentelemetry.io/otel"
+
+	"github.com/gaborage/go-bricks/logger"
+)
+
+const (
+	defaultOffsetStoreCount    = 500
+	defaultOffsetStoreInterval = 5 * time.Second
+
+	// redactedStreamURI stands in for a URI that could not be parsed, so a
+	// malformed value can never reach a log line with its credentials attached.
+	// #nosec G101 -- placeholder text, not a credential
+	redactedStreamURI = "rabbitmq-stream://****:****@<host>:<port>/<vhost>"
+)
+
+// ManagerOptions configures the stream-protocol Manager. The zero value of every
+// tuning field applies its default.
+type ManagerOptions struct {
+	// URI is the stream-protocol endpoint (rabbitmq-stream:// or rabbitmq-stream+tls://).
+	URI string
+	// AddressResolverHost and AddressResolverPort pin every connection to one
+	// entry point. Required behind a load balancer, NAT, or Docker port mapping,
+	// where the address the broker advertises is not reachable by the client.
+	AddressResolverHost string
+	AddressResolverPort int
+	// OffsetStoreCount is how many successfully handled messages accumulate
+	// before an offset is committed server-side.
+	OffsetStoreCount int
+	// OffsetStoreInterval is how long after the last commit a pending offset is
+	// committed anyway.
+	OffsetStoreInterval time.Duration
+	// Logger receives consumer lifecycle and handler-failure events. Required.
+	Logger logger.Logger
+}
+
+// consumerHandle is the subset of *ha.ReliableConsumer the manager drives. It
+// keeps stop/flush bookkeeping testable without a broker.
+type consumerHandle interface {
+	offsetStorer
+	Close() error
+	GetStatus() int
+}
+
+// runningConsumer pairs a live client consumer with the offset bookkeeping its
+// runner owns. The runner itself is retained by the client through the
+// messagesHandler callback, so only the tracker is kept here.
+type runningConsumer struct {
+	stream  string
+	name    string
+	handle  consumerHandle
+	tracker *offsetTracker
+}
+
+// Manager owns the single stream-protocol Environment of a single-tenant service
+// and the consumers started from its declarations. It is a plain struct on
+// purpose (ADR-045): app/ consumes it concretely, so there is no interface to
+// export and no second implementation to abstract over.
+type Manager struct {
+	opts ManagerOptions
+	log  logger.Logger
+
+	mu        sync.Mutex
+	env       *stream.Environment
+	consumers []*runningConsumer
+	started   bool
+	cancel    context.CancelFunc
+}
+
+// NewManager creates a Manager. It performs no I/O: the environment is dialed by
+// Start, so a service that declares no streams never opens a connection.
+func NewManager(opts ManagerOptions) *Manager {
+	if opts.OffsetStoreCount <= 0 {
+		opts.OffsetStoreCount = defaultOffsetStoreCount
+	}
+	if opts.OffsetStoreInterval <= 0 {
+		opts.OffsetStoreInterval = defaultOffsetStoreInterval
+	}
+	return &Manager{opts: opts, log: opts.Logger}
+}
+
+// Start dials the broker, replays the stream declarations, and starts one
+// reliable consumer per declared consumer. Empty declarations are a no-op that
+// dials nothing. Any consumer that fails to start stops the ones already
+// started and returns an error — the caller makes that fatal. A failure leaves
+// nothing to dispose: the connection is closed before the error returns, so a
+// caller that never calls Close does not leak it, and a retried Start cannot
+// orphan the previous environment.
+func (m *Manager) Start(ctx context.Context, decls *Declarations) error {
+	if decls == nil || decls.IsEmpty() {
+		return nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.started {
+		return errors.New("streams manager already started")
+	}
+
+	// NewEnvironment closes its own locator socket before returning, so a failed
+	// dial leaves nothing to clean up here.
+	env, err := stream.NewEnvironment(m.environmentOptions())
+	if err != nil {
+		return fmt.Errorf("failed to connect to stream endpoint %s: %w", redactStreamURI(m.opts.URI), safeEnvError(err))
+	}
+	m.env = env
+
+	m.log.Info().
+		Str("uri", redactStreamURI(m.opts.URI)).
+		Int("streams", len(decls.streams)).
+		Int("consumers", len(decls.consumers)).
+		Msg("Connected to RabbitMQ stream endpoint")
+
+	consumeCtx, cancel := context.WithCancel(ctx)
+	m.cancel = cancel
+
+	if err := m.declareStreams(env, decls); err != nil {
+		m.abortStartLocked()
+		return err
+	}
+
+	for _, decl := range decls.consumers {
+		if err := m.startConsumer(consumeCtx, env, decl); err != nil {
+			m.abortStartLocked()
+			return err
+		}
+	}
+
+	m.started = true
+	return nil
+}
+
+// environmentOptions renders the client environment configuration.
+func (m *Manager) environmentOptions() *stream.EnvironmentOptions {
+	opts := stream.NewEnvironmentOptions().SetUri(m.opts.URI)
+	if m.opts.AddressResolverHost != "" {
+		opts = opts.SetAddressResolver(stream.AddressResolver{
+			Host: m.opts.AddressResolverHost,
+			Port: m.opts.AddressResolverPort,
+		})
+	}
+	return opts
+}
+
+// declareStreams replays the declared streams. The client treats an identical
+// existing stream as success; a retention mismatch surfaces as
+// precondition-failed and aborts startup rather than silently consuming a stream
+// configured differently from the declaration.
+func (m *Manager) declareStreams(env *stream.Environment, decls *Declarations) error {
+	for _, s := range decls.streams {
+		if err := env.DeclareStream(s.Name, streamOptionsFrom(&s.Spec)); err != nil {
+			return fmt.Errorf("failed to declare stream %q: %w", s.Name, err)
+		}
+	}
+	return nil
+}
+
+// startConsumer starts one reliable consumer for a declaration. env is the
+// caller's snapshot of m.env, taken under m.mu.
+func (m *Manager) startConsumer(ctx context.Context, env *stream.Environment, decl *consumerDeclaration) error {
+	runner := &consumerRunner{
+		name:    decl.Name,
+		handler: decl.Handler,
+		tracker: newOffsetTracker(m.opts.OffsetStoreCount, m.opts.OffsetStoreInterval, nil),
+		log:     m.log,
+		tracer:  otel.Tracer(tracerName),
+		baseCtx: ctx,
+	}
+
+	opts := stream.NewConsumerOptions().
+		SetConsumerName(decl.Name).
+		SetOffset(m.resolveOffset(env, decl.Name, decl.Stream, decl.Start))
+
+	if decl.SAC {
+		// The promotion callback resolves the offset again: another group member
+		// may have advanced it while this one was passive.
+		//
+		// SECURITY: the client calls this from its own read-loop goroutine, outside
+		// m.mu and with no recover() anywhere in its call path. It therefore closes
+		// over this snapshot instead of reading m.env: that field is written under
+		// m.mu and nil'd by Close, so reading it here would be a data race, and a
+		// promotion frame arriving after Close would dereference nil and kill the
+		// process mid-shutdown. Taking m.mu here instead would deadlock — stopLocked
+		// holds it across a blocking consumer Close.
+		opts = opts.SetSingleActiveConsumer(stream.NewSingleActiveConsumer(
+			func(streamName string, _ bool) stream.OffsetSpecification {
+				return m.resolveOffset(env, decl.Name, streamName, decl.Start)
+			}))
+	}
+
+	consumer, err := ha.NewReliableConsumer(env, decl.Stream, opts, runner.messagesHandler)
+	if err != nil {
+		return fmt.Errorf("failed to start consumer %q on stream %q: %w", decl.Name, decl.Stream, err)
+	}
+
+	m.consumers = append(m.consumers, &runningConsumer{
+		stream:  decl.Stream,
+		name:    decl.Name,
+		handle:  consumer,
+		tracker: runner.tracker,
+	})
+
+	m.log.Info().
+		Str(logFieldStream, decl.Stream).
+		Str(logFieldConsumer, decl.Name).
+		Bool("single_active", decl.SAC).
+		Msg("Stream consumer started")
+
+	return nil
+}
+
+// resolveOffset asks the broker for the consumer's stored offset and falls back
+// to the declared start position when it has none. A stored offset always wins,
+// which is what makes restart behavior deterministic.
+//
+// The environment is a parameter, never m.env, so that no call path — including
+// the SAC promotion callback the client invokes from its own goroutine — can read
+// that guarded field without m.mu. m.log is immutable after NewManager.
+func (m *Manager) resolveOffset(env *stream.Environment, consumerName, streamName string, start OffsetStart) stream.OffsetSpecification {
+	stored, err := env.QueryOffset(consumerName, streamName)
+	if err != nil && !errors.Is(err, stream.OffsetNotFoundError) {
+		m.log.Warn().Err(err).
+			Str(logFieldStream, streamName).
+			Str(logFieldConsumer, consumerName).
+			Msg("Could not query stored stream offset; using the declared start position")
+	}
+	return offsetSpecFor(stored, err, start)
+}
+
+// safeEnvError strips the URI out of an environment-construction failure.
+//
+// SECURITY: the client parses the endpoint with url.Parse and returns its
+// *url.Error verbatim, whose Error() renders the raw URI — credentials included.
+// Only the cause is kept; the endpoint is reported separately, redacted. This is
+// reachable when config.Validate never ran (app.NewWithConfig, see
+// app/streams_setup.go).
+func safeEnvError(err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return fmt.Errorf("invalid stream URI: %w", urlErr.Err)
+	}
+	return err
+}
+
+// offsetSpecFor picks between a stored offset and the declared start position.
+func offsetSpecFor(stored int64, queryErr error, start OffsetStart) stream.OffsetSpecification {
+	if queryErr != nil {
+		return start.specification()
+	}
+	return stream.OffsetSpecification{}.Offset(stored + 1)
+}
+
+// streamOptionsFrom renders a StreamSpec as client stream options. Zero-value
+// fields are left unset so the broker's own defaults apply.
+func streamOptionsFrom(spec *StreamSpec) *stream.StreamOptions {
+	opts := stream.NewStreamOptions()
+	if spec == nil {
+		return opts
+	}
+	if spec.MaxAge > 0 {
+		// Truncate to whole seconds and floor at 1s, matching
+		// messaging.StreamQueueSpec: sub-second retention is inexpressible to the
+		// broker and would render "0s", and passing whole seconds keeps the
+		// client's round-to-nearest formatting from disagreeing with the AMQP
+		// lane's truncation on a value like 1500ms.
+		opts = opts.SetMaxAge(max(spec.MaxAge.Truncate(time.Second), time.Second))
+	}
+	if spec.MaxLengthBytes > 0 {
+		opts = opts.SetMaxLengthBytes(stream.ByteCapacity{}.B(spec.MaxLengthBytes))
+	}
+	if spec.MaxSegmentSizeBytes > 0 {
+		opts = opts.SetMaxSegmentSizeBytes(stream.ByteCapacity{}.B(spec.MaxSegmentSizeBytes))
+	}
+	return opts
+}
+
+// StopConsumers stops every consumer. Each one flushes its pending offset BEFORE
+// closing, so a clean shutdown does not replay successfully handled messages.
+// Idempotent.
+func (m *Manager) StopConsumers() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopLocked()
+}
+
+func (m *Manager) stopLocked() {
+	if m.cancel != nil {
+		m.cancel()
+		m.cancel = nil
+	}
+
+	for _, rc := range m.consumers {
+		if err := rc.tracker.flush(rc.handle); err != nil {
+			m.log.Warn().Err(err).
+				Str(logFieldStream, rc.stream).
+				Str(logFieldConsumer, rc.name).
+				Msg("Failed to flush stream offset on shutdown")
+		}
+		if err := rc.handle.Close(); err != nil {
+			m.log.Warn().Err(err).
+				Str(logFieldStream, rc.stream).
+				Str(logFieldConsumer, rc.name).
+				Msg("Failed to close stream consumer")
+		}
+	}
+
+	m.consumers = nil
+	m.started = false
+}
+
+// abortStartLocked unwinds a Start that failed after the dial: it stops whatever
+// consumers came up and disposes the environment, so a caller that treats the
+// error as fatal without calling Close leaks nothing and a retried Start cannot
+// orphan the previous connection pool.
+func (m *Manager) abortStartLocked() {
+	m.stopLocked()
+	if err := m.closeEnvLocked(); err != nil {
+		m.log.Warn().Err(err).Msg("Failed to close stream environment after a failed start")
+	}
+}
+
+// closeEnvLocked is the single disposal path for the environment. Nils the field
+// so a later Close short-circuits instead of closing twice.
+func (m *Manager) closeEnvLocked() error {
+	if m.env == nil {
+		return nil
+	}
+	env := m.env
+	m.env = nil
+	return env.Close()
+}
+
+// Close stops the consumers and closes the environment. Idempotent.
+func (m *Manager) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.stopLocked()
+	return m.closeEnvLocked()
+}
+
+// Stats reports the manager state for the readiness probe and /ready body.
+func (m *Manager) Stats() map[string]any {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	offsets := make(map[string]int64, len(m.consumers))
+	for _, rc := range m.consumers {
+		if offset, ok := rc.tracker.lastStored(); ok {
+			offsets[rc.stream+"/"+rc.name] = offset
+		}
+	}
+
+	return map[string]any{
+		"started":               m.started,
+		"consumers":             len(m.consumers),
+		"ready":                 m.readyLocked(),
+		"stored_offsets":        offsets,
+		"offset_store_count":    m.opts.OffsetStoreCount,
+		"offset_flush_interval": m.opts.OffsetStoreInterval.String(),
+	}
+}
+
+// Ready reports whether every started consumer is currently connected.
+func (m *Manager) Ready() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.readyLocked()
+}
+
+func (m *Manager) readyLocked() bool {
+	if !m.started {
+		return false
+	}
+	for _, rc := range m.consumers {
+		if rc.handle.GetStatus() != ha.StatusOpen {
+			return false
+		}
+	}
+	return true
+}
+
+// redactStreamURI masks the credentials in a stream URI so it can be logged.
+//
+// SECURITY: messaging.streams.uri carries a broker password. Everything that
+// logs the endpoint goes through this function, and an unparseable value degrades
+// to a fixed placeholder rather than echoing the raw input.
+func redactStreamURI(uri string) string {
+	u, err := url.Parse(uri)
+	if err != nil || u.Host == "" {
+		return redactedStreamURI
+	}
+
+	username := "****"
+	if u.User != nil && u.User.Username() != "" {
+		username = u.User.Username()
+	}
+
+	redacted := u.Scheme + "://" + username + ":****@" + u.Host + u.EscapedPath()
+	if u.RawQuery != "" {
+		redacted += "?<redacted>"
+	}
+	return redacted
+}

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -107,6 +107,11 @@ func NewManager(opts ManagerOptions) *Manager {
 // caller that never calls Close does not leak it, and a retried Start cannot
 // orphan the previous environment.
 //
+// Start is not a resume: once it has dialed, it refuses to run again until Close
+// disposes the environment. StopConsumers deliberately leaves that environment
+// open, so redialing over it would orphan a connection the registered closer
+// still owns.
+//
 // ctx contributes its VALUES to every handler invocation, never its cancellation:
 // consumers outlive the startup call that created them, and StopConsumers is what
 // ends them. See consumeContext.
@@ -118,8 +123,11 @@ func (m *Manager) Start(ctx context.Context, decls *Declarations) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.started {
-		return errors.New("streams manager already started")
+	// Guarded on the environment, not on started: stopLocked clears started but
+	// leaves m.env for Close, so a started-only guard would let a Start after
+	// StopConsumers dial over the live environment and orphan it.
+	if m.env != nil {
+		return errors.New("streams manager already started: Close it before starting again")
 	}
 
 	// NewEnvironment closes its own locator socket before returning, so a failed
@@ -312,6 +320,9 @@ func streamOptionsFrom(spec *StreamSpec) *stream.StreamOptions {
 // StopConsumers stops every consumer. Each one flushes its pending offset BEFORE
 // closing, so a clean shutdown does not replay successfully handled messages.
 // Idempotent.
+//
+// This is shutdown phase one, not a pause: the environment stays open for Close
+// to dispose, and Start stays refused until then.
 func (m *Manager) StopConsumers() {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -80,7 +80,16 @@ type Manager struct {
 
 // NewManager creates a Manager. It performs no I/O: the environment is dialed by
 // Start, so a service that declares no streams never opens a connection.
+//
+// Panics on a nil Logger. Every consumer lifecycle, handler-failure and shutdown
+// path dereferences it unguarded, so a wiring error would otherwise surface as a
+// nil dereference on the first log line — mid-consumption, in production, from a
+// goroutine the client owns and nothing recovers. Same fail-fast as
+// httpclient.NewBuilder, and it keeps this constructor's single return value.
 func NewManager(opts ManagerOptions) *Manager {
+	if opts.Logger == nil {
+		panic("streams: NewManager requires a non-nil Logger (pass deps.Logger)")
+	}
 	if opts.OffsetStoreCount <= 0 {
 		opts.OffsetStoreCount = defaultOffsetStoreCount
 	}
@@ -97,6 +106,10 @@ func NewManager(opts ManagerOptions) *Manager {
 // nothing to dispose: the connection is closed before the error returns, so a
 // caller that never calls Close does not leak it, and a retried Start cannot
 // orphan the previous environment.
+//
+// ctx contributes its VALUES to every handler invocation, never its cancellation:
+// consumers outlive the startup call that created them, and StopConsumers is what
+// ends them. See consumeContext.
 func (m *Manager) Start(ctx context.Context, decls *Declarations) error {
 	if decls == nil || decls.IsEmpty() {
 		return nil
@@ -123,7 +136,7 @@ func (m *Manager) Start(ctx context.Context, decls *Declarations) error {
 		Int("consumers", len(decls.consumers)).
 		Msg("Connected to RabbitMQ stream endpoint")
 
-	consumeCtx, cancel := context.WithCancel(ctx)
+	consumeCtx, cancel := consumeContext(ctx)
 	m.cancel = cancel
 
 	if err := m.declareStreams(env, decls); err != nil {
@@ -140,6 +153,16 @@ func (m *Manager) Start(ctx context.Context, decls *Declarations) error {
 
 	m.started = true
 	return nil
+}
+
+// consumeContext derives the context the handlers run under: the caller's values
+// (trace, tenant) are inherited, its cancellation is severed, and the returned
+// cancel func — owned by StopConsumers — becomes the only way to stop consumption.
+// Without the detach, a caller whose startup context is canceled after Start
+// returns would silently stop consuming; context.Background() would instead drop
+// the values the handlers' spans and logs are attributed by.
+func consumeContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithCancel(context.WithoutCancel(ctx))
 }
 
 // environmentOptions renders the client environment configuration.

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -1,0 +1,602 @@
+package streams
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/ha"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaborage/go-bricks/logger"
+)
+
+// fakeHandle stands in for *ha.ReliableConsumer so shutdown bookkeeping is
+// testable without a broker.
+type fakeHandle struct {
+	mu       sync.Mutex
+	events   []string
+	status   int
+	closeErr error
+	storeErr error
+}
+
+func (f *fakeHandle) StoreCustomOffset(offset int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.storeErr != nil {
+		return f.storeErr
+	}
+	f.events = append(f.events, fmt.Sprintf("store:%d", offset))
+	return nil
+}
+
+func (f *fakeHandle) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, "close")
+	return f.closeErr
+}
+
+func (f *fakeHandle) GetStatus() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.status
+}
+
+func (f *fakeHandle) recorded() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.events...)
+}
+
+// unreachableTestURI points at a port that refuses connections, so a dial fails fast.
+const unreachableTestURI = "rabbitmq-stream://guest:guest@127.0.0.1:1/%2f"
+
+// The shutdown and unwind warnings, verbatim. Tests assert on them so a guard
+// that stops distinguishing success from failure fails here.
+const (
+	msgFlushFailed         = "Failed to flush stream offset on shutdown"
+	msgCloseConsumerFailed = "Failed to close stream consumer"
+	msgCloseEnvFailed      = "Failed to close stream environment after a failed start"
+	msgOffsetStoreFailed   = "Failed to store stream offset"
+)
+
+// recordingLogger captures each event's level, attached error and terminal
+// message, so a test asserts what a shutdown actually told the operator instead
+// of swapping the process-global os.Stdout.
+type recordingLogger struct {
+	mu     sync.Mutex
+	events []recordedEvent
+}
+
+type recordedEvent struct {
+	l     *recordingLogger
+	level string
+	err   string
+	msg   string
+}
+
+func (l *recordingLogger) event(level string) logger.LogEvent {
+	return &recordedEvent{l: l, level: level}
+}
+func (l *recordingLogger) Info() logger.LogEvent                     { return l.event("info") }
+func (l *recordingLogger) Error() logger.LogEvent                    { return l.event("error") }
+func (l *recordingLogger) Debug() logger.LogEvent                    { return l.event("debug") }
+func (l *recordingLogger) Warn() logger.LogEvent                     { return l.event("warn") }
+func (l *recordingLogger) Fatal() logger.LogEvent                    { return l.event("fatal") }
+func (l *recordingLogger) WithContext(_ any) logger.Logger           { return l }
+func (l *recordingLogger) WithFields(_ map[string]any) logger.Logger { return l }
+
+func (l *recordingLogger) warnMessages() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := []string{}
+	for _, e := range l.events {
+		if e.level == "warn" {
+			out = append(out, e.msg)
+		}
+	}
+	return out
+}
+
+// warnError reports the error text attached to the first WARN carrying msg. An
+// empty string with ok=true means the line was emitted with no error at all,
+// which is what a guard reading the wrong way round produces.
+func (l *recordingLogger) warnError(msg string) (text string, ok bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, e := range l.events {
+		if e.level == "warn" && e.msg == msg {
+			return e.err, true
+		}
+	}
+	return "", false
+}
+
+func (e *recordedEvent) Msg(msg string) {
+	e.msg = msg
+	e.l.mu.Lock()
+	e.l.events = append(e.l.events, *e)
+	e.l.mu.Unlock()
+}
+func (e *recordedEvent) Msgf(format string, args ...any) { e.Msg(fmt.Sprintf(format, args...)) }
+func (e *recordedEvent) Err(err error) logger.LogEvent {
+	if err != nil {
+		e.err = err.Error()
+	}
+	return e
+}
+func (e *recordedEvent) Str(_, _ string) logger.LogEvent               { return e }
+func (e *recordedEvent) Int(_ string, _ int) logger.LogEvent           { return e }
+func (e *recordedEvent) Int64(_ string, _ int64) logger.LogEvent       { return e }
+func (e *recordedEvent) Uint64(_ string, _ uint64) logger.LogEvent     { return e }
+func (e *recordedEvent) Dur(_ string, _ time.Duration) logger.LogEvent { return e }
+func (e *recordedEvent) Interface(_ string, _ any) logger.LogEvent     { return e }
+func (e *recordedEvent) Bytes(_ string, _ []byte) logger.LogEvent      { return e }
+func (e *recordedEvent) Bool(_ string, _ bool) logger.LogEvent         { return e }
+func (e *recordedEvent) Enabled() bool                                 { return true }
+
+// recordingManager builds a manager with one attached fake consumer whose tracker
+// already has a pending offset, so both shutdown guards are reachable.
+func recordingManager(t *testing.T, handle *fakeHandle) (*Manager, *recordingLogger) {
+	t.Helper()
+	log := &recordingLogger{}
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: log})
+	tracker := newOffsetTracker(1000, time.Hour, nil)
+	require.NoError(t, tracker.record(4, nil, &fakeStorer{}))
+	attach(m, handle, tracker)
+	return m, log
+}
+
+func testManager(t *testing.T) *Manager {
+	t.Helper()
+	return NewManager(ManagerOptions{
+		URI:    "rabbitmq-stream://localhost:5552/%2f",
+		Logger: logger.New("error", false),
+	})
+}
+
+// attach wires a fake consumer into a manager as if Start had created it.
+func attach(m *Manager, handle consumerHandle, tracker *offsetTracker) {
+	m.consumers = append(m.consumers, &runningConsumer{
+		stream:  testStream,
+		name:    testConsumerName,
+		handle:  handle,
+		tracker: tracker,
+	})
+	m.started = true
+}
+
+func TestNewManagerAppliesOffsetStoreDefaults(t *testing.T) {
+	m := NewManager(ManagerOptions{URI: "rabbitmq-stream://localhost:5552/"})
+
+	assert.Equal(t, defaultOffsetStoreCount, m.opts.OffsetStoreCount)
+	assert.Equal(t, defaultOffsetStoreInterval, m.opts.OffsetStoreInterval)
+}
+
+func TestNewManagerKeepsExplicitOffsetStoreTuning(t *testing.T) {
+	m := NewManager(ManagerOptions{OffsetStoreCount: 7, OffsetStoreInterval: 250 * time.Millisecond})
+
+	assert.Equal(t, 7, m.opts.OffsetStoreCount)
+	assert.Equal(t, 250*time.Millisecond, m.opts.OffsetStoreInterval)
+}
+
+func TestManagerStartWithoutDeclarationsDoesNotDial(t *testing.T) {
+	// Port 1 refuses connections, so any dial attempt would surface as an error.
+	m := NewManager(ManagerOptions{URI: "rabbitmq-stream://guest:guest@127.0.0.1:1/%2f", Logger: logger.New("error", false)})
+
+	require.NoError(t, m.Start(context.Background(), nil))
+	require.NoError(t, m.Start(context.Background(), NewDeclarations()))
+
+	assert.Nil(t, m.env)
+	assert.False(t, m.started)
+}
+
+func TestManagerStartRejectsSecondStart(t *testing.T) {
+	m := testManager(t)
+	attach(m, &fakeHandle{status: ha.StatusOpen}, newOffsetTracker(1, time.Hour, nil))
+
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+
+	err := m.Start(context.Background(), decls)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already started")
+}
+
+func TestManagerStopConsumersFlushesBeforeClosing(t *testing.T) {
+	m := testManager(t)
+	handle := &fakeHandle{status: ha.StatusOpen}
+	tracker := newOffsetTracker(1000, time.Hour, nil)
+	require.NoError(t, tracker.record(88, nil, &fakeStorer{}))
+	attach(m, handle, tracker)
+
+	m.StopConsumers()
+
+	assert.Equal(t, []string{"store:88", "close"}, handle.recorded(),
+		"a clean shutdown commits the last handled offset before the consumer goes away")
+	assert.False(t, m.started)
+	assert.Empty(t, m.consumers)
+}
+
+func TestManagerStopConsumersIsIdempotent(t *testing.T) {
+	m := testManager(t)
+	handle := &fakeHandle{status: ha.StatusOpen}
+	attach(m, handle, newOffsetTracker(1000, time.Hour, nil))
+
+	m.StopConsumers()
+	m.StopConsumers()
+
+	assert.Equal(t, []string{"close"}, handle.recorded(), "nothing pending, and no second close")
+}
+
+// TestManagerStopConsumersToleratesFlushAndCloseErrors pins both shutdown
+// guards from the failing side: a flush that never reached the broker and a
+// consumer that would not close each surface to the operator with the underlying
+// error attached, and neither aborts the rest of the teardown.
+func TestManagerStopConsumersToleratesFlushAndCloseErrors(t *testing.T) {
+	m, log := recordingManager(t, &fakeHandle{
+		status:   ha.StatusOpen,
+		closeErr: errors.New("close failed"),
+		storeErr: errors.New("store failed"),
+	})
+
+	assert.NotPanics(t, m.StopConsumers)
+	assert.False(t, m.started)
+
+	assert.ElementsMatch(t, []string{msgFlushFailed, msgCloseConsumerFailed}, log.warnMessages())
+	flushErr, ok := log.warnError(msgFlushFailed)
+	require.True(t, ok)
+	assert.Equal(t, "store failed", flushErr)
+	closeErr, ok := log.warnError(msgCloseConsumerFailed)
+	require.True(t, ok)
+	assert.Equal(t, "close failed", closeErr)
+}
+
+// TestManagerStopConsumersIsSilentOnCleanShutdown is the other side of the same
+// two guards: a teardown whose flush and close both succeed reports no failure.
+func TestManagerStopConsumersIsSilentOnCleanShutdown(t *testing.T) {
+	handle := &fakeHandle{status: ha.StatusOpen}
+	m, log := recordingManager(t, handle)
+
+	m.StopConsumers()
+
+	assert.Equal(t, []string{"store:4", "close"}, handle.recorded())
+	assert.Empty(t, log.warnMessages(), "a clean shutdown reports nothing to the operator")
+}
+
+func TestManagerStopConsumersCancelsConsumeContext(t *testing.T) {
+	m := testManager(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	m.cancel = cancel
+	attach(m, &fakeHandle{status: ha.StatusOpen}, newOffsetTracker(1, time.Hour, nil))
+
+	m.StopConsumers()
+
+	require.Error(t, ctx.Err())
+	assert.Nil(t, m.cancel)
+}
+
+func TestManagerCloseWithoutEnvironmentIsIdempotent(t *testing.T) {
+	m := testManager(t)
+
+	require.NoError(t, m.Close())
+	require.NoError(t, m.Close())
+}
+
+func TestManagerStats(t *testing.T) {
+	m := NewManager(ManagerOptions{
+		URI:                 "rabbitmq-stream://localhost:5552/",
+		OffsetStoreCount:    9,
+		OffsetStoreInterval: 2 * time.Second,
+		Logger:              logger.New("error", false),
+	})
+	tracker := newOffsetTracker(1, time.Hour, nil)
+	require.NoError(t, tracker.record(31, nil, &fakeStorer{}))
+	attach(m, &fakeHandle{status: ha.StatusOpen}, tracker)
+
+	stats := m.Stats()
+
+	assert.Equal(t, true, stats["started"])
+	assert.Equal(t, 1, stats["consumers"])
+	assert.Equal(t, true, stats["ready"])
+	assert.Equal(t, map[string]int64{testStream + "/" + testConsumerName: 31}, stats["stored_offsets"])
+	assert.Equal(t, 9, stats["offset_store_count"])
+	assert.Equal(t, "2s", stats["offset_flush_interval"])
+}
+
+func TestManagerStatsOmitsUncommittedOffsets(t *testing.T) {
+	m := testManager(t)
+	attach(m, &fakeHandle{status: ha.StatusOpen}, newOffsetTracker(1000, time.Hour, nil))
+
+	stats := m.Stats()
+
+	assert.Empty(t, stats["stored_offsets"])
+}
+
+func TestManagerReady(t *testing.T) {
+	tests := []struct {
+		name    string
+		started bool
+		status  int
+		want    bool
+	}{
+		{name: "open_consumer_is_ready", started: true, status: ha.StatusOpen, want: true},
+		{name: "reconnecting_consumer_is_not_ready", started: true, status: ha.StatusReconnecting, want: false},
+		{name: "closed_consumer_is_not_ready", started: true, status: ha.StatusClosed, want: false},
+		{name: "never_started_is_not_ready", started: false, status: ha.StatusOpen, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := testManager(t)
+			attach(m, &fakeHandle{status: tt.status}, newOffsetTracker(1, time.Hour, nil))
+			m.started = tt.started
+
+			assert.Equal(t, tt.want, m.Ready())
+			assert.Equal(t, tt.want, m.Stats()["ready"])
+		})
+	}
+}
+
+func TestOffsetSpecFor(t *testing.T) {
+	tests := []struct {
+		name     string
+		stored   int64
+		queryErr error
+		start    OffsetStart
+		want     stream.OffsetSpecification
+	}{
+		{
+			name:   "stored_offset_resumes_one_past_it",
+			stored: 17,
+			start:  OffsetFirst(),
+			want:   stream.OffsetSpecification{}.Offset(18),
+		},
+		{
+			name:     "no_stored_offset_uses_declared_start",
+			queryErr: stream.OffsetNotFoundError,
+			start:    OffsetFirst(),
+			want:     stream.OffsetSpecification{}.First(),
+		},
+		{
+			name:     "query_failure_uses_declared_start",
+			queryErr: errors.New("boom"),
+			start:    OffsetLast(),
+			want:     stream.OffsetSpecification{}.Last(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, offsetSpecFor(tt.stored, tt.queryErr, tt.start))
+		})
+	}
+}
+
+func TestStreamOptionsFrom(t *testing.T) {
+	assert.Equal(t, stream.NewStreamOptions(), streamOptionsFrom(nil))
+	assert.Equal(t, stream.NewStreamOptions(), streamOptionsFrom(&StreamSpec{}),
+		"a zero spec leaves every retention knob to the broker")
+
+	opts := streamOptionsFrom(&StreamSpec{
+		MaxAge:              45 * time.Minute,
+		MaxLengthBytes:      2048,
+		MaxSegmentSizeBytes: 1024,
+	})
+
+	require.NotNil(t, opts)
+	assert.Equal(t, 45*time.Minute, opts.MaxAge)
+	assert.Equal(t, stream.ByteCapacity{}.B(2048), opts.MaxLengthBytes)
+	assert.Equal(t, stream.ByteCapacity{}.B(1024), opts.MaxSegmentSizeBytes)
+}
+
+// TestStreamOptionsFromClampsMaxAge pins the retention rendering against
+// messaging.StreamQueueSpec: truncate toward whole seconds, floor a non-zero
+// value at 1s, and leave zero alone so the broker default still applies. The
+// client formats MaxAge with %.0f (round to nearest), so 1500ms would reach the
+// broker as 2s here and 1s in the AMQP lane without the clamp.
+func TestStreamOptionsFromClampsMaxAge(t *testing.T) {
+	tests := []struct {
+		name   string
+		maxAge time.Duration
+		want   time.Duration
+	}{
+		{name: "sub_second_floors_to_one_second", maxAge: 500 * time.Millisecond, want: time.Second},
+		{name: "nanosecond_floors_to_one_second", maxAge: time.Nanosecond, want: time.Second},
+		{name: "fractional_second_truncates_down", maxAge: 1500 * time.Millisecond, want: time.Second},
+		{name: "whole_seconds_pass_through", maxAge: 90 * time.Second, want: 90 * time.Second},
+		{name: "zero_emits_no_max_age", maxAge: 0, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := streamOptionsFrom(&StreamSpec{MaxAge: tt.maxAge, MaxLengthBytes: 2048})
+
+			assert.Equal(t, tt.want, opts.MaxAge)
+			assert.Equal(t, stream.ByteCapacity{}.B(2048), opts.MaxLengthBytes,
+				"the MaxAge clamp must not disturb the other retention knobs")
+		})
+	}
+}
+
+func TestManagerEnvironmentOptions(t *testing.T) {
+	t.Run("without_address_resolver", func(t *testing.T) {
+		m := NewManager(ManagerOptions{URI: "rabbitmq-stream://localhost:5552/%2f"})
+
+		opts := m.environmentOptions()
+
+		assert.Nil(t, opts.AddressResolver)
+		require.Len(t, opts.ConnectionParameters, 1)
+		assert.Equal(t, "rabbitmq-stream://localhost:5552/%2f", opts.ConnectionParameters[0].Uri)
+	})
+
+	t.Run("with_address_resolver", func(t *testing.T) {
+		m := NewManager(ManagerOptions{
+			URI:                 "rabbitmq-stream://localhost:5552/%2f",
+			AddressResolverHost: "lb.example.com",
+			AddressResolverPort: 5553,
+		})
+
+		opts := m.environmentOptions()
+
+		require.NotNil(t, opts.AddressResolver)
+		assert.Equal(t, "lb.example.com", opts.AddressResolver.Host)
+		assert.Equal(t, 5553, opts.AddressResolver.Port)
+	})
+}
+
+func TestRedactStreamURI(t *testing.T) {
+	// Fixture value only — no real credential appears in this repository.
+	const fixturePassword = "fixture-pw"
+
+	tests := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{
+			name: "masks_password_keeps_username",
+			uri:  "rabbitmq-stream://svc:" + fixturePassword + "@broker:5552/%2f",
+			want: "rabbitmq-stream://svc:****@broker:5552/%2f",
+		},
+		{
+			name: "masks_both_when_no_userinfo",
+			uri:  "rabbitmq-stream://broker:5552/vhost",
+			want: "rabbitmq-stream://****:****@broker:5552/vhost",
+		},
+		{
+			name: "masks_query_string",
+			uri:  "rabbitmq-stream://svc:" + fixturePassword + "@broker:5552/?token=abc",
+			want: "rabbitmq-stream://svc:****@broker:5552/?<redacted>",
+		},
+		{
+			name: "unparseable_uri_degrades_to_placeholder",
+			uri:  "rabbitmq-stream://svc:" + fixturePassword + "@broker:55 52/%2f",
+			want: redactedStreamURI,
+		},
+		{
+			name: "empty_uri_degrades_to_placeholder",
+			uri:  "",
+			want: redactedStreamURI,
+		},
+		{
+			name: "tls_scheme_is_preserved",
+			uri:  "rabbitmq-stream+tls://svc:" + fixturePassword + "@broker:5551/%2f",
+			want: "rabbitmq-stream+tls://svc:****@broker:5551/%2f",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := redactStreamURI(tt.uri)
+
+			assert.Equal(t, tt.want, got)
+			assert.NotContains(t, got, fixturePassword, "the password must never survive redaction")
+		})
+	}
+}
+
+// TestManagerStartDoesNotLeakURIOnParseFailure covers the path reachable when
+// config.Validate never ran (app.NewWithConfig): the client returns a *url.Error
+// whose Error() renders the raw URI, credentials included.
+func TestManagerStartDoesNotLeakURIOnParseFailure(t *testing.T) {
+	const fixturePassword = "fixture-pw"
+	m := NewManager(ManagerOptions{
+		// A space makes url.Parse fail inside the client's environment constructor.
+		URI:    "rabbitmq-stream://svc:" + fixturePassword + "@broker:55 52/%2f",
+		Logger: logger.New("error", false),
+	})
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+
+	err := m.Start(context.Background(), decls)
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), fixturePassword, "the credential must not survive into the error")
+	assert.Contains(t, err.Error(), "invalid stream URI")
+	assert.Contains(t, err.Error(), redactedStreamURI,
+		"an unparseable endpoint degrades to the fixed placeholder rather than echoing the input")
+	assert.False(t, m.started)
+}
+
+func TestSafeEnvError(t *testing.T) {
+	// Not const: a constant expression here lets staticcheck evaluate the
+	// deliberately-invalid URL and report SA1007 on the fixture itself.
+	fixturePassword := "fixture-pw"
+	raw := "rabbitmq-stream://svc:" + fixturePassword + "@broker:55 52/"
+	_, parseErr := url.Parse(raw)
+	require.Error(t, parseErr)
+	require.Contains(t, parseErr.Error(), fixturePassword, "the premise: the vendor's error carries the credential")
+
+	safe := safeEnvError(parseErr)
+
+	assert.NotContains(t, safe.Error(), fixturePassword)
+	assert.Contains(t, safe.Error(), "invalid stream URI")
+
+	other := errors.New("connection refused")
+	assert.Equal(t, other, safeEnvError(other), "non-URL errors pass through untouched")
+}
+
+// TestManagerStartFailedDialLeavesNothingToDispose is the pre-dial half: the
+// environment was never stored, so Close is a no-op. The post-dial half — where
+// the environment exists and must be disposed — needs a broker and lives in
+// TestStreamsManagerDisposesEnvironmentOnDeclareFailureIntegration.
+func TestManagerStartFailedDialLeavesNothingToDispose(t *testing.T) {
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: logger.New("error", false)})
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+
+	require.Error(t, m.Start(context.Background(), decls))
+	assert.Nil(t, m.env)
+	require.NoError(t, m.Close(), "Close after a failed Start is a no-op")
+}
+
+// TestManagerAbortStartLockedDisposesEnvironment drives the post-dial unwind
+// directly: stopLocked alone left m.env non-nil, so a caller that never called
+// Close leaked it and a second Start orphaned it beyond any later Close.
+func TestManagerAbortStartLockedDisposesEnvironment(t *testing.T) {
+	m := testManager(t)
+	handle := &fakeHandle{status: ha.StatusOpen}
+	attach(m, handle, newOffsetTracker(1000, time.Hour, nil))
+
+	m.abortStartLocked()
+
+	assert.Nil(t, m.env, "the environment is disposed, not just the consumers")
+	assert.Empty(t, m.consumers)
+	assert.False(t, m.started)
+	assert.Equal(t, []string{"close"}, handle.recorded())
+
+	require.NoError(t, m.Close(), "the follow-up Close short-circuits instead of closing twice")
+}
+
+// TestManagerAbortStartLockedReportsOnlyRealDisposalFailures pins the unwind's
+// own guard: nothing was dialed, so closeEnvLocked has nothing to close and
+// returns nil. A guard reading that the wrong way round would tell the operator
+// the environment failed to close on every successful unwind.
+func TestManagerAbortStartLockedReportsOnlyRealDisposalFailures(t *testing.T) {
+	m, log := recordingManager(t, &fakeHandle{status: ha.StatusOpen})
+
+	m.abortStartLocked()
+
+	require.Nil(t, m.env, "the premise: there was no environment to dispose")
+	assert.NotContains(t, log.warnMessages(), msgCloseEnvFailed,
+		"a disposal that succeeded is not reported as a failure")
+	assert.Empty(t, log.warnMessages(), "the whole unwind is silent when every step succeeds")
+}
+
+func TestManagerCloseEnvLockedIsIdempotent(t *testing.T) {
+	m := testManager(t)
+
+	require.NoError(t, m.closeEnvLocked())
+	require.NoError(t, m.closeEnvLocked())
+	assert.Nil(t, m.env)
+}

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -212,9 +212,14 @@ func TestManagerStartWithoutDeclarationsDoesNotDial(t *testing.T) {
 	assert.False(t, m.started)
 }
 
+// The environment is installed alongside the consumer because Start sets it
+// before it sets started; attach alone would leave a state Start never produces.
+// The URI is unreachable so a guard that stopped holding surfaces as a dial
+// failure the message assertion rejects, rather than as a lucky local broker.
 func TestManagerStartRejectsSecondStart(t *testing.T) {
-	m := testManager(t)
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: logger.New("error", false)})
 	attach(m, &fakeHandle{status: ha.StatusOpen}, newOffsetTracker(1, time.Hour, nil))
+	m.env = &stream.Environment{}
 
 	decls := NewDeclarations()
 	decls.DeclareStream(testStream, nil)
@@ -641,6 +646,36 @@ func TestManagerAbortStartLockedReportsOnlyRealDisposalFailures(t *testing.T) {
 	assert.NotContains(t, log.warnMessages(), msgCloseEnvFailed,
 		"a disposal that succeeded is not reported as a failure")
 	assert.Empty(t, log.warnMessages(), "the whole unwind is silent when every step succeeds")
+}
+
+// TestManagerStartRefusesRestartAfterStopConsumers is the restart variant of the
+// environment-lifecycle class: stopLocked clears started but leaves m.env for
+// Close, so a guard reading only started let a second Start dial over the live
+// environment and orphan it beyond any later Close.
+//
+// The URI is unreachable on purpose: if the guard stopped holding, Start would
+// reach the dial and report a connection failure instead, which is what the
+// message assertion below separates from a genuine refusal.
+func TestManagerStartRefusesRestartAfterStopConsumers(t *testing.T) {
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: logger.New("error", false)})
+	handle := &fakeHandle{status: ha.StatusOpen}
+	attach(m, handle, newOffsetTracker(1000, time.Hour, nil))
+	env := &stream.Environment{}
+	m.env = env
+
+	m.StopConsumers()
+	require.False(t, m.started, "the premise: StopConsumers clears started")
+	require.Same(t, env, m.env, "the premise: StopConsumers leaves the environment for Close")
+
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	err := m.Start(context.Background(), decls)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already started",
+		"the restart is refused by the guard, not by a failed dial")
+	assert.Same(t, env, m.env, "the first environment is still the one Close disposes, not an orphan")
+	assert.False(t, m.started)
 }
 
 func TestManagerCloseEnvLockedIsIdempotent(t *testing.T) {

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -175,17 +175,30 @@ func attach(m *Manager, handle consumerHandle, tracker *offsetTracker) {
 }
 
 func TestNewManagerAppliesOffsetStoreDefaults(t *testing.T) {
-	m := NewManager(ManagerOptions{URI: "rabbitmq-stream://localhost:5552/"})
+	m := NewManager(ManagerOptions{URI: "rabbitmq-stream://localhost:5552/", Logger: logger.New("error", false)})
 
 	assert.Equal(t, defaultOffsetStoreCount, m.opts.OffsetStoreCount)
 	assert.Equal(t, defaultOffsetStoreInterval, m.opts.OffsetStoreInterval)
 }
 
 func TestNewManagerKeepsExplicitOffsetStoreTuning(t *testing.T) {
-	m := NewManager(ManagerOptions{OffsetStoreCount: 7, OffsetStoreInterval: 250 * time.Millisecond})
+	m := NewManager(ManagerOptions{
+		OffsetStoreCount:    7,
+		OffsetStoreInterval: 250 * time.Millisecond,
+		Logger:              logger.New("error", false),
+	})
 
 	assert.Equal(t, 7, m.opts.OffsetStoreCount)
 	assert.Equal(t, 250*time.Millisecond, m.opts.OffsetStoreInterval)
+}
+
+// TestNewManagerRequiresLogger pins the constructor guard: ManagerOptions.Logger
+// is documented as required and every log call dereferences it unguarded, so an
+// omitted logger must fail here rather than on the first consumer event.
+func TestNewManagerRequiresLogger(t *testing.T) {
+	assert.PanicsWithValue(t,
+		"streams: NewManager requires a non-nil Logger (pass deps.Logger)",
+		func() { NewManager(ManagerOptions{URI: unreachableTestURI}) })
 }
 
 func TestManagerStartWithoutDeclarationsDoesNotDial(t *testing.T) {
@@ -283,6 +296,42 @@ func TestManagerStopConsumersCancelsConsumeContext(t *testing.T) {
 
 	require.Error(t, ctx.Err())
 	assert.Nil(t, m.cancel)
+}
+
+// TestConsumeContextInheritsValuesWithoutCancellation is the first half of the
+// consume-context contract: the caller's context contributes its values and none
+// of its cancellation, so a startup context that is canceled once Start returned
+// cannot silently stop consumption.
+func TestConsumeContextInheritsValuesWithoutCancellation(t *testing.T) {
+	type tenantKey struct{}
+	parent, cancelParent := context.WithCancel(context.WithValue(context.Background(), tenantKey{}, "tenant-7"))
+	consumeCtx, cancel := consumeContext(parent)
+	defer cancel()
+
+	cancelParent()
+
+	require.NoError(t, consumeCtx.Err(), "the caller's cancellation must not reach the consumers")
+	assert.Equal(t, "tenant-7", consumeCtx.Value(tenantKey{}),
+		"the caller's values must reach the handlers' logs and spans")
+}
+
+// TestManagerStopConsumersStopsDetachedConsumeContext is the second half:
+// severing the caller's cancellation must not cost StopConsumers its own.
+func TestManagerStopConsumersStopsDetachedConsumeContext(t *testing.T) {
+	m := testManager(t)
+	parent, cancelParent := context.WithCancel(context.Background())
+	consumeCtx, cancel := consumeContext(parent)
+	m.cancel = cancel
+	attach(m, &fakeHandle{status: ha.StatusOpen}, newOffsetTracker(1, time.Hour, nil))
+
+	cancelParent()
+	require.NoError(t, consumeCtx.Err(), "the premise: the caller's context is canceled first")
+
+	m.StopConsumers()
+
+	require.ErrorIs(t, consumeCtx.Err(), context.Canceled)
+	assert.Nil(t, m.cancel)
+	assert.False(t, m.started)
 }
 
 func TestManagerCloseWithoutEnvironmentIsIdempotent(t *testing.T) {
@@ -430,7 +479,7 @@ func TestStreamOptionsFromClampsMaxAge(t *testing.T) {
 
 func TestManagerEnvironmentOptions(t *testing.T) {
 	t.Run("without_address_resolver", func(t *testing.T) {
-		m := NewManager(ManagerOptions{URI: "rabbitmq-stream://localhost:5552/%2f"})
+		m := NewManager(ManagerOptions{URI: "rabbitmq-stream://localhost:5552/%2f", Logger: logger.New("error", false)})
 
 		opts := m.environmentOptions()
 
@@ -444,6 +493,7 @@ func TestManagerEnvironmentOptions(t *testing.T) {
 			URI:                 "rabbitmq-stream://localhost:5552/%2f",
 			AddressResolverHost: "lb.example.com",
 			AddressResolverPort: 5553,
+			Logger:              logger.New("error", false),
 		})
 
 		opts := m.environmentOptions()

--- a/messaging/streams/runner.go
+++ b/messaging/streams/runner.go
@@ -1,0 +1,209 @@
+package streams
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/messaging/internal/tracking"
+)
+
+const (
+	// tracerName matches the AMQP lane's tracer so both messaging lanes land under
+	// one instrumentation scope.
+	tracerName = "go-bricks/messaging"
+
+	spanOperationReceive = "receive"
+	messagingSystem      = "rabbitmq"
+
+	logFieldStream   = "stream"
+	logFieldConsumer = "consumer"
+	logFieldOffset   = "offset"
+)
+
+// offsetStorer is the seam the stream client's consumers satisfy
+// (*stream.Consumer and *ha.ReliableConsumer both implement StoreCustomOffset).
+// The commit policy is written against it so it can be exercised without a broker.
+type offsetStorer interface {
+	StoreCustomOffset(offset int64) error
+}
+
+// offsetTracker owns the commit-after-success policy for one consumer.
+//
+// An offset reaches the broker only once its message has been handled without
+// error, and only when either countBeforeStorage successes have accumulated
+// since the last commit or flushInterval has elapsed since it. There is no
+// background goroutine: a stalled stream commits nothing, which is correct
+// because nothing new was handled.
+type offsetTracker struct {
+	countBeforeStorage int
+	flushInterval      time.Duration
+	now                func() time.Time
+
+	mu            sync.Mutex
+	pending       int
+	lastHandledOK int64
+	lastStoreAt   time.Time
+	storedOffset  int64
+	hasStored     bool
+}
+
+func newOffsetTracker(countBeforeStorage int, flushInterval time.Duration, now func() time.Time) *offsetTracker {
+	if now == nil {
+		now = time.Now
+	}
+	return &offsetTracker{
+		countBeforeStorage: countBeforeStorage,
+		flushInterval:      flushInterval,
+		now:                now,
+		lastStoreAt:        now(),
+	}
+}
+
+// record applies the policy to one handled message and reports a store failure.
+// A handler error contributes nothing: the offset of a failed message is never
+// committed, and a later success therefore commits a HIGHER offset — the failed
+// message is skipped, not redelivered.
+func (t *offsetTracker) record(offset int64, handleErr error, store offsetStorer) error {
+	if handleErr != nil {
+		return nil
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.lastHandledOK = offset
+	t.pending++
+
+	if t.pending < t.countBeforeStorage && t.now().Sub(t.lastStoreAt) < t.flushInterval {
+		return nil
+	}
+	return t.storeLocked(store)
+}
+
+// flush commits whatever is pending. It runs on stop so a clean shutdown does
+// not replay work that was already handled successfully.
+func (t *offsetTracker) flush(store offsetStorer) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.pending == 0 {
+		return nil
+	}
+	return t.storeLocked(store)
+}
+
+// storeLocked commits the last successfully handled offset. On failure the
+// pending counter is deliberately left intact so the next message retries.
+func (t *offsetTracker) storeLocked(store offsetStorer) error {
+	if err := store.StoreCustomOffset(t.lastHandledOK); err != nil {
+		return err
+	}
+	t.storedOffset = t.lastHandledOK
+	t.hasStored = true
+	t.pending = 0
+	t.lastStoreAt = t.now()
+	return nil
+}
+
+// lastStored reports the last offset committed to the broker.
+func (t *offsetTracker) lastStored() (offset int64, ok bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.storedOffset, t.hasStored
+}
+
+// consumerRunner adapts one declared consumer to the stream client's callback.
+type consumerRunner struct {
+	name    string
+	handler Handler
+	tracker *offsetTracker
+	log     logger.Logger
+	tracer  trace.Tracer
+
+	// baseCtx is held rather than passed because the client's MessagesHandler
+	// carries no context of its own. The manager cancels it in StopConsumers.
+	baseCtx context.Context
+}
+
+// messagesHandler is the callback handed to the stream client. The client
+// invokes it sequentially per consumer, and the framework keeps it that way:
+// handlers run inline with no worker pool, because a stream is an ordered log
+// and any parallelism would both break that order and make a committed offset
+// claim messages behind it were handled.
+func (r *consumerRunner) messagesHandler(consumerContext stream.ConsumerContext, message *amqp.Message) {
+	consumer := consumerContext.Consumer
+	r.deliver(consumer.GetStreamName(), consumer.GetOffset(), message, consumer)
+}
+
+// deliver runs the handler for one message, then applies the commit policy.
+func (r *consumerRunner) deliver(streamName string, offset int64, message *amqp.Message, store offsetStorer) {
+	ctx, span := r.tracer.Start(r.baseCtx, streamName+" "+spanOperationReceive,
+		trace.WithSpanKind(trace.SpanKindConsumer))
+	defer span.End()
+
+	msg := &Message{
+		Data:       message.GetData(),
+		Offset:     offset,
+		Stream:     streamName,
+		Properties: message.ApplicationProperties,
+	}
+
+	span.SetAttributes(
+		attribute.String(string(semconv.MessagingSystemKey), messagingSystem),
+		semconv.MessagingOperationName(spanOperationReceive),
+		semconv.MessagingDestinationName(streamName),
+		semconv.MessagingMessageBodySize(len(msg.Data)),
+	)
+
+	start := time.Now()
+	err := r.invoke(ctx, msg)
+	tracking.RecordStreamConsume(ctx, streamName, time.Since(start), err)
+
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		r.log.Error().Err(err).
+			Str(logFieldStream, streamName).
+			Str(logFieldConsumer, r.name).
+			Int64(logFieldOffset, offset).
+			Msg("Stream message handling failed - offset not committed")
+	}
+
+	if storeErr := r.tracker.record(offset, err, store); storeErr != nil {
+		r.log.Warn().Err(storeErr).
+			Str(logFieldStream, streamName).
+			Str(logFieldConsumer, r.name).
+			Int64(logFieldOffset, offset).
+			Msg("Failed to store stream offset")
+	}
+}
+
+// invoke calls the module handler, converting a panic into an error so the
+// offset is not committed and consumption continues with the next message.
+func (r *consumerRunner) invoke(ctx context.Context, msg *Message) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("panic in stream handler: %v", recovered)
+			r.log.Error().
+				Str(logFieldStream, msg.Stream).
+				Str(logFieldConsumer, r.name).
+				Int64(logFieldOffset, msg.Offset).
+				Interface("panic", recovered).
+				Bytes("stack", debug.Stack()).
+				Msg("Panic recovered in stream handler - offset not committed")
+		}
+	}()
+
+	return r.handler(ctx, msg)
+}

--- a/messaging/streams/runner.go
+++ b/messaging/streams/runner.go
@@ -133,7 +133,7 @@ type consumerRunner struct {
 
 	// baseCtx is held rather than passed because the client's MessagesHandler
 	// carries no context of its own. The manager cancels it in StopConsumers.
-	baseCtx context.Context
+	baseCtx context.Context // NOSONAR S8242: no parameter to pass it through - the vendor callback signature is fixed
 }
 
 // messagesHandler is the callback handed to the stream client. The client

--- a/messaging/streams/runner_test.go
+++ b/messaging/streams/runner_test.go
@@ -1,0 +1,355 @@
+package streams
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+
+	"github.com/gaborage/go-bricks/logger"
+)
+
+var errHandlerFailed = errors.New("handler failed")
+
+// fakeStorer records every offset handed to the broker, so tests assert exact
+// stored values rather than "was called".
+type fakeStorer struct {
+	mu      sync.Mutex
+	stored  []int64
+	failNow bool
+}
+
+func (f *fakeStorer) StoreCustomOffset(offset int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failNow {
+		return errors.New("store failed")
+	}
+	f.stored = append(f.stored, offset)
+	return nil
+}
+
+func (f *fakeStorer) offsets() []int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]int64(nil), f.stored...)
+}
+
+// fakeClock advances only when a test says so, so interval-triggered commits
+// never depend on sleeping.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Date(2026, 8, 12, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+func newTestRunner(t *testing.T, handler Handler, tracker *offsetTracker) *consumerRunner {
+	t.Helper()
+	return newTestRunnerWithLogger(t, handler, tracker, logger.New("error", false))
+}
+
+func newTestRunnerWithLogger(t *testing.T, handler Handler, tracker *offsetTracker, log logger.Logger) *consumerRunner {
+	t.Helper()
+	return &consumerRunner{
+		name:    testConsumerName,
+		handler: handler,
+		tracker: tracker,
+		log:     log,
+		tracer:  otel.Tracer(tracerName),
+		baseCtx: context.Background(),
+	}
+}
+
+func amqpMessage(body string) *amqp.Message {
+	return &amqp.Message{
+		Data:                  [][]byte{[]byte(body)},
+		ApplicationProperties: map[string]any{"kind": "test"},
+	}
+}
+
+func TestOffsetTrackerStoresAfterCountThreshold(t *testing.T) {
+	clock := newFakeClock()
+	tracker := newOffsetTracker(3, time.Hour, clock.Now)
+	storer := &fakeStorer{}
+
+	for offset := int64(10); offset <= 12; offset++ {
+		require.NoError(t, tracker.record(offset, nil, storer))
+	}
+
+	assert.Equal(t, []int64{12}, storer.offsets(), "exactly the third offset is committed")
+}
+
+func TestOffsetTrackerDoesNotStoreBeforeThreshold(t *testing.T) {
+	clock := newFakeClock()
+	tracker := newOffsetTracker(3, time.Hour, clock.Now)
+	storer := &fakeStorer{}
+
+	require.NoError(t, tracker.record(10, nil, storer))
+	require.NoError(t, tracker.record(11, nil, storer))
+
+	assert.Empty(t, storer.offsets())
+}
+
+func TestOffsetTrackerStoresAfterInterval(t *testing.T) {
+	clock := newFakeClock()
+	tracker := newOffsetTracker(1000, 5*time.Second, clock.Now)
+	storer := &fakeStorer{}
+
+	require.NoError(t, tracker.record(7, nil, storer))
+	assert.Empty(t, storer.offsets(), "interval has not elapsed yet")
+
+	clock.advance(5 * time.Second)
+	require.NoError(t, tracker.record(8, nil, storer))
+
+	assert.Equal(t, []int64{8}, storer.offsets())
+}
+
+func TestOffsetTrackerNeverStoresAFailedOffset(t *testing.T) {
+	clock := newFakeClock()
+	tracker := newOffsetTracker(1, time.Hour, clock.Now)
+	storer := &fakeStorer{}
+
+	require.NoError(t, tracker.record(41, errHandlerFailed, storer))
+
+	assert.Empty(t, storer.offsets(), "a failed message must not advance the stored offset")
+}
+
+func TestOffsetTrackerLaterSuccessStoresHigherOffset(t *testing.T) {
+	clock := newFakeClock()
+	tracker := newOffsetTracker(1, time.Hour, clock.Now)
+	storer := &fakeStorer{}
+
+	require.NoError(t, tracker.record(5, nil, storer))
+	require.NoError(t, tracker.record(6, errHandlerFailed, storer))
+	require.NoError(t, tracker.record(7, nil, storer))
+
+	assert.Equal(t, []int64{5, 7}, storer.offsets(), "the failed offset is skipped, not replayed")
+}
+
+func TestOffsetTrackerFlushCommitsPending(t *testing.T) {
+	clock := newFakeClock()
+	tracker := newOffsetTracker(1000, time.Hour, clock.Now)
+	storer := &fakeStorer{}
+
+	require.NoError(t, tracker.record(100, nil, storer))
+	require.NoError(t, tracker.record(101, nil, storer))
+	require.Empty(t, storer.offsets())
+
+	require.NoError(t, tracker.flush(storer))
+
+	assert.Equal(t, []int64{101}, storer.offsets(), "a clean stop commits the last handled offset")
+}
+
+func TestOffsetTrackerFlushWithNothingPendingIsNoop(t *testing.T) {
+	clock := newFakeClock()
+	tracker := newOffsetTracker(1, time.Hour, clock.Now)
+	storer := &fakeStorer{}
+
+	require.NoError(t, tracker.record(3, nil, storer))
+	require.Equal(t, []int64{3}, storer.offsets())
+
+	require.NoError(t, tracker.flush(storer))
+
+	assert.Equal(t, []int64{3}, storer.offsets(), "flush must not re-commit an already stored offset")
+}
+
+func TestOffsetTrackerFlushAfterOnlyFailuresStoresNothing(t *testing.T) {
+	clock := newFakeClock()
+	tracker := newOffsetTracker(1000, time.Hour, clock.Now)
+	storer := &fakeStorer{}
+
+	require.NoError(t, tracker.record(9, errHandlerFailed, storer))
+	require.NoError(t, tracker.flush(storer))
+
+	assert.Empty(t, storer.offsets())
+}
+
+func TestOffsetTrackerRetriesAfterStoreFailure(t *testing.T) {
+	clock := newFakeClock()
+	tracker := newOffsetTracker(1, time.Hour, clock.Now)
+	storer := &fakeStorer{failNow: true}
+
+	require.Error(t, tracker.record(20, nil, storer))
+	assert.Empty(t, storer.offsets())
+
+	storer.failNow = false
+	require.NoError(t, tracker.record(21, nil, storer))
+
+	assert.Equal(t, []int64{21}, storer.offsets(), "the next message retries the commit")
+}
+
+func TestOffsetTrackerLastStored(t *testing.T) {
+	clock := newFakeClock()
+	tracker := newOffsetTracker(1, time.Hour, clock.Now)
+	storer := &fakeStorer{}
+
+	offset, ok := tracker.lastStored()
+	assert.False(t, ok)
+	assert.Equal(t, int64(0), offset)
+
+	require.NoError(t, tracker.record(77, nil, storer))
+
+	offset, ok = tracker.lastStored()
+	assert.True(t, ok)
+	assert.Equal(t, int64(77), offset)
+}
+
+func TestOffsetTrackerDefaultsToWallClock(t *testing.T) {
+	tracker := newOffsetTracker(1, time.Hour, nil)
+
+	require.NotNil(t, tracker.now)
+	assert.WithinDuration(t, time.Now(), tracker.lastStoreAt, time.Minute)
+}
+
+func TestRunnerDeliverPassesMessageToHandler(t *testing.T) {
+	clock := newFakeClock()
+	var got *Message
+	runner := newTestRunner(t, func(_ context.Context, msg *Message) error {
+		got = msg
+		return nil
+	}, newOffsetTracker(1, time.Hour, clock.Now))
+	storer := &fakeStorer{}
+
+	runner.deliver(testStream, 55, amqpMessage("payload"), storer)
+
+	require.NotNil(t, got)
+	assert.Equal(t, []byte("payload"), got.Data)
+	assert.Equal(t, int64(55), got.Offset)
+	assert.Equal(t, testStream, got.Stream)
+	assert.Equal(t, map[string]any{"kind": "test"}, got.Properties)
+	assert.Equal(t, []int64{55}, storer.offsets())
+}
+
+func TestRunnerDeliverHandlerErrorSkipsOffsetCommit(t *testing.T) {
+	clock := newFakeClock()
+	runner := newTestRunner(t, func(context.Context, *Message) error {
+		return errHandlerFailed
+	}, newOffsetTracker(1, time.Hour, clock.Now))
+	storer := &fakeStorer{}
+
+	runner.deliver(testStream, 61, amqpMessage("payload"), storer)
+
+	assert.Empty(t, storer.offsets())
+}
+
+func TestRunnerDeliverRecoversPanicAndContinues(t *testing.T) {
+	clock := newFakeClock()
+	handled := 0
+	runner := newTestRunner(t, func(_ context.Context, msg *Message) error {
+		handled++
+		if msg.Offset == 1 {
+			panic("boom")
+		}
+		return nil
+	}, newOffsetTracker(1, time.Hour, clock.Now))
+	storer := &fakeStorer{}
+
+	assert.NotPanics(t, func() {
+		runner.deliver(testStream, 1, amqpMessage("first"), storer)
+		runner.deliver(testStream, 2, amqpMessage("second"), storer)
+	})
+
+	assert.Equal(t, 2, handled, "the stream continues after a panicking handler")
+	assert.Equal(t, []int64{2}, storer.offsets(), "the panicking message's offset is never committed")
+}
+
+func TestRunnerInvokeWrapsPanicAsError(t *testing.T) {
+	runner := newTestRunner(t, func(context.Context, *Message) error {
+		panic("kaboom")
+	}, newOffsetTracker(1, time.Hour, nil))
+
+	err := runner.invoke(context.Background(), &Message{Stream: testStream, Offset: 3})
+
+	require.Error(t, err)
+	assert.Equal(t, "panic in stream handler: kaboom", err.Error())
+}
+
+// TestRunnerDeliverSurvivesStoreFailure pins the commit guard from the failing
+// side: consumption continues, nothing reached the broker, and the operator is
+// told which offset did not land, with the store error attached.
+func TestRunnerDeliverSurvivesStoreFailure(t *testing.T) {
+	clock := newFakeClock()
+	log := &recordingLogger{}
+	runner := newTestRunnerWithLogger(t, func(context.Context, *Message) error { return nil },
+		newOffsetTracker(1, time.Hour, clock.Now), log)
+	storer := &fakeStorer{failNow: true}
+
+	assert.NotPanics(t, func() {
+		runner.deliver(testStream, 12, amqpMessage("payload"), storer)
+	})
+
+	assert.Empty(t, storer.offsets())
+	assert.Equal(t, []string{msgOffsetStoreFailed}, log.warnMessages())
+	storeErr, ok := log.warnError(msgOffsetStoreFailed)
+	require.True(t, ok)
+	assert.Equal(t, "store failed", storeErr)
+}
+
+// TestRunnerDeliverIsSilentWhenTheOffsetLands is the other side: the commit
+// succeeded, so the delivery reports no store failure.
+func TestRunnerDeliverIsSilentWhenTheOffsetLands(t *testing.T) {
+	clock := newFakeClock()
+	log := &recordingLogger{}
+	runner := newTestRunnerWithLogger(t, func(context.Context, *Message) error { return nil },
+		newOffsetTracker(1, time.Hour, clock.Now), log)
+	storer := &fakeStorer{}
+
+	runner.deliver(testStream, 12, amqpMessage("payload"), storer)
+
+	assert.Equal(t, []int64{12}, storer.offsets())
+	assert.Empty(t, log.warnMessages(), "a committed offset is not reported as a failure")
+}
+
+// TestRunnerDeliverHandlerErrorReportsNoStoreFailure covers the third path into
+// the commit guard: a failed handler contributes no offset, so record returns nil
+// and the delivery must not claim the offset failed to store. The handler failure
+// itself is reported at ERROR.
+func TestRunnerDeliverHandlerErrorReportsNoStoreFailure(t *testing.T) {
+	clock := newFakeClock()
+	log := &recordingLogger{}
+	runner := newTestRunnerWithLogger(t, func(context.Context, *Message) error { return errHandlerFailed },
+		newOffsetTracker(1, time.Hour, clock.Now), log)
+	storer := &fakeStorer{}
+
+	runner.deliver(testStream, 61, amqpMessage("payload"), storer)
+
+	assert.Empty(t, storer.offsets())
+	assert.Empty(t, log.warnMessages(),
+		"the offset was never eligible for a commit, so nothing failed to store")
+}
+
+func TestRunnerDeliverHandlesEmptyBody(t *testing.T) {
+	clock := newFakeClock()
+	var got *Message
+	runner := newTestRunner(t, func(_ context.Context, msg *Message) error {
+		got = msg
+		return nil
+	}, newOffsetTracker(1, time.Hour, clock.Now))
+
+	runner.deliver(testStream, 1, &amqp.Message{}, &fakeStorer{})
+
+	require.NotNil(t, got)
+	assert.Nil(t, got.Data)
+	assert.Nil(t, got.Properties)
+}

--- a/messaging/streams/streams_integration_test.go
+++ b/messaging/streams/streams_integration_test.go
@@ -1,0 +1,312 @@
+//go:build integration
+
+package streams
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/message"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/testing/containers"
+)
+
+const (
+	itStream       = "it-orders"
+	itConsumerName = "it-group"
+	itWaitTimeout  = 20 * time.Second
+	itPollInterval = 50 * time.Millisecond
+)
+
+// recorder collects the messages a handler saw, in arrival order.
+type recorder struct {
+	mu       sync.Mutex
+	offsets  []int64
+	bodies   []string
+	failAt   int64
+	failures int
+}
+
+func (r *recorder) handle(_ context.Context, msg *Message) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.offsets = append(r.offsets, msg.Offset)
+	r.bodies = append(r.bodies, string(msg.Data))
+	if r.failAt >= 0 && msg.Offset == r.failAt {
+		r.failures++
+		return errors.New("deliberate handler failure")
+	}
+	return nil
+}
+
+func (r *recorder) snapshot() (offsets []int64, bodies []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]int64(nil), r.offsets...), append([]string(nil), r.bodies...)
+}
+
+func (r *recorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.offsets)
+}
+
+// streamsTestEnv boots RabbitMQ with the stream plugin and returns the manager
+// options every test in this file uses.
+func streamsTestEnv(ctx context.Context, t *testing.T) ManagerOptions {
+	t.Helper()
+
+	cfg := containers.DefaultRabbitMQConfig()
+	cfg.EnableStreamPlugin = true
+	container := containers.MustStartRabbitMQContainer(ctx, t, cfg).WithCleanup(t)
+
+	return ManagerOptions{
+		URI: container.StreamURI(),
+		// Without the resolver the broker advertises its container-internal address
+		// and the client's follow-up dial from the host fails.
+		AddressResolverHost: container.Host(),
+		AddressResolverPort: container.StreamPort(),
+		OffsetStoreCount:    1,
+		OffsetStoreInterval: 100 * time.Millisecond,
+		Logger:              logger.New("error", false),
+	}
+}
+
+// publish writes n messages through a test-only producer environment. Producers
+// are deliberately outside the framework surface, so tests drive the client directly.
+func publish(t *testing.T, opts ManagerOptions, streamName string, bodies []string) {
+	t.Helper()
+
+	envOpts := stream.NewEnvironmentOptions().
+		SetUri(opts.URI).
+		SetAddressResolver(stream.AddressResolver{Host: opts.AddressResolverHost, Port: opts.AddressResolverPort})
+	env, err := stream.NewEnvironment(envOpts)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, env.Close()) }()
+
+	producer, err := env.NewProducer(streamName, stream.NewProducerOptions())
+	require.NoError(t, err)
+
+	batch := make([]message.StreamMessage, 0, len(bodies))
+	for _, body := range bodies {
+		batch = append(batch, amqp.NewMessage([]byte(body)))
+	}
+	require.NoError(t, producer.BatchSend(batch))
+	require.NoError(t, producer.Close())
+}
+
+func bodiesFrom(prefix string, from, count int) []string {
+	out := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		out = append(out, fmt.Sprintf("%s-%d", prefix, from+i))
+	}
+	return out
+}
+
+func startManager(t *testing.T, opts ManagerOptions, handler Handler) *Manager {
+	t.Helper()
+
+	decls := NewDeclarations()
+	decls.DeclareStream(itStream, &StreamSpec{MaxLengthBytes: 10 * 1024 * 1024})
+	decls.DeclareConsumer(&ConsumerOptions{
+		Stream:  itStream,
+		Name:    itConsumerName,
+		Start:   OffsetFirst(),
+		Handler: handler,
+	})
+
+	m := NewManager(opts)
+	require.NoError(t, m.Start(context.Background(), decls))
+	return m
+}
+
+func waitForCount(t *testing.T, r *recorder, want int) {
+	t.Helper()
+	require.Eventually(t, func() bool { return r.count() >= want }, itWaitTimeout, itPollInterval,
+		"expected %d messages, saw %d", want, r.count())
+}
+
+// TestStreamsManagerConsumesAndRestoresOffsetIntegration proves the server-side
+// offset contract end to end: a restarted manager with the same consumer name
+// resumes after the last committed offset instead of replaying the stream.
+func TestStreamsManagerConsumesAndRestoresOffsetIntegration(t *testing.T) {
+	ctx := context.Background()
+	opts := streamsTestEnv(ctx, t)
+
+	first := &recorder{failAt: -1}
+	m := startManager(t, opts, first.handle)
+
+	publish(t, opts, itStream, bodiesFrom("msg", 0, 10))
+	waitForCount(t, first, 10)
+
+	offsets, bodies := first.snapshot()
+	require.Len(t, offsets, 10)
+	assert.Equal(t, bodiesFrom("msg", 0, 10), bodies, "messages arrive in stream order")
+	for i := 1; i < len(offsets); i++ {
+		assert.Greater(t, offsets[i], offsets[i-1], "offsets are monotonically increasing")
+	}
+
+	require.Eventually(t, func() bool {
+		stored, ok := m.Stats()["stored_offsets"].(map[string]int64)
+		return ok && stored[itStream+"/"+itConsumerName] == offsets[9]
+	}, itWaitTimeout, itPollInterval, "the last handled offset must reach the broker")
+
+	m.StopConsumers()
+	require.NoError(t, m.Close())
+
+	// A fresh manager under the same consumer name must not re-read the first 10.
+	second := &recorder{failAt: -1}
+	m2 := startManager(t, opts, second.handle)
+	t.Cleanup(func() {
+		m2.StopConsumers()
+		require.NoError(t, m2.Close())
+	})
+
+	publish(t, opts, itStream, bodiesFrom("msg", 10, 3))
+	waitForCount(t, second, 3)
+
+	_, secondBodies := second.snapshot()
+	assert.Equal(t, bodiesFrom("msg", 10, 3), secondBodies,
+		"the stored offset wins over the declared Start position")
+	assert.Equal(t, 3, second.count(), "no message is replayed after a clean stop")
+}
+
+// TestStreamsManagerSkipsFailedMessageIntegration pins the documented consequence
+// of committing only after success: a failed message is skipped, never redelivered.
+func TestStreamsManagerSkipsFailedMessageIntegration(t *testing.T) {
+	ctx := context.Background()
+	opts := streamsTestEnv(ctx, t)
+
+	// Offset 4 is the fifth message in a fresh stream.
+	failing := &recorder{failAt: 4}
+	m := startManager(t, opts, failing.handle)
+
+	publish(t, opts, itStream, bodiesFrom("msg", 0, 10))
+	waitForCount(t, failing, 10)
+
+	offsets, _ := failing.snapshot()
+	assert.Equal(t, 1, failing.failures, "exactly one handler failure")
+	assert.Equal(t, int64(9), offsets[9], "the stream continued past the failure")
+
+	require.Eventually(t, func() bool {
+		stored, ok := m.Stats()["stored_offsets"].(map[string]int64)
+		return ok && stored[itStream+"/"+itConsumerName] == int64(9)
+	}, itWaitTimeout, itPollInterval, "a later success commits a HIGHER offset than the failed one")
+
+	m.StopConsumers()
+	require.NoError(t, m.Close())
+
+	replay := &recorder{failAt: -1}
+	m2 := startManager(t, opts, replay.handle)
+	t.Cleanup(func() {
+		m2.StopConsumers()
+		require.NoError(t, m2.Close())
+	})
+
+	publish(t, opts, itStream, bodiesFrom("msg", 10, 2))
+	waitForCount(t, replay, 2)
+
+	_, replayed := replay.snapshot()
+	assert.Equal(t, bodiesFrom("msg", 10, 2), replayed,
+		"the failed message is skipped on restart - streams have no redelivery")
+}
+
+// startSACManager starts a single active consumer, whose promotion callback is the
+// code path the client invokes from its own read-loop goroutine.
+func startSACManager(t *testing.T, opts ManagerOptions, handler Handler) *Manager {
+	t.Helper()
+
+	decls := NewDeclarations()
+	decls.DeclareStream(itStream, &StreamSpec{MaxLengthBytes: 10 * 1024 * 1024})
+	decls.DeclareConsumer(&ConsumerOptions{
+		Stream:  itStream,
+		Name:    itConsumerName,
+		Start:   OffsetFirst(),
+		SAC:     true,
+		Handler: handler,
+	})
+
+	m := NewManager(opts)
+	require.NoError(t, m.Start(context.Background(), decls))
+	return m
+}
+
+// TestStreamsManagerSingleActiveConsumerIntegration exercises the SAC promotion
+// callback the client fires outside the manager's lock. Run with -race, it covers
+// the environment snapshot that callback closes over: reading m.env there instead
+// would be an unsynchronized read of a field Close nils.
+func TestStreamsManagerSingleActiveConsumerIntegration(t *testing.T) {
+	ctx := context.Background()
+	opts := streamsTestEnv(ctx, t)
+
+	first := &recorder{failAt: -1}
+	m := startSACManager(t, opts, first.handle)
+
+	publish(t, opts, itStream, bodiesFrom("msg", 0, 6))
+	waitForCount(t, first, 6)
+
+	_, bodies := first.snapshot()
+	assert.Equal(t, bodiesFrom("msg", 0, 6), bodies, "the promoted consumer starts at the declared position")
+
+	require.Eventually(t, func() bool {
+		stored, ok := m.Stats()["stored_offsets"].(map[string]int64)
+		return ok && stored[itStream+"/"+itConsumerName] == 5
+	}, itWaitTimeout, itPollInterval, "the promoted consumer commits its offsets")
+
+	m.StopConsumers()
+	require.NoError(t, m.Close())
+
+	// A new group member is promoted in turn and must resume from the stored offset.
+	second := &recorder{failAt: -1}
+	m2 := startSACManager(t, opts, second.handle)
+	t.Cleanup(func() {
+		m2.StopConsumers()
+		require.NoError(t, m2.Close())
+	})
+
+	publish(t, opts, itStream, bodiesFrom("msg", 6, 2))
+	waitForCount(t, second, 2)
+
+	_, resumed := second.snapshot()
+	assert.Equal(t, bodiesFrom("msg", 6, 2), resumed,
+		"promotion resolves the stored offset, not the declared start position")
+}
+
+// TestStreamsManagerDisposesEnvironmentOnDeclareFailureIntegration exercises a real
+// post-dial failure: re-declaring an existing stream with different retention makes
+// the broker answer precondition-failed, so Start fails with the environment already
+// dialed. Manager is exported API, so a caller that treats that error as fatal
+// without calling Close must not leak the connection pool.
+func TestStreamsManagerDisposesEnvironmentOnDeclareFailureIntegration(t *testing.T) {
+	ctx := context.Background()
+	opts := streamsTestEnv(ctx, t)
+
+	first := NewManager(opts)
+	firstDecls := NewDeclarations()
+	firstDecls.DeclareStream(itStream, &StreamSpec{MaxAge: time.Hour})
+	require.NoError(t, first.Start(ctx, firstDecls))
+	first.StopConsumers()
+	require.NoError(t, first.Close())
+
+	// Same stream, different retention: the broker rejects the declaration.
+	second := NewManager(opts)
+	conflicting := NewDeclarations()
+	conflicting.DeclareStream(itStream, &StreamSpec{MaxAge: 48 * time.Hour})
+
+	err := second.Start(ctx, conflicting)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to declare stream")
+	assert.Nil(t, second.env, "the dialed environment is disposed by the failed Start itself")
+	assert.False(t, second.started)
+	require.NoError(t, second.Close(), "the caller's follow-up Close short-circuits instead of double-closing")
+}

--- a/testing/containers/rabbitmq.go
+++ b/testing/containers/rabbitmq.go
@@ -5,12 +5,24 @@ package containers
 import (
 	"context"
 	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/rabbitmq"
 	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	// streamPortSpec is the native stream-protocol port the rabbitmq_stream plugin binds.
+	streamPortSpec = "5552/tcp"
+
+	streamPluginReadyTimeout = 30 * time.Second
+	streamPluginPollInterval = 250 * time.Millisecond
 )
 
 // RabbitMQContainerConfig holds configuration for RabbitMQ test container
@@ -23,6 +35,9 @@ type RabbitMQContainerConfig struct {
 	Password string
 	// StartupTimeout for container initialization (default: 60 seconds)
 	StartupTimeout time.Duration
+	// EnableStreamPlugin publishes port 5552 and enables the rabbitmq_stream
+	// plugin after boot, for tests that speak the native stream protocol.
+	EnableStreamPlugin bool
 }
 
 // DefaultRabbitMQConfig returns a RabbitMQContainerConfig populated with sensible defaults.
@@ -41,10 +56,13 @@ func DefaultRabbitMQConfig() *RabbitMQContainerConfig {
 
 // RabbitMQContainer wraps testcontainers RabbitMQ container with helper methods
 type RabbitMQContainer struct {
-	container *rabbitmq.RabbitMQContainer
-	brokerURL string
-	host      string
-	port      int
+	container  *rabbitmq.RabbitMQContainer
+	brokerURL  string
+	host       string
+	port       int
+	streamPort int
+	username   string
+	password   string
 }
 
 // StartRabbitMQContainer starts a RabbitMQ testcontainer using the provided configuration.
@@ -65,8 +83,7 @@ func StartRabbitMQContainer(ctx context.Context, t *testing.T, cfg *RabbitMQCont
 
 	// Use composite wait strategy: log message (fast early signal) + port listening (network verification)
 	// This prevents race conditions where the log appears but RabbitMQ isn't ready to accept connections
-	rmqContainer, err := rabbitmq.Run(ctx,
-		fmt.Sprintf("rabbitmq:%s", cfg.ImageTag),
+	opts := []testcontainers.ContainerCustomizer{
 		rabbitmq.WithAdminUsername(cfg.Username),
 		rabbitmq.WithAdminPassword(cfg.Password),
 		testcontainers.WithWaitStrategy(
@@ -75,7 +92,14 @@ func StartRabbitMQContainer(ctx context.Context, t *testing.T, cfg *RabbitMQCont
 				wait.ForListeningPort("5672/tcp"),
 			).WithStartupTimeout(cfg.StartupTimeout),
 		),
-	)
+	}
+	if cfg.EnableStreamPlugin {
+		// The port must be published at creation time; the plugin that binds it is
+		// enabled after boot, so it cannot join the wait strategy above.
+		opts = append(opts, testcontainers.WithExposedPorts(streamPortSpec))
+	}
+
+	rmqContainer, err := rabbitmq.Run(ctx, fmt.Sprintf("rabbitmq:%s", cfg.ImageTag), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start RabbitMQ container: %w", err)
 	}
@@ -103,12 +127,53 @@ func StartRabbitMQContainer(ctx context.Context, t *testing.T, cfg *RabbitMQCont
 
 	t.Logf("RabbitMQ container started successfully at %s:%d", host, port)
 
-	return &RabbitMQContainer{
+	container := &RabbitMQContainer{
 		container: rmqContainer,
 		brokerURL: amqpURL,
 		host:      host,
 		port:      port,
-	}, nil
+		username:  cfg.Username,
+		password:  cfg.Password,
+	}
+
+	if cfg.EnableStreamPlugin {
+		streamPort, err := enableStreamPlugin(ctx, rmqContainer)
+		if err != nil {
+			_ = rmqContainer.Terminate(ctx)
+			return nil, err
+		}
+		container.streamPort = streamPort
+		t.Logf("RabbitMQ stream protocol available at %s:%d", host, streamPort)
+	}
+
+	return container, nil
+}
+
+// enableStreamPlugin turns on rabbitmq_stream in a running container and waits for
+// its listener to accept connections on the mapped port. The container's own wait
+// strategy ran before the plugin existed, so readiness is polled here.
+func enableStreamPlugin(ctx context.Context, c *rabbitmq.RabbitMQContainer) (port int, err error) {
+	code, reader, err := c.Exec(ctx, []string{"rabbitmq-plugins", "enable", "rabbitmq_stream"})
+	if err != nil {
+		return 0, fmt.Errorf("failed to enable rabbitmq_stream plugin: %w", err)
+	}
+	if code != 0 {
+		output, _ := io.ReadAll(reader)
+		return 0, fmt.Errorf("rabbitmq-plugins enable rabbitmq_stream exited %d: %s", code, output)
+	}
+
+	strategy := wait.ForListeningPort(streamPortSpec).
+		WithStartupTimeout(streamPluginReadyTimeout).
+		WithPollInterval(streamPluginPollInterval)
+	if err := strategy.WaitUntilReady(ctx, c); err != nil {
+		return 0, fmt.Errorf("rabbitmq_stream listener did not become ready: %w", err)
+	}
+
+	mapped, err := c.MappedPort(ctx, streamPortSpec)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get RabbitMQ stream port: %w", err)
+	}
+	return int(mapped.Num()), nil
 }
 
 // BrokerURL returns the AMQP connection URL for the running container.
@@ -124,6 +189,27 @@ func (r *RabbitMQContainer) Host() string {
 // Port returns the host-side port Docker mapped to the container's 5672.
 func (r *RabbitMQContainer) Port() int {
 	return r.port
+}
+
+// StreamPort returns the host-side port Docker mapped to the container's 5552.
+// Zero when the container was started without EnableStreamPlugin.
+func (r *RabbitMQContainer) StreamPort() int {
+	return r.streamPort
+}
+
+// StreamURI returns the native stream-protocol URI for the default vhost.
+// Clients must also pin an address resolver to Host/StreamPort: the broker
+// advertises its container-internal address, which the host cannot dial.
+func (r *RabbitMQContainer) StreamURI() string {
+	// url.UserPassword escapes credentials containing @ : or /, and JoinHostPort
+	// brackets an IPv6 literal, which some Docker setups return from Host(). The
+	// vhost is appended already-encoded: %2f is how the default "/" vhost is spelled.
+	u := url.URL{
+		Scheme: "rabbitmq-stream",
+		User:   url.UserPassword(r.username, r.password),
+		Host:   net.JoinHostPort(r.host, strconv.Itoa(r.streamPort)),
+	}
+	return u.String() + "/%2f"
 }
 
 // Terminate stops and removes the RabbitMQ container

--- a/testing/containers/rabbitmq.go
+++ b/testing/containers/rabbitmq.go
@@ -158,7 +158,10 @@ func enableStreamPlugin(ctx context.Context, c *rabbitmq.RabbitMQContainer) (por
 		return 0, fmt.Errorf("failed to enable rabbitmq_stream plugin: %w", err)
 	}
 	if code != 0 {
-		output, _ := io.ReadAll(reader)
+		output, readErr := io.ReadAll(reader)
+		if readErr != nil {
+			return 0, fmt.Errorf("rabbitmq-plugins enable rabbitmq_stream exited %d; reading its output failed: %w", code, readErr)
+		}
 		return 0, fmt.Errorf("rabbitmq-plugins enable rabbitmq_stream exited %d: %s", code, output)
 	}
 


### PR DESCRIPTION
## What

The consumption engine. `offsetTracker` owns the commit policy: an offset reaches the
broker only after its handler returns nil, on a count-or-interval trigger, with a final
flush on stop. `Manager` dials one stream Environment, declares streams, and runs an
`ha.ReliableConsumer` per declaration. Handlers run inline and sequentially — a stream
is an ordered log, so a worker pool would break ordering and make a committed offset
claim messages behind it were handled.

## Impact

Additive and still inert — no app wiring yet. The client's `SetAutoCommit` is
deliberately unused because it advances offsets for merely delivered messages. A failed
message is skipped, not redelivered: streams have no nack. Credential-bearing URIs are
redacted before logging.

## Verification

Exact stored offsets asserted via a fake storer and an injected clock — no sleeps, no
broker needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RabbitMQ stream management with stream declarations, consumer lifecycle controls, readiness status, and runtime statistics.
  * Added reliable sequential message processing with telemetry, structured logging, panic recovery, and offset commits after successful handling.
  * Added configurable offset storage by message count or time interval, including retries, shutdown flushing, and offset restoration.
  * Added single-active-consumer promotion and resumption support.
  * Added stream-consumption delivery and error metrics.

* **Security**
  * Credentials are redacted from connection-related errors and logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->