### PR TITLE
feat(config): add the messaging.streams configuration block

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -183,8 +183,9 @@ messaging:
   # Required only when a module implements app.StreamDeclarer. Separate listener
   # (default port 5552, rabbitmq_stream plugin); never derived from broker.url.
   # Single-tenant only: multitenant.enabled + a uri here fails startup.
+  # Credentials belong in the environment: MESSAGING_STREAMS_URI overrides uri.
   # streams:
-  #   uri: rabbitmq-stream://guest:guest@localhost:5552/%2f
+  #   uri: rabbitmq-stream://localhost:5552/%2f
   #   addressresolver:            # both or neither; needed behind a load balancer or NAT
   #     host: rabbitmq.example.com
   #     port: 5552

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -179,9 +179,9 @@ messaging:
   headers:
     x-app-name: my-service
     x-environment: development
-  # Native stream-protocol consumption (OPTIONAL - see wiki/streams.md).
-  # Required only when a module implements app.StreamDeclarer. Separate listener
-  # (default port 5552, rabbitmq_stream plugin); never derived from broker.url.
+  # Native stream-protocol consumption (OPTIONAL).
+  # Required only when a module declares native streams or consumers. Separate
+  # listener (default port 5552, rabbitmq_stream plugin); never derived from broker.url.
   # Single-tenant only: multitenant.enabled + a uri here fails startup.
   # Credentials belong in the environment: MESSAGING_STREAMS_URI overrides uri.
   # streams:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -179,6 +179,18 @@ messaging:
   headers:
     x-app-name: my-service
     x-environment: development
+  # Native stream-protocol consumption (OPTIONAL - see wiki/streams.md).
+  # Required only when a module implements app.StreamDeclarer. Separate listener
+  # (default port 5552, rabbitmq_stream plugin); never derived from broker.url.
+  # Single-tenant only: multitenant.enabled + a uri here fails startup.
+  # streams:
+  #   uri: rabbitmq-stream://guest:guest@localhost:5552/%2f
+  #   addressresolver:            # both or neither; needed behind a load balancer or NAT
+  #     host: rabbitmq.example.com
+  #     port: 5552
+  #   offsetstore:
+  #     countbeforestorage: 500   # handled messages before a server-side offset commit
+  #     flushinterval: 5s         # elapsed time before a pending offset is committed
 
 multitenant:
   enabled: false

