### PR TITLE
fix(mutate): sandbox gate builds away from shared GOCACHE

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -185,9 +185,13 @@ linters:
       # here — so the vendor import keeps `gojose`, which is exactly the
       # collision-avoidance case uber-go's "Import Aliasing" prescribes. The
       # importas entry still holds everywhere else.
+      # Deliberately unanchored: golangci's shared result cache can replay this
+      # finding under a prefixed path (e.g. ../<worktree>/cmd/seal-payload/...),
+      # which a ^-anchor fails to match — defense in depth behind per-tree lint
+      # caches. No other cmd/seal-payload path exists, so the wider match is safe.
       - linters:
           - importas
-        path: ^cmd/seal-payload/
+        path: cmd/seal-payload/
         text: 'go-jose/go-jose/v4'
     paths:
       - third_party$

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,8 @@ update: ## Update dependencies to latest versions
 # `go clean -cache` empties the MACHINE-WIDE build cache: every checkout and
 # session on this machine pays the rebuild, so keep it out of routine targets
 # (`make mutate` manages its own dedicated cache instead, retained until it
-# exceeds MUTATE_GOCACHE_CAP — scripts/mutatediff/sandbox.go).
+# exceeds MUTATE_GOCACHE_CAP; `0` disables the cap —
+# scripts/mutatediff/sandbox.go).
 clean: ## Clean build cache and test artifacts
 	go clean -cache -testcache
 	rm -f coverage.out coverage-integration.out coverage.html coverage.func

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,9 @@ update: ## Update dependencies to latest versions
 	go get -u ./...
 	go mod tidy
 
+# `go clean -cache` empties the MACHINE-WIDE build cache: every checkout and
+# session on this machine pays the rebuild, so keep it out of routine targets
+# (`make mutate` cleans its own dedicated cache instead — scripts/mutatediff/sandbox.go).
 clean: ## Clean build cache and test artifacts
 	go clean -cache -testcache
 	rm -f coverage.out coverage-integration.out coverage.html coverage.func
@@ -175,6 +178,10 @@ sec: ## Run gosec security scanner (pinned; identical to CI)
 	# non-issues, so gating them only here would diverge from the repo's gosec policy.
 	go run github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION) -exclude=G103,G104 ./...
 
+# Mutation builds and temp trees are sandboxed away from the machine-shared
+# GOCACHE and system temp, and cleaned by the gate itself; MUTATE_GOCACHE_CAP
+# (MiB, env-only, 0 = uncapped) bounds what the dedicated cache may leave on
+# disk. See scripts/mutatediff/sandbox.go.
 mutate: ## Diff-scoped mutation gate: mutants on changed lines vs origin/main must die (see wiki/testing.md#mutation-gate)
 	go run ./scripts/mutatediff -engine "$(GREMLINS_CMD)" -workers "$(MUTATE_WORKERS)" -cpu "$(MUTATE_CPU)" -cooldown "$(MUTATE_COOLDOWN)" $(if $(MUTATE_NO_CACHE),-no-cache,)
 

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,8 @@ update: ## Update dependencies to latest versions
 
 # `go clean -cache` empties the MACHINE-WIDE build cache: every checkout and
 # session on this machine pays the rebuild, so keep it out of routine targets
-# (`make mutate` cleans its own dedicated cache instead — scripts/mutatediff/sandbox.go).
+# (`make mutate` manages its own dedicated cache instead, retained until it
+# exceeds MUTATE_GOCACHE_CAP — scripts/mutatediff/sandbox.go).
 clean: ## Clean build cache and test artifacts
 	go clean -cache -testcache
 	rm -f coverage.out coverage-integration.out coverage.html coverage.func

--- a/scripts/mutatediff/main.go
+++ b/scripts/mutatediff/main.go
@@ -55,7 +55,7 @@ func main() {
 	os.Exit(code)
 }
 
