### PR TITLE
refactor(config): presence step heads normalize; split multitenant and databases

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -658,9 +658,9 @@ func TestEnvOverrideReachesRenamedKeys(t *testing.T) {
 //
 // This stays green without MULTITENANT_ENABLED=true (and thus without a
 // resolver.domain, now required alongside resolver.order for a composite
-// reaching validateMultitenantResolver) only because validateMultitenant
-// short-circuits at `if !mt.Enabled { return nil }` — Load() still calls
-// Validate(), it just never reaches the resolver checks here.
+// reaching checkMultitenantResolver) only because normalizeMultitenant and
+// checkMultitenant both short-circuit at `if !mt.Enabled { return nil }` —
+// Load() still calls Validate(), it just never reaches the resolver checks here.
 func TestEnvOverrideReachesResolverOrder(t *testing.T) {
 	clearEnvironmentVariables()
 	defer clearEnvironmentVariables()

--- a/config/phases.go
+++ b/config/phases.go
@@ -27,8 +27,15 @@ func Validate(cfg *Config) error {
 // normalize shapes cfg: infers what can be inferred, fills documented
 // defaults, and rejects only what it cannot shape — a contradiction, a value a
 // consumer would silently drop, or (for a fill step) a negative where zero
-// means "use the default".
+// means "use the default". Presence rejections precede shaping.
 func normalize(cfg *Config) error {
+	// Presence rejections precede shaping: a section delivered with only empty
+	// identity keys cannot be shaped, and its error must not be replaced by the
+	// generic "incomplete" one that shaping would raise (ADR-051).
+	if err := validateNoDeliveredEmptyDatabase(cfg); err != nil {
+		return fmt.Errorf("database config: %w", err)
+	}
+
 	if err := normalizeApp(&cfg.App); err != nil {
 		return fmt.Errorf("app config: %w", err)
 	}
@@ -37,12 +44,7 @@ func normalize(cfg *Config) error {
 		return fmt.Errorf("scheduler config: %w", err)
 	}
 
-	// The remaining validate* steps still interleave shaping and checks; PR2/PR3 split or move them.
-	if err := validateNoDeliveredEmptyDatabase(cfg); err != nil {
-		return fmt.Errorf("database config: %w", err)
-	}
-
-	if err := validateMultitenant(&cfg.Multitenant, &cfg.Database, &cfg.Messaging, &cfg.Source); err != nil {
+	if err := normalizeMultitenant(&cfg.Multitenant, &cfg.Source); err != nil {
 		return fmt.Errorf("multitenant config: %w", err)
 	}
 
@@ -55,10 +57,11 @@ func normalize(cfg *Config) error {
 		return fmt.Errorf("database config: %w", err)
 	}
 
-	if err := validateNamedDatabases(cfg.Databases, &cfg.Multitenant); err != nil {
+	if err := normalizeNamedDatabases(cfg.Databases); err != nil {
 		return fmt.Errorf("databases config: %w", err)
 	}
 
+	// validateCache and validateMessaging still interleave shaping and checks; PR3 splits them.
 	if err := validateCache(&cfg.Cache, cfg.Multitenant.Enabled); err != nil {
 		return fmt.Errorf("cache config: %w", err)
 	}
@@ -84,6 +87,14 @@ func check(cfg *Config) error {
 
 	if err := checkScheduler(&cfg.Scheduler); err != nil {
 		return fmt.Errorf("scheduler config: %w", err)
+	}
+
+	if err := checkMultitenant(&cfg.Multitenant, &cfg.Database, &cfg.Messaging, &cfg.Source); err != nil {
+		return fmt.Errorf("multitenant config: %w", err)
+	}
+
+	if err := checkNamedDatabases(cfg.Databases, &cfg.Multitenant); err != nil {
+		return fmt.Errorf("databases config: %w", err)
 	}
 
 	if err := checkLog(&cfg.Log); err != nil {

--- a/config/phases_test.go
+++ b/config/phases_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,6 +21,27 @@ func TestValidateRejectsNil(t *testing.T) {
 	require.ErrorIs(t, err, errNilConfig)
 }
 
+// idempotencyMultitenantFixture is a full literal config with static
+// multitenancy: two tenant databases (so the tenant map write-back path is
+// under the pin) and a named database. The root database is left absent — a
+// root database and static tenants both configured is a conflict
+// (validateNoSingleTenantConflict).
+func idempotencyMultitenantFixture() *Config {
+	cfg := createValidFullConfig()
+	cfg.Database = DatabaseConfig{}
+	cfg.Source = SourceConfig{Type: SourceTypeStatic}
+	cfg.Multitenant = MultitenantConfig{
+		Enabled:  true,
+		Resolver: ResolverConfig{Type: ResolverTypeHeader},
+		Tenants: map[string]TenantEntry{
+			"acme":   {Database: createValidDatabaseConfig()},
+			"globex": {Database: createValidDatabaseConfig()},
+		},
+	}
+	cfg.Databases = map[string]DatabaseConfig{"reporting": createValidDatabaseConfig()}
+	return cfg
+}
+
 // TestValidateIsIdempotent pins decision 5 of the normalize/check split design:
 // every construction path calls Validate, some more than once, so a second
 // pass must be a no-op. Two independently built configs are compared rather
@@ -31,6 +53,17 @@ func TestValidateIsIdempotent(t *testing.T) {
 		require.NoError(t, Validate(a))
 
 		b := idempotencyFixture()
+		require.NoError(t, Validate(b))
+		require.NoError(t, Validate(b))
+
+		require.Equal(t, a, b)
+	})
+
+	t.Run("literal_door_multitenant", func(t *testing.T) {
+		a := idempotencyMultitenantFixture()
+		require.NoError(t, Validate(a))
+
+		b := idempotencyMultitenantFixture()
 		require.NoError(t, Validate(b))
 		require.NoError(t, Validate(b))
 
@@ -89,5 +122,100 @@ func TestCheckDoesNotMutate(t *testing.T) {
 
 		require.Error(t, check(a))
 		require.Equal(t, a, b)
+	})
+}
+
+// TestNormalizeDeliveredEmptyWinsOverIncomplete pins the presence step's
+// position at the head of normalize (ADR-051): a root database delivered
+// through koanf with an empty identity key must fail with the delivered-empty
+// error, never the generic incomplete one a later shaping step would raise for
+// the same key. An app-side normalize rejection is planted so the pin fails if
+// the presence step slips below normalizeApp; the sibling proves the plant is
+// live.
+func TestNormalizeDeliveredEmptyWinsOverIncomplete(t *testing.T) {
+	t.Run("presence_wins", func(t *testing.T) {
+		cfg, err := loadDeliveredEmptyFixture(t, "", map[string]string{"DATABASE_HOST": "", "APP_STARTUP_TIMEOUT": "-1s"})
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assertDeliveredEmptyError(t, err.Error(), []string{"delivered empty", "database.host"}, []string{"incomplete", appStartupTimeoutField}, nil)
+	})
+
+	t.Run("plant_is_live", func(t *testing.T) {
+		cfg, err := loadDeliveredEmptyFixture(t, "", map[string]string{"APP_STARTUP_TIMEOUT": "-1s"})
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Contains(t, err.Error(), appStartupTimeoutField)
+	})
+}
+
+// TestNormalizeLiteralDoorIncompleteSurfaces pins the complementary door: a
+// hand-built Config literal carries no koanf handle, so
+// validateNoDeliveredEmptyDatabase is inert for it (see
+// TestValidateNoDeliveredEmptyDatabaseInertForLiteral) and normalizeDatabaseSection's
+// own rejection must surface instead.
+func TestNormalizeLiteralDoorIncompleteSurfaces(t *testing.T) {
+	cfg := createValidFullConfig()
+	cfg.Database = DatabaseConfig{Host: "db.internal"}
+
+	err := Validate(cfg)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "delivered empty")
+
+	var cfgErr *ConfigError
+	require.ErrorAs(t, err, &cfgErr)
+	assert.Equal(t, errCategoryInvalid, cfgErr.Category)
+	assert.Equal(t, "database.type", cfgErr.Field)
+}
+
+// TestNormalizeManagerDefaultsRootOnly pins that database.manager.* defaults
+// reach the root section only; a named or tenant section carrying a manager
+// block is rejected — pinned through Validate in validation_test.go.
+func TestNormalizeManagerDefaultsRootOnly(t *testing.T) {
+	cfg := idempotencyFixture()
+	require.NoError(t, Validate(cfg))
+
+	assert.Equal(t, defaultDatabaseManagerIdleTTL, cfg.Database.Manager.IdleTTL)
+	assert.Equal(t, defaultDatabaseManagerCleanupInterval, cfg.Database.Manager.CleanupInterval)
+	assert.Equal(t, defaultDatabaseManagerMaxSize, cfg.Database.Manager.MaxSize)
+	assert.Zero(t, cfg.Databases["reporting"].Manager)
+}
+
+// TestCheckSingleTenantConflictAfterNormalize pins the conflict rule through
+// the phase boundary: it now runs after root database and messaging
+// normalization, so a complete root section alongside static tenants must
+// still abort — normalization never adds identity to a section that had none.
+func TestCheckSingleTenantConflictAfterNormalize(t *testing.T) {
+	t.Run("root_database", func(t *testing.T) {
+		cfg := idempotencyMultitenantFixture()
+		cfg.Database = createValidDatabaseConfig()
+
+		err := Validate(cfg)
+		require.Error(t, err)
+		var cfgErr *ConfigError
+		require.ErrorAs(t, err, &cfgErr)
+		assert.Equal(t, fieldDatabase, cfgErr.Field)
+		assert.Contains(t, err.Error(), "not allowed when static tenants are configured")
+	})
+
+	// A static source with no tenant map has no static tenants: the root
+	// database stays legal, so the gate must be "at least one", not "any map".
+	t.Run("no_tenant_map_permits_root_database", func(t *testing.T) {
+		cfg := idempotencyMultitenantFixture()
+		cfg.Multitenant.Tenants = nil
+		cfg.Database = createValidDatabaseConfig()
+
+		require.NoError(t, Validate(cfg))
+	})
+
+	t.Run("root_messaging", func(t *testing.T) {
+		cfg := idempotencyMultitenantFixture()
+		cfg.Messaging.Broker.URL = "amqp://guest:guest@localhost:5672/"
+
+		err := Validate(cfg)
+		require.Error(t, err)
+		var cfgErr *ConfigError
+		require.ErrorAs(t, err, &cfgErr)
+		assert.Equal(t, fieldMessaging, cfgErr.Field)
+		assert.Contains(t, err.Error(), "not allowed when static tenants are configured")
 	})
 }

--- a/config/validation.go
+++ b/config/validation.go
@@ -595,6 +595,10 @@ func validateNoDeliveredEmptyDatabase(cfg *Config) error {
 // values (no koanf instance to consult) and dynamic-source tenant configs
 // (resolved from a remote store, never koanf). TLS material is likewise
 // excluded from this predicate — it identifies no database on its own.
+//
+// The answer must not change across normalizeDatabaseSection: normalization
+// never adds identity to a section that had none, which is what lets check
+// consult this predicate after normalize (validateNoSingleTenantConflict).
 func IsDatabaseConfigured(cfg *DatabaseConfig) bool {
 	return cfg.ConnectionString != "" ||
 		cfg.Type != "" ||
@@ -891,19 +895,30 @@ func validateCIDRList(field string, list []string) error {
 	return nil
 }
 
-func validateNamedDatabases(databases map[string]DatabaseConfig, mt *MultitenantConfig) error {
+// normalizeNamedDatabases shapes every databases.* section (opaque; see
+// normalizeDatabaseSection) and writes the result back so the defaults reach
+// downstream consumers such as TenantStore. The map-key rules (empty name,
+// reserved prefix, tenant-ID collision) are check's — see checkNamedDatabases.
+func normalizeNamedDatabases(databases map[string]DatabaseConfig) error {
 	// Sorted, like forEachDatabaseSection: with several malformed entries the
 	// startup error names the same one every run.
 	for _, name := range slices.Sorted(maps.Keys(databases)) {
-		if err := validateNamedDatabaseName(name, mt); err != nil {
-			return err
-		}
 		dbCfg := databases[name]
 		if err := normalizeDatabaseSection(&dbCfg, namedDatabaseSection(name)); err != nil {
 			return err
 		}
-		// Write back so the defaults reach downstream consumers such as TenantStore.
 		databases[name] = dbCfg
+	}
+	return nil
+}
+
+// checkNamedDatabases rejects a databases.* map key without touching its
+// section's content (that is normalizeNamedDatabases' job).
+func checkNamedDatabases(databases map[string]DatabaseConfig, mt *MultitenantConfig) error {
+	for _, name := range slices.Sorted(maps.Keys(databases)) {
+		if err := validateNamedDatabaseName(name, mt); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -1474,19 +1489,47 @@ func validateRedisCache(cfg *RedisConfig) error {
 	return nil
 }
 
-// validateMultitenant validates multi-tenant configuration and ensures no conflicts
-// with single-tenant settings. When multitenant is enabled, database and messaging
-// configurations must be provided by the tenant config provider.
-func validateMultitenant(mt *MultitenantConfig, db *DatabaseConfig, msg *MessagingConfig, source *SourceConfig) error {
+// normalizeMultitenant shapes the multitenant section: resolver and limits
+// fills, then (static source only) each tenant's database (opaque) and cache.
+// Map-key rules (empty/dotted ID, messaging consistency, single-tenant
+// conflicts) are check's — see checkMultitenant.
+func normalizeMultitenant(mt *MultitenantConfig, source *SourceConfig) error {
 	if !mt.Enabled {
 		return nil
 	}
 
-	if err := validateMultitenantResolver(&mt.Resolver); err != nil {
+	normalizeMultitenantResolver(&mt.Resolver)
+	normalizeMultitenantLimits(&mt.Limits)
+
+	if hasStaticTenants(source, mt) {
+		if err := normalizeMultitenantTenants(mt.Tenants); err != nil {
+			return fmt.Errorf("tenants: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// hasStaticTenants is the phase-shared gate for the static tenant map: dynamic
+// sources load tenants from an external store and never reach it. A delivered
+// but empty static map is not "has tenants" — check rejects that case.
+func hasStaticTenants(source *SourceConfig, mt *MultitenantConfig) bool {
+	return source.Type == SourceTypeStatic && len(mt.Tenants) > 0
+}
+
+// checkMultitenant rejects a normalized multitenant section without changing
+// it: resolver and limits enumerations, source type, and (static source only)
+// the tenant map's key rules and its conflicts with single-tenant config.
+func checkMultitenant(mt *MultitenantConfig, db *DatabaseConfig, msg *MessagingConfig, source *SourceConfig) error {
+	if !mt.Enabled {
+		return nil
+	}
+
+	if err := checkMultitenantResolver(&mt.Resolver); err != nil {
 		return fmt.Errorf("resolver: %w", err)
 	}
 
-	if err := validateMultitenantLimits(&mt.Limits); err != nil {
+	if err := checkMultitenantLimits(&mt.Limits); err != nil {
 		return fmt.Errorf("limits: %w", err)
 	}
 
@@ -1494,28 +1537,35 @@ func validateMultitenant(mt *MultitenantConfig, db *DatabaseConfig, msg *Messagi
 		return fmt.Errorf("source: %w", err)
 	}
 
-	if err := validateStaticTenantConfig(source, mt, db, msg); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// validateStaticTenantConfig validates static tenant configuration and conflicts
-func validateStaticTenantConfig(source *SourceConfig, mt *MultitenantConfig, db *DatabaseConfig, msg *MessagingConfig) error {
 	// For static sources, validate tenants if provided (optional but must be valid if present)
 	// For dynamic sources, tenants are optional and loaded from external store
 	if source.Type == SourceTypeStatic && mt.Tenants != nil {
 		if len(mt.Tenants) == 0 {
 			return errors.New("tenants: empty map provided - either omit tenants section or provide at least one tenant for static source")
 		}
-		if err := validateMultitenantTenants(mt.Tenants); err != nil {
+
+		if err := checkTenantMessagingConsistency(mt.Tenants); err != nil {
 			return fmt.Errorf("tenants: %w", err)
+		}
+
+		// Sorted, like forEachDatabaseSection: with several malformed tenants the
+		// startup error names the same one every run.
+		for _, tenantID := range slices.Sorted(maps.Keys(mt.Tenants)) {
+			if tenantID == "" {
+				return fmt.Errorf("tenants: %w", NewValidationError(fieldMultitenantTenants, "tenant ID cannot be empty"))
+			}
+			// A '.' collides with koanf's path delimiter: the constructed section
+			// path multitenant.tenants.<id>.database becomes ambiguous. Koanf has
+			// no delimiter escaping, so fail fast rather than let a later lookup
+			// consult the wrong flattened key.
+			if strings.Contains(tenantID, ".") {
+				return fmt.Errorf("tenants: %w", NewValidationError(fieldMultitenantTenants,
+					fmt.Sprintf("tenant ID %q cannot contain '.' (the config path delimiter)", tenantID)))
+			}
 		}
 	}
 
-	// For static sources with tenants, ensure no conflict with single-tenant config
-	if source.Type == SourceTypeStatic && mt.Tenants != nil && len(mt.Tenants) > 0 {
+	if hasStaticTenants(source, mt) {
 		return validateNoSingleTenantConflict(db, msg)
 	}
 
@@ -1543,15 +1593,28 @@ func validateNoSingleTenantConflict(db *DatabaseConfig, msg *MessagingConfig) er
 	return nil
 }
 
-// validateMultitenantResolver validates tenant resolver configuration
-func validateMultitenantResolver(cfg *ResolverConfig) error {
+// normalizeMultitenantResolver fills the header default and, when the config
+// builds a subdomain resolver, trims a delivered domain and prefixes it with
+// '.'. An empty domain stays empty for checkMultitenantResolver to reject.
+func normalizeMultitenantResolver(cfg *ResolverConfig) {
+	if cfg.Header == "" {
+		cfg.Header = "X-Tenant-ID"
+	}
+	if buildsSubdomainResolver(cfg) && domainDelivered(cfg.Domain) {
+		cfg.Domain = strings.TrimSpace(cfg.Domain)
+		if !strings.HasPrefix(cfg.Domain, ".") {
+			cfg.Domain = "." + cfg.Domain
+		}
+	}
+}
+
+// checkMultitenantResolver rejects an unknown resolver type, a composite order
+// that is missing or malformed, and the field requirements each type implies
+// (subdomain root domain, path prefix/segment).
+func checkMultitenantResolver(cfg *ResolverConfig) error {
 	validTypes := []string{ResolverTypeHeader, ResolverTypeSubdomain, ResolverTypePath, ResolverTypeComposite}
 	if !slices.Contains(validTypes, cfg.Type) {
 		return NewInvalidFieldError("multitenant.resolver.type", fmt.Sprintf(errNotSupportedFmt, cfg.Type), validTypes)
-	}
-
-	if cfg.Header == "" {
-		cfg.Header = "X-Tenant-ID"
 	}
 
 	if err := validateResolverOrder(cfg); err != nil {
@@ -1603,25 +1666,34 @@ func validateResolverOrder(cfg *ResolverConfig) error {
 }
 
 func validateSubdomainResolverFields(cfg *ResolverConfig) error {
-	if cfg.Type != ResolverTypeSubdomain && cfg.Type != ResolverTypeComposite {
+	if !buildsSubdomainResolver(cfg) {
 		return nil
 	}
-	// A composite whose order excludes subdomain never builds one, so it needs
-	// no root domain. Order is required and validated above, so a composite
-	// reaching this point always has an explicit, non-empty Order.
-	if cfg.Type == ResolverTypeComposite && !slices.Contains(cfg.Order, ResolverTypeSubdomain) {
-		return nil
-	}
-	// A domain of "." (or whitespace around it) strips to "" once the leading
-	// dot is trimmed, and newSubdomainResolver builds nil from that — so reject
-	// it here too, not just the plain-empty case.
-	if strings.TrimPrefix(strings.TrimSpace(cfg.Domain), ".") == "" {
+	if !domainDelivered(cfg.Domain) {
 		return NewMissingFieldError("multitenant.resolver.domain", "MULTITENANT_RESOLVER_DOMAIN", "multitenant.resolver.domain")
 	}
-	if !strings.HasPrefix(cfg.Domain, ".") {
-		cfg.Domain = "." + cfg.Domain
-	}
 	return nil
+}
+
+// buildsSubdomainResolver reports whether the config will construct a
+// subdomain resolver: type subdomain, or a composite whose order includes
+// one. Order is required and checked separately, so a composite reaching
+// the check always has an explicit, non-empty Order.
+func buildsSubdomainResolver(cfg *ResolverConfig) bool {
+	switch cfg.Type {
+	case ResolverTypeSubdomain:
+		return true
+	case ResolverTypeComposite:
+		return slices.Contains(cfg.Order, ResolverTypeSubdomain)
+	default:
+		return false
+	}
+}
+
+// domainDelivered treats "." and whitespace as no domain: once the leading dot
+// is trimmed nothing is left, and newSubdomainResolver builds nil from that.
+func domainDelivered(domain string) bool {
+	return strings.TrimPrefix(strings.TrimSpace(domain), ".") != ""
 }
 
 // validatePathResolverFields enforces path-segment + prefix rules for the path
@@ -1643,42 +1715,32 @@ func validatePathResolverFields(cfg *ResolverConfig) error {
 	return nil
 }
 
-// validateMultitenantLimits validates limits configuration with defaults
-func validateMultitenantLimits(cfg *LimitsConfig) error {
+// normalizeMultitenantLimits fills the tenant-count default. A negative value
+// is treated the same as zero — kept intentionally, not tightened to reject.
+func normalizeMultitenantLimits(cfg *LimitsConfig) {
 	if cfg.Tenants <= 0 {
 		cfg.Tenants = 100 // default
 	}
+}
+
+// checkMultitenantLimits rejects a tenant cap above 1000; zero and negatives
+// were already defaulted by normalizeMultitenantLimits.
+func checkMultitenantLimits(cfg *LimitsConfig) error {
 	if cfg.Tenants > 1000 {
 		return NewValidationError("multitenant.limits.tenants", "cannot exceed 1000")
 	}
 	return nil
 }
 
-// validateMultitenantTenants validates tenant configurations when they are provided
-func validateMultitenantTenants(tenants map[string]TenantEntry) error {
-	if len(tenants) == 0 {
-		return NewValidationError(fieldMultitenantTenants, "at least one tenant must be configured")
-	}
-
-	if err := checkTenantMessagingConsistency(tenants); err != nil {
-		return err
-	}
-
+// normalizeMultitenantTenants shapes each static tenant's database (opaque)
+// and cache, and writes the result back to the map. The tenant-ID rules
+// (empty, dotted) and cross-tenant messaging consistency are check's — see
+// checkMultitenant.
+func normalizeMultitenantTenants(tenants map[string]TenantEntry) error {
 	// Sorted, like forEachDatabaseSection: with several malformed tenants the
 	// startup error names the same one every run.
 	for _, tenantID := range slices.Sorted(maps.Keys(tenants)) {
 		tenant := tenants[tenantID]
-		if tenantID == "" {
-			return NewValidationError(fieldMultitenantTenants, "tenant ID cannot be empty")
-		}
-		// A '.' collides with koanf's path delimiter: the constructed section
-		// path multitenant.tenants.<id>.database becomes ambiguous. Koanf has
-		// no delimiter escaping, so fail fast rather than let a later lookup
-		// consult the wrong flattened key.
-		if strings.Contains(tenantID, ".") {
-			return NewValidationError(fieldMultitenantTenants,
-				fmt.Sprintf("tenant ID %q cannot contain '.' (the config path delimiter)", tenantID))
-		}
 
 		if err := normalizeDatabaseSection(&tenant.Database, tenantDatabaseSection(tenantID)); err != nil {
 			return err
@@ -1688,7 +1750,7 @@ func validateMultitenantTenants(tenants map[string]TenantEntry) error {
 			return err
 		}
 
-		// Persist defaults back to the map (see validateNamedDatabases for rationale).
+		// Persist defaults back to the map (see normalizeNamedDatabases for rationale).
 		tenants[tenantID] = tenant
 	}
 

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -38,6 +38,7 @@ const (
 	redisPortField               = "cache.redis.port"
 	logLevel                     = "log.level"
 	oracleConnectionIdentifier   = "oracle connection identifier"
+	appStartupTimeoutField       = "app.startup.timeout"
 )
 
 func makeSampleTenants() map[string]TenantEntry {
@@ -52,7 +53,7 @@ func makeSampleTenants() map[string]TenantEntry {
 			},
 			Messaging: TenantMessagingConfig{URL: testAMQPHost},
 			// Cache enabled with only a host: port/poolsize/timeouts are left
-			// at zero values so the shared sample exercises validateMultitenant's
+			// at zero values so the shared sample exercises normalizeMultitenant's
 			// per-tenant cache validation and default-application path. Without
 			// it, every multitenant test would silently skip tenant.Cache and
 			// mask the M6 fast-fail/defaulting behavior.
@@ -1669,9 +1670,8 @@ func TestValidateNamedDatabaseInfersTypeFromConnectionString(t *testing.T) {
 	databases := map[string]DatabaseConfig{
 		"reporting": {ConnectionString: testConnectionString},
 	}
-	mt := MultitenantConfig{Enabled: false}
 
-	err := validateNamedDatabases(databases, &mt)
+	err := normalizeNamedDatabases(databases)
 
 	require.NoError(t, err)
 	assert.Equal(t, PostgreSQL, databases["reporting"].Type)
@@ -2261,8 +2261,8 @@ func TestApplyDatabaseTimezoneInheritsToNamedDatabases(t *testing.T) {
 	// Exercises real propagation through the top-level Validate(*Config) wiring,
 	// not the standalone normalizeDatabaseSection call in isolation. Split into
 	// two scenarios because the framework forbids a root Database alongside
-	// static tenants. Either scenario regressing (e.g. validateNamedDatabases or
-	// validateMultitenantTenants dropping their normalizeDatabaseSection call)
+	// static tenants. Either scenario regressing (e.g. normalizeNamedDatabases or
+	// normalizeMultitenantTenants dropping their normalizeDatabaseSection call)
 	// would fail this test.
 	t.Run("root_explicit_named_defaults", func(t *testing.T) {
 		cfg := createValidFullConfig()
@@ -2324,7 +2324,7 @@ func TestApplyDatabaseTimezoneInheritsToNamedDatabases(t *testing.T) {
 // cache with a host but no port/poolsize is hardened at startup: Redis
 // defaults (port 6379, poolsize 10, timeouts) are applied and persisted back
 // to the tenants map, exactly as already done for tenant.Database. Without the
-// fix, validateMultitenantTenants never touches tenant.Cache, so the raw
+// fix, normalizeMultitenantTenants never touches tenant.Cache, so the raw
 // zero-value Redis config reaches the cache client and fails at first request
 // instead of at startup.
 func TestValidateMultitenantTenantsCacheDefaults(t *testing.T) {
@@ -2964,7 +2964,7 @@ func TestApplyStartupDefaultsNegativeValues(t *testing.T) {
 		{
 			name:          "negative_timeout_rejected",
 			config:        StartupConfig{Timeout: -1 * time.Second},
-			errorContains: "app.startup.timeout",
+			errorContains: appStartupTimeoutField,
 		},
 		{
 			name:          "negative_database_rejected",
@@ -3297,6 +3297,23 @@ func createValidLogConfig() LogConfig {
 	}
 }
 
+// normalizeAndCheckResolver runs both halves of the resolver split in phase
+// order, for tables whose cases need a fill before the rejection they pin.
+func normalizeAndCheckResolver(cfg *ResolverConfig) error {
+	normalizeMultitenantResolver(cfg)
+	return checkMultitenantResolver(cfg)
+}
+
+// normalizeAndCheckNamedDatabases runs both halves of the named-database
+// split in phase order: an incomplete section is normalize's rejection, a bad
+// name or tenant-ID collision is check's.
+func normalizeAndCheckNamedDatabases(databases map[string]DatabaseConfig, mt *MultitenantConfig) error {
+	if err := normalizeNamedDatabases(databases); err != nil {
+		return err
+	}
+	return checkNamedDatabases(databases, mt)
+}
+
 // createValidFullConfig returns a complete valid Config for testing
 func createValidFullConfig() *Config {
 	return &Config{
@@ -3385,7 +3402,7 @@ func TestValidateMultitenantDisabled(t *testing.T) {
 	}
 
 	sourceConfig := &SourceConfig{Type: SourceTypeStatic}
-	err := validateMultitenant(mtConfig, dbConfig, msgConfig, sourceConfig)
+	err := checkMultitenant(mtConfig, dbConfig, msgConfig, sourceConfig)
 	assert.NoError(t, err, "Validation should pass when multitenant is disabled")
 }
 
@@ -3538,7 +3555,7 @@ func TestValidateMultitenantSuccess(t *testing.T) {
 			if sourceConfig == nil {
 				sourceConfig = &SourceConfig{Type: SourceTypeStatic}
 			}
-			err := validateMultitenant(tt.mtConfig, tt.dbConfig, tt.msgConfig, sourceConfig)
+			err := checkMultitenant(tt.mtConfig, tt.dbConfig, tt.msgConfig, sourceConfig)
 			assert.NoError(t, err)
 		})
 	}
@@ -3725,7 +3742,7 @@ func TestValidateMultitenantFailures(t *testing.T) {
 			if sourceConfig == nil {
 				sourceConfig = &SourceConfig{Type: SourceTypeStatic}
 			}
-			err := validateMultitenant(tt.mtConfig, tt.dbConfig, tt.msgConfig, sourceConfig)
+			err := checkMultitenant(tt.mtConfig, tt.dbConfig, tt.msgConfig, sourceConfig)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectedError)
 		})
@@ -3737,19 +3754,28 @@ func TestValidateMultitenantFailures(t *testing.T) {
 // constructed section path multitenant.tenants.<id>.database would become
 // ambiguous.
 func TestValidateMultitenantTenantsRejectsDottedTenantID(t *testing.T) {
-	tenants := map[string]TenantEntry{
-		"tenant.a": {
-			Database: DatabaseConfig{
-				Type:     PostgreSQL,
-				Host:     testTenantDBHost,
-				Port:     5432,
-				Database: "tenant_a",
-				Username: "tenant_user",
+	// The dotted-ID rule lives in checkMultitenant's tenant loop, which runs
+	// after the resolver/limits checks — so the resolver must be valid on its
+	// own for the rejection under test to be the one that surfaces.
+	mt := &MultitenantConfig{
+		Enabled:  true,
+		Resolver: ResolverConfig{Type: "header", Header: testTenantHeader},
+		Limits:   LimitsConfig{Tenants: 100},
+		Tenants: map[string]TenantEntry{
+			"tenant.a": {
+				Database: DatabaseConfig{
+					Type:     PostgreSQL,
+					Host:     testTenantDBHost,
+					Port:     5432,
+					Database: "tenant_a",
+					Username: "tenant_user",
+				},
 			},
 		},
 	}
+	source := &SourceConfig{Type: SourceTypeStatic}
 
-	err := validateMultitenantTenants(tenants)
+	err := checkMultitenant(mt, &DatabaseConfig{}, &MessagingConfig{}, source)
 	assertValidationError(t, err, "cannot contain '.'")
 }
 
@@ -3760,6 +3786,7 @@ func TestValidateMultitenantResolver(t *testing.T) {
 		expectError    bool
 		errorContains  string
 		expectedHeader string // Check default header is set
+		expectedDomain string // Check the domain was normalized
 	}{
 		{
 			name: "valid_header_resolver",
@@ -3818,9 +3845,19 @@ func TestValidateMultitenantResolver(t *testing.T) {
 			name: "subdomain_domain_without_leading_dot",
 			config: ResolverConfig{
 				Type:   "subdomain",
-				Domain: "api.example.com", // Will be normalized to .api.example.com
+				Domain: "api.example.com",
 			},
-			expectError: false, // Now accepts and normalizes domains without leading dot
+			expectError:    false,
+			expectedDomain: testDomain,
+		},
+		{
+			name: "subdomain_domain_with_surrounding_whitespace",
+			config: ResolverConfig{
+				Type:   "subdomain",
+				Domain: "  api.example.com\t",
+			},
+			expectError:    false,
+			expectedDomain: testDomain,
 		},
 		{
 			name: "subdomain_domain_dot_only_rejected",
@@ -3847,16 +3884,26 @@ func TestValidateMultitenantResolver(t *testing.T) {
 			config: ResolverConfig{
 				Type:   "composite",
 				Header: testTenantHeader,
-				Domain: "api.example.com", // Will be normalized to .api.example.com
+				Domain: "api.example.com",
 				Order:  []string{ResolverTypeSubdomain, ResolverTypeHeader},
 			},
-			expectError: false, // Now accepts and normalizes domains without leading dot
+			expectError:    false,
+			expectedDomain: testDomain,
+		},
+		{
+			name: "header_resolver_stray_domain_left_alone",
+			config: ResolverConfig{
+				Type:   "header",
+				Domain: "api.example.com",
+			},
+			expectError:    false,
+			expectedDomain: "api.example.com",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateMultitenantResolver(&tt.config)
+			err := normalizeAndCheckResolver(&tt.config)
 			if tt.expectError {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorContains)
@@ -3865,6 +3912,9 @@ func TestValidateMultitenantResolver(t *testing.T) {
 				// Check if default header was set
 				if tt.expectedHeader != "" {
 					assert.Equal(t, tt.expectedHeader, tt.config.Header)
+				}
+				if tt.expectedDomain != "" {
+					assert.Equal(t, tt.expectedDomain, tt.config.Domain)
 				}
 			}
 		})
@@ -3966,7 +4016,7 @@ func TestResolverOrderValidationRejectsUnknown(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateMultitenantResolver(&tt.config)
+			err := normalizeAndCheckResolver(&tt.config)
 			if tt.expectError {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorContains)
@@ -3981,28 +4031,26 @@ func TestResolverOrderValidationRejectsUnknown(t *testing.T) {
 func TestValidateMultitenantLimits(t *testing.T) {
 	t.Run("defaults when zero", func(t *testing.T) {
 		cfg := LimitsConfig{Tenants: 0}
-		err := validateMultitenantLimits(&cfg)
-		assert.NoError(t, err)
+		normalizeMultitenantLimits(&cfg)
 		assert.Equal(t, 100, cfg.Tenants)
 	})
 
 	t.Run("defaults when negative", func(t *testing.T) {
 		cfg := LimitsConfig{Tenants: -1}
-		err := validateMultitenantLimits(&cfg)
-		assert.NoError(t, err)
+		normalizeMultitenantLimits(&cfg)
 		assert.Equal(t, 100, cfg.Tenants)
 	})
 
 	t.Run("supports upper bound", func(t *testing.T) {
 		cfg := LimitsConfig{Tenants: 1000}
-		err := validateMultitenantLimits(&cfg)
+		err := checkMultitenantLimits(&cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, 1000, cfg.Tenants)
 	})
 
 	t.Run("rejects exceeding upper bound", func(t *testing.T) {
 		cfg := LimitsConfig{Tenants: 1001}
-		err := validateMultitenantLimits(&cfg)
+		err := checkMultitenantLimits(&cfg)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "multitenant.limits.tenants cannot exceed 1000")
 	})
@@ -4106,7 +4154,7 @@ func TestValidateMultitenantDynamicSource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateMultitenant(tt.mtConfig, &DatabaseConfig{}, &MessagingConfig{}, tt.sourceConfig)
+			err := checkMultitenant(tt.mtConfig, &DatabaseConfig{}, &MessagingConfig{}, tt.sourceConfig)
 			if tt.expectError {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorText)
@@ -4458,7 +4506,7 @@ func TestValidateNamedDatabasesSuccess(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateNamedDatabases(tt.databases, &tt.mt)
+			err := checkNamedDatabases(tt.databases, &tt.mt)
 			assert.NoError(t, err)
 		})
 	}
@@ -4568,7 +4616,7 @@ func TestValidateNamedDatabasesFailures(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateNamedDatabases(tt.databases, &tt.mt)
+			err := normalizeAndCheckNamedDatabases(tt.databases, &tt.mt)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.errContains)
 		})
@@ -4590,7 +4638,7 @@ func TestValidateNamedDatabasesRejectsDottedName(t *testing.T) {
 	}
 	mt := MultitenantConfig{Enabled: false}
 
-	err := validateNamedDatabases(databases, &mt)
+	err := checkNamedDatabases(databases, &mt)
 	assertValidationError(t, err, "cannot contain '.'")
 }
 
@@ -4614,7 +4662,7 @@ func TestValidateNamedDatabasesNoConflictWhenMultitenantDisabled(t *testing.T) {
 		},
 	}
 
-	err := validateNamedDatabases(databases, &mt)
+	err := checkNamedDatabases(databases, &mt)
 	assert.NoError(t, err, "no conflict when multitenant is disabled")
 }
 
@@ -5612,7 +5660,7 @@ func TestValidateNoDeliveredEmptyDatabaseViaLoad(t *testing.T) {
 		},
 		{
 			// Koanf populates Multitenant.Tenants from YAML regardless of the enabled
-			// flag, but TenantStore, ManagerConfigBuilder and validateMultitenant all
+			// flag, but TenantStore, ManagerConfigBuilder and normalizeMultitenant all
 			// ignore the block in single-tenant mode — so a leftover tenants section is
 			// inert, and aborting startup over it would be a false abort on a config
 			// that runs today.


### PR DESCRIPTION
## What
Second hop of the normalize/check split (#1024). The delivered-empty presence check (ADR-051) now heads `normalize`, and the multitenant and named-database sections split into `normalizeX`/`checkX`: fills (resolver header, subdomain root-domain trim + `.` prefix, tenant cap, tenant database/cache shaping, named-database shaping + write-back) in normalize; enumerations, ADR-039 order, key rules, messaging consistency, and the single-tenant conflict in check. `hasStaticTenants` and `buildsSubdomainResolver`/`domainDelivered` are shared so the phases cannot disagree. Cache and messaging remain interleaved for PR3.

## Impact
First-error precedence inside these sections follows the phase order (a malformed tenant database now reports before a dotted tenant ID); every rejection stays fatal. Nothing exported changes.

## Verification
Whole-Config pins: static-multitenant idempotency, delivered-empty beats incomplete (koanf door, with a live plant proving head placement), literal door surfaces shaping's rejection, manager defaults root-only, single-tenant conflict still fires after root normalization. `make mutate` on the changed lines ran locally.

Refs #1024


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration validation ordering so the most relevant errors are reported first.
  * Ensured defaults apply correctly to the root database without affecting tenant databases.
  * Strengthened checks for database, messaging, tenant, and multitenant conflicts.
  * Improved resolver normalization, including whitespace trimming and consistent subdomain formatting.
  * Clarified validation of incomplete and empty delivered configurations.

* **Tests**
  * Expanded coverage for startup settings, named databases, tenant configuration, caches, limits, time zones, messaging, and resolver behavior.
  * Added checks confirming repeated normalization preserves configuration state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->