### PR TITLE
feat(streams): publish to super streams by routing key

### DIFF
--- a/messaging/streams/declarations.go
+++ b/messaging/streams/declarations.go
@@ -39,10 +39,22 @@ type consumerKey struct {
 }
 
 // publisherDeclaration is one declared publisher and the handle its declaring
-// module holds. Manager.Start binds the handle to a client producer.
+// module holds. Manager.Start binds the handle to a client producer. Super marks
+// which of the two declare methods produced it, because the two publish through
+// different client APIs.
 type publisherDeclaration struct {
 	Stream    string
+	Super     bool
 	Publisher *Publisher
+}
+
+// streamKindLabel names a target the way the declaration that produced it did, so
+// a panic or a validation error speaks the caller's vocabulary.
+func streamKindLabel(super bool) string {
+	if super {
+		return "super stream"
+	}
+	return "stream"
 }
 
 // Stats summarizes a declaration store.
@@ -168,9 +180,9 @@ func (d *Declarations) DeclareSuperStreamConsumer(opts *SuperStreamConsumerOptio
 // registerConsumer stores a consumer declaration of either kind, rejecting a
 // duplicate (target, name) pair in the vocabulary of the method that produced it.
 func (d *Declarations) registerConsumer(decl *consumerDeclaration) {
-	method, label := "DeclareConsumer", "stream"
+	method := "DeclareConsumer"
 	if decl.Super {
-		method, label = "DeclareSuperStreamConsumer", "super stream"
+		method = "DeclareSuperStreamConsumer"
 	}
 
 	key := consumerKey{Stream: decl.Stream, Name: decl.Name}
@@ -179,7 +191,7 @@ func (d *Declarations) registerConsumer(decl *consumerDeclaration) {
 			"streams: duplicate consumer declaration detected\n"+
 				"  %s=%s name=%s\n"+
 				"  Ensure each %s call is unique within DeclareStreams",
-			label, decl.Stream, decl.Name, method,
+			streamKindLabel(decl.Super), decl.Stream, decl.Name, method,
 		))
 	}
 
