### PR TITLE
feat(app): start native stream consumers during prepareRuntime

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gaborage/go-bricks/database"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/messaging/streams"
 	"github.com/gaborage/go-bricks/observability"
 	"github.com/gaborage/go-bricks/server"
 )
@@ -36,7 +37,10 @@ const (
 	componentDatabase  = "database"
 	componentMessaging = "messaging"
 	componentCache     = "cache"
-	errorKey           = "error"
+	componentStreams   = "streams"
+	// notReadyStatus marks a component that is reachable but not yet serving.
+	notReadyStatus = "not_ready"
+	errorKey       = "error"
 )
 
 var ErrNoTenantInContext = errors.New("no tenant in context")
@@ -84,6 +88,10 @@ type App struct {
 	messagingDeclarations *messaging.Declarations
 	messagingInitializer  *MessagingInitializer
 	connectionPreWarmer   *ConnectionPreWarmer
+
+	// streamsManager is created during prepareRuntime — never at build time — so
+	// its readiness probe and closer are registered there too (see streams_setup.go).
+	streamsManager *streams.Manager
 
 	closers      []namedCloser
 	healthProbes []Prober

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1309,7 +1309,7 @@ func TestMessagingDeclarationsBuiltOnceAndReused(t *testing.T) {
 	require.NoError(t, err)
 
 	// Declarations are built lazily during runtime preparation
-	require.NoError(t, fixture.app.prepareRuntime())
+	require.NoError(t, fixture.app.prepareRuntime(context.Background()))
 	assert.Equal(t, 1, counterModule.callCount, "DeclareMessaging should be called during runtime preparation")
 	assert.NotNil(t, fixture.app.messagingDeclarations, "messagingDeclarations should be built during runtime preparation")
 }

--- a/app/health.go
+++ b/app/health.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gaborage/go-bricks/database"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/messaging/streams"
 )
 
 // cacheProbePingTimeout caps the warm-path PING so a hung Redis reports unhealthy instead
@@ -180,7 +181,7 @@ func messagingManagerHealthProbe(msgManager *messaging.Manager, _ logger.Logger)
 			defer release() // probe holds no scope; release the lease when the check returns
 
 			if !client.IsReady() {
-				stats[statusKey] = "not_ready"
+				stats[statusKey] = notReadyStatus
 				return unhealthyStatus, stats, nil
 			}
 
@@ -190,6 +191,29 @@ func messagingManagerHealthProbe(msgManager *messaging.Manager, _ logger.Logger)
 			stats = getStatsOrEmpty(msgManager.Stats())
 			stats[statusKey] = healthyStatus
 			return healthyStatus, stats, nil
+		},
+	}
+}
+
+// streamsManagerHealthProbe creates a health probe for the native stream-protocol
+// manager. It is NON-critical: the reliable consumers reconnect on their own, so a
+// broker flap must not take the whole service out of the load balancer while they do.
+//
+// Unlike its siblings this probe is registered at runtime (see
+// prepareStreamConsumers) after a successful Start, so mgr is never nil and the
+// probe has no disabled arm: an absent registration already reports disabled
+// through componentReport.
+func streamsManagerHealthProbe(mgr *streams.Manager) Prober {
+	return healthProbeFunc{
+		name: componentStreams,
+		fn: func(context.Context) (string, map[string]any, error) {
+			stats := getStatsOrEmpty(mgr.Stats())
+			status := healthyStatus
+			if !mgr.Ready() {
+				status = notReadyStatus
+			}
+			stats[statusKey] = status
+			return status, stats, nil
 		},
 	}
 }

--- a/app/health_test.go
+++ b/app/health_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gaborage/go-bricks/internal/testutil"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/messaging/streams"
 	testmocks "github.com/gaborage/go-bricks/testing/mocks"
 )
 