--- a/config/types.go
+++ b/config/types.go
@@ -452,6 +452,53 @@ type MessagingConfig struct {
 	Headers   map[string]string   `koanf:"headers" json:"headers" yaml:"headers" toml:"headers" mapstructure:"headers"`
 	Reconnect ReconnectConfig     `koanf:"reconnect" json:"reconnect" yaml:"reconnect" toml:"reconnect" mapstructure:"reconnect"`
 	Publisher PublisherPoolConfig `koanf:"publisher" json:"publisher" yaml:"publisher" toml:"publisher" mapstructure:"publisher"`
+	Streams   StreamsConfig       `koanf:"streams" json:"streams" yaml:"streams" toml:"streams" mapstructure:"streams"`
+}
+
+// StreamsConfig holds native RabbitMQ stream-protocol settings (consumption).
+// Single-tenant only: multitenant.enabled together with a stream URI is a
+// startup validation error (see config/validation.go: validateMessagingStreams).
+type StreamsConfig struct {
+	// URI is the stream-protocol endpoint, scheme rabbitmq-stream:// (or
+	// rabbitmq-stream+tls://), default port 5552. Required when any module
+	// declares stream consumers. Deliberately NOT derived from
+	// messaging.broker.url — the stream protocol is a separate listener that a
+	// deployment may not expose at all (explicit > implicit).
+	URI string `koanf:"uri" json:"uri" yaml:"uri" toml:"uri" mapstructure:"uri"`
+
+	// AddressResolver pins the client to a single entry point (load balancer,
+	// NAT, or Docker port mapping), which the broker's own metadata cannot
+	// describe. Set both fields or neither.
+	AddressResolver StreamsAddressResolverConfig `koanf:"addressresolver" json:"addressresolver" yaml:"addressresolver" toml:"addressresolver" mapstructure:"addressresolver"`
+
+	// OffsetStore tunes how often successfully handled offsets are committed
+	// server-side.
+	OffsetStore StreamsOffsetStoreConfig `koanf:"offsetstore" json:"offsetstore" yaml:"offsetstore" toml:"offsetstore" mapstructure:"offsetstore"`
+}
+
+// StreamsAddressResolverConfig pins stream connections to one advertised endpoint.
+type StreamsAddressResolverConfig struct {
+	// Host is the entry-point hostname clients dial instead of the address the
+	// broker advertises in its metadata response.
+	Host string `koanf:"host" json:"host" yaml:"host" toml:"host" mapstructure:"host"`
+
+	// Port is the entry-point port. Must be 1-65535 when Host is set.
+	Port int `koanf:"port" json:"port" yaml:"port" toml:"port" mapstructure:"port"`
+}
+
+// StreamsOffsetStoreConfig tunes the server-side offset commit cadence.
+// Offsets are only ever committed AFTER a handler returned successfully, so
+// these keys trade commit traffic against how much already-handled work a
+// crash replays.
+type StreamsOffsetStoreConfig struct {
+	// CountBeforeStorage is how many successfully handled messages accumulate
+	// before the offset is committed. Default: 500. Must be >= 0 (0 applies the default).
+	CountBeforeStorage int `koanf:"countbeforestorage" json:"countbeforestorage" yaml:"countbeforestorage" toml:"countbeforestorage" mapstructure:"countbeforestorage"`
+
+	// FlushInterval is how long after the last commit a pending offset is
+	// committed even if CountBeforeStorage was not reached. Default: 5s.
+	// Must be >= 0 (0 applies the default).
+	FlushInterval time.Duration `koanf:"flushinterval" json:"flushinterval" yaml:"flushinterval" toml:"flushinterval" mapstructure:"flushinterval"`
 }
 
 // ReconnectConfig holds AMQP reconnection settings.

--- a/config/validation.go
+++ b/config/validation.go
@@ -298,10 +298,11 @@ func validateMessagingStreams(cfg *StreamsConfig, multitenant bool) error {
 				fmt.Sprintf(errNotSupportedFmt, u.Scheme),
 				[]string{streamsURIScheme + "://", streamsURITLSScheme + "://"})
 		}
