### PR TITLE
test(messaging): prove stream consumption against a live broker

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gaborage/go-bricks/database"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/messaging/streams"
 	"github.com/gaborage/go-bricks/observability"
 	"github.com/gaborage/go-bricks/server"
 )
@@ -36,7 +37,10 @@ const (
 	componentDatabase  = "database"
 	componentMessaging = "messaging"
 	componentCache     = "cache"
-	errorKey           = "error"
+	componentStreams   = "streams"
+	// notReadyStatus marks a component that is reachable but not yet serving.
+	notReadyStatus = "not_ready"
+	errorKey       = "error"
 )
 
 var ErrNoTenantInContext = errors.New("no tenant in context")
@@ -84,6 +88,10 @@ type App struct {
 	messagingDeclarations *messaging.Declarations
 	messagingInitializer  *MessagingInitializer
 	connectionPreWarmer   *ConnectionPreWarmer
+
+	// streamsManager is created during prepareRuntime — never at build time — so
+	// its readiness probe and closer are registered there too (see streams_setup.go).
+	streamsManager *streams.Manager
 
 	closers      []namedCloser
 	healthProbes []Prober

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1309,7 +1309,7 @@ func TestMessagingDeclarationsBuiltOnceAndReused(t *testing.T) {
 	require.NoError(t, err)
 
 	// Declarations are built lazily during runtime preparation
-	require.NoError(t, fixture.app.prepareRuntime())
+	require.NoError(t, fixture.app.prepareRuntime(context.Background()))
 	assert.Equal(t, 1, counterModule.callCount, "DeclareMessaging should be called during runtime preparation")
 	assert.NotNil(t, fixture.app.messagingDeclarations, "messagingDeclarations should be built during runtime preparation")
 }

--- a/app/health.go
+++ b/app/health.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gaborage/go-bricks/database"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/messaging/streams"
 )
 
 // cacheProbePingTimeout caps the warm-path PING so a hung Redis reports unhealthy instead
@@ -180,7 +181,7 @@ func messagingManagerHealthProbe(msgManager *messaging.Manager, _ logger.Logger)
 			defer release() // probe holds no scope; release the lease when the check returns
 
 			if !client.IsReady() {
-				stats[statusKey] = "not_ready"
+				stats[statusKey] = notReadyStatus
 				return unhealthyStatus, stats, nil
 			}
 
@@ -190,6 +191,29 @@ func messagingManagerHealthProbe(msgManager *messaging.Manager, _ logger.Logger)
 			stats = getStatsOrEmpty(msgManager.Stats())
 			stats[statusKey] = healthyStatus
 			return healthyStatus, stats, nil
+		},
+	}
+}
+
+// streamsManagerHealthProbe creates a health probe for the native stream-protocol
+// manager. It is NON-critical: the reliable consumers reconnect on their own, so a
+// broker flap must not take the whole service out of the load balancer while they do.
+//
+// Unlike its siblings this probe is registered at runtime (see
+// prepareStreamConsumers) after a successful Start, so mgr is never nil and the
+// probe has no disabled arm: an absent registration already reports disabled
+// through componentReport.
+func streamsManagerHealthProbe(mgr *streams.Manager) Prober {
+	return healthProbeFunc{
+		name: componentStreams,
+		fn: func(context.Context) (string, map[string]any, error) {
+			stats := getStatsOrEmpty(mgr.Stats())
+			status := healthyStatus
+			if !mgr.Ready() {
+				status = notReadyStatus
+			}
+			stats[statusKey] = status
+			return status, stats, nil
 		},
 	}
 }

--- a/app/health_test.go
+++ b/app/health_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gaborage/go-bricks/internal/testutil"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/messaging/streams"
 	testmocks "github.com/gaborage/go-bricks/testing/mocks"
 )
 
@@ -823,4 +824,20 @@ func TestDatabaseManagerHealthProbeStillProbesPerTenantControlPlaneDatabase(t *t
 	assert.Equal(t, unhealthyStatus, result.Status, "a resolvable control-plane database must be probed, not relabeled")
 	require.Error(t, result.Err)
 	assert.True(t, result.Critical, "and it must still gate readiness")
+}
+
+func TestStreamsManagerHealthProbeReportsNotReady(t *testing.T) {
+	mgr := streams.NewManager(streams.ManagerOptions{
+		URI:    unreachableStreamURI,
+		Logger: logger.New("error", false),
+	})
+
+	result := streamsManagerHealthProbe(mgr).Run(context.Background())
+
+	assert.Equal(t, componentStreams, result.Name)
+	assert.Equal(t, notReadyStatus, result.Status)
+	assert.NoError(t, result.Err)
+	assert.False(t, result.Critical, "a reconnecting stream consumer must not 503 the whole service")
+	assert.Equal(t, notReadyStatus, result.Details[statusKey])
+	assert.Equal(t, false, result.Details["started"])
 }

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -62,8 +62,10 @@ func (a *App) warnIfCleanupIntervalTooLate(keyPrefix string, cleanupInterval, id
 			"(lower " + keyPrefix + ".cleanupinterval or raise " + keyPrefix + ".idlettl)")
 }
 