@@ -191,6 +203,14 @@ func (d *Declarations) registerConsumer(decl *consumerDeclaration) {
 type PublisherOptions struct {
 	// Stream is the stream to publish to; it must be declared in the same Declarations.
 	Stream string
+}
+
+// SuperStreamPublisherOptions declares one super-stream publisher, which routes
+// each message to a partition by the murmur3 hash of its RoutingKey.
+type SuperStreamPublisherOptions struct {
+	// SuperStream is the super stream to publish to; it must be declared in the
+	// same Declarations.
+	SuperStream string
 }
 
 // DeclarePublisher registers a publisher on a plain stream and returns the handle
@@ -205,17 +225,44 @@ func (d *Declarations) DeclarePublisher(opts *PublisherOptions) *Publisher {
 		panic(nilDeclarationPanic("publisher", "DeclarePublisher", "PublisherOptions"))
 	}
 
-	if _, exists := d.publisherIndex[opts.Stream]; exists {
+	return d.registerPublisher(&publisherDeclaration{Stream: opts.Stream})
+}
+
+// DeclareSuperStreamPublisher registers a publisher across every partition of a
+// super stream and returns the handle to publish through. Panics on the same two
+// programming errors as DeclarePublisher.
+//
+// Every PublishMessage sent through the returned handle must carry a non-empty
+// RoutingKey: it is what picks the partition.
+func (d *Declarations) DeclareSuperStreamPublisher(opts *SuperStreamPublisherOptions) *Publisher {
+	if opts == nil {
+		panic(nilDeclarationPanic("publisher", "DeclareSuperStreamPublisher", "SuperStreamPublisherOptions"))
+	}
+
+	return d.registerPublisher(&publisherDeclaration{Stream: opts.SuperStream, Super: true})
+}
+
+// registerPublisher stores a publisher declaration of either kind, rejecting a
+// duplicate target in the vocabulary of the method that produced it, and returns
+// the handle its module publishes through. The two kinds share one index, so a
+// target already claimed by either method is a duplicate.
+func (d *Declarations) registerPublisher(decl *publisherDeclaration) *Publisher {
+	method := "DeclarePublisher"
+	if decl.Super {
+		method = "DeclareSuperStreamPublisher"
+	}
+
+	if _, exists := d.publisherIndex[decl.Stream]; exists {
 		panic(fmt.Sprintf(
 			"streams: duplicate publisher declaration detected\n"+
-				"  stream=%s\n"+
-				"  Ensure each DeclarePublisher call is unique within DeclareStreams",
-			opts.Stream,
+				"  %s=%s\n"+
+				"  Ensure each %s call is unique within DeclareStreams",
+			streamKindLabel(decl.Super), decl.Stream, method,
 		))
 	}
 
-	decl := &publisherDeclaration{Stream: opts.Stream, Publisher: newPublisher(opts.Stream)}
-	d.publisherIndex[opts.Stream] = decl
+	decl.Publisher = newPublisher(decl.Stream, decl.Super)
+	d.publisherIndex[decl.Stream] = decl
 	d.publishers = append(d.publishers, decl)
 	return decl.Publisher
 }
@@ -292,7 +339,7 @@ func (d *Declarations) publisherErrors() []error {
 	var errs []error
 	for _, p := range d.publishers {
 		if p.Stream == "" {
-			errs = append(errs, errors.New("publisher declaration has an empty stream name"))
+			errs = append(errs, fmt.Errorf("publisher declaration has an empty %s name", streamKindLabel(p.Super)))
 			continue
 		}
 		if err := d.publisherTargetError(p); err != nil {
@@ -302,17 +349,25 @@ func (d *Declarations) publisherErrors() []error {
 	return errs
 }
 
-// publisherTargetError checks that a publisher's target was declared, and
-// declared as a plain stream. A super stream is reached through a different
-// client API, so publishing to one as if it were plain cannot work.
+// publisherTargetError checks that a publisher's target was declared, and declared
+// as the kind the publisher publishes to it as. The two kinds reach the broker
+// through different client APIs, so publishing to one as the other cannot work.
 func (d *Declarations) publisherTargetError(p *publisherDeclaration) error {
-	if _, ok := d.streamIndex[p.Stream]; ok {
+	_, isStream := d.streamIndex[p.Stream]
+	_, isSuper := d.superStreamIndex[p.Stream]
+
+	switch {
+	case p.Super && isSuper, !p.Super && isStream:
 		return nil
+	case p.Super && isStream:
+		return fmt.Errorf("publisher publishes to %q as a super stream, but it is declared as a plain stream; use DeclarePublisher", p.Stream)
+	case !p.Super && isSuper:
+		return fmt.Errorf("publisher publishes to %q as a plain stream, but it is declared as a super stream; use DeclareSuperStreamPublisher", p.Stream)
+	case p.Super:
+		return fmt.Errorf("publisher references undeclared super stream %q", p.Stream)
+	default:
+		return fmt.Errorf("publisher references undeclared stream %q", p.Stream)
 	}
-	if _, ok := d.superStreamIndex[p.Stream]; ok {
-		return fmt.Errorf("publisher publishes to %q as a plain stream, but it is declared as a super stream", p.Stream)
-	}
-	return fmt.Errorf("publisher references undeclared stream %q", p.Stream)
 }
 
 // consumerTargetError checks that a consumer's target was declared, and declared

--- a/messaging/streams/declarations_test.go
+++ b/messaging/streams/declarations_test.go
@@ -621,16 +621,38 @@ func TestDeclarePublisherOnADifferentStreamIsAllowed(t *testing.T) {
 	require.NoError(t, d.Validate())
 }
 
-// TestValidateRejectsAMisdirectedPublisher pins the publisher's target rules: the
-// target has to exist, and it has to be a plain stream — a super stream is reached
-// through a different client API entirely.
+// declarePublisherOfKind declares a publisher through the method that matches the
+// kind under test, so one table can drive both.
+func declarePublisherOfKind(d *Declarations, target string, super bool) *Publisher {
+	if super {
+		return d.DeclareSuperStreamPublisher(&SuperStreamPublisherOptions{SuperStream: target})
+	}
+	return d.DeclarePublisher(&PublisherOptions{Stream: target})
+}
+
+// TestValidateRejectsAMisdirectedPublisher pins the publisher's target rules, and
+// in particular the four ways a publisher can name the wrong kind of target: the
+// two kinds reach the broker through different client APIs, so each mismatch names
+// the declare method that would have been right.
 func TestValidateRejectsAMisdirectedPublisher(t *testing.T) {
 	tests := []struct {
 		name    string
 		declare func(d *Declarations)
 		target  string
+		super   bool
 		wantErr string
 	}{
+		{
+			name:    "valid_plain_target",
+			declare: func(d *Declarations) { d.DeclareStream(testStream, nil) },
+			target:  testStream,
+		},
+		{
+			name:    "valid_super_target",
+			declare: func(d *Declarations) { d.DeclareSuperStream(testSuperStream, testPartitions, nil) },
+			target:  testSuperStream,
+			super:   true,
+		},
 		{
 			name:    "undeclared_target",
 			declare: func(*Declarations) {},
@@ -638,10 +660,24 @@ func TestValidateRejectsAMisdirectedPublisher(t *testing.T) {
 			wantErr: `publisher references undeclared stream "ghost"`,
 		},
 		{
-			name:    "super_stream_target",
+			name:    "undeclared_super_target",
+			declare: func(*Declarations) {},
+			target:  "ghost",
+			super:   true,
+			wantErr: `publisher references undeclared super stream "ghost"`,
+		},
+		{
+			name:    "plain_publisher_on_a_super_stream",
 			declare: func(d *Declarations) { d.DeclareSuperStream(testSuperStream, testPartitions, nil) },
 			target:  testSuperStream,
-			wantErr: "but it is declared as a super stream",
+			wantErr: `publisher publishes to "orders-partitioned" as a plain stream, but it is declared as a super stream; use DeclareSuperStreamPublisher`,
+		},
+		{
+			name:    "super_publisher_on_a_plain_stream",
+			declare: func(d *Declarations) { d.DeclareStream(testStream, nil) },
+			target:  testStream,
+			super:   true,
+			wantErr: `publisher publishes to "orders" as a super stream, but it is declared as a plain stream; use DeclarePublisher`,
 		},
 		{
 			name:    "empty_target",
@@ -649,16 +685,27 @@ func TestValidateRejectsAMisdirectedPublisher(t *testing.T) {
 			target:  "",
 			wantErr: "publisher declaration has an empty stream name",
 		},
+		{
+			name:    "empty_super_target",
+			declare: func(*Declarations) {},
+			target:  "",
+			super:   true,
+			wantErr: "publisher declaration has an empty super stream name",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := NewDeclarations()
 			tt.declare(d)
-			d.DeclarePublisher(&PublisherOptions{Stream: tt.target})
+			declarePublisherOfKind(d, tt.target, tt.super)
 
 			err := d.Validate()
 
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
@@ -677,4 +724,64 @@ func TestValidateReportsAnEmptyPublisherTargetOnce(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "publisher declaration has an empty stream name")
 	assert.NotContains(t, err.Error(), "references undeclared stream")
+}
+
+func TestDeclareSuperStreamPublisherReturnsAnUnboundHandle(t *testing.T) {
+	d := NewDeclarations()
+	d.DeclareSuperStream(testSuperStream, testPartitions, nil)
+
+	p := d.DeclareSuperStreamPublisher(&SuperStreamPublisherOptions{SuperStream: testSuperStream})
+
+	require.NotNil(t, p)
+	assert.Equal(t, testSuperStream, p.stream)
+	assert.True(t, p.super, "the handle knows its target is partitioned, which inverts the RoutingKey rule")
+	assert.False(t, d.IsEmpty())
+	assert.Equal(t, Stats{Streams: 1, SuperStreams: 1, Publishers: 1}, d.Stats())
+	require.NoError(t, d.Validate())
+	assert.ErrorIs(t,
+		p.Publish(context.Background(), &PublishMessage{Data: []byte("x"), RoutingKey: testRoutingKey}),
+		ErrPublisherNotStarted, "the handle stays inert until Manager.Start binds it")
+}
+
+func TestDeclareSuperStreamPublisherNilPanics(t *testing.T) {
+	d := NewDeclarations()
+
+	assert.PanicsWithValue(t,
+		"streams: nil publisher declaration detected\n"+
+			"  DeclareSuperStreamPublisher requires a non-nil *SuperStreamPublisherOptions\n"+
+			"  Pass &streams.SuperStreamPublisherOptions{...} at every DeclareSuperStreamPublisher call within DeclareStreams",
+		func() { d.DeclareSuperStreamPublisher(nil) })
+
+	assert.True(t, d.IsEmpty(), "the rejected declaration is not stored")
+}
+
+func TestDeclareSuperStreamPublisherDuplicatePanics(t *testing.T) {
+	d := NewDeclarations()
+	d.DeclareSuperStream(testSuperStream, testPartitions, nil)
+	d.DeclareSuperStreamPublisher(&SuperStreamPublisherOptions{SuperStream: testSuperStream})
+
+	assert.PanicsWithValue(t,
+		"streams: duplicate publisher declaration detected\n"+
+			"  super stream=orders-partitioned\n"+
+			"  Ensure each DeclareSuperStreamPublisher call is unique within DeclareStreams",
+		func() { d.DeclareSuperStreamPublisher(&SuperStreamPublisherOptions{SuperStream: testSuperStream}) })
+
+	assert.Equal(t, 1, d.Stats().Publishers, "the rejected declaration is not stored")
+}
+
+// TestDeclarePublisherAndSuperStreamPublisherShareTheDuplicateKey proves the two
+// declare methods index into one namespace, the same way the consumer pair does: a
+// target already claimed is a duplicate whichever method claimed it.
+func TestDeclarePublisherAndSuperStreamPublisherShareTheDuplicateKey(t *testing.T) {
+	d := NewDeclarations()
+	d.DeclareStream(testStream, nil)
+	d.DeclarePublisher(&PublisherOptions{Stream: testStream})
+
+	assert.PanicsWithValue(t,
+		"streams: duplicate publisher declaration detected\n"+
+			"  super stream=orders\n"+
+			"  Ensure each DeclareSuperStreamPublisher call is unique within DeclareStreams",
+		func() { d.DeclareSuperStreamPublisher(&SuperStreamPublisherOptions{SuperStream: testStream}) })
+
+	assert.Equal(t, 1, d.Stats().Publishers)
 }

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/ha"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/message"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
 	"go.opentelemetry.io/otel"
 
@@ -100,12 +101,14 @@ type Manager struct {
 	// is already gone.
 	flushBudget time.Duration
 
-	// newProducer constructs the client producer bindPublisher installs. Held as a
-	// field for the same reason as flushBudget, so a test can make construction
-	// fail: it dials, so no broker-free test could otherwise reach that path.
-	// Deliberately not a ManagerOptions field — an operator has no reason to
-	// substitute the client's own constructor.
-	newProducer producerFactory
+	// newProducer and newSuperProducer construct the client producer bindPublisher
+	// installs, one per declaration kind. Held as fields for the same reason as
+	// flushBudget, so a test can make construction fail: they dial, so no
+	// broker-free test could otherwise reach that path. Deliberately not
+	// ManagerOptions fields — an operator has no reason to substitute the client's
+	// own constructors.
+	newProducer      producerFactory
+	newSuperProducer superProducerFactory
 
 	mu         sync.Mutex
 	env        *stream.Environment
@@ -134,10 +137,11 @@ func NewManager(opts ManagerOptions) *Manager {
 		opts.OffsetStoreInterval = defaultOffsetStoreInterval
 	}
 	return &Manager{
-		opts:        opts,
-		log:         opts.Logger,
-		flushBudget: shutdownFlushBudget,
-		newProducer: newReliableProducer,
+		opts:             opts,
+		log:              opts.Logger,
+		flushBudget:      shutdownFlushBudget,
+		newProducer:      newReliableProducer,
+		newSuperProducer: newReliableSuperProducer,
 	}
 }
 
@@ -440,7 +444,7 @@ func (m *Manager) trackConsumer(decl *consumerDeclaration, handle consumerHandle
 func bindPublishers(ctx context.Context, decls []*publisherDeclaration, bind func(*publisherDeclaration) error) error {
 	for _, decl := range decls {
 		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("startup canceled before binding the publisher on stream %q: %w", decl.Stream, err)
+			return fmt.Errorf("startup canceled before binding the publisher on %s %q: %w", streamKindLabel(decl.Super), decl.Stream, err)
 		}
 		if err := bind(decl); err != nil {
 			return err
@@ -451,7 +455,7 @@ func bindPublishers(ctx context.Context, decls []*publisherDeclaration, bind fun
 		// nil into a Start that has no consumer loop left to notice — startConsumers
 		// checks ctx at the top of its body, which never runs with nothing declared.
 		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("startup canceled after binding the publisher on stream %q: %w", decl.Stream, err)
+			return fmt.Errorf("startup canceled after binding the publisher on %s %q: %w", streamKindLabel(decl.Super), decl.Stream, err)
 		}
 	}
 	return nil
@@ -459,9 +463,9 @@ func bindPublishers(ctx context.Context, decls []*publisherDeclaration, bind fun
 
 // bindPublisher constructs one client producer and hands it to its Publisher.
 func (m *Manager) bindPublisher(env *stream.Environment, decl *publisherDeclaration) error {
-	producer, err := m.newProducer(env, decl.Stream, decl.Publisher.confirmed)
+	producer, err := m.constructProducer(env, decl)
 	if err != nil {
-		return fmt.Errorf("failed to start the publisher on stream %q: %w", decl.Stream, err)
+		return fmt.Errorf("failed to start the publisher on %s %q: %w", streamKindLabel(decl.Super), decl.Stream, err)
 	}
 
 	decl.Publisher.bind(producer)
@@ -469,11 +473,49 @@ func (m *Manager) bindPublisher(env *stream.Environment, decl *publisherDeclarat
 
 	m.log.Info().
 		Str(logFieldStream, decl.Stream).
+		Bool("partitioned", decl.Super).
 		Msg("Stream publisher started")
 	return nil
 }
 
-// producerFactory constructs the client producer one publisher sends through.
+// constructProducer builds one declaration's client producer, on the client API
+// its kind requires.
+func (m *Manager) constructProducer(env *stream.Environment, decl *publisherDeclaration) (producerHandle, error) {
+	if decl.Super {
+		return m.newSuperProducer(env, decl.Stream, m.routingKeyExtractor(decl.Publisher), decl.Publisher.partitionsConfirmed)
+	}
+	return m.newProducer(env, decl.Stream, decl.Publisher.confirmed)
+}
+
+// routingKeyExtractor builds the hash-routing extractor of one super-stream
+// publisher: the client calls it inside its own Send to decide the partition, and
+// the answer is the key the caller registered with that exact message.
+//
+// It closes over m.log rather than reading a guarded field, for the reason spelled
+// out in startStreamConsumer: the client calls this from the sending goroutine,
+// outside m.mu, with no recover() in its call path. m.log is immutable after
+// NewManager, and the waiters map takes only its own lock.
+//
+// A miss cannot happen for a live send — the entry is removed only once the send
+// resolves, and a ctx expiry tombstones it precisely so a late route still finds
+// its key — so it means the correlation assumption broke and is reported at ERROR.
+// Returning "" then keeps the client from panicking; it does not pretend the
+// message landed where the caller asked.
+func (m *Manager) routingKeyExtractor(p *Publisher) func(message.StreamMessage) string {
+	return func(msg message.StreamMessage) string {
+		routingKey, ok := p.pending.routingKeyFor(msg)
+		if !ok {
+			m.log.Error().
+				Str(logFieldStream, p.stream).
+				Msg("No routing key registered for a super-stream message; it will be routed as if unkeyed")
+			return ""
+		}
+		return routingKey
+	}
+}
+
+// producerFactory constructs the client producer one plain-stream publisher sends
+// through.
 //
 // It is the constructor half of the producerHandle seam: producerHandle makes the
 // publish and confirmation policy testable without a broker, and this makes the
@@ -481,12 +523,30 @@ func (m *Manager) bindPublisher(env *stream.Environment, decl *publisherDeclarat
 // broker-free could otherwise reach the path where that fails.
 type producerFactory func(env *stream.Environment, streamName string, confirmed ha.ConfirmMessageHandler) (producerHandle, error)
 
+// superProducerFactory is the same seam for a super-stream publisher. It is a
+// separate type because the client's two reliable producers take neither the same
+// options nor the same confirmation shape: this one needs a routing strategy, and
+// confirms per partition.
+type superProducerFactory func(env *stream.Environment, superStream string,
+	routingKeyFor func(message.StreamMessage) string, confirmed ha.PartitionConfirmMessageHandler) (producerHandle, error)
+
 // newReliableProducer is the production factory. The producer options are the
 // client's defaults on purpose: deduplication, sub-entry batching and compression
 // are all deferred, and the default SubEntrySize of 1 is what makes the
 // confirmation's message pointer a valid correlation key.
 func newReliableProducer(env *stream.Environment, streamName string, confirmed ha.ConfirmMessageHandler) (producerHandle, error) {
 	return ha.NewReliableProducer(env, streamName, stream.NewProducerOptions(), confirmed)
+}
+
+// newReliableSuperProducer is the production factory for a super stream. Hash
+// routing is the only strategy offered: it is murmur3 with RabbitMQ's shared seed,
+// so a partition assignment made here matches what the Java, .NET and Python
+// clients compute for the same key. Key routing — which asks the broker to resolve
+// a key to partitions — is deferred.
+func newReliableSuperProducer(env *stream.Environment, superStream string,
+	routingKeyFor func(message.StreamMessage) string, confirmed ha.PartitionConfirmMessageHandler) (producerHandle, error) {
+	opts := stream.NewSuperStreamProducerOptions(stream.NewHashRoutingStrategy(routingKeyFor))
+	return ha.NewReliableSuperStreamProducer(env, superStream, opts, confirmed)
 }
 
 // envOffsetStorer commits one stream's offset through the environment's locator

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -544,7 +544,8 @@ func newReliableProducer(env *stream.Environment, streamName string, confirmed h
 // clients compute for the same key. Key routing — which asks the broker to resolve
 // a key to partitions — is deferred.
 func newReliableSuperProducer(env *stream.Environment, superStream string,
-	routingKeyFor func(message.StreamMessage) string, confirmed ha.PartitionConfirmMessageHandler) (producerHandle, error) {
+	routingKeyFor func(message.StreamMessage) string, confirmed ha.PartitionConfirmMessageHandler,
+) (producerHandle, error) {
 	opts := stream.NewSuperStreamProducerOptions(stream.NewHashRoutingStrategy(routingKeyFor))
 	return ha.NewReliableSuperStreamProducer(env, superStream, opts, confirmed)
 }

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/ha"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/message"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -96,6 +98,7 @@ const (
 	msgOffsetQueryFailed    = "Could not query the stored stream offset; attaching at a position that replays rather than skips"
 	msgFlushSkipped         = "Shutdown offset flush budget spent; offset not committed - handled messages will replay"
 	msgClosePublisherFailed = "Failed to close stream publisher"
+	msgRoutingKeyMissing    = "No routing key registered for a super-stream message; it will be routed as if unkeyed"
 )
 
 // recordingLogger captures each event's level, attached error and terminal
@@ -154,6 +157,20 @@ func (l *recordingLogger) warnStreams(msg string) []string {
 		}
 	}
 	return out
+}
+
+// fieldAt reports the string field key attached to the first event at level
+// carrying msg, so a test asserts WHICH subject a line named and not only that it
+// spoke.
+func (l *recordingLogger) fieldAt(level, msg, key string) string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, e := range l.events {
+		if e.level == level && e.msg == msg {
+			return e.fields[key]
+		}
+	}
+	return ""
 }
 
 // warnError reports the error text attached to the first WARN carrying msg. An
@@ -1145,7 +1162,7 @@ func TestManagerCloseEnvLockedIsIdempotent(t *testing.T) {
 
 // attachPublisher wires a fake producer into a manager as if Start had bound it.
 func attachPublisher(m *Manager, handle *fakeProducer) *Publisher {
-	return rebindPublisher(m, newPublisher(testStream), handle)
+	return rebindPublisher(m, newPublisher(testStream, false), handle)
 }
 
 // rebindPublisher binds an EXISTING publisher to a new producer, which is what a
@@ -1305,6 +1322,123 @@ func onePublisherDeclaration(t *testing.T) *publisherDeclaration {
 	decls := onePublisher(t)
 	require.Len(t, decls.publishers, 1)
 	return decls.publishers[0]
+}
+
+// oneSuperPublisherDeclaration is the same for a super-stream target, which binds
+// through the client's other producer constructor.
+func oneSuperPublisherDeclaration(t *testing.T) *publisherDeclaration {
+	t.Helper()
+	decls := NewDeclarations()
+	decls.DeclareSuperStream(testSuperStream, testPartitions, nil)
+	decls.DeclareSuperStreamPublisher(&SuperStreamPublisherOptions{SuperStream: testSuperStream})
+	require.Len(t, decls.publishers, 1)
+	return decls.publishers[0]
+}
+
+// unreachableProducer fails every construction, so a bind reaches its error path
+// without a broker.
+func unreachableProducer(*stream.Environment, string, ha.ConfirmMessageHandler) (producerHandle, error) {
+	return nil, errProducerConstruction
+}
+
+// unreachableSuperProducer is its super-stream twin.
+func unreachableSuperProducer(*stream.Environment, string, func(message.StreamMessage) string,
+	ha.PartitionConfirmMessageHandler) (producerHandle, error) {
+	return nil, errProducerConstruction
+}
+
+// TestManagerBindPublisherWrapsASuperConstructionFailure is the super-stream half
+// of the construction-failure path, and pins that the failure names the kind of
+// target the declaration asked for rather than calling every target a stream.
+func TestManagerBindPublisherWrapsASuperConstructionFailure(t *testing.T) {
+	m := testManager(t)
+	m.newProducer = unreachableProducer
+	m.newSuperProducer = unreachableSuperProducer
+	decl := oneSuperPublisherDeclaration(t)
+
+	err := m.bindPublisher(nil, decl)
+
+	require.ErrorIs(t, err, errProducerConstruction)
+	assert.Contains(t, err.Error(), `failed to start the publisher on super stream "`+testSuperStream+`"`)
+	assert.Empty(t, m.publishers)
+}
+
+// TestManagerBindPublisherBuildsASuperProducerForASuperTarget pins the dispatch: a
+// super declaration must reach the client's super-stream constructor, with a
+// routing extractor and the per-partition confirmation handler that constructor
+// requires. Binding it through the plain constructor would compile and then fail at
+// the broker, because a super stream is not a stream.
+func TestManagerBindPublisherBuildsASuperProducerForASuperTarget(t *testing.T) {
+	m := testManager(t)
+	m.newProducer = unreachableProducer // a plain bind here is the defect under test
+	handle := openProducer()
+	var gotStream string
+	var gotExtractor func(message.StreamMessage) string
+	var gotConfirmed ha.PartitionConfirmMessageHandler
+	m.newSuperProducer = func(_ *stream.Environment, superStream string,
+		routingKeyFor func(message.StreamMessage) string, confirmed ha.PartitionConfirmMessageHandler,
+	) (producerHandle, error) {
+		gotStream, gotExtractor, gotConfirmed = superStream, routingKeyFor, confirmed
+		return handle, nil
+	}
+	decl := oneSuperPublisherDeclaration(t)
+
+	require.NoError(t, m.bindPublisher(nil, decl))
+
+	assert.Equal(t, testSuperStream, gotStream, "the producer is built for the declared super stream")
+	require.NotNil(t, gotExtractor, "hash routing needs an extractor")
+	require.NotNil(t, gotConfirmed, "a super stream confirms per partition")
+	assert.Equal(t, []*Publisher{decl.Publisher}, m.publishers)
+	assert.Equal(t, ha.StatusOpen, decl.Publisher.status())
+}
+
+// TestManagerBindPublisherBuildsAPlainProducerForAPlainTarget is the other half of
+// that dispatch, and would fail if the two constructors were ever swapped.
+func TestManagerBindPublisherBuildsAPlainProducerForAPlainTarget(t *testing.T) {
+	m := testManager(t)
+	m.newSuperProducer = unreachableSuperProducer // a super bind here is the defect under test
+	handle := openProducer()
+	m.newProducer = func(*stream.Environment, string, ha.ConfirmMessageHandler) (producerHandle, error) {
+		return handle, nil
+	}
+
+	require.NoError(t, m.bindPublisher(nil, onePublisherDeclaration(t)))
+
+	require.Len(t, m.publishers, 1)
+	assert.Equal(t, ha.StatusOpen, m.publishers[0].status())
+}
+
+// TestManagerRoutingKeyExtractorAnswersTheRegisteredKey pins what the client asks
+// this for: the key the caller registered with that exact message, which is what
+// makes the partition assignment the caller's choice rather than a hash of "".
+func TestManagerRoutingKeyExtractorAnswersTheRegisteredKey(t *testing.T) {
+	log := &recordingLogger{}
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: log})
+	p := newPublisher(testSuperStream, true)
+	registered := amqp.NewMessage([]byte(testBody))
+	p.pending.add(registered, testRoutingKey)
+
+	key := m.routingKeyExtractor(p)(registered)
+
+	assert.Equal(t, testRoutingKey, key)
+	assert.Empty(t, log.messagesAt("error"), "a routed send is routine, not an incident")
+}
+
+// TestManagerRoutingKeyExtractorReportsAnUnregisteredMessage covers the miss the
+// tombstone lifecycle is supposed to make impossible: the extractor must not
+// panic the client's sending goroutine, and the operator has to hear about it,
+// because a miss means the correlation assumption broke.
+func TestManagerRoutingKeyExtractorReportsAnUnregisteredMessage(t *testing.T) {
+	log := &recordingLogger{}
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: log})
+	p := newPublisher(testSuperStream, true)
+
+	key := m.routingKeyExtractor(p)(amqp.NewMessage([]byte(testBody)))
+
+	assert.Empty(t, key)
+	assert.Equal(t, []string{msgRoutingKeyMissing}, log.messagesAt("error"))
+	assert.Equal(t, testSuperStream, log.fieldAt("error", msgRoutingKeyMissing, logFieldStream),
+		"the report names the publisher whose correlation broke")
 }
 
 // TestManagerStopClosesPublishersAfterConsumers pins the shutdown order. A

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -1343,7 +1343,8 @@ func unreachableProducer(*stream.Environment, string, ha.ConfirmMessageHandler) 
 
 // unreachableSuperProducer is its super-stream twin.
 func unreachableSuperProducer(*stream.Environment, string, func(message.StreamMessage) string,
-	ha.PartitionConfirmMessageHandler) (producerHandle, error) {
+	ha.PartitionConfirmMessageHandler,
+) (producerHandle, error) {
 	return nil, errProducerConstruction
 }
 

--- a/messaging/streams/publisher.go
+++ b/messaging/streams/publisher.go
@@ -157,9 +157,10 @@ func (ws *waiters) sweep(err error) {
 	clear(ws.m)
 }
 
-// Publisher publishes to one declared stream. It is obtained from
-// Declarations.DeclarePublisher at declaration time and is inert until
-// Manager.Start binds it to a client producer. Safe for concurrent use.
+// Publisher publishes to one declared stream or super stream. It is obtained from
+// Declarations.DeclarePublisher or DeclareSuperStreamPublisher at declaration time
+// and is inert until Manager.Start binds it to a client producer. Safe for
+// concurrent use.
 type Publisher struct {
 	stream string
 	// super marks a publisher whose target is a partitioned super stream, which
@@ -180,9 +181,10 @@ type Publisher struct {
 }
 
 // newPublisher builds the handle a declare method hands back to the module.
-func newPublisher(streamName string) *Publisher {
+func newPublisher(streamName string, super bool) *Publisher {
 	return &Publisher{
 		stream:   streamName,
+		super:    super,
 		tracer:   otel.Tracer(tracerName),
 		spanName: streamName + " " + spanOperationPublish,
 		spanStartOpts: []trace.SpanStartOption{
@@ -360,6 +362,27 @@ func (p *Publisher) confirmed(statuses []*stream.ConfirmationStatus) {
 		}
 		p.resolveConfirmation(cs.GetMessage(), cs.IsConfirmed(), cs.GetError())
 	}
+}
+
+// partitionsConfirmed is the super-stream half of confirmed: the client delivers
+// confirmations grouped by the partition each message was routed to, wrapping the
+// same status type the plain lane resolves.
+func (p *Publisher) partitionsConfirmed(confirms []*stream.PartitionPublishConfirm) {
+	p.confirmed(partitionStatuses(confirms))
+}
+
+// partitionStatuses flattens one batch of per-partition confirmations. Which
+// partition a message landed on is the routing strategy's business, not the
+// correlation's: a waiter is found by the message pointer alone.
+func partitionStatuses(confirms []*stream.PartitionPublishConfirm) []*stream.ConfirmationStatus {
+	var statuses []*stream.ConfirmationStatus
+	for _, confirm := range confirms {
+		if confirm == nil {
+			continue
+		}
+		statuses = append(statuses, confirm.ConfirmationStatus...)
+	}
+	return statuses
 }
 
 // resolveConfirmation settles one send from one broker confirmation. It is the

--- a/messaging/streams/publisher_test.go
+++ b/messaging/streams/publisher_test.go
@@ -107,17 +107,15 @@ func blockingProducer(t *testing.T) *fakeProducer {
 
 // boundPublisher builds the publisher a started manager would hand a module.
 func boundPublisher(handle producerHandle) *Publisher {
-	p := newPublisher(testStream)
+	p := newPublisher(testStream, false)
 	p.bind(handle)
 	return p
 }
 
 // boundSuperPublisher is the same for a super-stream target, whose routing rules
-// are the inverse. PR-scope note: no declare method produces one yet, so the
-// publish-side rules are exercised through the field the manager will set.
+// are the inverse.
 func boundSuperPublisher(handle producerHandle) *Publisher {
-	p := newPublisher(testSuperStream)
-	p.super = true
+	p := newPublisher(testSuperStream, true)
 	p.bind(handle)
 	return p
 }
@@ -286,14 +284,14 @@ func TestPublisherCloseReportsTheClientCloseError(t *testing.T) {
 // TestPublisherCloseWithoutABindingIsANoop covers a manager that aborts its start
 // before every publisher was bound.
 func TestPublisherCloseWithoutABindingIsANoop(t *testing.T) {
-	p := newPublisher(testStream)
+	p := newPublisher(testStream, false)
 
 	assert.NoError(t, p.closeBound())
 	assert.ErrorIs(t, p.Publish(context.Background(), &PublishMessage{Data: []byte(testBody)}), ErrPublisherClosed)
 }
 
 func TestPublisherPublishBeforeBindIsNotStarted(t *testing.T) {
-	p := newPublisher(testStream)
+	p := newPublisher(testStream, false)
 
 	err := p.Publish(context.Background(), &PublishMessage{Data: []byte(testBody)})
 
@@ -493,6 +491,43 @@ func TestPublisherConfirmedSkipsNilStatuses(t *testing.T) {
 	assert.Zero(t, pendingCount(p))
 }
 
+// TestPartitionStatusesFlattensEveryPartition pins the super-stream unwrapping: a
+// super producer confirms per partition, and every status inside every partition
+// has to reach the correlation — one dropped batch hangs its caller until close.
+func TestPartitionStatusesFlattensEveryPartition(t *testing.T) {
+	first, second, third := &stream.ConfirmationStatus{}, &stream.ConfirmationStatus{}, &stream.ConfirmationStatus{}
+
+	statuses := partitionStatuses([]*stream.PartitionPublishConfirm{
+		nil,
+		{Partition: testPartition0, ConfirmationStatus: []*stream.ConfirmationStatus{first}},
+		{Partition: testPartition1, ConfirmationStatus: []*stream.ConfirmationStatus{second, third}},
+	})
+
+	assert.Equal(t, []*stream.ConfirmationStatus{first, second, third}, statuses,
+		"every partition's statuses carry through, in order, and a nil batch is skipped")
+}
+
+// TestPublisherPartitionsConfirmedResolvesThroughTheSamePath proves a super
+// stream's confirmations land in the same correlation the plain lane uses.
+//
+// The client's ConfirmationStatus keeps its message in an unexported field, so a
+// broker-free test can only drive the nil one a zero value renders; the waiter is
+// registered under that same key, which is what makes the resolution observable.
+// The pointer correlation itself is proven against a broker in the integration suite.
+func TestPublisherPartitionsConfirmedResolvesThroughTheSamePath(t *testing.T) {
+	p := boundSuperPublisher(openProducer())
+	w := p.pending.add(nil, testRoutingKey)
+
+	p.partitionsConfirmed([]*stream.PartitionPublishConfirm{
+		{Partition: testPartition0, ConfirmationStatus: []*stream.ConfirmationStatus{{}}},
+	})
+
+	err := resolvedError(t, w)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), testSuperStream, "the failure names the publisher's own target")
+	assert.Zero(t, pendingCount(p), "a resolved send leaves no entry behind")
+}
+
 // TestPublisherRegisterSendResolvesASendThatRacedTheCloseSweep pins the window
 // the early closed check cannot cover: a close that completes — sweep included —
 // between a send's own closed check and its registration. The entry lands after
@@ -609,7 +644,7 @@ func TestPublisherBindingNamesWhyThereIsNoProducer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := newPublisher(testStream)
+			p := newPublisher(testStream, false)
 			tt.arrange(p)
 
 			bound, err := p.binding()

--- a/messaging/streams/streams.go
+++ b/messaging/streams/streams.go
@@ -45,8 +45,9 @@ type PublishMessage struct {
 	// copied, so the caller's own map is never written to.
 	Properties map[string]any
 	// RoutingKey selects the partition of a super stream (murmur3 hash — the
-	// RabbitMQ cross-client default). Leave it empty: every publisher this package
-	// hands out targets a plain stream, which rejects a non-empty key.
+	// RabbitMQ cross-client default). Required non-empty on a publisher declared
+	// with DeclareSuperStreamPublisher, and must be empty on one declared with
+	// DeclarePublisher, which targets a plain stream with no partitions to pick.
 	RoutingKey string
 }
 

--- a/messaging/streams/streams_integration_test.go
+++ b/messaging/streams/streams_integration_test.go
@@ -729,15 +729,116 @@ func hashPartitionIndex(t *testing.T, key string) int {
 	return slices.Index(names, routed[0])
 }
 
+// hashIndexByKey maps each routing key to the partition index the client's own
+// strategy picks for it, and reports how many distinct indices that is.
+func hashIndexByKey(t *testing.T, keys []string) (indexOf map[string]int, distinct int) {
+	t.Helper()
+
+	indexOf = make(map[string]int, len(keys))
+	seen := map[int]bool{}
+	for _, key := range keys {
+		indexOf[key] = hashPartitionIndex(t, key)
+		seen[indexOf[key]] = true
+	}
+	return indexOf, len(seen)
+}
+
+// publishKeyedBodies publishes perKey messages under each routing key and reports
+// the key every published body was sent with.
+func publishKeyedBodies(ctx context.Context, t *testing.T, publisher *Publisher, keys []string, perKey int) map[string]string {
+	t.Helper()
+
+	keyOf := make(map[string]string, len(keys)*perKey)
+	for _, key := range keys {
+		for i := range perKey {
+			body := fmt.Sprintf("%s-%d", key, i)
+			keyOf[body] = key
+
+			// The per-publish deadline is the latency bound: a confirmation that never
+			// arrived, or arrived correlated to the wrong message, surfaces here.
+			publishCtx, cancel := context.WithTimeout(ctx, itWaitTimeout)
+			err := publisher.Publish(publishCtx, &PublishMessage{Data: []byte(body), RoutingKey: key})
+			cancel()
+			require.NoError(t, err, "publish of %q must be confirmed by the broker", body)
+		}
+	}
+	return keyOf
+}
+
+// awaitBodies waits until every body reached the recorder. It gates on the bodies
+// themselves because a raw count is satisfied by duplicates.
+func awaitBodies(t *testing.T, r *recorder, want map[string]string) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		_, arrived := r.snapshot()
+		for body := range want {
+			if !slices.Contains(arrived, body) {
+				return false
+			}
+		}
+		return true
+	}, itWaitTimeout, itPollInterval, "every published message must reach the consumer")
+}
+
+// partitionByKey inverts the per-partition view into the partition each routing
+// key's messages arrived on, and counts how often each body arrived. A key whose
+// messages were split across partitions fails here.
+func partitionByKey(t *testing.T, r *recorder, keyOf map[string]string) (partitionOf map[string]string, arrivals map[string]int) {
+	t.Helper()
+
+	partitionOf = map[string]string{}
+	arrivals = make(map[string]int, len(keyOf))
+	_, perPartition := r.perStream()
+	for partition, bodies := range perPartition {
+		for _, body := range bodies {
+			arrivals[body]++
+			key, published := keyOf[body]
+			require.True(t, published, "an unpublished body arrived: %q", body)
+			if existing, seen := partitionOf[key]; seen {
+				require.Equal(t, existing, partition, "routing key %q was split across partitions", key)
+				continue
+			}
+			partitionOf[key] = partition
+		}
+	}
+	return partitionOf, arrivals
+}
+
+// assertArrivedExactlyOnce pins that the consumer saw each published body once.
+func assertArrivedExactlyOnce(t *testing.T, arrivals map[string]int, want int) {
+	t.Helper()
+
+	require.Len(t, arrivals, want, "every published message arrives")
+	for body, count := range arrivals {
+		assert.Equal(t, 1, count, "%q arrived more than once", body)
+	}
+}
+
+// assertHashGrouping asserts the grouping the broker produced is the grouping the
+// client's hash predicts: keys it sends to one index share a partition, and keys it
+// separates land apart.
+//
+// Comparing the GROUPING is the whole point, and is strictly stronger than "one key
+// lands on one partition": an extractor answering "" would satisfy the weaker check
+// trivially, because piling every message onto a single partition also keeps each
+// key together. It never compares partition NAMES, so it holds whatever order the
+// broker reports partitions in.
+func assertHashGrouping(t *testing.T, keys []string, indexOf map[string]int, partitionOf map[string]string) {
+	t.Helper()
+
+	for _, a := range keys {
+		for _, b := range keys {
+			assert.Equal(t, indexOf[a] == indexOf[b], partitionOf[a] == partitionOf[b],
+				"keys %q and %q are grouped differently than the client's hash routes them", a, b)
+		}
+	}
+}
+
 // TestStreamsSuperStreamPublisherPartitionsIntegration is the super-stream half of
 // the publish proof: every message is confirmed and consumed exactly once, and the
-// partition a message lands on is decided by its RoutingKey.
-//
-// The grouping assertion is what an extractor answering "" would fail — every
-// message would pile onto one partition, so keys the hash separates would stop
-// being separated. It compares which keys share a partition against which keys the
-// client's own strategy sends to one index, never partition names, so it holds
-// whatever order the broker reports partitions in.
+// partition a message lands on is decided by its RoutingKey — see
+// assertHashGrouping for why that last part is asserted as a grouping.
 func TestStreamsSuperStreamPublisherPartitionsIntegration(t *testing.T) {
 	ctx := context.Background()
 	opts := streamsTestEnv(ctx, t)
@@ -763,70 +864,16 @@ func TestStreamsSuperStreamPublisherPartitionsIntegration(t *testing.T) {
 	assert.True(t, m.Ready(), "a bound super-stream publisher counts towards readiness")
 
 	keys := []string{"customer-a", "customer-b", "customer-c", "customer-d", "customer-e", "customer-f"}
-	indexOf := make(map[string]int, len(keys))
-	distinct := map[int]bool{}
-	for _, key := range keys {
-		indexOf[key] = hashPartitionIndex(t, key)
-		distinct[indexOf[key]] = true
-	}
-	require.Greater(t, len(distinct), 1,
+	indexOf, distinct := hashIndexByKey(t, keys)
+	require.Greater(t, distinct, 1,
 		"the chosen routing keys must not all hash to one partition, or routing everything to one would pass")
 
-	const perKey = 3
-	keyOf := make(map[string]string, len(keys)*perKey)
-	for _, key := range keys {
-		for i := range perKey {
-			body := fmt.Sprintf("%s-%d", key, i)
-			keyOf[body] = key
+	keyOf := publishKeyedBodies(ctx, t, publisher, keys, 3)
+	awaitBodies(t, received, keyOf)
 
-			// The per-publish deadline is the latency bound: a confirmation that never
-			// arrived, or arrived correlated to the wrong message, surfaces here.
-			publishCtx, cancel := context.WithTimeout(ctx, itWaitTimeout)
-			err := publisher.Publish(publishCtx, &PublishMessage{Data: []byte(body), RoutingKey: key})
-			cancel()
-			require.NoError(t, err, "publish of %q must be confirmed by the broker", body)
-		}
-	}
-
-	// Gate on the bodies themselves: a raw count is satisfied by duplicates.
-	require.Eventually(t, func() bool {
-		_, arrived := received.snapshot()
-		for body := range keyOf {
-			if !slices.Contains(arrived, body) {
-				return false
-			}
-		}
-		return true
-	}, itWaitTimeout, itPollInterval, "every published message must reach the consumer")
-
-	// Invert the per-partition view into the partition each key's messages arrived on.
-	partitionOf := make(map[string]string, len(keys))
-	arrivals := make(map[string]int, len(keyOf))
-	_, perPartition := received.perStream()
-	for partition, bodies := range perPartition {
-		for _, body := range bodies {
-			arrivals[body]++
-			key, published := keyOf[body]
-			require.True(t, published, "an unpublished body arrived: %q", body)
-			if existing, seen := partitionOf[key]; seen {
-				require.Equal(t, existing, partition, "routing key %q was split across partitions", key)
-				continue
-			}
-			partitionOf[key] = partition
-		}
-	}
-
-	require.Len(t, arrivals, len(keyOf), "every published message arrives")
-	for body, count := range arrivals {
-		assert.Equal(t, 1, count, "%q arrived more than once", body)
-	}
-
-	for _, a := range keys {
-		for _, b := range keys {
-			assert.Equal(t, indexOf[a] == indexOf[b], partitionOf[a] == partitionOf[b],
-				"keys %q and %q are grouped differently than the client's hash routes them", a, b)
-		}
-	}
+	partitionOf, arrivals := partitionByKey(t, received, keyOf)
+	assertArrivedExactlyOnce(t, arrivals, len(keyOf))
+	assertHashGrouping(t, keys, indexOf, partitionOf)
 }
 
 // TestStreamsPublisherRejectedAfterStopIntegration pins the shutdown contract

--- a/messaging/streams/streams_integration_test.go
+++ b/messaging/streams/streams_integration_test.go
@@ -711,6 +711,124 @@ func TestStreamsPublisherRoundTripIntegration(t *testing.T) {
 	}
 }
 
+// hashPartitionIndex is the partition index the client's own murmur3 strategy
+// picks for a routing key. It is computed over placeholder partition names, so it
+// depends on the key alone and not on the order the broker reports the real
+// partitions in — which is what lets a test compare GROUPINGS rather than names.
+func hashPartitionIndex(t *testing.T, key string) int {
+	t.Helper()
+
+	names := make([]string, itPartitions)
+	for i := range names {
+		names[i] = fmt.Sprintf("p%d", i)
+	}
+	routed, err := stream.NewHashRoutingStrategy(func(message.StreamMessage) string { return key }).
+		Route(amqp.NewMessage(nil), names)
+	require.NoError(t, err)
+	require.Len(t, routed, 1)
+	return slices.Index(names, routed[0])
+}
+
+// TestStreamsSuperStreamPublisherPartitionsIntegration is the super-stream half of
+// the publish proof: every message is confirmed and consumed exactly once, and the
+// partition a message lands on is decided by its RoutingKey.
+//
+// The grouping assertion is what an extractor answering "" would fail — every
+// message would pile onto one partition, so keys the hash separates would stop
+// being separated. It compares which keys share a partition against which keys the
+// client's own strategy sends to one index, never partition names, so it holds
+// whatever order the broker reports partitions in.
+func TestStreamsSuperStreamPublisherPartitionsIntegration(t *testing.T) {
+	ctx := context.Background()
+	opts := streamsTestEnv(ctx, t)
+
+	received := &recorder{failAt: -1}
+
+	decls := NewDeclarations()
+	decls.DeclareSuperStream(itSuperStream, itPartitions, &StreamSpec{MaxLengthBytes: 10 * 1024 * 1024})
+	decls.DeclareSuperStreamConsumer(&SuperStreamConsumerOptions{
+		SuperStream: itSuperStream,
+		Name:        itSuperGroup,
+		Start:       OffsetFirst(),
+		Handler:     received.handle,
+	})
+	publisher := decls.DeclareSuperStreamPublisher(&SuperStreamPublisherOptions{SuperStream: itSuperStream})
+	require.NoError(t, decls.Validate())
+
+	m := NewManager(opts)
+	require.NoError(t, m.Start(ctx, decls))
+	t.Cleanup(func() { stopManager(t, m) })
+
+	assert.Equal(t, 1, m.Stats()["publishers"])
+	assert.True(t, m.Ready(), "a bound super-stream publisher counts towards readiness")
+
+	keys := []string{"customer-a", "customer-b", "customer-c", "customer-d", "customer-e", "customer-f"}
+	indexOf := make(map[string]int, len(keys))
+	distinct := map[int]bool{}
+	for _, key := range keys {
+		indexOf[key] = hashPartitionIndex(t, key)
+		distinct[indexOf[key]] = true
+	}
+	require.Greater(t, len(distinct), 1,
+		"the chosen routing keys must not all hash to one partition, or routing everything to one would pass")
+
+	const perKey = 3
+	keyOf := make(map[string]string, len(keys)*perKey)
+	for _, key := range keys {
+		for i := range perKey {
+			body := fmt.Sprintf("%s-%d", key, i)
+			keyOf[body] = key
+
+			// The per-publish deadline is the latency bound: a confirmation that never
+			// arrived, or arrived correlated to the wrong message, surfaces here.
+			publishCtx, cancel := context.WithTimeout(ctx, itWaitTimeout)
+			err := publisher.Publish(publishCtx, &PublishMessage{Data: []byte(body), RoutingKey: key})
+			cancel()
+			require.NoError(t, err, "publish of %q must be confirmed by the broker", body)
+		}
+	}
+
+	// Gate on the bodies themselves: a raw count is satisfied by duplicates.
+	require.Eventually(t, func() bool {
+		_, arrived := received.snapshot()
+		for body := range keyOf {
+			if !slices.Contains(arrived, body) {
+				return false
+			}
+		}
+		return true
+	}, itWaitTimeout, itPollInterval, "every published message must reach the consumer")
+
+	// Invert the per-partition view into the partition each key's messages arrived on.
+	partitionOf := make(map[string]string, len(keys))
+	arrivals := make(map[string]int, len(keyOf))
+	_, perPartition := received.perStream()
+	for partition, bodies := range perPartition {
+		for _, body := range bodies {
+			arrivals[body]++
+			key, published := keyOf[body]
+			require.True(t, published, "an unpublished body arrived: %q", body)
+			if existing, seen := partitionOf[key]; seen {
+				require.Equal(t, existing, partition, "routing key %q was split across partitions", key)
+				continue
+			}
+			partitionOf[key] = partition
+		}
+	}
+
+	require.Len(t, arrivals, len(keyOf), "every published message arrives")
+	for body, count := range arrivals {
+		assert.Equal(t, 1, count, "%q arrived more than once", body)
+	}
+
+	for _, a := range keys {
+		for _, b := range keys {
+			assert.Equal(t, indexOf[a] == indexOf[b], partitionOf[a] == partitionOf[b],
+				"keys %q and %q are grouped differently than the client's hash routes them", a, b)
+		}
+	}
+}
+
 // TestStreamsPublisherRejectedAfterStopIntegration pins the shutdown contract
 // against a real broker: once the manager stopped, the publisher refuses rather
 // than publishing into an environment about to be disposed.

--- a/wiki/adr_059_streams_consumption.md
+++ b/wiki/adr_059_streams_consumption.md
@@ -2,7 +2,7 @@
 
 - **Status**: Accepted
 - **Date**: 2026-08-12
-- **Related**: ADR-058 (the AMQP stream-queue lane and the two-lane framing), [ADR-040](adr_040_declaration_args_passthrough.md) (declaration args reach the broker), [ADR-045](adr_045_no_producer_side_manager_interfaces.md) (no exported manager interface), [ADR-041](adr_041_shared_ledger_tenancy.md) (single-tenant fail-fast precedent)
+- **Related**: ADR-058 (the AMQP stream-queue lane and the two-lane framing), [ADR-040](adr_040_declaration_args_passthrough.md) (declaration args reach the broker), [ADR-045](adr_045_no_producer_side_manager_interfaces.md) (no exported manager interface), [ADR-041](adr_041_shared_ledger_tenancy.md) (single-tenant fail-fast precedent), [ADR-063](adr_063_streams_native_publishing.md) (native publishing, which lifts the consume-only scope below)
 
 > **Amended (2026-08-13):** super streams, listed below as the third thing the
 > AMQP lane cannot do, are now implemented in this lane. The amendment settles
@@ -253,7 +253,9 @@ broker flap would be worse than the flap.
 
 ## Future work
 
-- Native publishing (must reuse this manager's Environment).
+- ~~Native publishing (must reuse this manager's Environment).~~ Done — see
+  [ADR-063](adr_063_streams_native_publishing.md), which reuses this Environment as
+  required and supersedes the "Consume only; publishing stays out" section above.
 - Multi-tenant fan-out: per-tenant Environments plus a stream-URI leg on the
   resource source; remove the `single-tenant only` fail-fast then.
 - Parking failed messages instead of skipping them.

--- a/wiki/adr_063_streams_native_publishing.md
+++ b/wiki/adr_063_streams_native_publishing.md
@@ -33,9 +33,11 @@ producer.
 
 ### The surface is synchronous and confirmed, and nothing else
 
-`Publisher.Publish(ctx, *PublishMessage) error` blocks until the broker confirms the message, the
-caller's context expires, or the publisher closes. There is no async callback surface and no
-fire-and-forget mode.
+`Publisher.Publish(ctx, *PublishMessage) error` rejects a malformed call outright — a nil message, a
+routing key that does not match the target kind, a publisher not yet bound or already closed — and
+otherwise blocks until one of four things happens: the broker confirms the message, the client's
+`Send` fails synchronously, the caller's context expires, or the publisher closes. There is no async
+callback surface and no fire-and-forget mode.
 
 That follows directly from the second context point: since a `nil` from the client's `Send` is
 compatible with a write that failed, the **confirmation is the only truth available**. A surface
@@ -53,12 +55,20 @@ Each in-flight send registers a waiter keyed by the `message.StreamMessage` hand
 so pointer identity is a valid correlation key and no framework-side sequence number, header or
 publishing ID is needed.
 
-This holds **only at the client's default `SubEntrySize` of 1**. Sub-entry aggregation would batch
-several messages behind one entry and break the one-to-one mapping, so the production producer
-options are the client's defaults verbatim — no `Name`, no `SubEntrySize`, no compression. That is
-not an oversight to be tuned later: it is a precondition of the correlation, and changing it means
-revisiting this decision. `messaging/streams/manager.go`'s `newReliableProducer` carries the note at
-the call site.
+This holds **only at the client's default `SubEntrySize` of 1** (`producer.go:219`). Sub-entry
+aggregation would batch several messages behind one entry and break the one-to-one mapping, so on the
+plain lane the production producer options are the client's defaults verbatim — no `Name`, no
+`SubEntrySize`, no compression — and `messaging/streams/manager.go`'s `newReliableProducer` carries
+that note at the call site.
+
+The super lane reaches the same guarantee by a different route, which is worth stating because the
+framework cannot state it directly: `SuperStreamProducerOptions` has no `SubEntrySize` field at all,
+and each partition's producer is built inside the client by `SuperStreamProducer.ConnectPartition`,
+which calls `NewProducerOptions()` itself (`super_stream_producer.go:267`). The default therefore
+holds per partition — but it is the client's own construction holding it, not anything this framework
+passes, so a change there would break the correlation with nothing on our side to notice. Either way
+this is not an oversight to be tuned later: it is a precondition of the correlation, and changing it
+means revisiting this decision.
 
 The correlation is proven end to end against a real broker rather than argued
 (`TestStreamsPublisherRoundTripIntegration`): if `GetMessage` ever stopped returning the message
@@ -72,17 +82,21 @@ bound on **how long `Publish` waits** — the framework adds no timeout of its o
 for one. It does not bound the send behind that wait: the goroutine runs on until the client's own
 send path unblocks, whatever the caller's context did.
 
-Abandoning that goroutine leaks it for as long as the reconnect lasts. This is the same trade
+Abandoning that goroutine leaks it until the client's send path releases it: during a reconnect that
+is as long as the reconnect lasts, but on the close path it can be permanent — see the close sweep
+below for why the broadcast that would release it never arrives. This is the same trade
 `Manager.flushOffsetsLocked` already documents and accepts: a leaked goroutine parked on a vendor
 condition variable is cheaper than a handler thread that cannot be interrupted, and the alternative —
 bounding a call that accepts neither context nor deadline — means reimplementing the client.
 
 ### A context expiry tombstones the correlation entry; it never removes it
 
-An entry leaves the map on exactly one of three events: its confirmation arrives, its `Send` returned
-a synchronous error (which the client never confirms), or the close sweep resolves it. **A context
-expiry does none of those.** It marks the waiter done, so the eventual confirmation resolves to a
-no-op, and leaves the entry in place.
+An entry leaves the map on exactly one of four events: its confirmation arrives, its `Send` returned a
+synchronous error (which the client never confirms), the close sweep resolves it, or — in the one race
+the sweep cannot cover — the send sees `closed` at registration and resolves itself, which is what
+stops an entry landing *after* the sweep from sitting outside every removal path. **A context expiry
+does none of those.** It marks the waiter done, so the eventual confirmation resolves to a no-op, and
+leaves the entry in place.
 
 That asymmetry is load-bearing for super streams. `HashRoutingStrategy.Route` is the first statement
 of the inner `SuperStreamProducer.Send`, but `isReadyToSend` parks the goroutine *before* it — so an
@@ -95,10 +109,10 @@ routed yet.
 
 A context-abandoned send holds both its goroutine and its tombstoned entry until the publisher closes,
 and **nothing caps how many of those can accumulate.** The client's `QueueSize` back-pressure does not:
-`isReadyToSend` parks in the `ha` layer (`reliable_common.go:114`) *before* `ReliableProducer.Send`
-delegates to the inner `stream.Producer` where that queue lives (`ha_publisher.go:116-120`), so a
-parked send never occupies queue capacity and never exerts back-pressure. The real bound is the
-caller's publish rate multiplied by the outage duration.
+`isReadyToSend` parks in the `ha` layer on a bare cond wait (`reliable_common.go:114`, the `Wait` at
+`:126`) *before* `ReliableProducer.Send` delegates to the inner `stream.Producer` where that queue
+lives (`ha_publisher.go:116-120`), so a parked send never occupies queue capacity and never exerts
+back-pressure. The real bound is the caller's publish rate multiplied by the outage duration.
 
 This is accepted for v1 rather than solved. The fix is an **outstanding-send limit** — a semaphore
 admitting N in-flight sends and failing the rest fast with a dedicated sentinel — which needs both
@@ -118,10 +132,11 @@ first, publishers close after them, because a handler may publish on its way out
 ### Closing sweeps every outstanding waiter with `ErrPublisherClosed`
 
 `Publisher` close resolves and removes every entry still in the map. This is mandatory, not
-belt-and-braces. The client's `entityClosed` confirmations (`producer.go:381-392`) cover only messages
-that reached its internal queue; a send parked in `isReadyToSend` was never enqueued and gets no
+belt-and-braces. The client's `entityClosed` confirmations (`markUnsentAsUnconfirmed`,
+`producer.go:374-395`) cover only messages that reached its internal queue; a send parked in
+`isReadyToSend` was never enqueued and gets no
 confirmation at all — and the super producer's normal-close path `break`s out of its event loop
-*before* the reconnection broadcast (`ha_super_stream_publisher.go:92-96`), so that goroutine may stay
+*before* the reconnection broadcast (`ha_super_stream_publisher.go:91-94`), so that goroutine may stay
 parked for good. Without the sweep, a `Publish` caller with no deadline of its own hangs across the
 whole shutdown. Resolution is idempotent, so a late `entityClosed` for a swept message is a no-op.
 
@@ -168,8 +183,13 @@ That context bounds how long `Publish` makes its caller wait; it does not bound 
 which is the known limitation above.
 
 **Negative — the wait is only as bounded as the caller's context.** A caller that passes
-`context.Background()` to `Publish` can wait for as long as the broker takes. Handler code inherits
-the HTTP layer's 5 s deadline and is fine; background work must pass a deadline of its own.
+`context.Background()` to `Publish` can wait for as long as the broker takes. Only an HTTP handler
+inherits a deadline for free — `server.timeout.middleware`, 5 s by default. Every other caller this
+lane attracts carries none: a stream consumer handler runs under `consumeContext`
+(`manager.go:249-251`), which is `context.WithCancel(context.WithoutCancel(ctx))` and therefore has no
+deadline at all, and scheduled jobs and relays are the same. A consumer republishing downstream is the
+likeliest publisher on this lane and the one with nothing to inherit, so it must pass a deadline of
+its own.
 
 **Negative — the correlation is a vendor-internal guarantee.** It rests on `ConfirmationStatus`
 returning the exact message pointer at `SubEntrySize = 1`. A client upgrade must re-verify that, and

--- a/wiki/adr_063_streams_native_publishing.md
+++ b/wiki/adr_063_streams_native_publishing.md
@@ -89,9 +89,22 @@ context expiry would answer `""`, hash it, and pile that message onto whichever 
 string lands on. Keeping the entry keeps the caller's partition choice intact for a send that has not
 routed yet.
 
-The cost is bounded and stated: a context-abandoned send whose broker never answers holds its
-tombstoned entry until the publisher closes. The map is otherwise unbounded by design, since the
-client's own `QueueSize` back-pressure bounds how many sends can be in flight.
+### Known limitation: outstanding sends are unbounded during a reconnect
+
+A context-abandoned send holds both its goroutine and its tombstoned entry until the publisher closes,
+and **nothing caps how many of those can accumulate.** The client's `QueueSize` back-pressure does not:
+`isReadyToSend` parks in the `ha` layer (`reliable_common.go:114`) *before* `ReliableProducer.Send`
+delegates to the inner `stream.Producer` where that queue lives (`ha_publisher.go:116-120`), so a
+parked send never occupies queue capacity and never exerts back-pressure. The real bound is the
+caller's publish rate multiplied by the outage duration.
+
+This is accepted for v1 rather than solved. The fix is an **outstanding-send limit** — a semaphore
+admitting N in-flight sends and failing the rest fast with a dedicated sentinel — which needs both
+that new error and a way to configure N, and v1 deliberately adds no configuration keys. It is listed
+under future work below. Until it exists, a service that publishes at high rate on a path with no
+deadline of its own is the shape to watch during a broker outage; the mitigations available today are
+a per-publish deadline (which caps how long each send waits, not how many accumulate) and alerting on
+the publish-error rate.
 
 ### Publishers bind before consumers start
 
@@ -158,14 +171,20 @@ the HTTP layer's 5 s deadline and is fine; background work must pass a deadline 
 returning the exact message pointer at `SubEntrySize = 1`. A client upgrade must re-verify that, and
 the integration round trip is what fails loudly if it ever stops holding.
 
-**Negative — abandoned sends leak a goroutine and hold a map entry.** Both are bounded by the
-publisher's lifetime and both are the accepted price of a vendor call that cannot be interrupted.
+**Negative — abandoned sends leak a goroutine and hold a map entry, with no cap on how many.** Both
+live until the publisher closes, and `QueueSize` does not bound them because a parked send never
+reaches the queue — see the known limitation above. That is the accepted price of a vendor call that
+cannot be interrupted, and an outstanding-send limit is the named follow-up.
 
 **Neutral — one publisher per target per process.** A second declaration on the same stream panics at
 startup, matching the consumer contract: it is a wiring mistake, not a fan-out.
 
 ## Future work
 
+- An **outstanding-send limit**: a semaphore admitting N in-flight sends and failing the rest with a
+  dedicated sentinel, so a broker outage cannot accumulate abandoned goroutines and tombstoned entries
+  without bound. Deferred out of v1 because it needs a new error sentinel and a configuration key, and
+  v1 adds none.
 - Producer-side deduplication, key routing, sub-entry batching and compression (see above).
 - Outbox integration, so transactionally recorded events can be relayed to a stream.
 - Multi-tenant fan-out, which publishing inherits from ADR-059's `single-tenant only` fail-fast.

--- a/wiki/adr_063_streams_native_publishing.md
+++ b/wiki/adr_063_streams_native_publishing.md
@@ -1,0 +1,182 @@
+# ADR-063: Native stream publishing is synchronous and confirmed, correlated by message pointer
+
+- **Status**: Accepted
+- **Date**: 2026-08-15
+- **Related**: [ADR-059](adr_059_streams_consumption.md) (the consume side, whose Environment this reuses), [ADR-058](adr_058_consumer_scoped_amqp_arguments.md) (the AMQP stream-queue lane), [ADR-045](adr_045_no_producer_side_manager_interfaces.md) (no exported manager interface), [ADR-033](adr_033_outbox_retry_count_status_parking.md) (bounded publish on the AMQP lane)
+
+## Context
+
+[ADR-059](adr_059_streams_consumption.md) added `messaging/streams` for **consumption only** and
+named native publishing as future work with one hard constraint: *"it must reuse the Environment
+this manager owns, not open a second connection path."* Until now a service that consumed a stream
+natively still had to publish to it through the AMQP lane (an exchange bound to a stream queue) or
+hand-roll a second client — and a super stream over AMQP is N unrelated queues with no partition
+routing at all.
+
+The client this lane already depends on (`rabbitmq-stream-go-client` v1.8.3) offers producers, but
+its publish path has two properties that decide the whole design:
+
+- **`Send` is asynchronous, and its error return proves nothing.** `checkWriteError`
+  (`pkg/ha/reliable_common.go`) swallows every write error except `FrameTooLarge`, returning `nil`
+  after a 500 ms sleep. A message is enqueued into client-side batching and confirmed later, out of
+  band, on a callback.
+- **`Send` can block without bound.** `isReadyToSend` does a bare `sync.Cond.Wait()` with no timeout
+  while the producer's status is `StatusReconnecting`, so a broker outage can park a caller
+  indefinitely.
+
+## Decision
+
+Add a publish surface to `messaging/streams`, on the Environment `Manager` already owns. Two declare
+methods return an inert handle at declaration time — `DeclarePublisher` for a plain stream,
+`DeclareSuperStreamPublisher` for a partitioned one — and `Manager.Start` binds each to a client
+producer.
+
+### The surface is synchronous and confirmed, and nothing else
+
+`Publisher.Publish(ctx, *PublishMessage) error` blocks until the broker confirms the message, the
+caller's context expires, or the publisher closes. There is no async callback surface and no
+fire-and-forget mode.
+
+That follows directly from the second context point: since a `nil` from the client's `Send` is
+compatible with a write that failed, the **confirmation is the only truth available**. A surface
+that returned after `Send` would be reporting success it cannot observe. Making the confirmation the
+return value puts the one fact the client can actually establish in the one place a caller cannot
+ignore it.
+
+A context expiry is **not** proof of failure: the send may still be in flight and may still land.
+Delivery stays at-least-once, exactly as on the consume side, and consumers must be idempotent.
+
+### Confirmations are correlated by message pointer, which requires `SubEntrySize = 1`
+
+Each in-flight send registers a waiter keyed by the `message.StreamMessage` handed to `Send`.
+`ConfirmationStatus.GetMessage()` returns that exact value (`producer.go:386` stores `ps.sourceMsg`),
+so pointer identity is a valid correlation key and no framework-side sequence number, header or
+publishing ID is needed.
+
+This holds **only at the client's default `SubEntrySize` of 1**. Sub-entry aggregation would batch
+several messages behind one entry and break the one-to-one mapping, so the production producer
+options are the client's defaults verbatim — no `Name`, no `SubEntrySize`, no compression. That is
+not an oversight to be tuned later: it is a precondition of the correlation, and changing it means
+revisiting this decision. `messaging/streams/manager.go`'s `newReliableProducer` carries the note at
+the call site.
+
+The correlation is proven end to end against a real broker rather than argued
+(`TestStreamsPublisherRoundTripIntegration`): if `GetMessage` ever stopped returning the message
+passed to `Send`, no waiter would resolve and every publish in that test would fail on its deadline.
+
+### The send runs on a goroutine the caller is willing to abandon
+
+Because `isReadyToSend` can park forever, `Publish` dispatches `handle.Send` on its own goroutine and
+selects between the waiter's channel and `ctx.Done()`. The caller's context is therefore the only
+bound on a publish — the framework adds no timeout of its own and no config key for one.
+
+Abandoning that goroutine leaks it for as long as the reconnect lasts. This is the same trade
+`Manager.flushOffsetsLocked` already documents and accepts: a leaked goroutine parked on a vendor
+condition variable is cheaper than a handler thread that cannot be interrupted, and the alternative —
+bounding a call that accepts neither context nor deadline — means reimplementing the client.
+
+### A context expiry tombstones the correlation entry; it never removes it
+
+An entry leaves the map on exactly one of three events: its confirmation arrives, its `Send` returned
+a synchronous error (which the client never confirms), or the close sweep resolves it. **A context
+expiry does none of those.** It marks the waiter done, so the eventual confirmation resolves to a
+no-op, and leaves the entry in place.
+
+That asymmetry is load-bearing for super streams. `HashRoutingStrategy.Route` is the first statement
+of the inner `SuperStreamProducer.Send`, but `isReadyToSend` parks the goroutine *before* it — so an
+abandoned send can ask for its routing key long after the caller gave up. Removing the entry on
+context expiry would answer `""`, hash it, and pile that message onto whichever partition the empty
+string lands on. Keeping the entry keeps the caller's partition choice intact for a send that has not
+routed yet.
+
+The cost is bounded and stated: a context-abandoned send whose broker never answers holds its
+tombstoned entry until the publisher closes. The map is otherwise unbounded by design, since the
+client's own `QueueSize` back-pressure bounds how many sends can be in flight.
+
+### Publishers bind before consumers start
+
+`Manager.Start` binds every declared publisher after the stream declarations and **before** it starts
+any consumer. A consumer handler may publish from its very first delivery, and an unbound publisher
+rejects that with `ErrPublisherNotStarted`. Shutdown runs the same order in reverse: consumers stop
+first, publishers close after them, because a handler may publish on its way out.
+
+### Closing sweeps every outstanding waiter with `ErrPublisherClosed`
+
+`Publisher` close resolves and removes every entry still in the map. This is mandatory, not
+belt-and-braces. The client's `entityClosed` confirmations (`producer.go:381-392`) cover only messages
+that reached its internal queue; a send parked in `isReadyToSend` was never enqueued and gets no
+confirmation at all — and the super producer's normal-close path `break`s out of its event loop
+*before* the reconnection broadcast (`ha_super_stream_publisher.go:92-96`), so that goroutine may stay
+parked for good. Without the sweep, a `Publish` caller with no deadline of its own hangs across the
+whole shutdown. Resolution is idempotent, so a late `entityClosed` for a swept message is a no-op.
+
+### Super streams route by murmur3 hash of a caller-supplied key
+
+`PublishMessage.RoutingKey` is **required non-empty** on a super-stream publisher and **must be
+empty** on a plain one; both are rejected before the client is touched. An empty key on a super
+stream is refused rather than defaulted precisely because hashing `""` is well-defined and silently
+wrong — every message would land on one partition.
+
+`stream.NewHashRoutingStrategy` is murmur3 with RabbitMQ's shared seed, so a partition assignment made
+here matches what the Java, .NET and Python clients compute for the same key. That interoperability is
+the reason it is the only strategy offered.
+
+### Shape follows the consume side
+
+Publishers reach the broker through the same `producerHandle` seam pattern the consumers use, so the
+confirmation-correlation policy is testable without a broker; the vendor constructors sit behind
+factory fields for the same reason. No `ModuleDeps` field is added — a module holds the handle its own
+`DeclareStreams` returned. Publishers count towards `Manager.Ready()` and `Stats()` alongside
+consumers, on the same non-critical probe. Metrics and spans reuse the AMQP lane's instruments and the
+`go-bricks/messaging` tracer, and trace context is injected through the framework's own `trace`
+package rather than the OTel propagator, so both messaging lanes write the same header names.
+
+Single-tenancy is inherited unchanged: this lane is still gated by `config.Validate` and
+`app.assertStreamsSingleTenant`, and publishing adds no tenancy work of its own.
+
+### Deferred, deliberately
+
+- **Producer deduplication** (`ProducerOptions.Name` plus publishing IDs) — needs caller-persistent
+  ID sequences and its own ADR.
+- **Key routing** (`KeyRoutingStrategy`, which asks the broker to resolve a key to partitions) — hash
+  routing is the cross-client default and the only one v1 offers.
+- **Sub-entry batching and compression** — incompatible with pointer correlation as it stands.
+- **Outbox relay to streams** — the transactional outbox stays on the AMQP lane.
+
+## Consequences
+
+**Positive.** A service that consumes a stream natively can now publish to it over the same
+connection, with a confirmed result rather than a hope. Super-stream partitioning is reachable from
+the framework surface for the first time, interoperably with the other RabbitMQ clients. No new
+configuration keys: the client's defaults and the caller's context bound everything.
+
+**Negative — a publish is only as bounded as its context.** A caller that passes
+`context.Background()` to `Publish` can wait for as long as the broker takes. Handler code inherits
+the HTTP layer's 5 s deadline and is fine; background work must pass a deadline of its own.
+
+**Negative — the correlation is a vendor-internal guarantee.** It rests on `ConfirmationStatus`
+returning the exact message pointer at `SubEntrySize = 1`. A client upgrade must re-verify that, and
+the integration round trip is what fails loudly if it ever stops holding.
+
+**Negative — abandoned sends leak a goroutine and hold a map entry.** Both are bounded by the
+publisher's lifetime and both are the accepted price of a vendor call that cannot be interrupted.
+
+**Neutral — one publisher per target per process.** A second declaration on the same stream panics at
+startup, matching the consumer contract: it is a wiring mistake, not a fan-out.
+
+## Future work
+
+- Producer-side deduplication, key routing, sub-entry batching and compression (see above).
+- Outbox integration, so transactionally recorded events can be relayed to a stream.
+- Multi-tenant fan-out, which publishing inherits from ADR-059's `single-tenant only` fail-fast.
+- Parking a message whose publish exhausted every retry, the publish-side twin of ADR-059's
+  failed-message parking.
+
+## References
+
+- [wiki/streams.md](streams.md) — consumer-facing guide
+- [ADR-059](adr_059_streams_consumption.md) — the consume side and the Environment this reuses
+- `messaging/streams/publisher.go` — the correlation, tombstone lifecycle and close sweep
+- `messaging/streams/manager.go` — producer construction, bind ordering and the routing extractor
+- `messaging/streams/declarations.go` — the two declare methods and their target validation
+- <https://www.rabbitmq.com/docs/streams#super-streams>

--- a/wiki/adr_063_streams_native_publishing.md
+++ b/wiki/adr_063_streams_native_publishing.md
@@ -68,7 +68,9 @@ passed to `Send`, no waiter would resolve and every publish in that test would f
 
 Because `isReadyToSend` can park forever, `Publish` dispatches `handle.Send` on its own goroutine and
 selects between the waiter's channel and `ctx.Done()`. The caller's context is therefore the only
-bound on a publish — the framework adds no timeout of its own and no config key for one.
+bound on **how long `Publish` waits** — the framework adds no timeout of its own and no config key
+for one. It does not bound the send behind that wait: the goroutine runs on until the client's own
+send path unblocks, whatever the caller's context did.
 
 Abandoning that goroutine leaks it for as long as the reconnect lasts. This is the same trade
 `Manager.flushOffsetsLocked` already documents and accepts: a leaked goroutine parked on a vendor
@@ -161,9 +163,11 @@ Single-tenancy is inherited unchanged: this lane is still gated by `config.Valid
 **Positive.** A service that consumes a stream natively can now publish to it over the same
 connection, with a confirmed result rather than a hope. Super-stream partitioning is reachable from
 the framework surface for the first time, interoperably with the other RabbitMQ clients. No new
-configuration keys: the client's defaults and the caller's context bound everything.
+configuration keys — the client's defaults and the caller's context are the only settings in play.
+That context bounds how long `Publish` makes its caller wait; it does not bound the send behind it,
+which is the known limitation above.
 
-**Negative — a publish is only as bounded as its context.** A caller that passes
+**Negative — the wait is only as bounded as the caller's context.** A caller that passes
 `context.Background()` to `Publish` can wait for as long as the broker takes. Handler code inherits
 the HTTP layer's 5 s deadline and is fine; background work must pass a deadline of its own.
 

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -1259,6 +1259,38 @@ Not covered: unrecognized-scheme DSNs (the vendor dispatch's `default` arm) and 
 ARE covered since #1002 routed that seam through the vendor gate. See
 [migrations.md](migrations.md) `[C59.11]`.
 
+### [ADR-063: Native Stream Publishing Is Synchronous and Confirmed, Correlated by Message Pointer](adr_063_streams_native_publishing.md)
+
+**Date:** 2026-08-15 | **Status:** Accepted
+
+[ADR-059](adr_059_streams_consumption.md) shipped `messaging/streams` for consumption only and left
+native publishing as future work with one constraint: it must reuse that manager's Environment. It
+now does. `DeclarePublisher` and `DeclareSuperStreamPublisher` return an inert handle at declaration
+time that `Manager.Start` binds to a client producer — before any consumer starts, because a handler
+may publish from its first delivery. The surface is **sync-confirmed only**: the client's `Send` is
+asynchronous and its `checkWriteError` swallows every write error except `FrameTooLarge`, so a `nil`
+from it proves nothing and the broker confirmation is the only observable truth. Confirmations are
+correlated by the **message pointer** the client hands back, which is valid only at the default
+`SubEntrySize` of 1 — the reason the producer options are the client's defaults verbatim, with no
+deduplication, batching or compression. Because the client's send path parks on a bare `sync.Cond`
+during a reconnect, the send runs on a goroutine the caller's context can abandon; a context expiry
+**tombstones** the correlation entry rather than removing it, so a send that has not routed yet still
+finds its routing key instead of hashing `""` onto one partition. Super streams route by murmur3 with
+RabbitMQ's shared seed, interoperable with the Java/.NET/Python clients; `RoutingKey` is required
+non-empty there and rejected on a plain stream.
+
+**Key Benefits:** A natively-consuming service can publish over the same connection with a confirmed
+result, and super-stream partitioning reaches the framework surface for the first time. No new config
+keys — the client's defaults and the caller's context bound everything. **Watch:** a publish is only
+as bounded as the context passed to it, so background callers must supply a deadline; a context
+timeout is **not** proof of failure, delivery stays at-least-once and consumers must be idempotent;
+an abandoned send leaks a vendor goroutine and holds its map entry until the publisher closes; and the
+correlation rests on a vendor-internal guarantee that a client upgrade must re-verify (the integration
+round trip is what fails loudly if it stops holding). Publisher close sweeps every outstanding waiter
+with `ErrPublisherClosed`, because the client's `entityClosed` confirmations cannot reach a send that
+never enqueued. Deduplication, key routing, sub-entry batching, compression and outbox relay are all
+deferred. See [streams.md](streams.md).
+
 ---
 
 ## ADR Lifecycle
@@ -1270,7 +1302,7 @@ ARE covered since #1002 routed that seam through the vendor gate. See
 
 ### Numbering Policy
 
-ADR numbers (ADR-001 through ADR-062) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
+ADR numbers (ADR-001 through ADR-063) reflect **decision/adoption sequence**, not strict chronological order. The authoritative timeline for each decision is the date in its individual ADR header (e.g., ADR-008 is dated 2025-01-10 while ADR-011 is dated 2025-11-09). When reviewing historical chronology, sort by the dates in the ADR index rather than by number. For example, [ADR-011](adr_011_redis_cache.md) introduced the `ModuleDeps` Cache extension — a breaking API change — and its number simply indicates it was the eleventh decision adopted, not that it followed ADR-010 temporally.
 
 ## Writing New ADRs
 

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -1281,8 +1281,9 @@ non-empty there and rejected on a plain stream.
 
 **Key Benefits:** A natively-consuming service can publish over the same connection with a confirmed
 result, and super-stream partitioning reaches the framework surface for the first time. No new config
-keys — the client's defaults and the caller's context bound everything. **Watch:** a publish is only
-as bounded as the context passed to it, so background callers must supply a deadline; a context
+keys — the client's defaults and the caller's context are the only settings in play, and that context
+bounds the caller's wait rather than the send behind it. **Watch:** that wait is only as bounded as
+the context passed to it, so background callers must supply a deadline; a context
 timeout is **not** proof of failure, delivery stays at-least-once and consumers must be idempotent;
 an abandoned send leaks a vendor goroutine and holds its map entry until the publisher closes, **with
 no cap on how many accumulate** during a reconnect (the client's `QueueSize` cannot bound them — a

--- a/wiki/architecture_decisions.md
+++ b/wiki/architecture_decisions.md
@@ -1284,12 +1284,14 @@ result, and super-stream partitioning reaches the framework surface for the firs
 keys — the client's defaults and the caller's context bound everything. **Watch:** a publish is only
 as bounded as the context passed to it, so background callers must supply a deadline; a context
 timeout is **not** proof of failure, delivery stays at-least-once and consumers must be idempotent;
-an abandoned send leaks a vendor goroutine and holds its map entry until the publisher closes; and the
-correlation rests on a vendor-internal guarantee that a client upgrade must re-verify (the integration
-round trip is what fails loudly if it stops holding). Publisher close sweeps every outstanding waiter
-with `ErrPublisherClosed`, because the client's `entityClosed` confirmations cannot reach a send that
-never enqueued. Deduplication, key routing, sub-entry batching, compression and outbox relay are all
-deferred. See [streams.md](streams.md).
+an abandoned send leaks a vendor goroutine and holds its map entry until the publisher closes, **with
+no cap on how many accumulate** during a reconnect (the client's `QueueSize` cannot bound them — a
+send parked in `isReadyToSend` never reaches the queue), so the growth is publish-rate × outage; and
+the correlation rests on a vendor-internal guarantee that a client upgrade must re-verify (the
+integration round trip is what fails loudly if it stops holding). Publisher close sweeps every
+outstanding waiter with `ErrPublisherClosed`, because the client's `entityClosed` confirmations cannot
+reach a send that never enqueued. An outstanding-send limit, deduplication, key routing, sub-entry
+batching, compression and outbox relay are all deferred. See [streams.md](streams.md).
 
 ---
 


### PR DESCRIPTION
## What

Native stream publishing reached plain streams only, so a partitioned target had
no publish path at all. `DeclareSuperStreamPublisher` now returns a `*Publisher`
that routes each message to a partition by `RoutingKey`, using the client's
murmur3 hash strategy — the same seed the Java, .NET and Python clients use, so
partition assignment is interoperable across them.

## Impact

Additive; no existing API changes. `PublishMessage.RoutingKey` is now required
non-empty for a super stream and must stay empty for a plain one — publishing to
either kind as the other fails validation at startup, naming the declare method
to use instead. Recorded as ADR-063.

## Verification

An integration test publishes across six routing keys to a three-partition super
stream and asserts key-to-partition grouping matches the client's own hash
strategy, so an extractor that silently returned an empty key would fail rather
than pass by landing everything on one partition.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native publishing support for plain streams and super streams.
  * Added broker-confirmed publishing with readiness, lifecycle, and cancellation handling.
  * Super-stream messages now route consistently to partitions using required routing keys.
  * Publishing confirmations and delivery outcomes are supported across partitioned streams.

* **Bug Fixes**
  * Improved validation and error reporting for invalid stream types, names, and routing keys.

* **Documentation**
  * Added and updated architecture documentation covering native stream publishing and routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->