### PR TITLE
feat(streams): consume super streams as a partitioned group

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -2966,8 +2966,12 @@ queue := decls.DeclareStreamQueue("orders.events.stream", &messaging.StreamQueue
 For **server-side offset tracking** (a restart resumes from the last stored offset), single
 active consumer, or super streams, use the native stream protocol instead: implement
 `app.StreamDeclarer` and set `messaging.streams.uri`. Handlers run inline and sequentially
-within a stream, and an offset is committed only after a handler returns nil — delivery is
-at-least-once, so make handlers idempotent. See [wiki/streams.md](wiki/streams.md):
+within a stream. A handler returning nil advances the *tracked* position only; that
+position is stored on the broker once `messaging.streams.offsetstore.countbeforestorage`
+successes have accumulated or `messaging.streams.offsetstore.flushinterval` has elapsed,
+plus a final flush when consumers stop — so a restart replays everything handled since the
+last stored offset. Delivery is at-least-once, so make handlers idempotent. See
+[wiki/streams.md](wiki/streams.md):
 
 ```go
 func (m *Module) DeclareStreams(decls *streams.Declarations) {

--- a/llms.txt
+++ b/llms.txt
@@ -2965,9 +2965,9 @@ queue := decls.DeclareStreamQueue("orders.events.stream", &messaging.StreamQueue
 
 For **server-side offset tracking** (a restart resumes from the last stored offset), single
 active consumer, or super streams, use the native stream protocol instead: implement
-`app.StreamDeclarer` and set `messaging.streams.uri`. Handlers run inline and sequentially,
-and an offset is committed only after a handler returns nil — delivery is at-least-once, so
-make handlers idempotent. See [wiki/streams.md](wiki/streams.md):
+`app.StreamDeclarer` and set `messaging.streams.uri`. Handlers run inline and sequentially
+within a stream, and an offset is committed only after a handler returns nil — delivery is
+at-least-once, so make handlers idempotent. See [wiki/streams.md](wiki/streams.md):
 
 ```go
 func (m *Module) DeclareStreams(decls *streams.Declarations) {
@@ -2980,6 +2980,24 @@ func (m *Module) DeclareStreams(decls *streams.Declarations) {
 		},
 	})
 }
+```
+
+For a **super stream** (a stream partitioned into `<name>-0`…`<name>-(n-1)`, RabbitMQ
+3.13+), declare it with a partition count and consume it as one group. There is no `SAC`
+field — super-stream consumption is always a single active consumer group, which is what
+restores a stored offset per partition. Offsets, order and the commit policy are
+per-partition, and the handler is called **concurrently across partitions**, so it must be
+goroutine-safe:
+
+```go
+decls.DeclareSuperStream("orders", 3, &streams.StreamSpec{MaxLengthBytes: 5 << 30})
+decls.DeclareSuperStreamConsumer(&streams.SuperStreamConsumerOptions{
+	SuperStream: "orders", Name: "order-projector",
+	Start: streams.OffsetFirst(),
+	Handler: func(ctx context.Context, msg *streams.Message) error {
+		return m.svc.Project(ctx, msg.Data) // msg.Stream is the partition
+	},
+})
 ```
 
 ### Step 3: Implement the Producer (publish messages)

--- a/llms.txt
+++ b/llms.txt
@@ -2989,9 +2989,11 @@ func (m *Module) DeclareStreams(decls *streams.Declarations) {
 For a **super stream** (a stream partitioned into `<name>-0`…`<name>-(n-1)`, RabbitMQ
 3.13+), declare it with a partition count and consume it as one group. There is no `SAC`
 field — super-stream consumption is always a single active consumer group, which is what
-restores a stored offset per partition. Offsets, order and the commit policy are
-per-partition, and the handler is called **concurrently across partitions**, so it must be
-goroutine-safe:
+restores a stored offset per partition. Within one `Name`, each partition has exactly one
+active member at a time and the broker spreads partitions across the group, so members
+beyond the partition count are standbys and a promoted member resolves that partition's
+stored offset. Offsets, order and the commit policy are per-partition, and the handler is
+called **concurrently across partitions**, so it must be goroutine-safe:
 
 ```go
 decls.DeclareSuperStream("orders", 3, &streams.StreamSpec{MaxLengthBytes: 5 << 30})