-// prepareRuntime prepares the application for runtime execution
-func (a *App) prepareRuntime() error {
+// prepareRuntime prepares the application for runtime execution. ctx is the
+// startup context: components it starts that outlive startup inherit that
+// context's values rather than beginning from a bare context.Background().
+func (a *App) prepareRuntime(ctx context.Context) error {
 	if err := a.buildMessagingDeclarations(); err != nil {
 		return err
 	}
@@ -78,7 +80,7 @@ func (a *App) prepareRuntime() error {
 		return err
 	}
 
-	if err := a.prepareStreamConsumers(); err != nil {
+	if err := a.prepareStreamConsumers(ctx); err != nil {
 		return err
 	}
 
@@ -304,7 +306,9 @@ func (a *App) drainServerError(ch <-chan error) error {
 // Run starts the application and blocks until a shutdown signal is received.
 // It handles graceful shutdown with a timeout.
 func (a *App) Run() error {
-	if err := a.prepareRuntime(); err != nil {
+	// Run is the process entry point, so the startup context is rooted here and
+	// threaded down; nothing above it has a context to inherit.
+	if err := a.prepareRuntime(context.Background()); err != nil {
 		return err
 	}
 

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -78,6 +78,10 @@ func (a *App) prepareRuntime() error {
 		return err
 	}
 
+	if err := a.prepareStreamConsumers(); err != nil {
+		return err
+	}
+
 	if !a.cfg.Multitenant.Enabled && a.connectionPreWarmer != nil && a.connectionPreWarmer.IsAvailable() {
 		a.connectionPreWarmer.LogAvailability()
 		if err := a.connectionPreWarmer.PreWarmSingleTenant(context.Background(), decls); err != nil {
@@ -502,6 +506,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 	//    the messaging-manager closer). Done before module shutdown so the framework stops
 	//    delivering fresh messages to modules that are about to be torn down.
 	a.shutdownConsumers()
+	a.shutdownStreamConsumers()
 
 	// 3. Shut down modules — no new HTTP requests or AMQP deliveries are admitted at this
 	//    point. AMQP handlers already in flight may still be unwinding after cancellation.
@@ -572,6 +577,31 @@ func publicDBStats(details map[string]any) map[string]any {
 	return public
 }
 
+// streamsOffsetsKey is the streams.Manager.Stats() entry publicStreamsStats withholds
+// from /ready.
+const streamsOffsetsKey = "stored_offsets"
+
+// publicStreamsStats renders streams_stats for the unauthenticated /ready body: the
+// scalar counters, never the per-consumer offset map.
+//
+// SECURITY: Manager.Stats()["stored_offsets"] is keyed "<stream>/<consumer>" — the
+// declared stream and consumer-group names, which are internal topology and usually
+// name the domain — and its values are live offsets, so differencing two polls of an
+// endpoint with no authentication and no IP allowlist yields the per-stream message
+// rate. Every other component publishes only counters here; this is the one whose
+// stats carry identifiers.
+//
+// Like publicDBStats, the redaction belongs at this render site rather than in
+// Manager.Stats() or the probe: the access-controlled <debug.pathprefix>/health-debug
+// renders the same details map and operators need the offsets there, so this copies
+// rather than mutating the caller's map.
+func publicStreamsStats(details map[string]any) map[string]any {
+	public := make(map[string]any, len(details))
+	maps.Copy(public, details)
+	delete(public, streamsOffsetsKey)
+	return public
+}
+
 // readyCheck handles the health check endpoint
 func (a *App) readyCheck(c server.HandlerContext) error {
 	ctx := c.RequestContext()
@@ -617,7 +647,7 @@ func (a *App) readyCheck(c server.HandlerContext) error {
 	messagingStatus, messagingStats := componentReport(componentStatus, componentMessaging)
 	cacheStatus, cacheStats := componentReport(componentStatus, componentCache)
 
-	return c.JSON(http.StatusOK, map[string]any{
+	body := map[string]any{
 		statusKey:          readyStatus,
 		"time":             time.Now().Unix(),
 		componentDatabase:  dbStatus.Status,
@@ -631,5 +661,14 @@ func (a *App) readyCheck(c server.HandlerContext) error {
 			"environment": a.cfg.App.Env,
 			"version":     a.cfg.App.Version,
 		},
-	})
+	}
+
+	// Streams are reported only where they exist: the probe is registered at
+	// runtime, so services that declare no streams keep the body they had.
+	if streamsStatus, streamsStats := componentReport(componentStatus, componentStreams); streamsStatus != disabledStatus {
+		body[componentStreams] = streamsStatus
+		body["streams_stats"] = publicStreamsStats(streamsStats)
+	}
+
+	return c.JSON(http.StatusOK, body)
 }

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -869,3 +869,114 @@ func runReadyCheck(t *testing.T, app *App, cfg *config.Config) (body map[string]
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
 	return body, w.Code
 }
+
+// TestReadyCheckOmitsStreamsWhenNoneDeclared pins that services without streams keep
+// the /ready body they had: the component is reported only where a probe exists.
+func TestReadyCheckOmitsStreamsWhenNoneDeclared(t *testing.T) {
+	cfg := &config.Config{App: config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"}}
+	app := &App{cfg: cfg, logger: logger.New("error", false), healthProbes: []Prober{}}
+
+	body, code := runReadyCheck(t, app, cfg)
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.NotContains(t, body, componentStreams)
+	assert.NotContains(t, body, "streams_stats")
+}
+
+// TestReadyCheckReportsStreamsWhenProbed is the other half: once the runtime probe is
+// registered the component and its stats reach the body.
+func TestReadyCheckReportsStreamsWhenProbed(t *testing.T) {
+	cfg := &config.Config{App: config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"}}
+	app := &App{cfg: cfg, logger: logger.New("error", false), healthProbes: []Prober{
+		healthProbeFunc{
+			name: componentStreams,
+			fn: func(context.Context) (string, map[string]any, error) {
+				return healthyStatus, map[string]any{statusKey: healthyStatus, "consumers": 2}, nil
+			},
+		},
+	}}
+
+	body, code := runReadyCheck(t, app, cfg)
+
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, healthyStatus, body[componentStreams])
+	assert.Equal(t, map[string]any{statusKey: healthyStatus, "consumers": float64(2)}, body["streams_stats"])
+}
+
+// streamsProbeWithOffsets returns a probe whose details carry the identifier-bearing
+// stored_offsets map a real streams.Manager reports.
+func streamsProbeWithOffsets(streamName, consumerName string) Prober {
+	return healthProbeFunc{
+		name: componentStreams,
+		fn: func(context.Context) (string, map[string]any, error) {
+			return healthyStatus, map[string]any{
+				statusKey:            healthyStatus,
+				"started":            true,
+				"consumers":          1,
+				streamsOffsetsKey:    map[string]int64{streamName + "/" + consumerName: 4242},
+				"offset_store_count": 500,
+			}, nil
+		},
+	}
+}
+
+// TestReadyCheckWithholdsStreamIdentifiers is the /ready half of the disclosure
+// guard: the unauthenticated body must carry the counters but never the stream or
+// consumer-group names, and never the live offsets that differencing two polls
+// would turn into a per-stream message rate.
+func TestReadyCheckWithholdsStreamIdentifiers(t *testing.T) {
+	cfg := &config.Config{App: config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"}}
+	app := &App{cfg: cfg, logger: logger.New("error", false), healthProbes: []Prober{
+		streamsProbeWithOffsets("payments-ledger", "fraud-scoring"),
+	}}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, readyEndpoint, http.NoBody)
+	w := httptest.NewRecorder()
+	require.NoError(t, app.readyCheck(server.NewHandlerContextForTest(w, req, cfg)))
+
+	body := w.Body.String()
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NotContains(t, body, "payments-ledger", "the declared stream name must not reach an unauthenticated body")
+	assert.NotContains(t, body, "fraud-scoring", "the consumer-group name must not reach an unauthenticated body")
+	assert.NotContains(t, body, streamsOffsetsKey)
+	assert.NotContains(t, body, "4242", "live offsets must not reach an unauthenticated body")
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &decoded))
+	stats, ok := decoded["streams_stats"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(1), stats["consumers"], "the counters survive the filter")
+	assert.Equal(t, true, stats["started"])
+}
+
+// TestHealthDebugRetainsStreamIdentifiers is the other half: the access-controlled
+// debug endpoint still renders the offsets operators need.
+func TestHealthDebugRetainsStreamIdentifiers(t *testing.T) {
+	cfg := &config.Config{App: config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"}}
+	app := &App{cfg: cfg, logger: logger.New("error", false), healthProbes: []Prober{
+		streamsProbeWithOffsets("payments-ledger", "fraud-scoring"),
+	}}
+
+	handlers := NewDebugHandlers(app, &config.DebugConfig{Enabled: true, PathPrefix: "/_debug"}, app.logger)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/health-debug", http.NoBody)
+	w := httptest.NewRecorder()
+	require.NoError(t, handlers.handleHealthDebug(server.NewHandlerContextForTest(w, req, nil)))
+
+	body := w.Body.String()
+	assert.Contains(t, body, streamsOffsetsKey)
+	assert.Contains(t, body, "payments-ledger/fraud-scoring")
+	assert.Contains(t, body, "4242")
+}
+
+func TestPublicStreamsStatsCopiesRatherThanMutates(t *testing.T) {
+	details := map[string]any{
+		statusKey:         healthyStatus,
+		streamsOffsetsKey: map[string]int64{"orders/projector": 7},
+	}
+
+	public := publicStreamsStats(details)
+
+	assert.NotContains(t, public, streamsOffsetsKey)
+	assert.Equal(t, healthyStatus, public[statusKey])
+	assert.Contains(t, details, streamsOffsetsKey, "the caller's map must not be mutated")
+}

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -199,7 +199,7 @@ func TestPrepareRuntimeWithScheduler(t *testing.T) {
 	}
 
 	// Call prepareRuntime
-	err = app.prepareRuntime()
+	err = app.prepareRuntime(context.Background())
 	assert.NoError(t, err)
 
 	// Verify RegisterJobs was called on the provider
@@ -254,7 +254,7 @@ func TestPrepareRuntimeFailsWhenDeclarationsExistAndMessagingUnconfigured(t *tes
 	app := newLifecycleCheckApp(t, cfg)
 	require.NoError(t, app.RegisterModule(publisherDeclaringModule{}))
 
-	err := app.prepareRuntime()
+	err := app.prepareRuntime(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "messaging is not configured")
 	assert.Contains(t, err.Error(), "publishers=1")
@@ -271,7 +271,7 @@ func TestPrepareRuntimeAllowsEmptyDeclarationsWithMessagingUnconfigured(t *testi
 	}
 	app := newLifecycleCheckApp(t, cfg)
 
-	require.NoError(t, app.prepareRuntime())
+	require.NoError(t, app.prepareRuntime(context.Background()))
 }
 
 // TestPrepareRuntimeSkipsCheckInMultiTenantMode verifies that the static check
@@ -287,7 +287,7 @@ func TestPrepareRuntimeSkipsCheckInMultiTenantMode(t *testing.T) {
 	app := newLifecycleCheckApp(t, cfg)
 	require.NoError(t, app.RegisterModule(publisherDeclaringModule{}))
 
-	require.NoError(t, app.prepareRuntime())
+	require.NoError(t, app.prepareRuntime(context.Background()))
 }
 
 // TestPrepareRuntimeSucceedsWithDeclarationsAndConfiguredMessaging is the
@@ -304,7 +304,7 @@ func TestPrepareRuntimeSucceedsWithDeclarationsAndConfiguredMessaging(t *testing
 	app := newLifecycleCheckApp(t, cfg)
 	require.NoError(t, app.RegisterModule(publisherDeclaringModule{}))
 
-	require.NoError(t, app.prepareRuntime())
+	require.NoError(t, app.prepareRuntime(context.Background()))
 }
 
 // debugCheckConfig builds a config whose Debug block enables one endpoint, leaving the
@@ -344,7 +344,7 @@ func TestPrepareRuntimeFailsWhenDebugEndpointsHaveNoAccessControl(t *testing.T) 
 		t.Run(tt.name, func(t *testing.T) {
 			app := newLifecycleCheckApp(t, debugCheckConfig(nil, tt.bearerToken))
 
-			err := app.prepareRuntime()
+			err := app.prepareRuntime(context.Background())
 
 			require.Error(t, err)
 			// prepareRuntime passes its callees' errors through untouched, so the error
@@ -373,7 +373,7 @@ func TestPrepareRuntimeAllowsDebugEndpointsWithAccessControl(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			app := newLifecycleCheckApp(t, debugCheckConfig(tt.allowedIPs, tt.bearerToken))
 
-			require.NoError(t, app.prepareRuntime())
+			require.NoError(t, app.prepareRuntime(context.Background()))
 		})
 	}
 }
@@ -408,7 +408,7 @@ func TestPrepareRuntimeSucceedsWithNoMessagingConfigured(t *testing.T) {
 	require.True(t, a.messagingInitializer.IsAvailable(),
 		"a messaging manager is built even with no broker configured — the premise of this guard")
 
-	require.NoError(t, a.prepareRuntime())
+	require.NoError(t, a.prepareRuntime(context.Background()))
 }
 
 // globalMWCapturingServer implements ServerRunner (via embedded mockServer) plus the

--- a/app/module.go
+++ b/app/module.go
@@ -14,6 +14,7 @@ import (
 	dbtypes "github.com/gaborage/go-bricks/database/types"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/messaging/streams"
 	"github.com/gaborage/go-bricks/server"
 )
 
@@ -40,6 +41,14 @@ type RouteRegisterer interface {
 // during application startup.
 type MessagingDeclarer interface {
 	DeclareMessaging(decls *messaging.Declarations)
+}
+
+// StreamDeclarer is an optional interface that modules can implement to declare
+// RabbitMQ streams and consumers served over the native stream protocol.
+// Modules that implement this interface will have DeclareStreams called automatically
+// during application startup. Single-tenant only — see wiki/streams.md.
+type StreamDeclarer interface {
+	DeclareStreams(decls *streams.Declarations)
 }
 
 // GlobalMiddlewareRegisterer is an optional interface that modules can implement to

--- a/app/module_registry.go
+++ b/app/module_registry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gaborage/go-bricks/jose"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/messaging/streams"
 	"github.com/gaborage/go-bricks/server"
 )
 
@@ -303,6 +304,37 @@ func (r *ModuleRegistry) DeclareMessaging(decls *messaging.Declarations) error {
 		Int("publishers", stats.Publishers).
 		Int("consumers", stats.Consumers).
 		Msg("Messaging declarations collected and validated successfully")
+
+	return nil
+}
+
+// DeclareStreams calls DeclareStreams on modules that implement StreamDeclarer.
+// Modules without stream declarations are silently skipped.
+func (r *ModuleRegistry) DeclareStreams(decls *streams.Declarations) error {
+	if decls == nil {
+		return errors.New("stream declarations store is nil")
+	}
+
+	for _, module := range r.modules {
+		if sd, ok := module.(StreamDeclarer); ok {
+			r.logger.Info().
+				Str("module", module.Name()).
+				Msg("Collecting module stream declarations")
+
+			sd.DeclareStreams(decls)
+		}
+	}
+
+	if err := decls.Validate(); err != nil {
+		r.logger.Error().Err(err).Msg("Stream declaration validation failed")
+		return fmt.Errorf("stream declaration validation failed: %w", err)
+	}
+
+	stats := decls.Stats()
+	r.logger.Info().
+		Int("streams", stats.Streams).
+		Int("consumers", stats.Consumers).
+		Msg("Stream declarations collected and validated successfully")
 
 	return nil
 }

--- a/app/module_registry_test.go
+++ b/app/module_registry_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gaborage/go-bricks/config"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	"github.com/gaborage/go-bricks/messaging/streams"
 	"github.com/gaborage/go-bricks/server"
 )
 
@@ -314,4 +315,65 @@ func TestRegisterAcceptsModulesWhenDatabaseRequirementDoesNotApply(t *testing.T)
 			require.NoError(t, newDBRequirementRegistry(tt.rootDBAbsent).Register(tt.module))
 		})
 	}
+}
+
+func TestModuleRegistryDeclareStreamsCollectsFromDeclarers(t *testing.T) {
+	log := logger.New("error", false)
+	registry := NewModuleRegistry(&ModuleDeps{Logger: log, Config: &config.Config{}})
+	declarer := &streamModule{name: "orders", declaration: declareOneConsumer}
+	require.NoError(t, registry.Register(declarer))
+	require.NoError(t, registry.Register(&minimalModule{name: "plain"}))
+
+	decls := streams.NewDeclarations()
+	require.NoError(t, registry.DeclareStreams(decls))
+
+	assert.Equal(t, 1, declarer.calls, "a declarer is invoked exactly once")
+	assert.Equal(t, streams.Stats{Streams: 1, Consumers: 1}, decls.Stats())
+}
+
+func TestModuleRegistryDeclareStreamsRejectsNilStore(t *testing.T) {
+	registry := NewModuleRegistry(&ModuleDeps{Logger: logger.New("error", false), Config: &config.Config{}})
+
+	err := registry.DeclareStreams(nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stream declarations store is nil")
+}
+
+func TestModuleRegistryDeclareStreamsFailsOnInvalidDeclarations(t *testing.T) {
+	log := logger.New("error", false)
+	registry := NewModuleRegistry(&ModuleDeps{Logger: log, Config: &config.Config{}})
+	require.NoError(t, registry.Register(&streamModule{name: "orders", declaration: func(decls *streams.Declarations) {
+		decls.DeclareConsumer(&streams.ConsumerOptions{Stream: "ghost", Name: testStreamConsumer})
+	}}))
+
+	err := registry.DeclareStreams(streams.NewDeclarations())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stream declaration validation failed")
+	assert.Contains(t, err.Error(), "references undeclared stream")
+}
+
+func TestModuleRegistryDeclareStreamsWithNoDeclarersIsEmpty(t *testing.T) {
+	log := logger.New("error", false)
+	registry := NewModuleRegistry(&ModuleDeps{Logger: log, Config: &config.Config{}})
+	require.NoError(t, registry.Register(&minimalModule{name: "plain"}))
+
+	decls := streams.NewDeclarations()
+	require.NoError(t, registry.DeclareStreams(decls))
+
+	assert.True(t, decls.IsEmpty())
+}
+
+// warnLines returns every recorded warn-level event.
+func (l *recLogger) warnLines() []recEvent {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var out []recEvent
+	for _, e := range l.events {
+		if e.level == "warn" {
+			out = append(out, e)
+		}
+	}
+	return out
 }

--- a/app/streams_setup.go
+++ b/app/streams_setup.go
@@ -1,0 +1,131 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/gaborage/go-bricks/messaging/streams"
+)
+
+// plaintextStreamScheme is the non-TLS stream-protocol scheme
+// warnIfPlaintextStreamURI flags outside development.
+const plaintextStreamScheme = "rabbitmq-stream"
+
+// prepareStreamConsumers collects the modules' native stream declarations and,
+// when there are any, starts the stream-protocol consumers.
+//
+// Everything happens at RUNTIME on purpose: the manager does not exist while the
+// builder runs, so its readiness probe and its closer are both registered here
+// rather than in createHealthProbes or Builder.RegisterClosers, which are
+// snapshotted before prepareRuntime runs. This is safe because prepareRuntime is
+// single-threaded and completes before the server starts serving /ready.
+func (a *App) prepareStreamConsumers() error {
+	if a.registry == nil {
+		return errors.New("module registry not initialized")
+	}
+
+	decls := streams.NewDeclarations()
+	if err := a.registry.DeclareStreams(decls); err != nil {
+		return err
+	}
+	if decls.IsEmpty() {
+		return nil
+	}
+
+	if err := a.assertStreamsSingleTenant(); err != nil {
+		return err
+	}
+
+	if err := a.assertStreamsConfigured(decls); err != nil {
+		return err
+	}
+
+	cfg := a.cfg.Messaging.Streams
+	a.warnIfPlaintextStreamURI(cfg.URI)
+	mgr := streams.NewManager(streams.ManagerOptions{
+		URI:                 cfg.URI,
+		AddressResolverHost: cfg.AddressResolver.Host,
+		AddressResolverPort: cfg.AddressResolver.Port,
+		OffsetStoreCount:    cfg.OffsetStore.CountBeforeStorage,
+		OffsetStoreInterval: cfg.OffsetStore.FlushInterval,
+		Logger:              a.logger,
+	})
+
+	// A service that declared stream consumers and cannot start them would serve
+	// HTTP while consuming nothing, so startup fails rather than booting green.
+	if err := mgr.Start(context.Background(), decls); err != nil {
+		if closeErr := mgr.Close(); closeErr != nil {
+			a.logger.Warn().Err(closeErr).Msg("Failed to close stream environment after a failed start")
+		}
+		return fmt.Errorf("failed to start stream consumers: %w", err)
+	}
+
+	a.streamsManager = mgr
+	a.registerCloser("streams manager", mgr)
+	a.healthProbes = append(a.healthProbes, streamsManagerHealthProbe(mgr))
+
+	return nil
+}
+
+// assertStreamsSingleTenant re-asserts the tenancy invariant at runtime.
+//
+// SECURITY: config.Validate already rejects multitenant.enabled beside a stream
+// URI, but app.NewWithConfig takes a hand-built config and never calls it — the
+// documented bypass untypedConnectionStringPaths guards against for database
+// types. Without this repeat, such a service would boot green and run stream
+// handlers against one shared Environment with no tenant in context, which is
+// precisely what the gate exists to prevent.
+func (a *App) assertStreamsSingleTenant() error {
+	if !a.cfg.Multitenant.Enabled {
+		return nil
+	}
+	return errors.New("messaging.streams is single-tenant only; multi-tenant stream consumption " +
+		"is not yet supported, but stream declarations were registered with multitenant.enabled: true; " +
+		"config.Validate rejects this combination and a config built without it is re-checked here")
+}
+
+// warnIfPlaintextStreamURI flags a plaintext stream endpoint outside development:
+// the broker credentials in the URI then cross the network in the clear. It warns
+// rather than fails because the framework exposes no TLS configuration surface yet
+// (ADR-059 future work), so failing closed would leave such deployments no option.
+func (a *App) warnIfPlaintextStreamURI(uri string) {
+	if a.cfg.App.IsDevelopment() {
+		return
+	}
+	u, err := url.Parse(uri)
+	if err != nil || u.Scheme != plaintextStreamScheme {
+		return
+	}
+	a.logger.Warn().
+		Str("environment", a.cfg.App.Env).
+		Msg("messaging.streams.uri uses the plaintext stream protocol; broker credentials cross the network unencrypted — " +
+			"terminate TLS in front of the broker or use rabbitmq-stream+tls://")
+}
+
+// assertStreamsConfigured fails fast when a module declared streams but no
+// stream endpoint is configured — without it the declarations would be silently
+// dropped, exactly as assertMessagingConfiguredIfDeclared prevents for AMQP.
+func (a *App) assertStreamsConfigured(decls *streams.Declarations) error {
+	if a.cfg.Messaging.Streams.URI != "" {
+		return nil
+	}
+	s := decls.Stats()
+	return fmt.Errorf("stream declarations were registered "+
+		"(streams=%d, consumers=%d) "+
+		"but the stream protocol is not configured; "+
+		"set messaging.streams.uri (or env MESSAGING_STREAMS_URI)",
+		s.Streams, s.Consumers)
+}
+
+// shutdownStreamConsumers stops stream consumers before modules are torn down.
+// Each consumer flushes its pending offset first; the environment itself is
+// closed later by the registered closer. No-op when no streams were declared.
+func (a *App) shutdownStreamConsumers() {
+	if a.streamsManager == nil {
+		return
+	}
+	a.logger.Info().Msg("Stopping stream consumers")
+	a.streamsManager.StopConsumers()
+}

--- a/app/streams_setup.go
+++ b/app/streams_setup.go
@@ -21,7 +21,7 @@ const plaintextStreamScheme = "rabbitmq-stream"
 // rather than in createHealthProbes or Builder.RegisterClosers, which are
 // snapshotted before prepareRuntime runs. This is safe because prepareRuntime is
 // single-threaded and completes before the server starts serving /ready.
-func (a *App) prepareStreamConsumers() error {
+func (a *App) prepareStreamConsumers(ctx context.Context) error {
 	if a.registry == nil {
 		return errors.New("module registry not initialized")
 	}
@@ -55,7 +55,9 @@ func (a *App) prepareStreamConsumers() error {
 
 	// A service that declared stream consumers and cannot start them would serve
 	// HTTP while consuming nothing, so startup fails rather than booting green.
-	if err := mgr.Start(context.Background(), decls); err != nil {
+	// The startup context is handed over for its values only — Start severs its
+	// cancellation, so shutdownStreamConsumers stays the thing that stops them.
+	if err := mgr.Start(ctx, decls); err != nil {
 		if closeErr := mgr.Close(); closeErr != nil {
 			a.logger.Warn().Err(closeErr).Msg("Failed to close stream environment after a failed start")
 		}

--- a/app/streams_setup_test.go
+++ b/app/streams_setup_test.go
@@ -1,0 +1,235 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaborage/go-bricks/config"
+	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/messaging/streams"
+)
+
+const (
+	testStreamName         = "orders"
+	testStreamConsumer     = "orders-processor"
+	unreachableStreamURI   = "rabbitmq-stream://guest:guest@127.0.0.1:1/%2f"
+	streamsUnconfiguredMsg = "set messaging.streams.uri"
+)
+
+// streamModule implements Module + StreamDeclarer.
+type streamModule struct {
+	name        string
+	calls       int
+	declaration func(decls *streams.Declarations)
+}
+
+func (m *streamModule) Name() string             { return m.name }
+func (m *streamModule) Init(_ *ModuleDeps) error { return nil }
+func (m *streamModule) Shutdown() error          { return nil }
+func (m *streamModule) DeclareStreams(decls *streams.Declarations) {
+	m.calls++
+	if m.declaration != nil {
+		m.declaration(decls)
+	}
+}
+
+func declareOneConsumer(decls *streams.Declarations) {
+	decls.DeclareStream(testStreamName, nil)
+	decls.DeclareConsumer(&streams.ConsumerOptions{
+		Stream:  testStreamName,
+		Name:    testStreamConsumer,
+		Handler: func(context.Context, *streams.Message) error { return nil },
+	})
+}
+
+func newStreamsApp(t *testing.T, streamsCfg config.StreamsConfig, modules ...Module) *App {
+	t.Helper()
+	return newStreamsAppWithLogger(t, logger.New("error", false), streamsCfg, modules...)
+}
+
+func newStreamsAppWithLogger(t *testing.T, log logger.Logger, streamsCfg config.StreamsConfig, modules ...Module) *App {
+	t.Helper()
+
+	cfg := &config.Config{
+		App:       config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"},
+		Messaging: config.MessagingConfig{Streams: streamsCfg},
+	}
+	registry := NewModuleRegistry(&ModuleDeps{Logger: log, Config: cfg})
+	for _, m := range modules {
+		require.NoError(t, registry.Register(m))
+	}
+
+	return &App{cfg: cfg, logger: log, registry: registry}
+}
+
+func TestPrepareStreamConsumersWithoutDeclarationsIsNoop(t *testing.T) {
+	a := newStreamsApp(t, config.StreamsConfig{}, &minimalModule{name: "plain"})
+
+	require.NoError(t, a.prepareStreamConsumers())
+
+	assert.Nil(t, a.streamsManager)
+	assert.Empty(t, a.healthProbes, "a streams-free service keeps its probe list unchanged")
+	assert.Empty(t, a.closers)
+}
+
+func TestPrepareStreamConsumersRequiresRegistry(t *testing.T) {
+	a := &App{logger: logger.New("error", false)}
+
+	err := a.prepareStreamConsumers()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "module registry not initialized")
+}
+
+func TestPrepareStreamConsumersFailsWhenDeclaredButUnconfigured(t *testing.T) {
+	a := newStreamsApp(t, config.StreamsConfig{},
+		&streamModule{name: "orders", declaration: declareOneConsumer})
+
+	err := a.prepareStreamConsumers()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stream declarations were registered")
+	assert.Contains(t, err.Error(), "streams=1, consumers=1")
+	assert.Contains(t, err.Error(), streamsUnconfiguredMsg)
+	assert.Nil(t, a.streamsManager)
+}
+
+func TestPrepareStreamConsumersPropagatesValidationFailure(t *testing.T) {
+	a := newStreamsApp(t, config.StreamsConfig{URI: unreachableStreamURI},
+		&streamModule{name: "orders", declaration: func(decls *streams.Declarations) {
+			decls.DeclareConsumer(&streams.ConsumerOptions{
+				Stream:  "undeclared",
+				Name:    testStreamConsumer,
+				Handler: func(context.Context, *streams.Message) error { return nil },
+			})
+		}})
+
+	err := a.prepareStreamConsumers()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stream declaration validation failed")
+	assert.Nil(t, a.streamsManager)
+}
+
+func TestPrepareStreamConsumersFailsWhenBrokerUnreachable(t *testing.T) {
+	a := newStreamsApp(t, config.StreamsConfig{URI: unreachableStreamURI},
+		&streamModule{name: "orders", declaration: declareOneConsumer})
+
+	err := a.prepareStreamConsumers()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to start stream consumers")
+	assert.NotContains(t, err.Error(), "guest:guest", "the stream URI's credentials must never reach an error message")
+	assert.Nil(t, a.streamsManager, "a failed start registers neither a probe nor a closer")
+	assert.Empty(t, a.healthProbes)
+	assert.Empty(t, a.closers)
+}
+
+// TestPrepareStreamConsumersReportsOnlyRealCleanupFailures pins the guard on the
+// failed-start cleanup. The dial never completed, so the manager holds no
+// environment and Close is a no-op; a guard reading its result the wrong way
+// round would tell the operator the environment failed to close on every single
+// failed startup, burying the real cause.
+func TestPrepareStreamConsumersReportsOnlyRealCleanupFailures(t *testing.T) {
+	log := &recLogger{}
+	a := newStreamsAppWithLogger(t, log, config.StreamsConfig{URI: unreachableStreamURI},
+		&streamModule{name: "orders", declaration: declareOneConsumer})
+
+	err := a.prepareStreamConsumers()
+
+	require.Error(t, err, "the premise: the start fails before an environment exists")
+	assert.False(t, loggedMsgContains(log, "Failed to close stream environment"),
+		"a cleanup that had nothing to close is not reported as a failure")
+}
+
+func TestPrepareStreamConsumersInvokesEveryDeclarerOnce(t *testing.T) {
+	m := &streamModule{name: "orders", declaration: declareOneConsumer}
+	a := newStreamsApp(t, config.StreamsConfig{}, m)
+
+	_ = a.prepareStreamConsumers()
+
+	assert.Equal(t, 1, m.calls)
+}
+
+func TestShutdownStreamConsumersWithoutManagerIsNoop(t *testing.T) {
+	a := &App{logger: logger.New("error", false)}
+
+	assert.NotPanics(t, a.shutdownStreamConsumers)
+}
+
+func TestShutdownStreamConsumersStopsTheManager(t *testing.T) {
+	a := &App{logger: logger.New("error", false)}
+	a.streamsManager = streams.NewManager(streams.ManagerOptions{
+		URI:    unreachableStreamURI,
+		Logger: a.logger,
+	})
+
+	a.shutdownStreamConsumers()
+
+	assert.Equal(t, false, a.streamsManager.Stats()["started"])
+}
+
+// TestPrepareStreamConsumersRejectsMultiTenantBypass drives the documented
+// config.Validate bypass: NewWithConfig accepts a hand-built config, so a
+// multi-tenant service with a stream URI and a declaring module would otherwise
+// boot green and run handlers with no tenant in context.
+func TestPrepareStreamConsumersRejectsMultiTenantBypass(t *testing.T) {
+	a := newStreamsApp(t, config.StreamsConfig{URI: unreachableStreamURI},
+		&streamModule{name: "orders", declaration: declareOneConsumer})
+	a.cfg.Multitenant.Enabled = true
+
+	err := a.prepareStreamConsumers()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "single-tenant only")
+	assert.Nil(t, a.streamsManager, "no Environment is built for a multi-tenant service")
+	assert.Empty(t, a.healthProbes)
+	assert.Empty(t, a.closers)
+}
+
+// TestPrepareStreamConsumersAllowsSingleTenant is the negative half: the re-check
+// must not block the supported deployment.
+func TestPrepareStreamConsumersAllowsSingleTenant(t *testing.T) {
+	a := newStreamsApp(t, config.StreamsConfig{}, &minimalModule{name: "plain"})
+	a.cfg.Multitenant.Enabled = false
+
+	require.NoError(t, a.assertStreamsSingleTenant())
+}
+
+func TestWarnIfPlaintextStreamURI(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      string
+		uri      string
+		wantWarn bool
+	}{
+		{name: "plaintext_outside_development_warns", env: "production", uri: "rabbitmq-stream://broker:5552/", wantWarn: true},
+		{name: "plaintext_in_development_is_silent", env: "development", uri: "rabbitmq-stream://broker:5552/"},
+		{name: "tls_scheme_is_silent", env: "production", uri: "rabbitmq-stream+tls://broker:5551/"},
+		{name: "unparseable_uri_is_silent", env: "production", uri: "rabbitmq-stream://broker:55 52/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := &recLogger{}
+			a := &App{
+				cfg:    &config.Config{App: config.AppConfig{Name: testApp, Env: tt.env, Version: "1.0.0"}},
+				logger: log,
+			}
+
+			a.warnIfPlaintextStreamURI(tt.uri)
+
+			warnings := log.warnLines()
+			if !tt.wantWarn {
+				assert.Empty(t, warnings)
+				return
+			}
+			require.Len(t, warnings, 1)
+			assert.Contains(t, warnings[0].msg, "plaintext stream protocol")
+			assert.NotContains(t, warnings[0].msg, "broker:5552", "the endpoint itself stays out of the warning")
+		})
+	}
+}

--- a/app/streams_setup_test.go
+++ b/app/streams_setup_test.go
@@ -68,7 +68,7 @@ func newStreamsAppWithLogger(t *testing.T, log logger.Logger, streamsCfg config.
 func TestPrepareStreamConsumersWithoutDeclarationsIsNoop(t *testing.T) {
 	a := newStreamsApp(t, config.StreamsConfig{}, &minimalModule{name: "plain"})
 
-	require.NoError(t, a.prepareStreamConsumers())
+	require.NoError(t, a.prepareStreamConsumers(context.Background()))
 
 	assert.Nil(t, a.streamsManager)
 	assert.Empty(t, a.healthProbes, "a streams-free service keeps its probe list unchanged")
@@ -78,7 +78,7 @@ func TestPrepareStreamConsumersWithoutDeclarationsIsNoop(t *testing.T) {
 func TestPrepareStreamConsumersRequiresRegistry(t *testing.T) {
 	a := &App{logger: logger.New("error", false)}
 
-	err := a.prepareStreamConsumers()
+	err := a.prepareStreamConsumers(context.Background())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "module registry not initialized")
@@ -88,7 +88,7 @@ func TestPrepareStreamConsumersFailsWhenDeclaredButUnconfigured(t *testing.T) {
 	a := newStreamsApp(t, config.StreamsConfig{},
 		&streamModule{name: "orders", declaration: declareOneConsumer})
 
-	err := a.prepareStreamConsumers()
+	err := a.prepareStreamConsumers(context.Background())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "stream declarations were registered")
@@ -107,7 +107,7 @@ func TestPrepareStreamConsumersPropagatesValidationFailure(t *testing.T) {
 			})
 		}})
 
-	err := a.prepareStreamConsumers()
+	err := a.prepareStreamConsumers(context.Background())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "stream declaration validation failed")
@@ -118,7 +118,7 @@ func TestPrepareStreamConsumersFailsWhenBrokerUnreachable(t *testing.T) {
 	a := newStreamsApp(t, config.StreamsConfig{URI: unreachableStreamURI},
 		&streamModule{name: "orders", declaration: declareOneConsumer})
 
-	err := a.prepareStreamConsumers()
+	err := a.prepareStreamConsumers(context.Background())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to start stream consumers")
@@ -126,6 +126,24 @@ func TestPrepareStreamConsumersFailsWhenBrokerUnreachable(t *testing.T) {
 	assert.Nil(t, a.streamsManager, "a failed start registers neither a probe nor a closer")
 	assert.Empty(t, a.healthProbes)
 	assert.Empty(t, a.closers)
+}
+
+// TestPrepareStreamConsumersIgnoresCallerCancellation is the app half of the
+// consume-context contract: the startup context reaches the manager for its
+// values, and its cancellation carries no weight here — consumer lifetime belongs
+// to StopConsumers, so an already-canceled context changes nothing about how
+// startup succeeds or fails.
+func TestPrepareStreamConsumersIgnoresCallerCancellation(t *testing.T) {
+	a := newStreamsApp(t, config.StreamsConfig{URI: unreachableStreamURI},
+		&streamModule{name: "orders", declaration: declareOneConsumer})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := a.prepareStreamConsumers(ctx)
+
+	require.Error(t, err, "the premise: this broker is unreachable")
+	assert.Contains(t, err.Error(), "failed to start stream consumers")
+	assert.NotErrorIs(t, err, context.Canceled, "startup never consults the caller's cancellation")
 }
 
 // TestPrepareStreamConsumersReportsOnlyRealCleanupFailures pins the guard on the
@@ -138,7 +156,7 @@ func TestPrepareStreamConsumersReportsOnlyRealCleanupFailures(t *testing.T) {
 	a := newStreamsAppWithLogger(t, log, config.StreamsConfig{URI: unreachableStreamURI},
 		&streamModule{name: "orders", declaration: declareOneConsumer})
 
-	err := a.prepareStreamConsumers()
+	err := a.prepareStreamConsumers(context.Background())
 
 	require.Error(t, err, "the premise: the start fails before an environment exists")
 	assert.False(t, loggedMsgContains(log, "Failed to close stream environment"),
@@ -149,7 +167,7 @@ func TestPrepareStreamConsumersInvokesEveryDeclarerOnce(t *testing.T) {
 	m := &streamModule{name: "orders", declaration: declareOneConsumer}
 	a := newStreamsApp(t, config.StreamsConfig{}, m)
 
-	_ = a.prepareStreamConsumers()
+	_ = a.prepareStreamConsumers(context.Background())
 
 	assert.Equal(t, 1, m.calls)
 }
@@ -181,7 +199,7 @@ func TestPrepareStreamConsumersRejectsMultiTenantBypass(t *testing.T) {
 		&streamModule{name: "orders", declaration: declareOneConsumer})
 	a.cfg.Multitenant.Enabled = true
 
-	err := a.prepareStreamConsumers()
+	err := a.prepareStreamConsumers(context.Background())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "single-tenant only")

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -179,6 +179,18 @@ messaging:
   headers:
     x-app-name: my-service
     x-environment: development
+  # Native stream-protocol consumption (OPTIONAL - see wiki/streams.md).
+  # Required only when a module implements app.StreamDeclarer. Separate listener
+  # (default port 5552, rabbitmq_stream plugin); never derived from broker.url.
+  # Single-tenant only: multitenant.enabled + a uri here fails startup.
+  # streams:
+  #   uri: rabbitmq-stream://guest:guest@localhost:5552/%2f
+  #   addressresolver:            # both or neither; needed behind a load balancer or NAT
+  #     host: rabbitmq.example.com
+  #     port: 5552
+  #   offsetstore:
+  #     countbeforestorage: 500   # handled messages before a server-side offset commit
+  #     flushinterval: 5s         # elapsed time before a pending offset is committed
 
 multitenant:
   enabled: false

--- a/config/types.go
+++ b/config/types.go
@@ -452,6 +452,53 @@ type MessagingConfig struct {
 	Headers   map[string]string   `koanf:"headers" json:"headers" yaml:"headers" toml:"headers" mapstructure:"headers"`
 	Reconnect ReconnectConfig     `koanf:"reconnect" json:"reconnect" yaml:"reconnect" toml:"reconnect" mapstructure:"reconnect"`
 	Publisher PublisherPoolConfig `koanf:"publisher" json:"publisher" yaml:"publisher" toml:"publisher" mapstructure:"publisher"`
+	Streams   StreamsConfig       `koanf:"streams" json:"streams" yaml:"streams" toml:"streams" mapstructure:"streams"`
+}
+
+// StreamsConfig holds native RabbitMQ stream-protocol settings (consumption).
+// Single-tenant only: multitenant.enabled together with a stream URI is a
+// startup validation error (see config/validation.go: validateMessagingStreams).
+type StreamsConfig struct {
+	// URI is the stream-protocol endpoint, scheme rabbitmq-stream:// (or
+	// rabbitmq-stream+tls://), default port 5552. Required when any module
+	// declares stream consumers. Deliberately NOT derived from
+	// messaging.broker.url — the stream protocol is a separate listener that a
+	// deployment may not expose at all (explicit > implicit).
+	URI string `koanf:"uri" json:"uri" yaml:"uri" toml:"uri" mapstructure:"uri"`
+
+	// AddressResolver pins the client to a single entry point (load balancer,
+	// NAT, or Docker port mapping), which the broker's own metadata cannot
+	// describe. Set both fields or neither.
+	AddressResolver StreamsAddressResolverConfig `koanf:"addressresolver" json:"addressresolver" yaml:"addressresolver" toml:"addressresolver" mapstructure:"addressresolver"`
+
+	// OffsetStore tunes how often successfully handled offsets are committed
+	// server-side.
+	OffsetStore StreamsOffsetStoreConfig `koanf:"offsetstore" json:"offsetstore" yaml:"offsetstore" toml:"offsetstore" mapstructure:"offsetstore"`
+}
+
+// StreamsAddressResolverConfig pins stream connections to one advertised endpoint.
+type StreamsAddressResolverConfig struct {
+	// Host is the entry-point hostname clients dial instead of the address the
+	// broker advertises in its metadata response.
+	Host string `koanf:"host" json:"host" yaml:"host" toml:"host" mapstructure:"host"`
+
+	// Port is the entry-point port. Must be 1-65535 when Host is set.
+	Port int `koanf:"port" json:"port" yaml:"port" toml:"port" mapstructure:"port"`
+}
+
+// StreamsOffsetStoreConfig tunes the server-side offset commit cadence.
+// Offsets are only ever committed AFTER a handler returned successfully, so
+// these keys trade commit traffic against how much already-handled work a
+// crash replays.
+type StreamsOffsetStoreConfig struct {
+	// CountBeforeStorage is how many successfully handled messages accumulate
+	// before the offset is committed. Default: 500. Must be >= 0 (0 applies the default).
+	CountBeforeStorage int `koanf:"countbeforestorage" json:"countbeforestorage" yaml:"countbeforestorage" toml:"countbeforestorage" mapstructure:"countbeforestorage"`
+
+	// FlushInterval is how long after the last commit a pending offset is
+	// committed even if CountBeforeStorage was not reached. Default: 5s.
+	// Must be >= 0 (0 applies the default).
+	FlushInterval time.Duration `koanf:"flushinterval" json:"flushinterval" yaml:"flushinterval" toml:"flushinterval" mapstructure:"flushinterval"`
 }
 
 // ReconnectConfig holds AMQP reconnection settings.

--- a/config/validation.go
+++ b/config/validation.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"slices"
 	"strings"
 	"time"
@@ -64,6 +65,15 @@ const (
 	defaultPublisherIdleTTLMultiTenant = 10 * time.Minute
 	defaultPublisherCleanupInterval    = 2 * time.Minute // Publisher-pool cleanup goroutine frequency
 	defaultMaxPublishAttempts          = 5               // Bounded publish retry attempts before giving up
+)
+
+// Native stream-protocol (messaging.streams.*) defaults
+const (
+	defaultStreamsOffsetCount    = 500             // Handled messages before a server-side offset commit
+	defaultStreamsOffsetInterval = 5 * time.Second // Elapsed time before a pending offset is committed
+
+	streamsURIScheme    = "rabbitmq-stream"
+	streamsURITLSScheme = "rabbitmq-stream+tls"
 )
 
 // Cache manager defaults
@@ -250,7 +260,81 @@ func validateDebug(cfg *DebugConfig) error {
 // Returns an error if any setting is invalid; otherwise nil.
 func validateMessaging(cfg *MessagingConfig, multitenant bool) error {
 	// Apply messaging defaults (reconnection, publisher pool)
-	return applyMessagingDefaults(cfg, multitenant)
+	if err := applyMessagingDefaults(cfg, multitenant); err != nil {
+		return err
+	}
+
+	return validateMessagingStreams(&cfg.Streams, multitenant)
+}
+
+// validateMessagingStreams validates the native stream-protocol block and applies
+// its offset-store defaults.
+//
+// SECURITY: messaging.streams.uri carries broker credentials, so no error raised
+// here echoes the URI — only the config key and the offending scheme reach the
+// message.
+func validateMessagingStreams(cfg *StreamsConfig, multitenant bool) error {
+	if err := applyStreamsDefaults(cfg); err != nil {
+		return err
+	}
+
+	if cfg.URI != "" {
+		// Multi-tenant stream consumption would need one Environment per tenant and a
+		// per-tenant stream URI leg; until that exists the combination fails loudly
+		// instead of consuming one tenant's streams on behalf of all of them.
+		if multitenant {
+			return NewValidationError("messaging.streams",
+				"single-tenant only; multi-tenant stream consumption is not yet supported")
+		}
+
+		u, err := url.Parse(cfg.URI)
+		if err != nil {
+			return NewValidationError("messaging.streams.uri", "must be a valid URI")
+		}
+		if u.Scheme != streamsURIScheme && u.Scheme != streamsURITLSScheme {
+			return NewInvalidFieldError("messaging.streams.uri",
+				fmt.Sprintf(errNotSupportedFmt, u.Scheme),
+				[]string{streamsURIScheme + "://", streamsURITLSScheme + "://"})
+		}
+		// A missing "//" parses as an opaque URI with no host: it clears the scheme
+		// check but has nothing to dial, and redactStreamURI cannot render it, so the
+		// startup failure would name no endpoint at all.
+		if u.Host == "" {
+			return NewValidationError("messaging.streams.uri",
+				"must include a host, e.g. "+streamsURIScheme+"://<user>:<password>@<host>:5552/%2f")
+		}
+	}
+
+	return validateStreamsAddressResolver(&cfg.AddressResolver)
+}
+
+// validateStreamsAddressResolver enforces the both-or-neither rule: a host with no
+// port cannot be dialed, and a port with no host silently does nothing.
+func validateStreamsAddressResolver(cfg *StreamsAddressResolverConfig) error {
+	if cfg.Host == "" && cfg.Port == 0 {
+		return nil
+	}
+	if cfg.Host == "" {
+		return NewValidationError("messaging.streams.addressresolver.host",
+			"must be set when messaging.streams.addressresolver.port is set")
+	}
+	if cfg.Port < 1 || cfg.Port > 65535 {
+		return NewInvalidFieldError("messaging.streams.addressresolver.port",
+			fmt.Sprintf(errInvalidField, cfg.Port), []string{portRange})
+	}
+	return nil
+}
+
+// applyStreamsDefaults materializes the offset-store defaults with the same
+// "zero applies the default, negative is invalid" rule the rest of the messaging
+// block uses.
+func applyStreamsDefaults(cfg *StreamsConfig) error {
+	if err := applyNonNegativeDefault(&cfg.OffsetStore.CountBeforeStorage, defaultStreamsOffsetCount,
+		"messaging.streams.offsetstore.countbeforestorage"); err != nil {
+		return err
+	}
+	return applyNonNegativeDefault(&cfg.OffsetStore.FlushInterval, defaultStreamsOffsetInterval,
+		"messaging.streams.offsetstore.flushinterval")
 }
 
 // validateApp validates the application configuration in cfg.

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -5499,3 +5499,208 @@ func TestDatabaseIdentityKeysMatchPredicate(t *testing.T) {
 		})
 	}
 }
+
+// streamsFixturePassword is a fixture value, not a credential — the leak assertions
+// below prove it never reaches an error string.
+const streamsFixturePassword = "fixture-pw"
+
+func TestValidateMessagingStreamsURIScheme(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr string
+	}{
+		{name: "unset_uri_is_valid", uri: ""},
+		{name: "plain_scheme_accepted", uri: "rabbitmq-stream://svc:" + streamsFixturePassword + "@broker:5552/%2f"},
+		{name: "tls_scheme_accepted", uri: "rabbitmq-stream+tls://svc:" + streamsFixturePassword + "@broker:5551/%2f"},
+		{
+			name:    "amqp_scheme_rejected",
+			uri:     "amqp://svc:" + streamsFixturePassword + "@broker:5672/",
+			wantErr: "'amqp' is not supported must be one of: rabbitmq-stream://, rabbitmq-stream+tls://",
+		},
+		{
+			name:    "schemeless_value_rejected",
+			uri:     "broker:5552",
+			wantErr: "is not supported",
+		},
+		{
+			name:    "unparseable_uri_rejected",
+			uri:     "rabbitmq-stream://svc:" + streamsFixturePassword + "@broker:55 52/",
+			wantErr: "messaging.streams.uri must be a valid URI",
+		},
+		{
+			// The realistic typo: a missing "//" parses as an opaque URI whose scheme
+			// still passes the allowlist, leaving nothing to dial.
+			name:    "missing_double_slash_rejected",
+			uri:     "rabbitmq-stream:broker:5552",
+			wantErr: "messaging.streams.uri must include a host",
+		},
+		{
+			name:    "host_less_uri_with_credentials_rejected",
+			uri:     "rabbitmq-stream:svc:" + streamsFixturePassword + "@/vhost",
+			wantErr: "messaging.streams.uri must include a host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &MessagingConfig{Streams: StreamsConfig{URI: tt.uri}}
+
+			err := validateMessaging(cfg, false)
+
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.NotContains(t, err.Error(), streamsFixturePassword,
+				"messaging.streams.uri carries credentials; they must never reach an error message")
+		})
+	}
+}
+
+func TestValidateMessagingStreamsRejectsMultiTenant(t *testing.T) {
+	cfg := &MessagingConfig{Streams: StreamsConfig{
+		URI: "rabbitmq-stream://svc:" + streamsFixturePassword + "@broker:5552/%2f",
+	}}
+
+	err := validateMessaging(cfg, true)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "messaging.streams single-tenant only")
+	assert.Contains(t, err.Error(), "multi-tenant stream consumption is not yet supported")
+	assert.NotContains(t, err.Error(), streamsFixturePassword)
+}
+
+func TestValidateMessagingStreamsAllowsMultiTenantWithoutURI(t *testing.T) {
+	cfg := &MessagingConfig{}
+
+	require.NoError(t, validateMessaging(cfg, true),
+		"multi-tenant deployments that declare no streams stay valid")
+}
+
+func TestValidateMessagingStreamsAddressResolver(t *testing.T) {
+	tests := []struct {
+		name     string
+		resolver StreamsAddressResolverConfig
+		wantErr  string
+	}{
+		{name: "both_unset", resolver: StreamsAddressResolverConfig{}},
+		{name: "both_set", resolver: StreamsAddressResolverConfig{Host: "lb.example.com", Port: 5552}},
+		// Both ends of the accepted range are inclusive; without these the range
+		// check could be off by one at either edge and every other case still pass.
+		{name: "lowest_valid_port", resolver: StreamsAddressResolverConfig{Host: "lb.example.com", Port: 1}},
+		{name: "highest_valid_port", resolver: StreamsAddressResolverConfig{Host: "lb.example.com", Port: 65535}},
+		{
+			name:     "port_without_host",
+			resolver: StreamsAddressResolverConfig{Port: 5552},
+			wantErr:  "messaging.streams.addressresolver.host must be set",
+		},
+		{
+			name:     "host_without_port",
+			resolver: StreamsAddressResolverConfig{Host: "lb.example.com"},
+			wantErr:  "messaging.streams.addressresolver.port invalid value: 0 must be one of: 1-65535",
+		},
+		{
+			name:     "port_above_range",
+			resolver: StreamsAddressResolverConfig{Host: "lb.example.com", Port: 65536},
+			wantErr:  "messaging.streams.addressresolver.port invalid value: 65536 must be one of: 1-65535",
+		},
+		{
+			name:     "negative_port",
+			resolver: StreamsAddressResolverConfig{Host: "lb.example.com", Port: -1},
+			wantErr:  "messaging.streams.addressresolver.port invalid value: -1 must be one of: 1-65535",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &MessagingConfig{Streams: StreamsConfig{AddressResolver: tt.resolver}}
+
+			err := validateMessaging(cfg, false)
+
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestApplyStreamsDefaults(t *testing.T) {
+	t.Run("zero_applies_defaults", func(t *testing.T) {
+		cfg := &MessagingConfig{}
+
+		require.NoError(t, validateMessaging(cfg, false))
+
+		assert.Equal(t, 500, cfg.Streams.OffsetStore.CountBeforeStorage)
+		assert.Equal(t, defaultStreamsOffsetCount, cfg.Streams.OffsetStore.CountBeforeStorage)
+		assert.Equal(t, 5*time.Second, cfg.Streams.OffsetStore.FlushInterval)
+		assert.Equal(t, defaultStreamsOffsetInterval, cfg.Streams.OffsetStore.FlushInterval)
+	})
+
+	t.Run("explicit_values_preserved", func(t *testing.T) {
+		cfg := &MessagingConfig{Streams: StreamsConfig{OffsetStore: StreamsOffsetStoreConfig{
+			CountBeforeStorage: 25,
+			FlushInterval:      750 * time.Millisecond,
+		}}}
+
+		require.NoError(t, validateMessaging(cfg, false))
+
+		assert.Equal(t, 25, cfg.Streams.OffsetStore.CountBeforeStorage)
+		assert.Equal(t, 750*time.Millisecond, cfg.Streams.OffsetStore.FlushInterval)
+	})
+
+	t.Run("negative_count_rejected", func(t *testing.T) {
+		cfg := &MessagingConfig{Streams: StreamsConfig{OffsetStore: StreamsOffsetStoreConfig{CountBeforeStorage: -1}}}
+
+		err := validateMessaging(cfg, false)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "messaging.streams.offsetstore.countbeforestorage must be non-negative")
+	})
+
+	t.Run("negative_interval_rejected", func(t *testing.T) {
+		cfg := &MessagingConfig{Streams: StreamsConfig{OffsetStore: StreamsOffsetStoreConfig{FlushInterval: -time.Second}}}
+
+		err := validateMessaging(cfg, false)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "messaging.streams.offsetstore.flushinterval must be non-negative")
+	})
+}
+
+// TestValidateStreamsRejectsMultiTenantEndToEnd proves the fail-fast reaches the
+// public Validate(cfg) entry point, not just the internal seam.
+func TestValidateStreamsRejectsMultiTenantEndToEnd(t *testing.T) {
+	cfg := &Config{
+		App:    createValidAppConfig(),
+		Server: createValidServerConfig(),
+		Log:    createValidLogConfig(),
+		Messaging: MessagingConfig{Streams: StreamsConfig{
+			URI: "rabbitmq-stream://svc:" + streamsFixturePassword + "@broker:5552/%2f",
+		}},
+		Multitenant: MultitenantConfig{
+			Enabled:  true,
+			Resolver: ResolverConfig{Type: "header", Header: testTenantHeader},
+			Tenants: map[string]TenantEntry{
+				"acme": {Database: DatabaseConfig{
+					Type:     PostgreSQL,
+					Host:     "acme.db",
+					Port:     5432,
+					Database: "acme",
+					Username: "acme_user",
+				}},
+			},
+		},
+		Source: SourceConfig{Type: SourceTypeStatic},
+	}
+
+	err := Validate(cfg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "single-tenant only")
+}

--- a/messaging/streams/streams_integration_test.go
+++ b/messaging/streams/streams_integration_test.go
@@ -1,0 +1,312 @@
+//go:build integration
+
+package streams
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/message"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/testing/containers"
+)
+
+const (
+	itStream       = "it-orders"
+	itConsumerName = "it-group"
+	itWaitTimeout  = 20 * time.Second
+	itPollInterval = 50 * time.Millisecond
+)
+
+// recorder collects the messages a handler saw, in arrival order.
+type recorder struct {
+	mu       sync.Mutex
+	offsets  []int64
+	bodies   []string
+	failAt   int64
+	failures int
+}
+
+func (r *recorder) handle(_ context.Context, msg *Message) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.offsets = append(r.offsets, msg.Offset)
+	r.bodies = append(r.bodies, string(msg.Data))
+	if r.failAt >= 0 && msg.Offset == r.failAt {
+		r.failures++
+		return errors.New("deliberate handler failure")
+	}
+	return nil
+}
+
+func (r *recorder) snapshot() (offsets []int64, bodies []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]int64(nil), r.offsets...), append([]string(nil), r.bodies...)
+}
+
+func (r *recorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.offsets)
+}
+
+// streamsTestEnv boots RabbitMQ with the stream plugin and returns the manager
+// options every test in this file uses.
+func streamsTestEnv(ctx context.Context, t *testing.T) ManagerOptions {
+	t.Helper()
+
+	cfg := containers.DefaultRabbitMQConfig()
+	cfg.EnableStreamPlugin = true
+	container := containers.MustStartRabbitMQContainer(ctx, t, cfg).WithCleanup(t)
+
+	return ManagerOptions{
+		URI: container.StreamURI(),
+		// Without the resolver the broker advertises its container-internal address
+		// and the client's follow-up dial from the host fails.
+		AddressResolverHost: container.Host(),
+		AddressResolverPort: container.StreamPort(),
+		OffsetStoreCount:    1,
+		OffsetStoreInterval: 100 * time.Millisecond,
+		Logger:              logger.New("error", false),
+	}
+}
+
+// publish writes n messages through a test-only producer environment. Producers
+// are deliberately outside the framework surface, so tests drive the client directly.
+func publish(t *testing.T, opts ManagerOptions, streamName string, bodies []string) {
+	t.Helper()
+
+	envOpts := stream.NewEnvironmentOptions().
+		SetUri(opts.URI).
+		SetAddressResolver(stream.AddressResolver{Host: opts.AddressResolverHost, Port: opts.AddressResolverPort})
+	env, err := stream.NewEnvironment(envOpts)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, env.Close()) }()
+
+	producer, err := env.NewProducer(streamName, stream.NewProducerOptions())
+	require.NoError(t, err)
+
+	batch := make([]message.StreamMessage, 0, len(bodies))
+	for _, body := range bodies {
+		batch = append(batch, amqp.NewMessage([]byte(body)))
+	}
+	require.NoError(t, producer.BatchSend(batch))
+	require.NoError(t, producer.Close())
+}
+
+func bodiesFrom(prefix string, from, count int) []string {
+	out := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		out = append(out, fmt.Sprintf("%s-%d", prefix, from+i))
+	}
+	return out
+}
+
+func startManager(t *testing.T, opts ManagerOptions, handler Handler) *Manager {
+	t.Helper()
+
+	decls := NewDeclarations()
+	decls.DeclareStream(itStream, &StreamSpec{MaxLengthBytes: 10 * 1024 * 1024})
+	decls.DeclareConsumer(&ConsumerOptions{
+		Stream:  itStream,
+		Name:    itConsumerName,
+		Start:   OffsetFirst(),
+		Handler: handler,
+	})
+
+	m := NewManager(opts)
+	require.NoError(t, m.Start(context.Background(), decls))
+	return m
+}
+
+func waitForCount(t *testing.T, r *recorder, want int) {
+	t.Helper()
+	require.Eventually(t, func() bool { return r.count() >= want }, itWaitTimeout, itPollInterval,
+		"expected %d messages, saw %d", want, r.count())
+}
+
+// TestStreamsManagerConsumesAndRestoresOffsetIntegration proves the server-side
+// offset contract end to end: a restarted manager with the same consumer name
+// resumes after the last committed offset instead of replaying the stream.
+func TestStreamsManagerConsumesAndRestoresOffsetIntegration(t *testing.T) {
+	ctx := context.Background()
+	opts := streamsTestEnv(ctx, t)
+
+	first := &recorder{failAt: -1}
+	m := startManager(t, opts, first.handle)
+
+	publish(t, opts, itStream, bodiesFrom("msg", 0, 10))
+	waitForCount(t, first, 10)
+
+	offsets, bodies := first.snapshot()
+	require.Len(t, offsets, 10)
+	assert.Equal(t, bodiesFrom("msg", 0, 10), bodies, "messages arrive in stream order")
+	for i := 1; i < len(offsets); i++ {
+		assert.Greater(t, offsets[i], offsets[i-1], "offsets are monotonically increasing")
+	}
+
+	require.Eventually(t, func() bool {
+		stored, ok := m.Stats()["stored_offsets"].(map[string]int64)
+		return ok && stored[itStream+"/"+itConsumerName] == offsets[9]
+	}, itWaitTimeout, itPollInterval, "the last handled offset must reach the broker")
+
+	m.StopConsumers()
+	require.NoError(t, m.Close())
+
+	// A fresh manager under the same consumer name must not re-read the first 10.
+	second := &recorder{failAt: -1}
+	m2 := startManager(t, opts, second.handle)
+	t.Cleanup(func() {
+		m2.StopConsumers()
+		require.NoError(t, m2.Close())
+	})
+
+	publish(t, opts, itStream, bodiesFrom("msg", 10, 3))
+	waitForCount(t, second, 3)
+
+	_, secondBodies := second.snapshot()
+	assert.Equal(t, bodiesFrom("msg", 10, 3), secondBodies,
+		"the stored offset wins over the declared Start position")
+	assert.Equal(t, 3, second.count(), "no message is replayed after a clean stop")
+}
+
+// TestStreamsManagerSkipsFailedMessageIntegration pins the documented consequence
+// of committing only after success: a failed message is skipped, never redelivered.
+func TestStreamsManagerSkipsFailedMessageIntegration(t *testing.T) {
+	ctx := context.Background()
+	opts := streamsTestEnv(ctx, t)
+
+	// Offset 4 is the fifth message in a fresh stream.
+	failing := &recorder{failAt: 4}
+	m := startManager(t, opts, failing.handle)
+
+	publish(t, opts, itStream, bodiesFrom("msg", 0, 10))
+	waitForCount(t, failing, 10)
+
+	offsets, _ := failing.snapshot()
+	assert.Equal(t, 1, failing.failures, "exactly one handler failure")
+	assert.Equal(t, int64(9), offsets[9], "the stream continued past the failure")
+
+	require.Eventually(t, func() bool {
+		stored, ok := m.Stats()["stored_offsets"].(map[string]int64)
+		return ok && stored[itStream+"/"+itConsumerName] == int64(9)
+	}, itWaitTimeout, itPollInterval, "a later success commits a HIGHER offset than the failed one")
+
+	m.StopConsumers()
+	require.NoError(t, m.Close())
+
+	replay := &recorder{failAt: -1}
+	m2 := startManager(t, opts, replay.handle)
+	t.Cleanup(func() {
+		m2.StopConsumers()
+		require.NoError(t, m2.Close())
+	})
+
+	publish(t, opts, itStream, bodiesFrom("msg", 10, 2))
+	waitForCount(t, replay, 2)
+
+	_, replayed := replay.snapshot()
+	assert.Equal(t, bodiesFrom("msg", 10, 2), replayed,
+		"the failed message is skipped on restart - streams have no redelivery")
+}
+
+// startSACManager starts a single active consumer, whose promotion callback is the
+// code path the client invokes from its own read-loop goroutine.
+func startSACManager(t *testing.T, opts ManagerOptions, handler Handler) *Manager {
+	t.Helper()
+
+	decls := NewDeclarations()
+	decls.DeclareStream(itStream, &StreamSpec{MaxLengthBytes: 10 * 1024 * 1024})
+	decls.DeclareConsumer(&ConsumerOptions{
+		Stream:  itStream,
+		Name:    itConsumerName,
+		Start:   OffsetFirst(),
+		SAC:     true,
+		Handler: handler,
+	})
+
+	m := NewManager(opts)
+	require.NoError(t, m.Start(context.Background(), decls))
+	return m
+}
+
+// TestStreamsManagerSingleActiveConsumerIntegration exercises the SAC promotion
+// callback the client fires outside the manager's lock. Run with -race, it covers
+// the environment snapshot that callback closes over: reading m.env there instead
+// would be an unsynchronized read of a field Close nils.
+func TestStreamsManagerSingleActiveConsumerIntegration(t *testing.T) {
+	ctx := context.Background()
+	opts := streamsTestEnv(ctx, t)
+
+	first := &recorder{failAt: -1}
+	m := startSACManager(t, opts, first.handle)
+
+	publish(t, opts, itStream, bodiesFrom("msg", 0, 6))
+	waitForCount(t, first, 6)
+
+	_, bodies := first.snapshot()
+	assert.Equal(t, bodiesFrom("msg", 0, 6), bodies, "the promoted consumer starts at the declared position")
+
+	require.Eventually(t, func() bool {
+		stored, ok := m.Stats()["stored_offsets"].(map[string]int64)
+		return ok && stored[itStream+"/"+itConsumerName] == 5
+	}, itWaitTimeout, itPollInterval, "the promoted consumer commits its offsets")
+
+	m.StopConsumers()
+	require.NoError(t, m.Close())
+
+	// A new group member is promoted in turn and must resume from the stored offset.
+	second := &recorder{failAt: -1}
+	m2 := startSACManager(t, opts, second.handle)
+	t.Cleanup(func() {
+		m2.StopConsumers()
+		require.NoError(t, m2.Close())
+	})
+
+	publish(t, opts, itStream, bodiesFrom("msg", 6, 2))
+	waitForCount(t, second, 2)
+
+	_, resumed := second.snapshot()
+	assert.Equal(t, bodiesFrom("msg", 6, 2), resumed,
+		"promotion resolves the stored offset, not the declared start position")
+}
+
+// TestStreamsManagerDisposesEnvironmentOnDeclareFailureIntegration exercises a real
+// post-dial failure: re-declaring an existing stream with different retention makes
+// the broker answer precondition-failed, so Start fails with the environment already
+// dialed. Manager is exported API, so a caller that treats that error as fatal
+// without calling Close must not leak the connection pool.
+func TestStreamsManagerDisposesEnvironmentOnDeclareFailureIntegration(t *testing.T) {
+	ctx := context.Background()
+	opts := streamsTestEnv(ctx, t)
+
+	first := NewManager(opts)
+	firstDecls := NewDeclarations()
+	firstDecls.DeclareStream(itStream, &StreamSpec{MaxAge: time.Hour})
+	require.NoError(t, first.Start(ctx, firstDecls))
+	first.StopConsumers()
+	require.NoError(t, first.Close())
+
+	// Same stream, different retention: the broker rejects the declaration.
+	second := NewManager(opts)
+	conflicting := NewDeclarations()
+	conflicting.DeclareStream(itStream, &StreamSpec{MaxAge: 48 * time.Hour})
+
+	err := second.Start(ctx, conflicting)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to declare stream")
+	assert.Nil(t, second.env, "the dialed environment is disposed by the failed Start itself")
+	assert.False(t, second.started)
+	require.NoError(t, second.Close(), "the caller's follow-up Close short-circuits instead of double-closing")
+}

