### PR TITLE
fix(migration)!: redact role passwords before the newline split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,6 +417,7 @@ GoBricks breaks its own API surface when justified. Greenfield work uses the new
 - **OTel log-record identity (ADR-055, ADR-056):** top-level fields keyed `service.*`, `telemetry.sdk.*`, or `deployment.environment.name` reach OTLP as `app.<key>`; framework record attributes shrink to `log.type`, identity stays in `ResourceLogs.resource`.
 - **Consumer-scoped AMQP args (ADR-058):** `ConsumeOptions`/`ConsumerOptions`/`ConsumerDeclaration` gain `Args`, forwarded to `basic.consume` — that is where `x-stream-offset` goes; `DeclareStreamQueue` sets only queue type + retention. A map field makes all three non-comparable: `==` and map-key use stop compiling.
 - **Cache conditional release (ADR-060):** `cache.Cache` gains `CompareAndDelete`; every implementer must add it, including test doubles `go build` skips — use `go vet ./...`. Release locks with it, not `Delete`, and acquire with a positive TTL.
+- **Role password control chars (ADR-061):** `PGRoleSpec.Validate` rejects CR/LF/NUL in `MigratorPassword`/`RuntimePassword` — match `errors.Is(err, migration.ErrPGRolePasswordHasControlChar)`; trim file-sourced secrets.
 
 ## File Organization
 