--- a/llms.txt
+++ b/llms.txt
@@ -2985,11 +2985,13 @@ func (m *Module) DeclareStreams(decls *streams.Declarations) {
 ```
 
 For a **super stream** (a stream partitioned into `<name>-0`…`<name>-(n-1)`, RabbitMQ
-3.13+), declare it with a partition count and consume it as one group. There is no `SAC`
-field — super-stream consumption is always a single active consumer group, which is what
-restores a stored offset per partition. Within one `Name`, each partition has exactly one
-active member. Offsets, order and the commit policy are per-partition, and the handler is
-called **concurrently across partitions**, so it must be goroutine-safe — see
+3.13+), declare it with a partition count and consume it as one group. The count is
+fixed at declaration time — re-declaring with a different one is accepted silently and
+changes nothing. There is no `SAC` field — super-stream consumption is always a single
+active consumer group, which is what restores a stored offset per partition. Within one
+`Name`, each partition has exactly one active member. Offsets, order and the commit
+policy are per-partition, and the handler is called **concurrently across partitions**,
+so it must be goroutine-safe — see
 [wiki/streams.md#super-streams](wiki/streams.md#super-streams):
 
 ```go

--- a/llms.txt
+++ b/llms.txt
@@ -2966,12 +2966,10 @@ queue := decls.DeclareStreamQueue("orders.events.stream", &messaging.StreamQueue
 For **server-side offset tracking** (a restart resumes from the last stored offset), single
 active consumer, or super streams, use the native stream protocol instead: implement
 `app.StreamDeclarer` and set `messaging.streams.uri`. Handlers run inline and sequentially
-within a stream. A handler returning nil advances the *tracked* position only; that
-position is stored on the broker once `messaging.streams.offsetstore.countbeforestorage`
-successes have accumulated or `messaging.streams.offsetstore.flushinterval` has elapsed,
-plus a final flush when consumers stop — so a restart replays everything handled since the
-last stored offset. Delivery is at-least-once, so make handlers idempotent. See
-[wiki/streams.md](wiki/streams.md):
+within a stream. A handler returning nil advances the *tracked* position, and commits are
+batched — so a restart replays everything handled since the last stored offset. Delivery is
+at-least-once, so make handlers idempotent. See
+[wiki/streams.md#offset-semantics](wiki/streams.md#offset-semantics):
 
 ```go
 func (m *Module) DeclareStreams(decls *streams.Declarations) {
@@ -2990,10 +2988,9 @@ For a **super stream** (a stream partitioned into `<name>-0`…`<name>-(n-1)`, R
 3.13+), declare it with a partition count and consume it as one group. There is no `SAC`
 field — super-stream consumption is always a single active consumer group, which is what
 restores a stored offset per partition. Within one `Name`, each partition has exactly one
-active member at a time and the broker spreads partitions across the group, so members
-beyond the partition count are standbys and a promoted member resolves that partition's
-stored offset. Offsets, order and the commit policy are per-partition, and the handler is
-called **concurrently across partitions**, so it must be goroutine-safe:
+active member. Offsets, order and the commit policy are per-partition, and the handler is
+called **concurrently across partitions**, so it must be goroutine-safe — see
+[wiki/streams.md#super-streams](wiki/streams.md#super-streams):
 
 ```go
 decls.DeclareSuperStream("orders", 3, &streams.StreamSpec{MaxLengthBytes: 5 << 30})

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -427,10 +427,19 @@ func offsetSpecFor(stored int64, queryErr error, start OffsetStart, localOffset 
 	}
 }
 
-// streamOptionsFrom renders a StreamSpec as client stream options. Zero-value
+// retentionOptions is the setter triple both client option types expose, each
+// returning its own type. The self-reference on T is what lets one renderer serve
+// both, so a StreamSpec field cannot reach the broker on one kind and be dropped on
+// the other.
+type retentionOptions[T any] interface {
+	SetMaxAge(time.Duration) T
+	SetMaxLengthBytes(*stream.ByteCapacity) T
+	SetMaxSegmentSizeBytes(*stream.ByteCapacity) T
+}
+
+// applyRetention renders a StreamSpec onto either client option type. Zero-value
 // fields are left unset so the broker's own defaults apply.
-func streamOptionsFrom(spec *StreamSpec) *stream.StreamOptions {
-	opts := stream.NewStreamOptions()
+func applyRetention[T retentionOptions[T]](opts T, spec *StreamSpec) T {
 	if spec == nil {
 		return opts
 	}
@@ -446,24 +455,15 @@ func streamOptionsFrom(spec *StreamSpec) *stream.StreamOptions {
 	return opts
 }
 
+// streamOptionsFrom renders a StreamSpec as client stream options.
+func streamOptionsFrom(spec *StreamSpec) *stream.StreamOptions {
+	return applyRetention(stream.NewStreamOptions(), spec)
+}
+
 // partitionOptionsFrom renders a StreamSpec as super-stream partition options; the
-// retention applies to every partition. Zero-value fields are left unset so the
-// broker's own defaults apply.
+// retention applies to every partition.
 func partitionOptionsFrom(partitions int, spec *StreamSpec) *stream.PartitionsOptions {
-	opts := stream.NewPartitionsOptions(partitions)
-	if spec == nil {
-		return opts
-	}
-	if spec.MaxAge > 0 {
-		opts = opts.SetMaxAge(clampedMaxAge(spec.MaxAge))
-	}
-	if spec.MaxLengthBytes > 0 {
-		opts = opts.SetMaxLengthBytes(stream.ByteCapacity{}.B(spec.MaxLengthBytes))
-	}
-	if spec.MaxSegmentSizeBytes > 0 {
-		opts = opts.SetMaxSegmentSizeBytes(stream.ByteCapacity{}.B(spec.MaxSegmentSizeBytes))
-	}
-	return opts
+	return applyRetention(stream.NewPartitionsOptions(partitions), spec)
 }
 
 // clampedMaxAge renders a retention age the way both client renderers and the AMQP

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -159,6 +159,11 @@ func (m *Manager) Start(ctx context.Context, decls *Declarations) error {
 		return err
 	}
 
+	if err := m.declareSuperStreams(env, decls); err != nil {
+		m.abortStartLocked()
+		return err
+	}
+
 	for _, decl := range decls.consumers {
 		if err := m.startConsumer(consumeCtx, env, decl); err != nil {
 			m.abortStartLocked()
@@ -205,17 +210,31 @@ func (m *Manager) declareStreams(env *stream.Environment, decls *Declarations) e
 	return nil
 }
 
-// startConsumer starts one reliable consumer for a declaration. env is the
-// caller's snapshot of m.env, taken under m.mu.
-func (m *Manager) startConsumer(ctx context.Context, env *stream.Environment, decl *consumerDeclaration) error {
-	runner := &consumerRunner{
-		name:    decl.Name,
-		handler: decl.Handler,
-		offsets: m.newOffsetBook(),
-		log:     m.log,
-		tracer:  otel.Tracer(tracerName),
-		baseCtx: ctx,
+// declareSuperStreams replays the declared super streams. Note the asymmetry with
+// declareStreams: the client swallows StreamAlreadyExists here, so a super stream
+// that already exists with a DIFFERENT partition count or retention is accepted
+// silently — see wiki/streams.md.
+func (m *Manager) declareSuperStreams(env *stream.Environment, decls *Declarations) error {
+	for _, s := range decls.superStreams {
+		if err := env.DeclareSuperStream(s.Name, partitionOptionsFrom(s.Partitions, &s.Spec)); err != nil {
+			return fmt.Errorf("failed to declare super stream %q: %w", s.Name, err)
+		}
 	}
+	return nil
+}
+
+// startConsumer starts one consumer for a declaration, on the client API its kind
+// requires. env is the caller's snapshot of m.env, taken under m.mu.
+func (m *Manager) startConsumer(ctx context.Context, env *stream.Environment, decl *consumerDeclaration) error {
+	if decl.Super {
+		return m.startSuperStreamConsumer(ctx, env, decl)
+	}
+	return m.startStreamConsumer(ctx, env, decl)
+}
+
+// startStreamConsumer starts one reliable consumer on a plain stream.
+func (m *Manager) startStreamConsumer(ctx context.Context, env *stream.Environment, decl *consumerDeclaration) error {
+	runner := m.newRunner(ctx, decl)
 
 	opts := stream.NewConsumerOptions().
 		SetConsumerName(decl.Name).
@@ -243,21 +262,86 @@ func (m *Manager) startConsumer(ctx context.Context, env *stream.Environment, de
 		return fmt.Errorf("failed to start consumer %q on stream %q: %w", decl.Name, decl.Stream, err)
 	}
 
+	// One stream, so one flush target: the reliable consumer itself.
+	m.trackConsumer(decl, consumer, runner, func(string) offsetStorer { return consumer })
+	return nil
+}
+
+// startSuperStreamConsumer starts one reliable consumer across every partition of
+// a super stream. env is the caller's snapshot of m.env, taken under m.mu.
+func (m *Manager) startSuperStreamConsumer(ctx context.Context, env *stream.Environment, decl *consumerDeclaration) error {
+	runner := m.newRunner(ctx, decl)
+
+	// Always a single active consumer group. The client attaches every partition
+	// with one shared offset specification, so this callback — which the broker
+	// fires once per partition, on promotion — is the only place a per-partition
+	// stored offset can be restored. See ADR-059.
+	//
+	// SECURITY: the env snapshot rather than m.env, for the reason spelled out in
+	// startStreamConsumer: the client calls this from its own goroutine, outside
+	// m.mu, with no recover() in its call path.
+	opts := stream.NewSuperStreamConsumerOptions().
+		SetConsumerName(decl.Name).
+		SetSingleActiveConsumer(stream.NewSingleActiveConsumer(
+			func(partition string, _ bool) stream.OffsetSpecification {
+				return m.resolveOffset(env, decl.Name, partition, decl.Start, runner.offsets)
+			}))
+
+	consumer, err := ha.NewReliableSuperStreamConsumer(env, decl.Stream, runner.messagesHandler, opts)
+	if err != nil {
+		return fmt.Errorf("failed to start consumer %q on super stream %q: %w", decl.Name, decl.Stream, err)
+	}
+
+	// The shutdown flush goes through the environment, per partition:
+	// *ha.ReliableSuperStreamConsumer has no StoreCustomOffset, and the partition
+	// consumer that delivered the last message may already have been replaced by a
+	// reconnect.
+	m.trackConsumer(decl, consumer, runner, func(partition string) offsetStorer {
+		return envOffsetStorer{env: env, consumer: decl.Name, stream: partition}
+	})
+	return nil
+}
+
+// newRunner builds the delivery callback state of one declared consumer.
+func (m *Manager) newRunner(ctx context.Context, decl *consumerDeclaration) *consumerRunner {
+	return &consumerRunner{
+		name:    decl.Name,
+		handler: decl.Handler,
+		offsets: m.newOffsetBook(),
+		log:     m.log,
+		tracer:  otel.Tracer(tracerName),
+		baseCtx: ctx,
+	}
+}
+
+// trackConsumer records a started consumer for readiness, stats and shutdown.
+func (m *Manager) trackConsumer(decl *consumerDeclaration, handle consumerHandle, runner *consumerRunner, storerFor func(streamName string) offsetStorer) {
 	m.consumers = append(m.consumers, &runningConsumer{
 		stream:    decl.Stream,
 		name:      decl.Name,
-		handle:    consumer,
+		handle:    handle,
 		offsets:   runner.offsets,
-		storerFor: func(string) offsetStorer { return consumer },
+		storerFor: storerFor,
 	})
 
 	m.log.Info().
 		Str(logFieldStream, decl.Stream).
 		Str(logFieldConsumer, decl.Name).
 		Bool("single_active", decl.SAC).
+		Bool("partitioned", decl.Super).
 		Msg("Stream consumer started")
+}
 
-	return nil
+// envOffsetStorer commits one stream's offset through the environment's locator
+// connection instead of through a consumer.
+type envOffsetStorer struct {
+	env      *stream.Environment
+	consumer string
+	stream   string
+}
+
+func (s envOffsetStorer) StoreCustomOffset(offset int64) error {
+	return s.env.StoreOffset(s.consumer, s.stream, offset)
 }
 
 // newOffsetBook builds the offset bookkeeping of one consumer, with the manager's
@@ -351,12 +435,7 @@ func streamOptionsFrom(spec *StreamSpec) *stream.StreamOptions {
 		return opts
 	}
 	if spec.MaxAge > 0 {
-		// Truncate to whole seconds and floor at 1s, matching
-		// messaging.StreamQueueSpec: sub-second retention is inexpressible to the
-		// broker and would render "0s", and passing whole seconds keeps the
-		// client's round-to-nearest formatting from disagreeing with the AMQP
-		// lane's truncation on a value like 1500ms.
-		opts = opts.SetMaxAge(max(spec.MaxAge.Truncate(time.Second), time.Second))
+		opts = opts.SetMaxAge(clampedMaxAge(spec.MaxAge))
 	}
 	if spec.MaxLengthBytes > 0 {
 		opts = opts.SetMaxLengthBytes(stream.ByteCapacity{}.B(spec.MaxLengthBytes))
@@ -365,6 +444,38 @@ func streamOptionsFrom(spec *StreamSpec) *stream.StreamOptions {
 		opts = opts.SetMaxSegmentSizeBytes(stream.ByteCapacity{}.B(spec.MaxSegmentSizeBytes))
 	}
 	return opts
+}
+
+// partitionOptionsFrom renders a StreamSpec as super-stream partition options; the
+// retention applies to every partition. Zero-value fields are left unset so the
+// broker's own defaults apply.
+func partitionOptionsFrom(partitions int, spec *StreamSpec) *stream.PartitionsOptions {
+	opts := stream.NewPartitionsOptions(partitions)
+	if spec == nil {
+		return opts
+	}
+	if spec.MaxAge > 0 {
+		opts = opts.SetMaxAge(clampedMaxAge(spec.MaxAge))
+	}
+	if spec.MaxLengthBytes > 0 {
+		opts = opts.SetMaxLengthBytes(stream.ByteCapacity{}.B(spec.MaxLengthBytes))
+	}
+	if spec.MaxSegmentSizeBytes > 0 {
+		opts = opts.SetMaxSegmentSizeBytes(stream.ByteCapacity{}.B(spec.MaxSegmentSizeBytes))
+	}
+	return opts
+}
+
+// clampedMaxAge renders a retention age the way both client renderers and the AMQP
+// lane agree on: truncated to whole seconds, floored at 1s.
+//
+// Second granularity is RabbitMQ's, so a sub-second value is inexpressible — the
+// super-stream renderer truncates it (int(MaxAge.Seconds())) and the plain-stream
+// one rounds it, so without the floor the same 500ms would disable retention on one
+// and keep a second of it on the other. Truncating first also keeps 1500ms from
+// reaching the broker as 2s here and 1s in the AMQP lane.
+func clampedMaxAge(maxAge time.Duration) time.Duration {
+	return max(maxAge.Truncate(time.Second), time.Second)
 }
 
 // StopConsumers stops every consumer. Each one flushes its pending offset BEFORE

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -145,10 +145,13 @@ func (m *Manager) Start(ctx context.Context, decls *Declarations) error {
 	}
 	m.env = env
 
+	// Stats rather than len(decls.streams), which omits the super streams.
+	stats := decls.Stats()
 	m.log.Info().
 		Str("uri", redactStreamURI(m.opts.URI)).
-		Int("streams", len(decls.streams)).
-		Int("consumers", len(decls.consumers)).
+		Int("streams", stats.Streams).
+		Int("super_streams", stats.SuperStreams).
+		Int("consumers", stats.Consumers).
 		Msg("Connected to RabbitMQ stream endpoint")
 
 	consumeCtx, cancel := consumeContext(ctx)

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -19,6 +19,22 @@ const (
 	defaultOffsetStoreCount    = 500
 	defaultOffsetStoreInterval = 5 * time.Second
 
+	// shutdownFlushBudget bounds the total wall-clock time StopConsumers spends
+	// committing offsets before it gives up on the rest.
+	//
+	// A healthy flush is one round trip per tracked stream and lands in
+	// milliseconds, so this only ever bites when the broker is unreachable —
+	// exactly the case that must not stall a pod drain. It sits at the low end of
+	// the framework's other shutdown budgets (server.timeout.shutdown 10s,
+	// scheduler.timeout.shutdown 30s) on purpose: those drain real user requests
+	// and real jobs, whereas this drains an OPTIMIZATION. Losing it replays
+	// messages that handlers are already required to be idempotent about, so
+	// trading bounded replay for a faster drain is the right way round. 5s also
+	// matches messaging.reconnect.readytimeout, the framework's other "how long do
+	// we wait on a broker that may be cold before giving up on something optional"
+	// budget.
+	shutdownFlushBudget = 5 * time.Second
+
 	// redactedStreamURI stands in for a URI that could not be parsed, so a
 	// malformed value can never reach a log line with its credentials attached.
 	// #nosec G101 -- placeholder text, not a credential
@@ -78,6 +94,12 @@ type Manager struct {
 	opts ManagerOptions
 	log  logger.Logger
 
+	// flushBudget is shutdownFlushBudget, held as a field so tests can shrink it.
+	// Deliberately not a ManagerOptions field: an operator has no way to know
+	// better than the framework here, and the value only matters when the broker
+	// is already gone.
+	flushBudget time.Duration
+
 	mu        sync.Mutex
 	env       *stream.Environment
 	consumers []*runningConsumer
@@ -103,7 +125,7 @@ func NewManager(opts ManagerOptions) *Manager {
 	if opts.OffsetStoreInterval <= 0 {
 		opts.OffsetStoreInterval = defaultOffsetStoreInterval
 	}
-	return &Manager{opts: opts, log: opts.Logger}
+	return &Manager{opts: opts, log: opts.Logger, flushBudget: shutdownFlushBudget}
 }
 
 // Start dials the broker, replays the stream declarations, and starts one
@@ -544,13 +566,14 @@ func (m *Manager) stopLocked() {
 		m.cancel = nil
 	}
 
+	// One budget for the whole phase rather than one per consumer: what this bounds
+	// is how long App.Shutdown waits, and granting each consumer the full budget
+	// would multiply the very delay it exists to cap.
+	flushCtx, cancelFlush := context.WithTimeout(context.Background(), m.flushBudget)
+	defer cancelFlush()
+
 	for _, rc := range m.consumers {
-		for _, failure := range rc.offsets.flush(rc.storerFor) {
-			m.log.Warn().Err(failure.err).
-				Str(logFieldStream, failure.stream).
-				Str(logFieldConsumer, rc.name).
-				Msg("Failed to flush stream offset on shutdown")
-		}
+		m.flushOffsetsLocked(flushCtx, rc)
 		if err := rc.handle.Close(); err != nil {
 			m.log.Warn().Err(err).
 				Str(logFieldStream, rc.stream).
@@ -561,6 +584,62 @@ func (m *Manager) stopLocked() {
 
 	m.consumers = nil
 	m.started = false
+}
+
+// flushOffsetsLocked commits one consumer's pending offsets, giving up once the
+// shutdown flush budget is spent.
+//
+// The flush runs on its own goroutine because it cannot be interrupted from the
+// outside. A super stream's offsets are committed through the environment's
+// locator (envOffsetStorer), and every locator call begins with the client's
+// maybeReconnectLocator — an unbounded, context-free `for err != nil { sleep;
+// connect }` with no attempt cap and no deadline. Against a broker that is down,
+// the FIRST such commit never returns, so a budget checked between partitions
+// would never get its turn: the loop has to be able to walk away from a call in
+// flight, not merely decline to start the next one.
+//
+// Walking away abandons that goroutine for the remaining life of the process.
+// That is the trade being made deliberately: the process is already shutting
+// down, and a leaked goroutine is cheaper than a Shutdown that never returns
+// while holding m.mu — which is what stalls Ready() and Stats(), and with them
+// /ready, for the whole of a pod drain.
+func (m *Manager) flushOffsetsLocked(ctx context.Context, rc *runningConsumer) {
+	// Checked before starting, so an already-spent budget skips the commit outright
+	// instead of attempting one more. Attempting it is what risks another unbounded
+	// block, which is the thing being prevented.
+	if ctx.Err() != nil {
+		m.warnFlushSkipped(rc)
+		return
+	}
+
+	// Buffered: an abandoned flush must still be able to deliver its result and
+	// exit rather than block forever on a send nobody is left to receive.
+	done := make(chan []flushFailure, 1)
+	go func() { done <- rc.offsets.flush(rc.storerFor) }()
+
+	select {
+	case failures := <-done:
+		for _, failure := range failures {
+			m.log.Warn().Err(failure.err).
+				Str(logFieldStream, failure.stream).
+				Str(logFieldConsumer, rc.name).
+				Msg("Failed to flush stream offset on shutdown")
+		}
+	case <-ctx.Done():
+		m.warnFlushSkipped(rc)
+	}
+}
+
+// warnFlushSkipped reports a shutdown flush the manager gave up on, naming the
+// stream the way a flush failure does. Not committing replays the messages the
+// commit would have covered, which at-least-once delivery already permits and
+// idempotent handlers already absorb.
+func (m *Manager) warnFlushSkipped(rc *runningConsumer) {
+	m.log.Warn().
+		Str(logFieldStream, rc.stream).
+		Str(logFieldConsumer, rc.name).
+		Dur("flush_budget", m.flushBudget).
+		Msg("Shutdown offset flush budget spent; offset not committed - handled messages will replay")
 }
 
 // abortStartLocked unwinds a Start that failed after the dial: it stops whatever

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -157,8 +157,9 @@ func (m *Manager) Start(ctx context.Context, decls *Declarations) error {
 	consumeCtx, cancel := consumeContext(ctx)
 	m.cancel = cancel
 
-	// The caller's ctx, not consumeCtx: declaration is startup work, and a caller
-	// that gave up on startup must be able to cut it short.
+	// Every phase below is checked against the caller's ctx, never consumeCtx: all
+	// of it is startup work a caller that gave up must be able to cut short.
+	// consumeCtx is only what the consumers it starts go on running under.
 	if err := m.declareStreams(ctx, env, decls); err != nil {
 		m.abortStartLocked()
 		return err
@@ -169,11 +170,14 @@ func (m *Manager) Start(ctx context.Context, decls *Declarations) error {
 		return err
 	}
 
-	for _, decl := range decls.consumers {
-		if err := m.startConsumer(consumeCtx, env, decl); err != nil {
-			m.abortStartLocked()
-			return err
-		}
+	// startOne binds consumeCtx, so that is what travels DOWN into each consumer and
+	// keeps its handlers alive past this call; ctx stays the loop's own, only CHECKED.
+	startOne := func(decl *consumerDeclaration) error {
+		return m.startConsumer(consumeCtx, env, decl)
+	}
+	if err := startConsumers(ctx, decls.consumers, startOne); err != nil {
+		m.abortStartLocked()
+		return err
 	}
 
 	m.started = true
@@ -213,7 +217,7 @@ func (m *Manager) environmentOptions() *stream.EnvironmentOptions {
 func (m *Manager) declareStreams(ctx context.Context, env *stream.Environment, decls *Declarations) error {
 	for _, s := range decls.streams {
 		if err := ctx.Err(); err != nil {
-			return err
+			return fmt.Errorf("startup canceled before declaring stream %q: %w", s.Name, err)
 		}
 		if err := env.DeclareStream(s.Name, streamOptionsFrom(&s.Spec)); err != nil {
 			return fmt.Errorf("failed to declare stream %q: %w", s.Name, err)
@@ -230,10 +234,31 @@ func (m *Manager) declareStreams(ctx context.Context, env *stream.Environment, d
 func (m *Manager) declareSuperStreams(ctx context.Context, env *stream.Environment, decls *Declarations) error {
 	for _, s := range decls.superStreams {
 		if err := ctx.Err(); err != nil {
-			return err
+			return fmt.Errorf("startup canceled before declaring super stream %q: %w", s.Name, err)
 		}
 		if err := env.DeclareSuperStream(s.Name, partitionOptionsFrom(s.Partitions, &s.Spec)); err != nil {
 			return fmt.Errorf("failed to declare super stream %q: %w", s.Name, err)
+		}
+	}
+	return nil
+}
+
+// startConsumers starts each declaration in turn, checking ctx before every one:
+// a start opens a subscription, so a caller that gave up on startup stops paying
+// for the consumers not yet started. It stops at the first failure, leaving the
+// already-started ones for the caller to unwind.
+//
+// start is a parameter rather than a method call because it is the only part that
+// reaches the broker — *stream.Environment is a concrete vendor type with no seam
+// to fake — so keeping it out is what lets this loop's cancellation and fail-fast
+// policy be exercised without one.
+func startConsumers(ctx context.Context, decls []*consumerDeclaration, start func(*consumerDeclaration) error) error {
+	for _, decl := range decls {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("startup canceled before starting consumer %q: %w", decl.Name, err)
+		}
+		if err := start(decl); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -137,10 +137,17 @@ func (m *Manager) Start(ctx context.Context, decls *Declarations) error {
 		return errors.New("streams manager already started: Close it before starting again")
 	}
 
-	// NewEnvironment closes its own locator socket before returning, so a failed
-	// dial leaves nothing to clean up here.
+	// NewEnvironment returns a non-nil Environment BESIDE a non-nil error, so the
+	// failure path has something to dispose and `env != nil` is not a success test.
+	// v1.8.3 does tear the locator socket down itself, but only through an internal
+	// `defer client.Close()` it documents nowhere, and Client.connect opens the
+	// socket and starts its read goroutine before authentication — so disposing it
+	// here is what keeps a rejected credential from depending on that detail.
 	env, err := stream.NewEnvironment(m.environmentOptions())
 	if err != nil {
+		if env != nil {
+			_ = env.Close()
+		}
 		return fmt.Errorf("failed to connect to stream endpoint %s: %w", redactStreamURI(m.opts.URI), safeEnvError(err))
 	}
 	m.env = env

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -157,12 +157,14 @@ func (m *Manager) Start(ctx context.Context, decls *Declarations) error {
 	consumeCtx, cancel := consumeContext(ctx)
 	m.cancel = cancel
 
-	if err := m.declareStreams(env, decls); err != nil {
+	// The caller's ctx, not consumeCtx: declaration is startup work, and a caller
+	// that gave up on startup must be able to cut it short.
+	if err := m.declareStreams(ctx, env, decls); err != nil {
 		m.abortStartLocked()
 		return err
 	}
 
-	if err := m.declareSuperStreams(env, decls); err != nil {
+	if err := m.declareSuperStreams(ctx, env, decls); err != nil {
 		m.abortStartLocked()
 		return err
 	}
@@ -204,8 +206,15 @@ func (m *Manager) environmentOptions() *stream.EnvironmentOptions {
 // existing stream as success; a retention mismatch surfaces as
 // precondition-failed and aborts startup rather than silently consuming a stream
 // configured differently from the declaration.
-func (m *Manager) declareStreams(env *stream.Environment, decls *Declarations) error {
+//
+// Each declaration is a blocking broker round trip the client gives no context of
+// its own, so ctx is checked between them: a caller that gave up on startup stops
+// paying for the rest of the fan-out.
+func (m *Manager) declareStreams(ctx context.Context, env *stream.Environment, decls *Declarations) error {
 	for _, s := range decls.streams {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err := env.DeclareStream(s.Name, streamOptionsFrom(&s.Spec)); err != nil {
 			return fmt.Errorf("failed to declare stream %q: %w", s.Name, err)
 		}
@@ -217,8 +226,12 @@ func (m *Manager) declareStreams(env *stream.Environment, decls *Declarations) e
 // declareStreams: the client swallows StreamAlreadyExists here, so a super stream
 // that already exists with a DIFFERENT partition count or retention is accepted
 // silently — see wiki/streams.md.
-func (m *Manager) declareSuperStreams(env *stream.Environment, decls *Declarations) error {
+// Like declareStreams, it checks ctx between round trips.
+func (m *Manager) declareSuperStreams(ctx context.Context, env *stream.Environment, decls *Declarations) error {
 	for _, s := range decls.superStreams {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err := env.DeclareSuperStream(s.Name, partitionOptionsFrom(s.Partitions, &s.Spec)); err != nil {
 			return fmt.Errorf("failed to declare super stream %q: %w", s.Name, err)
 		}

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -247,13 +247,13 @@ func (m *Manager) startStreamConsumer(ctx context.Context, env *stream.Environme
 		// The promotion callback resolves the offset again: another group member
 		// may have advanced it while this one was passive.
 		//
-		// SECURITY: the client calls this from its own read-loop goroutine, outside
-		// m.mu and with no recover() anywhere in its call path. It therefore closes
-		// over this snapshot instead of reading m.env: that field is written under
-		// m.mu and nil'd by Close, so reading it here would be a data race, and a
-		// promotion frame arriving after Close would dereference nil and kill the
-		// process mid-shutdown. Taking m.mu here instead would deadlock — stopLocked
-		// holds it across a blocking consumer Close.
+		// The client calls it from its own read-loop goroutine, outside m.mu and with
+		// no recover() anywhere in its call path. It therefore closes over this
+		// snapshot instead of reading m.env: that field is written under m.mu and
+		// nil'd by Close, so reading it here would be a data race, and a promotion
+		// frame arriving after Close would dereference nil and kill the process
+		// mid-shutdown. Taking m.mu here instead would deadlock — stopLocked holds
+		// it across a blocking consumer Close.
 		opts = opts.SetSingleActiveConsumer(stream.NewSingleActiveConsumer(
 			func(streamName string, _ bool) stream.OffsetSpecification {
 				return m.resolveOffset(env, decl.Name, streamName, decl.Start, runner.offsets)
@@ -280,8 +280,8 @@ func (m *Manager) startSuperStreamConsumer(ctx context.Context, env *stream.Envi
 	// fires once per partition, on promotion — is the only place a per-partition
 	// stored offset can be restored. See ADR-059.
 	//
-	// SECURITY: the env snapshot rather than m.env, for the reason spelled out in
-	// startStreamConsumer: the client calls this from its own goroutine, outside
+	// It closes over the env snapshot rather than m.env, for the reason spelled out
+	// in startStreamConsumer: the client calls this from its own goroutine, outside
 	// m.mu, with no recover() in its call path.
 	opts := stream.NewSuperStreamConsumerOptions().
 		SetConsumerName(decl.Name).

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -75,6 +75,7 @@ const (
 	msgCloseEnvFailed      = "Failed to close stream environment after a failed start"
 	msgOffsetStoreFailed   = "Failed to store stream offset"
 	msgOffsetQueryFailed   = "Could not query the stored stream offset; attaching at a position that replays rather than skips"
+	msgFlushSkipped        = "Shutdown offset flush budget spent; offset not committed - handled messages will replay"
 )
 
 // recordingLogger captures each event's level, attached error and terminal
@@ -90,6 +91,9 @@ type recordedEvent struct {
 	level string
 	err   string
 	msg   string
+	// fields captures the string fields attached to the event, so a test can
+	// assert WHICH stream a shutdown line named rather than only that it spoke.
+	fields map[string]string
 }
 
 func (l *recordingLogger) event(level string) logger.LogEvent {
@@ -116,6 +120,21 @@ func (l *recordingLogger) messagesAt(level string) []string {
 }
 
 func (l *recordingLogger) warnMessages() []string { return l.messagesAt("warn") }
+
+// warnStreams reports the stream named by every WARN carrying msg, in order, so a
+// test asserts which streams a shutdown accounted for rather than only how many
+// lines it emitted.
+func (l *recordingLogger) warnStreams(msg string) []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := []string{}
+	for _, e := range l.events {
+		if e.level == "warn" && e.msg == msg {
+			out = append(out, e.fields[logFieldStream])
+		}
+	}
+	return out
+}
 
 // warnError reports the error text attached to the first WARN carrying msg. An
 // empty string with ok=true means the line was emitted with no error at all,
@@ -144,7 +163,14 @@ func (e *recordedEvent) Err(err error) logger.LogEvent {
 	}
 	return e
 }
-func (e *recordedEvent) Str(_, _ string) logger.LogEvent               { return e }
+
+func (e *recordedEvent) Str(key, value string) logger.LogEvent {
+	if e.fields == nil {
+		e.fields = map[string]string{}
+	}
+	e.fields[key] = value
+	return e
+}
 func (e *recordedEvent) Int(_ string, _ int) logger.LogEvent           { return e }
 func (e *recordedEvent) Int64(_ string, _ int64) logger.LogEvent       { return e }
 func (e *recordedEvent) Uint64(_ string, _ uint64) logger.LogEvent     { return e }
@@ -230,6 +256,112 @@ func TestManagerStopConsumersFlushesEveryTrackedStream(t *testing.T) {
 	assert.Equal(t, []int64{501}, storer1.offsets())
 	assert.Equal(t, []string{"close"}, handle.recorded(), "the handle itself stores nothing")
 	assert.Empty(t, m.consumers)
+}
+
+// blockingStorer stands in for a commit against a broker that is down. The
+// client's locator reconnect loop has no attempt cap and no deadline, so such a
+// call never returns on its own; release is how the test ends it once the
+// assertions are made.
+type blockingStorer struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingStorer() *blockingStorer {
+	return &blockingStorer{entered: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (b *blockingStorer) StoreCustomOffset(int64) error {
+	b.once.Do(func() { close(b.entered) })
+	<-b.release
+	return nil
+}
+
+// TestManagerStopConsumersAbandonsFlushWhenBudgetSpent pins the shutdown flush
+// budget. A super stream commits through the environment's locator, and every
+// locator call starts with a reconnect loop the client gives no deadline, so a
+// broker that is down makes the commit hang forever. Without a budget that hang
+// happens while stopLocked holds m.mu, which takes Ready() and Stats() — and with
+// them /ready — down for the whole of a pod drain.
+//
+// The first consumer's commit never returns. What is asserted is that shutdown
+// completes anyway, that the consumer BEHIND it is not put through a budget
+// already spent, and that both are named at WARN so the replay is not silent.
+func TestManagerStopConsumersAbandonsFlushWhenBudgetSpent(t *testing.T) {
+	log := &recordingLogger{}
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: log})
+	m.flushBudget = 50 * time.Millisecond
+
+	blocked := newBlockingStorer()
+	defer close(blocked.release)
+
+	stuck := &fakeHandle{status: ha.StatusOpen}
+	stuckBook := newOffsetBook(func() *offsetTracker { return newOffsetTracker(1000, time.Hour, nil) })
+	require.NoError(t, stuckBook.trackerFor(testPartition0).record(11, nil, blocked))
+
+	behind := &fakeHandle{status: ha.StatusOpen}
+	behindStorer := &fakeStorer{}
+	behindBook := newOffsetBook(func() *offsetTracker { return newOffsetTracker(1000, time.Hour, nil) })
+	require.NoError(t, behindBook.trackerFor(testPartition1).record(501, nil, behindStorer))
+	require.Empty(t, behindStorer.offsets(), "the premise: the second consumer's offset is still pending")
+
+	m.consumers = append(m.consumers,
+		&runningConsumer{
+			stream: testSuperStream, name: testConsumerName, handle: stuck, offsets: stuckBook,
+			storerFor: func(string) offsetStorer { return blocked },
+		},
+		&runningConsumer{
+			stream: testStream, name: secondConsumerName, handle: behind, offsets: behindBook,
+			storerFor: func(string) offsetStorer { return behindStorer },
+		},
+	)
+	m.started = true
+
+	returned := make(chan struct{})
+	go func() {
+		m.StopConsumers()
+		close(returned)
+	}()
+
+	select {
+	case <-blocked.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the blocked commit was never attempted, so this test is not exercising the hang it claims to")
+	}
+
+	select {
+	case <-returned:
+	case <-time.After(10 * time.Second):
+		t.Fatal("StopConsumers never returned: the flush budget did not bound a commit that cannot finish")
+	}
+
+	assert.Empty(t, behindStorer.offsets(),
+		"a budget already spent must skip the remaining flush outright, not attempt one more")
+	assert.Equal(t, []string{testSuperStream, testStream}, log.warnStreams(msgFlushSkipped),
+		"every skipped flush is reported at WARN, naming its stream")
+	assert.Equal(t, []string{"close"}, stuck.recorded(),
+		"an abandoned flush must still let its consumer be closed")
+	assert.Equal(t, []string{"close"}, behind.recorded())
+	assert.Empty(t, m.consumers)
+	assert.False(t, m.started)
+}
+
+// TestManagerStopConsumersFlushesWithinBudget is the other half of the budget:
+// with the broker answering, every offset is still committed and nothing is
+// skipped. Without it, a budget wired to skip unconditionally would pass the
+// abandonment test above.
+func TestManagerStopConsumersFlushesWithinBudget(t *testing.T) {
+	log := &recordingLogger{}
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: log})
+	handle, storer0, storer1 := attachPartitioned(t, m, 1000)
+
+	m.StopConsumers()
+
+	assert.Equal(t, []int64{11}, storer0.offsets())
+	assert.Equal(t, []int64{501}, storer1.offsets())
+	assert.Empty(t, log.warnStreams(msgFlushSkipped), "a flush that lands well inside the budget skips nothing")
+	assert.Equal(t, []string{"close"}, handle.recorded())
 }
 
 // TestManagerStatsKeysOffsetsByTrackedStream pins the /ready body's key: a position

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -604,6 +604,66 @@ func TestStreamOptionsFromClampsMaxAge(t *testing.T) {
 	}
 }
 
+func TestPartitionOptionsFrom(t *testing.T) {
+	assert.Equal(t, stream.NewPartitionsOptions(testPartitions), partitionOptionsFrom(testPartitions, nil))
+	assert.Equal(t, stream.NewPartitionsOptions(testPartitions), partitionOptionsFrom(testPartitions, &StreamSpec{}),
+		"a zero spec leaves every retention knob to the broker")
+
+	opts := partitionOptionsFrom(5, &StreamSpec{
+		MaxAge:              45 * time.Minute,
+		MaxLengthBytes:      2048,
+		MaxSegmentSizeBytes: 1024,
+	})
+
+	require.NotNil(t, opts)
+	assert.Equal(t, 5, opts.Partitions)
+	assert.Equal(t, 45*time.Minute, opts.MaxAge)
+	assert.Equal(t, stream.ByteCapacity{}.B(2048), opts.MaxLengthBytes)
+	assert.Equal(t, stream.ByteCapacity{}.B(1024), opts.MaxSegmentSizeBytes)
+}
+
+// TestPartitionOptionsFromClampsMaxAge repeats the plain lane's clamp on the
+// super-stream renderer, which needs it more: it formats MaxAge with
+// int(MaxAge.Seconds()), so an unclamped sub-second value would reach the broker as
+// "0s" and silently disable the retention the caller declared.
+func TestPartitionOptionsFromClampsMaxAge(t *testing.T) {
+	tests := []struct {
+		name   string
+		maxAge time.Duration
+		want   time.Duration
+	}{
+		{name: "sub_second_floors_to_one_second", maxAge: 500 * time.Millisecond, want: time.Second},
+		{name: "nanosecond_floors_to_one_second", maxAge: time.Nanosecond, want: time.Second},
+		{name: "fractional_second_truncates_down", maxAge: 1500 * time.Millisecond, want: time.Second},
+		{name: "whole_seconds_pass_through", maxAge: 90 * time.Second, want: 90 * time.Second},
+		{name: "zero_emits_no_max_age", maxAge: 0, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := partitionOptionsFrom(testPartitions, &StreamSpec{MaxAge: tt.maxAge, MaxLengthBytes: 2048})
+
+			assert.Equal(t, tt.want, opts.MaxAge)
+			assert.Equal(t, testPartitions, opts.Partitions, "the MaxAge clamp must not disturb the partition count")
+			assert.Equal(t, stream.ByteCapacity{}.B(2048), opts.MaxLengthBytes,
+				"the MaxAge clamp must not disturb the other retention knobs")
+		})
+	}
+}
+
+// TestClampedMaxAgeKeepsBothRenderersInAgreement is the property the shared clamp
+// exists for: a stream and a super stream declared with the same retention must
+// send the broker the same age, despite the client rounding one and truncating the
+// other.
+func TestClampedMaxAgeKeepsBothRenderersInAgreement(t *testing.T) {
+	for _, maxAge := range []time.Duration{time.Nanosecond, 500 * time.Millisecond, 1500 * time.Millisecond, 90 * time.Second, time.Hour} {
+		spec := &StreamSpec{MaxAge: maxAge}
+
+		assert.Equal(t, streamOptionsFrom(spec).MaxAge, partitionOptionsFrom(testPartitions, spec).MaxAge,
+			"both lanes must render %s identically", maxAge)
+	}
+}
+
 func TestManagerEnvironmentOptions(t *testing.T) {
 	t.Run("without_address_resolver", func(t *testing.T) {
 		m := NewManager(ManagerOptions{URI: "rabbitmq-stream://localhost:5552/%2f", Logger: logger.New("error", false)})

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -17,6 +17,14 @@ import (
 	"github.com/gaborage/go-bricks/logger"
 )
 
+// secondConsumerName is the second member of a two-declaration fan-out.
+const secondConsumerName = testConsumerName + "-2"
+
+// errStartAttempted marks a consumer start that should never have been reached.
+var errStartAttempted = errors.New("consumer start attempted")
+
+func failingStart(*consumerDeclaration) error { return errStartAttempted }
+
 // fakeHandle stands in for *ha.ReliableConsumer so shutdown bookkeeping is
 // testable without a broker.
 type fakeHandle struct {
@@ -296,25 +304,39 @@ func TestManagerStartRejectsSecondStart(t *testing.T) {
 	assert.Contains(t, err.Error(), "already started")
 }
 
-// TestManagerDeclareAbortsOnACanceledContext pins that a canceled startup stops
-// the declaration fan-out before it reaches the broker. The environment is nil, so
-// any call that got as far as the client would panic rather than return.
-func TestManagerDeclareAbortsOnACanceledContext(t *testing.T) {
+// TestManagerStartupAbortsOnACanceledContext pins that a canceled startup stops
+// every one of Start's fan-outs before it reaches the broker, and names the phase
+// it stopped in. The environment is nil, so any call that got as far as the client
+// would panic rather than return.
+func TestManagerStartupAbortsOnACanceledContext(t *testing.T) {
 	decls := NewDeclarations()
 	decls.DeclareStream(testStream, nil)
 	decls.DeclareSuperStream(testSuperStream, 2, nil)
+	decls.DeclareConsumer(&ConsumerOptions{Stream: testStream, Name: testConsumerName, Handler: noopHandler})
 
 	tests := []struct {
-		name    string
-		declare func(m *Manager, ctx context.Context) error
+		name      string
+		phase     func(m *Manager, ctx context.Context) error
+		wantPhase string
 	}{
 		{
-			name:    "plain_streams",
-			declare: func(m *Manager, ctx context.Context) error { return m.declareStreams(ctx, nil, decls) },
+			name:      "plain_streams",
+			phase:     func(m *Manager, ctx context.Context) error { return m.declareStreams(ctx, nil, decls) },
+			wantPhase: `declaring stream "` + testStream + `"`,
 		},
 		{
-			name:    "super_streams",
-			declare: func(m *Manager, ctx context.Context) error { return m.declareSuperStreams(ctx, nil, decls) },
+			name:      "super_streams",
+			phase:     func(m *Manager, ctx context.Context) error { return m.declareSuperStreams(ctx, nil, decls) },
+			wantPhase: `declaring super stream "` + testSuperStream + `"`,
+		},
+		{
+			// The starter fails loudly, so a guard that let the loop reach it would
+			// surface errStartAttempted here instead of the cancellation.
+			name: "consumers",
+			phase: func(_ *Manager, ctx context.Context) error {
+				return startConsumers(ctx, decls.consumers, failingStart)
+			},
+			wantPhase: `starting consumer "` + testConsumerName + `"`,
 		},
 	}
 
@@ -325,9 +347,11 @@ func TestManagerDeclareAbortsOnACanceledContext(t *testing.T) {
 			cancel()
 
 			var err error
-			require.NotPanics(t, func() { err = tt.declare(m, ctx) })
+			require.NotPanics(t, func() { err = tt.phase(m, ctx) })
 
 			assert.ErrorIs(t, err, context.Canceled)
+			assert.Contains(t, err.Error(), tt.wantPhase,
+				"the caller must be told which startup phase the cancellation stopped")
 		})
 	}
 }
@@ -340,6 +364,48 @@ func TestManagerDeclareProceedsOnALiveContext(t *testing.T) {
 	m := testManager(t)
 
 	assert.Panics(t, func() { _ = m.declareStreams(context.Background(), nil, decls) })
+}
+
+// twoConsumers declares a pair so the fan-out has a second iteration to reach —
+// with one declaration, stopping early and running to completion look identical.
+func twoConsumers(t *testing.T) *Declarations {
+	t.Helper()
+	decls := NewDeclarations()
+	decls.DeclareConsumer(&ConsumerOptions{Stream: testStream, Name: testConsumerName, Handler: noopHandler})
+	decls.DeclareConsumer(&ConsumerOptions{Stream: testStream, Name: secondConsumerName, Handler: noopHandler})
+	return decls
+}
+
+// TestStartConsumersStartsEveryDeclaration pins that a live context does not
+// short-circuit the fan-out: every declaration is started, in order.
+func TestStartConsumersStartsEveryDeclaration(t *testing.T) {
+	decls := twoConsumers(t)
+
+	var started []string
+	err := startConsumers(context.Background(), decls.consumers, func(decl *consumerDeclaration) error {
+		started = append(started, decl.Name)
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{testConsumerName, secondConsumerName}, started,
+		"a live context starts every consumer, not just the first")
+}
+
+// TestStartConsumersStopsAtTheFirstFailure pins the other half: a start that fails
+// reaches the caller unchanged — Start turns it into an aborted startup — and the
+// declarations behind it are never attempted.
+func TestStartConsumersStopsAtTheFirstFailure(t *testing.T) {
+	decls := twoConsumers(t)
+
+	var attempted []string
+	err := startConsumers(context.Background(), decls.consumers, func(decl *consumerDeclaration) error {
+		attempted = append(attempted, decl.Name)
+		return errStartAttempted
+	})
+
+	require.ErrorIs(t, err, errStartAttempted)
+	assert.Equal(t, []string{testConsumerName}, attempted, "the fan-out stops at the first failure")
 }
 
 func TestManagerStopConsumersFlushesBeforeClosing(t *testing.T) {

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -296,6 +296,52 @@ func TestManagerStartRejectsSecondStart(t *testing.T) {
 	assert.Contains(t, err.Error(), "already started")
 }
 
+// TestManagerDeclareAbortsOnACanceledContext pins that a canceled startup stops
+// the declaration fan-out before it reaches the broker. The environment is nil, so
+// any call that got as far as the client would panic rather than return.
+func TestManagerDeclareAbortsOnACanceledContext(t *testing.T) {
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	decls.DeclareSuperStream(testSuperStream, 2, nil)
+
+	tests := []struct {
+		name    string
+		declare func(m *Manager, ctx context.Context) error
+	}{
+		{
+			name:    "plain_streams",
+			declare: func(m *Manager, ctx context.Context) error { return m.declareStreams(ctx, nil, decls) },
+		},
+		{
+			name:    "super_streams",
+			declare: func(m *Manager, ctx context.Context) error { return m.declareSuperStreams(ctx, nil, decls) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := testManager(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			var err error
+			require.NotPanics(t, func() { err = tt.declare(m, ctx) })
+
+			assert.ErrorIs(t, err, context.Canceled)
+		})
+	}
+}
+
+// A live context must not short-circuit the fan-out: the nil environment proves
+// the broker call is attempted by panicking, which the guard would have prevented.
+func TestManagerDeclareProceedsOnALiveContext(t *testing.T) {
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	m := testManager(t)
+
+	assert.Panics(t, func() { _ = m.declareStreams(context.Background(), nil, decls) })
+}
+
 func TestManagerStopConsumersFlushesBeforeClosing(t *testing.T) {
 	m := testManager(t)
 	handle := &fakeHandle{status: ha.StatusOpen}

--- a/messaging/streams/runner.go
+++ b/messaging/streams/runner.go
@@ -221,11 +221,15 @@ type consumerRunner struct {
 	baseCtx context.Context // NOSONAR S8242: no parameter to pass it through - the vendor callback signature is fixed
 }
 
-// messagesHandler is the callback handed to the stream client. The client
-// invokes it sequentially per consumer, and the framework keeps it that way:
-// handlers run inline with no worker pool, because a stream is an ordered log
-// and any parallelism would both break that order and make a committed offset
-// claim messages behind it were handled.
+// messagesHandler is the callback handed to the stream client. The client invokes
+// it sequentially per STREAM — which for a super stream means per partition, where
+// one runner serves every partition and the client calls this from one goroutine
+// each, concurrently. The framework keeps that shape: handlers run inline with no
+// worker pool, because a stream is an ordered log and parallelism *within* one
+// would break that order and make a committed offset claim messages behind it were
+// handled. Anything reachable from here that is not per-stream state must
+// therefore be safe for concurrent use — the offset book is, precisely because it
+// hands each stream its own tracker.
 func (r *consumerRunner) messagesHandler(consumerContext stream.ConsumerContext, message *amqp.Message) {
 	consumer := consumerContext.Consumer
 	r.deliver(consumer.GetStreamName(), consumer.GetOffset(), message, consumer)

--- a/messaging/streams/streams_integration_test.go
+++ b/messaging/streams/streams_integration_test.go
@@ -23,15 +23,20 @@ import (
 const (
 	itStream       = "it-orders"
 	itConsumerName = "it-group"
+	itSuperStream  = "it-orders-super"
+	itSuperGroup   = "it-super-group"
+	itPartitions   = 3
 	itWaitTimeout  = 20 * time.Second
 	itPollInterval = 50 * time.Millisecond
 )
 
-// recorder collects the messages a handler saw, in arrival order.
+// recorder collects the messages a handler saw, in arrival order. A super-stream
+// handler is called concurrently across partitions, so every field is guarded.
 type recorder struct {
 	mu       sync.Mutex
 	offsets  []int64
 	bodies   []string
+	streams  []string
 	failAt   int64
 	failures int
 }
@@ -41,11 +46,26 @@ func (r *recorder) handle(_ context.Context, msg *Message) error {
 	defer r.mu.Unlock()
 	r.offsets = append(r.offsets, msg.Offset)
 	r.bodies = append(r.bodies, string(msg.Data))
+	r.streams = append(r.streams, msg.Stream)
 	if r.failAt >= 0 && msg.Offset == r.failAt {
 		r.failures++
 		return errors.New("deliberate handler failure")
 	}
 	return nil
+}
+
+// perStream splits what arrived by the stream it arrived on, which for a super
+// stream is the partition.
+func (r *recorder) perStream() (offsets map[string][]int64, bodies map[string][]string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	offsets, bodies = map[string][]int64{}, map[string][]string{}
+	for i, name := range r.streams {
+		offsets[name] = append(offsets[name], r.offsets[i])
+		bodies[name] = append(bodies[name], r.bodies[i])
+	}
+	return offsets, bodies
 }
 
 func (r *recorder) snapshot() (offsets []int64, bodies []string) {
@@ -81,9 +101,9 @@ func streamsTestEnv(ctx context.Context, t *testing.T) ManagerOptions {
 	}
 }
 
-// publish writes n messages through a test-only producer environment. Producers
-// are deliberately outside the framework surface, so tests drive the client directly.
-func publish(t *testing.T, opts ManagerOptions, streamName string, bodies []string) {
+// testEnvironment dials the broker the way the manager does, for the test's own
+// producing and querying.
+func testEnvironment(t *testing.T, opts ManagerOptions) *stream.Environment {
 	t.Helper()
 
 	envOpts := stream.NewEnvironmentOptions().
@@ -91,6 +111,15 @@ func publish(t *testing.T, opts ManagerOptions, streamName string, bodies []stri
 		SetAddressResolver(stream.AddressResolver{Host: opts.AddressResolverHost, Port: opts.AddressResolverPort})
 	env, err := stream.NewEnvironment(envOpts)
 	require.NoError(t, err)
+	return env
+}
+
+// publish writes n messages through a test-only producer environment. Producers
+// are deliberately outside the framework surface, so tests drive the client directly.
+func publish(t *testing.T, opts ManagerOptions, streamName string, bodies []string) {
+	t.Helper()
+
+	env := testEnvironment(t, opts)
 	defer func() { require.NoError(t, env.Close()) }()
 
 	producer, err := env.NewProducer(streamName, stream.NewProducerOptions())
@@ -218,6 +247,177 @@ func TestStreamsManagerSkipsFailedMessageIntegration(t *testing.T) {
 	_, replayed := replay.snapshot()
 	assert.Equal(t, bodiesFrom("msg", 10, 2), replayed,
 		"the failed message is skipped on restart - streams have no redelivery")
+}
+
+// partitionName is how the broker names a super stream's partitions.
+func partitionName(superStream string, index int) string {
+	return fmt.Sprintf("%s-%d", superStream, index)
+}
+
+// publishAcrossPartitions writes bodies round-robin into the super stream's
+// partitions and reports what went where. A partition is itself a plain stream, so
+// publishing into it directly is exactly what a routing strategy would do — and it
+// keeps which body lands on which partition deterministic, which a hash strategy
+// would not.
+func publishAcrossPartitions(t *testing.T, opts ManagerOptions, bodies []string) map[string][]string {
+	t.Helper()
+
+	perPartition := make(map[string][]string, itPartitions)
+	for i, body := range bodies {
+		name := partitionName(itSuperStream, i%itPartitions)
+		perPartition[name] = append(perPartition[name], body)
+	}
+	for name, batch := range perPartition {
+		publish(t, opts, name, batch)
+	}
+	return perPartition
+}
+
+// startSuperStreamManager starts one super-stream consumer group member.
+func startSuperStreamManager(t *testing.T, opts ManagerOptions, handler Handler) *Manager {
+	t.Helper()
+
+	decls := NewDeclarations()
+	decls.DeclareSuperStream(itSuperStream, itPartitions, &StreamSpec{MaxLengthBytes: 10 * 1024 * 1024})
+	decls.DeclareSuperStreamConsumer(&SuperStreamConsumerOptions{
+		SuperStream: itSuperStream,
+		Name:        itSuperGroup,
+		Start:       OffsetFirst(),
+		Handler:     handler,
+	})
+
+	m := NewManager(opts)
+	require.NoError(t, m.Start(context.Background(), decls))
+	return m
+}
+
+func stopManager(t *testing.T, m *Manager) {
+	t.Helper()
+	m.StopConsumers()
+	require.NoError(t, m.Close())
+}
+
+// TestStreamsManagerConsumesSuperStreamPartitionsIntegration proves the whole
+// per-partition contract against a broker: every partition is consumed, order is
+// preserved within each one, offsets are committed per partition, and a restarted
+// group member resumes on each partition independently instead of replaying it.
+func TestStreamsManagerConsumesSuperStreamPartitionsIntegration(t *testing.T) {
+	ctx := context.Background()
+	opts := streamsTestEnv(ctx, t)
+
+	first := &recorder{failAt: -1}
+	m := startSuperStreamManager(t, opts, first.handle)
+
+	published := publishAcrossPartitions(t, opts, bodiesFrom("msg", 0, 30))
+	waitForCount(t, first, 30)
+
+	offsets, bodies := first.perStream()
+	require.Len(t, bodies, itPartitions, "every partition delivered")
+	for i := range itPartitions {
+		name := partitionName(itSuperStream, i)
+		assert.Equal(t, published[name], bodies[name], "partition %s keeps its publish order", name)
+		for j := 1; j < len(offsets[name]); j++ {
+			assert.Greater(t, offsets[name][j], offsets[name][j-1],
+				"offsets are monotonic within partition %s", name)
+		}
+	}
+
+	require.Eventually(t, func() bool {
+		stored, ok := m.Stats()["stored_offsets"].(map[string]int64)
+		if !ok || len(stored) != itPartitions {
+			return false
+		}
+		for i := range itPartitions {
+			if stored[partitionName(itSuperStream, i)+"/"+itSuperGroup] != 9 {
+				return false
+			}
+		}
+		return true
+	}, itWaitTimeout, itPollInterval, "each partition commits its own last handled offset")
+
+	stopManager(t, m)
+
+	// A fresh member under the same group name must resume on every partition.
+	second := &recorder{failAt: -1}
+	m2 := startSuperStreamManager(t, opts, second.handle)
+	t.Cleanup(func() { stopManager(t, m2) })
+
+	resumed := publishAcrossPartitions(t, opts, bodiesFrom("msg", 30, 9))
+	waitForCount(t, second, 9)
+
+	_, secondBodies := second.perStream()
+	assert.Equal(t, resumed, secondBodies, "the stored offset wins per partition, not per super stream")
+	assert.Equal(t, 9, second.count(), "no partition replays what the previous member committed")
+}
+
+// TestStreamsManagerSuperStreamDistributesPartitionsIntegration exercises the
+// group: two members of one super-stream consumer group share the partitions, each
+// message is handled by exactly one of them, and stopping the first hands its
+// partitions to the second, resumed from the offsets it had committed.
+func TestStreamsManagerSuperStreamDistributesPartitionsIntegration(t *testing.T) {
+	ctx := context.Background()
+	opts := streamsTestEnv(ctx, t)
+
+	firstMember := &recorder{failAt: -1}
+	m1 := startSuperStreamManager(t, opts, firstMember.handle)
+	secondMember := &recorder{failAt: -1}
+	m2 := startSuperStreamManager(t, opts, secondMember.handle)
+	t.Cleanup(func() { stopManager(t, m2) })
+
+	publishAcrossPartitions(t, opts, bodiesFrom("msg", 0, 30))
+	require.Eventually(t, func() bool { return firstMember.count()+secondMember.count() >= 30 },
+		itWaitTimeout, itPollInterval, "the group as a whole consumes every partition")
+
+	_, firstBodies := firstMember.snapshot()
+	_, secondBodies := secondMember.snapshot()
+	assert.ElementsMatch(t, bodiesFrom("msg", 0, 30), append(append([]string{}, firstBodies...), secondBodies...),
+		"each message reaches exactly one member: a partition has one active consumer")
+	assert.NotEmpty(t, firstBodies, "partitions are spread across the group, not served by one member")
+	assert.NotEmpty(t, secondBodies)
+
+	// The surviving member takes over the partitions the leaving one was active on.
+	stopManager(t, m1)
+	handedOver := secondMember.count()
+
+	publishAcrossPartitions(t, opts, bodiesFrom("msg", 30, 15))
+	require.Eventually(t, func() bool { return secondMember.count() >= handedOver+15 },
+		itWaitTimeout, itPollInterval, "the survivor is promoted on the orphaned partitions")
+
+	_, afterTakeover := secondMember.snapshot()
+	assert.ElementsMatch(t, bodiesFrom("msg", 30, 15), afterTakeover[handedOver:],
+		"promotion resumes at the stored offsets, so nothing already handled is replayed")
+}
+
+// TestStreamsManagerSuperStreamPartitionMismatchIsSilentIntegration pins an
+// asymmetry with the plain lane that operators need to know about: DeclareStream
+// surfaces a retention mismatch as precondition-failed, but the client swallows
+// StreamAlreadyExists for super streams, so re-declaring one with a different
+// partition count is accepted and the existing topology is kept.
+func TestStreamsManagerSuperStreamPartitionMismatchIsSilentIntegration(t *testing.T) {
+	ctx := context.Background()
+	opts := streamsTestEnv(ctx, t)
+
+	first := NewManager(opts)
+	firstDecls := NewDeclarations()
+	firstDecls.DeclareSuperStream(itSuperStream, itPartitions, nil)
+	require.NoError(t, first.Start(ctx, firstDecls))
+	stopManager(t, first)
+
+	second := NewManager(opts)
+	conflicting := NewDeclarations()
+	conflicting.DeclareSuperStream(itSuperStream, itPartitions+2, nil)
+
+	err := second.Start(ctx, conflicting)
+
+	require.NoError(t, err, "the broker does not reject the wider declaration")
+	t.Cleanup(func() { stopManager(t, second) })
+
+	env := testEnvironment(t, opts)
+	defer func() { require.NoError(t, env.Close()) }()
+	partitions, err := env.QueryPartitions(itSuperStream)
+	require.NoError(t, err)
+	assert.Len(t, partitions, itPartitions,
+		"the declared widening never reached the topology - the first declaration still stands")
 }
 
 // startSACManager starts a single active consumer, whose promotion callback is the

--- a/messaging/streams/streams_integration_test.go
+++ b/messaging/streams/streams_integration_test.go
@@ -298,6 +298,52 @@ func stopManager(t *testing.T, m *Manager) {
 	require.NoError(t, m.Close())
 }
 
+// warmUpGroup publishes throwaway rounds until every member has handled a message,
+// which is the only observable proof the join's rebalance landed: until it does, the
+// first member is still active on every partition. A round published before it lands
+// is consumed by the member losing the partition, hence the retry. The returned
+// bodies must stay out of whatever the caller measures.
+func warmUpGroup(t *testing.T, opts ManagerOptions, members ...*recorder) []string {
+	t.Helper()
+
+	warmUp := bodiesFrom("warmup", 0, itPartitions)
+	promoted := func() bool {
+		for _, m := range members {
+			if m.count() == 0 {
+				return false
+			}
+		}
+		return true
+	}
+
+	const rounds = 4
+	for range rounds {
+		publishAcrossPartitions(t, opts, warmUp)
+		deadline := time.Now().Add(itWaitTimeout / rounds)
+		for time.Now().Before(deadline) {
+			if promoted() {
+				return warmUp
+			}
+			time.Sleep(itPollInterval)
+		}
+	}
+	require.FailNow(t, "the group never converged: a member was never promoted on any partition")
+	return nil
+}
+
+// handledSince returns the bodies a member handled after baseline that belong to
+// want, which keeps the warm-up traffic out of what a test measures.
+func handledSince(r *recorder, baseline int, want []string) []string {
+	_, bodies := r.snapshot()
+	out := make([]string, 0, len(bodies)-baseline)
+	for _, body := range bodies[baseline:] {
+		if slices.Contains(want, body) {
+			out = append(out, body)
+		}
+	}
+	return out
+}
+
 // TestStreamsManagerConsumesSuperStreamPartitionsIntegration proves the whole
 // per-partition contract against a broker: every partition is consumed, order is
 // preserved within each one, offsets are committed per partition, and a restarted
@@ -365,13 +411,28 @@ func TestStreamsManagerSuperStreamDistributesPartitionsIntegration(t *testing.T)
 	m2 := startSuperStreamManager(t, opts, secondMember.handle)
 	t.Cleanup(func() { stopManager(t, m2) })
 
-	publishAcrossPartitions(t, opts, bodiesFrom("msg", 0, 30))
-	require.Eventually(t, func() bool { return firstMember.count()+secondMember.count() >= 30 },
-		itWaitTimeout, itPollInterval, "the group as a whole consumes every partition")
+	// Exclusivity is a property of a settled group, so nothing is measured until the
+	// join's rebalance has demonstrably landed on both members.
+	warmUp := warmUpGroup(t, opts, firstMember, secondMember)
+	firstBase, secondBase := firstMember.count(), secondMember.count()
 
-	_, firstBodies := firstMember.snapshot()
-	_, secondBodies := secondMember.snapshot()
-	assert.ElementsMatch(t, bodiesFrom("msg", 0, 30), append(append([]string{}, firstBodies...), secondBodies...),
+	measured := bodiesFrom("msg", 0, 30)
+	publishAcrossPartitions(t, opts, measured)
+	// Gate on the measured bodies themselves: a raw count is satisfied by duplicates.
+	require.Eventually(t, func() bool {
+		seen := slices.Concat(handledSince(firstMember, firstBase, measured),
+			handledSince(secondMember, secondBase, measured))
+		for _, body := range measured {
+			if !slices.Contains(seen, body) {
+				return false
+			}
+		}
+		return true
+	}, itWaitTimeout, itPollInterval, "the group as a whole consumes every partition")
+
+	firstBodies := handledSince(firstMember, firstBase, measured)
+	secondBodies := handledSince(secondMember, secondBase, measured)
+	assert.ElementsMatch(t, measured, slices.Concat(firstBodies, secondBodies),
 		"each message reaches exactly one member: a partition has one active consumer")
 	assert.NotEmpty(t, firstBodies, "partitions are spread across the group, not served by one member")
 	assert.NotEmpty(t, secondBodies)
@@ -398,7 +459,7 @@ func TestStreamsManagerSuperStreamDistributesPartitionsIntegration(t *testing.T)
 	// survivor's promotion queries the locator, an ordering window ADR-059 accepts as replay.
 	assert.Subset(t, afterTakeover[handedOver:], newBodies,
 		"promotion resumes the orphaned partitions and delivers everything published after it")
-	assert.Subset(t, bodiesFrom("msg", 0, 45), afterTakeover[handedOver:],
+	assert.Subset(t, slices.Concat(warmUp, bodiesFrom("msg", 0, 45)), afterTakeover[handedOver:],
 		"any extra is a replay of an already-published body, never a fabricated one")
 }
 

--- a/messaging/streams/streams_integration_test.go
+++ b/messaging/streams/streams_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -379,13 +380,26 @@ func TestStreamsManagerSuperStreamDistributesPartitionsIntegration(t *testing.T)
 	stopManager(t, m1)
 	handedOver := secondMember.count()
 
-	publishAcrossPartitions(t, opts, bodiesFrom("msg", 30, 15))
-	require.Eventually(t, func() bool { return secondMember.count() >= handedOver+15 },
-		itWaitTimeout, itPollInterval, "the survivor is promoted on the orphaned partitions")
+	newBodies := bodiesFrom("msg", 30, 15)
+	publishAcrossPartitions(t, opts, newBodies)
+	// Gate on the new bodies themselves: a raw count is satisfied by 15 replays alone.
+	require.Eventually(t, func() bool {
+		_, seen := secondMember.snapshot()
+		for _, body := range newBodies {
+			if !slices.Contains(seen[handedOver:], body) {
+				return false
+			}
+		}
+		return true
+	}, itWaitTimeout, itPollInterval, "the survivor is promoted on the orphaned partitions")
 
 	_, afterTakeover := secondMember.snapshot()
-	assert.ElementsMatch(t, bodiesFrom("msg", 30, 15), afterTakeover[handedOver:],
-		"promotion resumes at the stored offsets, so nothing already handled is replayed")
+	// Not exact equality: the leaver commits over its consumer connection while the
+	// survivor's promotion queries the locator, an ordering window ADR-059 accepts as replay.
+	assert.Subset(t, afterTakeover[handedOver:], newBodies,
+		"promotion resumes the orphaned partitions and delivers everything published after it")
+	assert.Subset(t, bodiesFrom("msg", 0, 45), afterTakeover[handedOver:],
+		"any extra is a replay of an already-published body, never a fabricated one")
 }
 
 // TestStreamsManagerSuperStreamPartitionMismatchIsSilentIntegration pins an

--- a/messaging/streams/streams_integration_test.go
+++ b/messaging/streams/streams_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"sync"
 	"testing"
@@ -298,36 +299,88 @@ func stopManager(t *testing.T, m *Manager) {
 	require.NoError(t, m.Close())
 }
 
-// warmUpGroup publishes throwaway rounds until every member has handled a message,
-// which is the only observable proof the join's rebalance landed: until it does, the
-// first member is still active on every partition. A round published before it lands
-// is consumed by the member losing the partition, hence the retry. The returned
+// partitionBaselines snapshots how many messages each member has handled per
+// partition, so the next round's deliveries can be read as a delta.
+func partitionBaselines(members []*recorder) []map[string]int {
+	baselines := make([]map[string]int, len(members))
+	for i, m := range members {
+		_, bodies := m.perStream()
+		counts := make(map[string]int, len(bodies))
+		for name, handled := range bodies {
+			counts[name] = len(handled)
+		}
+		baselines[i] = counts
+	}
+	return baselines
+}
+
+// roundOwnership derives the partition -> member index map of a single warm-up round
+// from the delta since baselines. Ownership is read per round on purpose: a
+// cumulative view would keep listing an outgoing member as a co-owner of a partition
+// it has already handed over, and could never stabilize. It reports ok only when
+// every partition was served, by exactly one member.
+func roundOwnership(members []*recorder, baselines []map[string]int) (owners map[string]int, ok bool) {
+	owners = make(map[string]int, itPartitions)
+	for i, m := range members {
+		_, bodies := m.perStream()
+		for name, handled := range bodies {
+			if len(handled) <= baselines[i][name] {
+				continue
+			}
+			if _, contested := owners[name]; contested {
+				// Two members served one partition: the handover is still in flight.
+				return nil, false
+			}
+			owners[name] = i
+		}
+	}
+	return owners, len(owners) == itPartitions
+}
+
+// warmUpGroup publishes throwaway rounds until the group's partition assignment has
+// demonstrably stopped moving: every partition served within one round, and the same
+// partition -> member map derived from two consecutive rounds. One round proves only
+// that *a* rebalance landed, never that *the* rebalance finished — itPartitions
+// partitions over two members settle unevenly, so the member that ends up owning two
+// of them starts handling messages the moment its first handover lands, with the
+// second still in flight. A round published into a partition mid-handover is consumed
+// by the member losing it and may then be replayed to the member gaining it (the
+// consumer-connection vs locator-connection window ADR-059 accepts), which is why the
+// gate needs a second agreeing round and why the whole thing retries. The returned
 // bodies must stay out of whatever the caller measures.
 func warmUpGroup(t *testing.T, opts ManagerOptions, members ...*recorder) []string {
 	t.Helper()
 
 	warmUp := bodiesFrom("warmup", 0, itPartitions)
-	promoted := func() bool {
-		for _, m := range members {
-			if m.count() == 0 {
-				return false
-			}
-		}
-		return true
-	}
 
-	const rounds = 4
+	const rounds = 6
+	var previous map[string]int
 	for range rounds {
+		baselines := partitionBaselines(members)
 		publishAcrossPartitions(t, opts, warmUp)
+
+		var current map[string]int
 		deadline := time.Now().Add(itWaitTimeout / rounds)
 		for time.Now().Before(deadline) {
-			if promoted() {
-				return warmUp
+			if owners, ok := roundOwnership(members, baselines); ok {
+				current = owners
+				break
 			}
 			time.Sleep(itPollInterval)
 		}
+		if current == nil {
+			// An inconclusive round breaks the chain: the next pair must agree on its own.
+			previous = nil
+			continue
+		}
+		if maps.Equal(previous, current) {
+			return warmUp
+		}
+		previous = current
 	}
-	require.FailNow(t, "the group never converged: a member was never promoted on any partition")
+	require.FailNow(t, "the group never converged",
+		"no two consecutive rounds derived the same owner for all %d partitions; the last round derived %v (empty: a partition went unserved or was served by two members)",
+		itPartitions, previous)
 	return nil
 }
 

--- a/wiki/adr_059_streams_consumption.md
+++ b/wiki/adr_059_streams_consumption.md
@@ -178,6 +178,32 @@ partition consumer that delivered the last message may already have been replace
 by a reconnect. It goes through `Environment.StoreOffset(consumer, partition,
 offset)` instead, on the locator connection.
 
+That splits commits across two connections, and the broker applies whichever
+arrives last: a delivery goroutine's in-flight commit and the shutdown flush can
+land out of order even though the tracker's lock issues them in order, so a stop
+racing a final delivery may leave the older position stored and replay from it on
+restart. It costs duplicate work, not correctness — delivery is at-least-once and
+handlers are idempotent — so it is accepted rather than serialized.
+
+### Known limitation: an uncapped locator reconnect can stall one partition
+
+`Environment.QueryOffset` — which the promotion callback calls to resolve a
+partition's position — routes through the client's `maybeReconnectLocator`, a
+`for err != nil { sleep; connect }` loop with no cap, no deadline and no context
+(`pkg/stream/environment.go`). The callback runs on that partition's read loop, so
+a locator outage during a promotion blocks it: the broker never receives the
+consumer-update response and the partition consumes nothing until the process
+restarts. `ReliableSuperStreamConsumer.GetStatus` reads a stored field that a
+blocked read loop never updates, so `Manager.Ready` — and `/ready` — stay green
+over it.
+
+This is accepted rather than fixed: bounding a vendor call that accepts neither
+context nor timeout means either reimplementing the offset query or wrapping it in
+a goroutine whose abandonment leaks, and the client's `MaxConsumersPerClient: 1`
+holds the blast radius to a single partition. The operational answer is to alert on
+consumed-message rate per partition instead of readiness alone, which
+[wiki/streams.md](streams.md) documents as a trap.
+
 ### Declaring a super stream needs RabbitMQ 3.13+, and a mismatch is silent
 
 The client gates `DeclareSuperStream` on `is313OrMore`; plain-stream SAC needs

--- a/wiki/adr_059_streams_consumption.md
+++ b/wiki/adr_059_streams_consumption.md
@@ -4,6 +4,12 @@
 - **Date**: 2026-08-12
 - **Related**: ADR-058 (the AMQP stream-queue lane and the two-lane framing), [ADR-040](adr_040_declaration_args_passthrough.md) (declaration args reach the broker), [ADR-045](adr_045_no_producer_side_manager_interfaces.md) (no exported manager interface), [ADR-041](adr_041_shared_ledger_tenancy.md) (single-tenant fail-fast precedent)
 
+> **Amended (2026-08-13):** super streams, listed below as the third thing the
+> AMQP lane cannot do, are now implemented in this lane. The amendment settles
+> what that costs: super-stream consumption is always a SAC group, offsets are
+> tracked per partition, and the "handlers run inline, sequentially" rule below
+> holds only *within* a partition — see [Amendment: super streams](#amendment-super-streams).
+
 ## Context
 
 ADR-058 established the AMQP 0.9.1 lane:
@@ -81,10 +87,9 @@ runs handlers inline on the client's callback. A stream is an ordered log: a
 worker pool would break that order *and* make a committed offset lie, because
 the offset only means "everything up to here was handled" when handling is
 sequential. Parallelism therefore comes from super-stream partitions — each
-partition gets its own active consumer, and order is preserved within one —
-which is future work in this lane, not from threads inside a process. SAC is not
-that lever: exactly one group member consumes, so it buys failover, not
-throughput.
+partition gets its own active consumer, and order is preserved within one — not
+from threads inside a process. On a plain stream SAC is not that lever either:
+exactly one group member consumes, so it buys failover, not throughput.
 
 ### Single-tenant only, enforced by config validation
 
@@ -118,6 +123,77 @@ interface ([ADR-045](adr_045_no_producer_side_manager_interfaces.md)) — and no
 `ModuleDeps` field is added, because consumption needs no per-request accessor.
 Metrics reuse the AMQP instruments rather than minting a second meter.
 
+## Amendment: super streams
+
+*Added 2026-08-13, extending the decision above rather than replacing it.*
+`DeclareSuperStream` + `DeclareSuperStreamConsumer` consume a partitioned stream
+through `ha.NewReliableSuperStreamConsumer`. Everything above still holds per
+partition: commit-after-success, the count/interval policy, skip-on-failure, the
+shutdown flush, and at-least-once delivery.
+
+### Super-stream consumption is always a single active consumer group
+
+`SuperStreamConsumerOptions` has no `SAC` field, where the plain
+`ConsumerOptions` does. At client v1.8.3 that is not a preference, it is the only
+correct shape:
+
+- `SuperStreamConsumer.init` attaches **every** partition with the single
+  `SuperStreamConsumerOptions.Offset` — there is one offset specification for the
+  whole super stream.
+- A per-partition position can therefore only be supplied by the SAC
+  `ConsumerUpdate` callback, which the broker fires once per partition on
+  promotion.
+- The one other candidate, `OffsetSpecification.LastConsumed()`, is documented
+  `Deprecated` upstream in favour of `QueryOffset` + `Offset(n)`.
+
+A non-SAC super-stream consumer would therefore replay every partition from
+`Start` on every restart, contradicting "a stored offset always wins" above.
+Since a lone group member is promoted on every partition, always-SAC costs a
+single-instance deployment nothing, and a flag whose only setting is broken is
+worse than no flag. The implementation plan specified a `SAC bool` here; it was
+dropped for these reasons, and should not be restored without first checking
+whether the client has grown a per-partition offset seam.
+
+### Handlers are concurrent across partitions — a contract change
+
+Each partition is a separate connection with its own delivery loop, so the
+framework `Handler` is called **concurrently across partitions** and must be
+goroutine-safe when registered with `DeclareSuperStreamConsumer`. Within one
+partition it stays sequential and ordered, which is what keeps a committed
+offset truthful. Modules written against the plain lane, where a handler is
+never called concurrently, must be re-checked for shared mutable state before
+being pointed at a super stream.
+
+### Offsets are per partition, and the shutdown flush goes through the environment
+
+One consumer now tracks one committed position per partition
+(`consumerContext.Consumer.GetStreamName()` names it, and `Message.Stream`
+carries it to the handler). `Stats` and `/ready` report them keyed
+`<partition>/<consumer name>`.
+
+In-flight commits still go through the consumer the client hands to the delivery
+callback. The **shutdown flush** cannot: `*ha.ReliableSuperStreamConsumer` has no
+`StoreCustomOffset` at all (only the plain `*ha.ReliableConsumer` does), and the
+partition consumer that delivered the last message may already have been replaced
+by a reconnect. It goes through `Environment.StoreOffset(consumer, partition,
+offset)` instead, on the locator connection.
+
+### Declaring a super stream needs RabbitMQ 3.13+, and a mismatch is silent
+
+The client gates `DeclareSuperStream` on `is313OrMore`; plain-stream SAC needs
+only 3.11+. Because the framework always declares before consuming, 3.13 is the
+floor for this feature.
+
+`Environment.DeclareSuperStream` swallows `StreamAlreadyExists`, where
+`DeclareStream` surfaces a retention mismatch as precondition-failed. Re-declaring
+a super stream with a **different partition count is therefore accepted silently**
+and the existing topology is kept — pinned by
+`TestStreamsManagerSuperStreamPartitionMismatchIsSilentIntegration`. Failing
+closed would mean querying the partitions before declaring and comparing, which
+buys a startup abort in exchange for a second round trip and a new failure mode
+against ops-provisioned topologies; the trap is documented in
+[wiki/streams.md](streams.md) instead. Revisit if it bites.
+
 ## Consequences
 
 **Positive.** A restart resumes from the last stored offset, with no client-side
@@ -135,8 +211,8 @@ versions, and the `go.work.sum` gate is where that lands.
 
 **Negative — throughput per consumer is bounded by one handler.** A slow handler
 is a slow stream. That is the price of ordered, truthful offsets, and the
-mitigation is partitioning (future work), not threading — adding SAC members
-adds standbys, not consumers.
+mitigation is partitioning (see the amendment), not threading — adding SAC
+members to a *plain* stream adds standbys, not consumers.
 
 **Negative — a failed message is lost to the consumer.** See above. Until
 parking exists, a handler that must not lose a message has to persist it itself.

--- a/wiki/streams.md
+++ b/wiki/streams.md
@@ -212,6 +212,15 @@ func (m *Module) DeclareStreams(decls *streams.Declarations) {
   topology nor fails — the service simply keeps consuming the partitions that
   exist. Change the count by declaring a new super stream, not by editing the
   old one.
+- **Trap: a locator outage during promotion can stall one partition, and
+  `/ready` will not say so.** Resolving a partition's offset asks the broker,
+  and the client's locator reconnect is uncapped — it retries forever, with no
+  timeout to give up on. That call runs on the partition's own read loop, so
+  while it is stuck the broker never gets its promotion answer and that
+  partition consumes nothing. The consumer's status field is untouched by a
+  blocked read loop, so readiness still reports healthy. Alert on
+  **consumed-message rate per partition**, not on `/ready` alone; a restart
+  clears it. Blast radius is one partition per stall.
 - Producer-side routing (which partition a message lands on) is out of scope
   here, as all stream publishing is. Publish through the AMQP lane or a
   dedicated client; the partition a message reached is on `msg.Stream`.

--- a/wiki/streams.md
+++ b/wiki/streams.md
@@ -17,8 +17,8 @@ lane (a stream queue bound to an exchange) or a dedicated client — see
 | Start position | `x-stream-offset` consumer arg | `Start` + stored offset |
 | Offset tracking | client-side, session-local | **server-side, survives restarts** |
 | Single active consumer | no | yes |
-| Super streams | no | Phase 3 |
-| Handler concurrency | worker pool (`NumCPU*4`) | **sequential, inline** |
+| Super streams | no | yes (RabbitMQ 3.13+) |
+| Handler concurrency | worker pool (`NumCPU*4`) | **sequential per stream**, one goroutine per partition |
 | Multi-tenant | yes | no — single-tenant only |
 
 Pick the AMQP lane when port 5552 is not reachable or the deployment is
@@ -134,13 +134,18 @@ Anything that must not be lost belongs in the handler's own durable store.
 Parking failed messages is future work
 ([ADR-059](adr_059_streams_consumption.md)).
 
-**Handlers run inline and sequentially — there is no worker pool.** A stream is
-an ordered log: parallel handlers would break that order and make a committed
-offset claim that messages behind it were handled. This is the deliberate
-opposite of the AMQP lane's `NumCPU*4` default. Parallel consumption comes from
-super-stream partitions — one active consumer per partition, order preserved
-within each — which is Phase 3, not from threads inside one process. SAC is not
-a throughput lever; see below.
+**Handlers run inline and sequentially within a stream — there is no worker
+pool.** A stream is an ordered log: parallel handlers would break that order and
+make a committed offset claim that messages behind it were handled. This is the
+deliberate opposite of the AMQP lane's `NumCPU*4` default.
+
+Parallelism comes from **partitions**, not from threads. Each partition of a
+super stream is a separate connection with its own delivery loop, so a
+super-stream handler is called **concurrently across partitions** — sequential
+and ordered within one, concurrent between them. **A handler registered with
+`DeclareSuperStreamConsumer` must be goroutine-safe**; one registered with
+`DeclareConsumer` on a plain stream never needs to be. On a plain stream, SAC is
+not a throughput lever; see below.
 
 **There is no handler timeout.** Unlike an HTTP handler, a stream handler gets no
 deadline: the context it receives is canceled only by `StopConsumers`, so a
@@ -152,11 +157,64 @@ bound your own work (`context.WithTimeout` around the slow call).
 ## Single active consumer
 
 `SAC: true` makes the broker deliver to exactly one member of the consumer-name
-group at a time (RabbitMQ 3.11+). This is **failover, not parallelism**: the
-other members are standbys promoted when the active one goes away, so more
-members buy availability, not throughput. On promotion the framework re-resolves
-the stored offset, so a takeover resumes where the previous active member
-committed.
+group at a time (RabbitMQ 3.11+). On a **plain stream** this is **failover, not
+parallelism**: the other members are standbys promoted when the active one goes
+away, so more members buy availability, not throughput. On promotion the
+framework re-resolves the stored offset, so a takeover resumes where the previous
+active member committed.
+
+On a **super stream** the same mechanism does more, which is why the flag is not
+the caller's there: the broker distributes the *partitions* across the group, so
+a second member consumes the partitions the first is not active on. Same
+mechanism, two outcomes — failover on one stream, shared partitions on a super
+stream.
+
+## Super streams
+
+A super stream is a partitioned stream: `n` ordinary streams the broker names
+`<name>-0` … `<name>-(n-1)`, addressed as one. Order holds within a partition,
+not across the whole super stream, and the framework tracks a **separate committed
+offset per partition**.
+
+```go
+func (m *Module) DeclareStreams(decls *streams.Declarations) {
+    decls.DeclareSuperStream("orders", 3, &streams.StreamSpec{
+        MaxLengthBytes: 5 * 1024 * 1024 * 1024, // applies to every partition
+    })
+
+    decls.DeclareSuperStreamConsumer(&streams.SuperStreamConsumerOptions{
+        SuperStream: "orders",
+        Name:        "order-projector", // offset key per partition, and the group identity
+        Start:       streams.OffsetFirst(),
+        Handler:     m.svc.HandleOrder, // called concurrently across partitions
+    })
+}
+```
+
+- **There is no `SAC` field, and consumption is always a SAC group.** The client
+  attaches every partition with one shared offset specification, so the promotion
+  callback — fired once per partition — is the only place a per-partition stored
+  offset can be restored; without it a restart would replay every partition from
+  `Start`. A lone member is promoted on every partition, so a single-instance
+  service loses nothing. See [ADR-059](adr_059_streams_consumption.md).
+- **Scale by adding members, up to the partition count.** Members beyond `n` are
+  standbys. Partitions are fixed at declaration time; sizing them is a capacity
+  decision, not something to change casually (see the mismatch trap below).
+- Offsets, the commit policy, the skip-on-failure semantics and the shutdown
+  flush all work per partition. `/ready` and `Stats` report one position per
+  partition, keyed `<partition>/<consumer name>`.
+- Declaring a super stream requires **RabbitMQ 3.13+** (the client's
+  `DeclareSuperStream` command); plain-stream SAC only needs 3.11+.
+- **Trap: re-declaring a super stream with a different partition count is
+  accepted silently.** Where `DeclareStream` surfaces a retention mismatch as
+  precondition-failed and aborts startup, the client swallows "already exists"
+  for super streams, so a changed `partitions` value neither reshapes the
+  topology nor fails — the service simply keeps consuming the partitions that
+  exist. Change the count by declaring a new super stream, not by editing the
+  old one.
+- Producer-side routing (which partition a message lands on) is out of scope
+  here, as all stream publishing is. Publish through the AMQP lane or a
+  dedicated client; the partition a message reached is on `msg.Stream`.
 
 ## Observability
 
@@ -177,6 +235,8 @@ implemented (future work).
 ## Operations
 
 - Enable the plugin: `rabbitmq-plugins enable rabbitmq_stream`.
+- RabbitMQ 3.11+ for single active consumer, **3.13+ for super streams** — the
+  framework declares one at startup, and that command is 3.13-only.
 - Publish port 5552 (or 5551 for TLS) and make it reachable from the service.
 - Behind an LB or NAT, set `messaging.streams.addressresolver.*`.
 - Streams need explicit retention (`MaxAge` / `MaxLengthBytes`); they do not

--- a/wiki/streams.md
+++ b/wiki/streams.md
@@ -125,6 +125,16 @@ it: nothing waits for an in-flight handler callback, so one that finishes after
 the flush is never committed. **Delivery is at-least-once — a message may be
 handled more than once, so handlers must be idempotent.**
 
+That final flush is **bounded to 5 seconds in total**, across every consumer.
+A super stream commits through the environment's locator connection, and the
+client reconnects that locator in a retry loop with no attempt cap and no
+deadline — so against a broker that is down, one commit would otherwise never
+return and shutdown would never complete. When the budget runs out the
+remaining commits are skipped and each is logged at WARN naming its stream
+(`Shutdown offset flush budget spent`). Skipping only widens the replay window
+that at-least-once delivery already allows for, which is why it is preferred
+over a shutdown that hangs and takes `/ready` down with it for the whole drain.
+
 **A failed message is skipped, not redelivered.** Streams have no nack: on a
 handler error (or a recovered panic) the failure is logged and counted, the
 offset is not committed, and the next message is processed. The skip only sticks


### PR DESCRIPTION
## What

Adds the consumer side. The manager attaches a `ReliableSuperStreamConsumer` per declared super-stream consumer, resolves each partition's stored offset in the SAC promotion callback, and flushes per-partition positions through `Environment.StoreOffset` on shutdown — `*ha.ReliableSuperStreamConsumer` has no `StoreCustomOffset`.

## Impact

Super streams require RabbitMQ 3.13+, and their handlers must be goroutine-safe: partitions are consumed concurrently. A partition-count mismatch on re-declaration is silently ignored by the client — probed live on 3.13.7, declaring 3 then re-declaring 5 returns `nil` while `QueryPartitions` still reports 3. That is pinned by a test and documented in ADR-059 rather than worked around.

## Verification

Stacked PR — CI runs CodeQL only. `make check`, `go test -race`, and the 7-test Docker integration suite ran locally. The group-convergence gate was run 5× to disprove a timing race, and was probed for failure to confirm it can fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native RabbitMQ super-stream support with partitioned consumption and per-partition offset tracking.
  * Enabled concurrent processing across partitions while preserving message order within each partition.
  * Added consumer scaling, ownership recovery, and restart replay from stored offsets.
  * Improved startup cancellation, failure handling, and retention configuration.
  * Added bounded shutdown flushing for tracked offsets.

* **Documentation**
  * Expanded guidance on super-stream setup, requirements, routing, scaling, retention, and consumption behavior.
  * Clarified handler concurrency and offset-tracking requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->