--- a/testing/containers/rabbitmq.go
+++ b/testing/containers/rabbitmq.go
@@ -5,12 +5,24 @@ package containers
 import (
 	"context"
 	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/rabbitmq"
 	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	// streamPortSpec is the native stream-protocol port the rabbitmq_stream plugin binds.
+	streamPortSpec = "5552/tcp"
+
+	streamPluginReadyTimeout = 30 * time.Second
+	streamPluginPollInterval = 250 * time.Millisecond
 )
 
 // RabbitMQContainerConfig holds configuration for RabbitMQ test container
@@ -23,6 +35,9 @@ type RabbitMQContainerConfig struct {
 	Password string
 	// StartupTimeout for container initialization (default: 60 seconds)
 	StartupTimeout time.Duration
+	// EnableStreamPlugin publishes port 5552 and enables the rabbitmq_stream
+	// plugin after boot, for tests that speak the native stream protocol.
+	EnableStreamPlugin bool
 }
 
 // DefaultRabbitMQConfig returns a RabbitMQContainerConfig populated with sensible defaults.
@@ -41,10 +56,13 @@ func DefaultRabbitMQConfig() *RabbitMQContainerConfig {
 
 // RabbitMQContainer wraps testcontainers RabbitMQ container with helper methods
 type RabbitMQContainer struct {
-	container *rabbitmq.RabbitMQContainer
-	brokerURL string
-	host      string
-	port      int
+	container  *rabbitmq.RabbitMQContainer
+	brokerURL  string
+	host       string
+	port       int
+	streamPort int
+	username   string
+	password   string
 }
 
 // StartRabbitMQContainer starts a RabbitMQ testcontainer using the provided configuration.
@@ -65,8 +83,7 @@ func StartRabbitMQContainer(ctx context.Context, t *testing.T, cfg *RabbitMQCont
 
 	// Use composite wait strategy: log message (fast early signal) + port listening (network verification)
 	// This prevents race conditions where the log appears but RabbitMQ isn't ready to accept connections
-	rmqContainer, err := rabbitmq.Run(ctx,
-		fmt.Sprintf("rabbitmq:%s", cfg.ImageTag),
+	opts := []testcontainers.ContainerCustomizer{
 		rabbitmq.WithAdminUsername(cfg.Username),
 		rabbitmq.WithAdminPassword(cfg.Password),
 		testcontainers.WithWaitStrategy(
@@ -75,7 +92,14 @@ func StartRabbitMQContainer(ctx context.Context, t *testing.T, cfg *RabbitMQCont
 				wait.ForListeningPort("5672/tcp"),
 			).WithStartupTimeout(cfg.StartupTimeout),
 		),
-	)
+	}
+	if cfg.EnableStreamPlugin {
+		// The port must be published at creation time; the plugin that binds it is
+		// enabled after boot, so it cannot join the wait strategy above.
+		opts = append(opts, testcontainers.WithExposedPorts(streamPortSpec))
+	}
+
+	rmqContainer, err := rabbitmq.Run(ctx, fmt.Sprintf("rabbitmq:%s", cfg.ImageTag), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start RabbitMQ container: %w", err)
 	}
@@ -103,12 +127,53 @@ func StartRabbitMQContainer(ctx context.Context, t *testing.T, cfg *RabbitMQCont
 
 	t.Logf("RabbitMQ container started successfully at %s:%d", host, port)
 
-	return &RabbitMQContainer{
+	container := &RabbitMQContainer{
 		container: rmqContainer,
 		brokerURL: amqpURL,
 		host:      host,
 		port:      port,
-	}, nil
+		username:  cfg.Username,
+		password:  cfg.Password,
+	}
+
+	if cfg.EnableStreamPlugin {
+		streamPort, err := enableStreamPlugin(ctx, rmqContainer)
+		if err != nil {
+			_ = rmqContainer.Terminate(ctx)
+			return nil, err
+		}
+		container.streamPort = streamPort
+		t.Logf("RabbitMQ stream protocol available at %s:%d", host, streamPort)
+	}
+
+	return container, nil
+}
+
+// enableStreamPlugin turns on rabbitmq_stream in a running container and waits for
+// its listener to accept connections on the mapped port. The container's own wait
+// strategy ran before the plugin existed, so readiness is polled here.
+func enableStreamPlugin(ctx context.Context, c *rabbitmq.RabbitMQContainer) (port int, err error) {
+	code, reader, err := c.Exec(ctx, []string{"rabbitmq-plugins", "enable", "rabbitmq_stream"})
+	if err != nil {
+		return 0, fmt.Errorf("failed to enable rabbitmq_stream plugin: %w", err)
+	}
+	if code != 0 {
+		output, _ := io.ReadAll(reader)
+		return 0, fmt.Errorf("rabbitmq-plugins enable rabbitmq_stream exited %d: %s", code, output)
+	}
+
+	strategy := wait.ForListeningPort(streamPortSpec).
+		WithStartupTimeout(streamPluginReadyTimeout).
+		WithPollInterval(streamPluginPollInterval)
+	if err := strategy.WaitUntilReady(ctx, c); err != nil {
+		return 0, fmt.Errorf("rabbitmq_stream listener did not become ready: %w", err)
+	}
+
+	mapped, err := c.MappedPort(ctx, streamPortSpec)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get RabbitMQ stream port: %w", err)
+	}
+	return int(mapped.Num()), nil
 }
 
 // BrokerURL returns the AMQP connection URL for the running container.
@@ -124,6 +189,27 @@ func (r *RabbitMQContainer) Host() string {
 // Port returns the host-side port Docker mapped to the container's 5672.
 func (r *RabbitMQContainer) Port() int {
 	return r.port
+}
+
+// StreamPort returns the host-side port Docker mapped to the container's 5552.
+// Zero when the container was started without EnableStreamPlugin.
+func (r *RabbitMQContainer) StreamPort() int {
+	return r.streamPort
+}
+
+// StreamURI returns the native stream-protocol URI for the default vhost.
+// Clients must also pin an address resolver to Host/StreamPort: the broker
+// advertises its container-internal address, which the host cannot dial.
+func (r *RabbitMQContainer) StreamURI() string {
+	// url.UserPassword escapes credentials containing @ : or /, and JoinHostPort
+	// brackets an IPv6 literal, which some Docker setups return from Host(). The
+	// vhost is appended already-encoded: %2f is how the default "/" vhost is spelled.
+	u := url.URL{
+		Scheme: "rabbitmq-stream",
+		User:   url.UserPassword(r.username, r.password),
+		Host:   net.JoinHostPort(r.host, strconv.Itoa(r.streamPort)),
+	}
+	return u.String() + "/%2f"
 }
 
 // Terminate stops and removes the RabbitMQ container


### PR DESCRIPTION
## What

Proves the lane against a real broker. Extends the RabbitMQ testcontainer with an
`EnableStreamPlugin` option that enables `rabbitmq_stream`, exposes 5552 and waits for
the listener, then adds four integration tests over the manager.

## Impact

Test-only. `StreamURI` is now built with `url.URL` and `net.JoinHostPort` instead of
string concatenation, so a password containing `@`, `:` or `/` and an IPv6 container
host both work.

## Verification

Four tests pass against a live broker under `-race`: server-side offset restore across a
manager restart, skip-on-handler-error, single-active-consumer promotion, and
environment disposal after a post-dial `Start` failure. The address resolver is required
under Docker port mapping — without it the broker advertises its container-internal
address and the follow-up dial fails.