-		// A missing "//" parses as an opaque URI with no host: it clears the scheme
-		// check but has nothing to dial, and redactStreamURI cannot render it, so the
-		// startup failure would name no endpoint at all.
-		if u.Host == "" {
+		// Nothing to dial in either shape: a missing "//" parses opaque with no host,
+		// and "://:5552" gives a port-only Host that a Host == "" check lets through.
+		// Hostname() strips the port, so it catches both; neither names a host in the
+		// manager's connect error, which shows the fixed placeholder or a bare "@:5552".
+		if u.Hostname() == "" {
 			return NewValidationError(fieldMessagingStreamsURI,
 				"must include a host, e.g. "+streamsURIScheme+"://<user>:<password>@<host>:5552/%2f")
 		}

--- a/config/validation.go
+++ b/config/validation.go
@@ -173,6 +173,8 @@ const (
 	fieldServerForwardedClientCertRequire = "server.forwardedclientcert.require"
 
 	fieldServerTrustedProxies = "server.trustedproxies"
+
+	fieldMessagingStreamsURI = "messaging.streams.uri"
 )
 
 func Validate(cfg *Config) error {
@@ -289,10 +291,10 @@ func validateMessagingStreams(cfg *StreamsConfig, multitenant bool) error {
 
 		u, err := url.Parse(cfg.URI)
 		if err != nil {
-			return NewValidationError("messaging.streams.uri", "must be a valid URI")
+			return NewValidationError(fieldMessagingStreamsURI, "must be a valid URI")
 		}
 		if u.Scheme != streamsURIScheme && u.Scheme != streamsURITLSScheme {
-			return NewInvalidFieldError("messaging.streams.uri",
+			return NewInvalidFieldError(fieldMessagingStreamsURI,
 				fmt.Sprintf(errNotSupportedFmt, u.Scheme),
 				[]string{streamsURIScheme + "://", streamsURITLSScheme + "://"})
 		}
@@ -300,7 +302,7 @@ func validateMessagingStreams(cfg *StreamsConfig, multitenant bool) error {
 		// check but has nothing to dial, and redactStreamURI cannot render it, so the
 		// startup failure would name no endpoint at all.
 		if u.Host == "" {
-			return NewValidationError("messaging.streams.uri",
+			return NewValidationError(fieldMessagingStreamsURI,
 				"must include a host, e.g. "+streamsURIScheme+"://<user>:<password>@<host>:5552/%2f")
 		}
 	}

--- a/config/validation.go
+++ b/config/validation.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"slices"
 	"strings"
 	"time"
@@ -64,6 +65,15 @@ const (
 	defaultPublisherIdleTTLMultiTenant = 10 * time.Minute
 	defaultPublisherCleanupInterval    = 2 * time.Minute // Publisher-pool cleanup goroutine frequency
 	defaultMaxPublishAttempts          = 5               // Bounded publish retry attempts before giving up
+)
+
+// Native stream-protocol (messaging.streams.*) defaults
+const (
+	defaultStreamsOffsetCount    = 500             // Handled messages before a server-side offset commit
+	defaultStreamsOffsetInterval = 5 * time.Second // Elapsed time before a pending offset is committed
+
+	streamsURIScheme    = "rabbitmq-stream"
+	streamsURITLSScheme = "rabbitmq-stream+tls"
 )
 
 // Cache manager defaults
@@ -250,7 +260,81 @@ func validateDebug(cfg *DebugConfig) error {
 // Returns an error if any setting is invalid; otherwise nil.
 func validateMessaging(cfg *MessagingConfig, multitenant bool) error {
 	// Apply messaging defaults (reconnection, publisher pool)
-	return applyMessagingDefaults(cfg, multitenant)
+	if err := applyMessagingDefaults(cfg, multitenant); err != nil {
+		return err
+	}
+
+	return validateMessagingStreams(&cfg.Streams, multitenant)
+}
+
+// validateMessagingStreams validates the native stream-protocol block and applies
+// its offset-store defaults.
+//
+// SECURITY: messaging.streams.uri carries broker credentials, so no error raised
+// here echoes the URI — only the config key and the offending scheme reach the
+// message.
+func validateMessagingStreams(cfg *StreamsConfig, multitenant bool) error {
+	if err := applyStreamsDefaults(cfg); err != nil {
+		return err
+	}
+
+	if cfg.URI != "" {
+		// Multi-tenant stream consumption would need one Environment per tenant and a
+		// per-tenant stream URI leg; until that exists the combination fails loudly
+		// instead of consuming one tenant's streams on behalf of all of them.
+		if multitenant {
+			return NewValidationError("messaging.streams",
+				"single-tenant only; multi-tenant stream consumption is not yet supported")
+		}
+
+		u, err := url.Parse(cfg.URI)
+		if err != nil {
+			return NewValidationError("messaging.streams.uri", "must be a valid URI")
+		}
+		if u.Scheme != streamsURIScheme && u.Scheme != streamsURITLSScheme {
+			return NewInvalidFieldError("messaging.streams.uri",
+				fmt.Sprintf(errNotSupportedFmt, u.Scheme),
+				[]string{streamsURIScheme + "://", streamsURITLSScheme + "://"})
+		}
+		// A missing "//" parses as an opaque URI with no host: it clears the scheme
+		// check but has nothing to dial, and redactStreamURI cannot render it, so the
+		// startup failure would name no endpoint at all.
+		if u.Host == "" {
+			return NewValidationError("messaging.streams.uri",
+				"must include a host, e.g. "+streamsURIScheme+"://<user>:<password>@<host>:5552/%2f")
+		}
+	}
+
+	return validateStreamsAddressResolver(&cfg.AddressResolver)
+}
+
+// validateStreamsAddressResolver enforces the both-or-neither rule: a host with no
+// port cannot be dialed, and a port with no host silently does nothing.
+func validateStreamsAddressResolver(cfg *StreamsAddressResolverConfig) error {
+	if cfg.Host == "" && cfg.Port == 0 {
+		return nil
+	}
+	if cfg.Host == "" {
+		return NewValidationError("messaging.streams.addressresolver.host",
+			"must be set when messaging.streams.addressresolver.port is set")
+	}
+	if cfg.Port < 1 || cfg.Port > 65535 {
+		return NewInvalidFieldError("messaging.streams.addressresolver.port",
+			fmt.Sprintf(errInvalidField, cfg.Port), []string{portRange})
+	}
+	return nil
+}
+
+// applyStreamsDefaults materializes the offset-store defaults with the same
+// "zero applies the default, negative is invalid" rule the rest of the messaging
+// block uses.
+func applyStreamsDefaults(cfg *StreamsConfig) error {
+	if err := applyNonNegativeDefault(&cfg.OffsetStore.CountBeforeStorage, defaultStreamsOffsetCount,
+		"messaging.streams.offsetstore.countbeforestorage"); err != nil {
+		return err
+	}
+	return applyNonNegativeDefault(&cfg.OffsetStore.FlushInterval, defaultStreamsOffsetInterval,
+		"messaging.streams.offsetstore.flushinterval")
 }
 
 // validateApp validates the application configuration in cfg.

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -5499,3 +5499,208 @@ func TestDatabaseIdentityKeysMatchPredicate(t *testing.T) {
 		})
 	}
 }
+
+// streamsFixturePassword is a fixture value, not a credential — the leak assertions
+// below prove it never reaches an error string.
+const streamsFixturePassword = "fixture-pw"
+
+func TestValidateMessagingStreamsURIScheme(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr string
+	}{
+		{name: "unset_uri_is_valid", uri: ""},
+		{name: "plain_scheme_accepted", uri: "rabbitmq-stream://svc:" + streamsFixturePassword + "@broker:5552/%2f"},
+		{name: "tls_scheme_accepted", uri: "rabbitmq-stream+tls://svc:" + streamsFixturePassword + "@broker:5551/%2f"},
+		{
+			name:    "amqp_scheme_rejected",
+			uri:     "amqp://svc:" + streamsFixturePassword + "@broker:5672/",
+			wantErr: "'amqp' is not supported must be one of: rabbitmq-stream://, rabbitmq-stream+tls://",
+		},
+		{
+			name:    "schemeless_value_rejected",
+			uri:     "broker:5552",
+			wantErr: "is not supported",
+		},
+		{
+			name:    "unparseable_uri_rejected",
+			uri:     "rabbitmq-stream://svc:" + streamsFixturePassword + "@broker:55 52/",
+			wantErr: "messaging.streams.uri must be a valid URI",
+		},
+		{
+			// The realistic typo: a missing "//" parses as an opaque URI whose scheme
+			// still passes the allowlist, leaving nothing to dial.
+			name:    "missing_double_slash_rejected",
+			uri:     "rabbitmq-stream:broker:5552",
+			wantErr: "messaging.streams.uri must include a host",
+		},
+		{
+			name:    "host_less_uri_with_credentials_rejected",
+			uri:     "rabbitmq-stream:svc:" + streamsFixturePassword + "@/vhost",
+			wantErr: "messaging.streams.uri must include a host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &MessagingConfig{Streams: StreamsConfig{URI: tt.uri}}
+
+			err := validateMessaging(cfg, false)
+
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.NotContains(t, err.Error(), streamsFixturePassword,
+				"messaging.streams.uri carries credentials; they must never reach an error message")
+		})
+	}
+}
+
+func TestValidateMessagingStreamsRejectsMultiTenant(t *testing.T) {
+	cfg := &MessagingConfig{Streams: StreamsConfig{
+		URI: "rabbitmq-stream://svc:" + streamsFixturePassword + "@broker:5552/%2f",
+	}}
+
+	err := validateMessaging(cfg, true)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "messaging.streams single-tenant only")
+	assert.Contains(t, err.Error(), "multi-tenant stream consumption is not yet supported")
+	assert.NotContains(t, err.Error(), streamsFixturePassword)
+}
+
+func TestValidateMessagingStreamsAllowsMultiTenantWithoutURI(t *testing.T) {
+	cfg := &MessagingConfig{}
+
+	require.NoError(t, validateMessaging(cfg, true),
+		"multi-tenant deployments that declare no streams stay valid")
+}
+
+func TestValidateMessagingStreamsAddressResolver(t *testing.T) {
+	tests := []struct {
+		name     string
+		resolver StreamsAddressResolverConfig
+		wantErr  string
+	}{
+		{name: "both_unset", resolver: StreamsAddressResolverConfig{}},
+		{name: "both_set", resolver: StreamsAddressResolverConfig{Host: "lb.example.com", Port: 5552}},
+		// Both ends of the accepted range are inclusive; without these the range
+		// check could be off by one at either edge and every other case still pass.
+		{name: "lowest_valid_port", resolver: StreamsAddressResolverConfig{Host: "lb.example.com", Port: 1}},
+		{name: "highest_valid_port", resolver: StreamsAddressResolverConfig{Host: "lb.example.com", Port: 65535}},
+		{
+			name:     "port_without_host",
+			resolver: StreamsAddressResolverConfig{Port: 5552},
+			wantErr:  "messaging.streams.addressresolver.host must be set",
+		},
+		{
+			name:     "host_without_port",
+			resolver: StreamsAddressResolverConfig{Host: "lb.example.com"},
+			wantErr:  "messaging.streams.addressresolver.port invalid value: 0 must be one of: 1-65535",
+		},
+		{
+			name:     "port_above_range",
+			resolver: StreamsAddressResolverConfig{Host: "lb.example.com", Port: 65536},
+			wantErr:  "messaging.streams.addressresolver.port invalid value: 65536 must be one of: 1-65535",
+		},
+		{
+			name:     "negative_port",
+			resolver: StreamsAddressResolverConfig{Host: "lb.example.com", Port: -1},
+			wantErr:  "messaging.streams.addressresolver.port invalid value: -1 must be one of: 1-65535",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &MessagingConfig{Streams: StreamsConfig{AddressResolver: tt.resolver}}
+
+			err := validateMessaging(cfg, false)
+
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestApplyStreamsDefaults(t *testing.T) {
+	t.Run("zero_applies_defaults", func(t *testing.T) {
+		cfg := &MessagingConfig{}
+
+		require.NoError(t, validateMessaging(cfg, false))
+
+		assert.Equal(t, 500, cfg.Streams.OffsetStore.CountBeforeStorage)
+		assert.Equal(t, defaultStreamsOffsetCount, cfg.Streams.OffsetStore.CountBeforeStorage)
+		assert.Equal(t, 5*time.Second, cfg.Streams.OffsetStore.FlushInterval)
+		assert.Equal(t, defaultStreamsOffsetInterval, cfg.Streams.OffsetStore.FlushInterval)
+	})
+
+	t.Run("explicit_values_preserved", func(t *testing.T) {
+		cfg := &MessagingConfig{Streams: StreamsConfig{OffsetStore: StreamsOffsetStoreConfig{
+			CountBeforeStorage: 25,
+			FlushInterval:      750 * time.Millisecond,
+		}}}
+
+		require.NoError(t, validateMessaging(cfg, false))
+
+		assert.Equal(t, 25, cfg.Streams.OffsetStore.CountBeforeStorage)
+		assert.Equal(t, 750*time.Millisecond, cfg.Streams.OffsetStore.FlushInterval)
+	})
+
+	t.Run("negative_count_rejected", func(t *testing.T) {
+		cfg := &MessagingConfig{Streams: StreamsConfig{OffsetStore: StreamsOffsetStoreConfig{CountBeforeStorage: -1}}}
+
+		err := validateMessaging(cfg, false)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "messaging.streams.offsetstore.countbeforestorage must be non-negative")
+	})
+
+	t.Run("negative_interval_rejected", func(t *testing.T) {
+		cfg := &MessagingConfig{Streams: StreamsConfig{OffsetStore: StreamsOffsetStoreConfig{FlushInterval: -time.Second}}}
+
+		err := validateMessaging(cfg, false)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "messaging.streams.offsetstore.flushinterval must be non-negative")
+	})
+}
+
+// TestValidateStreamsRejectsMultiTenantEndToEnd proves the fail-fast reaches the
+// public Validate(cfg) entry point, not just the internal seam.
+func TestValidateStreamsRejectsMultiTenantEndToEnd(t *testing.T) {
+	cfg := &Config{
+		App:    createValidAppConfig(),
+		Server: createValidServerConfig(),
+		Log:    createValidLogConfig(),
+		Messaging: MessagingConfig{Streams: StreamsConfig{
+			URI: "rabbitmq-stream://svc:" + streamsFixturePassword + "@broker:5552/%2f",
+		}},
+		Multitenant: MultitenantConfig{
+			Enabled:  true,
+			Resolver: ResolverConfig{Type: "header", Header: testTenantHeader},
+			Tenants: map[string]TenantEntry{
+				"acme": {Database: DatabaseConfig{
+					Type:     PostgreSQL,
+					Host:     "acme.db",
+					Port:     5432,
+					Database: "acme",
+					Username: "acme_user",
+				}},
+			},
+		},
+		Source: SourceConfig{Type: SourceTypeStatic},
+	}
+
+	err := Validate(cfg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "single-tenant only")
+}

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -5540,6 +5540,18 @@ func TestValidateMessagingStreamsURIScheme(t *testing.T) {
 			uri:     "rabbitmq-stream:svc:" + streamsFixturePassword + "@/vhost",
 			wantErr: "messaging.streams.uri must include a host",
 		},
+		{
+			// url.URL.Host carries the port, so ":5552" is a non-empty Host with an
+			// empty Hostname: a Host == "" check passes it through with nothing to dial.
+			name:    "port_without_hostname_rejected",
+			uri:     "rabbitmq-stream://:5552/%2f",
+			wantErr: "messaging.streams.uri must include a host",
+		},
+		{
+			name:    "port_without_hostname_with_credentials_rejected",
+			uri:     "rabbitmq-stream://svc:" + streamsFixturePassword + "@:5552/%2f",
+			wantErr: "messaging.streams.uri must include a host",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

Adds the `messaging.streams` config block: `uri`, `addressresolver.{host,port}` and
`offsetstore.{countbeforestorage,flushinterval}`, with validation. The URI scheme must
be `rabbitmq-stream` or `rabbitmq-stream+tls`, a host is required, and the address
resolver takes both fields or neither. Defaults are 500 messages and 5s.

## Impact

Additive — the block is optional and absent config changes nothing. Multi-tenant plus
streams is a hard validation error: single-tenant only, for now. Validation errors never
echo the URI, which carries credentials; they name the key and the problem.

## Verification

Table cases pin scheme accept/reject, the missing-`//` host-less typo, the resolver XOR,
the port boundaries at exactly 1 and 65535, and that no error string contains the
fixture password.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional configuration for consuming RabbitMQ streams through the native stream protocol.
  * Added support for stream address resolution and configurable offset commit behavior.
  * Added documented examples and defaults for stream settings.

* **Bug Fixes**
  * Improved validation for stream URIs, hosts, ports, and offset settings.
  * Prevented unsupported multi-tenant stream configurations.
  * Ensured sensitive credentials are excluded from validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->