### PR TITLE
fix(testing): permit transient non-exclusive queues in RabbitMQ testcontainer

### DIFF
--- a/testing/containers/rabbitmq.go
+++ b/testing/containers/rabbitmq.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,6 +25,12 @@ const (
 	streamPluginReadyTimeout = 30 * time.Second
 	streamPluginPollInterval = 250 * time.Millisecond
 )
+
+// RabbitMQ 4.3.0 moved `transient_nonexcl_queues` to denied_by_default and
+// closes the connection (541) on a transient non-exclusive declare. The
+// framework still supports that queue shape, so the test broker opts back
+// in the same way a permitting production broker would.
+const permitDeprecatedFeaturesConf = "deprecated_features.permit.transient_nonexcl_queues = true\n"
 
 // RabbitMQContainerConfig holds configuration for RabbitMQ test container
 type RabbitMQContainerConfig struct {
@@ -92,6 +99,11 @@ func StartRabbitMQContainer(ctx context.Context, t *testing.T, cfg *RabbitMQCont
 				wait.ForListeningPort("5672/tcp"),
 			).WithStartupTimeout(cfg.StartupTimeout),
 		),
+		testcontainers.WithFiles(testcontainers.ContainerFile{
+			Reader:            strings.NewReader(permitDeprecatedFeaturesConf),
+			ContainerFilePath: "/etc/rabbitmq/conf.d/99-go-bricks-permit.conf",
+			FileMode:          0o644,
+		}),
 	}
 	if cfg.EnableStreamPlugin {
 		// The port must be published at creation time; the plugin that binds it is

--- a/wiki/messaging.md
+++ b/wiki/messaging.md
@@ -39,6 +39,8 @@ decls.DeclareConsumer(&messaging.ConsumerOptions{
 - Publishers: `Mandatory: false`, `Immediate: false`
 - Consumers: `AutoAck: false`, `Exclusive: false`, `NoLocal: false`
 
+RabbitMQ 4.3.0 denies `transient_nonexcl_queues` by default: a queue declared with both `Durable: false` and `Exclusive: false` gets the connection closed with a 541 instead of the queue created. The helpers above are unaffected — `NewQueue` defaults to `Durable: true` — but a hand-built `QueueDeclaration` using that transient shape needs the broker configured with `deprecated_features.permit.transient_nonexcl_queues = true`, which is what GoBricks' own RabbitMQ test container sets.
+
 **Key Helpers:** `DeclareTopicExchange()`, `DeclareQueue()`, `DeclareBinding()`, `DeclarePublisher()`, `DeclareConsumer()`
 
 **Re-declaring one queue name is allowed when the shapes are compatible.** Two declarations of the same queue *merge*: the four flags (`Durable`, `AutoDelete`, `Exclusive`, `NoWait`) must be equal, and any `Args` key they share must carry the same value; the union of their `Args` is what reaches the broker. So `DeclareQueueWithDLQ("orders.events.queue", nil)` and `DeclareQueue("orders.events.queue")` from two different modules now compose, instead of whichever ran last silently dropping the other's dead-letter args — declaration order across modules is invisible at any single call site, and the pre-merge behavior could revert a queue to dropping failed deliveries with no error and no WARN. Incompatible shapes (a differing flag, or one `Args` key with two values) keep the first declaration and fail startup with a single aggregate error naming every conflict:


### PR DESCRIPTION
## What
RabbitMQ 4.3.0 denies the deprecated `transient_nonexcl_queues` feature by
default, so the 4.3.4 image bump (#994) killed every messaging integration
test declaring a transient non-exclusive queue — the broker closes the
connection with `Exception (541) INTERNAL_ERROR`. The test container now
injects `/etc/rabbitmq/conf.d/99-go-bricks-permit.conf` re-permitting the
feature, keeping the framework's full declarable surface testable on 4.2 and
4.3 images alike.

## Impact
None at runtime. wiki/messaging.md now warns that a hand-built
`QueueDeclaration` with `Durable: false, Exclusive: false` needs the same
broker-side permit on RabbitMQ 4.3+ (helper defaults are durable and
unaffected).

## Verification
Messaging integration suite ran green locally against both
rabbitmq:4.2.9-management-alpine (current pin) and 4.3.4-management-alpine
(the Renovate target). Mutation gate: zero mutants on changed lines is
expected — the Go change lives in integration-tagged test infrastructure.
CodeRabbit review lands via the PR bot on push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated RabbitMQ test containers to support transient, non-exclusive queues with newer RabbitMQ versions.
  * Preserved compatibility for manually configured transient queue declarations.

* **Documentation**
  * Clarified RabbitMQ 4.3.0 behavior and configuration requirements.
  * Documented that standard GoBricks queue helpers remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->