@@ -823,4 +824,20 @@ func TestDatabaseManagerHealthProbeStillProbesPerTenantControlPlaneDatabase(t *t
 	assert.Equal(t, unhealthyStatus, result.Status, "a resolvable control-plane database must be probed, not relabeled")
 	require.Error(t, result.Err)
 	assert.True(t, result.Critical, "and it must still gate readiness")
+}
+
+func TestStreamsManagerHealthProbeReportsNotReady(t *testing.T) {
+	mgr := streams.NewManager(streams.ManagerOptions{
+		URI:    unreachableStreamURI,
+		Logger: logger.New("error", false),
+	})
+
+	result := streamsManagerHealthProbe(mgr).Run(context.Background())
+
+	assert.Equal(t, componentStreams, result.Name)
+	assert.Equal(t, notReadyStatus, result.Status)
+	assert.NoError(t, result.Err)
+	assert.False(t, result.Critical, "a reconnecting stream consumer must not 503 the whole service")
+	assert.Equal(t, notReadyStatus, result.Details[statusKey])
+	assert.Equal(t, false, result.Details["started"])
 }

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -86,7 +86,7 @@ func (a *App) prepareRuntime(ctx context.Context) error {
 
 	if !a.cfg.Multitenant.Enabled && a.connectionPreWarmer != nil && a.connectionPreWarmer.IsAvailable() {
 		a.connectionPreWarmer.LogAvailability()
-		if err := a.connectionPreWarmer.PreWarmSingleTenant(context.Background(), decls); err != nil {
+		if err := a.connectionPreWarmer.PreWarmSingleTenant(ctx, decls); err != nil {
 			a.logger.Warn().Err(err).Msg("Pre-warming completed with warnings")
 		}
 	}

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -62,8 +62,10 @@ func (a *App) warnIfCleanupIntervalTooLate(keyPrefix string, cleanupInterval, id
 			"(lower " + keyPrefix + ".cleanupinterval or raise " + keyPrefix + ".idlettl)")
 }
 
-// prepareRuntime prepares the application for runtime execution
-func (a *App) prepareRuntime() error {
+// prepareRuntime prepares the application for runtime execution. ctx is the
+// startup context: components it starts that outlive startup inherit that
+// context's values rather than beginning from a bare context.Background().
+func (a *App) prepareRuntime(ctx context.Context) error {
 	if err := a.buildMessagingDeclarations(); err != nil {
 		return err
 	}
@@ -78,7 +80,7 @@ func (a *App) prepareRuntime() error {
 		return err
 	}
 
-	if err := a.prepareStreamConsumers(); err != nil {
+	if err := a.prepareStreamConsumers(ctx); err != nil {
 		return err
 	}
 
@@ -304,7 +306,9 @@ func (a *App) drainServerError(ch <-chan error) error {
 // Run starts the application and blocks until a shutdown signal is received.
 // It handles graceful shutdown with a timeout.
 func (a *App) Run() error {
-	if err := a.prepareRuntime(); err != nil {
+	// Run is the process entry point, so the startup context is rooted here and
+	// threaded down; nothing above it has a context to inherit.
+	if err := a.prepareRuntime(context.Background()); err != nil {
 		return err
 	}
 

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -78,6 +78,10 @@ func (a *App) prepareRuntime() error {
 		return err
 	}
 
+	if err := a.prepareStreamConsumers(); err != nil {
+		return err
+	}
+
 	if !a.cfg.Multitenant.Enabled && a.connectionPreWarmer != nil && a.connectionPreWarmer.IsAvailable() {
 		a.connectionPreWarmer.LogAvailability()
 		if err := a.connectionPreWarmer.PreWarmSingleTenant(context.Background(), decls); err != nil {
@@ -502,6 +506,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 	//    the messaging-manager closer). Done before module shutdown so the framework stops
 	//    delivering fresh messages to modules that are about to be torn down.
 	a.shutdownConsumers()
+	a.shutdownStreamConsumers()
 
 	// 3. Shut down modules — no new HTTP requests or AMQP deliveries are admitted at this
 	//    point. AMQP handlers already in flight may still be unwinding after cancellation.
@@ -572,6 +577,31 @@ func publicDBStats(details map[string]any) map[string]any {
 	return public
 }
 
+// streamsOffsetsKey is the streams.Manager.Stats() entry publicStreamsStats withholds
+// from /ready.
+const streamsOffsetsKey = "stored_offsets"
+
+// publicStreamsStats renders streams_stats for the unauthenticated /ready body: the
+// scalar counters, never the per-consumer offset map.
+//
+// SECURITY: Manager.Stats()["stored_offsets"] is keyed "<stream>/<consumer>" — the
+// declared stream and consumer-group names, which are internal topology and usually
+// name the domain — and its values are live offsets, so differencing two polls of an
+// endpoint with no authentication and no IP allowlist yields the per-stream message
+// rate. Every other component publishes only counters here; this is the one whose
+// stats carry identifiers.
+//
+// Like publicDBStats, the redaction belongs at this render site rather than in
+// Manager.Stats() or the probe: the access-controlled <debug.pathprefix>/health-debug
+// renders the same details map and operators need the offsets there, so this copies
+// rather than mutating the caller's map.
+func publicStreamsStats(details map[string]any) map[string]any {
+	public := make(map[string]any, len(details))
+	maps.Copy(public, details)
+	delete(public, streamsOffsetsKey)
+	return public
+}
+
 // readyCheck handles the health check endpoint
 func (a *App) readyCheck(c server.HandlerContext) error {
 	ctx := c.RequestContext()
@@ -617,7 +647,7 @@ func (a *App) readyCheck(c server.HandlerContext) error {
 	messagingStatus, messagingStats := componentReport(componentStatus, componentMessaging)
 	cacheStatus, cacheStats := componentReport(componentStatus, componentCache)
 
-	return c.JSON(http.StatusOK, map[string]any{
+	body := map[string]any{
 		statusKey:          readyStatus,
 		"time":             time.Now().Unix(),
 		componentDatabase:  dbStatus.Status,
@@ -631,5 +661,14 @@ func (a *App) readyCheck(c server.HandlerContext) error {
 			"environment": a.cfg.App.Env,
 			"version":     a.cfg.App.Version,
 		},
-	})
+	}
+
+	// Streams are reported only where they exist: the probe is registered at
+	// runtime, so services that declare no streams keep the body they had.
+	if streamsStatus, streamsStats := componentReport(componentStatus, componentStreams); streamsStatus != disabledStatus {
+		body[componentStreams] = streamsStatus
+		body["streams_stats"] = publicStreamsStats(streamsStats)
+	}
+
+	return c.JSON(http.StatusOK, body)
 }

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -869,3 +869,114 @@ func runReadyCheck(t *testing.T, app *App, cfg *config.Config) (body map[string]
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
 	return body, w.Code
 }
+
+// TestReadyCheckOmitsStreamsWhenNoneDeclared pins that services without streams keep
+// the /ready body they had: the component is reported only where a probe exists.
+func TestReadyCheckOmitsStreamsWhenNoneDeclared(t *testing.T) {
+	cfg := &config.Config{App: config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"}}
+	app := &App{cfg: cfg, logger: logger.New("error", false), healthProbes: []Prober{}}
+
+	body, code := runReadyCheck(t, app, cfg)
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.NotContains(t, body, componentStreams)
+	assert.NotContains(t, body, "streams_stats")
+}
+
+// TestReadyCheckReportsStreamsWhenProbed is the other half: once the runtime probe is
+// registered the component and its stats reach the body.
+func TestReadyCheckReportsStreamsWhenProbed(t *testing.T) {
+	cfg := &config.Config{App: config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"}}
+	app := &App{cfg: cfg, logger: logger.New("error", false), healthProbes: []Prober{
+		healthProbeFunc{
+			name: componentStreams,
+			fn: func(context.Context) (string, map[string]any, error) {
+				return healthyStatus, map[string]any{statusKey: healthyStatus, "consumers": 2}, nil
+			},
+		},
+	}}
+
+	body, code := runReadyCheck(t, app, cfg)
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, healthyStatus, body[componentStreams])
+	assert.Equal(t, map[string]any{statusKey: healthyStatus, "consumers": float64(2)}, body["streams_stats"])
+}
+
+// streamsProbeWithOffsets returns a probe whose details carry the identifier-bearing
+// stored_offsets map a real streams.Manager reports.
+func streamsProbeWithOffsets(streamName, consumerName string) Prober {
+	return healthProbeFunc{
+		name: componentStreams,
+		fn: func(context.Context) (string, map[string]any, error) {
+			return healthyStatus, map[string]any{
+				statusKey:            healthyStatus,
+				"started":            true,
+				"consumers":          1,
+				streamsOffsetsKey:    map[string]int64{streamName + "/" + consumerName: 4242},
+				"offset_store_count": 500,
+			}, nil
+		},
+	}
+}
+
+// TestReadyCheckWithholdsStreamIdentifiers is the /ready half of the disclosure
+// guard: the unauthenticated body must carry the counters but never the stream or
+// consumer-group names, and never the live offsets that differencing two polls
+// would turn into a per-stream message rate.
+func TestReadyCheckWithholdsStreamIdentifiers(t *testing.T) {
+	cfg := &config.Config{App: config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"}}
+	app := &App{cfg: cfg, logger: logger.New("error", false), healthProbes: []Prober{
+		streamsProbeWithOffsets("payments-ledger", "fraud-scoring"),
+	}}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, readyEndpoint, http.NoBody)
+	w := httptest.NewRecorder()
+	require.NoError(t, app.readyCheck(server.NewHandlerContextForTest(w, req, cfg)))
+
+	body := w.Body.String()
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NotContains(t, body, "payments-ledger", "the declared stream name must not reach an unauthenticated body")
+	assert.NotContains(t, body, "fraud-scoring", "the consumer-group name must not reach an unauthenticated body")
+	assert.NotContains(t, body, streamsOffsetsKey)
+	assert.NotContains(t, body, "4242", "live offsets must not reach an unauthenticated body")
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &decoded))
+	stats, ok := decoded["streams_stats"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(1), stats["consumers"], "the counters survive the filter")
+	assert.Equal(t, true, stats["started"])
+}
+
+// TestHealthDebugRetainsStreamIdentifiers is the other half: the access-controlled
+// debug endpoint still renders the offsets operators need.
+func TestHealthDebugRetainsStreamIdentifiers(t *testing.T) {
+	cfg := &config.Config{App: config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"}}
+	app := &App{cfg: cfg, logger: logger.New("error", false), healthProbes: []Prober{
+		streamsProbeWithOffsets("payments-ledger", "fraud-scoring"),
+	}}
+
+	handlers := NewDebugHandlers(app, &config.DebugConfig{Enabled: true, PathPrefix: "/_debug"}, app.logger)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/health-debug", http.NoBody)
+	w := httptest.NewRecorder()
+	require.NoError(t, handlers.handleHealthDebug(server.NewHandlerContextForTest(w, req, nil)))
+
+	body := w.Body.String()
+	assert.Contains(t, body, streamsOffsetsKey)
+	assert.Contains(t, body, "payments-ledger/fraud-scoring")
+	assert.Contains(t, body, "4242")
+}
+
+func TestPublicStreamsStatsCopiesRatherThanMutates(t *testing.T) {
+	details := map[string]any{
+		statusKey:         healthyStatus,
+		streamsOffsetsKey: map[string]int64{"orders/projector": 7},
+	}
+
+	public := publicStreamsStats(details)
+
+	assert.NotContains(t, public, streamsOffsetsKey)
+	assert.Equal(t, healthyStatus, public[statusKey])
+	assert.Contains(t, details, streamsOffsetsKey, "the caller's map must not be mutated")
+}

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -199,7 +199,7 @@ func TestPrepareRuntimeWithScheduler(t *testing.T) {
 	}
 
 	// Call prepareRuntime
-	err = app.prepareRuntime()
+	err = app.prepareRuntime(context.Background())
 	assert.NoError(t, err)
 
 	// Verify RegisterJobs was called on the provider
@@ -254,7 +254,7 @@ func TestPrepareRuntimeFailsWhenDeclarationsExistAndMessagingUnconfigured(t *tes
 	app := newLifecycleCheckApp(t, cfg)
 	require.NoError(t, app.RegisterModule(publisherDeclaringModule{}))
 
-	err := app.prepareRuntime()
+	err := app.prepareRuntime(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "messaging is not configured")
 	assert.Contains(t, err.Error(), "publishers=1")
@@ -271,7 +271,7 @@ func TestPrepareRuntimeAllowsEmptyDeclarationsWithMessagingUnconfigured(t *testi
 	}
 	app := newLifecycleCheckApp(t, cfg)
 
-	require.NoError(t, app.prepareRuntime())
+	require.NoError(t, app.prepareRuntime(context.Background()))
 }
 
 // TestPrepareRuntimeSkipsCheckInMultiTenantMode verifies that the static check
@@ -287,7 +287,7 @@ func TestPrepareRuntimeSkipsCheckInMultiTenantMode(t *testing.T) {
 	app := newLifecycleCheckApp(t, cfg)
 	require.NoError(t, app.RegisterModule(publisherDeclaringModule{}))
 
-	require.NoError(t, app.prepareRuntime())
+	require.NoError(t, app.prepareRuntime(context.Background()))
 }
 
 // TestPrepareRuntimeSucceedsWithDeclarationsAndConfiguredMessaging is the
@@ -304,7 +304,7 @@ func TestPrepareRuntimeSucceedsWithDeclarationsAndConfiguredMessaging(t *testing
 	app := newLifecycleCheckApp(t, cfg)
 	require.NoError(t, app.RegisterModule(publisherDeclaringModule{}))
 
-	require.NoError(t, app.prepareRuntime())
+	require.NoError(t, app.prepareRuntime(context.Background()))
 }
 
 // debugCheckConfig builds a config whose Debug block enables one endpoint, leaving the
@@ -344,7 +344,7 @@ func TestPrepareRuntimeFailsWhenDebugEndpointsHaveNoAccessControl(t *testing.T) 
 		t.Run(tt.name, func(t *testing.T) {
 			app := newLifecycleCheckApp(t, debugCheckConfig(nil, tt.bearerToken))
 
-			err := app.prepareRuntime()
+			err := app.prepareRuntime(context.Background())
 
 			require.Error(t, err)
 			// prepareRuntime passes its callees' errors through untouched, so the error
@@ -373,7 +373,7 @@ func TestPrepareRuntimeAllowsDebugEndpointsWithAccessControl(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			app := newLifecycleCheckApp(t, debugCheckConfig(tt.allowedIPs, tt.bearerToken))
 
-			require.NoError(t, app.prepareRuntime())
+			require.NoError(t, app.prepareRuntime(context.Background()))
 		})
 	}
 }
@@ -408,7 +408,7 @@ func TestPrepareRuntimeSucceedsWithNoMessagingConfigured(t *testing.T) {
 	require.True(t, a.messagingInitializer.IsAvailable(),
 		"a messaging manager is built even with no broker configured — the premise of this guard")
 
-	require.NoError(t, a.prepareRuntime())
+	require.NoError(t, a.prepareRuntime(context.Background()))
 }
 
 // globalMWCapturingServer implements ServerRunner (via embedded mockServer) plus the

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -272,6 +273,55 @@ func TestPrepareRuntimeAllowsEmptyDeclarationsWithMessagingUnconfigured(t *testi
 	app := newLifecycleCheckApp(t, cfg)
 
 	require.NoError(t, app.prepareRuntime(context.Background()))
+}
+
+type preWarmCtxSentinelKey struct{}
+
+// ctxRecordingDBConfigProvider captures the sentinel carried by the context that
+// reaches DBConfig — the first ctx-aware seam below PreWarmSingleTenant.
+type ctxRecordingDBConfigProvider struct {
+	mu   sync.Mutex
+	seen any
+}
+
+func (p *ctxRecordingDBConfigProvider) DBConfig(ctx context.Context, _ string) (*config.DatabaseConfig, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.seen = ctx.Value(preWarmCtxSentinelKey{})
+	return &config.DatabaseConfig{Type: dbTypePostgres}, nil
+}
+
+// TestPrepareRuntimePropagatesContextToPreWarm pins that prepareRuntime hands its
+// own ctx to PreWarmSingleTenant instead of a fresh context.Background(): a
+// sentinel value on the caller's context must survive down to the pre-warm
+// database seam. The value is the right observable because resourcepool detaches
+// cancellation with context.WithoutCancel, which preserves values — so a deadline
+// or cancellation would not survive that hop, but a value does.
+func TestPrepareRuntimePropagatesContextToPreWarm(t *testing.T) {
+	cfg := &config.Config{
+		App:         config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"},
+		Multitenant: config.MultitenantConfig{Enabled: false},
+	}
+	a := newLifecycleCheckApp(t, cfg)
+
+	provider := &ctxRecordingDBConfigProvider{}
+	connector := func(*config.DatabaseConfig, logger.Logger) (database.Interface, error) {
+		return dbtesting.NewTestDB(dbTypePostgres), nil
+	}
+	dbManager := database.NewDbManager(provider, a.logger,
+		database.DbManagerOptions{MaxSize: 1, IdleTTL: time.Minute}, connector)
+	defer func() { _ = dbManager.Close() }()
+
+	a.dbManager = dbManager
+	a.connectionPreWarmer = NewConnectionPreWarmer(a.logger, dbManager, nil)
+
+	ctx := context.WithValue(context.Background(), preWarmCtxSentinelKey{}, "from-prepare-runtime")
+	require.NoError(t, a.prepareRuntime(ctx))
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	assert.Equal(t, "from-prepare-runtime", provider.seen,
+		"prepareRuntime must pass its own context to PreWarmSingleTenant; context.Background() drops the sentinel")
 }
 
 // TestPrepareRuntimeSkipsCheckInMultiTenantMode verifies that the static check

--- a/app/module.go
+++ b/app/module.go
@@ -14,6 +14,7 @@ import (
 	dbtypes "github.com/gaborage/go-bricks/database/types"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/messaging/streams"
 	"github.com/gaborage/go-bricks/server"
 )
 
@@ -40,6 +41,14 @@ type RouteRegisterer interface {
 // during application startup.
 type MessagingDeclarer interface {
 	DeclareMessaging(decls *messaging.Declarations)
+}
+
+// StreamDeclarer is an optional interface that modules can implement to declare
+// RabbitMQ streams and consumers served over the native stream protocol.
+// Modules that implement this interface will have DeclareStreams called automatically
+// during application startup. Single-tenant only — see wiki/streams.md.
+type StreamDeclarer interface {
+	DeclareStreams(decls *streams.Declarations)
 }
 
 // GlobalMiddlewareRegisterer is an optional interface that modules can implement to

--- a/app/module_registry.go
+++ b/app/module_registry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gaborage/go-bricks/jose"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/messaging/streams"
 	"github.com/gaborage/go-bricks/server"
 )
 
@@ -303,6 +304,37 @@ func (r *ModuleRegistry) DeclareMessaging(decls *messaging.Declarations) error {
 		Int("publishers", stats.Publishers).
 		Int("consumers", stats.Consumers).
 		Msg("Messaging declarations collected and validated successfully")
+
+	return nil
+}
+
+// DeclareStreams calls DeclareStreams on modules that implement StreamDeclarer.
+// Modules without stream declarations are silently skipped.
+func (r *ModuleRegistry) DeclareStreams(decls *streams.Declarations) error {
+	if decls == nil {
+		return errors.New("stream declarations store is nil")
+	}
+
+	for _, module := range r.modules {
+		if sd, ok := module.(StreamDeclarer); ok {
+			r.logger.Info().
+				Str("module", module.Name()).
+				Msg("Collecting module stream declarations")
+
+			sd.DeclareStreams(decls)
+		}
+	}
+
+	if err := decls.Validate(); err != nil {
+		r.logger.Error().Err(err).Msg("Stream declaration validation failed")
+		return fmt.Errorf("stream declaration validation failed: %w", err)
+	}
+
+	stats := decls.Stats()
+	r.logger.Info().
+		Int("streams", stats.Streams).
+		Int("consumers", stats.Consumers).
+		Msg("Stream declarations collected and validated successfully")
 
 	return nil
 }

--- a/app/module_registry_test.go
+++ b/app/module_registry_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gaborage/go-bricks/config"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/messaging/streams"
 	"github.com/gaborage/go-bricks/server"
 )
 
@@ -314,4 +315,65 @@ func TestRegisterAcceptsModulesWhenDatabaseRequirementDoesNotApply(t *testing.T)
 			require.NoError(t, newDBRequirementRegistry(tt.rootDBAbsent).Register(tt.module))
 		})
 	}
+}
+
+func TestModuleRegistryDeclareStreamsCollectsFromDeclarers(t *testing.T) {
+	log := logger.New("error", false)
+	registry := NewModuleRegistry(&ModuleDeps{Logger: log, Config: &config.Config{}})
+	declarer := &streamModule{name: "orders", declaration: declareOneConsumer}
+	require.NoError(t, registry.Register(declarer))
+	require.NoError(t, registry.Register(&minimalModule{name: "plain"}))
+
+	decls := streams.NewDeclarations()
+	require.NoError(t, registry.DeclareStreams(decls))
+
+	assert.Equal(t, 1, declarer.calls, "a declarer is invoked exactly once")
+	assert.Equal(t, streams.Stats{Streams: 1, Consumers: 1}, decls.Stats())
+}
+
+func TestModuleRegistryDeclareStreamsRejectsNilStore(t *testing.T) {
+	registry := NewModuleRegistry(&ModuleDeps{Logger: logger.New("error", false), Config: &config.Config{}})
+
+	err := registry.DeclareStreams(nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stream declarations store is nil")
+}
+
+func TestModuleRegistryDeclareStreamsFailsOnInvalidDeclarations(t *testing.T) {
+	log := logger.New("error", false)
+	registry := NewModuleRegistry(&ModuleDeps{Logger: log, Config: &config.Config{}})
+	require.NoError(t, registry.Register(&streamModule{name: "orders", declaration: func(decls *streams.Declarations) {
+		decls.DeclareConsumer(&streams.ConsumerOptions{Stream: "ghost", Name: testStreamConsumer})
+	}}))
+
+	err := registry.DeclareStreams(streams.NewDeclarations())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stream declaration validation failed")
+	assert.Contains(t, err.Error(), "references undeclared stream")
+}
+
+func TestModuleRegistryDeclareStreamsWithNoDeclarersIsEmpty(t *testing.T) {
+	log := logger.New("error", false)
+	registry := NewModuleRegistry(&ModuleDeps{Logger: log, Config: &config.Config{}})
+	require.NoError(t, registry.Register(&minimalModule{name: "plain"}))
+
+	decls := streams.NewDeclarations()
+	require.NoError(t, registry.DeclareStreams(decls))
+
+	assert.True(t, decls.IsEmpty())
+}
+
+// warnLines returns every recorded warn-level event.
+func (l *recLogger) warnLines() []recEvent {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var out []recEvent
+	for _, e := range l.events {
+		if e.level == "warn" {
+			out = append(out, e)
+		}
+	}
+	return out
 }

--- a/app/streams_setup.go
+++ b/app/streams_setup.go
@@ -1,0 +1,131 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/gaborage/go-bricks/messaging/streams"
+)
+
+// plaintextStreamScheme is the non-TLS stream-protocol scheme
+// warnIfPlaintextStreamURI flags outside development.
+const plaintextStreamScheme = "rabbitmq-stream"
+
+// prepareStreamConsumers collects the modules' native stream declarations and,
+// when there are any, starts the stream-protocol consumers.
+//
+// Everything happens at RUNTIME on purpose: the manager does not exist while the
+// builder runs, so its readiness probe and its closer are both registered here
+// rather than in createHealthProbes or Builder.RegisterClosers, which are
+// snapshotted before prepareRuntime runs. This is safe because prepareRuntime is
+// single-threaded and completes before the server starts serving /ready.
+func (a *App) prepareStreamConsumers() error {
+	if a.registry == nil {
+		return errors.New("module registry not initialized")
+	}
+
+	decls := streams.NewDeclarations()
+	if err := a.registry.DeclareStreams(decls); err != nil {
+		return err
+	}
+	if decls.IsEmpty() {
+		return nil
+	}
+
+	if err := a.assertStreamsSingleTenant(); err != nil {
+		return err
+	}
+
+	if err := a.assertStreamsConfigured(decls); err != nil {
+		return err
+	}
+
+	cfg := a.cfg.Messaging.Streams
+	a.warnIfPlaintextStreamURI(cfg.URI)
+	mgr := streams.NewManager(streams.ManagerOptions{
+		URI:                 cfg.URI,
+		AddressResolverHost: cfg.AddressResolver.Host,
+		AddressResolverPort: cfg.AddressResolver.Port,
+		OffsetStoreCount:    cfg.OffsetStore.CountBeforeStorage,
+		OffsetStoreInterval: cfg.OffsetStore.FlushInterval,
+		Logger:              a.logger,
+	})
+
+	// A service that declared stream consumers and cannot start them would serve
+	// HTTP while consuming nothing, so startup fails rather than booting green.
+	if err := mgr.Start(context.Background(), decls); err != nil {
+		if closeErr := mgr.Close(); closeErr != nil {
+			a.logger.Warn().Err(closeErr).Msg("Failed to close stream environment after a failed start")
+		}
+		return fmt.Errorf("failed to start stream consumers: %w", err)
+	}
+
+	a.streamsManager = mgr
+	a.registerCloser("streams manager", mgr)
+	a.healthProbes = append(a.healthProbes, streamsManagerHealthProbe(mgr))
+
+	return nil
+}
+
+// assertStreamsSingleTenant re-asserts the tenancy invariant at runtime.
+//
+// SECURITY: config.Validate already rejects multitenant.enabled beside a stream
+// URI, but app.NewWithConfig takes a hand-built config and never calls it — the
+// documented bypass untypedConnectionStringPaths guards against for database
+// types. Without this repeat, such a service would boot green and run stream
+// handlers against one shared Environment with no tenant in context, which is
+// precisely what the gate exists to prevent.
+func (a *App) assertStreamsSingleTenant() error {
+	if !a.cfg.Multitenant.Enabled {
+		return nil
+	}
+	return errors.New("messaging.streams is single-tenant only; multi-tenant stream consumption " +
+		"is not yet supported, but stream declarations were registered with multitenant.enabled: true; " +
+		"config.Validate rejects this combination and a config built without it is re-checked here")
+}
+
+// warnIfPlaintextStreamURI flags a plaintext stream endpoint outside development:
+// the broker credentials in the URI then cross the network in the clear. It warns
+// rather than fails because the framework exposes no TLS configuration surface yet
+// (ADR-059 future work), so failing closed would leave such deployments no option.
+func (a *App) warnIfPlaintextStreamURI(uri string) {
+	if a.cfg.App.IsDevelopment() {
+		return
+	}
+	u, err := url.Parse(uri)
+	if err != nil || u.Scheme != plaintextStreamScheme {
+		return
+	}
+	a.logger.Warn().
+		Str("environment", a.cfg.App.Env).
+		Msg("messaging.streams.uri uses the plaintext stream protocol; broker credentials cross the network unencrypted — " +
+			"terminate TLS in front of the broker or use rabbitmq-stream+tls://")
+}
+
+// assertStreamsConfigured fails fast when a module declared streams but no
+// stream endpoint is configured — without it the declarations would be silently
+// dropped, exactly as assertMessagingConfiguredIfDeclared prevents for AMQP.
+func (a *App) assertStreamsConfigured(decls *streams.Declarations) error {
+	if a.cfg.Messaging.Streams.URI != "" {
+		return nil
+	}
+	s := decls.Stats()
+	return fmt.Errorf("stream declarations were registered "+
+		"(streams=%d, consumers=%d) "+
+		"but the stream protocol is not configured; "+
+		"set messaging.streams.uri (or env MESSAGING_STREAMS_URI)",
+		s.Streams, s.Consumers)
+}
+
+// shutdownStreamConsumers stops stream consumers before modules are torn down.
+// Each consumer flushes its pending offset first; the environment itself is
+// closed later by the registered closer. No-op when no streams were declared.
+func (a *App) shutdownStreamConsumers() {
+	if a.streamsManager == nil {
+		return
+	}
+	a.logger.Info().Msg("Stopping stream consumers")
+	a.streamsManager.StopConsumers()
+}

--- a/app/streams_setup.go
+++ b/app/streams_setup.go
@@ -21,7 +21,7 @@ const plaintextStreamScheme = "rabbitmq-stream"
 // rather than in createHealthProbes or Builder.RegisterClosers, which are
 // snapshotted before prepareRuntime runs. This is safe because prepareRuntime is
 // single-threaded and completes before the server starts serving /ready.
-func (a *App) prepareStreamConsumers() error {
+func (a *App) prepareStreamConsumers(ctx context.Context) error {
 	if a.registry == nil {
 		return errors.New("module registry not initialized")
 	}
@@ -55,7 +55,9 @@ func (a *App) prepareStreamConsumers() error {
 
 	// A service that declared stream consumers and cannot start them would serve
 	// HTTP while consuming nothing, so startup fails rather than booting green.
-	if err := mgr.Start(context.Background(), decls); err != nil {
+	// The startup context is handed over for its values only — Start severs its
+	// cancellation, so shutdownStreamConsumers stays the thing that stops them.
+	if err := mgr.Start(ctx, decls); err != nil {
 		if closeErr := mgr.Close(); closeErr != nil {
 			a.logger.Warn().Err(closeErr).Msg("Failed to close stream environment after a failed start")
 		}

--- a/app/streams_setup_test.go
+++ b/app/streams_setup_test.go
@@ -1,0 +1,235 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaborage/go-bricks/config"
+	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/messaging/streams"
+)
+
+const (
+	testStreamName         = "orders"
+	testStreamConsumer     = "orders-processor"
+	unreachableStreamURI   = "rabbitmq-stream://guest:guest@127.0.0.1:1/%2f"
+	streamsUnconfiguredMsg = "set messaging.streams.uri"
+)
+
+// streamModule implements Module + StreamDeclarer.
+type streamModule struct {
+	name        string
+	calls       int
+	declaration func(decls *streams.Declarations)
+}
+
+func (m *streamModule) Name() string             { return m.name }
+func (m *streamModule) Init(_ *ModuleDeps) error { return nil }
+func (m *streamModule) Shutdown() error          { return nil }
+func (m *streamModule) DeclareStreams(decls *streams.Declarations) {
+	m.calls++
+	if m.declaration != nil {
+		m.declaration(decls)
+	}
+}
+
+func declareOneConsumer(decls *streams.Declarations) {
+	decls.DeclareStream(testStreamName, nil)
+	decls.DeclareConsumer(&streams.ConsumerOptions{
+		Stream:  testStreamName,
+		Name:    testStreamConsumer,
+		Handler: func(context.Context, *streams.Message) error { return nil },
+	})
+}
+
+func newStreamsApp(t *testing.T, streamsCfg config.StreamsConfig, modules ...Module) *App {
+	t.Helper()
+	return newStreamsAppWithLogger(t, logger.New("error", false), streamsCfg, modules...)
+}
+
+func newStreamsAppWithLogger(t *testing.T, log logger.Logger, streamsCfg config.StreamsConfig, modules ...Module) *App {
+	t.Helper()
+
+	cfg := &config.Config{
+		App:       config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"},
+		Messaging: config.MessagingConfig{Streams: streamsCfg},
+	}
+	registry := NewModuleRegistry(&ModuleDeps{Logger: log, Config: cfg})
+	for _, m := range modules {
+		require.NoError(t, registry.Register(m))
+	}
+
+	return &App{cfg: cfg, logger: log, registry: registry}
+}
+
+func TestPrepareStreamConsumersWithoutDeclarationsIsNoop(t *testing.T) {
+	a := newStreamsApp(t, config.StreamsConfig{}, &minimalModule{name: "plain"})
+
+	require.NoError(t, a.prepareStreamConsumers())
+
+	assert.Nil(t, a.streamsManager)
+	assert.Empty(t, a.healthProbes, "a streams-free service keeps its probe list unchanged")
+	assert.Empty(t, a.closers)
+}
+
+func TestPrepareStreamConsumersRequiresRegistry(t *testing.T) {
+	a := &App{logger: logger.New("error", false)}
+
+	err := a.prepareStreamConsumers()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "module registry not initialized")
+}
+
+func TestPrepareStreamConsumersFailsWhenDeclaredButUnconfigured(t *testing.T) {
+	a := newStreamsApp(t, config.StreamsConfig{},
+		&streamModule{name: "orders", declaration: declareOneConsumer})
+
+	err := a.prepareStreamConsumers()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stream declarations were registered")
+	assert.Contains(t, err.Error(), "streams=1, consumers=1")
+	assert.Contains(t, err.Error(), streamsUnconfiguredMsg)
+	assert.Nil(t, a.streamsManager)
+}
+
+func TestPrepareStreamConsumersPropagatesValidationFailure(t *testing.T) {
+	a := newStreamsApp(t, config.StreamsConfig{URI: unreachableStreamURI},
+		&streamModule{name: "orders", declaration: func(decls *streams.Declarations) {
+			decls.DeclareConsumer(&streams.ConsumerOptions{
+				Stream:  "undeclared",
+				Name:    testStreamConsumer,
+				Handler: func(context.Context, *streams.Message) error { return nil },
+			})
+		}})
+
+	err := a.prepareStreamConsumers()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stream declaration validation failed")
+	assert.Nil(t, a.streamsManager)
+}
+
+func TestPrepareStreamConsumersFailsWhenBrokerUnreachable(t *testing.T) {
+	a := newStreamsApp(t, config.StreamsConfig{URI: unreachableStreamURI},
+		&streamModule{name: "orders", declaration: declareOneConsumer})
+
+	err := a.prepareStreamConsumers()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to start stream consumers")
+	assert.NotContains(t, err.Error(), "guest:guest", "the stream URI's credentials must never reach an error message")
+	assert.Nil(t, a.streamsManager, "a failed start registers neither a probe nor a closer")
+	assert.Empty(t, a.healthProbes)
+	assert.Empty(t, a.closers)
+}
+
+// TestPrepareStreamConsumersReportsOnlyRealCleanupFailures pins the guard on the
+// failed-start cleanup. The dial never completed, so the manager holds no
+// environment and Close is a no-op; a guard reading its result the wrong way
+// round would tell the operator the environment failed to close on every single
+// failed startup, burying the real cause.
+func TestPrepareStreamConsumersReportsOnlyRealCleanupFailures(t *testing.T) {
+	log := &recLogger{}
+	a := newStreamsAppWithLogger(t, log, config.StreamsConfig{URI: unreachableStreamURI},
+		&streamModule{name: "orders", declaration: declareOneConsumer})
+
+	err := a.prepareStreamConsumers()
+
+	require.Error(t, err, "the premise: the start fails before an environment exists")
+	assert.False(t, loggedMsgContains(log, "Failed to close stream environment"),
+		"a cleanup that had nothing to close is not reported as a failure")
+}
+
+func TestPrepareStreamConsumersInvokesEveryDeclarerOnce(t *testing.T) {
+	m := &streamModule{name: "orders", declaration: declareOneConsumer}
+	a := newStreamsApp(t, config.StreamsConfig{}, m)
+
+	_ = a.prepareStreamConsumers()
+
+	assert.Equal(t, 1, m.calls)
+}
+
+func TestShutdownStreamConsumersWithoutManagerIsNoop(t *testing.T) {
+	a := &App{logger: logger.New("error", false)}
+
+	assert.NotPanics(t, a.shutdownStreamConsumers)
+}
+
+func TestShutdownStreamConsumersStopsTheManager(t *testing.T) {
+	a := &App{logger: logger.New("error", false)}
+	a.streamsManager = streams.NewManager(streams.ManagerOptions{
+		URI:    unreachableStreamURI,
+		Logger: a.logger,
+	})
+
+	a.shutdownStreamConsumers()
+
+	assert.Equal(t, false, a.streamsManager.Stats()["started"])
+}
+
+// TestPrepareStreamConsumersRejectsMultiTenantBypass drives the documented
+// config.Validate bypass: NewWithConfig accepts a hand-built config, so a
+// multi-tenant service with a stream URI and a declaring module would otherwise
+// boot green and run handlers with no tenant in context.
+func TestPrepareStreamConsumersRejectsMultiTenantBypass(t *testing.T) {
+	a := newStreamsApp(t, config.StreamsConfig{URI: unreachableStreamURI},
+		&streamModule{name: "orders", declaration: declareOneConsumer})
+	a.cfg.Multitenant.Enabled = true
+
+	err := a.prepareStreamConsumers()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "single-tenant only")
+	assert.Nil(t, a.streamsManager, "no Environment is built for a multi-tenant service")
+	assert.Empty(t, a.healthProbes)
+	assert.Empty(t, a.closers)
+}
+
+// TestPrepareStreamConsumersAllowsSingleTenant is the negative half: the re-check
+// must not block the supported deployment.
+func TestPrepareStreamConsumersAllowsSingleTenant(t *testing.T) {
+	a := newStreamsApp(t, config.StreamsConfig{}, &minimalModule{name: "plain"})
+	a.cfg.Multitenant.Enabled = false
+
+	require.NoError(t, a.assertStreamsSingleTenant())
+}
+
+func TestWarnIfPlaintextStreamURI(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      string
+		uri      string
+		wantWarn bool
+	}{
+		{name: "plaintext_outside_development_warns", env: "production", uri: "rabbitmq-stream://broker:5552/", wantWarn: true},
+		{name: "plaintext_in_development_is_silent", env: "development", uri: "rabbitmq-stream://broker:5552/"},
+		{name: "tls_scheme_is_silent", env: "production", uri: "rabbitmq-stream+tls://broker:5551/"},
+		{name: "unparseable_uri_is_silent", env: "production", uri: "rabbitmq-stream://broker:55 52/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := &recLogger{}
+			a := &App{
+				cfg:    &config.Config{App: config.AppConfig{Name: testApp, Env: tt.env, Version: "1.0.0"}},
+				logger: log,
+			}
+
+			a.warnIfPlaintextStreamURI(tt.uri)
+
+			warnings := log.warnLines()
+			if !tt.wantWarn {
+				assert.Empty(t, warnings)
+				return
+			}
+			require.Len(t, warnings, 1)
+			assert.Contains(t, warnings[0].msg, "plaintext stream protocol")
+			assert.NotContains(t, warnings[0].msg, "broker:5552", "the endpoint itself stays out of the warning")
+		})
+	}
+}

--- a/app/streams_setup_test.go
+++ b/app/streams_setup_test.go
@@ -68,7 +68,7 @@ func newStreamsAppWithLogger(t *testing.T, log logger.Logger, streamsCfg config.
 func TestPrepareStreamConsumersWithoutDeclarationsIsNoop(t *testing.T) {
 	a := newStreamsApp(t, config.StreamsConfig{}, &minimalModule{name: "plain"})
 
-	require.NoError(t, a.prepareStreamConsumers())
+	require.NoError(t, a.prepareStreamConsumers(context.Background()))
 
 	assert.Nil(t, a.streamsManager)
 	assert.Empty(t, a.healthProbes, "a streams-free service keeps its probe list unchanged")
@@ -78,7 +78,7 @@ func TestPrepareStreamConsumersWithoutDeclarationsIsNoop(t *testing.T) {
 func TestPrepareStreamConsumersRequiresRegistry(t *testing.T) {
 	a := &App{logger: logger.New("error", false)}
 
-	err := a.prepareStreamConsumers()
+	err := a.prepareStreamConsumers(context.Background())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "module registry not initialized")
@@ -88,7 +88,7 @@ func TestPrepareStreamConsumersFailsWhenDeclaredButUnconfigured(t *testing.T) {
 	a := newStreamsApp(t, config.StreamsConfig{},
 		&streamModule{name: "orders", declaration: declareOneConsumer})
 
-	err := a.prepareStreamConsumers()
+	err := a.prepareStreamConsumers(context.Background())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "stream declarations were registered")
@@ -107,7 +107,7 @@ func TestPrepareStreamConsumersPropagatesValidationFailure(t *testing.T) {
 			})
 		}})
 
-	err := a.prepareStreamConsumers()
+	err := a.prepareStreamConsumers(context.Background())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "stream declaration validation failed")
@@ -118,7 +118,7 @@ func TestPrepareStreamConsumersFailsWhenBrokerUnreachable(t *testing.T) {
 	a := newStreamsApp(t, config.StreamsConfig{URI: unreachableStreamURI},
 		&streamModule{name: "orders", declaration: declareOneConsumer})
 
-	err := a.prepareStreamConsumers()
+	err := a.prepareStreamConsumers(context.Background())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to start stream consumers")
@@ -126,6 +126,24 @@ func TestPrepareStreamConsumersFailsWhenBrokerUnreachable(t *testing.T) {
 	assert.Nil(t, a.streamsManager, "a failed start registers neither a probe nor a closer")
 	assert.Empty(t, a.healthProbes)
 	assert.Empty(t, a.closers)
+}
+
+// TestPrepareStreamConsumersIgnoresCallerCancellation is the app half of the
+// consume-context contract: the startup context reaches the manager for its
+// values, and its cancellation carries no weight here — consumer lifetime belongs
+// to StopConsumers, so an already-canceled context changes nothing about how
+// startup succeeds or fails.
+func TestPrepareStreamConsumersIgnoresCallerCancellation(t *testing.T) {
+	a := newStreamsApp(t, config.StreamsConfig{URI: unreachableStreamURI},
+		&streamModule{name: "orders", declaration: declareOneConsumer})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := a.prepareStreamConsumers(ctx)
+
+	require.Error(t, err, "the premise: this broker is unreachable")
+	assert.Contains(t, err.Error(), "failed to start stream consumers")
+	assert.NotErrorIs(t, err, context.Canceled, "startup never consults the caller's cancellation")
 }
 
 // TestPrepareStreamConsumersReportsOnlyRealCleanupFailures pins the guard on the
@@ -138,7 +156,7 @@ func TestPrepareStreamConsumersReportsOnlyRealCleanupFailures(t *testing.T) {
 	a := newStreamsAppWithLogger(t, log, config.StreamsConfig{URI: unreachableStreamURI},
 		&streamModule{name: "orders", declaration: declareOneConsumer})
 
-	err := a.prepareStreamConsumers()
+	err := a.prepareStreamConsumers(context.Background())
 
 	require.Error(t, err, "the premise: the start fails before an environment exists")
 	assert.False(t, loggedMsgContains(log, "Failed to close stream environment"),
@@ -149,7 +167,7 @@ func TestPrepareStreamConsumersInvokesEveryDeclarerOnce(t *testing.T) {
 	m := &streamModule{name: "orders", declaration: declareOneConsumer}
 	a := newStreamsApp(t, config.StreamsConfig{}, m)
 
-	_ = a.prepareStreamConsumers()
+	_ = a.prepareStreamConsumers(context.Background())
 
 	assert.Equal(t, 1, m.calls)
 }
@@ -181,7 +199,7 @@ func TestPrepareStreamConsumersRejectsMultiTenantBypass(t *testing.T) {
 		&streamModule{name: "orders", declaration: declareOneConsumer})
 	a.cfg.Multitenant.Enabled = true
 
-	err := a.prepareStreamConsumers()
+	err := a.prepareStreamConsumers(context.Background())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "single-tenant only")


### PR DESCRIPTION
## What

Wires stream consumption into the application lifecycle. Modules opt in by implementing
`StreamDeclarer`; `prepareRuntime` collects declarations, builds the manager and starts
consumers, then registers a readiness probe and a closer. Declaring consumers without
`messaging.streams.uri` aborts startup.

## Impact

Additive — a service declaring no stream consumers dials nothing, and its `/ready` body
is byte-identical to before. The probe and closer register at runtime, not build time,
because `createHealthProbes` is snapshotted before the manager exists. `/ready` withholds
stream and consumer names and offsets, mirroring how `publicDBStats` already strips
per-tenant keys; the access-controlled debug endpoint keeps them. The single-tenant rule
is re-asserted here, since a hand-built config can bypass `config.Validate`.

## Verification

Tests pin the streams-free boot, the multi-tenant bypass, and both halves of the
`/ready` filter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional RabbitMQ Streams support, including stream and native-protocol consumer declarations.
  * Streams now start and stop with the application lifecycle.
  * Added stream health, readiness, and diagnostic reporting.

* **Bug Fixes**
  * Public readiness responses now omit sensitive stream identifiers, consumer details, and stored offsets.
  * Added validation and clearer handling for invalid, unsupported, or unavailable stream configurations.
  * Improved startup cancellation and cleanup when stream connections fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->