### PR TITLE
chore(docs): scaffold docs/agents config for engineering skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@
 !docs/superpowers/specs/*.md
 !docs/superpowers/plans/*.md
 !docs/design/*.md
+!docs/agents/*.md
+!CONTEXT.md
 
 !.github/workflows/*.yml
 !.github/workflows/*.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -443,7 +443,7 @@ GoBricks breaks its own API surface when justified. Greenfield work uses the new
 
 ### Issue tracker
 
-GitHub Issues via `gh`; titles `<area>: <description>`, labels `area/*` + `kind/*`. See `docs/agents/issue-tracker.md`.
+GitHub Issues via `gh`; titles `<area>: <description>`, labels `area/*` + `kind/*` or `bug`/`documentation`, plus `needs-triage`. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,3 +438,17 @@ GoBricks breaks its own API surface when justified. Greenfield work uses the new
 - **.claude/tasks/** — Development task planning.
 - **llms.txt** — Quick reference examples for LLM code generation.
 - Tests alongside source files (`*_test.go`).
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues via `gh`; titles `<area>: <description>`, labels `area/*` + `kind/*`. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context; ADRs live in `wiki/adr_NNN_*.md`, not `docs/adr/`. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -5,8 +5,8 @@ How the engineering skills should consume this repo's domain documentation when 
 ## Before exploring, read these
 
 - **`CONTEXT.md`** at the repo root — the glossary. It does not exist yet; `/domain-modeling` creates it lazily
-  when a term actually gets resolved. It is allowlisted in `.gitignore` (`!CONTEXT.md`), so it will be tracked
-  the moment it appears.
+  when a term actually gets resolved. It is allowlisted in `.gitignore` (`!CONTEXT.md`), so it will not be ignored
+  and can be added to the change when it appears.
 - **`wiki/architecture_decisions.md`** — the ADR index. Skim it for decisions touching the area you're about to
   work in, then read the linked `wiki/adr_NNN_<slug>.md` file(s).
 - **`wiki/<topic>.md`** — deep dives per subsystem (`database.md`, `messaging.md`, `outbox.md`, …). CLAUDE.md's

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,72 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the glossary. It does not exist yet; `/domain-modeling` creates it lazily
+  when a term actually gets resolved. It is allowlisted in `.gitignore` (`!CONTEXT.md`), so it will be tracked
+  the moment it appears.
+- **`wiki/architecture_decisions.md`** — the ADR index. Skim it for decisions touching the area you're about to
+  work in, then read the linked `wiki/adr_NNN_<slug>.md` file(s).
+- **`wiki/<topic>.md`** — deep dives per subsystem (`database.md`, `messaging.md`, `outbox.md`, …). CLAUDE.md's
+  Quick Reference lists them; read the one for the package you're touching.
+
+If `CONTEXT.md` doesn't exist, **proceed silently**. Don't flag its absence; don't suggest creating it upfront.
+
+## File structure
+
+Single-context repo. ADRs live in `wiki/`, **not** `docs/adr/` — never create `docs/adr/`.
+
+```text
+/
+├── CONTEXT.md                        ← glossary (lazily created)
+├── wiki/
+│   ├── architecture_decisions.md     ← ADR index; every ADR has an entry here
+│   ├── adr_001_enhanced_handler_system.md
+│   ├── …
+│   ├── adr_062_database_tls_fail_closed.md
+│   ├── migrations.md                 ← breaking-change atoms, one per hop
+│   └── <topic>.md                    ← subsystem deep dives
+└── docs/agents/                      ← this file and its siblings
+```
+
+## Recording an ADR
+
+When `/domain-modeling` (or any skill) records a decision, follow the existing convention exactly:
+
+1. **File:** `wiki/adr_NNN_<snake_slug>.md`, `NNN` = next number after the highest existing one. In-flight PRs
+   may already hold a number — check open PRs and cross-references, not just `ls`.
+2. **Header:**
+
+   ```markdown
+   # ADR-NNN: <Title>
+
+   **Status:** Accepted
+   **Date:** YYYY-MM-DD
+
+   ## Context
+   ## Decision
+   ## Consequences
+   ```
+
+3. **Index — mandatory:** add a `### [ADR-NNN: <Title>](adr_NNN_<slug>.md)` entry to
+   `wiki/architecture_decisions.md` (date, status, one-paragraph summary, `**Key Benefits:**` line, `---`
+   separator) **and** bump the `ADR-001 through ADR-NNN` counter at the foot of that file. File + index move
+   together — an ADR without an index entry is a CodeRabbit finding.
+4. **Breaking change?** Also add an atom to `wiki/migrations.md`, list it under CLAUDE.md `## Breaking Changes`,
+   and use a `!` commit type (`fix(scope)!:`).
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use
+the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project
+doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-016 (session timezone UTC) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -4,7 +4,7 @@ Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all o
 
 ## Conventions
 
-- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Create an issue**: `gh issue create --title "..." --body-file <body-file>` for multi-line bodies. Use `--body` only for single-line text.
 - **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
 - **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -29,7 +29,7 @@ Infer the repo from `git remote -v` — `gh` does this automatically when run in
 When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
 
 - **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
-- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **List external PRs for triage**: `gh pr list --json` does not expose `authorAssociation`; use `gh search prs --repo <owner>/<repo> --state open --json number,title,body,labels,author,authorAssociation` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, `FIRST_TIMER`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`). Fetch comment bodies per PR with `gh pr view <number> --comments`.
 - **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
 
 GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,54 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Repo conventions
+
+- **Title:** `<area>: <description>`, lowercase (e.g. `outbox: dead-letter relay after N retries`).
+- **Labels:** one `area/<package>` (e.g. `area/outbox`) plus one `kind/feature|refactor|tech-debt|exploration|security`,
+  or a top-level `bug` / `documentation`. Add `needs-triage` on creation.
+- **Bodies:** pass multi-line bodies via `--body-file` — inline heredocs mangle backticks.
+- **PR auto-close:** `Closes #NNN` must be a bare trailing line in the PR body; the repo squash-merges and
+  discards commit bodies, so the PR body is the only surface GitHub reads.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## What

Matt Pocock's engineering skills (`to-tickets`, `triage`, `to-spec`, `wayfinder`, `domain-modeling`, `code-review`) read per-repo config from `docs/agents/*.md` and a `## Agent skills` block in `CLAUDE.md`; neither existed, so they fell back to defaults — including a `docs/adr/0001-*.md` layout that would fork a second ADR system beside `wiki/adr_NNN_*.md`. This adds the three config files (GitHub tracker with the repo's `<area>:` title and `area/*`+`kind/*` label conventions; default triage labels; single-context domain docs pointed at the wiki ADR contract), the CLAUDE.md block, and the `.gitignore` allowlist entries.

## Impact

None for consumers. Skills now use `wiki/adr_NNN_*.md` + index instead of creating `docs/adr/`. Labels `needs-info`, `ready-for-agent`, `ready-for-human` were created on the repo.

## Verification

CI gates only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for agent workflows, including issue tracking, triage labels, and domain exploration.
  * Documented conventions for architecture decisions, glossary usage, repository structure, and resolving documentation conflicts.
  * Added instructions for issue and pull request operations, ticket workflows, dependency tracking, and navigation.
  * Linked the new agent guides from the project documentation.
* **Chores**
  * Updated repository file rules to include the new Markdown documentation and root context file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->