### PR TITLE
fix(mutate): skip packages whose dry run yields no report

### DIFF
--- a/scripts/mutatediff/main.go
+++ b/scripts/mutatediff/main.go
@@ -263,6 +263,11 @@ func reportPathFor(pkg, reportDir string) string {
 	return filepath.Join(reportDir, name)
 }
 
+// errMissingReport marks a report file the engine exited zero without writing.
+// It is deliberately distinct from fs.ErrNotExist: an unavailable engine binary
+// also fails with a chain wrapping ENOENT, and that must stay fatal.
+var errMissingReport = errors.New("engine exited zero without writing a report")
+
 // runEngine invokes gremlins for pkg and returns the report it wrote. extra
 // carries mode-specific flags (--dry-run, the coefficient, the worker count).
 func runEngine(ctx context.Context, engineArgs []string, pkg, reportPath string, extra []string, out io.Writer) ([]byte, error) {
@@ -275,6 +280,9 @@ func runEngine(ctx context.Context, engineArgs []string, pkg, reportPath string,
 	}
 	reportJSON, readErr := os.ReadFile(reportPath) // #nosec G304 -- path built from a per-run os.MkdirTemp dir + package-derived name, not user input
 	if readErr != nil {
+		if errors.Is(readErr, fs.ErrNotExist) {
+			return nil, fmt.Errorf("no report for %s: %w", pkg, errMissingReport)
+		}
 		return nil, fmt.Errorf("no report for %s: %w", pkg, readErr)
 	}
 	return reportJSON, nil
@@ -295,9 +303,10 @@ func mutatePackage(ctx context.Context, engineArgs []string, pkg, reportDir stri
 	if err != nil {
 		// A missing report after a zero exit is gremlins' shape for a package with
 		// no mutatable statements (e.g. constants-only): it prints "No results to
-		// report." and writes nothing. Engine failures surface earlier as
-		// "engine failed" and stay fatal.
-		if errors.Is(err, fs.ErrNotExist) {
+		// report." and writes nothing. runEngine tags exactly that case with
+		// errMissingReport; every other failure — including an engine binary whose
+		// own error chain wraps ENOENT — stays fatal.
+		if errors.Is(err, errMissingReport) {
 			fmt.Fprintf(out, "mutatediff: %s produced no dry-run report (no mutatable statements), skipping\n", pkg)
 			return nil, nil, false, nil
 		}

--- a/scripts/mutatediff/main.go
+++ b/scripts/mutatediff/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -291,6 +293,14 @@ func mutatePackage(ctx context.Context, engineArgs []string, pkg, reportDir stri
 	dryJSON, err := runEngine(ctx, engineArgs, pkg, reportPathFor(pkg, reportDir)+".dry",
 		[]string{"--dry-run", workersFlag, "1"}, out)
 	if err != nil {
+		// A missing report after a zero exit is gremlins' shape for a package with
+		// no mutatable statements (e.g. constants-only): it prints "No results to
+		// report." and writes nothing. Engine failures surface earlier as
+		// "engine failed" and stay fatal.
+		if errors.Is(err, fs.ErrNotExist) {
+			fmt.Fprintf(out, "mutatediff: %s produced no dry-run report (no mutatable statements), skipping\n", pkg)
+			return nil, nil, false, nil
+		}
 		return nil, nil, false, err
 	}
 	onChanged, cErr := countOnChangedLines(dryJSON, pkg, changed)

--- a/scripts/mutatediff/main_test.go
+++ b/scripts/mutatediff/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -99,9 +100,6 @@ func TestRunNoOpDiffLeavesEnvironmentAlone(t *testing.T) {
 	}
 }
 
-// TestMutatePackageReportsFailureAsNotRun pins the signal the cooldown depends
-// on: a package whose engine never executed mutants generated no load, so the
-// caller must be able to tell it apart from a package that ran.
 // TestMutatePackageSkipsWhenEngineWritesNoDryReport pins the constants-only
 // package case: gremlins exits 0 without writing a report when a package has
 // no mutatable statements, and the gate must skip it rather than abort the
@@ -121,6 +119,29 @@ func TestMutatePackageSkipsWhenEngineWritesNoDryReport(t *testing.T) {
 	}
 }
 
+// TestMutatePackageUnavailableEngineStaysFatal pins the boundary of the skip:
+// an engine binary that does not exist fails with an error chain wrapping
+// fs.ErrNotExist (ENOENT), which must NOT be mistaken for the missing-report
+// zero-mutants case — a gate whose engine cannot start has verified nothing.
+func TestMutatePackageUnavailableEngineStaysFatal(t *testing.T) {
+	var buf bytes.Buffer
+	missing := filepath.Join(t.TempDir(), "no-such-engine")
+	_, _, ran, err := mutatePackage(t.Context(), []string{missing}, "./scripts/mutatediff",
+		t.TempDir(), map[string][]lineRange{}, 1, &buf)
+	if err == nil {
+		t.Fatal("want an error from an engine binary that does not exist")
+	}
+	if ran {
+		t.Error("ran = true, want false when the engine never started")
+	}
+	if strings.Contains(buf.String(), "skipping") {
+		t.Errorf("dead engine reported as a skip, output: %q", buf.String())
+	}
+}
+
+// TestMutatePackageReportsFailureAsNotRun pins the signal the cooldown depends
+// on: a package whose engine never executed mutants generated no load, so the
+// caller must be able to tell it apart from a package that ran.
 func TestMutatePackageReportsFailureAsNotRun(t *testing.T) {
 	var buf bytes.Buffer
 	// An engine that cannot run at all fails before any verdict; the point here is

--- a/scripts/mutatediff/main_test.go
+++ b/scripts/mutatediff/main_test.go
@@ -102,6 +102,25 @@ func TestRunNoOpDiffLeavesEnvironmentAlone(t *testing.T) {
 // TestMutatePackageReportsFailureAsNotRun pins the signal the cooldown depends
 // on: a package whose engine never executed mutants generated no load, so the
 // caller must be able to tell it apart from a package that ran.
+// TestMutatePackageSkipsWhenEngineWritesNoDryReport pins the constants-only
+// package case: gremlins exits 0 without writing a report when a package has
+// no mutatable statements, and the gate must skip it rather than abort the
+// whole run. `true` reproduces that shape — zero exit, no report file.
+func TestMutatePackageSkipsWhenEngineWritesNoDryReport(t *testing.T) {
+	var buf bytes.Buffer
+	_, _, ran, err := mutatePackage(t.Context(), []string{"true"}, "./internal/testutil",
+		t.TempDir(), map[string][]lineRange{}, 1, &buf)
+	if err != nil {
+		t.Fatalf("want nil error for a zero-exit engine with no report, got %v", err)
+	}
+	if ran {
+		t.Error("ran = true, want false when no mutants were executed")
+	}
+	if !strings.Contains(buf.String(), "no dry-run report") {
+		t.Errorf("skip reason not reported, output: %q", buf.String())
+	}
+}
+
 func TestMutatePackageReportsFailureAsNotRun(t *testing.T) {
 	var buf bytes.Buffer
 	// An engine that cannot run at all fails before any verdict; the point here is


### PR DESCRIPTION
## What
gremlins exits 0 without writing a report file for a package with no mutatable statements (constants-only packages print "No results to report."), and mutatediff treated the missing dry-run report as fatal — a comment edit in `internal/testutil/constants.go` aborted the entire gate. The dry-run phase now treats a missing report after a zero engine exit as the zero-mutants case and skips the package.

## Impact
None. Engine failures still surface as fatal "engine failed" errors, and a missing report after the live run remains fatal.

## Verification
Reproduced against the real gate: `make mutate` on the successor branch now logs `./internal/testutil produced no dry-run report (no mutatable statements), skipping` and completes. `scripts/` is excluded from mutation scope by design (gremlins misverdicts nested package main), so the new unit test is this change's net: it pins the skip path, and the pre-existing failure test pins that engine errors stay fatal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Packages without mutation candidates are now skipped gracefully when no dry-run report is produced.
  * Other mutation analysis errors, including unavailable analysis tools, continue to be reported normally.

* **Tests**
  * Added coverage confirming successful runs without a dry-run report complete without errors and execute no mutants.
  * Added coverage confirming unavailable analysis tools remain fatal and are not marked as skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->