### PR TITLE
docs: add .out-of-scope knowledge base with config presence-module entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 !docs/design/*.md
 !docs/agents/*.md
 !CONTEXT.md
+!.out-of-scope/*.md
 
 !.github/workflows/*.yml
 !.github/workflows/*.yaml

--- a/.out-of-scope/config-presence-module.md
+++ b/.out-of-scope/config-presence-module.md
@@ -1,0 +1,27 @@
+# Config presence module
+
+**Decision:** Deferred (YAGNI) — not built until a trigger below fires.
+
+**Reason:** "Was this section delivered?" is answered two ways today: koanf
+key presence (`databaseIdentityKeys`, consulted by the delivered-empty check)
+and decoded-value emptiness (`IsDatabaseConfigured`). A single presence seam
+that answers from whichever backing exists would move the hand-built /
+dynamic-tenant blind spot from a comment into a code path — but a seam with
+one adapter and one consumer is an abstraction without a second point to
+justify it. The two answers stay pinned together by a test until then
+(ADR-047, ADR-051 mechanics).
+
+**Reopen when either fires:**
+
+1. A second consumer needs the presence answer — a non-database section that
+   must distinguish "delivered empty" from "absent".
+2. The hand-built / dynamic-source blind spot causes a real incident — a
+   section boots as absent when it was delivered empty.
+
+If built, the natural home is the normalize phase from the `Validate`
+normalize/check split.
+
+**Prior requests:**
+
+- [#1022](https://github.com/gaborage/go-bricks/issues/1022) — closed
+  2026-08-16 (deferred, this entry)


### PR DESCRIPTION
## What
`/triage` had nowhere durable to record a deferred or rejected enhancement, so the reasoning lived only in a closed issue. This adds the `.out-of-scope/` knowledge base (allowlisted in `.gitignore`) with its first entry: the config presence module from #1022, deferred until a second presence consumer or a delivered-empty blind-spot incident appears.

## Impact
None for consumers. Future `/triage` runs read `.out-of-scope/*.md` and surface matches before re-evaluating a request.

## Verification
CI gates only.

Closes #1022


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a decision record documenting that the configuration presence module is deferred.
  * Recorded current presence-check approaches, potential future implementation guidance, and reopening criteria.

* **Chores**
  * Updated ignore rules to allow Markdown documentation in the designated out-of-scope directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->