### PR TITLE
fix(deps): upgrade integration images and Renovate-manage the pins

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -296,11 +296,27 @@ jobs:
       - name: Pre-pull container images
         run: |
           echo "Warming Docker cache with container images..."
-          docker pull postgres:17.10-alpine &
+          pids=""
+          # renovate: datasource=docker depName=postgres
+          docker pull postgres:18.6-alpine &
+          pids="$pids $!"
+          # renovate: datasource=docker depName=gvenzl/oracle-free
           docker pull gvenzl/oracle-free:23.26.2-slim &
-          docker pull rabbitmq:3.13.7-management-alpine &
-          docker pull redis:7.4.9-alpine &
-          wait
+          pids="$pids $!"
+          # renovate: datasource=docker depName=rabbitmq
+          docker pull rabbitmq:4.2.9-management-alpine &
+          pids="$pids $!"
+          # renovate: datasource=docker depName=redis
+          docker pull redis:8.10.0-alpine &
+          pids="$pids $!"
+          rc=0
+          for pid in $pids; do
+            wait "$pid" || rc=1
+          done
+          if [ "$rc" -ne 0 ]; then
+            echo "One or more image pulls failed" >&2
+            exit 1
+          fi
           echo "All container images cached"
 
       - name: Cache Flyway CLI