-func run(ctx context.Context, engine, baseRef string, th throttle, useCache bool, out io.Writer) int {
+func run(ctx context.Context, engine, baseRef string, th throttle, useCache bool, out io.Writer) (code int) {
 	engineArgs := strings.Fields(engine)
 	if len(engineArgs) == 0 {
 		return fail("engine command is blank")
@@ -96,11 +96,17 @@ func run(ctx context.Context, engine, baseRef string, th throttle, useCache bool
 	// After the sandbox env is pinned, every temp path below — the report dir,
 	// gremlins' working copies, measureSuite's coverage scratch — lands inside
 	// the per-run root, and every child build lands in the dedicated cache.
-	sb, sbErr := setupSandbox(out)
+	sb, sbErr := setupSandbox(ctx, out)
 	if sbErr != nil {
 		return fail("%v", sbErr)
 	}
-	defer sb.cleanup(out)
+	// A failed cleanup flips a clean verdict to failure — the gate's contract
+	// includes leaving the machine tidy — but never masks a real failure code.
+	defer func() {
+		if cleanErr := sb.cleanup(out); cleanErr != nil && code == 0 {
+			code = fail("sandbox cleanup: %v", cleanErr)
+		}
+	}()
 	// Explicitly inside the per-run root, so sb.cleanup owns its removal and
 	// the containment survives reordering.
 	reportDir := filepath.Join(sb.runTmp, "reports")

--- a/scripts/mutatediff/main.go
+++ b/scripts/mutatediff/main.go
@@ -93,11 +93,20 @@ func run(ctx context.Context, engine, baseRef string, th throttle, useCache bool
 		return fail("%v", budgetErr)
 	}
 	fmt.Fprintln(out, describeBudget(th.cooldown, b))
-	reportDir, err := os.MkdirTemp("", "mutatediff-*")
-	if err != nil {
-		return fail("%v", err)
+	// After the sandbox env is pinned, every temp path below — the report dir,
+	// gremlins' working copies, measureSuite's coverage scratch — lands inside
+	// the per-run root, and every child build lands in the dedicated cache.
+	sb, sbErr := setupSandbox(out)
+	if sbErr != nil {
+		return fail("%v", sbErr)
 	}
-	defer os.RemoveAll(reportDir)
+	defer sb.cleanup(out)
+	// Explicitly inside the per-run root, so sb.cleanup owns its removal and
+	// the containment survives reordering.
+	reportDir := filepath.Join(sb.runTmp, "reports")
+	if mkErr := os.MkdirAll(reportDir, 0o750); mkErr != nil {
+		return fail("%v", mkErr)
+	}
 	gr := &gateRun{
 		engineArgs: engineArgs,
 		reportDir:  reportDir,

--- a/scripts/mutatediff/sandbox.go
+++ b/scripts/mutatediff/sandbox.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// The gate's children build thousands of mutants. Flowing those artifacts
+// through the machine-shared GOCACHE fills the disk with objects no other
+// build will ever read, and the only shared-cache remedy (`go clean -cache`)
+// destroys every other session's warm build state. The sandbox scopes both
+// to paths this run owns: a dedicated persistent build cache, wiped only when
+// it outgrows its cap, and a per-run temp root that swallows the engine's
+// working copies (gremlins-*), the report dir, and coverage scratch files.
+//
+// The dedicated cache lives under os.UserCacheDir, never inside the repo:
+// gremlins copies the whole module root per worker with an unfiltered
+// filepath.Walk (workdir.go), so an in-repo cache would be hauled into every
+// working copy.
+const (
+	// gocacheCapEnv bounds, in MiB, what the dedicated build cache may leave
+	// on disk after a run. An explicit 0 disables the cap; unset or
+	// unparsable falls back to the default (MUTATE_CEILING_FLOOR precedent).
+	gocacheCapEnv = "MUTATE_GOCACHE_CAP"
+	// defaultGocacheCapMiB bounds what a session leaves behind while holding
+	// one heavy run's build state (measured: one database-package run writes
+	// ~3.0 GiB, a repeat run grows it to ~5.7 GiB — repeat mutant builds miss
+	// the cache because gremlins' per-run workdir paths enter the action IDs).
+	// At this cap the wipe fires roughly every second heavy run, and the
+	// measured cold-vs-warm penalty it re-imposes is ~42s on a ~7 min run.
+	defaultGocacheCapMiB = 4096
+	// runTmpPrefix names the per-run temp root. The stale sweep keys on it:
+	// a run killed with SIGKILL never reaches its defers, so the next run
+	// removes what it left.
+	runTmpPrefix = "mutatediff-run-"
+	// staleRunTTL is how old an orphaned run root must be before the sweep
+	// takes it. A gate run lasts minutes, so nothing this old is live, and a
+	// concurrent session's tree is never yanked.
+	staleRunTTL = 24 * time.Hour
+	mib         = 1 << 20
+)
+
+// tempEnvVars covers os.TempDir on every platform: TMPDIR on Unix, TMP and
+// TEMP on Windows. Pinning all three is harmless where a name is unused.
+var tempEnvVars = []string{"TMPDIR", "TMP", "TEMP"}
+
+// sandbox is the pair of roots one run owns, plus the cap that decides the
+// build cache's fate at cleanup.
+type sandbox struct {
+	gocache  string
+	runTmp   string
+	capBytes int64
+}
+
+// setupSandbox resolves the machine-specific roots and delegates. Split from
+// setupSandboxAt so the dir/env/sweep logic stays testable on every platform
+// without faking os.UserCacheDir.
+func setupSandbox(out io.Writer) (*sandbox, error) {
+	base, err := os.UserCacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve user cache dir for the dedicated build cache: %w", err)
+	}
+	return setupSandboxAt(filepath.Join(base, "mutatediff"), os.TempDir(), time.Now(), out)
+}
+
+// setupSandboxAt creates both roots and pins them on this process's
+// environment so every descendant inherits them — the same seam budget.apply
+// uses, and for the same reason: measureSuite's warming passes and the
+// engine's coverage read must land in one cache, or the measured baseline is
+// a lie.
+func setupSandboxAt(cacheBase, sysTmp string, now time.Time, out io.Writer) (*sandbox, error) {
+	gocache := filepath.Join(cacheBase, "gocache")
+	if err := os.MkdirAll(gocache, 0o750); err != nil {
+		return nil, fmt.Errorf("create dedicated build cache: %w", err)
+	}
+	sweepStaleRunDirs(sysTmp, now, out)
+	runTmp, err := os.MkdirTemp(sysTmp, runTmpPrefix+"*")
+	if err != nil {
+		return nil, fmt.Errorf("create per-run temp root: %w", err)
+	}
+	if err := os.Setenv("GOCACHE", gocache); err != nil {
+		return nil, fmt.Errorf("pin GOCACHE: %w", err)
+	}
+	for _, key := range tempEnvVars {
+		if err := os.Setenv(key, runTmp); err != nil {
+			return nil, fmt.Errorf("pin %s: %w", key, err)
+		}
+	}
+	fmt.Fprintf(out, "mutatediff: sandboxed build cache %s, temp root %s\n", gocache, runTmp)
+	return &sandbox{gocache: gocache, runTmp: runTmp, capBytes: gocacheCap()}, nil
+}
+
+// cleanup releases what the run created. Deferred in run, so it fires on
+// failures the same as on passes; only SIGKILL skips it, and the startup
+// sweep covers that. The cap wipe assumes gate runs on one machine do not
+// overlap — they are serialized locally by convention, and the shared cache
+// is not safe to wipe under a concurrent run.
+func (s *sandbox) cleanup(out io.Writer) {
+	if err := os.RemoveAll(s.runTmp); err != nil {
+		fmt.Fprintf(out, "WARN: could not remove temp root %s: %v\n", s.runTmp, err)
+	}
+	if s.capBytes <= 0 {
+		return
+	}
+	size := dirSize(s.gocache)
+	if size <= s.capBytes {
+		fmt.Fprintf(out, "mutatediff: build cache %s within its %s cap\n", formatMiB(size), formatMiB(s.capBytes))
+		return
+	}
+	fmt.Fprintf(out, "mutatediff: build cache %s exceeds its %s cap — wiping %s\n", formatMiB(size), formatMiB(s.capBytes), s.gocache)
+	if err := os.RemoveAll(s.gocache); err != nil {
+		fmt.Fprintf(out, "WARN: could not wipe build cache: %v\n", err)
+	}
+}
+
+// gocacheCap reads the cap in MiB and returns bytes. Unset or unparsable
+// values fall back to the default rather than failing the gate; 0 is the
+// documented opt-out.
+func gocacheCap() int64 {
+	raw := strings.TrimSpace(os.Getenv(gocacheCapEnv))
+	if raw == "" {
+		return defaultGocacheCapMiB * mib
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || v < 0 || v > math.MaxInt64/mib {
+		return defaultGocacheCapMiB * mib
+	}
+	return v * mib
+}
+
+// sweepStaleRunDirs removes orphaned per-run roots older than staleRunTTL.
+func sweepStaleRunDirs(sysTmp string, now time.Time, out io.Writer) {
+	entries, err := os.ReadDir(sysTmp)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), runTmpPrefix) {
+			continue
+		}
+		info, infoErr := e.Info()
+		if infoErr != nil {
+			continue
+		}
+		if now.Sub(info.ModTime()) <= staleRunTTL {
+			continue
+		}
+		p := filepath.Join(sysTmp, e.Name())
+		if rmErr := os.RemoveAll(p); rmErr != nil {
+			fmt.Fprintf(out, "WARN: could not remove stale run root %s: %v\n", p, rmErr)
+			continue
+		}
+		fmt.Fprintf(out, "mutatediff: removed stale run root %s\n", p)
+	}
+}
+
+// dirSize sums regular file sizes best-effort: an unreadable entry counts as
+// zero, degrading to a smaller measurement rather than a failed cleanup.
+func dirSize(root string) int64 {
+	var total int64
+	_ = filepath.WalkDir(root, func(_ string, d fs.DirEntry, err error) error {
+		if err == nil && !d.IsDir() {
+			if info, infoErr := d.Info(); infoErr == nil {
+				total += info.Size()
+			}
+		}
+		return nil
+	})
+	return total
+}
+
+func formatMiB(bytes int64) string {
+	return fmt.Sprintf("%dMiB", bytes/mib)
+}

--- a/scripts/mutatediff/sandbox.go
+++ b/scripts/mutatediff/sandbox.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -62,12 +64,12 @@ type sandbox struct {
 // setupSandbox resolves the machine-specific roots and delegates. Split from
 // setupSandboxAt so the dir/env/sweep logic stays testable on every platform
 // without faking os.UserCacheDir.
-func setupSandbox(out io.Writer) (*sandbox, error) {
+func setupSandbox(ctx context.Context, out io.Writer) (*sandbox, error) {
 	base, err := os.UserCacheDir()
 	if err != nil {
 		return nil, fmt.Errorf("resolve user cache dir for the dedicated build cache: %w", err)
 	}
-	return setupSandboxAt(filepath.Join(base, "mutatediff"), os.TempDir(), time.Now(), out)
+	return setupSandboxAt(ctx, filepath.Join(base, "mutatediff"), os.TempDir(), time.Now(), out)
 }
 
 // setupSandboxAt creates both roots and pins them on this process's
@@ -75,7 +77,11 @@ func setupSandbox(out io.Writer) (*sandbox, error) {
 // uses, and for the same reason: measureSuite's warming passes and the
 // engine's coverage read must land in one cache, or the measured baseline is
 // a lie.
-func setupSandboxAt(cacheBase, sysTmp string, now time.Time, out io.Writer) (*sandbox, error) {
+func setupSandboxAt(ctx context.Context, cacheBase, sysTmp string, now time.Time, out io.Writer) (*sandbox, error) {
+	// A canceled run must not begin a lifecycle it would immediately abandon.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	gocache := filepath.Join(cacheBase, "gocache")
 	if err := os.MkdirAll(gocache, 0o750); err != nil {
 		return nil, fmt.Errorf("create dedicated build cache: %w", err)
@@ -97,27 +103,31 @@ func setupSandboxAt(cacheBase, sysTmp string, now time.Time, out io.Writer) (*sa
 	return &sandbox{gocache: gocache, runTmp: runTmp, capBytes: gocacheCap()}, nil
 }
 
-// cleanup releases what the run created. Deferred in run, so it fires on
+// cleanup releases what the run created and reports what it could not: a
+// gate whose cleanup failed must not exit clean, or the debris this sandbox
+// exists to prevent comes back silently. Deferred in run, so it fires on
 // failures the same as on passes; only SIGKILL skips it, and the startup
 // sweep covers that. The cap wipe assumes gate runs on one machine do not
 // overlap — they are serialized locally by convention, and the shared cache
 // is not safe to wipe under a concurrent run.
-func (s *sandbox) cleanup(out io.Writer) {
+func (s *sandbox) cleanup(out io.Writer) error {
+	var errs []error
 	if err := os.RemoveAll(s.runTmp); err != nil {
-		fmt.Fprintf(out, "WARN: could not remove temp root %s: %v\n", s.runTmp, err)
+		errs = append(errs, fmt.Errorf("remove temp root: %w", err))
 	}
 	if s.capBytes <= 0 {
-		return
+		return errors.Join(errs...)
 	}
 	size := dirSize(s.gocache)
 	if size <= s.capBytes {
 		fmt.Fprintf(out, "mutatediff: build cache %s within its %s cap\n", formatMiB(size), formatMiB(s.capBytes))
-		return
+		return errors.Join(errs...)
 	}
 	fmt.Fprintf(out, "mutatediff: build cache %s exceeds its %s cap — wiping %s\n", formatMiB(size), formatMiB(s.capBytes), s.gocache)
 	if err := os.RemoveAll(s.gocache); err != nil {
-		fmt.Fprintf(out, "WARN: could not wipe build cache: %v\n", err)
+		errs = append(errs, fmt.Errorf("wipe build cache: %w", err))
 	}
+	return errors.Join(errs...)
 }
 
 // gocacheCap reads the cap in MiB and returns bytes. Unset or unparsable

--- a/scripts/mutatediff/sandbox_test.go
+++ b/scripts/mutatediff/sandbox_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGocacheCapParsesEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want int64
+	}{
+		{name: "empty_defaults", raw: "", want: defaultGocacheCapMiB * mib},
+		{name: "positive_mib", raw: "1", want: mib},
+		{name: "zero_disables_cap", raw: "0", want: 0},
+		{name: "negative_defaults", raw: "-5", want: defaultGocacheCapMiB * mib},
+		{name: "unparsable_defaults", raw: "abc", want: defaultGocacheCapMiB * mib},
+		{name: "whitespace_trimmed", raw: " 2 ", want: 2 * mib},
+		{name: "max_mib_that_fits", raw: "8796093022207", want: 8796093022207 * mib},
+		{name: "overflow_defaults", raw: "8796093022208", want: defaultGocacheCapMiB * mib},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(gocacheCapEnv, tt.raw)
+			assert.Equal(t, tt.want, gocacheCap())
+		})
+	}
+}
+
+func TestDirSizeSumsNestedFiles(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "sub"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "a"), []byte("abc"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "sub", "b"), []byte("defgh"), 0o600))
+	assert.Equal(t, int64(8), dirSize(root))
+}
+
+func TestDirSizeMissingRootIsZero(t *testing.T) {
+	assert.Equal(t, int64(0), dirSize(filepath.Join(t.TempDir(), "absent")))
+}
+
+func TestSweepStaleRunDirsRemovesOnlyOldMatchingDirs(t *testing.T) {
+	sysTmp := t.TempDir()
+	now := time.Now()
+	old := now.Add(-staleRunTTL - time.Hour)
+	mkdir := func(name string, mtime time.Time) string {
+		p := filepath.Join(sysTmp, name)
+		require.NoError(t, os.Mkdir(p, 0o750))
+		require.NoError(t, os.Chtimes(p, mtime, mtime))
+		return p
+	}
+	stale := mkdir("mutatediff-run-stale", old)
+	fresh := mkdir("mutatediff-run-fresh", now)
+	// Exactly at the TTL is not yet stale: the sweep takes only what is older.
+	edge := mkdir("mutatediff-run-edge", now.Add(-staleRunTTL))
+	foreign := mkdir("other-tool-stale", old)
+	staleFile := filepath.Join(sysTmp, "mutatediff-run-file")
+	require.NoError(t, os.WriteFile(staleFile, []byte("x"), 0o600))
+	require.NoError(t, os.Chtimes(staleFile, old, old))
+
+	var out strings.Builder
+	sweepStaleRunDirs(sysTmp, now, &out)
+
+	assert.NoDirExists(t, stale)
+	assert.DirExists(t, fresh)
+	assert.DirExists(t, edge)
+	assert.DirExists(t, foreign)
+	assert.FileExists(t, staleFile)
+	assert.Contains(t, out.String(), "removed stale run root")
+}
+
+func TestSandboxCleanup(t *testing.T) {
+	tests := []struct {
+		name           string
+		cacheBytes     int
+		capBytes       int64
+		wantCacheWiped bool
+		// Empty means the output must not mention the cap at all.
+		wantMsg string
+	}{
+		// Cap exactly at the size: at the cap is within it, not over it.
+		{name: "at_cap_keeps_cache", cacheBytes: 4, capBytes: 4, wantCacheWiped: false, wantMsg: "within its"},
+		{name: "over_cap_wipes_cache", cacheBytes: 5, capBytes: 4, wantCacheWiped: true, wantMsg: "exceeds its 0MiB cap — wiping"},
+		{name: "zero_cap_never_wipes", cacheBytes: 5, capBytes: 0, wantCacheWiped: false, wantMsg: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gocache := t.TempDir()
+			runTmp := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(gocache, "obj"), make([]byte, tt.cacheBytes), 0o600))
+			require.NoError(t, os.WriteFile(filepath.Join(runTmp, "scratch"), []byte("x"), 0o600))
+
+			var out strings.Builder
+			s := &sandbox{gocache: gocache, runTmp: runTmp, capBytes: tt.capBytes}
+			s.cleanup(&out)
+
+			assert.NoDirExists(t, runTmp)
+			if tt.wantCacheWiped {
+				assert.NoDirExists(t, gocache)
+			} else {
+				assert.DirExists(t, gocache)
+			}
+			if tt.wantMsg == "" {
+				assert.NotContains(t, out.String(), "cap")
+			} else {
+				assert.Contains(t, out.String(), tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestSetupSandboxAtPinsEnvAndCreatesRoots(t *testing.T) {
+	// t.Setenv registers restoration for the vars setupSandboxAt overwrites.
+	for _, key := range append([]string{"GOCACHE"}, tempEnvVars...) {
+		t.Setenv(key, "")
+	}
+	cacheBase := t.TempDir()
+	sysTmp := t.TempDir()
+	now := time.Now()
+	stale := filepath.Join(sysTmp, "mutatediff-run-orphan")
+	require.NoError(t, os.Mkdir(stale, 0o750))
+	old := now.Add(-staleRunTTL - time.Hour)
+	require.NoError(t, os.Chtimes(stale, old, old))
+
+	var out strings.Builder
+	s, err := setupSandboxAt(cacheBase, sysTmp, now, &out)
+	require.NoError(t, err)
+
+	wantCache := filepath.Join(cacheBase, "gocache")
+	assert.Equal(t, wantCache, s.gocache)
+	assert.Equal(t, wantCache, os.Getenv("GOCACHE"))
+	assert.DirExists(t, wantCache)
+	assert.DirExists(t, s.runTmp)
+	assert.True(t, strings.HasPrefix(filepath.Base(s.runTmp), runTmpPrefix))
+	for _, key := range tempEnvVars {
+		assert.Equal(t, s.runTmp, os.Getenv(key), key)
+	}
+	assert.Equal(t, gocacheCap(), s.capBytes)
+	assert.NoDirExists(t, stale)
+	assert.Contains(t, out.String(), "sandboxed build cache")
+}

--- a/scripts/mutatediff/sandbox_test.go
+++ b/scripts/mutatediff/sandbox_test.go
@@ -166,6 +166,9 @@ func TestSandboxCleanupReportsRemovalFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("read-only parent does not block removal on Windows")
 	}
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the read-only parent this test relies on")
+	}
 	parent := t.TempDir()
 	runTmp := filepath.Join(parent, "run")
 	require.NoError(t, os.Mkdir(runTmp, 0o750))

--- a/scripts/mutatediff/sandbox_test.go
+++ b/scripts/mutatediff/sandbox_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -99,7 +101,7 @@ func TestSandboxCleanup(t *testing.T) {
 
 			var out strings.Builder
 			s := &sandbox{gocache: gocache, runTmp: runTmp, capBytes: tt.capBytes}
-			s.cleanup(&out)
+			require.NoError(t, s.cleanup(&out))
 
 			assert.NoDirExists(t, runTmp)
 			if tt.wantCacheWiped {
@@ -130,7 +132,7 @@ func TestSetupSandboxAtPinsEnvAndCreatesRoots(t *testing.T) {
 	require.NoError(t, os.Chtimes(stale, old, old))
 
 	var out strings.Builder
-	s, err := setupSandboxAt(cacheBase, sysTmp, now, &out)
+	s, err := setupSandboxAt(context.Background(), cacheBase, sysTmp, now, &out)
 	require.NoError(t, err)
 
 	wantCache := filepath.Join(cacheBase, "gocache")
@@ -145,4 +147,36 @@ func TestSetupSandboxAtPinsEnvAndCreatesRoots(t *testing.T) {
 	assert.Equal(t, gocacheCap(), s.capBytes)
 	assert.NoDirExists(t, stale)
 	assert.Contains(t, out.String(), "sandboxed build cache")
+}
+
+func TestSetupSandboxAtCanceledContextCreatesNothing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cacheBase := filepath.Join(t.TempDir(), "cachebase")
+
+	var out strings.Builder
+	s, err := setupSandboxAt(ctx, cacheBase, t.TempDir(), time.Now(), &out)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, s)
+	assert.NoDirExists(t, cacheBase)
+}
+
+func TestSandboxCleanupReportsRemovalFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("read-only parent does not block removal on Windows")
+	}
+	parent := t.TempDir()
+	runTmp := filepath.Join(parent, "run")
+	require.NoError(t, os.Mkdir(runTmp, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(runTmp, "scratch"), []byte("x"), 0o600))
+	require.NoError(t, os.Chmod(parent, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o750) })
+
+	var out strings.Builder
+	s := &sandbox{gocache: t.TempDir(), runTmp: runTmp, capBytes: 0}
+	err := s.cleanup(&out)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remove temp root")
 }

--- a/wiki/testing.md
+++ b/wiki/testing.md
@@ -371,6 +371,7 @@ Knobs (all `?=`, so the environment overrides):
 | `MUTATE_CEILING_FLOOR` | 30s | Minimum per-mutant ceiling (any `time.ParseDuration` string). |
 | `MUTATE_FALLBACK_COEFFICIENT` | 600 | Used only when a package's coefficient cannot be computed. |
 | `MUTATE_NO_CACHE` | *(empty)* | Any non-empty value bypasses the result cache below and re-mutates every package in the diff. |
+| `MUTATE_GOCACHE_CAP` | 4096 | Cap, in MiB, on the gate's dedicated build cache (below). Env-only — read by `mutatediff`, not declared in the Makefile. `0` removes the cap; unset or unparsable falls back to the default. |
 
 The budget is applied once, on `mutatediff`'s own environment, so gremlins, its
 coverage pass, `measureSuite`'s timing passes, and every mutant's `go test` all
@@ -379,6 +380,26 @@ per-mutant ceiling divides the real suite by a cache-served replay, so measuring
 the two under different budgets would corrupt every ceiling. The `-coefficient`
 path is deliberately excluded, because it serves `make mutate-baseline`, whose
 mutants run unbudgeted.
+
+### Disk sandbox
+
+The same set-once-on-own-environment seam isolates the gate's disk footprint
+(`scripts/mutatediff/sandbox.go`). Mutant builds otherwise flow through the
+machine-shared `GOCACHE` — thousands of objects no other build will ever read —
+and the only shared-cache remedy, `go clean -cache`, destroys every other
+session's warm state. Instead the gate pins `GOCACHE` to a dedicated persistent
+cache under the user cache dir (`~/Library/Caches/mutatediff/gocache` on macOS)
+and the temp variables (`TMPDIR`/`TMP`/`TEMP`) to a per-run root, so gremlins'
+working copies, the report dir, and coverage scratch files all land inside one
+tree. Cleanup is deferred in `run`, so it fires on failures the same as on
+passes: the per-run root is removed, and the dedicated cache is wiped only when
+it exceeds `MUTATE_GOCACHE_CAP`. A run killed with `SIGKILL` skips its defers;
+the next run's startup sweep removes orphaned `mutatediff-run-*` roots older
+than 24h. The dedicated cache must stay **outside the repo**: gremlins copies
+the whole module root per worker with an unfiltered `filepath.Walk`, so an
+in-repo cache would be hauled into every working copy. The `-coefficient` and
+`-merge` paths are unsandboxed — they serve `make mutate-baseline` in ephemeral
+CI runners.
 
 The cooldown gives no relief inside a single package — `mutatediff` drives
 gremlins once per package and cannot interrupt its internal mutant loop. For a


### PR DESCRIPTION
## What

`make mutate` filled the disk through the machine-shared GOCACHE, and the only shared-cache remedy (`go clean -cache`) destroys every session's warm builds; interrupted runs also left `gremlins-*`/`mutatediff-*` debris in system temp. mutatediff now pins a dedicated persistent GOCACHE (outside the repo — gremlins' unfiltered per-worker copy would haul an in-repo cache into every working copy) plus a per-run temp root, cleans both on success and failure, sweeps SIGKILL orphans at startup, and wipes the cache only past `MUTATE_GOCACHE_CAP` (MiB, default 4096, 0 = uncapped).

## Impact

None for CI — `mutate-baseline`'s `-coefficient`/`-merge` paths stay unsandboxed by design. Local `make mutate` pays a measured ~+10% after a cap wipe (7:07 cold vs 6:25 warm); the shared GOCACHE is no longer touched.

## Verification

Six on-chassis runs: isolation (3.0 GiB landed in the dedicated cache, shared cache +88 MB tool builds only), SIGINT mid-engine cleanup with result cache unpolluted, cap-fire wipe with gate verdict unaffected, and the timed cold/warm pair. `make mutate` structurally no-ops on this diff (`scripts/` is scope-excluded), so the sandbox unit tests plus that empirical set carry the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Mutation-testing runs now use isolated temporary workspaces and dedicated build caches.
  * Old run directories are cleaned up automatically.
  * Configurable cache size limits help prevent excessive disk usage.
  * Routine build commands preserve the machine-wide Go build cache.
  * Cleanup errors are reported instead of being silently ignored.
  * Improved compatibility for linting across prefixed worktree paths.

* **Documentation**
  * Added guidance on cache limits, sandboxing, cleanup behavior, and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->