### PR TITLE
refactor(config,app): delete the mirrored defaults the bypass required

### DIFF
--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -39,8 +39,8 @@ func (a *App) startMaintenanceLoops() {
 }
 
 // cleanupIntervalTooLate reports whether cleanupInterval sweeps no more often than
-// idleTTL. idleTTL <= 0 returns false: config.Validate defaults IdleTTL
-// unconditionally, so this guard only covers Validate-bypassing callers.
+// idleTTL. idleTTL <= 0 cannot occur on a validated config; the branch defends
+// direct App construction in tests.
 func cleanupIntervalTooLate(cleanupInterval, idleTTL time.Duration) bool {
 	if idleTTL <= 0 {
 		return false

--- a/app/managers.go
+++ b/app/managers.go
@@ -11,30 +11,6 @@ import (
 	"github.com/gaborage/go-bricks/messaging"
 )
 
-// Documented operator-configurable defaults. These mirror the values applied by
-// config validation (see config/validation.go: applyMessagingDefaults and
-// applyCacheManagerDefaults) so the builder honors the same documented behavior
-// even when invoked without a fully-validated config (e.g. in unit tests).
-// defaultPublisherIdleTTL (single-tenant) has a third copy: messaging.NewMessagingManager's
-// fallback (messaging/manager.go) for bare callers that bypass this builder — that
-// fallback is single-tenant-only (see its comment), since a bare caller supplies no
-// deployment-mode signal.
-const (
-	defaultPublisherMaxCached = 50
-	defaultPublisherIdleTTL   = 1 * time.Hour // Single-tenant default; see config/validation.go
-	// defaultPublisherIdleTTLMultiTenant mirrors config/validation.go's
-	// defaultPublisherIdleTTLMultiTenant. Kept as a separate copy (not imported) for the
-	// same reason as defaultPublisherIdleTTL above: this builder must honor the documented
-	// default even when constructed directly, bypassing config validation.
-	defaultPublisherIdleTTLMultiTenant = 10 * time.Minute
-	defaultCacheMaxSize                = 100
-	defaultCacheIdleTTL                = 15 * time.Minute
-	defaultCacheCleanupInterval        = 5 * time.Minute
-	defaultDatabaseMaxSize             = 10
-	defaultDatabaseIdleTTL             = 1 * time.Hour    // mirrors config/validation.go
-	defaultDatabaseIdleTTLMultiTenant  = 30 * time.Minute // mirrors config/validation.go
-)
-
 // ManagerConfigBuilder creates configuration options for database and messaging managers
 // based on deployment mode (single-tenant vs multi-tenant).
 type ManagerConfigBuilder struct {
@@ -62,11 +38,9 @@ type ManagerConfigBuilder struct {
 	resendDelay       time.Duration
 	// publisherConfig carries operator-configurable messaging publisher pool
 	// settings (messaging.publisher.*), sourced from validated config by bootstrap.
-	// When unset, documented defaults are applied as fallbacks.
 	publisherConfig config.PublisherPoolConfig
 	// cacheConfig carries operator-configurable cache manager settings
 	// (cache.manager.*), sourced from validated config by bootstrap.
-	// When unset, documented defaults are applied as fallbacks.
 	cacheConfig config.CacheManagerConfig
 	// dbConfig holds database.manager.* settings, set by bootstrap from validated config.
 	dbConfig config.DatabaseManagerConfig
@@ -80,48 +54,29 @@ func NewManagerConfigBuilder(multiTenantEnabled bool, tenantLimit int) *ManagerC
 	}
 }
 
-// resolveMaxSize treats non-positive as unset (not just zero) so a negative from a
-// Validate-bypassing path (a Builder assembled without WithConfig, or a unit test
-// building this type directly) can't skip the mode-aware fallback and reach the
-// managers' own <=0->default coercion (see database/manager.go, messaging/manager.go).
-func (b *ManagerConfigBuilder) resolveMaxSize(operatorValue, singleTenantDefault int) int {
+// resolveMaxSize returns the operator's validated value, or — multi-tenant
+// only — scales a deliberately-preserved zero to the tenant limit (#661).
+// Single-tenant zeros cannot reach here: config.Validate stamps the default.
+func (b *ManagerConfigBuilder) resolveMaxSize(operatorValue int) int {
 	if operatorValue > 0 {
 		return operatorValue
 	}
-	if b.multiTenantEnabled {
-		return b.tenantLimit
-	}
-	return singleTenantDefault
+	return b.tenantLimit
 }
 
-// resolveIdleTTL mirrors resolveMaxSize: the fallback is inert once config.Validate stamps defaults, but load-bearing when Validate is bypassed (a Builder assembled without WithConfig, unit tests).
-func (b *ManagerConfigBuilder) resolveIdleTTL(operatorValue, multiTenantDefault, singleTenantDefault time.Duration) time.Duration {
-	if operatorValue > 0 {
-		return operatorValue
-	}
-	if b.multiTenantEnabled {
-		return multiTenantDefault
-	}
-	return singleTenantDefault
-}
-
-// BuildDatabaseOptions creates database manager options based on deployment mode.
-// Multi-tenant mode uses tenant limits and shorter TTL for dynamic scaling.
-// Single-tenant mode uses smaller fixed limits and longer TTL for stability.
+// BuildDatabaseOptions creates database manager options from validated config.
 func (b *ManagerConfigBuilder) BuildDatabaseOptions() database.DbManagerOptions {
 	return database.DbManagerOptions{
-		MaxSize: b.resolveMaxSize(b.dbConfig.MaxSize, defaultDatabaseMaxSize),
-		IdleTTL: b.resolveIdleTTL(b.dbConfig.IdleTTL, defaultDatabaseIdleTTLMultiTenant, defaultDatabaseIdleTTL),
+		MaxSize: b.resolveMaxSize(b.dbConfig.MaxSize),
+		IdleTTL: b.dbConfig.IdleTTL,
 	}
 }
 
-// BuildMessagingOptions creates messaging manager options based on deployment mode.
-// Multi-tenant mode uses tenant limits and shorter TTL for dynamic scaling.
-// Single-tenant mode uses smaller fixed limits and a longer TTL (same 1h as the DB pool).
+// BuildMessagingOptions creates messaging manager options from validated config.
 func (b *ManagerConfigBuilder) BuildMessagingOptions() messaging.ManagerOptions {
 	return messaging.ManagerOptions{
-		MaxPublishers:      b.resolveMaxSize(b.publisherConfig.MaxCached, defaultPublisherMaxCached),
-		IdleTTL:            b.resolveIdleTTL(b.publisherConfig.IdleTTL, defaultPublisherIdleTTLMultiTenant, defaultPublisherIdleTTL),
+		MaxPublishers:      b.resolveMaxSize(b.publisherConfig.MaxCached),
+		IdleTTL:            b.publisherConfig.IdleTTL,
 		ConnectionTimeout:  b.connectionTimeout,
 		MaxPublishAttempts: b.maxPublishAttempts,
 		ReadyTimeout:       b.readyTimeout,
@@ -132,38 +87,22 @@ func (b *ManagerConfigBuilder) BuildMessagingOptions() messaging.ManagerOptions 
 	}
 }
 
-// BuildCacheOptions creates cache manager options based on deployment mode.
-// Multi-tenant mode uses tenant limits and shorter TTL for dynamic scaling.
-// Single-tenant mode uses smaller fixed limits and longer TTL.
+// BuildCacheOptions creates cache manager options from validated config.
 func (b *ManagerConfigBuilder) BuildCacheOptions() cache.ManagerConfig {
-	// Operator config (cache.manager.*) is the source of truth. Mode-specific
-	// values are only fallbacks when the operator left the key unset (zero).
-	// Not resolveMaxSize: cache.NewCacheManager rejects negatives (unlike the
-	// db/messaging managers, which coerce), so a negative must pass through and
+	// Operator config (cache.manager.*) is the source of truth. Multi-tenant zero is
+	// deliberately preserved by config.Validate (#661), so it scales to the tenant
+	// limit here. Not resolveMaxSize: cache.NewCacheManager rejects negatives (unlike
+	// the db/messaging managers, which coerce), so a negative must pass through and
 	// fail loudly there instead of being silently swallowed into a live pool.
 	maxSize := b.cacheConfig.MaxSize
-	if maxSize == 0 {
-		if b.multiTenantEnabled {
-			maxSize = b.tenantLimit
-		} else {
-			maxSize = defaultCacheMaxSize
-		}
-	}
-
-	idleTTL := b.cacheConfig.IdleTTL
-	if idleTTL == 0 {
-		idleTTL = defaultCacheIdleTTL // Documented default (same for both modes)
-	}
-
-	cleanupInterval := b.cacheConfig.CleanupInterval
-	if cleanupInterval == 0 {
-		cleanupInterval = defaultCacheCleanupInterval // Documented default (same for both modes)
+	if maxSize == 0 && b.multiTenantEnabled {
+		maxSize = b.tenantLimit
 	}
 
 	return cache.ManagerConfig{
 		MaxSize:         maxSize,
-		IdleTTL:         idleTTL,
-		CleanupInterval: cleanupInterval,
+		IdleTTL:         b.cacheConfig.IdleTTL,
+		CleanupInterval: b.cacheConfig.CleanupInterval,
 	}
 }
 

--- a/app/managers_test.go
+++ b/app/managers_test.go
@@ -23,6 +23,14 @@ const (
 	largeLimitTenantTest         = "large tenant limit"
 )
 
+var (
+	validSingleTenantDBConfig        = config.DatabaseManagerConfig{MaxSize: 10, IdleTTL: time.Hour}
+	validMultiTenantDBConfig         = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
+	validSingleTenantPublisherConfig = config.PublisherPoolConfig{MaxCached: 50, IdleTTL: time.Hour}
+	validMultiTenantPublisherConfig  = config.PublisherPoolConfig{IdleTTL: 10 * time.Minute}
+	validMultiTenantCacheConfig      = config.CacheManagerConfig{IdleTTL: 15 * time.Minute, CleanupInterval: 5 * time.Minute}
+)
+
 func TestNewManagerConfigBuilder(t *testing.T) {
 	t.Run("single-tenant configuration", func(t *testing.T) {
 		builder := NewManagerConfigBuilder(false, 100)
@@ -60,7 +68,7 @@ func TestNewManagerConfigBuilder(t *testing.T) {
 func TestManagerConfigBuilderBuildDatabaseOptions(t *testing.T) {
 	t.Run("single-tenant database options", func(t *testing.T) {
 		builder := NewManagerConfigBuilder(false, 100)
-		builder.dbConfig = config.DatabaseManagerConfig{MaxSize: 10, IdleTTL: time.Hour}
+		builder.dbConfig = validSingleTenantDBConfig
 
 		options := builder.BuildDatabaseOptions()
 
@@ -71,7 +79,7 @@ func TestManagerConfigBuilderBuildDatabaseOptions(t *testing.T) {
 	t.Run("multi-tenant database options", func(t *testing.T) {
 		tenantLimit := 250
 		builder := NewManagerConfigBuilder(true, tenantLimit)
-		builder.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
+		builder.dbConfig = validMultiTenantDBConfig
 
 		options := builder.BuildDatabaseOptions()
 
@@ -81,7 +89,7 @@ func TestManagerConfigBuilderBuildDatabaseOptions(t *testing.T) {
 
 	t.Run(zeroLimitMultiTenantTest, func(t *testing.T) {
 		builder := NewManagerConfigBuilder(true, 0)
-		builder.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
+		builder.dbConfig = validMultiTenantDBConfig
 
 		options := builder.BuildDatabaseOptions()
 
@@ -91,7 +99,7 @@ func TestManagerConfigBuilderBuildDatabaseOptions(t *testing.T) {
 
 	t.Run(negativeLimitMultiTenantTest, func(t *testing.T) {
 		builder := NewManagerConfigBuilder(true, -5)
-		builder.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
+		builder.dbConfig = validMultiTenantDBConfig
 
 		options := builder.BuildDatabaseOptions()
 
@@ -102,7 +110,7 @@ func TestManagerConfigBuilderBuildDatabaseOptions(t *testing.T) {
 	t.Run(largeLimitTenantTest, func(t *testing.T) {
 		largeLimit := 10000
 		builder := NewManagerConfigBuilder(true, largeLimit)
-		builder.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
+		builder.dbConfig = validMultiTenantDBConfig
 
 		options := builder.BuildDatabaseOptions()
 
@@ -130,7 +138,7 @@ func TestManagerConfigBuilderPassesValidatedValuesThrough(t *testing.T) {
 func TestManagerConfigBuilderBuildMessagingOptions(t *testing.T) {
 	t.Run("single-tenant messaging options", func(t *testing.T) {
 		builder := NewManagerConfigBuilder(false, 100)
-		builder.publisherConfig = config.PublisherPoolConfig{MaxCached: 50, IdleTTL: time.Hour}
+		builder.publisherConfig = validSingleTenantPublisherConfig
 
 		options := builder.BuildMessagingOptions()
 
@@ -141,7 +149,7 @@ func TestManagerConfigBuilderBuildMessagingOptions(t *testing.T) {
 	t.Run("multi-tenant messaging options", func(t *testing.T) {
 		tenantLimit := 300
 		builder := NewManagerConfigBuilder(true, tenantLimit)
-		builder.publisherConfig = config.PublisherPoolConfig{IdleTTL: 10 * time.Minute}
+		builder.publisherConfig = validMultiTenantPublisherConfig
 
 		options := builder.BuildMessagingOptions()
 
@@ -151,7 +159,7 @@ func TestManagerConfigBuilderBuildMessagingOptions(t *testing.T) {
 
 	t.Run(zeroLimitMultiTenantTest, func(t *testing.T) {
 		builder := NewManagerConfigBuilder(true, 0)
-		builder.publisherConfig = config.PublisherPoolConfig{IdleTTL: 10 * time.Minute}
+		builder.publisherConfig = validMultiTenantPublisherConfig
 
 		options := builder.BuildMessagingOptions()
 
@@ -161,7 +169,7 @@ func TestManagerConfigBuilderBuildMessagingOptions(t *testing.T) {
 
 	t.Run(negativeLimitMultiTenantTest, func(t *testing.T) {
 		builder := NewManagerConfigBuilder(true, -3)
-		builder.publisherConfig = config.PublisherPoolConfig{IdleTTL: 10 * time.Minute}
+		builder.publisherConfig = validMultiTenantPublisherConfig
 
 		options := builder.BuildMessagingOptions()
 
@@ -172,7 +180,7 @@ func TestManagerConfigBuilderBuildMessagingOptions(t *testing.T) {
 	t.Run(largeLimitTenantTest, func(t *testing.T) {
 		largeLimit := 5000
 		builder := NewManagerConfigBuilder(true, largeLimit)
-		builder.publisherConfig = config.PublisherPoolConfig{IdleTTL: 10 * time.Minute}
+		builder.publisherConfig = validMultiTenantPublisherConfig
 
 		options := builder.BuildMessagingOptions()
 
@@ -278,7 +286,7 @@ func TestManagerConfigBuilderHonorsConfigDefaults(t *testing.T) {
 	t.Run("multi-tenant database zero dbConfig scales to tenant limit", func(t *testing.T) {
 		// Pins #661: unset database.manager.maxsize must fall through to the tenant limit, not literal 0.
 		builder := NewManagerConfigBuilder(true, 250)
-		builder.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
+		builder.dbConfig = validMultiTenantDBConfig
 		opts := builder.BuildDatabaseOptions()
 		assert.Equal(t, 250, opts.MaxSize, "unset database.manager.maxsize must scale to the tenant limit")
 		assert.Equal(t, 30*time.Minute, opts.IdleTTL, "validated database.manager.idlettl must pass through unchanged")
@@ -287,7 +295,7 @@ func TestManagerConfigBuilderHonorsConfigDefaults(t *testing.T) {
 	t.Run("multi-tenant cache zero cacheConfig scales to tenant limit", func(t *testing.T) {
 		// Pins #668: unset cache.manager.maxsize must scale to the tenant limit (>100), not cap at 100.
 		builder := NewManagerConfigBuilder(true, 500)
-		builder.cacheConfig = config.CacheManagerConfig{IdleTTL: 15 * time.Minute, CleanupInterval: 5 * time.Minute}
+		builder.cacheConfig = validMultiTenantCacheConfig
 		opts := builder.BuildCacheOptions()
 		assert.Equal(t, 500, opts.MaxSize, "unset cache.manager.maxsize must scale to the tenant limit")
 		assert.Equal(t, 15*time.Minute, opts.IdleTTL, "validated cache.manager.idlettl must pass through unchanged")
@@ -407,7 +415,7 @@ func TestManagerConfigBuilderBuildCacheOptions(t *testing.T) {
 	t.Run("multi-tenant cache options", func(t *testing.T) {
 		tenantLimit := 250
 		builder := NewManagerConfigBuilder(true, tenantLimit)
-		builder.cacheConfig = config.CacheManagerConfig{IdleTTL: 15 * time.Minute, CleanupInterval: 5 * time.Minute}
+		builder.cacheConfig = validMultiTenantCacheConfig
 
 		options := builder.BuildCacheOptions()
 
@@ -418,7 +426,7 @@ func TestManagerConfigBuilderBuildCacheOptions(t *testing.T) {
 
 	t.Run(zeroLimitMultiTenantTest, func(t *testing.T) {
 		builder := NewManagerConfigBuilder(true, 0)
-		builder.cacheConfig = config.CacheManagerConfig{IdleTTL: 15 * time.Minute, CleanupInterval: 5 * time.Minute}
+		builder.cacheConfig = validMultiTenantCacheConfig
 
 		options := builder.BuildCacheOptions()
 
@@ -429,7 +437,7 @@ func TestManagerConfigBuilderBuildCacheOptions(t *testing.T) {
 
 	t.Run(negativeLimitMultiTenantTest, func(t *testing.T) {
 		builder := NewManagerConfigBuilder(true, -3)
-		builder.cacheConfig = config.CacheManagerConfig{IdleTTL: 15 * time.Minute, CleanupInterval: 5 * time.Minute}
+		builder.cacheConfig = validMultiTenantCacheConfig
 
 		options := builder.BuildCacheOptions()
 
@@ -441,7 +449,7 @@ func TestManagerConfigBuilderBuildCacheOptions(t *testing.T) {
 	t.Run(largeLimitTenantTest, func(t *testing.T) {
 		largeLimit := 5000
 		builder := NewManagerConfigBuilder(true, largeLimit)
-		builder.cacheConfig = config.CacheManagerConfig{IdleTTL: 15 * time.Minute, CleanupInterval: 5 * time.Minute}
+		builder.cacheConfig = validMultiTenantCacheConfig
 
 		options := builder.BuildCacheOptions()
 
@@ -454,8 +462,8 @@ func TestManagerConfigBuilderBuildCacheOptions(t *testing.T) {
 func TestManagerConfigBuilderConsistency(t *testing.T) {
 	t.Run("single-tenant configuration consistency", func(t *testing.T) {
 		builder := NewManagerConfigBuilder(false, 999) // Tenant limit should be ignored: validated operator values win.
-		builder.dbConfig = config.DatabaseManagerConfig{MaxSize: 10, IdleTTL: time.Hour}
-		builder.publisherConfig = config.PublisherPoolConfig{MaxCached: 50, IdleTTL: time.Hour}
+		builder.dbConfig = validSingleTenantDBConfig
+		builder.publisherConfig = validSingleTenantPublisherConfig
 
 		dbOptions := builder.BuildDatabaseOptions()
 		msgOptions := builder.BuildMessagingOptions()
@@ -471,8 +479,8 @@ func TestManagerConfigBuilderConsistency(t *testing.T) {
 	t.Run("multi-tenant configuration consistency", func(t *testing.T) {
 		tenantLimit := 200
 		builder := NewManagerConfigBuilder(true, tenantLimit)
-		builder.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
-		builder.publisherConfig = config.PublisherPoolConfig{IdleTTL: 10 * time.Minute}
+		builder.dbConfig = validMultiTenantDBConfig
+		builder.publisherConfig = validMultiTenantPublisherConfig
 
 		dbOptions := builder.BuildDatabaseOptions()
 		msgOptions := builder.BuildMessagingOptions()
@@ -506,12 +514,12 @@ func TestManagerConfigBuilderConsistency(t *testing.T) {
 func TestManagerConfigBuilderEdgeCases(t *testing.T) {
 	t.Run("configuration differences between modes", func(t *testing.T) {
 		singleTenant := NewManagerConfigBuilder(false, 100)
-		singleTenant.dbConfig = config.DatabaseManagerConfig{MaxSize: 10, IdleTTL: time.Hour}
-		singleTenant.publisherConfig = config.PublisherPoolConfig{MaxCached: 50, IdleTTL: time.Hour}
+		singleTenant.dbConfig = validSingleTenantDBConfig
+		singleTenant.publisherConfig = validSingleTenantPublisherConfig
 
 		multiTenant := NewManagerConfigBuilder(true, 100)
-		multiTenant.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
-		multiTenant.publisherConfig = config.PublisherPoolConfig{IdleTTL: 10 * time.Minute}
+		multiTenant.dbConfig = validMultiTenantDBConfig
+		multiTenant.publisherConfig = validMultiTenantPublisherConfig
 
 		singleDbOpts := singleTenant.BuildDatabaseOptions()
 		multiDbOpts := multiTenant.BuildDatabaseOptions()
@@ -527,8 +535,8 @@ func TestManagerConfigBuilderEdgeCases(t *testing.T) {
 
 	t.Run("expected TTL relationships", func(t *testing.T) {
 		builder := NewManagerConfigBuilder(true, 100)
-		builder.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
-		builder.publisherConfig = config.PublisherPoolConfig{IdleTTL: 10 * time.Minute}
+		builder.dbConfig = validMultiTenantDBConfig
+		builder.publisherConfig = validMultiTenantPublisherConfig
 
 		dbOptions := builder.BuildDatabaseOptions()
 		msgOptions := builder.BuildMessagingOptions()
@@ -541,12 +549,12 @@ func TestManagerConfigBuilderEdgeCases(t *testing.T) {
 
 	t.Run("single-tenant ignores tenant limit parameter", func(t *testing.T) {
 		builder1 := NewManagerConfigBuilder(false, 1)
-		builder1.dbConfig = config.DatabaseManagerConfig{MaxSize: 10, IdleTTL: time.Hour}
-		builder1.publisherConfig = config.PublisherPoolConfig{MaxCached: 50, IdleTTL: time.Hour}
+		builder1.dbConfig = validSingleTenantDBConfig
+		builder1.publisherConfig = validSingleTenantPublisherConfig
 
 		builder2 := NewManagerConfigBuilder(false, 10000)
-		builder2.dbConfig = config.DatabaseManagerConfig{MaxSize: 10, IdleTTL: time.Hour}
-		builder2.publisherConfig = config.PublisherPoolConfig{MaxCached: 50, IdleTTL: time.Hour}
+		builder2.dbConfig = validSingleTenantDBConfig
+		builder2.publisherConfig = validSingleTenantPublisherConfig
 
 		// Both should produce identical options since a validated operator value ignores tenantLimit
 		dbOpts1 := builder1.BuildDatabaseOptions()

--- a/app/managers_test.go
+++ b/app/managers_test.go
@@ -60,6 +60,7 @@ func TestNewManagerConfigBuilder(t *testing.T) {
 func TestManagerConfigBuilderBuildDatabaseOptions(t *testing.T) {
 	t.Run("single-tenant database options", func(t *testing.T) {
 		builder := NewManagerConfigBuilder(false, 100)
+		builder.dbConfig = config.DatabaseManagerConfig{MaxSize: 10, IdleTTL: time.Hour}
 
 		options := builder.BuildDatabaseOptions()
 
@@ -70,6 +71,7 @@ func TestManagerConfigBuilderBuildDatabaseOptions(t *testing.T) {
 	t.Run("multi-tenant database options", func(t *testing.T) {
 		tenantLimit := 250
 		builder := NewManagerConfigBuilder(true, tenantLimit)
+		builder.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
 
 		options := builder.BuildDatabaseOptions()
 
@@ -79,6 +81,7 @@ func TestManagerConfigBuilderBuildDatabaseOptions(t *testing.T) {
 
 	t.Run(zeroLimitMultiTenantTest, func(t *testing.T) {
 		builder := NewManagerConfigBuilder(true, 0)
+		builder.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
 
 		options := builder.BuildDatabaseOptions()
 
@@ -88,6 +91,7 @@ func TestManagerConfigBuilderBuildDatabaseOptions(t *testing.T) {
 
 	t.Run(negativeLimitMultiTenantTest, func(t *testing.T) {
 		builder := NewManagerConfigBuilder(true, -5)
+		builder.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
 
 		options := builder.BuildDatabaseOptions()
 
@@ -98,43 +102,38 @@ func TestManagerConfigBuilderBuildDatabaseOptions(t *testing.T) {
 	t.Run(largeLimitTenantTest, func(t *testing.T) {
 		largeLimit := 10000
 		builder := NewManagerConfigBuilder(true, largeLimit)
+		builder.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
 
 		options := builder.BuildDatabaseOptions()
 
 		assert.Equal(t, largeLimit, options.MaxSize)
 		assert.Equal(t, 30*time.Minute, options.IdleTTL)
 	})
+}
 
-	// Negatives can reach here via the app.NewWithConfig Validate-bypass; they must resolve to the mode default, not leak into NewDbManager's <=0 coercion (see resolveMaxSize).
-	t.Run("negative_operator_values_treated_as_unset_multi_tenant", func(t *testing.T) {
-		builder := NewManagerConfigBuilder(true, 42)
-		builder.dbConfig = config.DatabaseManagerConfig{MaxSize: -1, IdleTTL: -time.Second}
+func TestManagerConfigBuilderScalesZeroMaxSizeToTenantLimitInMultiTenant(t *testing.T) {
+	b := NewManagerConfigBuilder(true, 250)
+	// Multi-tenant zero is deliberate (config preserves it, #661): scale to the limit.
+	assert.Equal(t, 250, b.BuildDatabaseOptions().MaxSize)
+	assert.Equal(t, 250, b.BuildMessagingOptions().MaxPublishers)
+	assert.Equal(t, 250, b.BuildCacheOptions().MaxSize)
+}
 
-		options := builder.BuildDatabaseOptions()
-
-		assert.Equal(t, 42, options.MaxSize)
-		assert.Equal(t, 30*time.Minute, options.IdleTTL)
-	})
-
-	t.Run("negative_operator_values_treated_as_unset_single_tenant", func(t *testing.T) {
-		builder := NewManagerConfigBuilder(false, 0)
-		builder.dbConfig = config.DatabaseManagerConfig{MaxSize: -1, IdleTTL: -time.Second}
-
-		options := builder.BuildDatabaseOptions()
-
-		assert.Equal(t, 10, options.MaxSize)
-		assert.Equal(t, 1*time.Hour, options.IdleTTL)
-	})
+func TestManagerConfigBuilderPassesValidatedValuesThrough(t *testing.T) {
+	b := NewManagerConfigBuilder(false, 0)
+	b.dbConfig = config.DatabaseManagerConfig{MaxSize: 7, IdleTTL: 3 * time.Minute}
+	opts := b.BuildDatabaseOptions()
+	assert.Equal(t, 7, opts.MaxSize)
+	assert.Equal(t, 3*time.Minute, opts.IdleTTL)
 }
 
 func TestManagerConfigBuilderBuildMessagingOptions(t *testing.T) {
 	t.Run("single-tenant messaging options", func(t *testing.T) {
 		builder := NewManagerConfigBuilder(false, 100)
+		builder.publisherConfig = config.PublisherPoolConfig{MaxCached: 50, IdleTTL: time.Hour}
 
 		options := builder.BuildMessagingOptions()
 
-		// With no operator override, single-tenant falls back to the documented
-		// messaging.publisher defaults (maxcached=50, idlettl=1h).
 		assert.Equal(t, 50, options.MaxPublishers)
 		assert.Equal(t, 1*time.Hour, options.IdleTTL)
 	})
@@ -142,18 +141,17 @@ func TestManagerConfigBuilderBuildMessagingOptions(t *testing.T) {
 	t.Run("multi-tenant messaging options", func(t *testing.T) {
 		tenantLimit := 300
 		builder := NewManagerConfigBuilder(true, tenantLimit)
+		builder.publisherConfig = config.PublisherPoolConfig{IdleTTL: 10 * time.Minute}
 
 		options := builder.BuildMessagingOptions()
 
 		assert.Equal(t, tenantLimit, options.MaxPublishers)
-		// 10m: the multi-tenant messaging.publisher.idlettl default (see
-		// config/validation.go: defaultPublisherIdleTTLMultiTenant), not the fictional 5m
-		// this test previously asserted.
 		assert.Equal(t, 10*time.Minute, options.IdleTTL)
 	})
 
 	t.Run(zeroLimitMultiTenantTest, func(t *testing.T) {
 		builder := NewManagerConfigBuilder(true, 0)
+		builder.publisherConfig = config.PublisherPoolConfig{IdleTTL: 10 * time.Minute}
 
 		options := builder.BuildMessagingOptions()
 
@@ -163,6 +161,7 @@ func TestManagerConfigBuilderBuildMessagingOptions(t *testing.T) {
 
 	t.Run(negativeLimitMultiTenantTest, func(t *testing.T) {
 		builder := NewManagerConfigBuilder(true, -3)
+		builder.publisherConfig = config.PublisherPoolConfig{IdleTTL: 10 * time.Minute}
 
 		options := builder.BuildMessagingOptions()
 
@@ -173,6 +172,7 @@ func TestManagerConfigBuilderBuildMessagingOptions(t *testing.T) {
 	t.Run(largeLimitTenantTest, func(t *testing.T) {
 		largeLimit := 5000
 		builder := NewManagerConfigBuilder(true, largeLimit)
+		builder.publisherConfig = config.PublisherPoolConfig{IdleTTL: 10 * time.Minute}
 
 		options := builder.BuildMessagingOptions()
 
@@ -229,40 +229,6 @@ func TestManagerConfigBuilderBuildMessagingOptions(t *testing.T) {
 }
 
 func TestManagerConfigBuilderHonorsConfigDefaults(t *testing.T) {
-	// Config validation applies defaults: messaging.publisher.maxcached=50, messaging.publisher.idlettl=1h
-	// cache.manager.maxsize=100, cache.manager.idlettl=15m, cache.manager.cleanupinterval=5m
-
-	t.Run("single-tenant BuildMessagingOptions should honor config defaults not hardcoded 10", func(t *testing.T) {
-		builder := NewManagerConfigBuilder(false, 100)
-		// Currently hardcodes MaxPublishers=10, should instead read from cfg.Messaging.Publisher.MaxCached
-		opts := builder.BuildMessagingOptions()
-		assert.Equal(t, 50, opts.MaxPublishers, "should honor messaging.publisher.maxcached config default of 50, not hardcode 10")
-	})
-
-	t.Run("single-tenant BuildMessagingOptions IdleTTL should honor config default 1h not hardcoded 30m", func(t *testing.T) {
-		builder := NewManagerConfigBuilder(false, 100)
-		opts := builder.BuildMessagingOptions()
-		assert.Equal(t, 1*time.Hour, opts.IdleTTL, "should honor messaging.publisher.idlettl config default of 1h, not hardcode 30m")
-	})
-
-	t.Run("single-tenant BuildCacheOptions should honor config defaults not hardcoded 10", func(t *testing.T) {
-		builder := NewManagerConfigBuilder(false, 100)
-		opts := builder.BuildCacheOptions()
-		assert.Equal(t, 100, opts.MaxSize, "should honor cache.manager.maxsize config default of 100, not hardcode 10")
-	})
-
-	t.Run("single-tenant BuildCacheOptions IdleTTL should honor config default 15m not hardcoded 1h", func(t *testing.T) {
-		builder := NewManagerConfigBuilder(false, 100)
-		opts := builder.BuildCacheOptions()
-		assert.Equal(t, 15*time.Minute, opts.IdleTTL, "should honor cache.manager.idlettl config default of 15m, not hardcode 1h")
-	})
-
-	t.Run("single-tenant BuildCacheOptions CleanupInterval should honor config default 5m not hardcoded 15m", func(t *testing.T) {
-		builder := NewManagerConfigBuilder(false, 100)
-		opts := builder.BuildCacheOptions()
-		assert.Equal(t, 5*time.Minute, opts.CleanupInterval, "should honor cache.manager.cleanupinterval config default of 5m, not hardcode 15m")
-	})
-
 	t.Run("operator override reaches messaging options", func(t *testing.T) {
 		builder := NewManagerConfigBuilder(false, 100)
 		builder.publisherConfig = config.PublisherPoolConfig{MaxCached: 77, IdleTTL: 3 * time.Minute}
@@ -294,18 +260,6 @@ func TestManagerConfigBuilderHonorsConfigDefaults(t *testing.T) {
 		assert.Equal(t, 888, opts.MaxPublishers, "operator messaging.publisher.maxcached override must win over tenant limit")
 	})
 
-	t.Run("single-tenant BuildDatabaseOptions should honor config defaults not hardcoded 10", func(t *testing.T) {
-		builder := NewManagerConfigBuilder(false, 100)
-		opts := builder.BuildDatabaseOptions()
-		assert.Equal(t, 10, opts.MaxSize, "should honor database.manager.maxsize config default of 10")
-	})
-
-	t.Run("single-tenant BuildDatabaseOptions IdleTTL should honor config default 1h", func(t *testing.T) {
-		builder := NewManagerConfigBuilder(false, 100)
-		opts := builder.BuildDatabaseOptions()
-		assert.Equal(t, 1*time.Hour, opts.IdleTTL, "should honor database.manager.idlettl config default of 1h")
-	})
-
 	t.Run("operator override reaches database options", func(t *testing.T) {
 		builder := NewManagerConfigBuilder(false, 100)
 		builder.dbConfig = config.DatabaseManagerConfig{MaxSize: 33, IdleTTL: 8 * time.Minute}
@@ -321,21 +275,23 @@ func TestManagerConfigBuilderHonorsConfigDefaults(t *testing.T) {
 		assert.Equal(t, 777, opts.MaxSize, "operator database.manager.maxsize override must win over tenant limit")
 	})
 
-	t.Run("multi-tenant database zero dbConfig scales to tenant limit and 30m", func(t *testing.T) {
-		// Pins #661: unset dbConfig must fall through to multi-tenant defaults, not literal 0.
+	t.Run("multi-tenant database zero dbConfig scales to tenant limit", func(t *testing.T) {
+		// Pins #661: unset database.manager.maxsize must fall through to the tenant limit, not literal 0.
 		builder := NewManagerConfigBuilder(true, 250)
+		builder.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
 		opts := builder.BuildDatabaseOptions()
 		assert.Equal(t, 250, opts.MaxSize, "unset database.manager.maxsize must scale to the tenant limit")
-		assert.Equal(t, 30*time.Minute, opts.IdleTTL, "unset database.manager.idlettl must fall back to multi-tenant 30m")
+		assert.Equal(t, 30*time.Minute, opts.IdleTTL, "validated database.manager.idlettl must pass through unchanged")
 	})
 
 	t.Run("multi-tenant cache zero cacheConfig scales to tenant limit", func(t *testing.T) {
 		// Pins #668: unset cache.manager.maxsize must scale to the tenant limit (>100), not cap at 100.
 		builder := NewManagerConfigBuilder(true, 500)
+		builder.cacheConfig = config.CacheManagerConfig{IdleTTL: 15 * time.Minute, CleanupInterval: 5 * time.Minute}
 		opts := builder.BuildCacheOptions()
 		assert.Equal(t, 500, opts.MaxSize, "unset cache.manager.maxsize must scale to the tenant limit")
-		assert.Equal(t, 15*time.Minute, opts.IdleTTL, "unset cache.manager.idlettl must fall back to 15m")
-		assert.Equal(t, 5*time.Minute, opts.CleanupInterval, "unset cache.manager.cleanupinterval must fall back to 5m")
+		assert.Equal(t, 15*time.Minute, opts.IdleTTL, "validated cache.manager.idlettl must pass through unchanged")
+		assert.Equal(t, 5*time.Minute, opts.CleanupInterval, "validated cache.manager.cleanupinterval must pass through unchanged")
 	})
 }
 
@@ -439,11 +395,10 @@ func TestResourceManagerFactoryWarnsOnUnderProvisionedPool(t *testing.T) {
 func TestManagerConfigBuilderBuildCacheOptions(t *testing.T) {
 	t.Run("single-tenant cache options", func(t *testing.T) {
 		builder := NewManagerConfigBuilder(false, 100)
+		builder.cacheConfig = config.CacheManagerConfig{MaxSize: 100, IdleTTL: 15 * time.Minute, CleanupInterval: 5 * time.Minute}
 
 		options := builder.BuildCacheOptions()
 
-		// With no operator override, single-tenant falls back to the documented
-		// cache.manager defaults (maxsize=100, idlettl=15m, cleanupinterval=5m).
 		assert.Equal(t, 100, options.MaxSize)
 		assert.Equal(t, 15*time.Minute, options.IdleTTL)
 		assert.Equal(t, 5*time.Minute, options.CleanupInterval)
@@ -452,6 +407,7 @@ func TestManagerConfigBuilderBuildCacheOptions(t *testing.T) {
 	t.Run("multi-tenant cache options", func(t *testing.T) {
 		tenantLimit := 250
 		builder := NewManagerConfigBuilder(true, tenantLimit)
+		builder.cacheConfig = config.CacheManagerConfig{IdleTTL: 15 * time.Minute, CleanupInterval: 5 * time.Minute}
 
 		options := builder.BuildCacheOptions()
 
@@ -462,6 +418,7 @@ func TestManagerConfigBuilderBuildCacheOptions(t *testing.T) {
 
 	t.Run(zeroLimitMultiTenantTest, func(t *testing.T) {
 		builder := NewManagerConfigBuilder(true, 0)
+		builder.cacheConfig = config.CacheManagerConfig{IdleTTL: 15 * time.Minute, CleanupInterval: 5 * time.Minute}
 
 		options := builder.BuildCacheOptions()
 
@@ -472,6 +429,7 @@ func TestManagerConfigBuilderBuildCacheOptions(t *testing.T) {
 
 	t.Run(negativeLimitMultiTenantTest, func(t *testing.T) {
 		builder := NewManagerConfigBuilder(true, -3)
+		builder.cacheConfig = config.CacheManagerConfig{IdleTTL: 15 * time.Minute, CleanupInterval: 5 * time.Minute}
 
 		options := builder.BuildCacheOptions()
 
@@ -483,6 +441,7 @@ func TestManagerConfigBuilderBuildCacheOptions(t *testing.T) {
 	t.Run(largeLimitTenantTest, func(t *testing.T) {
 		largeLimit := 5000
 		builder := NewManagerConfigBuilder(true, largeLimit)
+		builder.cacheConfig = config.CacheManagerConfig{IdleTTL: 15 * time.Minute, CleanupInterval: 5 * time.Minute}
 
 		options := builder.BuildCacheOptions()
 
@@ -494,24 +453,26 @@ func TestManagerConfigBuilderBuildCacheOptions(t *testing.T) {
 
 func TestManagerConfigBuilderConsistency(t *testing.T) {
 	t.Run("single-tenant configuration consistency", func(t *testing.T) {
-		builder := NewManagerConfigBuilder(false, 999) // Tenant limit should be ignored
+		builder := NewManagerConfigBuilder(false, 999) // Tenant limit should be ignored: validated operator values win.
+		builder.dbConfig = config.DatabaseManagerConfig{MaxSize: 10, IdleTTL: time.Hour}
+		builder.publisherConfig = config.PublisherPoolConfig{MaxCached: 50, IdleTTL: time.Hour}
 
 		dbOptions := builder.BuildDatabaseOptions()
 		msgOptions := builder.BuildMessagingOptions()
 
-		// Single-tenant ignores tenantLimit: DB keeps its fixed size, messaging
-		// falls back to the documented messaging.publisher.maxcached default (50).
 		assert.Equal(t, 10, dbOptions.MaxSize)
 		assert.Equal(t, 50, msgOptions.MaxPublishers)
 
 		// Invariant: the DB pool must never be shorter-lived than the messaging pool
-		// (DB connections are heavier to re-establish). Currently both default to 1h.
+		// (DB connections are heavier to re-establish).
 		assert.GreaterOrEqual(t, dbOptions.IdleTTL, msgOptions.IdleTTL, "DB pool IdleTTL must be >= messaging pool IdleTTL in single-tenant mode")
 	})
 
 	t.Run("multi-tenant configuration consistency", func(t *testing.T) {
 		tenantLimit := 200
 		builder := NewManagerConfigBuilder(true, tenantLimit)
+		builder.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
+		builder.publisherConfig = config.PublisherPoolConfig{IdleTTL: 10 * time.Minute}
 
 		dbOptions := builder.BuildDatabaseOptions()
 		msgOptions := builder.BuildMessagingOptions()
@@ -545,7 +506,12 @@ func TestManagerConfigBuilderConsistency(t *testing.T) {
 func TestManagerConfigBuilderEdgeCases(t *testing.T) {
 	t.Run("configuration differences between modes", func(t *testing.T) {
 		singleTenant := NewManagerConfigBuilder(false, 100)
+		singleTenant.dbConfig = config.DatabaseManagerConfig{MaxSize: 10, IdleTTL: time.Hour}
+		singleTenant.publisherConfig = config.PublisherPoolConfig{MaxCached: 50, IdleTTL: time.Hour}
+
 		multiTenant := NewManagerConfigBuilder(true, 100)
+		multiTenant.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
+		multiTenant.publisherConfig = config.PublisherPoolConfig{IdleTTL: 10 * time.Minute}
 
 		singleDbOpts := singleTenant.BuildDatabaseOptions()
 		multiDbOpts := multiTenant.BuildDatabaseOptions()
@@ -561,6 +527,8 @@ func TestManagerConfigBuilderEdgeCases(t *testing.T) {
 
 	t.Run("expected TTL relationships", func(t *testing.T) {
 		builder := NewManagerConfigBuilder(true, 100)
+		builder.dbConfig = config.DatabaseManagerConfig{IdleTTL: 30 * time.Minute}
+		builder.publisherConfig = config.PublisherPoolConfig{IdleTTL: 10 * time.Minute}
 
 		dbOptions := builder.BuildDatabaseOptions()
 		msgOptions := builder.BuildMessagingOptions()
@@ -573,9 +541,14 @@ func TestManagerConfigBuilderEdgeCases(t *testing.T) {
 
 	t.Run("single-tenant ignores tenant limit parameter", func(t *testing.T) {
 		builder1 := NewManagerConfigBuilder(false, 1)
-		builder2 := NewManagerConfigBuilder(false, 10000)
+		builder1.dbConfig = config.DatabaseManagerConfig{MaxSize: 10, IdleTTL: time.Hour}
+		builder1.publisherConfig = config.PublisherPoolConfig{MaxCached: 50, IdleTTL: time.Hour}
 
-		// Both should produce identical options since single-tenant ignores tenantLimit
+		builder2 := NewManagerConfigBuilder(false, 10000)
+		builder2.dbConfig = config.DatabaseManagerConfig{MaxSize: 10, IdleTTL: time.Hour}
+		builder2.publisherConfig = config.PublisherPoolConfig{MaxCached: 50, IdleTTL: time.Hour}
+
+		// Both should produce identical options since a validated operator value ignores tenantLimit
 		dbOpts1 := builder1.BuildDatabaseOptions()
 		dbOpts2 := builder2.BuildDatabaseOptions()
 		msgOpts1 := builder1.BuildMessagingOptions()

--- a/config/config.go
+++ b/config/config.go
@@ -326,7 +326,7 @@ func loadDefaults(k *koanf.Koanf) error {
 		"app.rate.burst":                200,
 		"app.rate.ippreguard.enabled":   true,
 		"app.rate.ippreguard.threshold": 2000,
-		"app.startup.timeout":           "10s",
+		"app.startup.timeout":           defaultStartupTimeout.String(),
 
 		"server.host":               "0.0.0.0",
 		fieldServerPort:             8080,
@@ -345,10 +345,10 @@ func loadDefaults(k *koanf.Koanf) error {
 		// Database defaults not provided for deterministic behavior
 		// Database will only be enabled when explicitly configured
 
-		// Cache defaults. These mirror the defaultRedis* constants in validation.go
-		// (the single source of truth, also applied to per-tenant caches via
-		// applyRedisDefaults) — keep the two in sync. koanf duration defaults are
-		// strings, so the time.Duration constants are rendered via .String().
+		// Cache defaults. Rendered from the same constants applyRedisDefaults uses;
+		// TestKoanfDefaultsMatchApplyDefaultsForSharedKeys pins the equality. koanf
+		// duration defaults are strings, so the time.Duration constants are rendered
+		// via .String().
 		"cache.enabled":               false,
 		"cache.type":                  CacheTypeRedis,
 		"cache.redis.host":            defaultHost,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1379,4 +1379,5 @@ func TestKoanfDefaultsMatchApplyDefaultsForSharedKeys(t *testing.T) {
 	assert.Equal(t, applied.Cache.Redis.MinRetryBackoff, loaded.Cache.Redis.MinRetryBackoff)
 	assert.Equal(t, applied.Cache.Redis.MaxRetryBackoff, loaded.Cache.Redis.MaxRetryBackoff)
 	assert.Equal(t, applied.Cache.Redis.PoolSize, loaded.Cache.Redis.PoolSize)
+	assert.Equal(t, applied.Cache.Redis.Port, loaded.Cache.Redis.Port)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1341,3 +1341,42 @@ app:
 		assert.Contains(t, err.Error(), "failed to load config.production.yaml")
 	})
 }
+
+// loadDefaultConfig loads koanf defaults (no YAML, no env) and unmarshals them the
+// same way Load does, so a test can inspect the resulting typed Config.
+func loadDefaultConfig(t *testing.T) (*Config, error) {
+	t.Helper()
+	k := koanf.New(".")
+	if err := loadDefaults(k); err != nil {
+		return nil, err
+	}
+	var cfg Config
+	if err := k.UnmarshalWithConf("", &cfg, koanf.UnmarshalConf{
+		DecoderConfig: buildDecoderConfig(),
+	}); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// TestKoanfDefaultsMatchApplyDefaultsForSharedKeys pins the two default-rendering
+// mechanisms to one source: koanf defaults (Load path) and apply*Defaults (Validate
+// path) must produce the same values wherever both speak. A new shared default
+// belongs in a constant both sides render.
+func TestKoanfDefaultsMatchApplyDefaultsForSharedKeys(t *testing.T) {
+	loaded, err := loadDefaultConfig(t)
+	require.NoError(t, err)
+
+	applied := &Config{}
+	require.NoError(t, applyStartupDefaults(&applied.App.Startup))
+	applyRedisDefaults(&applied.Cache.Redis)
+
+	assert.Equal(t, applied.App.Startup.Timeout, loaded.App.Startup.Timeout)
+	assert.Equal(t, applied.Cache.Redis.DialTimeout, loaded.Cache.Redis.DialTimeout)
+	assert.Equal(t, applied.Cache.Redis.ReadTimeout, loaded.Cache.Redis.ReadTimeout)
+	assert.Equal(t, applied.Cache.Redis.WriteTimeout, loaded.Cache.Redis.WriteTimeout)
+	assert.Equal(t, applied.Cache.Redis.MaxRetries, loaded.Cache.Redis.MaxRetries)
+	assert.Equal(t, applied.Cache.Redis.MinRetryBackoff, loaded.Cache.Redis.MinRetryBackoff)
+	assert.Equal(t, applied.Cache.Redis.MaxRetryBackoff, loaded.Cache.Redis.MaxRetryBackoff)
+	assert.Equal(t, applied.Cache.Redis.PoolSize, loaded.Cache.Redis.PoolSize)
+}

--- a/messaging/manager.go
+++ b/messaging/manager.go
@@ -109,13 +109,11 @@ func NewMessagingManager(resourceSource BrokerURLProvider, log logger.Logger, op
 		opts.MaxPublishers = 50 // sensible default
 	}
 	if opts.IdleTTL <= 0 {
-		// Single-tenant default only: this package has no deployment-mode signal (a bare
-		// caller passes only ManagerOptions), so it cannot apply the multi-tenant 10m default.
-		// The real production path always resolves IdleTTL before it reaches here — via
-		// config.Validate() (config/validation.go: applyMessagingDefaults, mode-aware) and
-		// app.ManagerConfigBuilder.BuildMessagingOptions (app/managers.go, same mode split) —
-		// so this branch only serves bare/direct callers that bypass both.
-		opts.IdleTTL = 1 * time.Hour // kept in sync with app.defaultPublisherIdleTTL (see app/managers.go)
+		// Interface default for bare callers constructing a manager without the app
+		// builder; single-tenant value — a bare caller supplies no deployment-mode
+		// signal. The app path always arrives with IdleTTL already stamped by
+		// config.Validate (ADR-064).
+		opts.IdleTTL = 1 * time.Hour
 	}
 
 	// Default to real client factory if none provided

--- a/wiki/adr_064_app_validates_every_config.md
+++ b/wiki/adr_064_app_validates_every_config.md
@@ -30,9 +30,9 @@ hidden "already validated" state is introduced.
   fails at construction instead of booting on whatever the mirrors papered
   over. Remedy per field is the `ConfigError`'s own action line. See
   [migrations.md](migrations.md) [C59.12].
-- The app-side mirrors become dead weight and are deleted in the follow-up PR
-  (`app/managers.go` default constants, the mode fallbacks in
-  `resolveMaxSize`/`resolveIdleTTL`). `lifecycle.go`'s bypass guard is kept —
+- The app-side mirrors become dead weight and are deleted by the companion
+  refactor in the same stack (`app/managers.go` default constants, the mode
+  fallbacks in `resolveMaxSize`/`resolveIdleTTL`). `lifecycle.go`'s bypass guard is kept —
   only its comment is re-scoped, from describing a Validate bypass to
   describing direct-construction defense-in-depth.
   `messaging.NewMessagingManager` keeps its fallback: it is that standalone

--- a/wiki/adr_064_app_validates_every_config.md
+++ b/wiki/adr_064_app_validates_every_config.md
@@ -32,7 +32,9 @@ hidden "already validated" state is introduced.
   [migrations.md](migrations.md) [C59.12].
 - The app-side mirrors become dead weight and are deleted in the follow-up PR
   (`app/managers.go` default constants, the mode fallbacks in
-  `resolveMaxSize`/`resolveIdleTTL`, `lifecycle.go`'s bypass guard).
+  `resolveMaxSize`/`resolveIdleTTL`). `lifecycle.go`'s bypass guard is kept —
+  only its comment is re-scoped, from describing a Validate bypass to
+  describing direct-construction defense-in-depth.
   `messaging.NewMessagingManager` keeps its fallback: it is that standalone
   package's interface default for bare callers, not a mirror.
 - Test fixtures must be valid configs — a fixture that could not boot in

--- a/wiki/forwarded_client_cert.md
+++ b/wiki/forwarded_client_cert.md
@@ -24,10 +24,12 @@ server:
 ```
 
 `require: true` registers the middleware even if `enabled` was left `false`, emitting a
-startup WARN that names both keys — otherwise a config assembled in Go and passed to
-`app.NewWithConfig` (which skips `config.Validate`) would serve every request
-unauthenticated while asserting the opposite. On the YAML path `config.Validate` still
-rejects the combination outright, so the WARN only ever appears for programmatic configs.
+startup WARN that names both keys — otherwise a config path that skips `config.Validate`
+entirely (a `Builder` assembled without `WithConfig`, or any `Config` built by hand) would
+serve every request unauthenticated while asserting the opposite. On the YAML and
+`app.NewWithConfig` paths `config.Validate` runs and rejects the combination outright
+(ADR-064), so the WARN only ever appears for configs that bypass `app.Builder.WithConfig`
+altogether.
 
 ## What gets parsed
 

--- a/wiki/forwarded_client_cert.md
+++ b/wiki/forwarded_client_cert.md
@@ -25,7 +25,7 @@ server:
 
 `require: true` registers the middleware even if `enabled` was left `false`, emitting a
 startup WARN that names both keys — otherwise a config path that skips `config.Validate`
-entirely (a `Builder` assembled without `WithConfig`, or any `Config` built by hand) would
+entirely (a `Builder` assembled without `WithConfig`) would
 serve every request unauthenticated while asserting the opposite. On the YAML and
 `app.NewWithConfig` paths `config.Validate` runs and rejects the combination outright
 (ADR-064), so the WARN only ever appears for configs that bypass `app.Builder.WithConfig`

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -2510,9 +2510,11 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   spread across forged keys now concentrates on real ones — expect `429`
   rates to move in both directions. (ii) `client_ip` values change wherever a proxy is in
   play; a chart grouped by it will show a different population. (iii) A
-  malformed `server.trustedproxies` entry now **aborts startup** — except on
-  the `config.Validate`-free `app.NewWithConfig` path, where it is skipped
-  with an ERROR log instead — rather than being dropped with a warning:
+  malformed `server.trustedproxies` entry now **aborts startup** on every
+  `app` construction path — `app.NewWithConfig` runs `config.Validate` too
+  since ADR-064 — except when `server.New` is called directly, outside the
+  `app` package's `config.Validate`, where it is skipped with an ERROR log
+  instead — rather than being dropped with a warning:
   `net.ParseCIDR` must accept it (a bare
   `10.0.0.5` is rejected — write `10.0.0.5/32`), host bits must be clear
   (`10.1.2.3/8` is rejected because it silently widens to `10.0.0.0/8`), and
@@ -3098,7 +3100,7 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
 - gate: match = a hand-built config violating any `config.Validate` rule — empty `app.name` or
   `app.version`, zero `server.timeout.*`, an invalid `database.type`, a negative pool value — now
   fails construction with `invalid configuration: …` naming the field. no-match = you construct via
-  `app.New`/`NewWithOptions`, or you already ran `config.Validate` first.
+  `app.New`, or `NewWithOptions` with the default loader, or you already ran `config.Validate` first.
 - apply: fix the config, not the call site — each rejection's `ConfigError` carries an action line.
   Test fixtures are the common hit: give them `app.name`, `app.version`, positive server timeouts.
 - verify: run your service's tests; construction-time failures name the field.

--- a/wiki/streams.md
+++ b/wiki/streams.md
@@ -53,10 +53,10 @@ messaging:
   dropped.
 - `multitenant.enabled` together with a stream `uri` is a **startup validation
   error**. Per-tenant stream consumption needs one Environment per tenant, which
-  does not exist yet. `config.Validate` enforces this, so a service assembled by
-  hand — `app.NewWithConfig` takes a `*config.Config` and never validates it —
-  would slip past; startup repeats the check before building the manager, and
-  both paths carry the `single-tenant only` marker.
+  does not exist yet. `config.Validate` enforces this, and `app.NewWithConfig`
+  runs `config.Validate` too (ADR-064), so this shape is caught at
+  construction; startup repeats the check before building the manager as
+  defense-in-depth, and both paths carry the `single-tenant only` marker.
 - Plaintext `rabbitmq-stream://` is accepted but **logs a WARN outside
   development**: the URI's credentials cross the network in the clear. There is
   no TLS configuration surface yet (see [ADR-059](adr_059_streams_consumption.md)


### PR DESCRIPTION
## What
ADR-064 (PR #1019) made every construction path validate, which turned the bypass-era machinery into dead weight: nine mirrored default constants and the mode fallbacks in `app/managers.go` are deleted (only the deliberate multi-tenant zero-to-tenant-limit scaling remains, #661), and koanf defaults now render from the same constants the apply-phase uses, pinned by test.

## Impact
None. Every deleted branch was unreachable on a validated config; `messaging.NewMessagingManager` keeps its own bare-caller fallback, re-documented as an interface default.

## Verification
`make mutate`: all mutants on changed lines killed. The koanf/apply pinning test's drift detection was itself verified by mutating a default and watching it fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Manager settings now consistently honor validated configuration values, including zero idle timeouts and multi-tenant size limits.
  * Startup and cache defaults are aligned across configuration loading and validation.
  * Invalid configurations are rejected consistently during application construction and startup.

* **Documentation**
  * Clarified configuration behavior and safeguards for direct application construction.
  * Updated guidance for trusted proxies, migrations, streams, and default settings.

* **Tests**
  * Added coverage for validated values, zero-value scaling, and consistency between configured and applied defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->