--- a/renovate.json
+++ b/renovate.json
@@ -56,7 +56,8 @@
       ],
       "matchStrings": [
         "// renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+\\w+:\\s+\"(?<currentValue>[^\"]+)\""
-      ]
+      ],
+      "versioningTemplate": "docker"
     },
     {
       "customType": "regex",
@@ -66,7 +67,8 @@
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+docker pull \\S+:(?<currentValue>\\S+)"
-      ]
+      ],
+      "versioningTemplate": "docker"
     },
     {
       "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,26 @@
     },
     {
       "customType": "regex",
+      "description": "Bump testcontainers image tags pinned as Go string literals in testing/containers. These defaults are invisible to every built-in manager, so they rot silently (RabbitMQ sat on EOL 3.13.7 until 2026-08). The inline '// renovate:' annotation above each pin supplies the datasource + depName; the field shape is generic (any string field, like the Makefile manager's \\w+_VERSION) so a field rename cannot silently detach the pin; docker versioning keeps the '-management-alpine'-style suffix stable across bumps. Only annotated pins are managed — annotate the other containers to opt them in.",
+      "managerFilePatterns": [
+        "/(^|/)testing/containers/[^/]+\\.go$/"
+      ],
+      "matchStrings": [
+        "// renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+\\w+:\\s+\"(?<currentValue>[^\"]+)\""
+      ]
+    },
+    {
+      "customType": "regex",
+      "description": "Bump annotated 'docker pull' pins in workflow run: scripts — the CI cache pre-warm duplicates the testing/containers image tags, and shell literals are invisible to built-in managers (the RabbitMQ copy sat stale next to the bumped Go pin until both were annotated). Same-depName updates land in one Renovate PR, keeping the pre-pull and the Go default in lockstep.",
+      "managerFilePatterns": [
+        "/(^|/)\\.github/workflows/[^/]+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+docker pull \\S+:(?<currentValue>\\S+)"
+      ]
+    },
+    {
+      "customType": "regex",
       "description": "Track the CI-pinned Flyway CLI version. Flyway 12.x tarballs ship only from Redgate's server (Maven Central stopped at 11.8.2), but flyway/flyway still tags GitHub releases (flyway-X.Y.Z), so github-releases tracks the version number; the SHA256 gate + test fixtures make the resulting bump PR fail CI until a maintainer re-pins the checksum and fixtures — that failing PR is the intended alert.",
       "managerFilePatterns": [
         "/(^|/)\\.github/workflows/[^/]+\\.ya?ml$/"

--- a/testing/containers/oracle.go
+++ b/testing/containers/oracle.go
@@ -20,7 +20,7 @@ import (
 
 // OracleContainerConfig holds configuration for Oracle test container
 type OracleContainerConfig struct {
-	// ImageTag specifies the Oracle version (default: "23.26.2-slim")
+	// ImageTag specifies the Oracle version (default: the pin in DefaultOracleConfig)
 	ImageTag string
 	// Password for SYSTEM, SYS, and APP users (default: "testpass")
 	Password string
@@ -34,10 +34,11 @@ type OracleContainerConfig struct {
 
 // DefaultOracleConfig returns an OracleContainerConfig populated with sensible defaults.
 //
-// The returned configuration sets ImageTag to "23.26.2-slim", Password to "testpass",
-// Database to "FREEPDB1" (Oracle Free default PDB), AppUser to "testuser", and StartupTimeout to 120 seconds.
+// The returned configuration sets Password to "testpass", Database to "FREEPDB1"
+// (Oracle Free default PDB), AppUser to "testuser", and StartupTimeout to 120 seconds.
 func DefaultOracleConfig() *OracleContainerConfig {
 	return &OracleContainerConfig{
+		// renovate: datasource=docker depName=gvenzl/oracle-free
 		ImageTag:       "23.26.2-slim",
 		Password:       "testpass",
 		Database:       "FREEPDB1", // Oracle Free default PDB name

--- a/testing/containers/postgresql.go
+++ b/testing/containers/postgresql.go
@@ -15,7 +15,7 @@ import (
 
 // PostgreSQLContainerConfig holds configuration for PostgreSQL test container
 type PostgreSQLContainerConfig struct {
-	// ImageTag specifies the PostgreSQL version (default: "17.10-alpine")
+	// ImageTag specifies the PostgreSQL version (default: the pin in DefaultPostgreSQLConfig)
 	ImageTag string
 	// Username for PostgreSQL authentication (default: "testuser")
 	Username string
@@ -29,11 +29,12 @@ type PostgreSQLContainerConfig struct {
 
 // DefaultPostgreSQLConfig returns a PostgreSQLContainerConfig populated with sensible defaults.
 //
-// The returned configuration sets ImageTag to "17.10-alpine", Username to "testuser", Password to "testpass",
+// The returned configuration sets Username to "testuser", Password to "testpass",
 // Database to "testdb", and StartupTimeout to 60 seconds.
 func DefaultPostgreSQLConfig() *PostgreSQLContainerConfig {
 	return &PostgreSQLContainerConfig{
-		ImageTag:       "17.10-alpine",
+		// renovate: datasource=docker depName=postgres
+		ImageTag:       "18.6-alpine",
 		Username:       "testuser",
 		Password:       "testpass",
 		Database:       "testdb",

--- a/testing/containers/rabbitmq.go
+++ b/testing/containers/rabbitmq.go
@@ -27,7 +27,7 @@ const (
 
 // RabbitMQContainerConfig holds configuration for RabbitMQ test container
 type RabbitMQContainerConfig struct {
-	// ImageTag specifies the RabbitMQ version (default: "3.13.7-management-alpine")
+	// ImageTag specifies the RabbitMQ version (default: the pin in DefaultRabbitMQConfig)
 	ImageTag string
 	// Username for RabbitMQ authentication (default: "guest")
 	Username string
@@ -42,12 +42,12 @@ type RabbitMQContainerConfig struct {
 
 // DefaultRabbitMQConfig returns a RabbitMQContainerConfig populated with sensible defaults.
 //
-// The returned configuration sets ImageTag to "3.13.7-management-alpine", Username to "guest",
-// Password to "guest", and StartupTimeout to 60 seconds. The container uses the default
-// RabbitMQ virtual host "/".
+// The returned configuration sets Username to "guest", Password to "guest", and StartupTimeout
+// to 60 seconds. The container uses the default RabbitMQ virtual host "/".
 func DefaultRabbitMQConfig() *RabbitMQContainerConfig {
 	return &RabbitMQContainerConfig{
-		ImageTag:       "3.13.7-management-alpine",
+		// renovate: datasource=docker depName=rabbitmq
+		ImageTag:       "4.2.9-management-alpine",
 		Username:       "guest",
 		Password:       "guest",
 		StartupTimeout: 60 * time.Second,

--- a/testing/containers/redis.go
+++ b/testing/containers/redis.go
@@ -15,7 +15,7 @@ import (
 
 // RedisContainerConfig holds configuration for Redis test container
 type RedisContainerConfig struct {
-	// ImageTag specifies the Redis version (default: "7.4.9-alpine")
+	// ImageTag specifies the Redis version (default: the pin in DefaultRedisConfig)
 	ImageTag string
 	// StartupTimeout for container initialization (default: 60 seconds)
 	StartupTimeout time.Duration
@@ -23,10 +23,11 @@ type RedisContainerConfig struct {
 
 // DefaultRedisConfig returns a RedisContainerConfig populated with sensible defaults.
 //
-// The returned configuration sets ImageTag to "7.4.9-alpine" and StartupTimeout to 60 seconds.
+// The returned configuration sets StartupTimeout to 60 seconds.
 func DefaultRedisConfig() *RedisContainerConfig {
 	return &RedisContainerConfig{
-		ImageTag:       "7.4.9-alpine",
+		// renovate: datasource=docker depName=redis
+		ImageTag:       "8.10.0-alpine",
 		StartupTimeout: 60 * time.Second,
 	}
 }


### PR DESCRIPTION
## What

Integration-suite container pins were stale (RabbitMQ 3.13.7 is EOL) and invisible to Renovate — they live as Go string literals in `testing/containers/*.go` plus duplicate `docker pull` literals in ci-v2.yml's cache pre-warm, hand-synced and silently drifting. RabbitMQ moves to `4.2.9-management-alpine`, PostgreSQL to `18.6-alpine`, Redis to `8.10.0-alpine` (Oracle already current), and two new regex `customManagers` track all eight annotated sites so both copies of each pin bump together in one Renovate PR. The pre-pull step also now fails when any pull fails, instead of a bare `wait` that reported success unconditionally.

## Impact

None for consumers of `testing/containers` — `ImageTag` overrides still work; suites now exercise RabbitMQ 4.x (Khepri metadata store), PostgreSQL 18, Redis 8.

## Verification

Full `make test-integration` green against the bumped images locally (CI cannot show this: its own pre-pull was part of the change). RabbitMQ 4.x removal audit: per-channel QoS only, no mirroring/ha-* args, durable declarations, unchanged wait-strategy log line and stream-plugin path. `renovate-config-validator` passes; both manager regexes proven to extract all eight sites with consistent values per dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated default PostgreSQL, RabbitMQ, Redis, and Oracle container versions used by integration testing.
  * Improved integration test setup to download required service images concurrently and verify each download succeeds.

* **Maintenance**
  * Added automated tracking for container image versions to help keep test environments current.
  * Clarified configuration documentation for default image versions and startup settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->