### PR TITLE
build(make): pin the vuln gate to CI's toolchain, not go.work's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,8 +152,18 @@ verify-mod: ## Verify go.mod/go.sum are tidy and go.work.sum is settled (mirrors
 	go mod tidy
 	git diff --exit-code go.mod go.sum go.work.sum
 
-vuln: ## Run govulncheck vulnerability scan (pinned; identical to CI)
-	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
+# GOWORK=off like `lint`, but here it decides what the gate can even see: in
+# workspace mode go.work's own `go` line drives toolchain selection and go.mod's
+# `toolchain` directive is ignored, so a developer whose local Go is older than
+# that directive scans an older stdlib than CI, which installs the directive's
+# version via setup-go's go-version-file. That made this gate silently blind —
+# a toolchain bump remediating stdlib advisories still reported every one of them
+# locally until GOWORK=off let the directive win. Nothing else about the verdict
+# moves: only *called* vulnerabilities exit nonzero, and the reachable package set
+# is identical in both modes (tools/migration is a separate module, excluded from
+# ./... either way, and CI scans it in its own vuln-migrate-tool job).
+vuln: ## Run govulncheck vulnerability scan (pinned + GOWORK=off, mirroring CI)
+	GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
 
 sec: ## Run gosec security scanner (pinned; identical to CI)
 	# gosec only accepts relative patterns — the previous $(PKGS) import paths

--- a/tools/migration/Makefile
+++ b/tools/migration/Makefile
@@ -65,8 +65,13 @@ verify-mod: ## Verify go.mod/go.sum are tidy (mirrors CI)
 dev-deps: ## Install development dependencies
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
-vuln: ## Run govulncheck vulnerability scan (pinned; identical to CI)
-	go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
+# GOWORK=off for the reason spelled out on the root Makefile's `vuln` target:
+# go.work is one directory up, and in workspace mode its `go` line — not this
+# module's `toolchain` directive — picks the toolchain, so the scan silently
+# reports an older stdlib than the CI job it is supposed to mirror. Package scope
+# is unaffected (3 packages either way).
+vuln: ## Run govulncheck vulnerability scan (pinned + GOWORK=off, mirroring CI)
+	GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION) ./...
 
 sec: ## Run gosec security scanner (pinned; identical to CI)
 	go run github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION) ./cmd/... ./internal/...


### PR DESCRIPTION
## What

`make vuln` ran in workspace mode, where `go.work`'s `go` line — not `go.mod`'s `toolchain` directive — picks the toolchain, so it scanned an older stdlib than the CI job it mirrors. On a go1.26.5 machine it still reported all seven advisories #980 had just remediated, while CI reported none. Both `vuln` targets now set `GOWORK=off`, as the root `lint` target already does.

## Impact

Developer tooling only; CI's verdict is unmoved. `make vuln` now fails locally exactly when CI would, surfacing advisories a stale local Go was hiding.

## Verification

`make check` passes end-to-end for the first time since the advisories landed; before this change it failed at the vuln step on the same tree. The reachable package set is identical in both modes — 61 packages at the root, 3 in `tools/migration` — so only the toolchain moved, not the scan's scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability scanning to use the module’s declared toolchain consistently.
  * Preserved the pinned scanner version, package scope, and existing failure behavior.
  * Applied the same scanning improvements to migration tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->