### PR TITLE
chore(deps): update module github.com/gaborage/go-bricks to v0.59.0

### DIFF
--- a/tools/migration/README.md
+++ b/tools/migration/README.md
@@ -18,14 +18,14 @@ Deep dives:
 
 ## Install
 
-CLI releases are tagged `tools/migration/vX.Y.Z` (first: `v0.38.0`; latest: `v0.58.1`). Once a tag exists:
+CLI releases are tagged `tools/migration/vX.Y.Z` (first: `v0.38.0`; latest: `v0.59.0`). Once a tag exists:
 
 ```bash
 # Latest CLI release:
 go install github.com/gaborage/go-bricks/tools/migration/cmd/go-bricks-migrate@latest
 
 # Pin to a specific release:
-go install github.com/gaborage/go-bricks/tools/migration/cmd/go-bricks-migrate@v0.58.1
+go install github.com/gaborage/go-bricks/tools/migration/cmd/go-bricks-migrate@v0.59.0
 
 # From a clone (contributors):
 cd tools/migration && make build   # produces ./go-bricks-migrate

--- a/tools/migration/go.mod
+++ b/tools/migration/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.43.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.37
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.44.6
-	github.com/gaborage/go-bricks v0.58.1
+	github.com/gaborage/go-bricks v0.59.0
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/knadh/koanf/parsers/yaml v1.1.1
@@ -53,7 +53,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.30.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
@@ -106,13 +105,9 @@ require (
 	go.opentelemetry.io/otel/trace v1.45.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/crypto v0.55.0 // indirect
-	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260810153831-ec0a7760b754 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260810153831-ec0a7760b754 // indirect
-	google.golang.org/protobuf v1.36.12 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/tools/migration/go.sum
+++ b/tools/migration/go.sum
@@ -74,8 +74,8 @@ github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeO
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
-github.com/gaborage/go-bricks v0.58.1 h1:FvQB1Zueofx9yKu28uFBTb+iScXAURgEffBV/ZvToKA=
-github.com/gaborage/go-bricks v0.58.1/go.mod h1:IjFyXA3HiURlSv+O1MfZUk2UTf66Ob4sVc5wBx8X3dA=
+github.com/gaborage/go-bricks v0.59.0 h1:fUhG//xoSMt54vLk23XunEZ6+G8Viu3Stlmx01TYBcw=
+github.com/gaborage/go-bricks v0.59.0/go.mod h1:vzOhnKvADWOQ6ITfNN0hv6pJFm03JnOHqvNigVFVUe8=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.4 h1:tG4xh9yMsRCAiodLVTxyrkzSZ9+o0L1Kg/+cPVcbP/8=
 github.com/go-logr/logr v1.4.4/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
## What

`tools/migration/go.mod` still pinned go-bricks `v0.58.1` after the framework
released `v0.59.0`, so `scripts/release-cli.sh` refuses to cut
`tools/migration/v0.59.0` — it asserts `VERSION` equals the pinned version.
This bumps the pin and refreshes the README's `latest` pointer and pinned
install example.

## Impact

None for framework consumers. Unblocks `make release-cli VERSION=v0.59.0`;
the README's `v0.59.0` claim becomes true the moment that tag is pushed.

## Verification

`go mod tidy` drops five indirects `v0.59.0` no longer reaches
(grpc-gateway/v2, `x/net`, genproto api + rpc, protobuf); isolated
(`GOWORK=off`) and workspace-mode tidy converge, and `go.work.sum` needed no
top-up. `GOWORK=off make -C tools/migration check` passes against the
*released* framework — the mode CI never runs, and the same gate
`release-cli.sh` re-runs before signing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration tool installation instructions to reference the latest v0.59.0 release.

* **Chores**
  * Updated the migration tool’s supporting packages to align with the v0.59.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->