### PR TITLE
fix(streams): resume from a known position when an offset query fails

### DIFF
--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -219,7 +219,7 @@ func (m *Manager) startConsumer(ctx context.Context, env *stream.Environment, de
 
 	opts := stream.NewConsumerOptions().
 		SetConsumerName(decl.Name).
-		SetOffset(m.resolveOffset(env, decl.Name, decl.Stream, decl.Start))
+		SetOffset(m.resolveOffset(env, decl.Name, decl.Stream, decl.Start, runner.offsets))
 
 	if decl.SAC {
 		// The promotion callback resolves the offset again: another group member
@@ -234,7 +234,7 @@ func (m *Manager) startConsumer(ctx context.Context, env *stream.Environment, de
 		// holds it across a blocking consumer Close.
 		opts = opts.SetSingleActiveConsumer(stream.NewSingleActiveConsumer(
 			func(streamName string, _ bool) stream.OffsetSpecification {
-				return m.resolveOffset(env, decl.Name, streamName, decl.Start)
+				return m.resolveOffset(env, decl.Name, streamName, decl.Start, runner.offsets)
 			}))
 	}
 
@@ -270,20 +270,33 @@ func (m *Manager) newOffsetBook() *offsetBook {
 
 // resolveOffset asks the broker for the consumer's stored offset and falls back
 // to the declared start position when it has none. A stored offset always wins,
-// which is what makes restart behavior deterministic.
+// which is what makes restart behavior deterministic. committed is the consumer's
+// own bookkeeping, consulted only when the broker cannot be asked.
 //
 // The environment is a parameter, never m.env, so that no call path — including
 // the SAC promotion callback the client invokes from its own goroutine — can read
-// that guarded field without m.mu. m.log is immutable after NewManager.
-func (m *Manager) resolveOffset(env *stream.Environment, consumerName, streamName string, start OffsetStart) stream.OffsetSpecification {
+// that guarded field without m.mu. m.log is immutable after NewManager, and the
+// book takes only its own lock, so neither is a route back to m.mu.
+func (m *Manager) resolveOffset(env *stream.Environment, consumerName, streamName string, start OffsetStart, committed *offsetBook) stream.OffsetSpecification {
 	stored, err := env.QueryOffset(consumerName, streamName)
-	if err != nil && !errors.Is(err, stream.OffsetNotFoundError) {
-		m.log.Warn().Err(err).
-			Str(logFieldStream, streamName).
-			Str(logFieldConsumer, consumerName).
-			Msg("Could not query stored stream offset; using the declared start position")
+	localOffset, hasLocal := committed.stored()[streamName]
+	m.reportOffsetQuery(err, consumerName, streamName, hasLocal)
+	return offsetSpecFor(stored, err, start, localOffset, hasLocal)
+}
+
+// reportOffsetQuery reports a failed offset query at ERROR. A missing offset is
+// routine first-run behavior and stays silent; anything else means the attach
+// position was chosen without the broker's answer, which replays messages — a
+// data-affecting event an operator should see, not a warning among warnings.
+func (m *Manager) reportOffsetQuery(err error, consumerName, streamName string, hasLocal bool) {
+	if err == nil || errors.Is(err, stream.OffsetNotFoundError) {
+		return
 	}
-	return offsetSpecFor(stored, err, start)
+	m.log.Error().Err(err).
+		Str(logFieldStream, streamName).
+		Str(logFieldConsumer, consumerName).
+		Bool("resumed_from_local_commit", hasLocal).
+		Msg("Could not query the stored stream offset; attaching at a position that replays rather than skips")
 }
 
 // safeEnvError strips the URI out of an environment-construction failure.
@@ -301,12 +314,33 @@ func safeEnvError(err error) error {
 	return err
 }
 
-// offsetSpecFor picks between a stored offset and the declared start position.
-func offsetSpecFor(stored int64, queryErr error, start OffsetStart) stream.OffsetSpecification {
-	if queryErr != nil {
+// offsetSpecFor picks the position to attach at, given the broker's answer and
+// whatever this process has committed itself.
+//
+// Only a MISSING offset falls back to the declared start. Any other query failure
+// must not: with the zero-value Start meaning "next message written from now", a
+// transient RPC error would attach past everything written since the last commit,
+// and streams have no redelivery to get it back. Delivery is at-least-once and
+// handlers are documented idempotent, so replaying is the affordable mistake and
+// skipping is not.
+func offsetSpecFor(stored int64, queryErr error, start OffsetStart, localOffset int64, hasLocal bool) stream.OffsetSpecification {
+	switch {
+	case queryErr == nil:
+		return stream.OffsetSpecification{}.Offset(stored + 1)
+	case errors.Is(queryErr, stream.OffsetNotFoundError):
+		// Nothing was ever committed under this name: a first run, which is exactly
+		// what the declared start position is for.
 		return start.specification()
+	case hasLocal:
+		// The broker could not be asked, but this process committed a position for
+		// this stream itself. It is no older than the broker's, so it is the closest
+		// truth available.
+		return stream.OffsetSpecification{}.Offset(localOffset + 1)
+	default:
+		// Nothing is known at all. Replaying what retention still holds is bounded
+		// and idempotent; guessing forward is neither.
+		return stream.OffsetSpecification{}.First()
 	}
-	return stream.OffsetSpecification{}.Offset(stored + 1)
 }
 
 // streamOptionsFrom renders a StreamSpec as client stream options. Zero-value

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -45,22 +45,29 @@ type ManagerOptions struct {
 	Logger logger.Logger
 }
 
-// consumerHandle is the subset of *ha.ReliableConsumer the manager drives. It
-// keeps stop/flush bookkeeping testable without a broker.
+// consumerHandle is the subset of the client's reliable consumers the manager
+// drives. It keeps stop bookkeeping testable without a broker, and it is
+// deliberately narrower than offset storage: *ha.ReliableSuperStreamConsumer has
+// no StoreCustomOffset at all, so the flush target is a per-stream function
+// instead (see runningConsumer.storerFor).
 type consumerHandle interface {
-	offsetStorer
 	Close() error
 	GetStatus() int
 }
 
 // runningConsumer pairs a live client consumer with the offset bookkeeping its
 // runner owns. The runner itself is retained by the client through the
-// messagesHandler callback, so only the tracker is kept here.
+// messagesHandler callback, so only the book is kept here.
 type runningConsumer struct {
-	stream  string
-	name    string
-	handle  consumerHandle
-	tracker *offsetTracker
+	stream string
+	name   string
+	handle consumerHandle
+	// offsets tracks one committed position per stream this consumer reads.
+	offsets *offsetBook
+	// storerFor resolves the flush target of one of those streams. Only the
+	// shutdown flush needs it; every in-flight commit goes through the consumer
+	// the client hands to the delivery callback.
+	storerFor func(streamName string) offsetStorer
 }
 
 // Manager owns the single stream-protocol Environment of a single-tenant service
@@ -204,7 +211,7 @@ func (m *Manager) startConsumer(ctx context.Context, env *stream.Environment, de
 	runner := &consumerRunner{
 		name:    decl.Name,
 		handler: decl.Handler,
-		tracker: newOffsetTracker(m.opts.OffsetStoreCount, m.opts.OffsetStoreInterval, nil),
+		offsets: m.newOffsetBook(),
 		log:     m.log,
 		tracer:  otel.Tracer(tracerName),
 		baseCtx: ctx,
@@ -237,10 +244,11 @@ func (m *Manager) startConsumer(ctx context.Context, env *stream.Environment, de
 	}
 
 	m.consumers = append(m.consumers, &runningConsumer{
-		stream:  decl.Stream,
-		name:    decl.Name,
-		handle:  consumer,
-		tracker: runner.tracker,
+		stream:    decl.Stream,
+		name:      decl.Name,
+		handle:    consumer,
+		offsets:   runner.offsets,
+		storerFor: func(string) offsetStorer { return consumer },
 	})
 
 	m.log.Info().
@@ -250,6 +258,14 @@ func (m *Manager) startConsumer(ctx context.Context, env *stream.Environment, de
 		Msg("Stream consumer started")
 
 	return nil
+}
+
+// newOffsetBook builds the offset bookkeeping of one consumer, with the manager's
+// commit policy applied to every stream it ends up tracking.
+func (m *Manager) newOffsetBook() *offsetBook {
+	return newOffsetBook(func() *offsetTracker {
+		return newOffsetTracker(m.opts.OffsetStoreCount, m.opts.OffsetStoreInterval, nil)
+	})
 }
 
 // resolveOffset asks the broker for the consumer's stored offset and falls back
@@ -336,9 +352,9 @@ func (m *Manager) stopLocked() {
 	}
 
 	for _, rc := range m.consumers {
-		if err := rc.tracker.flush(rc.handle); err != nil {
-			m.log.Warn().Err(err).
-				Str(logFieldStream, rc.stream).
+		for _, failure := range rc.offsets.flush(rc.storerFor) {
+			m.log.Warn().Err(failure.err).
+				Str(logFieldStream, failure.stream).
 				Str(logFieldConsumer, rc.name).
 				Msg("Failed to flush stream offset on shutdown")
 		}
@@ -390,10 +406,12 @@ func (m *Manager) Stats() map[string]any {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	// Keyed by the stream a position belongs to, which for a super stream is the
+	// partition rather than the declared name.
 	offsets := make(map[string]int64, len(m.consumers))
 	for _, rc := range m.consumers {
-		if offset, ok := rc.tracker.lastStored(); ok {
-			offsets[rc.stream+"/"+rc.name] = offset
+		for streamName, offset := range rc.offsets.stored() {
+			offsets[streamName+"/"+rc.name] = offset
 		}
 	}
 

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -66,6 +66,7 @@ const (
 	msgCloseConsumerFailed = "Failed to close stream consumer"
 	msgCloseEnvFailed      = "Failed to close stream environment after a failed start"
 	msgOffsetStoreFailed   = "Failed to store stream offset"
+	msgOffsetQueryFailed   = "Could not query the stored stream offset; attaching at a position that replays rather than skips"
 )
 
 // recordingLogger captures each event's level, attached error and terminal
@@ -94,17 +95,19 @@ func (l *recordingLogger) Fatal() logger.LogEvent                    { return l.
 func (l *recordingLogger) WithContext(_ any) logger.Logger           { return l }
 func (l *recordingLogger) WithFields(_ map[string]any) logger.Logger { return l }
 
-func (l *recordingLogger) warnMessages() []string {
+func (l *recordingLogger) messagesAt(level string) []string {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	out := []string{}
 	for _, e := range l.events {
-		if e.level == "warn" {
+		if e.level == level {
 			out = append(out, e.msg)
 		}
 	}
 	return out
 }
+
+func (l *recordingLogger) warnMessages() []string { return l.messagesAt("warn") }
 
 // warnError reports the error text attached to the first WARN carrying msg. An
 // empty string with ok=true means the line was emitted with no error at all,
@@ -464,13 +467,20 @@ func TestManagerReady(t *testing.T) {
 	}
 }
 
+// TestOffsetSpecFor covers the four ways a position is chosen. Only a MISSING
+// offset may fall back to the declared start: any other query failure answered
+// with a start position would skip — fatally so for the zero-value OffsetNext,
+// which attaches past everything written since the last commit, and streams have
+// no redelivery to get it back.
 func TestOffsetSpecFor(t *testing.T) {
 	tests := []struct {
-		name     string
-		stored   int64
-		queryErr error
-		start    OffsetStart
-		want     stream.OffsetSpecification
+		name        string
+		stored      int64
+		queryErr    error
+		start       OffsetStart
+		localOffset int64
+		hasLocal    bool
+		want        stream.OffsetSpecification
 	}{
 		{
 			name:   "stored_offset_resumes_one_past_it",
@@ -485,16 +495,65 @@ func TestOffsetSpecFor(t *testing.T) {
 			want:     stream.OffsetSpecification{}.First(),
 		},
 		{
-			name:     "query_failure_uses_declared_start",
+			name:        "query_failure_resumes_from_the_local_commit",
+			queryErr:    errors.New("boom"),
+			start:       OffsetNext(),
+			localOffset: 41,
+			hasLocal:    true,
+			want:        stream.OffsetSpecification{}.Offset(42),
+		},
+		{
+			name:     "query_failure_without_a_local_commit_replays_from_first",
+			queryErr: errors.New("boom"),
+			start:    OffsetNext(),
+			want:     stream.OffsetSpecification{}.First(),
+		},
+		{
+			name:     "query_failure_never_answers_with_the_declared_start",
 			queryErr: errors.New("boom"),
 			start:    OffsetLast(),
-			want:     stream.OffsetSpecification{}.Last(),
+			want:     stream.OffsetSpecification{}.First(),
+		},
+		{
+			name:        "a_stored_offset_still_wins_over_the_local_commit",
+			stored:      90,
+			localOffset: 5,
+			hasLocal:    true,
+			start:       OffsetFirst(),
+			want:        stream.OffsetSpecification{}.Offset(91),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, offsetSpecFor(tt.stored, tt.queryErr, tt.start))
+			assert.Equal(t, tt.want, offsetSpecFor(tt.stored, tt.queryErr, tt.start, tt.localOffset, tt.hasLocal))
+		})
+	}
+}
+
+// TestManagerReportOffsetQuery pins the level and the silence either side of it: a
+// failed query changes where a consumer attaches, so it is an ERROR, while the
+// routine missing-offset case must not add noise to every first run.
+func TestManagerReportOffsetQuery(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantError []string
+	}{
+		{name: "successful_query_is_silent", err: nil},
+		{name: "missing_offset_is_silent", err: stream.OffsetNotFoundError},
+		{name: "query_failure_is_reported_at_error", err: errors.New("boom"), wantError: []string{msgOffsetQueryFailed}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := &recordingLogger{}
+			m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: log})
+
+			m.reportOffsetQuery(tt.err, testConsumerName, testPartition0, false)
+
+			assert.ElementsMatch(t, tt.wantError, log.messagesAt("error"))
+			assert.Empty(t, log.messagesAt("warn"), "a lost position is not a warning")
 		})
 	}
 }

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -163,15 +163,78 @@ func testManager(t *testing.T) *Manager {
 	})
 }
 
-// attach wires a fake consumer into a manager as if Start had created it.
-func attach(m *Manager, handle consumerHandle, tracker *offsetTracker) {
+// attach wires a fake consumer into a manager as if Start had created it: one
+// stream, whose flush target is the handle itself — the plain lane's shape.
+func attach(m *Manager, handle *fakeHandle, tracker *offsetTracker) {
+	book := bookOf(tracker)
+	book.trackerFor(testStream)
 	m.consumers = append(m.consumers, &runningConsumer{
-		stream:  testStream,
-		name:    testConsumerName,
-		handle:  handle,
-		tracker: tracker,
+		stream:    testStream,
+		name:      testConsumerName,
+		handle:    handle,
+		offsets:   book,
+		storerFor: func(string) offsetStorer { return handle },
 	})
 	m.started = true
+}
+
+// attachPartitioned wires one consumer that tracks two streams, the shape a super
+// stream produces: one book, one flush target per partition.
+// countBeforeStorage decides whether the two recorded offsets are still pending
+// (a high threshold) or already committed (1).
+func attachPartitioned(t *testing.T, m *Manager, countBeforeStorage int) (handle *fakeHandle, storer0, storer1 *fakeStorer) {
+	t.Helper()
+	handle = &fakeHandle{status: ha.StatusOpen}
+	storer0, storer1 = &fakeStorer{}, &fakeStorer{}
+	book := newOffsetBook(func() *offsetTracker { return newOffsetTracker(countBeforeStorage, time.Hour, nil) })
+	require.NoError(t, book.trackerFor(testPartition0).record(11, nil, storer0))
+	require.NoError(t, book.trackerFor(testPartition1).record(501, nil, storer1))
+
+	m.consumers = append(m.consumers, &runningConsumer{
+		stream:  testSuperStream,
+		name:    testConsumerName,
+		handle:  handle,
+		offsets: book,
+		storerFor: storerByStream(map[string]offsetStorer{
+			testPartition0: storer0,
+			testPartition1: storer1,
+		}),
+	})
+	m.started = true
+	return handle, storer0, storer1
+}
+
+// TestManagerStopConsumersFlushesEveryTrackedStream extends the shutdown flush to
+// a consumer that tracks more than one stream: every partition's pending offset is
+// committed through the storer that reaches it, and only then is the consumer
+// closed.
+func TestManagerStopConsumersFlushesEveryTrackedStream(t *testing.T) {
+	m := testManager(t)
+	handle, storer0, storer1 := attachPartitioned(t, m, 1000)
+	require.Empty(t, storer0.offsets(), "the premise: both offsets are still pending")
+
+	m.StopConsumers()
+
+	assert.Equal(t, []int64{11}, storer0.offsets())
+	assert.Equal(t, []int64{501}, storer1.offsets())
+	assert.Equal(t, []string{"close"}, handle.recorded(), "the handle itself stores nothing")
+	assert.Empty(t, m.consumers)
+}
+
+// TestManagerStatsKeysOffsetsByTrackedStream pins the /ready body's key: a position
+// is reported under the stream it belongs to, which for a super stream is the
+// partition rather than the declared name.
+func TestManagerStatsKeysOffsetsByTrackedStream(t *testing.T) {
+	m := testManager(t)
+	attachPartitioned(t, m, 1)
+
+	stats := m.Stats()
+
+	assert.Equal(t, map[string]int64{
+		testPartition0 + "/" + testConsumerName: 11,
+		testPartition1 + "/" + testConsumerName: 501,
+	}, stats["stored_offsets"])
+	assert.Equal(t, 1, stats["consumers"], "the two partitions are one consumer")
 }
 
 func TestNewManagerAppliesOffsetStoreDefaults(t *testing.T) {

--- a/messaging/streams/runner.go
+++ b/messaging/streams/runner.go
@@ -41,9 +41,11 @@ type offsetStorer interface {
 }
 
 // errNoOffsetStorer reports a commit that had no storer to reach the broker
-// through. Trackers are created per delivered stream while the storer comes from
-// a separate resolver, so the two can disagree about the stream set; the commit is
-// then refused rather than dereferenced, which would panic on the shutdown flush.
+// through. The manager resolves a non-nil storer for every stream name, so this
+// is not a state production reaches: it is defense in depth at the last frame
+// before this package dereferences an interface it does not own, on a path that
+// also runs during shutdown, where a panic would cost every other stream the
+// commit it was about to make.
 var errNoOffsetStorer = errors.New("no offset storer for this stream; offset not committed")
 
 // offsetTracker owns the commit-after-success policy for one consumer.

--- a/messaging/streams/runner.go
+++ b/messaging/streams/runner.go
@@ -3,6 +3,7 @@ package streams
 import (
 	"context"
 	"fmt"
+	"maps"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -123,11 +124,83 @@ func (t *offsetTracker) lastStored() (offset int64, ok bool) {
 	return t.storedOffset, t.hasStored
 }
 
+// flushFailure is one stream's failed offset commit, reported by offsetBook.flush
+// so the caller can name the stream that did not land.
+type flushFailure struct {
+	stream string
+	err    error
+}
+
+// offsetBook holds the offset trackers of one running consumer, keyed by the
+// stream a delivery arrived on: exactly one entry for a plain stream, one per
+// partition for a super stream. Partitions must not share a tracker — a commit
+// says "everything up to here was handled on THIS stream", which stops being true
+// the moment two partitions advance one counter.
+//
+// Trackers are created on first delivery, so a partition that never delivered has
+// nothing to flush and nothing to report.
+type offsetBook struct {
+	newTracker func() *offsetTracker
+
+	mu       sync.Mutex
+	trackers map[string]*offsetTracker
+}
+
+func newOffsetBook(newTracker func() *offsetTracker) *offsetBook {
+	return &offsetBook{newTracker: newTracker, trackers: make(map[string]*offsetTracker)}
+}
+
+// trackerFor returns one stream's tracker, creating it on first use. The client
+// calls this from one delivery goroutine per partition, so the map is guarded even
+// though each tracker only ever serves a single one of them.
+func (b *offsetBook) trackerFor(streamName string) *offsetTracker {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	tracker, ok := b.trackers[streamName]
+	if !ok {
+		tracker = b.newTracker()
+		b.trackers[streamName] = tracker
+	}
+	return tracker
+}
+
+// flush commits every stream's pending offset through the storer that reaches it,
+// and reports the ones that failed rather than stopping at the first: a partition
+// whose commit did not land must not cost the others theirs.
+func (b *offsetBook) flush(storerFor func(streamName string) offsetStorer) []flushFailure {
+	var failures []flushFailure
+	for streamName, tracker := range b.snapshot() {
+		if err := tracker.flush(storerFor(streamName)); err != nil {
+			failures = append(failures, flushFailure{stream: streamName, err: err})
+		}
+	}
+	return failures
+}
+
+// stored reports the last committed offset per stream, omitting the streams that
+// have not committed one yet.
+func (b *offsetBook) stored() map[string]int64 {
+	offsets := make(map[string]int64)
+	for streamName, tracker := range b.snapshot() {
+		if offset, ok := tracker.lastStored(); ok {
+			offsets[streamName] = offset
+		}
+	}
+	return offsets
+}
+
+func (b *offsetBook) snapshot() map[string]*offsetTracker {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return maps.Clone(b.trackers)
+}
+
 // consumerRunner adapts one declared consumer to the stream client's callback.
 type consumerRunner struct {
 	name    string
 	handler Handler
-	tracker *offsetTracker
+	offsets *offsetBook
 	log     logger.Logger
 	tracer  trace.Tracer
 
@@ -180,7 +253,7 @@ func (r *consumerRunner) deliver(streamName string, offset int64, message *amqp.
 			Msg("Stream message handling failed - offset not committed")
 	}
 
-	if storeErr := r.tracker.record(offset, err, store); storeErr != nil {
+	if storeErr := r.offsets.trackerFor(streamName).record(offset, err, store); storeErr != nil {
 		r.log.Warn().Err(storeErr).
 			Str(logFieldStream, streamName).
 			Str(logFieldConsumer, r.name).

--- a/messaging/streams/runner.go
+++ b/messaging/streams/runner.go
@@ -2,6 +2,7 @@ package streams
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"runtime/debug"
@@ -38,6 +39,12 @@ const (
 type offsetStorer interface {
 	StoreCustomOffset(offset int64) error
 }
+
+// errNoOffsetStorer reports a commit that had no storer to reach the broker
+// through. Trackers are created per delivered stream while the storer comes from
+// a separate resolver, so the two can disagree about the stream set; the commit is
+// then refused rather than dereferenced, which would panic on the shutdown flush.
+var errNoOffsetStorer = errors.New("no offset storer for this stream; offset not committed")
 
 // offsetTracker owns the commit-after-success policy for one consumer.
 //
@@ -107,6 +114,9 @@ func (t *offsetTracker) flush(store offsetStorer) error {
 // storeLocked commits the last successfully handled offset. On failure the
 // pending counter is deliberately left intact so the next message retries.
 func (t *offsetTracker) storeLocked(store offsetStorer) error {
+	if store == nil {
+		return errNoOffsetStorer
+	}
 	if err := store.StoreCustomOffset(t.lastHandledOK); err != nil {
 		return err
 	}

--- a/messaging/streams/runner_test.go
+++ b/messaging/streams/runner_test.go
@@ -263,10 +263,10 @@ func TestOffsetTrackerReportsAMissingStorer(t *testing.T) {
 	}
 }
 
-// TestOffsetBookFlushReportsAStreamWithNoStorer is the realistic shape of that
-// disagreement: the book holds a tracker for every delivered stream while the
-// resolver knows only some, and the shutdown flush must name the odd one out
-// instead of taking the process down with it.
+// TestOffsetBookFlushReportsAStreamWithNoStorer pins the book-level half of that
+// guard, with a resolver no production path builds: one stream left unanswered,
+// and the shutdown flush must name it among the failures while every other stream
+// still commits, instead of taking the process down with it.
 func TestOffsetBookFlushReportsAStreamWithNoStorer(t *testing.T) {
 	clock := newFakeClock()
 	book := newOffsetBook(func() *offsetTracker { return newOffsetTracker(1000, time.Hour, clock.Now) })

--- a/messaging/streams/runner_test.go
+++ b/messaging/streams/runner_test.go
@@ -17,6 +17,12 @@ import (
 
 var errHandlerFailed = errors.New("handler failed")
 
+// The broker names a super stream's partitions "<name>-<index>".
+const (
+	testPartition0 = testSuperStream + "-0"
+	testPartition1 = testSuperStream + "-1"
+)
+
 // fakeStorer records every offset handed to the broker, so tests assert exact
 // stored values rather than "was called".
 type fakeStorer struct {
@@ -74,11 +80,35 @@ func newTestRunnerWithLogger(t *testing.T, handler Handler, tracker *offsetTrack
 	return &consumerRunner{
 		name:    testConsumerName,
 		handler: handler,
-		tracker: tracker,
+		offsets: bookOf(tracker),
 		log:     log,
 		tracer:  otel.Tracer(tracerName),
 		baseCtx: context.Background(),
 	}
+}
+
+// bookOf wraps one prepared tracker in a book that hands it out for every stream,
+// which is how a plain single-stream consumer's bookkeeping behaves.
+func bookOf(tracker *offsetTracker) *offsetBook {
+	return newOffsetBook(func() *offsetTracker { return tracker })
+}
+
+func newTestRunnerWithBook(t *testing.T, handler Handler, book *offsetBook) *consumerRunner {
+	t.Helper()
+	return &consumerRunner{
+		name:    testConsumerName,
+		handler: handler,
+		offsets: book,
+		log:     logger.New("error", false),
+		tracer:  otel.Tracer(tracerName),
+		baseCtx: context.Background(),
+	}
+}
+
+// storerByStream resolves a flush target per stream, standing in for the manager's
+// runningConsumer.storerFor.
+func storerByStream(storers map[string]offsetStorer) func(string) offsetStorer {
+	return func(streamName string) offsetStorer { return storers[streamName] }
 }
 
 func amqpMessage(body string) *amqp.Message {
@@ -220,6 +250,93 @@ func TestOffsetTrackerDefaultsToWallClock(t *testing.T) {
 
 	require.NotNil(t, tracker.now)
 	assert.WithinDuration(t, time.Now(), tracker.lastStoreAt, time.Minute)
+}
+
+func TestOffsetBookKeepsOneTrackerPerStream(t *testing.T) {
+	created := 0
+	book := newOffsetBook(func() *offsetTracker {
+		created++
+		return newOffsetTracker(1, time.Hour, nil)
+	})
+
+	first := book.trackerFor(testPartition0)
+	again := book.trackerFor(testPartition0)
+	other := book.trackerFor(testPartition1)
+
+	assert.Same(t, first, again, "a stream keeps its tracker across deliveries")
+	assert.NotSame(t, first, other, "a second stream gets its own tracker")
+	assert.Equal(t, 2, created, "trackers are created on first delivery, not per message")
+}
+
+// TestOffsetBookIsolatesPartitionOffsets is the reason the book exists. Two
+// partitions are delivered alternately with a count threshold of 2: each commits
+// its OWN second message. Sharing one tracker would instead commit on the second
+// and fourth delivery overall, so the offsets would land on the wrong partitions.
+func TestOffsetBookIsolatesPartitionOffsets(t *testing.T) {
+	clock := newFakeClock()
+	runner := newTestRunnerWithBook(t, func(context.Context, *Message) error { return nil },
+		newOffsetBook(func() *offsetTracker { return newOffsetTracker(2, time.Hour, clock.Now) }))
+	storer0, storer1 := &fakeStorer{}, &fakeStorer{}
+
+	runner.deliver(testPartition0, 10, amqpMessage("a"), storer0)
+	runner.deliver(testPartition1, 500, amqpMessage("b"), storer1)
+	runner.deliver(testPartition0, 11, amqpMessage("c"), storer0)
+	runner.deliver(testPartition1, 501, amqpMessage("d"), storer1)
+
+	assert.Equal(t, []int64{11}, storer0.offsets(), "partition 0 commits its own second offset")
+	assert.Equal(t, []int64{501}, storer1.offsets(), "partition 1 commits its own second offset")
+	assert.Equal(t, map[string]int64{testPartition0: 11, testPartition1: 501}, runner.offsets.stored())
+}
+
+func TestOffsetBookFlushCommitsEveryStream(t *testing.T) {
+	clock := newFakeClock()
+	book := newOffsetBook(func() *offsetTracker { return newOffsetTracker(1000, time.Hour, clock.Now) })
+	storer0, storer1 := &fakeStorer{}, &fakeStorer{}
+	require.NoError(t, book.trackerFor(testPartition0).record(7, nil, storer0))
+	require.NoError(t, book.trackerFor(testPartition1).record(42, nil, storer1))
+	require.Empty(t, storer0.offsets(), "the premise: nothing committed before the flush")
+
+	failures := book.flush(storerByStream(map[string]offsetStorer{
+		testPartition0: storer0,
+		testPartition1: storer1,
+	}))
+
+	assert.Empty(t, failures)
+	assert.Equal(t, []int64{7}, storer0.offsets())
+	assert.Equal(t, []int64{42}, storer1.offsets())
+}
+
+// TestOffsetBookFlushReportsEveryFailure pins that one partition's failed commit
+// does not cost the others theirs, and that each failure names its own stream.
+func TestOffsetBookFlushReportsEveryFailure(t *testing.T) {
+	clock := newFakeClock()
+	book := newOffsetBook(func() *offsetTracker { return newOffsetTracker(1000, time.Hour, clock.Now) })
+	failing, landing := &fakeStorer{failNow: true}, &fakeStorer{}
+	// Below the count threshold, so neither commit is attempted before the flush.
+	require.NoError(t, book.trackerFor(testPartition0).record(7, nil, failing))
+	require.NoError(t, book.trackerFor(testPartition1).record(42, nil, landing))
+
+	failures := book.flush(storerByStream(map[string]offsetStorer{
+		testPartition0: failing,
+		testPartition1: landing,
+	}))
+
+	require.Len(t, failures, 1)
+	assert.Equal(t, testPartition0, failures[0].stream)
+	assert.EqualError(t, failures[0].err, "store failed")
+	assert.Equal(t, []int64{42}, landing.offsets(), "the healthy partition still commits")
+}
+
+func TestOffsetBookStoredOmitsStreamsWithoutACommit(t *testing.T) {
+	clock := newFakeClock()
+	book := newOffsetBook(func() *offsetTracker { return newOffsetTracker(1000, time.Hour, clock.Now) })
+	storer := &fakeStorer{}
+	book.trackerFor(testPartition0)
+	require.NoError(t, book.trackerFor(testPartition1).record(9, nil, storer))
+	require.NoError(t, book.trackerFor(testPartition1).flush(storer))
+
+	assert.Equal(t, map[string]int64{testPartition1: 9}, book.stored(),
+		"a partition that never committed contributes no position")
 }
 
 func TestRunnerDeliverPassesMessageToHandler(t *testing.T) {

--- a/messaging/streams/runner_test.go
+++ b/messaging/streams/runner_test.go
@@ -21,6 +21,7 @@ var errHandlerFailed = errors.New("handler failed")
 const (
 	testPartition0 = testSuperStream + "-0"
 	testPartition1 = testSuperStream + "-1"
+	testPartition2 = testSuperStream + "-2"
 )
 
 // fakeStorer records every offset handed to the broker, so tests assert exact
@@ -29,11 +30,17 @@ type fakeStorer struct {
 	mu      sync.Mutex
 	stored  []int64
 	failNow bool
+	// failErr, when set, is returned instead of the shared "store failed" error, so
+	// a test running two failing storers can tell their failures apart.
+	failErr error
 }
 
 func (f *fakeStorer) StoreCustomOffset(offset int64) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.failErr != nil {
+		return f.failErr
+	}
 	if f.failNow {
 		return errors.New("store failed")
 	}
@@ -359,24 +366,41 @@ func TestOffsetBookFlushCommitsEveryStream(t *testing.T) {
 	assert.Equal(t, []int64{42}, storer1.offsets())
 }
 
-// TestOffsetBookFlushReportsEveryFailure pins that one partition's failed commit
-// does not cost the others theirs, and that each failure names its own stream.
+// TestOffsetBookFlushReportsEveryFailure pins that a failed commit does not stop
+// the loop: with TWO of three partitions refusing, both are reported — not just
+// whichever the flush reached first — each failure carries its own partition's
+// error, and the healthy partition still commits. Two failures are what make this
+// discriminating; a single one cannot tell "reports every failure" apart from
+// "stops at the first". flush ranges over a map, so the report order is deliberately
+// not asserted.
 func TestOffsetBookFlushReportsEveryFailure(t *testing.T) {
 	clock := newFakeClock()
 	book := newOffsetBook(func() *offsetTracker { return newOffsetTracker(1000, time.Hour, clock.Now) })
-	failing, landing := &fakeStorer{failNow: true}, &fakeStorer{}
-	// Below the count threshold, so neither commit is attempted before the flush.
-	require.NoError(t, book.trackerFor(testPartition0).record(7, nil, failing))
+	errPartition0, errPartition2 := errors.New("partition 0 store failed"), errors.New("partition 2 store failed")
+	failing0, failing2 := &fakeStorer{failErr: errPartition0}, &fakeStorer{failErr: errPartition2}
+	landing := &fakeStorer{}
+	// Below the count threshold, so no commit is attempted before the flush.
+	require.NoError(t, book.trackerFor(testPartition0).record(7, nil, failing0))
 	require.NoError(t, book.trackerFor(testPartition1).record(42, nil, landing))
+	require.NoError(t, book.trackerFor(testPartition2).record(99, nil, failing2))
 
 	failures := book.flush(storerByStream(map[string]offsetStorer{
-		testPartition0: failing,
+		testPartition0: failing0,
 		testPartition1: landing,
+		testPartition2: failing2,
 	}))
 
-	require.Len(t, failures, 1)
-	assert.Equal(t, testPartition0, failures[0].stream)
-	assert.EqualError(t, failures[0].err, "store failed")
+	require.Len(t, failures, 2, "the first failure must not end the loop")
+	reported := make([]string, 0, len(failures))
+	errByStream := make(map[string]error, len(failures))
+	for _, failure := range failures {
+		reported = append(reported, failure.stream)
+		errByStream[failure.stream] = failure.err
+	}
+	assert.ElementsMatch(t, []string{testPartition0, testPartition2}, reported,
+		"both failing partitions are named, in whatever order the map yielded them")
+	assert.ErrorIs(t, errByStream[testPartition0], errPartition0, "each failure carries its own partition's error")
+	assert.ErrorIs(t, errByStream[testPartition2], errPartition2)
 	assert.Equal(t, []int64{42}, landing.offsets(), "the healthy partition still commits")
 }
 

--- a/messaging/streams/runner_test.go
+++ b/messaging/streams/runner_test.go
@@ -229,6 +229,59 @@ func TestOffsetTrackerRetriesAfterStoreFailure(t *testing.T) {
 	assert.Equal(t, []int64{21}, storer.offsets(), "the next message retries the commit")
 }
 
+// TestOffsetTrackerReportsAMissingStorer pins the guard on both commit paths: a
+// nil storer must surface as an error, never a nil dereference.
+func TestOffsetTrackerReportsAMissingStorer(t *testing.T) {
+	tests := []struct {
+		name   string
+		commit func(tracker *offsetTracker) error
+	}{
+		{
+			name:   "record_reaching_the_count_threshold",
+			commit: func(tracker *offsetTracker) error { return tracker.record(5, nil, nil) },
+		},
+		{
+			name:   "flush_on_shutdown",
+			commit: func(tracker *offsetTracker) error { return tracker.flush(nil) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clock := newFakeClock()
+			tracker := newOffsetTracker(2, time.Hour, clock.Now)
+			// Leaves one offset pending, so both paths reach the commit.
+			require.NoError(t, tracker.record(4, nil, &fakeStorer{}))
+
+			var err error
+			require.NotPanics(t, func() { err = tt.commit(tracker) })
+
+			require.ErrorIs(t, err, errNoOffsetStorer)
+			_, ok := tracker.lastStored()
+			assert.False(t, ok, "a refused commit stores no offset")
+		})
+	}
+}
+
+// TestOffsetBookFlushReportsAStreamWithNoStorer is the realistic shape of that
+// disagreement: the book holds a tracker for every delivered stream while the
+// resolver knows only some, and the shutdown flush must name the odd one out
+// instead of taking the process down with it.
+func TestOffsetBookFlushReportsAStreamWithNoStorer(t *testing.T) {
+	clock := newFakeClock()
+	book := newOffsetBook(func() *offsetTracker { return newOffsetTracker(1000, time.Hour, clock.Now) })
+	landing := &fakeStorer{}
+	require.NoError(t, book.trackerFor(testPartition0).record(7, nil, landing))
+	require.NoError(t, book.trackerFor(testPartition1).record(42, nil, landing))
+
+	failures := book.flush(storerByStream(map[string]offsetStorer{testPartition1: landing}))
+
+	require.Len(t, failures, 1)
+	assert.Equal(t, testPartition0, failures[0].stream)
+	assert.ErrorIs(t, failures[0].err, errNoOffsetStorer)
+	assert.Equal(t, []int64{42}, landing.offsets(), "the resolved partition still commits")
+}
+
 func TestOffsetTrackerLastStored(t *testing.T) {
 	clock := newFakeClock()
 	tracker := newOffsetTracker(1, time.Hour, clock.Now)

--- a/wiki/streams.md
+++ b/wiki/streams.md
@@ -107,6 +107,14 @@ the framework queries the broker for the consumer name's stored offset and
 resumes at `stored + 1`. `Start` only applies when the broker has no offset for
 that name, which makes restart behavior deterministic.
 
+**A failed offset query never falls back to `Start`.** If the broker cannot be
+asked — a connection or RPC failure, as opposed to simply having no offset — the
+framework resumes from the position this process last committed, or from the
+oldest retained message if it has committed none, and logs the choice at ERROR.
+Falling back to `Start` would mean attaching at `OffsetNext()` by default, i.e.
+past everything written since the last commit, and a stream has no redelivery to
+get it back. Replay is the affordable failure here; a silent skip is not.
+
 **Offsets are committed only AFTER a handler returned successfully.** The
 client's own auto-commit is deliberately not used: it advances the offset for
 messages the handler may have failed. A commit happens when either


### PR DESCRIPTION
## What

`offsetSpecFor` collapsed every `QueryOffset` failure to the declared `Start`; with the default `OffsetNext` a transient RPC error attached the consumer at "next message from now", permanently skipping everything since the stored offset. Only a *missing* offset falls back to `Start` now — any other failure resumes from this process's last commit, or `First` if it has none. The per-consumer offset tracker also becomes an `offsetBook` keyed by the arriving stream, the shape a super-stream consumer needs.

## Impact

Streams have no redelivery, so that skip was unrecoverable message loss — and the plain lane's opt-in SAC carries the bug today, which is why it lands here rather than with the super-stream consumer. The offset-query report moves WARN to ERROR. `consumerHandle` narrows to `Close` + `GetStatus`; `Stats` keys stored offsets by tracked stream.

## Verification

Stacked PR — `ci-v2.yml` is `pull_request: branches: [main]`, so CI runs CodeQL only. `make check`, `go test -race`, and the Docker integration suite ran locally against this head.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved offset tracking and recovery across multiple streams or partitions.
  - Consumers now resume from locally committed positions when broker offset queries fail.
  - Without a local position, consumers start from the oldest retained message.
  - Shutdown flushes pending offsets for every tracked stream and reports individual failures.

- **Documentation**
  - Added guidance on offset-query failure handling and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->