### PR TITLE
feat(streams): declare super streams and their consumers

### DIFF
--- a/messaging/streams/declarations.go
+++ b/messaging/streams/declarations.go
@@ -11,14 +11,25 @@ type streamDeclaration struct {
 	Spec StreamSpec
 }
 
+// superStreamDeclaration is one declared super stream: a stream partitioned into
+// Partitions individual streams the broker names "<Name>-0" … "<Name>-(n-1)".
+// The spec applies to every partition.
+type superStreamDeclaration struct {
+	Name       string
+	Partitions int
+	Spec       StreamSpec
+}
+
 // consumerDeclaration is one declared consumer, deep-copied from the caller's
-// ConsumerOptions at registration time.
+// options at registration time. Super marks which of the two declare methods
+// produced it, because the two consume through different client APIs.
 type consumerDeclaration struct {
 	Stream  string
 	Name    string
 	Start   OffsetStart
 	SAC     bool
 	Handler Handler
+	Super   bool
 }
 
 // consumerKey identifies a consumer for duplicate detection.
@@ -29,25 +40,32 @@ type consumerKey struct {
 
 // Stats summarizes a declaration store.
 type Stats struct {
-	Streams   int
+	// Streams counts every declared stream, super streams included.
+	Streams int
+	// SuperStreams counts how many of Streams are partitioned super streams.
+	SuperStreams int
+	// Consumers counts every declared consumer, of either kind.
 	Consumers int
 }
 
 // Declarations collects the stream infrastructure and consumers a set of modules
 // declares. It is populated once at startup, validated, then replayed by Manager.
 type Declarations struct {
-	streams       []*streamDeclaration
-	streamIndex   map[string]*streamDeclaration
-	consumers     []*consumerDeclaration
-	consumerIndex map[consumerKey]*consumerDeclaration
-	conflicts     []error
+	streams          []*streamDeclaration
+	streamIndex      map[string]*streamDeclaration
+	superStreams     []*superStreamDeclaration
+	superStreamIndex map[string]*superStreamDeclaration
+	consumers        []*consumerDeclaration
+	consumerIndex    map[consumerKey]*consumerDeclaration
+	conflicts        []error
 }
 
 // NewDeclarations creates an empty declaration store.
 func NewDeclarations() *Declarations {
 	return &Declarations{
-		streamIndex:   make(map[string]*streamDeclaration),
-		consumerIndex: make(map[consumerKey]*consumerDeclaration),
+		streamIndex:      make(map[string]*streamDeclaration),
+		superStreamIndex: make(map[string]*superStreamDeclaration),
+		consumerIndex:    make(map[consumerKey]*consumerDeclaration),
 	}
 }
 
@@ -73,6 +91,29 @@ func (d *Declarations) DeclareStream(name string, spec *StreamSpec) {
 	d.streams = append(d.streams, decl)
 }
 
+// DeclareSuperStream registers a super stream of partitions partitions. A nil
+// spec leaves retention to the broker; a non-nil one applies to every partition.
+// Re-declaring the same name identically is a no-op; a conflicting partition
+// count or spec is reported by Validate.
+func (d *Declarations) DeclareSuperStream(name string, partitions int, spec *StreamSpec) {
+	decl := &superStreamDeclaration{Name: name, Partitions: partitions}
+	if spec != nil {
+		decl.Spec = *spec
+	}
+
+	if existing, ok := d.superStreamIndex[name]; ok {
+		if *existing != *decl {
+			d.conflicts = append(d.conflicts, fmt.Errorf(
+				"super stream %q declared twice with different definitions (%+v vs %+v)",
+				name, *existing, *decl))
+		}
+		return
+	}
+
+	d.superStreamIndex[name] = decl
+	d.superStreams = append(d.superStreams, decl)
+}
+
 // DeclareConsumer registers a stream consumer.
 // Panics on a nil options pointer, and if the same (stream, name) pair was
 // already declared. Both are programming errors: a nil declaration would consume
@@ -80,30 +121,66 @@ func (d *Declarations) DeclareStream(name string, spec *StreamSpec) {
 // offset group inside one process.
 func (d *Declarations) DeclareConsumer(opts *ConsumerOptions) {
 	if opts == nil {
-		panic("streams: nil consumer declaration detected\n" +
-			"  DeclareConsumer requires a non-nil *ConsumerOptions\n" +
-			"  Pass &streams.ConsumerOptions{...} at every DeclareConsumer call within DeclareStreams")
+		panic(nilConsumerPanic("DeclareConsumer", "ConsumerOptions"))
 	}
 
-	key := consumerKey{Stream: opts.Stream, Name: opts.Name}
-	if _, exists := d.consumerIndex[key]; exists {
-		panic(fmt.Sprintf(
-			"streams: duplicate consumer declaration detected\n"+
-				"  stream=%s name=%s\n"+
-				"  Ensure each DeclareConsumer call is unique within DeclareStreams",
-			opts.Stream, opts.Name,
-		))
-	}
-
-	decl := &consumerDeclaration{
+	d.registerConsumer(&consumerDeclaration{
 		Stream:  opts.Stream,
 		Name:    opts.Name,
 		Start:   opts.Start,
 		SAC:     opts.SAC,
 		Handler: opts.Handler,
+	})
+}
+
+// DeclareSuperStreamConsumer registers one consumer over every partition of a
+// super stream. Panics on the same two programming errors as DeclareConsumer.
+//
+// The declaration is always a single active consumer group — see
+// SuperStreamConsumerOptions for why the choice is not the caller's.
+func (d *Declarations) DeclareSuperStreamConsumer(opts *SuperStreamConsumerOptions) {
+	if opts == nil {
+		panic(nilConsumerPanic("DeclareSuperStreamConsumer", "SuperStreamConsumerOptions"))
 	}
+
+	d.registerConsumer(&consumerDeclaration{
+		Stream:  opts.SuperStream,
+		Name:    opts.Name,
+		Start:   opts.Start,
+		SAC:     true,
+		Handler: opts.Handler,
+		Super:   true,
+	})
+}
+
+// registerConsumer stores a consumer declaration of either kind, rejecting a
+// duplicate (target, name) pair in the vocabulary of the method that produced it.
+func (d *Declarations) registerConsumer(decl *consumerDeclaration) {
+	method, label := "DeclareConsumer", "stream"
+	if decl.Super {
+		method, label = "DeclareSuperStreamConsumer", "super stream"
+	}
+
+	key := consumerKey{Stream: decl.Stream, Name: decl.Name}
+	if _, exists := d.consumerIndex[key]; exists {
+		panic(fmt.Sprintf(
+			"streams: duplicate consumer declaration detected\n"+
+				"  %s=%s name=%s\n"+
+				"  Ensure each %s call is unique within DeclareStreams",
+			label, decl.Stream, decl.Name, method,
+		))
+	}
+
 	d.consumerIndex[key] = decl
 	d.consumers = append(d.consumers, decl)
+}
+
+// nilConsumerPanic renders the nil-declaration panic for one declare method.
+func nilConsumerPanic(method, optionsType string) string {
+	return fmt.Sprintf("streams: nil consumer declaration detected\n"+
+		"  %s requires a non-nil *%s\n"+
+		"  Pass &streams.%s{...} at every %s call within DeclareStreams",
+		method, optionsType, optionsType, method)
 }
 
 // Validate reports every problem in the store at once.
@@ -114,7 +191,20 @@ func (d *Declarations) Validate() error {
 		if s.Name == "" {
 			errs = append(errs, errors.New("stream declaration has an empty name"))
 		}
-		errs = append(errs, negativeRetentionErrors(s.Name, s.Spec)...)
+		errs = append(errs, negativeRetentionErrors("stream", s.Name, s.Spec)...)
+	}
+
+	for _, s := range d.superStreams {
+		if s.Name == "" {
+			errs = append(errs, errors.New("super stream declaration has an empty name"))
+		}
+		if s.Partitions < 1 {
+			errs = append(errs, fmt.Errorf("super stream %q declares %d partitions; at least 1 is required", s.Name, s.Partitions))
+		}
+		if _, ok := d.streamIndex[s.Name]; ok {
+			errs = append(errs, fmt.Errorf("%q is declared both as a stream and as a super stream", s.Name))
+		}
+		errs = append(errs, negativeRetentionErrors("super stream", s.Name, s.Spec)...)
 	}
 
 	for _, c := range d.consumers {
@@ -124,38 +214,63 @@ func (d *Declarations) Validate() error {
 		if c.Handler == nil {
 			errs = append(errs, fmt.Errorf("consumer %q on stream %q has a nil handler", c.Name, c.Stream))
 		}
-		if _, ok := d.streamIndex[c.Stream]; !ok {
-			errs = append(errs, fmt.Errorf("consumer %q references undeclared stream %q", c.Name, c.Stream))
+		if err := d.consumerTargetError(c); err != nil {
+			errs = append(errs, err)
 		}
 	}
 
 	return errors.Join(errs...)
 }
 
+// consumerTargetError checks that a consumer's target was declared, and declared
+// as the kind the consumer consumes it as. The two kinds reach the broker through
+// different client APIs, so consuming one as the other cannot work.
+func (d *Declarations) consumerTargetError(c *consumerDeclaration) error {
+	_, isStream := d.streamIndex[c.Stream]
+	_, isSuper := d.superStreamIndex[c.Stream]
+
+	switch {
+	case c.Super && isSuper, !c.Super && isStream:
+		return nil
+	case c.Super && isStream:
+		return fmt.Errorf("consumer %q consumes %q as a super stream, but it is declared as a plain stream; use DeclareConsumer", c.Name, c.Stream)
+	case !c.Super && isSuper:
+		return fmt.Errorf("consumer %q consumes %q as a plain stream, but it is declared as a super stream; use DeclareSuperStreamConsumer", c.Name, c.Stream)
+	case c.Super:
+		return fmt.Errorf("consumer %q references undeclared super stream %q", c.Name, c.Stream)
+	default:
+		return fmt.Errorf("consumer %q references undeclared stream %q", c.Name, c.Stream)
+	}
+}
+
 // negativeRetentionErrors rejects negative retention values. The manager applies
 // each field only when it is positive, so a negative one would be dropped on the
 // way to the broker and the stream would silently retain by the broker's default
 // instead of the caller's declaration. Zero is how that default is asked for.
-func negativeRetentionErrors(name string, spec StreamSpec) []error {
+func negativeRetentionErrors(kind, name string, spec StreamSpec) []error {
 	var errs []error
 	if spec.MaxAge < 0 {
-		errs = append(errs, fmt.Errorf("stream %q has a negative MaxAge (%s); zero leaves retention to the broker", name, spec.MaxAge))
+		errs = append(errs, fmt.Errorf("%s %q has a negative MaxAge (%s); zero leaves retention to the broker", kind, name, spec.MaxAge))
 	}
 	if spec.MaxLengthBytes < 0 {
-		errs = append(errs, fmt.Errorf("stream %q has a negative MaxLengthBytes (%d); zero leaves retention to the broker", name, spec.MaxLengthBytes))
+		errs = append(errs, fmt.Errorf("%s %q has a negative MaxLengthBytes (%d); zero leaves retention to the broker", kind, name, spec.MaxLengthBytes))
 	}
 	if spec.MaxSegmentSizeBytes < 0 {
-		errs = append(errs, fmt.Errorf("stream %q has a negative MaxSegmentSizeBytes (%d); zero leaves retention to the broker", name, spec.MaxSegmentSizeBytes))
+		errs = append(errs, fmt.Errorf("%s %q has a negative MaxSegmentSizeBytes (%d); zero leaves retention to the broker", kind, name, spec.MaxSegmentSizeBytes))
 	}
 	return errs
 }
 
 // IsEmpty reports whether nothing was declared.
 func (d *Declarations) IsEmpty() bool {
-	return len(d.streams) == 0 && len(d.consumers) == 0
+	return len(d.streams) == 0 && len(d.superStreams) == 0 && len(d.consumers) == 0
 }
 
 // Stats returns the declaration counts.
 func (d *Declarations) Stats() Stats {
-	return Stats{Streams: len(d.streams), Consumers: len(d.consumers)}
+	return Stats{
+		Streams:      len(d.streams) + len(d.superStreams),
+		SuperStreams: len(d.superStreams),
+		Consumers:    len(d.consumers),
+	}
 }

--- a/messaging/streams/declarations_test.go
+++ b/messaging/streams/declarations_test.go
@@ -12,6 +12,8 @@ import (
 const (
 	testStream       = "orders"
 	testConsumerName = "orders-processor"
+	testSuperStream  = "orders-partitioned"
+	testPartitions   = 3
 )
 
 func noopHandler(context.Context, *Message) error { return nil }
@@ -141,6 +143,286 @@ func TestDeclareConsumerSameNameOnDifferentStreamsIsAllowed(t *testing.T) {
 
 	assert.Equal(t, Stats{Streams: 2, Consumers: 2}, d.Stats())
 	require.NoError(t, d.Validate())
+}
+
+func TestDeclareSuperStreamStoresDefinition(t *testing.T) {
+	d := NewDeclarations()
+	spec := &StreamSpec{MaxAge: 90 * time.Second, MaxLengthBytes: 1024, MaxSegmentSizeBytes: 512}
+
+	d.DeclareSuperStream(testSuperStream, testPartitions, spec)
+
+	require.Len(t, d.superStreams, 1)
+	assert.Equal(t, testSuperStream, d.superStreams[0].Name)
+	assert.Equal(t, testPartitions, d.superStreams[0].Partitions)
+	assert.Equal(t, StreamSpec{MaxAge: 90 * time.Second, MaxLengthBytes: 1024, MaxSegmentSizeBytes: 512}, d.superStreams[0].Spec)
+	assert.False(t, d.IsEmpty(), "a super stream alone is a declaration")
+	assert.Empty(t, d.streams, "a super stream is not stored as a plain stream")
+}
+
+func TestDeclareSuperStreamNilSpecLeavesRetentionUnset(t *testing.T) {
+	d := NewDeclarations()
+
+	d.DeclareSuperStream(testSuperStream, testPartitions, nil)
+
+	require.Len(t, d.superStreams, 1)
+	assert.Equal(t, StreamSpec{}, d.superStreams[0].Spec)
+}
+
+func TestDeclareSuperStreamCopiesSpec(t *testing.T) {
+	d := NewDeclarations()
+	spec := &StreamSpec{MaxAge: time.Minute}
+
+	d.DeclareSuperStream(testSuperStream, testPartitions, spec)
+	spec.MaxAge = time.Hour
+	spec.MaxLengthBytes = 99
+
+	assert.Equal(t, StreamSpec{MaxAge: time.Minute}, d.superStreams[0].Spec,
+		"stored spec must not follow the caller's struct")
+}
+
+func TestDeclareSuperStreamIdenticalRedeclarationIsNoop(t *testing.T) {
+	d := NewDeclarations()
+
+	d.DeclareSuperStream(testSuperStream, testPartitions, &StreamSpec{MaxAge: time.Minute})
+	d.DeclareSuperStream(testSuperStream, testPartitions, &StreamSpec{MaxAge: time.Minute})
+
+	assert.Len(t, d.superStreams, 1)
+	require.NoError(t, d.Validate())
+}
+
+// TestDeclareSuperStreamConflictingRedeclarationFailsValidation covers both halves
+// of a super stream's identity: the partition count is as much part of it as the
+// retention spec, so a mismatch in either must be reported rather than silently
+// keeping whichever declaration ran first.
+func TestDeclareSuperStreamConflictingRedeclarationFailsValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		partitions int
+		spec       *StreamSpec
+	}{
+		{name: "different_partition_count", partitions: 5, spec: &StreamSpec{MaxAge: time.Minute}},
+		{name: "different_retention_spec", partitions: testPartitions, spec: &StreamSpec{MaxAge: time.Hour}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDeclarations()
+			d.DeclareSuperStream(testSuperStream, testPartitions, &StreamSpec{MaxAge: time.Minute})
+
+			d.DeclareSuperStream(testSuperStream, tt.partitions, tt.spec)
+
+			err := d.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), `super stream "orders-partitioned" declared twice with different definitions`)
+			assert.Len(t, d.superStreams, 1, "the conflicting declaration is reported, not stored")
+		})
+	}
+}
+
+// TestDeclareSuperStreamConsumerIsAlwaysSingleActive pins the deviation from the
+// plain lane: SAC is not the caller's choice on a super stream, because the
+// promotion callback is the only per-partition offset seam the client offers.
+func TestDeclareSuperStreamConsumerIsAlwaysSingleActive(t *testing.T) {
+	d := NewDeclarations()
+	d.DeclareSuperStream(testSuperStream, testPartitions, nil)
+
+	d.DeclareSuperStreamConsumer(&SuperStreamConsumerOptions{
+		SuperStream: testSuperStream,
+		Name:        testConsumerName,
+		Handler:     noopHandler,
+	})
+
+	require.Len(t, d.consumers, 1)
+	assert.True(t, d.consumers[0].SAC, "super-stream consumption is always a SAC group")
+	assert.True(t, d.consumers[0].Super)
+	require.NoError(t, d.Validate())
+}
+
+func TestDeclareSuperStreamConsumerCopiesOptions(t *testing.T) {
+	d := NewDeclarations()
+	opts := &SuperStreamConsumerOptions{
+		SuperStream: testSuperStream,
+		Name:        testConsumerName,
+		Start:       OffsetFirst(),
+		Handler:     noopHandler,
+	}
+
+	d.DeclareSuperStreamConsumer(opts)
+	opts.Name = "mutated"
+	opts.Start = OffsetLast()
+
+	require.Len(t, d.consumers, 1)
+	assert.Equal(t, testSuperStream, d.consumers[0].Stream)
+	assert.Equal(t, testConsumerName, d.consumers[0].Name)
+	assert.Equal(t, OffsetFirst(), d.consumers[0].Start)
+}
+
+func TestDeclareSuperStreamConsumerNilPanics(t *testing.T) {
+	d := NewDeclarations()
+
+	assert.PanicsWithValue(t,
+		"streams: nil consumer declaration detected\n"+
+			"  DeclareSuperStreamConsumer requires a non-nil *SuperStreamConsumerOptions\n"+
+			"  Pass &streams.SuperStreamConsumerOptions{...} at every DeclareSuperStreamConsumer call within DeclareStreams",
+		func() { d.DeclareSuperStreamConsumer(nil) })
+
+	assert.True(t, d.IsEmpty(), "the rejected declaration is not stored")
+}
+
+func TestDeclareSuperStreamConsumerDuplicatePanics(t *testing.T) {
+	d := NewDeclarations()
+	d.DeclareSuperStream(testSuperStream, testPartitions, nil)
+	d.DeclareSuperStreamConsumer(&SuperStreamConsumerOptions{
+		SuperStream: testSuperStream, Name: testConsumerName, Handler: noopHandler,
+	})
+
+	assert.PanicsWithValue(t,
+		"streams: duplicate consumer declaration detected\n"+
+			"  super stream=orders-partitioned name=orders-processor\n"+
+			"  Ensure each DeclareSuperStreamConsumer call is unique within DeclareStreams",
+		func() {
+			d.DeclareSuperStreamConsumer(&SuperStreamConsumerOptions{
+				SuperStream: testSuperStream, Name: testConsumerName, Handler: noopHandler,
+			})
+		})
+}
+
+func TestStatsCountsSuperStreamsInBothFields(t *testing.T) {
+	d := NewDeclarations()
+	d.DeclareStream(testStream, nil)
+	d.DeclareSuperStream(testSuperStream, testPartitions, nil)
+	d.DeclareConsumer(&ConsumerOptions{Stream: testStream, Name: testConsumerName, Handler: noopHandler})
+	d.DeclareSuperStreamConsumer(&SuperStreamConsumerOptions{
+		SuperStream: testSuperStream, Name: testConsumerName, Handler: noopHandler,
+	})
+
+	assert.Equal(t, Stats{Streams: 2, SuperStreams: 1, Consumers: 2}, d.Stats(),
+		"Streams counts every declared stream so a super-stream-only service is not reported as having none")
+	require.NoError(t, d.Validate())
+}
+
+// TestValidateSuperStreamDeclarations covers the rules a super stream adds, and in
+// particular the four ways a consumer can name the wrong kind of target: the two
+// kinds reach the broker through different client APIs, so each mismatch names the
+// declare method that would have been right.
+func TestValidateSuperStreamDeclarations(t *testing.T) {
+	tests := []struct {
+		name    string
+		build   func(d *Declarations)
+		wantErr string
+	}{
+		{
+			name: "valid_super_stream_and_consumer",
+			build: func(d *Declarations) {
+				d.DeclareSuperStream(testSuperStream, testPartitions, &StreamSpec{MaxLengthBytes: 1024})
+				d.DeclareSuperStreamConsumer(&SuperStreamConsumerOptions{
+					SuperStream: testSuperStream, Name: testConsumerName, Handler: noopHandler,
+				})
+			},
+		},
+		{
+			name: "empty_super_stream_name",
+			build: func(d *Declarations) {
+				d.DeclareSuperStream("", testPartitions, nil)
+			},
+			wantErr: "super stream declaration has an empty name",
+		},
+		{
+			name: "zero_partitions",
+			build: func(d *Declarations) {
+				d.DeclareSuperStream(testSuperStream, 0, nil)
+			},
+			wantErr: `super stream "orders-partitioned" declares 0 partitions; at least 1 is required`,
+		},
+		{
+			name: "negative_partitions",
+			build: func(d *Declarations) {
+				d.DeclareSuperStream(testSuperStream, -2, nil)
+			},
+			wantErr: `super stream "orders-partitioned" declares -2 partitions; at least 1 is required`,
+		},
+		{
+			name: "single_partition_is_allowed",
+			build: func(d *Declarations) {
+				d.DeclareSuperStream(testSuperStream, 1, nil)
+			},
+		},
+		{
+			name: "name_declared_as_both_kinds",
+			build: func(d *Declarations) {
+				d.DeclareStream(testStream, nil)
+				d.DeclareSuperStream(testStream, testPartitions, nil)
+			},
+			wantErr: `"orders" is declared both as a stream and as a super stream`,
+		},
+		{
+			name: "negative_retention_names_the_super_stream_kind",
+			build: func(d *Declarations) {
+				d.DeclareSuperStream(testSuperStream, testPartitions, &StreamSpec{MaxAge: -time.Hour})
+			},
+			wantErr: `super stream "orders-partitioned" has a negative MaxAge (-1h0m0s); zero leaves retention to the broker`,
+		},
+		{
+			name: "super_consumer_on_undeclared_super_stream",
+			build: func(d *Declarations) {
+				d.DeclareSuperStreamConsumer(&SuperStreamConsumerOptions{
+					SuperStream: "ghost", Name: testConsumerName, Handler: noopHandler,
+				})
+			},
+			wantErr: `consumer "orders-processor" references undeclared super stream "ghost"`,
+		},
+		{
+			name: "super_consumer_on_a_plain_stream",
+			build: func(d *Declarations) {
+				d.DeclareStream(testStream, nil)
+				d.DeclareSuperStreamConsumer(&SuperStreamConsumerOptions{
+					SuperStream: testStream, Name: testConsumerName, Handler: noopHandler,
+				})
+			},
+			wantErr: `consumer "orders-processor" consumes "orders" as a super stream, but it is declared as a plain stream; use DeclareConsumer`,
+		},
+		{
+			name: "plain_consumer_on_a_super_stream",
+			build: func(d *Declarations) {
+				d.DeclareSuperStream(testSuperStream, testPartitions, nil)
+				d.DeclareConsumer(&ConsumerOptions{
+					Stream: testSuperStream, Name: testConsumerName, Handler: noopHandler,
+				})
+			},
+			wantErr: `consumer "orders-processor" consumes "orders-partitioned" as a plain stream, but it is declared as a super stream; use DeclareSuperStreamConsumer`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDeclarations()
+			tt.build(d)
+
+			err := d.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestDeclareConsumerAndSuperStreamConsumerShareTheDuplicateKey proves the two
+// declare methods index into one namespace: the same name on the same target is a
+// duplicate whichever method declared it first, so a typo cannot start two members
+// of one offset group inside one process.
+func TestDeclareConsumerAndSuperStreamConsumerShareTheDuplicateKey(t *testing.T) {
+	d := NewDeclarations()
+	d.DeclareStream(testStream, nil)
+	d.DeclareConsumer(&ConsumerOptions{Stream: testStream, Name: testConsumerName, Handler: noopHandler})
+
+	assert.Panics(t, func() {
+		d.DeclareSuperStreamConsumer(&SuperStreamConsumerOptions{
+			SuperStream: testStream, Name: testConsumerName, Handler: noopHandler,
+		})
+	})
 }
 
 func TestValidateStreamDeclarations(t *testing.T) {

--- a/messaging/streams/streams.go
+++ b/messaging/streams/streams.go
@@ -18,6 +18,11 @@ import (
 // not for the stream: the failure is logged and counted, the offset is NOT
 // committed, and consumption continues with the next message. Streams have no
 // nack or redelivery, so handlers must be idempotent.
+//
+// Calls are sequential within one stream — and within one partition of a super
+// stream — but CONCURRENT across the partitions of a super stream, because each
+// partition is a separate connection with its own delivery loop. A handler
+// registered with DeclareSuperStreamConsumer must therefore be goroutine-safe.
 type Handler func(ctx context.Context, msg *Message) error
 
 // Message is the framework view of a stream delivery.
@@ -117,5 +122,31 @@ type ConsumerOptions struct {
 	// messages at a time (RabbitMQ 3.11+).
 	SAC bool
 	// Handler processes each message. Required.
+	Handler Handler
+}
+
+// SuperStreamConsumerOptions declares one consumer over every partition of a
+// super stream.
+//
+// There is deliberately no SAC field: super-stream consumption is ALWAYS a single
+// active consumer group. The client attaches every partition with one shared
+// offset specification, so the SAC promotion callback — which the broker fires
+// once per partition — is the only place a per-partition stored offset can be
+// restored. Without it a restart would replay every partition from Start, which
+// contradicts the stored-offset-wins contract the plain lane documents. A lone
+// member is promoted on every partition, so a single-instance deployment loses
+// nothing. See ADR-059.
+type SuperStreamConsumerOptions struct {
+	// SuperStream is the super stream to consume; it must be declared in the same
+	// Declarations.
+	SuperStream string
+	// Name is the consumer/group name. Required: the broker stores an offset per
+	// partition under it, and it is the group identity partitions are distributed by.
+	Name string
+	// Start is where a partition begins when the broker holds no stored offset for
+	// Name on that partition.
+	Start OffsetStart
+	// Handler processes each message. Required, and called concurrently across
+	// partitions — see Handler.
 	Handler Handler
 }


### PR DESCRIPTION
## What

`messaging/streams` had no way to declare a partitioned stream. `DeclareSuperStream` registers one, `DeclareSuperStreamConsumer` registers a consumer over every partition, and `Validate` learns the rules that come with it. The manager does not replay them yet — that lands in the two successor PRs.

## Impact

A super-stream `Handler` must be goroutine-safe: delivery stays sequential within a partition but runs concurrent *across* partitions, unlike the plain lane. `SuperStreamConsumerOptions` deliberately has no `SAC` field — at client v1.8.3 the SAC callback is the only place a per-partition stored offset can be restored, so a non-SAC super-stream consumer would replay every partition on every restart. `Stats.Streams` now counts super streams, with `Stats.SuperStreams` as the subset.

## Verification

CI gates only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for declaring and consuming super streams with configurable partitions.
  * Added super-stream consumer options, including names, starting offsets, and handlers.
  * Added statistics for tracking super streams alongside streams and consumers.
  * Added validation for stream types, names, partitions, retention settings, and consumer registrations.
  * Super-stream partitions can be processed concurrently while preserving sequential handling within each partition.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->