### PR TITLE
refactor(config): split cache and messaging into normalize and check phases

### DIFF
--- a/app/managers.go
+++ b/app/managers.go
@@ -236,7 +236,7 @@ func (f *ResourceManagerFactory) CreateMessagingManager(
 // It fails closed: a nil manager registers no cache readiness probe, so /ready reports
 // the cache "disabled" and answers 200 — a service that asked for a cache, got none, and
 // joined the rotation anyway. Returning the error instead of logging it still matters after
-// WithConfig's config.Validate call (ADR-064): validateCache only checks Manager.MaxSize/IdleTTL
+// WithConfig's config.Validate call (ADR-064): normalizeCache only fills Manager.MaxSize/IdleTTL/CleanupInterval
 // when cache.enabled is true, so a negative value on a disabled cache reaches here unvalidated.
 func (f *ResourceManagerFactory) CreateCacheManager(
 	resourceSource TenantStore,

--- a/config/phases.go
+++ b/config/phases.go
@@ -61,12 +61,11 @@ func normalize(cfg *Config) error {
 		return fmt.Errorf("databases config: %w", err)
 	}
 
-	// validateCache and validateMessaging still interleave shaping and checks; PR3 splits them.
-	if err := validateCache(&cfg.Cache, cfg.Multitenant.Enabled); err != nil {
+	if err := normalizeCache(&cfg.Cache, cfg.Multitenant.Enabled); err != nil {
 		return fmt.Errorf("cache config: %w", err)
 	}
 
-	if err := validateMessaging(&cfg.Messaging, cfg.Multitenant.Enabled); err != nil {
+	if err := normalizeMessaging(&cfg.Messaging, cfg.Multitenant.Enabled); err != nil {
 		return fmt.Errorf("messaging config: %w", err)
 	}
 
@@ -99,6 +98,14 @@ func check(cfg *Config) error {
 
 	if err := checkLog(&cfg.Log); err != nil {
 		return fmt.Errorf("log config: %w", err)
+	}
+
+	if err := checkCache(&cfg.Cache); err != nil {
+		return fmt.Errorf("cache config: %w", err)
+	}
+
+	if err := checkMessaging(&cfg.Messaging, cfg.Multitenant.Enabled); err != nil {
+		return fmt.Errorf("messaging config: %w", err)
 	}
 
 	if err := checkKeyStore(&cfg.KeyStore); err != nil {

--- a/config/phases_test.go
+++ b/config/phases_test.go
@@ -273,6 +273,8 @@ func TestNormalizeDisabledCacheCarriesRedisDefaults(t *testing.T) {
 
 		require.NoError(t, Validate(cfg))
 		assert.Equal(t, defaultRedisPort, cfg.Cache.Redis.Port)
+		assert.Equal(t, defaultRedisPoolSize, cfg.Cache.Redis.PoolSize)
+		assert.Equal(t, defaultRedisDialTimeout, cfg.Cache.Redis.DialTimeout)
 	})
 }
 

--- a/config/phases_test.go
+++ b/config/phases_test.go
@@ -2,15 +2,16 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// idempotencyFixture is a full literal config with a named database, so the
-// map write-back path is under the pin. Static tenants join it with PR2's
-// fixtures.
-func idempotencyFixture() *Config {
+// singleTenantFixture is a full literal config with a named database, so the
+// map write-back path is under every pin that uses it; staticMultitenantFixture
+// is its static-tenant counterpart.
+func singleTenantFixture() *Config {
 	cfg := createValidFullConfig()
 	cfg.Databases = map[string]DatabaseConfig{"reporting": createValidDatabaseConfig()}
 	return cfg
@@ -21,12 +22,12 @@ func TestValidateRejectsNil(t *testing.T) {
 	require.ErrorIs(t, err, errNilConfig)
 }
 
-// idempotencyMultitenantFixture is a full literal config with static
+// staticMultitenantFixture is a full literal config with static
 // multitenancy: two tenant databases (so the tenant map write-back path is
 // under the pin) and a named database. The root database is left absent — a
 // root database and static tenants both configured is a conflict
 // (validateNoSingleTenantConflict).
-func idempotencyMultitenantFixture() *Config {
+func staticMultitenantFixture() *Config {
 	cfg := createValidFullConfig()
 	cfg.Database = DatabaseConfig{}
 	cfg.Source = SourceConfig{Type: SourceTypeStatic}
@@ -49,10 +50,10 @@ func idempotencyMultitenantFixture() *Config {
 // with the value it is compared against and could not catch a mutation.
 func TestValidateIsIdempotent(t *testing.T) {
 	t.Run("literal_door", func(t *testing.T) {
-		a := idempotencyFixture()
+		a := singleTenantFixture()
 		require.NoError(t, Validate(a))
 
-		b := idempotencyFixture()
+		b := singleTenantFixture()
 		require.NoError(t, Validate(b))
 		require.NoError(t, Validate(b))
 
@@ -60,10 +61,10 @@ func TestValidateIsIdempotent(t *testing.T) {
 	})
 
 	t.Run("literal_door_multitenant", func(t *testing.T) {
-		a := idempotencyMultitenantFixture()
+		a := staticMultitenantFixture()
 		require.NoError(t, Validate(a))
 
-		b := idempotencyMultitenantFixture()
+		b := staticMultitenantFixture()
 		require.NoError(t, Validate(b))
 		require.NoError(t, Validate(b))
 
@@ -171,7 +172,7 @@ func TestNormalizeLiteralDoorIncompleteSurfaces(t *testing.T) {
 // reach the root section only; a named or tenant section carrying a manager
 // block is rejected — pinned through Validate in validation_test.go.
 func TestNormalizeManagerDefaultsRootOnly(t *testing.T) {
-	cfg := idempotencyFixture()
+	cfg := singleTenantFixture()
 	require.NoError(t, Validate(cfg))
 
 	assert.Equal(t, defaultDatabaseManagerIdleTTL, cfg.Database.Manager.IdleTTL)
@@ -186,7 +187,7 @@ func TestNormalizeManagerDefaultsRootOnly(t *testing.T) {
 // still abort — normalization never adds identity to a section that had none.
 func TestCheckSingleTenantConflictAfterNormalize(t *testing.T) {
 	t.Run("root_database", func(t *testing.T) {
-		cfg := idempotencyMultitenantFixture()
+		cfg := staticMultitenantFixture()
 		cfg.Database = createValidDatabaseConfig()
 
 		err := Validate(cfg)
@@ -200,7 +201,7 @@ func TestCheckSingleTenantConflictAfterNormalize(t *testing.T) {
 	// A static source with no tenant map has no static tenants: the root
 	// database stays legal, so the gate must be "at least one", not "any map".
 	t.Run("no_tenant_map_permits_root_database", func(t *testing.T) {
-		cfg := idempotencyMultitenantFixture()
+		cfg := staticMultitenantFixture()
 		cfg.Multitenant.Tenants = nil
 		cfg.Database = createValidDatabaseConfig()
 
@@ -208,7 +209,7 @@ func TestCheckSingleTenantConflictAfterNormalize(t *testing.T) {
 	})
 
 	t.Run("root_messaging", func(t *testing.T) {
-		cfg := idempotencyMultitenantFixture()
+		cfg := staticMultitenantFixture()
 		cfg.Messaging.Broker.URL = "amqp://guest:guest@localhost:5672/"
 
 		err := Validate(cfg)
@@ -218,4 +219,73 @@ func TestCheckSingleTenantConflictAfterNormalize(t *testing.T) {
 		assert.Equal(t, fieldMessaging, cfgErr.Field)
 		assert.Contains(t, err.Error(), "not allowed when static tenants are configured")
 	})
+}
+
+// TestNormalizeModeDefaults pins whole-Config test 5: Multitenant.Enabled
+// selects the manager/cache/messaging mode-dependent defaults through the full
+// Validate entry point — single-tenant stamps the flat pool defaults,
+// multi-tenant preserves zero so the manager builders scale to the tenant
+// limit.
+func TestNormalizeModeDefaults(t *testing.T) {
+	t.Run("single_tenant", func(t *testing.T) {
+		cfg := singleTenantFixture()
+		cfg.Cache = CacheConfig{Enabled: true, Type: CacheTypeRedis, Redis: RedisConfig{Host: "localhost"}}
+
+		require.NoError(t, Validate(cfg))
+
+		assert.Equal(t, defaultCacheMaxSize, cfg.Cache.Manager.MaxSize)
+		assert.Equal(t, defaultMaxPublishers, cfg.Messaging.Publisher.MaxCached)
+		assert.Equal(t, defaultPublisherIdleTTL, cfg.Messaging.Publisher.IdleTTL)
+		assert.Equal(t, defaultDatabaseManagerIdleTTL, cfg.Database.Manager.IdleTTL)
+	})
+
+	t.Run("multi_tenant", func(t *testing.T) {
+		cfg := staticMultitenantFixture()
+		cfg.Cache = CacheConfig{Enabled: true, Type: CacheTypeRedis, Redis: RedisConfig{Host: "localhost"}}
+
+		require.NoError(t, Validate(cfg))
+
+		assert.Zero(t, cfg.Cache.Manager.MaxSize, "preserved so the cache pool scales to the tenant limit")
+		assert.Zero(t, cfg.Messaging.Publisher.MaxCached, "preserved so the publisher pool scales to the tenant limit")
+		assert.Equal(t, defaultPublisherIdleTTLMultiTenant, cfg.Messaging.Publisher.IdleTTL)
+		assert.Equal(t, defaultDatabaseManagerIdleTTLMultiTenant, cfg.Database.Manager.IdleTTL)
+	})
+}
+
+// TestNormalizeDisabledCacheCarriesRedisDefaults pins decision 13: Redis
+// defaults are filled unconditionally, even when the cache is disabled —
+// closing the top-level gap where an enabled hand-built cache with a zero
+// port/poolsize used to fail while koanf already gives 6379/10.
+func TestNormalizeDisabledCacheCarriesRedisDefaults(t *testing.T) {
+	t.Run("disabled_cache_carries_redis_defaults", func(t *testing.T) {
+		cfg := createValidFullConfig() // cache disabled
+
+		require.NoError(t, Validate(cfg))
+
+		assert.Equal(t, defaultRedisPort, cfg.Cache.Redis.Port)
+		assert.Equal(t, defaultRedisPoolSize, cfg.Cache.Redis.PoolSize)
+		assert.Equal(t, defaultRedisDialTimeout, cfg.Cache.Redis.DialTimeout)
+	})
+
+	t.Run("enabled_hand_built_zero_port_passes", func(t *testing.T) {
+		cfg := createValidFullConfig()
+		cfg.Cache = CacheConfig{Enabled: true, Type: CacheTypeRedis, Redis: RedisConfig{Host: "localhost"}}
+
+		require.NoError(t, Validate(cfg))
+		assert.Equal(t, defaultRedisPort, cfg.Cache.Redis.Port)
+	})
+}
+
+// TestCheckSeesNormalizedValues pins whole-Config test 7: check's cross-field
+// rules run against normalize's filled defaults, not zero — messaging
+// reconnect.maxdelay >= reconnect.delay compares the filled Delay, proving
+// check ran after normalize.
+func TestCheckSeesNormalizedValues(t *testing.T) {
+	cfg := createValidFullConfig()
+	cfg.Messaging.Reconnect.MaxDelay = time.Second // Delay left zero: normalize fills 5s
+
+	err := Validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "messaging.reconnect.maxdelay")
+	assert.Contains(t, err.Error(), "must be >= messaging.reconnect.delay")
 }

--- a/config/types.go
+++ b/config/types.go
@@ -445,7 +445,7 @@ type OutputConfig struct {
 
 // MessagingConfig holds messaging/broker settings.
 // Production-safe defaults are applied unconditionally at startup — even when
-// messaging.broker.url is unset (see config/validation.go: validateMessaging).
+// messaging.broker.url is unset (see config/validation.go: normalizeMessaging).
 type MessagingConfig struct {
 	Broker    BrokerConfig        `koanf:"broker" json:"broker" yaml:"broker" toml:"broker" mapstructure:"broker"`
 	Routing   RoutingConfig       `koanf:"routing" json:"routing" yaml:"routing" toml:"routing" mapstructure:"routing"`
@@ -457,7 +457,7 @@ type MessagingConfig struct {
 
 // StreamsConfig holds native RabbitMQ stream-protocol settings (consumption).
 // Single-tenant only: multitenant.enabled together with a stream URI is a
-// startup validation error (see config/validation.go: validateMessagingStreams).
+// startup validation error (see config/validation.go: checkMessagingStreams).
 type StreamsConfig struct {
 	// URI is the stream-protocol endpoint, scheme rabbitmq-stream:// (or
 	// rabbitmq-stream+tls://), default port 5552. Required when any module

--- a/config/validation.go
+++ b/config/validation.go
@@ -199,43 +199,43 @@ func checkDebug(cfg *DebugConfig) error {
 	return validateCIDRList("debug.trustedproxies", cfg.TrustedProxies)
 }
 
-// validateMessaging validates messaging configuration and applies defaults.
-// multitenant selects the deployment-mode-dependent Publisher.IdleTTL and
-// Publisher.MaxCached defaults (see applyMessagingDefaults); it has no effect
-// on any other field.
+// normalizeMessaging shapes messaging configuration: reconnect/publisher pool
+// defaults (multitenant selects the deployment-mode-dependent Publisher.IdleTTL
+// and Publisher.MaxCached defaults — see applyMessagingDefaults) and the
+// streams offset-store defaults.
 //
 // Defaults are applied unconditionally, even when the root broker URL is empty
-// (IsMessagingConfigured is false). Multi-tenant deployments carry broker URLs
-// per-tenant — a root broker URL is rejected there by
-// validateNoSingleTenantConflict, though other root messaging.* keys remain
-// legal and are the tuning seam for per-tenant clients — yet per-tenant AMQP
-// clients and the outbox relay still run with the client-side
-// reconnect/publisher defaults. Leaving cfg.Messaging.* at zero would silently
-// defeat cross-field validators that read the effective values (e.g. outbox's
-// publishtimeout >= connectiontimeout and >= readytimeout Fail-Fast checks), so
-// defaults are materialized in every deployment mode.
-//
-// Returns an error if any setting is invalid; otherwise nil.
-func validateMessaging(cfg *MessagingConfig, multitenant bool) error {
-	// Apply messaging defaults (reconnection, publisher pool)
+// (IsMessagingConfigured is false): per-tenant AMQP clients and the outbox
+// relay still run with these defaults, and check's cross-field rules read the
+// effective values.
+func normalizeMessaging(cfg *MessagingConfig, multitenant bool) error {
 	if err := applyMessagingDefaults(cfg, multitenant); err != nil {
 		return err
 	}
 
-	return validateMessagingStreams(&cfg.Streams, multitenant)
+	return applyStreamsDefaults(&cfg.Streams)
 }
 
-// validateMessagingStreams validates the native stream-protocol block and applies
-// its offset-store defaults.
+// checkMessaging rejects an inverted reconnect.maxdelay/delay pair, then the
+// streams block.
+func checkMessaging(cfg *MessagingConfig, multitenant bool) error {
+	// Both sides are defaulted by normalizeMessaging, so this compares effective
+	// values. computeBackoff silently clamps an inverted pair (maxdelay <
+	// delay), which would leave the configured ceiling ignored.
+	if cfg.Reconnect.MaxDelay < cfg.Reconnect.Delay {
+		return NewValidationError("messaging.reconnect.maxdelay", "must be >= messaging.reconnect.delay")
+	}
+
+	return checkMessagingStreams(&cfg.Streams, multitenant)
+}
+
+// checkMessagingStreams rejects a stream URI with an unsupported scheme or no
+// host, streams in multi-tenant mode, and a half-set address resolver.
 //
 // SECURITY: messaging.streams.uri carries broker credentials, so no error raised
 // here echoes the URI — only the config key and the offending scheme reach the
 // message.
-func validateMessagingStreams(cfg *StreamsConfig, multitenant bool) error {
-	if err := applyStreamsDefaults(cfg); err != nil {
-		return err
-	}
-
+func checkMessagingStreams(cfg *StreamsConfig, multitenant bool) error {
 	if cfg.URI != "" {
 		// Multi-tenant stream consumption would need one Environment per tenant and a
 		// per-tenant stream URI leg; until that exists the combination fails loudly
@@ -1021,17 +1021,7 @@ func applyMessagingDefaults(cfg *MessagingConfig, multitenant bool) error {
 		return err
 	}
 
-	if err := applyModeAwarePoolDefault(&cfg.Publisher.MaxCached, defaultMaxPublishers, "messaging.publisher.maxcached", multitenant); err != nil {
-		return err
-	}
-
-	// Both sides are defaulted above, so this cross-field check always compares
-	// effective values. computeBackoff silently clamps an inverted pair
-	// (maxdelay < delay), which would leave the configured ceiling ignored.
-	if cfg.Reconnect.MaxDelay < cfg.Reconnect.Delay {
-		return NewValidationError("messaging.reconnect.maxdelay", "must be >= messaging.reconnect.delay")
-	}
-	return nil
+	return applyModeAwarePoolDefault(&cfg.Publisher.MaxCached, defaultMaxPublishers, "messaging.publisher.maxcached", multitenant)
 }
 
 // applyModeAwarePoolDefault handles pool-size keys whose multi-tenant default is
@@ -1400,28 +1390,34 @@ func checkLog(cfg *LogConfig) error {
 	return nil
 }
 
-// validateCache validates cache configuration. multitenant selects the
-// deployment-mode-dependent Manager.MaxSize default (see applyCacheManagerDefaults).
-// Returns nil if cache is disabled or if all settings are valid.
-func validateCache(cfg *CacheConfig, multitenant bool) error {
+// normalizeCache fills Redis defaults unconditionally, even when the cache is
+// disabled — koanf already fills cache.redis.* in that state, and an enabled
+// hand-built cache with a zero port/poolsize must not fail where koanf gives
+// 6379/10. Manager defaults (mode-dependent MaxSize, see
+// applyCacheManagerDefaults) fill only when enabled: koanf carries no
+// cache.manager.* defaults, and a disabled cache's negative manager value is
+// CreateCacheManager's to reject (ADR-054), not Validate's.
+func normalizeCache(cfg *CacheConfig, multitenant bool) error {
+	applyRedisDefaults(&cfg.Redis)
+
+	if cfg.Enabled {
+		return applyCacheManagerDefaults(cfg, multitenant)
+	}
+	return nil
+}
+
+// checkCache rejects an enabled cache's type and Redis fields; a disabled
+// cache is not checked.
+func checkCache(cfg *CacheConfig) error {
 	if !cfg.Enabled {
 		return nil
-	}
-
-	if err := applyCacheManagerDefaults(cfg, multitenant); err != nil {
-		return err
 	}
 
 	validTypes := []string{CacheTypeRedis}
 	if !slices.Contains(validTypes, cfg.Type) {
 		return NewInvalidFieldError("cache.type", fmt.Sprintf(errNotSupportedFmt, cfg.Type), validTypes)
 	}
-
-	if cfg.Type == CacheTypeRedis {
-		return validateRedisCache(&cfg.Redis)
-	}
-
-	return nil
+	return validateRedisCache(&cfg.Redis)
 }
 
 // applyRedisDefaults fills in production-safe Redis defaults for any unset
@@ -1551,16 +1547,9 @@ func checkMultitenant(mt *MultitenantConfig, db *DatabaseConfig, msg *MessagingC
 		// Sorted, like forEachDatabaseSection: with several malformed tenants the
 		// startup error names the same one every run.
 		for _, tenantID := range slices.Sorted(maps.Keys(mt.Tenants)) {
-			if tenantID == "" {
-				return fmt.Errorf("tenants: %w", NewValidationError(fieldMultitenantTenants, "tenant ID cannot be empty"))
-			}
-			// A '.' collides with koanf's path delimiter: the constructed section
-			// path multitenant.tenants.<id>.database becomes ambiguous. Koanf has
-			// no delimiter escaping, so fail fast rather than let a later lookup
-			// consult the wrong flattened key.
-			if strings.Contains(tenantID, ".") {
-				return fmt.Errorf("tenants: %w", NewValidationError(fieldMultitenantTenants,
-					fmt.Sprintf("tenant ID %q cannot contain '.' (the config path delimiter)", tenantID)))
+			tenant := mt.Tenants[tenantID]
+			if err := checkMultitenantTenantEntry(tenantID, &tenant); err != nil {
+				return fmt.Errorf("tenants: %w", err)
 			}
 		}
 	}
@@ -1570,6 +1559,24 @@ func checkMultitenant(mt *MultitenantConfig, db *DatabaseConfig, msg *MessagingC
 	}
 
 	return nil
+}
+
+// checkMultitenantTenantEntry rejects one static tenant's ID and cache
+// section: an empty or dotted ID, or (once the ID is valid) whatever
+// checkTenantCache rejects.
+func checkMultitenantTenantEntry(tenantID string, entry *TenantEntry) error {
+	if tenantID == "" {
+		return NewValidationError(fieldMultitenantTenants, "tenant ID cannot be empty")
+	}
+	// A '.' collides with koanf's path delimiter: the constructed section path
+	// multitenant.tenants.<id>.database becomes ambiguous. Koanf has no
+	// delimiter escaping, so fail fast rather than let a later lookup consult
+	// the wrong flattened key.
+	if strings.Contains(tenantID, ".") {
+		return NewValidationError(fieldMultitenantTenants,
+			fmt.Sprintf("tenant ID %q cannot contain '.' (the config path delimiter)", tenantID))
+	}
+	return checkTenantCache(tenantID, &entry.Cache)
 }
 
 // validateNoSingleTenantConflict checks for conflicts with single-tenant configuration
@@ -1746,7 +1753,7 @@ func normalizeMultitenantTenants(tenants map[string]TenantEntry) error {
 			return err
 		}
 
-		if err := validateTenantCache(tenantID, &tenant.Cache); err != nil {
+		if err := normalizeTenantCache(&tenant.Cache); err != nil {
 			return err
 		}
 
@@ -1785,23 +1792,22 @@ func checkTenantMessagingConsistency(tenants map[string]TenantEntry) error {
 	return nil
 }
 
-// validateTenantCache validates a tenant's cache configuration with the same
-// fail-fast posture as the tenant database: an enabled-but-misconfigured cache
-// must crash at startup, not at the first per-request cache access (see
-// tenant_store.go CacheConfig). Per-tenant cache keys have no koanf defaults, so
-// this mirrors the top-level cache.type and cache.redis.* defaults before
-// validating: it defaults the type to redis and fills in the Redis defaults
-// (port 6379, poolsize 10, timeouts). A missing host still fails fast inside
-// validateCache. The CacheConfig is mutated in place via the pointer.
-func validateTenantCache(tenantID string, cache *CacheConfig) error {
-	if cache.Enabled {
-		if cache.Type == "" {
-			cache.Type = CacheTypeRedis
-		}
-		applyRedisDefaults(&cache.Redis)
+// normalizeTenantCache shapes a tenant's cache configuration with the same
+// fail-fast posture as the tenant database: an enabled-but-misconfigured
+// cache must crash at startup, not at the first per-request cache access (see
+// tenant_store.go CacheConfig). Per-tenant cache keys have no koanf defaults,
+// so the type defaults to redis here before normalizeCache fills the rest.
+func normalizeTenantCache(cache *CacheConfig) error {
+	if cache.Enabled && cache.Type == "" {
+		cache.Type = CacheTypeRedis
 	}
 	// per-tenant caches only exist in multi-tenant mode
-	if err := validateCache(cache, true); err != nil {
+	return normalizeCache(cache, true)
+}
+
+// checkTenantCache is checkCache with the tenant named in the error.
+func checkTenantCache(tenantID string, cache *CacheConfig) error {
+	if err := checkCache(cache); err != nil {
 		return fmt.Errorf("tenant %s cache: %w", tenantID, err)
 	}
 	return nil

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -2481,7 +2481,7 @@ func TestApplyMessagingDefaults(t *testing.T) {
 			// Single-tenant mode: these cases exercise the non-IdleTTL defaults and the
 			// single-tenant IdleTTL default; see TestApplyMessagingDefaultsIdleTTLModeAware
 			// for the mode-dependent IdleTTL behavior.
-			err := validateMessaging(&tt.config, false)
+			err := normalizeMessaging(&tt.config, false)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedReconnectDelay, tt.config.Reconnect.Delay, "Reconnect.Delay mismatch")
 			assert.Equal(t, tt.expectedReinitDelay, tt.config.Reconnect.ReinitDelay, "Reconnect.ReinitDelay mismatch")
@@ -2503,14 +2503,14 @@ func TestApplyMessagingDefaults(t *testing.T) {
 func TestApplyMessagingDefaultsIdleTTLModeAware(t *testing.T) {
 	t.Run("single_tenant_unset_defaults_to_1h", func(t *testing.T) {
 		cfg := &MessagingConfig{Broker: BrokerConfig{URL: testAMQPHost}}
-		require.NoError(t, validateMessaging(cfg, false))
+		require.NoError(t, normalizeMessaging(cfg, false))
 		assert.Equal(t, defaultPublisherIdleTTL, cfg.Publisher.IdleTTL)
 		assert.Equal(t, 1*time.Hour, cfg.Publisher.IdleTTL)
 	})
 
 	t.Run("multi_tenant_unset_defaults_to_10m", func(t *testing.T) {
 		cfg := &MessagingConfig{Broker: BrokerConfig{URL: testAMQPHost}}
-		require.NoError(t, validateMessaging(cfg, true))
+		require.NoError(t, normalizeMessaging(cfg, true))
 		assert.Equal(t, defaultPublisherIdleTTLMultiTenant, cfg.Publisher.IdleTTL)
 		assert.Equal(t, 10*time.Minute, cfg.Publisher.IdleTTL)
 	})
@@ -2520,14 +2520,14 @@ func TestApplyMessagingDefaultsIdleTTLModeAware(t *testing.T) {
 			Broker:    BrokerConfig{URL: testAMQPHost},
 			Publisher: PublisherPoolConfig{IdleTTL: 42 * time.Minute},
 		}
-		require.NoError(t, validateMessaging(cfg, true))
+		require.NoError(t, normalizeMessaging(cfg, true))
 		assert.Equal(t, 42*time.Minute, cfg.Publisher.IdleTTL)
 	})
 }
 
 // TestValidateMessagingPublisherIdleTTLModeAwareEndToEnd proves the mode-aware
 // default reaches Publisher.IdleTTL through the full Validate(cfg) entry point
-// (not just the internal validateMessaging seam), matching the real config.Load()
+// (not just the internal normalizeMessaging seam), matching the real config.Load()
 // path that runs before app/bootstrap.go builds the manager options.
 func TestValidateMessagingPublisherIdleTTLModeAwareEndToEnd(t *testing.T) {
 	t.Run("single_tenant_validate_yields_1h", func(t *testing.T) {
@@ -2564,7 +2564,7 @@ func TestValidateMessagingPublisherIdleTTLModeAwareEndToEnd(t *testing.T) {
 func TestApplyMessagingDefaultsMaxPublishAttempts(t *testing.T) {
 	t.Run("zero_gets_default", func(t *testing.T) {
 		cfg := &MessagingConfig{Broker: BrokerConfig{URL: testAMQPHost}}
-		require.NoError(t, validateMessaging(cfg, false))
+		require.NoError(t, normalizeMessaging(cfg, false))
 		assert.Equal(t, defaultMaxPublishAttempts, cfg.Reconnect.MaxPublishAttempts)
 	})
 	t.Run("explicit_value_preserved", func(t *testing.T) {
@@ -2572,7 +2572,7 @@ func TestApplyMessagingDefaultsMaxPublishAttempts(t *testing.T) {
 			Broker:    BrokerConfig{URL: testAMQPHost},
 			Reconnect: ReconnectConfig{MaxPublishAttempts: 9},
 		}
-		require.NoError(t, validateMessaging(cfg, false))
+		require.NoError(t, normalizeMessaging(cfg, false))
 		assert.Equal(t, 9, cfg.Reconnect.MaxPublishAttempts)
 	})
 }
@@ -2580,7 +2580,7 @@ func TestApplyMessagingDefaultsMaxPublishAttempts(t *testing.T) {
 func TestApplyMessagingDefaultsReadyTimeout(t *testing.T) {
 	t.Run("zero_gets_default", func(t *testing.T) {
 		cfg := &MessagingConfig{Broker: BrokerConfig{URL: testAMQPHost}}
-		require.NoError(t, validateMessaging(cfg, false))
+		require.NoError(t, normalizeMessaging(cfg, false))
 		assert.Equal(t, defaultReadyTimeout, cfg.Reconnect.ReadyTimeout)
 	})
 	t.Run("explicit_value_preserved", func(t *testing.T) {
@@ -2588,7 +2588,7 @@ func TestApplyMessagingDefaultsReadyTimeout(t *testing.T) {
 			Broker:    BrokerConfig{URL: testAMQPHost},
 			Reconnect: ReconnectConfig{ReadyTimeout: 9 * time.Second},
 		}
-		require.NoError(t, validateMessaging(cfg, false))
+		require.NoError(t, normalizeMessaging(cfg, false))
 		assert.Equal(t, 9*time.Second, cfg.Reconnect.ReadyTimeout)
 	})
 }
@@ -2596,7 +2596,7 @@ func TestApplyMessagingDefaultsReadyTimeout(t *testing.T) {
 func TestApplyMessagingDefaultsCleanupInterval(t *testing.T) {
 	t.Run("zero_gets_default", func(t *testing.T) {
 		cfg := &MessagingConfig{Broker: BrokerConfig{URL: testAMQPHost}}
-		require.NoError(t, validateMessaging(cfg, false))
+		require.NoError(t, normalizeMessaging(cfg, false))
 		assert.Equal(t, defaultPublisherCleanupInterval, cfg.Publisher.CleanupInterval)
 	})
 	t.Run("explicit_value_preserved", func(t *testing.T) {
@@ -2604,7 +2604,7 @@ func TestApplyMessagingDefaultsCleanupInterval(t *testing.T) {
 			Broker:    BrokerConfig{URL: testAMQPHost},
 			Publisher: PublisherPoolConfig{CleanupInterval: 90 * time.Second},
 		}
-		require.NoError(t, validateMessaging(cfg, false))
+		require.NoError(t, normalizeMessaging(cfg, false))
 		assert.Equal(t, 90*time.Second, cfg.Publisher.CleanupInterval)
 	})
 }
@@ -2699,7 +2699,7 @@ func TestApplyMessagingDefaultsNegativeValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateMessaging(&tt.config, false)
+			err := normalizeMessaging(&tt.config, false)
 			assertValidationError(t, err, tt.errorContains)
 		})
 	}
@@ -2758,7 +2758,7 @@ func TestApplyCacheManagerDefaults(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateCache(&tt.config, false)
+			err := normalizeCache(&tt.config, false)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedMaxSize, tt.config.Manager.MaxSize, "Manager.MaxSize mismatch")
 			assert.Equal(t, tt.expectedIdleTTL, tt.config.Manager.IdleTTL, "Manager.IdleTTL mismatch")
@@ -2807,7 +2807,7 @@ func TestApplyCacheManagerDefaultsNegativeValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateCache(&tt.config, false)
+			err := normalizeCache(&tt.config, false)
 			assertValidationError(t, err, tt.errorContains)
 		})
 	}
@@ -3314,6 +3314,25 @@ func normalizeAndCheckNamedDatabases(databases map[string]DatabaseConfig, mt *Mu
 	return checkNamedDatabases(databases, mt)
 }
 
+// normalizeAndCheckMessaging runs both halves of the messaging split in phase
+// order, for tables whose cases need a fill before the rejection they pin.
+func normalizeAndCheckMessaging(cfg *MessagingConfig, multitenant bool) error {
+	if err := normalizeMessaging(cfg, multitenant); err != nil {
+		return err
+	}
+	return checkMessaging(cfg, multitenant)
+}
+
+// normalizeTenantsAndCheckMultitenant runs the tenant half of normalize before
+// checkMultitenant: check assumes normalize already ran (per-tenant cache
+// defaults included), and these fixtures are hand-built. Only the tenant loop
+// runs — the resolver/limits fills would change what the failure tables assert.
+func normalizeTenantsAndCheckMultitenant(t *testing.T, mt *MultitenantConfig, db *DatabaseConfig, msg *MessagingConfig, source *SourceConfig) error {
+	t.Helper()
+	require.NoError(t, normalizeMultitenantTenants(mt.Tenants))
+	return checkMultitenant(mt, db, msg, source)
+}
+
 // createValidFullConfig returns a complete valid Config for testing
 func createValidFullConfig() *Config {
 	return &Config{
@@ -3555,7 +3574,7 @@ func TestValidateMultitenantSuccess(t *testing.T) {
 			if sourceConfig == nil {
 				sourceConfig = &SourceConfig{Type: SourceTypeStatic}
 			}
-			err := checkMultitenant(tt.mtConfig, tt.dbConfig, tt.msgConfig, sourceConfig)
+			err := normalizeTenantsAndCheckMultitenant(t, tt.mtConfig, tt.dbConfig, tt.msgConfig, sourceConfig)
 			assert.NoError(t, err)
 		})
 	}
@@ -3742,7 +3761,7 @@ func TestValidateMultitenantFailures(t *testing.T) {
 			if sourceConfig == nil {
 				sourceConfig = &SourceConfig{Type: SourceTypeStatic}
 			}
-			err := checkMultitenant(tt.mtConfig, tt.dbConfig, tt.msgConfig, sourceConfig)
+			err := normalizeTenantsAndCheckMultitenant(t, tt.mtConfig, tt.dbConfig, tt.msgConfig, sourceConfig)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectedError)
 		})
@@ -4167,7 +4186,7 @@ func TestValidateMultitenantDynamicSource(t *testing.T) {
 
 func TestValidateCacheDisabled(t *testing.T) {
 	cfg := CacheConfig{Enabled: false}
-	err := validateCache(&cfg, false)
+	err := checkCache(&cfg)
 	assert.NoError(t, err)
 }
 
@@ -4190,7 +4209,7 @@ func TestValidateCacheSuccess(t *testing.T) {
 		},
 	}
 
-	err := validateCache(&cfg, false)
+	err := checkCache(&cfg)
 	assert.NoError(t, err)
 }
 
@@ -4224,7 +4243,7 @@ func TestValidateCacheTypeFailures(t *testing.T) {
 				Type:    tt.cacheType,
 			}
 
-			err := validateCache(&cfg, false)
+			err := checkCache(&cfg)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectedError)
 		})
@@ -4345,7 +4364,7 @@ func TestValidateRedisCacheFailures(t *testing.T) {
 				Redis:   tt.redis,
 			}
 
-			err := validateCache(&cfg, false)
+			err := checkCache(&cfg)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectedError)
 		})
@@ -4408,7 +4427,7 @@ func TestValidateRedisCacheEdgeCases(t *testing.T) {
 				Redis:   tt.redis,
 			}
 
-			err := validateCache(&cfg, false)
+			err := checkCache(&cfg)
 			if tt.valid {
 				assert.NoError(t, err)
 			} else {
@@ -5152,13 +5171,13 @@ func TestLoadFailsOnAllInvalidCIDRAllowlistEnv(t *testing.T) {
 
 // TestValidateMessagingAppliesDefaultsWhenBrokerURLEmpty pins the #659 fix: defaults
 // and negative-value rejection apply even when the root broker URL is empty (see
-// validateMessaging's doc comment for why). Field-by-field defaulting is covered by
+// normalizeMessaging's doc comment for why). Field-by-field defaulting is covered by
 // TestApplyMessagingDefaults; these subtests pin the no-gate behavior and the
 // mode-aware Publisher defaults.
 func TestValidateMessagingAppliesDefaultsWhenBrokerURLEmpty(t *testing.T) {
 	t.Run("single_tenant_empty_broker_applies_defaults", func(t *testing.T) {
 		cfg := &MessagingConfig{} // empty Broker.URL
-		require.NoError(t, validateMessaging(cfg, false))
+		require.NoError(t, normalizeMessaging(cfg, false))
 
 		assert.Equal(t, defaultConnectionTimeout, cfg.Reconnect.ConnectionTimeout)
 		assert.Equal(t, defaultPublisherIdleTTL, cfg.Publisher.IdleTTL)
@@ -5167,7 +5186,7 @@ func TestValidateMessagingAppliesDefaultsWhenBrokerURLEmpty(t *testing.T) {
 
 	t.Run("multi_tenant_empty_broker_applies_mode_aware_publisher_defaults", func(t *testing.T) {
 		cfg := &MessagingConfig{}
-		require.NoError(t, validateMessaging(cfg, true))
+		require.NoError(t, normalizeMessaging(cfg, true))
 
 		assert.Equal(t, defaultConnectionTimeout, cfg.Reconnect.ConnectionTimeout)
 		assert.Equal(t, defaultPublisherIdleTTLMultiTenant, cfg.Publisher.IdleTTL)
@@ -5178,12 +5197,12 @@ func TestValidateMessagingAppliesDefaultsWhenBrokerURLEmpty(t *testing.T) {
 
 	t.Run("empty_broker_negative_value_rejected", func(t *testing.T) {
 		cfg := &MessagingConfig{Reconnect: ReconnectConfig{Delay: -1}}
-		require.Error(t, validateMessaging(cfg, false))
+		require.Error(t, normalizeMessaging(cfg, false))
 	})
 
 	t.Run("multi_tenant_negative_maxcached_rejected", func(t *testing.T) {
 		cfg := &MessagingConfig{Publisher: PublisherPoolConfig{MaxCached: -1}}
-		require.Error(t, validateMessaging(cfg, true))
+		require.Error(t, normalizeMessaging(cfg, true))
 	})
 }
 
@@ -5193,23 +5212,32 @@ func TestValidateMessagingAppliesDefaultsWhenBrokerURLEmpty(t *testing.T) {
 func TestValidateMessagingRejectsMaxDelayBelowDelay(t *testing.T) {
 	t.Run("explicit_maxdelay_below_default_delay_rejected", func(t *testing.T) {
 		cfg := &MessagingConfig{Reconnect: ReconnectConfig{MaxDelay: 2 * time.Second}} // delay defaults to 5s
-		err := validateMessaging(cfg, false)
+		err := normalizeAndCheckMessaging(cfg, false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "messaging.reconnect.maxdelay")
 	})
 
 	t.Run("explicit_delay_above_default_maxdelay_rejected", func(t *testing.T) {
 		cfg := &MessagingConfig{Reconnect: ReconnectConfig{Delay: 90 * time.Second}} // maxdelay defaults to 60s
-		require.Error(t, validateMessaging(cfg, false))
+		require.Error(t, normalizeAndCheckMessaging(cfg, false))
 	})
 
 	t.Run("consistent_pair_accepted", func(t *testing.T) {
 		cfg := &MessagingConfig{Reconnect: ReconnectConfig{Delay: 10 * time.Second, MaxDelay: 2 * time.Minute}}
-		require.NoError(t, validateMessaging(cfg, false))
+		require.NoError(t, normalizeAndCheckMessaging(cfg, false))
 	})
 
 	t.Run("defaults_accepted", func(t *testing.T) {
-		require.NoError(t, validateMessaging(&MessagingConfig{}, false))
+		require.NoError(t, normalizeAndCheckMessaging(&MessagingConfig{}, false))
+	})
+
+	// The mode flag only selects Publisher.IdleTTL/MaxCached defaults; the
+	// maxdelay >= delay rule itself is mode-independent.
+	t.Run("multi_tenant_maxdelay_below_delay_rejected", func(t *testing.T) {
+		cfg := &MessagingConfig{Reconnect: ReconnectConfig{MaxDelay: 2 * time.Second}}
+		err := normalizeAndCheckMessaging(cfg, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "messaging.reconnect.maxdelay")
 	})
 }
 
@@ -5217,7 +5245,7 @@ func TestValidateMessagingRejectsMaxDelayBelowDelay(t *testing.T) {
 // static config — where the root broker URL is necessarily empty — yields effective
 // messaging defaults through the full Validate() entry point, so the outbox
 // publishtimeout Fail-Fast guards have real values to compare against (see
-// validateMessaging's doc comment).
+// normalizeMessaging's doc comment).
 func TestValidateMultiTenantStaticAppliesMessagingDefaultsEndToEnd(t *testing.T) {
 	cfg := &Config{
 		App:    createValidAppConfig(),
@@ -5810,7 +5838,7 @@ func TestValidateMessagingStreamsURIScheme(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &MessagingConfig{Streams: StreamsConfig{URI: tt.uri}}
 
-			err := validateMessaging(cfg, false)
+			err := checkMessaging(cfg, false)
 
 			if tt.wantErr == "" {
 				require.NoError(t, err)
@@ -5829,7 +5857,7 @@ func TestValidateMessagingStreamsRejectsMultiTenant(t *testing.T) {
 		URI: "rabbitmq-stream://svc:" + streamsFixturePassword + "@broker:5552/%2f",
 	}}
 
-	err := validateMessaging(cfg, true)
+	err := checkMessaging(cfg, true)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "messaging.streams single-tenant only")
@@ -5840,7 +5868,7 @@ func TestValidateMessagingStreamsRejectsMultiTenant(t *testing.T) {
 func TestValidateMessagingStreamsAllowsMultiTenantWithoutURI(t *testing.T) {
 	cfg := &MessagingConfig{}
 
-	require.NoError(t, validateMessaging(cfg, true),
+	require.NoError(t, checkMessaging(cfg, true),
 		"multi-tenant deployments that declare no streams stay valid")
 }
 
@@ -5882,7 +5910,7 @@ func TestValidateMessagingStreamsAddressResolver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &MessagingConfig{Streams: StreamsConfig{AddressResolver: tt.resolver}}
 
-			err := validateMessaging(cfg, false)
+			err := checkMessaging(cfg, false)
 
 			if tt.wantErr == "" {
 				require.NoError(t, err)
@@ -5898,7 +5926,7 @@ func TestApplyStreamsDefaults(t *testing.T) {
 	t.Run("zero_applies_defaults", func(t *testing.T) {
 		cfg := &MessagingConfig{}
 
-		require.NoError(t, validateMessaging(cfg, false))
+		require.NoError(t, normalizeMessaging(cfg, false))
 
 		assert.Equal(t, 500, cfg.Streams.OffsetStore.CountBeforeStorage)
 		assert.Equal(t, defaultStreamsOffsetCount, cfg.Streams.OffsetStore.CountBeforeStorage)
@@ -5912,7 +5940,7 @@ func TestApplyStreamsDefaults(t *testing.T) {
 			FlushInterval:      750 * time.Millisecond,
 		}}}
 
-		require.NoError(t, validateMessaging(cfg, false))
+		require.NoError(t, normalizeMessaging(cfg, false))
 
 		assert.Equal(t, 25, cfg.Streams.OffsetStore.CountBeforeStorage)
 		assert.Equal(t, 750*time.Millisecond, cfg.Streams.OffsetStore.FlushInterval)
@@ -5921,7 +5949,7 @@ func TestApplyStreamsDefaults(t *testing.T) {
 	t.Run("negative_count_rejected", func(t *testing.T) {
 		cfg := &MessagingConfig{Streams: StreamsConfig{OffsetStore: StreamsOffsetStoreConfig{CountBeforeStorage: -1}}}
 
-		err := validateMessaging(cfg, false)
+		err := normalizeMessaging(cfg, false)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "messaging.streams.offsetstore.countbeforestorage must be non-negative")
@@ -5930,7 +5958,7 @@ func TestApplyStreamsDefaults(t *testing.T) {
 	t.Run("negative_interval_rejected", func(t *testing.T) {
 		cfg := &MessagingConfig{Streams: StreamsConfig{OffsetStore: StreamsOffsetStoreConfig{FlushInterval: -time.Second}}}
 
-		err := validateMessaging(cfg, false)
+		err := normalizeMessaging(cfg, false)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "messaging.streams.offsetstore.flushinterval must be non-negative")

--- a/docs/superpowers/specs/2026-08-16-config-normalize-check-split.md
+++ b/docs/superpowers/specs/2026-08-16-config-normalize-check-split.md
@@ -62,7 +62,7 @@ the normalize phase for the keys normalize owns.
 5. `Multitenant.Enabled` true/false → manager / cache / messaging mode defaults; a disabled cache
    still carries redis defaults (decision 13).
 6. Manager defaults on the root only; named/tenant untouched, and rejected if set.
-7. Checks see normalized values — messaging `publishtimeout >= connectiontimeout` runs against filled
+7. Checks see normalized values — messaging `reconnect.maxdelay >= reconnect.delay` runs against filled
    defaults, not zero.
 
 ### Phase assignment per section (today's `validateX` → `normalizeX` / `checkX`)
@@ -73,11 +73,11 @@ the normalize phase for the keys normalize owns.
 | app | startup timeout defaults | name/version required, env format, rate non-negative |
 | server | — | port, timeouts (incl. middleware < write), gzip/bodylimit non-negative, trusted proxies, TLS material shape, FCC require-without-enabled |
 | scheduler | timezone normalization | CIDR lists |
-| multitenant | resolver header/domain defaults, limits default, tenant database sections (opaque), tenant cache defaults | single-tenant conflicts, source type, resolver order required |
+| multitenant | resolver header/domain defaults, limits default, tenant database sections (opaque), tenant cache defaults | resolver type/order/domain/path rules, limits cap, source type, delivered-but-empty static map, tenant ID rules, cross-tenant messaging consistency, tenant cache, single-tenant conflicts |
 | database | root section (opaque), manager defaults (root only), named sections (opaque) | name-vs-tenant collisions, manager-outside-root (stays inside the opaque module) |
 | log | — | level |
-| cache | manager defaults, redis defaults (unconditional) | redis field ranges when enabled |
-| messaging | reconnect / publisher / streams offset-store defaults | negatives, URI scheme, address-resolver both-or-neither, cross-field timeouts |
+| cache | redis defaults (unconditional), manager defaults when enabled | type enumeration and redis field ranges when enabled |
+| messaging | reconnect / publisher / streams offset-store defaults (negatives rejected by the fill) | `reconnect.maxdelay >= reconnect.delay`, streams URI scheme/host and single-tenant-only, address-resolver both-or-neither |
 | keystore | — | secretminlength non-negative, entry shape |
 | debug | — | trusted proxies |
 


### PR DESCRIPTION
## What
Last hop of the normalize/check split: cache and messaging leave the interleaved path, so nothing in `normalize` mixes shaping and rejecting any more. `normalizeCache` fills Redis defaults unconditionally (koanf parity) and manager defaults when enabled; `checkCache` owns type + Redis ranges; the tenant cache follows the same shape; `normalizeMessaging` fills, `checkMessaging` owns `reconnect.maxdelay >= reconnect.delay` and the streams block.

## Impact
An enabled hand-built cache with zero `port`/`poolsize` now boots with the defaults instead of failing. A disabled cache's `Redis` fields read the defaults instead of zero. First-error precedence inside cache/messaging follows the phase order; every rejection stays fatal.

## Verification
Whole-Config pins: mode defaults through both fixtures, disabled cache carries Redis defaults, the closed gap, and check reading a filled value (an inverted maxdelay against a defaulted delay is rejected). `make mutate` on the changed lines ran locally.

Closes #1024


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration processing so defaults are applied consistently before validation.
  * Added mode-aware defaults for messaging and cache settings, including Redis and reconnect options.
  * Improved validation for cache, messaging, multitenant, and stream configurations.
  * Added checks for conflicting or invalid reconnect settings.
  * Improved handling of disabled and manually configured caches.

* **Documentation**
  * Updated configuration validation documentation to reflect the latest behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->