--- a/migration/roles.go
+++ b/migration/roles.go
@@ -290,10 +290,9 @@ func quotePGStringLiteral(s string) string {
 // Order matters: a password containing a newline would otherwise leave the
 // first-line fragment ending mid-literal, which the pattern cannot match.
 func summarizeStmt(stmt string) string {
-	redacted := pgPasswordLiteralPattern.ReplaceAllString(stmt, "${1}'[REDACTED]'")
-	first := redacted
-	if idx := strings.IndexByte(redacted, '\n'); idx > 0 {
-		first = redacted[:idx]
+	first := pgPasswordLiteralPattern.ReplaceAllString(stmt, "${1}'[REDACTED]'")
+	if idx := strings.IndexByte(first, '\n'); idx > 0 {
+		first = first[:idx]
 	}
 	first = strings.TrimSpace(first)
 	if len(first) > 80 {

--- a/migration/roles.go
+++ b/migration/roles.go
@@ -74,9 +74,10 @@ var ErrInvalidPGIdentifier = errors.New("migration: PostgreSQL identifier reject
 // subprocess environment.
 var ErrPGRolePasswordHasControlChar = errors.New("migration: role password contains forbidden control character (CR/LF/NUL)")
 
-// Field name constants used in Validate error messages. Exported via
-// ErrInvalidPGIdentifier so callers (including tests) can assert which
-// field failed without coupling to the literal string.
+// Field name constants used in Validate error messages — the identifier
+// fields via ErrInvalidPGIdentifier, the password fields via
+// ErrPGRolePasswordHasControlChar — so callers (including tests) can assert
+// which field failed without coupling to the literal string.
 const (
 	pgRoleFieldSchema           = "Schema"
 	pgRoleFieldMigratorRole     = "MigratorRole"

--- a/migration/roles.go
+++ b/migration/roles.go
@@ -65,13 +65,24 @@ type PGRoleSpec struct {
 // fails the safe-identifier check enforced by ProvisionPGRoles.
 var ErrInvalidPGIdentifier = errors.New("migration: PostgreSQL identifier rejected")
 
+// ErrPGRolePasswordHasControlChar is returned by Validate when a role password
+// contains CR, LF, or NUL. Such a password cannot be carried log-safely through
+// the provisioning path: summarizeStmt collapses a failing statement to its
+// first line, so an embedded newline would split a redacted summary apart.
+// PostgreSQL itself accepts these passwords — the rejection is ours, at this
+// API's boundary. Mirrors ErrEnvFieldHasControlChar, which guards the Flyway
+// subprocess environment.
+var ErrPGRolePasswordHasControlChar = errors.New("migration: role password contains forbidden control character (CR/LF/NUL)")
+
 // Field name constants used in Validate error messages. Exported via
 // ErrInvalidPGIdentifier so callers (including tests) can assert which
 // field failed without coupling to the literal string.
 const (
-	pgRoleFieldSchema       = "Schema"
-	pgRoleFieldMigratorRole = "MigratorRole"
-	pgRoleFieldRuntimeRole  = "RuntimeRole"
+	pgRoleFieldSchema           = "Schema"
+	pgRoleFieldMigratorRole     = "MigratorRole"
+	pgRoleFieldRuntimeRole      = "RuntimeRole"
+	pgRoleFieldMigratorPassword = "MigratorPassword"
+	pgRoleFieldRuntimePassword  = "RuntimePassword"
 )
 
 // safePGIdentifier matches the conservative ASCII subset of PostgreSQL
@@ -83,8 +94,10 @@ const (
 var safePGIdentifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,62}$`)
 
 // Validate reports whether the spec's identifiers pass the safe-identifier
-// check and the two roles differ. Returns ErrInvalidPGIdentifier wrapped
-// with the offending field name (and value) on failure.
+// check, the two roles differ, and neither password carries CR, LF, or NUL.
+// Returns ErrInvalidPGIdentifier wrapped with the offending field name (and
+// value) for an identifier failure, or ErrPGRolePasswordHasControlChar wrapped
+// with the offending field name — never the value — for a password failure.
 func (s *PGRoleSpec) Validate() error {
 	for _, f := range []struct{ name, value string }{
 		{pgRoleFieldSchema, s.Schema},
@@ -97,6 +110,14 @@ func (s *PGRoleSpec) Validate() error {
 	}
 	if s.MigratorRole == s.RuntimeRole {
 		return fmt.Errorf("%w: MigratorRole and RuntimeRole must differ", ErrInvalidPGIdentifier)
+	}
+	for _, f := range []struct{ name, value string }{
+		{pgRoleFieldMigratorPassword, s.MigratorPassword},
+		{pgRoleFieldRuntimePassword, s.RuntimePassword},
+	} {
+		if strings.ContainsAny(f.value, "\r\n\x00") {
+			return fmt.Errorf("%w: %s", ErrPGRolePasswordHasControlChar, f.name)
+		}
 	}
 	return nil
 }
@@ -262,16 +283,18 @@ func quotePGStringLiteral(s string) string {
 // chars, for use in provisioning error messages. Keeps the wrapping error
 // short while still naming the failing statement.
 //
-// Redacts any `PASSWORD '<literal>'` clause before truncation so a failure
-// on ALTER ROLE ... PASSWORD doesn't leak the resolved secret into the
-// returned error string (which downstream callers may log).
+// Redacts any `PASSWORD '<literal>'` clause before the first-line split and
+// truncation so a failure on ALTER ROLE ... PASSWORD doesn't leak the resolved
+// secret into the returned error string (which downstream callers may log).
+// Order matters: a password containing a newline would otherwise leave the
+// first-line fragment ending mid-literal, which the pattern cannot match.
 func summarizeStmt(stmt string) string {
-	first := stmt
-	if idx := strings.IndexByte(stmt, '\n'); idx > 0 {
-		first = stmt[:idx]
+	redacted := pgPasswordLiteralPattern.ReplaceAllString(stmt, "${1}'[REDACTED]'")
+	first := redacted
+	if idx := strings.IndexByte(redacted, '\n'); idx > 0 {
+		first = redacted[:idx]
 	}
 	first = strings.TrimSpace(first)
-	first = pgPasswordLiteralPattern.ReplaceAllString(first, "${1}'[REDACTED]'")
 	if len(first) > 80 {
 		first = first[:80] + "..."
 	}

--- a/migration/roles_test.go
+++ b/migration/roles_test.go
@@ -328,39 +328,46 @@ func TestSummarizeStmtTruncatesMultilineRedactedStatement(t *testing.T) {
 // log-safely.
 func TestPGRoleSpecValidateRejectsControlCharPasswords(t *testing.T) {
 	tests := []struct {
-		name  string
-		spec  *PGRoleSpec
-		field string
+		name     string
+		spec     *PGRoleSpec
+		field    string
+		badValue string
 	}{
 		{
-			name:  "migrator_password_lf",
-			spec:  &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", MigratorPassword: "bad\npw"},
-			field: pgRoleFieldMigratorPassword,
+			name:     "migrator_password_lf",
+			spec:     &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", MigratorPassword: "bad\npw"},
+			field:    pgRoleFieldMigratorPassword,
+			badValue: "bad\npw",
 		},
 		{
-			name:  "migrator_password_cr",
-			spec:  &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", MigratorPassword: "bad\rpw"},
-			field: pgRoleFieldMigratorPassword,
+			name:     "migrator_password_cr",
+			spec:     &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", MigratorPassword: "bad\rpw"},
+			field:    pgRoleFieldMigratorPassword,
+			badValue: "bad\rpw",
 		},
 		{
-			name:  "migrator_password_nul",
-			spec:  &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", MigratorPassword: "bad\x00pw"},
-			field: pgRoleFieldMigratorPassword,
+			name:     "migrator_password_nul",
+			spec:     &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", MigratorPassword: "bad\x00pw"},
+			field:    pgRoleFieldMigratorPassword,
+			badValue: "bad\x00pw",
 		},
 		{
-			name:  "runtime_password_lf",
-			spec:  &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", RuntimePassword: "bad\npw"},
-			field: pgRoleFieldRuntimePassword,
+			name:     "runtime_password_lf",
+			spec:     &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", RuntimePassword: "bad\npw"},
+			field:    pgRoleFieldRuntimePassword,
+			badValue: "bad\npw",
 		},
 		{
-			name:  "runtime_password_cr",
-			spec:  &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", RuntimePassword: "bad\rpw"},
-			field: pgRoleFieldRuntimePassword,
+			name:     "runtime_password_cr",
+			spec:     &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", RuntimePassword: "bad\rpw"},
+			field:    pgRoleFieldRuntimePassword,
+			badValue: "bad\rpw",
 		},
 		{
-			name:  "runtime_password_nul",
-			spec:  &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", RuntimePassword: "bad\x00pw"},
-			field: pgRoleFieldRuntimePassword,
+			name:     "runtime_password_nul",
+			spec:     &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", RuntimePassword: "bad\x00pw"},
+			field:    pgRoleFieldRuntimePassword,
+			badValue: "bad\x00pw",
 		},
 	}
 	for _, tt := range tests {
@@ -370,7 +377,7 @@ func TestPGRoleSpecValidateRejectsControlCharPasswords(t *testing.T) {
 			assert.True(t, errors.Is(err, ErrPGRolePasswordHasControlChar),
 				"want wrapped ErrPGRolePasswordHasControlChar, got %v", err)
 			assert.Contains(t, err.Error(), tt.field)
-			assert.NotContains(t, err.Error(), tt.spec.MigratorPassword+tt.spec.RuntimePassword,
+			assert.NotContains(t, err.Error(), tt.badValue,
 				"the error must name the field, never the password value")
 		})
 	}

--- a/migration/roles_test.go
+++ b/migration/roles_test.go
@@ -286,3 +286,101 @@ func TestSummarizeStmtRedactsPasswordLiteral(t *testing.T) {
 		})
 	}
 }
+
+// TestSummarizeStmtRedactsMultilinePassword pins the redact-before-split
+// ordering. A password carrying a newline produces a multi-line ALTER ROLE
+// statement; splitting first would leave a fragment ending mid-literal that
+// the closing-quote-anchored pattern cannot match, leaking the first line of
+// the secret verbatim into the wrapped error.
+func TestSummarizeStmtRedactsMultilinePassword(t *testing.T) {
+	stmt := `ALTER ROLE "tenant_a_app" PASSWORD ` + quotePGStringLiteral("line1\nline2")
+	got := summarizeStmt(stmt)
+	assert.Contains(t, got, "[REDACTED]")
+	assert.NotContains(t, got, "line1")
+	assert.NotContains(t, got, "line2")
+	assert.NotContains(t, got, "\n", "the summary must stay single-line")
+}
+
+// TestSummarizeStmtLeadingNewlineKeepsStatement covers a newline at index 0:
+// the idx > 0 guard must decline to split, since slicing [:0] would discard
+// the whole statement and return an empty summary.
+func TestSummarizeStmtLeadingNewlineKeepsStatement(t *testing.T) {
+	got := summarizeStmt("\n" + `ALTER ROLE "x" PASSWORD 'p'`)
+	assert.Equal(t, `ALTER ROLE "x" PASSWORD '[REDACTED]'`, got)
+}
+
+// TestSummarizeStmtTruncatesMultilineRedactedStatement verifies truncation
+// still applies once a multi-line statement collapses into a single redacted
+// line longer than the 80-char budget.
+func TestSummarizeStmtTruncatesMultilineRedactedStatement(t *testing.T) {
+	ident := strings.Repeat("r", 63)
+	stmt := `ALTER ROLE "` + ident + `" PASSWORD ` + quotePGStringLiteral("sec\nret")
+	got := summarizeStmt(stmt)
+	assert.Len(t, got, 83)
+	assert.True(t, strings.HasSuffix(got, "..."))
+	assert.NotContains(t, got, "sec")
+	assert.NotContains(t, got, "ret")
+}
+
+// TestPGRoleSpecValidateRejectsControlCharPasswords pins the CR/LF/NUL
+// rejection on both password fields. PostgreSQL accepts such passwords; the
+// restriction is this API's, because the provisioning path cannot carry them
+// log-safely.
+func TestPGRoleSpecValidateRejectsControlCharPasswords(t *testing.T) {
+	tests := []struct {
+		name  string
+		spec  *PGRoleSpec
+		field string
+	}{
+		{
+			name:  "migrator_password_lf",
+			spec:  &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", MigratorPassword: "bad\npw"},
+			field: pgRoleFieldMigratorPassword,
+		},
+		{
+			name:  "migrator_password_cr",
+			spec:  &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", MigratorPassword: "bad\rpw"},
+			field: pgRoleFieldMigratorPassword,
+		},
+		{
+			name:  "migrator_password_nul",
+			spec:  &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", MigratorPassword: "bad\x00pw"},
+			field: pgRoleFieldMigratorPassword,
+		},
+		{
+			name:  "runtime_password_lf",
+			spec:  &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", RuntimePassword: "bad\npw"},
+			field: pgRoleFieldRuntimePassword,
+		},
+		{
+			name:  "runtime_password_cr",
+			spec:  &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", RuntimePassword: "bad\rpw"},
+			field: pgRoleFieldRuntimePassword,
+		},
+		{
+			name:  "runtime_password_nul",
+			spec:  &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r", RuntimePassword: "bad\x00pw"},
+			field: pgRoleFieldRuntimePassword,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.spec.Validate()
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrPGRolePasswordHasControlChar),
+				"want wrapped ErrPGRolePasswordHasControlChar, got %v", err)
+			assert.Contains(t, err.Error(), tt.field)
+			assert.NotContains(t, err.Error(), tt.spec.MigratorPassword+tt.spec.RuntimePassword,
+				"the error must name the field, never the password value")
+		})
+	}
+
+	clean := &PGRoleSpec{
+		Schema: "s", MigratorRole: "m", RuntimeRole: "r",
+		MigratorPassword: "clean-migrator-pw", RuntimePassword: "clean-runtime-pw",
+	}
+	assert.NoError(t, clean.Validate(), "control-char-free passwords stay valid")
+
+	empty := &PGRoleSpec{Schema: "s", MigratorRole: "m", RuntimeRole: "r"}
+	assert.NoError(t, empty.Validate(), "empty passwords stay valid — they emit no ALTER ROLE statement")
+}

--- a/wiki/adr_061_role_password_control_chars.md
+++ b/wiki/adr_061_role_password_control_chars.md
@@ -1,0 +1,116 @@
+# ADR-061: Redact Role Passwords Before the First-Line Split, and Reject Control Characters in Them
+
+- **Status**: Accepted
+- **Date**: 2026-08-14
+- **Related**: [migrations.md](migrations.md) `[C59.5]` · `migration/roles.go`
+
+## Context
+
+`summarizeStmt` exists for one reason: to keep a resolved role password out of the error strings
+`ProvisionPGRoles` wraps around a failing statement, because callers log those errors. It did the
+two operations in the wrong order.
+
+The pre-fix body split the statement at its first newline **before** applying the redaction regex:
+
+```go
+first := stmt
+if idx := strings.IndexByte(stmt, '\n'); idx > 0 {
+	first = stmt[:idx]
+}
+first = strings.TrimSpace(first)
+first = pgPasswordLiteralPattern.ReplaceAllString(first, "${1}'[REDACTED]'")
+```
+
+The pattern is `(?i)(PASSWORD\s+)'(?:[^']|'')*'` — it is anchored on the **closing** quote. A
+password containing a newline produces a multi-line `ALTER ROLE … PASSWORD '…` statement whose
+first-line fragment ends mid-literal, with no closing quote in it. The pattern matches nothing, the
+substitution is a no-op, and the fragment — including the first line of the secret — is interpolated
+verbatim into the returned error.
+
+The failing input shape is not exotic. A trailing `\n` is what a file-sourced or `echo`-piped secret
+normally carries, and nothing upstream normalizes: `quotePGStringLiteral` doubles single quotes and
+passes newlines straight through, and `PGRoleSpec` has no in-repo producer at all — it is a
+consumer-facing API, so the password arrives from caller code and `Validate` is the only boundary
+the framework owns.
+
+Two properties of the existing code are worth stating so they are not mistaken for part of the bug.
+The 80-character truncation already ran *after* redaction; only the newline split ran before it.
+And Go's `regexp` is RE2, where a negated class `[^']` **does** match `\n` (only `.` excludes it
+without `(?s)`) — so applying the same pattern to the whole multi-line statement matches and
+redacts correctly, and no flag change is needed.
+
+## Decision
+
+**Redact first, then split and truncate.** `summarizeStmt` now runs
+`pgPasswordLiteralPattern.ReplaceAllString` over the full `stmt` and derives the first line from the
+already-redacted string. The reorder alone closes the leak for every password shape, because the
+pattern can now always see its closing quote.
+
+**And reject CR, LF, and NUL in `PGRoleSpec.MigratorPassword` / `RuntimePassword`** at `Validate`,
+via a new exported sentinel `ErrPGRolePasswordHasControlChar`. `Validate` is called by both entry
+points that build role statements (`ProvisionPGRoles` and `PGRoleProvisioningSQL`), and
+`buildPGRoleStatements` is unexported and reachable only through those two, so the guard is live on
+every path. An empty password stays valid — `strings.ContainsAny("", …)` is false, and an empty
+password deliberately emits no `ALTER ROLE … PASSWORD` statement at all.
+
+The error names the field and never the value. The check is placed after the existing
+identifier and role-differ checks, so all current error precedence is preserved.
+
+The reorder is the fix; the rejection is defence in depth. A newline-bearing password still round-
+trips safely through `summarizeStmt` after the reorder, but it remains a value the provisioning
+path cannot represent on one line, and rejecting it removes a whole class of future single-line
+assumptions rather than relying on every downstream formatter to be as careful.
+
+**PostgreSQL itself accepts such passwords.** The restriction is this API's, taken because the
+provisioning path cannot carry them log-safely — not a claim about what the server permits.
+
+## Alternatives considered
+
+**Normalize instead of reject** — trim or escape the newline before building the statement.
+Rejected: it silently changes a credential. A caller who genuinely intended a trailing newline
+would provision a role whose password is not the value they passed, then authenticate against
+something they never set, and the mismatch would surface far from here as an unexplained auth
+failure. Rejection at the boundary is the honest outcome; `migration/secrets.go` decodes a
+`config.DatabaseConfig` from a secret payload and is deliberately left alone for the same reason.
+
+**Reuse `flyway.go`'s `validateEnvFields` / `ErrEnvFieldHasControlChar`.** Rejected: that guard
+protects a different boundary — the environment handed to the Flyway subprocess — and its message
+("env field") would misname a `PGRoleSpec` failure. The two guards share a four-line shape and a
+deliberately identical character set (CR/LF/NUL, not "all control characters") so the boundaries
+agree, but they are not folded into a shared helper: one is `config.DatabaseConfig`-shaped, the
+other `PGRoleSpec`-shaped, and the abstraction would cost more than the duplication.
+
+**Add a minimum-length gate, mirroring `redactPassword`.** Rejected, and worth recording so it is
+not proposed again. `flyway.go`'s `redactPassword` redacts by *substring*, comparing output against
+the secret's bytes, which false-positives on short passwords — hence its
+`minRedactablePasswordLength` floor and `ErrDatabasePasswordTooShort`. `summarizeStmt`'s redaction
+is **structural**: it matches the `PASSWORD '…'` clause by shape and never looks at the secret's
+bytes, so a 3-character role password redacts exactly as safely as a 40-character one. Importing
+that coupling would add a failure mode with no corresponding hazard.
+
+## Consequences
+
+**Positive.** The redaction now holds for the input shape secrets pipelines most commonly produce.
+A newline-bearing password is refused at the API boundary with a message that names the field and
+not the value.
+
+**Negative.** This is breaking. A `PGRoleSpec` carrying a CR/LF/NUL password used to provision
+successfully; `ProvisionPGRoles` and `PGRoleProvisioningSQL` now return an error instead. All three
+symbols are exported, `go get`-consumed API. Callers sourcing a password from a file or a command
+substitution must `strings.TrimSpace` it before handing it over. The new sentinel is itself additive
+and apidiff-compatible — the rejection is what breaks.
+
+**Operational.** This fix stops future leaks, not past ones. Any environment where a provisioning
+failure was logged while a role password contained a newline should treat that credential as
+disclosed and rotate it. `[C59.5]` in [migrations.md](migrations.md) carries the detection command
+and the rotation guidance.
+
+**Maintenance.** If a third password field is ever added to `PGRoleSpec`, the control-char loop in
+`Validate` must gain it — the loop is the single place that enumerates them.
+
+## References
+
+- `migration/roles.go` — `summarizeStmt`, `PGRoleSpec.Validate`, `ErrPGRolePasswordHasControlChar`
+- `migration/flyway.go` — `validateEnvFields` / `ErrEnvFieldHasControlChar`, the precedent this mirrors
+- [migration_roles.md](migration_roles.md) — the migrator-vs-runtime role-separation model
+- [migrations.md](migrations.md) `[C59.5]`

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -1195,6 +1195,34 @@ to `Delete` reinstates the original hazard behind an API that reads as safe. `fa
 distinguish a failed comparison from an already-gone key, which is why the result is named
 `deleted`. See [migrations.md](migrations.md) `[C59.3]`.
 
+### [ADR-061: Redact Role Passwords Before the First-Line Split, and Reject Control Characters in Them](adr_061_role_password_control_chars.md)
+
+**Date:** 2026-08-14 | **Status:** Accepted
+
+`summarizeStmt` exists to keep a resolved role password out of the provisioning errors callers log,
+but it split the statement at its first newline **before** applying the redaction regex — and that
+pattern, `(?i)(PASSWORD\s+)'(?:[^']|'')*'`, is anchored on the closing quote. A password containing
+a newline (the trailing `\n` a file-sourced or `echo`-piped secret normally carries) produced a
+multi-line `ALTER ROLE … PASSWORD '…` whose first-line fragment ended mid-literal, matched nothing,
+and reached the returned error verbatim. Nothing upstream normalized: `quotePGStringLiteral` passes
+newlines through, and `PGRoleSpec` has no in-repo producer, so `Validate` is the only boundary the
+framework owns. The redaction now runs over the whole statement before the split and the truncation
+(Go's RE2 `[^']` matches `\n`, so no `(?s)` is needed), and `PGRoleSpec.Validate` additionally
+rejects CR/LF/NUL in either password field with the new `ErrPGRolePasswordHasControlChar`, naming
+the field and never the value.
+
+**Key Benefits:** The redaction holds for the input shape secrets pipelines most commonly produce,
+and a value the provisioning path cannot carry on one line is refused at the boundary rather than
+trusted to every downstream formatter. The character set (CR/LF/NUL, not "all control characters")
+deliberately matches `flyway.go`'s `ErrEnvFieldHasControlChar` so the two boundaries agree.
+**Watch:** this is **breaking** — a spec carrying such a password used to provision successfully, so
+`ProvisionPGRoles` and `PGRoleProvisioningSQL` now return an error, and callers reading a password
+from a file or command substitution must `strings.TrimSpace` it first. Empty passwords stay valid.
+Normalization was rejected because trimming silently changes a credential, and no
+`minRedactablePasswordLength`-style floor is imported: this redaction is *structural*, never
+comparing against the secret's bytes. The fix stops future leaks, not past ones — rotate any
+credential whose provisioning failure was logged. See [migrations.md](migrations.md) `[C59.5]`.
+
 ---
 
 ## ADR Lifecycle
@@ -1206,7 +1234,7 @@ distinguish a failed comparison from an already-gone key, which is why the resul
 
 ### Numbering Policy
 
-ADR numbers (ADR-001 through ADR-060) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
+ADR numbers (ADR-001 through ADR-061) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
 
 ## Writing New ADRs
 

--- a/wiki/migration_roles.md
+++ b/wiki/migration_roles.md
@@ -92,6 +92,7 @@ names across databases would need to revisit this.
 
 ```go
 import (
+    "fmt"
     "os"
     "strings"
 

--- a/wiki/migration_roles.md
+++ b/wiki/migration_roles.md
@@ -96,9 +96,9 @@ import "github.com/gaborage/go-bricks/migration"
 spec := &migration.PGRoleSpec{
     Schema:           "tenant_a",
     MigratorRole:     "migrator",
-    MigratorPassword: os.Getenv("MIGRATOR_PASSWORD"), // optional, omit if managed externally
+    MigratorPassword: strings.TrimSpace(os.Getenv("MIGRATOR_PASSWORD")), // optional, omit if managed externally
     RuntimeRole:      "tenant_a_app",
-    RuntimePassword:  os.Getenv("TENANT_A_RUNTIME_PASSWORD"),
+    RuntimePassword:  strings.TrimSpace(os.Getenv("TENANT_A_RUNTIME_PASSWORD")),
 }
 
 // db is an *sql.DB authenticated as a role with CREATEROLE — typically the
@@ -107,6 +107,14 @@ if err := migration.ProvisionPGRoles(ctx, db, spec); err != nil {
     return fmt.Errorf("provision tenant %q: %w", spec.Schema, err)
 }
 ```
+
+The `strings.TrimSpace` calls are not decorative: `Validate` rejects a
+password containing CR, LF, or NUL with `ErrPGRolePasswordHasControlChar`,
+naming the offending field and never its value, and a trailing newline is
+what a file-sourced or `echo`-piped secret routinely carries. PostgreSQL
+itself accepts such passwords — the restriction is the framework's, taken
+because the provisioning path cannot carry them log-safely (see
+[ADR-061](adr_061_role_password_control_chars.md)).
 
 All operations are idempotent — rerunning with the same spec is a no-op
 except that `MigratorPassword` / `RuntimePassword` (when non-empty) are
@@ -152,7 +160,8 @@ deployment. Treat its credentials accordingly:
 - **Rotation:** Pass the new password as `MigratorPassword` on the next
   provisioning call. The helper emits `ALTER ROLE ... PASSWORD ...`
   unconditionally when the field is non-empty, so rerunning with a rotated
-  secret is sufficient.
+  secret is sufficient — trim it first if it came from a file, a mounted
+  secret, or a command substitution, since a stray CR/LF/NUL is rejected.
 
 For the AWS Secrets Manager naming convention used by `go-bricks-migrate`,
 see [multi_tenant_migration.md](multi_tenant_migration.md#aws-secrets-manager-convention).

--- a/wiki/migration_roles.md
+++ b/wiki/migration_roles.md
@@ -91,7 +91,12 @@ names across databases would need to revisit this.
 ## Using the helper
 
 ```go
-import "github.com/gaborage/go-bricks/migration"
+import (
+    "os"
+    "strings"
+
+    "github.com/gaborage/go-bricks/migration"
+)
 
 spec := &migration.PGRoleSpec{
     Schema:           "tenant_a",

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -44,7 +44,7 @@ v0.39.1 ─E40─ v0.40.0 ─E401─ v0.40.1 ─E41─ v0.41.0 ─E42─ v0.42.0
 | E57 | v0.56.0 → v0.57.0 | silent-behavior + breaking (C57.4, C57.5, C57.6, C57.7, C57.8 abort startup; C57.9 fails `httpclient` construction) | 9 | C57.7 (only partially — a direct call still compiles; see its scope) | if any alert, runbook, synthetic check, or contract test parses the driver error out of `/ready`'s database `503` body, repoint it at the app log or `<debug.pathprefix>/health-debug` (default `/_sys`) — the field is now the fixed string `database unavailable` (C57.1); and if you implement your own critical `app.Prober`, its `503` body now reads `<Name> unavailable` instead of its raw error, since sanitization became the default rather than an opt-in (C57.2); and if anything reads `db_stats.connections` out of `/ready`'s **200** body — a per-tenant pool dashboard, an activity alert, a test pinning the key set — repoint it at `<debug.pathprefix>/health-debug` or the OTel database metrics, because that array is gone from `/ready`; a repo-local grep alone will not find an out-of-repo dashboard (C57.3); and check every environment with `outbox.enabled: true` or `inbox.enabled: true` (outside per-tenant fan-out or a dynamic source) for a configured, reachable database whose ledger table exists — or whose `autocreatetable` can create it — because Init now aborts startup instead of booting green (C57.4); and check every `database.connectionstring` (root, `databases.*`, `multitenant.tenants.*`) with no `database.type` set — a recognized scheme (`postgres://`, `postgresql://`, `oracle://`) now infers its type and actually dials instead of booting into a dead connection, and an unrecognized scheme on the built-in connector now fails startup instead of failing at first query (C57.5); and check every environment for a database identity key delivered as an empty string (an empty `secretKeyRef`, `envsubst` over an unset variable) — that shape used to load silently as database-free and now aborts startup naming the key (C57.6); and check every environment for `debug.enabled: true` (`DEBUG_ENABLED=true`) with at least one `debug.endpoints.*` flag on, an empty `debug.allowedips` and no `debug.bearertoken` — all four required, and that service refuses to start after the bump; and if you assemble config in Go, check for a `Debug` block with `Enabled: true` and any endpoint flag but no `AllowedIPs` — that path never received the loopback default, so the refusal is reachable there by omission; grep shortlists, booting in staging decides (C57.7); and check every **single-tenant** service that declares AMQP consumers for a broker that is reachable, accepts its credentials, and accepts its declarations at boot, because a consumer bootstrap failure now aborts startup instead of logging one WARN and serving HTTP while consuming nothing forever — publisher-only and messaging-free services are unaffected (C57.8); and read every `WithJOSE` policy and direct `jose.Seal` call for an explicitly-set algorithm outside the allowlist — `KeyAlg: RSA1_5` or a non-AEAD `Enc` sealed successfully before and now fails `Build()` at startup, while a policy that named no algorithms at all takes the package defaults and starts working instead of failing every request (C57.9) |
 | E58 | v0.57.0 → v0.58.0 | compile-break + breaking (C58.3 aborts startup) + behavior (C58.4, C58.5) | 5 | C58.1 C58.2 C58.3 | check every environment for a **negative** `cache.manager.maxsize` or `cache.manager.idlettl`, and — in multi-tenant mode with `cache.manager.maxsize` unset — a negative `multitenant.limits.tenants`, which becomes the pool size. Under `cache.enabled: false` such a value used to be inert and now aborts startup (C58.3); and if any dashboard, alert, or saved query reads OTLP-exported log records by a `service.*`, `telemetry.sdk.*`, or `deployment.environment.name` **record** attribute your code sets as a log field, re-key it to the `app.`-prefixed name (C58.4); and audit the log backend for dashboards, alerts, or saved queries filtering log records by **any** record-level resource attribute — the framework's `service.*` / `telemetry.sdk.*` / `deployment.environment.name` plus every key your deployment injects via `OTEL_RESOURCE_ATTRIBUTES` (`k8s.pod.name`, …) — since all of them move to resource level only; no code grep finds these (C58.5) |
 | E581 | v0.58.0 → v0.58.1 | silent-behavior | 3 | none | if you cache any type carrying a time.Time, decide before the bump whether a compare-and-set on a sub-second timestamp may fail during the rolling deploy (C581.1); and if `observability.logs.samplingrate` is set to any value strictly between 0.0 and 1.0, expect the exported INFO/DEBUG log volume AND the membership of the sampled set to change: a rate at or above 0.00005 and below 0.01 exported nothing before the bump and starts exporting its configured fraction after it, a rate that is not a whole percent stops flooring (0.999 was 99%, now 99.9%), and every fractional rate redraws which traces land in the sample; a rate below 0.00005, plus 0.0 and 1.0, are unaffected (C581.2); and if you call `Close()` directly on a `DbManager`/`CacheManager`/`messaging.Manager`, know that a handle still borrowed by in-flight work now stays open until its final release instead of closing immediately (C581.3) |
-| E59 | v0.58.1 → v0.59.0 | compile-break (C59.2, C59.3) + silent-behavior (C59.1, C59.4) | 4 | C59.2 C59.3 | if your service sits behind a proxy on a **public** address (CloudFront, a partner edge), set `server.trustedproxies` to its CIDR range before the bump — otherwise that proxy is itself returned as the client and every caller behind it collapses into a single rate-limit bucket; and check the load balancer for any mode that writes a non-IP `X-Forwarded-For` entry — on AWS ALB that is `routing.http.xff_client_port.enabled` (appends `client_ip:port`) and, separately, `routing.http.xff_header_processing.mode = remove` — since either keys the entire fleet on the load balancer's own address after the bump and `server.trustedproxies` cannot fix it; the remedy is deployment-side (C59.1); and if any of your code — **including test files**, which `go build` does not compile — implements `cache.Cache`, add the new `CompareAndDelete` method, and before swapping a lock's `Delete` release for it make sure the lock is acquired with a **positive** TTL, since a `ttl == 0` lock that a token-verified release declines to remove is held forever (C59.3); and grep your **test** files for a `cache/testing.MockCache` handed a context that is already canceled or expired while the call is expected to succeed — the mock's cancellation check no longer depends on a configured `WithDelay`, so that call now returns the context's error (C59.4) |
+| E59 | v0.58.1 → v0.59.0 | compile-break (C59.2, C59.3) + silent-behavior (C59.1, C59.4) + breaking (C59.5 rejects a password) | 5 | C59.2 C59.3 | if your service sits behind a proxy on a **public** address (CloudFront, a partner edge), set `server.trustedproxies` to its CIDR range before the bump — otherwise that proxy is itself returned as the client and every caller behind it collapses into a single rate-limit bucket; and check the load balancer for any mode that writes a non-IP `X-Forwarded-For` entry — on AWS ALB that is `routing.http.xff_client_port.enabled` (appends `client_ip:port`) and, separately, `routing.http.xff_header_processing.mode = remove` — since either keys the entire fleet on the load balancer's own address after the bump and `server.trustedproxies` cannot fix it; the remedy is deployment-side (C59.1); and if any of your code — **including test files**, which `go build` does not compile — implements `cache.Cache`, add the new `CompareAndDelete` method, and before swapping a lock's `Delete` release for it make sure the lock is acquired with a **positive** TTL, since a `ttl == 0` lock that a token-verified release declines to remove is held forever (C59.3); and grep your **test** files for a `cache/testing.MockCache` handed a context that is already canceled or expired while the call is expected to succeed — the mock's cancellation check no longer depends on a configured `WithDelay`, so that call now returns the context's error (C59.4); and if you call `ProvisionPGRoles` or `PGRoleProvisioningSQL` with a `PGRoleSpec` whose `MigratorPassword` or `RuntimePassword` is read from a file, a mounted secret, an environment read, or a command substitution, `strings.TrimSpace` it before the bump — a password containing CR, LF, or NUL is now rejected by `Validate` instead of provisioning, and any credential whose provisioning failure was logged while its password contained a newline should be rotated, since the first line of that secret reached the error string (C59.5) |
 
 **4 — Read each atom's gate before acting.** Every atom carries `when: match | no-match | always`:
 
@@ -2277,7 +2277,14 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   compiling (C59.2). Separately, `cache.Cache` gains a `CompareAndDelete`
   method — the safe, token-verified release the interface never had, since
   its only release was unconditional `Delete` — so every implementer must
-  add it (C59.3).
+  add it (C59.3). Separately again, `migration`'s `summarizeStmt` now redacts
+  the `PASSWORD '…'` clause **before** splitting a failing statement at its
+  first newline — the old order left the first-line fragment ending
+  mid-literal, so the closing-quote-anchored pattern matched nothing and the
+  first line of a newline-bearing password reached the logged error verbatim
+  — and `PGRoleSpec.Validate` now rejects CR, LF, or NUL in either password
+  field, so a spec that used to provision successfully returns an error
+  (C59.5).
 - build-caught: C59.2 C59.3 (via `go vet` — `go build` does not compile test files)
 - preflight: **two** actions. (i) If a proxy in front of the service sits on
   a **public** address, set `server.trustedproxies` to its CIDR range before
@@ -2295,7 +2302,16 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   `X-Real-IP` fallback is deliberately gone. **`server.trustedproxies` does
   not rescue either case**: the chain is abandoned before trust is
   consulted. The only remedy is deployment-side (turn the attribute off, or
-  normalize the header).
+  normalize the header). (iii) If you provision PostgreSQL roles through
+  `ProvisionPGRoles` or `PGRoleProvisioningSQL`, trace where each
+  `MigratorPassword` / `RuntimePassword` comes from and `strings.TrimSpace`
+  any value read from a file, a mounted secret, an environment read, a
+  command substitution, or a secret-manager payload — a trailing newline is
+  what those producers routinely append, and after the bump `Validate`
+  rejects it instead of provisioning. Nothing is compiler-caught here, so a
+  staging provisioning run against the real secret source is the decisive
+  check. Rotate any credential whose provisioning failure was logged while
+  its password contained a newline.
 - exit: `go get github.com/gaborage/go-bricks@v0.59.0 && go mod tidy && go build ./... && go test ./...`
 
 ### [C59.1] Rate-limit buckets and logged client addresses key on the trusted-proxy-derived IP · silent-behavior · when: match
@@ -2525,6 +2541,47 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
 - verify: `go test ./...`
 - ref: [ADR-060](adr_060_cache_compare_and_delete.md) (Consequences — why the guard was restructured) ·
   `cache/testing/mock_cache.go` (`waitDelay`) · [testing.md](testing.md#cache-testing)
+
+### [C59.5] A `PGRoleSpec` password containing CR, LF, or NUL now fails `Validate` · breaking · when: match
+
+- detect: `git grep -nE '(Migrator|Runtime)Password[[:space:]]*[:=]' -- '*.go'` lists every site that
+  populates a `PGRoleSpec` password. For each, trace where the value comes from: a literal or an
+  already-trimmed string is safe, while `os.ReadFile`, a mounted-secret read, a command substitution,
+  or a secret-manager payload can all carry a trailing newline. Keep every pattern free of the PCRE
+  escapes — `git grep -E` is POSIX ERE and silently ignores them, so a pattern carrying one matches
+  nothing and the gate falsely reports "not affected". Nothing here is compiler-caught: the failure is
+  a returned error at run time, so a staging provisioning run is the authoritative answer.
+- scope: `migration/roles.go` only — `PGRoleSpec.Validate`, reached by both `ProvisionPGRoles` and
+  `PGRoleProvisioningSQL` (`buildPGRoleStatements` is unexported and reachable only through those
+  two, so no path bypasses the check). `Validate` now rejects `MigratorPassword` or `RuntimePassword`
+  containing CR, LF, or NUL, wrapping the new exported sentinel `ErrPGRolePasswordHasControlChar`
+  with the offending **field name** — never the value. The check runs after the existing identifier
+  and role-differ checks, so all previous error precedence is preserved, and an **empty** password
+  stays valid (it deliberately emits no `ALTER ROLE … PASSWORD` statement at all). The character set
+  is CR/LF/NUL, not "all control characters", matching `flyway.go`'s `ErrEnvFieldHasControlChar` so
+  the two boundaries agree. PostgreSQL itself accepts such passwords — the restriction is this API's,
+  because the provisioning path cannot carry them log-safely. Shipped alongside the fix that motivated
+  it: `summarizeStmt` now redacts the `PASSWORD '…'` clause **before** splitting the statement at its
+  first newline, which is not itself breaking.
+- gate: match = you build a `PGRoleSpec` whose `MigratorPassword` or `RuntimePassword` is sourced from
+  a file, a mounted secret, an environment read, a command substitution, or a secret-manager payload —
+  any producer that can append a newline. no-match = both password fields are always empty (credentials
+  managed out-of-band), or every value is a literal or already passed through `strings.TrimSpace`.
+- before: `ProvisionPGRoles` / `PGRoleProvisioningSQL` accepted the password and emitted a multi-line
+  `ALTER ROLE … PASSWORD 'line1\nline2'`. Worse, if that statement then failed, `summarizeStmt` split
+  the statement before redacting it, so the closing-quote-anchored pattern could not match the
+  first-line fragment and the first line of the secret was interpolated verbatim into the returned
+  error — which callers log.
+- after: `Validate` returns an error wrapping `ErrPGRolePasswordHasControlChar`, naming the field, and
+  provisioning does not run. Match it with `errors.Is`, never `==`. The remedy is to trim at the
+  source — `strings.TrimSpace(string(b))` on the file or secret read — not to strip inside the
+  framework, which would silently provision a credential different from the one you passed. **Rotate
+  any credential** whose provisioning failure was logged while its password contained a newline: this
+  change stops future leaks, not past ones.
+- verify: `go build ./... && go test ./...`, then confirm no provisioning password is read from a file
+  or a command substitution without `strings.TrimSpace`, and run one provisioning pass in staging with
+  the real secret source — a trailing newline that survived to production would now abort the run.
+- ref: [ADR-061](adr_061_role_password_control_chars.md) · `migration/roles.go`
 
 ---
 

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -2286,7 +2286,7 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   field, so a spec that used to provision successfully returns an error
   (C59.5).
 - build-caught: C59.2 C59.3 (via `go vet` — `go build` does not compile test files)
-- preflight: **two** actions. (i) If a proxy in front of the service sits on
+- preflight: **three** actions. (i) If a proxy in front of the service sits on
   a **public** address, set `server.trustedproxies` to its CIDR range before
   the bump — without an entry it is untrusted, so it is returned as the
   client and every caller behind it collapses into one bucket. (ii) Check


### PR DESCRIPTION
## What

`summarizeStmt` split a failing statement at its first newline *before* applying the closing-quote-anchored redaction regex, so a newline-bearing password left a fragment ending mid-literal that matched nothing and reached the logged error verbatim. Redaction now runs over the whole statement first, and `PGRoleSpec.Validate` rejects CR/LF/NUL via the new `ErrPGRolePasswordHasControlChar`.

## Impact

Breaking: such a password now fails `ProvisionPGRoles` / `PGRoleProvisioningSQL` — trim file- or command-sourced secrets at the source (ADR-061, C59.5). Rotate any credential whose provisioning failure was logged while its password held a newline. Merge before release-please #964: if v0.59.0 tags first, hop E59 closes and C59.5 moves to E60.

## Verification

Both plan-mandated hand-mutations failed at their named assertions — gremlins mutates neither a reorder nor a string literal, so the machine gate cannot cover either. `make mutate` needed `MUTATE_NO_CACHE=1` to clear load-induced timeouts before reporting all changed-line mutants killed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - PostgreSQL role passwords containing carriage returns, line feeds, or NUL characters are now rejected with a clear validation error.
  - Passwords are redacted from statement-related error summaries before truncation, preventing credential exposure, including multiline secrets.
  - Empty and valid passwords continue to be accepted.

- **Documentation**
  - Added guidance to trim file-, environment-, mount-, and command-sourced secrets.
  - Documented validation behavior, credential rotation, preflight checks, and staging verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->