### PR TITLE
refactor(streams): route the manager through an unexported Environment port

### DIFF
--- a/app/streams_setup.go
+++ b/app/streams_setup.go
@@ -57,9 +57,11 @@ func (a *App) prepareStreamConsumers(ctx context.Context) error {
 	// A service that declared streams and cannot start them would serve HTTP while
 	// consuming nothing and publishing nowhere, so startup fails rather than
 	// booting green.
-	// The startup context is handed over for its values only — Start severs its
-	// cancellation, so shutdownStreamConsumers stays the thing that stops them.
-	if err := mgr.Start(ctx, decls); err != nil {
+	// The startup context is handed over for its values only: WithoutCancel makes
+	// that literal — the manager's own startup gates honor cancellation for callers
+	// that want it, and this caller does not — so shutdownStreamConsumers stays the
+	// thing that stops the consumers. Same detachment the AMQP lane applies.
+	if err := mgr.Start(context.WithoutCancel(ctx), decls); err != nil {
 		if closeErr := mgr.Close(); closeErr != nil {
 			a.logger.Warn().Err(closeErr).Msg("Failed to close stream environment after a failed start")
 		}

--- a/docs/superpowers/plans/2026-08-16-streams-environment-port.md
+++ b/docs/superpowers/plans/2026-08-16-streams-environment-port.md
@@ -62,8 +62,10 @@
   - `type messageHandler func(streamName string, offset int64, msg *amqp.Message, store offsetStorer)`
   - `type environment interface { DeclareStream(name string, opts *stream.StreamOptions) error; DeclareSuperStream(name string, opts *stream.PartitionsOptions) error; QueryOffset(consumer, streamName string) (int64, error); StoreOffset(consumer, streamName string, offset int64) error; NewConsumer(streamName string, opts *stream.ConsumerOptions, handler messageHandler) (consumerHandle, error); NewSuperStreamConsumer(superStream string, opts *stream.SuperStreamConsumerOptions, handler messageHandler) (consumerHandle, error); NewProducer(streamName string, opts *stream.ProducerOptions, confirmed ha.ConfirmMessageHandler) (producerHandle, error); NewSuperStreamProducer(superStream string, opts *stream.SuperStreamProducerOptions, confirmed ha.PartitionConfirmMessageHandler) (producerHandle, error); Close() error }`
   - `Manager.dialEnvironment func(*stream.EnvironmentOptions) (environment, error)`
-  - test helpers: `newFakeEnvironment() *fakeEnvironment`, `dialFake(m *Manager, fake *fakeEnvironment)`, `fakeEnvironment.failOn(key string, err error)`, `fakeEnvironment.setOffset` / `storedOffset` / `recorded` / `consumer` / `consumerOptions` / `producer` / `superProducerOptions` / `useProducer`, `fakeConsumer.deliver(streamName string, offset int64, msg *amqp.Message)`, `fakeConsumer.promote(streamName string) stream.OffsetSpecification`
+  - test helpers: `newFakeEnvironment() *fakeEnvironment`, `dialFake(m *Manager, fake *fakeEnvironment)`, `fakeEnvironment.failOn(key string, err error)`, `fakeEnvironment.setOffset` / `storedOffset` / `recorded` / `consumer` / `consumerOptions` / `producer` / `superProducerOptions` / `useProducer(p *fakeProducer)` (as delivered — Task 3 dropped the redundant stream argument), `fakeConsumer.deliver(streamName string, offset int64, msg *amqp.Message)`, `fakeConsumer.promote(streamName string) stream.OffsetSpecification`
 - Consumes, **unchanged**: `consumerHandle` (`manager.go:70-73`), `producerHandle` (`publisher.go:41-45`), `offsetStorer` (`runner.go:39-41`), `consumerRunner.deliver(streamName string, offset int64, message *amqp.Message, store offsetStorer)` (`runner.go:239`), `fakeHandle` / `fakeProducer` (existing test doubles).
+
+> **As delivered:** `useProducer` takes only the producer (`useProducer(p *fakeProducer)`) and the fake keeps one prepared producer (`preparedProd`) rather than a per-stream map — every test starts one publisher, so `unparam` rejected the stream argument in Task 3. The code blocks below are the plan as written; the tree is the authority.
 
 - [ ] **Step 1: Write the failing test — the manager must dial through a swappable seam**
 
@@ -1902,7 +1904,7 @@ func TestManagerStopClosesPublishersAfterConsumers(t *testing.T) {
 	var order []string
 	producer := openProducer()
 	producer.onClose = func() { order = append(order, "publisher") }
-	fake.useProducer(testStream, producer)
+	fake.useProducer(producer) // as delivered: the fake hands p back for the one publisher a test starts
 
 	decls := oneConsumerDecls()
 	decls.DeclarePublisher(&PublisherOptions{Stream: testStream})

--- a/docs/superpowers/plans/2026-08-16-streams-environment-port.md
+++ b/docs/superpowers/plans/2026-08-16-streams-environment-port.md
@@ -1,0 +1,2275 @@
+# Streams Environment Port Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Put an *Environment port* between `messaging/streams`' `Manager` and the RabbitMQ stream client so `Manager.Start` — declare, bind, start, unwind — runs end to end in a unit test against an in-memory fake.
+
+**Architecture:** An unexported `environment` interface with one method per vendor call the manager makes, a `vendorEnvironment` adapter wrapping `*stream.Environment`, and an unexported `dialEnvironment` field on `Manager` that tests overwrite (the same seam shape as the AMQP lane's `amqpDialFunc`, minus the process-global). The vendor callback `stream.MessagesHandler` — whose `stream.ConsumerContext` no test can construct — is unwrapped inside the adapter, so the port hands the runner a go-bricks-shaped `func(streamName string, offset int64, msg *amqp.Message, store offsetStorer)`; the `store` argument is the delivering consumer, exactly what `runner.messagesHandler` passes today. `producerFactory`/`superProducerFactory` fold into the port. Nothing exported changes, and **no commit path moves**.
+
+**Tech Stack:** Go 1.26 · `github.com/rabbitmq/rabbitmq-stream-go-client@v1.8.3` (`pkg/stream`, `pkg/ha`, `pkg/amqp`, `pkg/message`) · testify (`assert`/`require`) · `go test -race`.
+
+**Spec:** [docs/superpowers/specs/2026-08-16-messaging-environment-port-and-delivery-pipeline-design.md](../specs/2026-08-16-messaging-environment-port-and-delivery-pipeline-design.md) — **decisions 1–6 only** ("Environment port (card 8)", Stack B PR1). Decisions 7–13 (the delivery pipeline) are PR2/PR3 and are **out of scope**: do not create `messaging/internal/delivery`, do not touch `StartConsumeSpan`, `RecordAMQPConsumeMetrics`, `registry.go`, or trace extraction in `runner.deliver`.
+
+**Vocabulary:** [CONTEXT.md](../../../CONTEXT.md) — the seam is the **Environment port**. Use those words in comments; avoid "env", "client", "connection" as its name.
+
+## Global Constraints
+
+- Test function names are **camelCase** (`TestManagerStartDeclaresBeforeItBinds`); table-driven case names are **snake_case** (`{name: "stored_offset_wins"}`). 100% compliance across >800 test functions — no exceptions.
+- Commit with `git commit -F <file>`; the repo's commit hook rejects heredoc `-m`. **Never** pass `--no-gpg-sign` — if signing fails, stop and report it.
+- Implementers do **not** run `make check`, `make mutate`, or `git push`. The controller runs every gate (Task 5). Implementers run only the targeted `go test` commands each step names.
+- **No exported API change.** `NewManager`, `ManagerOptions`, `Manager`'s exported methods, `Publisher`, `Declarations`, `Handler`, `Message` keep their current signatures. `app/` consumes only those (`app/streams_setup.go:48`, `app/readiness.go:208`, `app/lifecycle.go:583`).
+- **No commit path moves.** This is a seam extraction, not a behavior change: an in-flight commit still goes through the consumer that delivered the message, and the shutdown flush still goes through `runningConsumer.storerFor`. Any diff that changes which object a `StoreCustomOffset` lands on is a plan violation.
+- `messaging/streams` must **not** import `github.com/gaborage/go-bricks/messaging`. It imports `messaging/internal/tracking` today (`runner.go:20`, `publisher.go:22`) and nothing else from the parent — keep it that way.
+- No ADR, no `wiki/migrations.md` atom: nothing exported moves.
+- Every new production comment earns its place — non-obvious intent only (`CLAUDE.md` → "Keep comments bare-minimum").
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `messaging/streams/environment.go` **(new)** | The Environment port: the `environment` interface, the `messageHandler` shape, the `vendorEnvironment` adapter, the vendor `stream.MessagesHandler` unwrapping, and the production dial. |
+| `messaging/streams/manager.go` **(modify)** | `env` typed as the port; new `dialEnvironment` field; producer factories deleted and folded into `constructProducer`; every `*stream.Environment` parameter becomes `environment`. |
+| `messaging/streams/runner.go` **(modify)** | `messagesHandler` deleted — the vendor unwrapping moves into the adapter. `deliver` and the offset bookkeeping are untouched. |
+| `messaging/streams/environment_fake_test.go` **(new, test-only)** | `fakeEnvironment` — call-order recording, per-method error injection, in-memory offsets, drivable consumer handles — plus the `dialFake` / `startOnFake` helpers. |
+| `messaging/streams/manager_test.go` **(modify)** | The in-process `Start` suite; the `attach*` helpers deleted and their tests rebuilt on `Start`. |
+| `messaging/streams/streams_integration_test.go` **(modify)** | One container test shrunk (Task 4); the other nine unchanged. |
+
+`messaging/streams/runner_test.go` is **not** modified by any task: `deliver` keeps its signature, so all twelve of its call sites and the `storerByStream` / `bookOf` helpers stay exactly as they are.
+
+## Design decisions this plan locks in
+
+**How the plain lane's `offsetStorer` is reached through the port.** `consumerHandle` stays exactly `{Close() error; GetStatus() int}` (`manager.go:70-73`) and `startStreamConsumer` type-asserts the returned handle to the existing `offsetStorer` (`runner.go:39-41`) when it builds the shutdown-flush resolver: `*ha.ReliableSuperStreamConsumer` genuinely has no `StoreCustomOffset` — it exposes only `GetStreamName`, `GetStatus`, `GetStatusAsString`, `Close` (`$(go env GOMODCACHE)/github.com/rabbitmq/rabbitmq-stream-go-client@v1.8.3/pkg/ha/ha_super_stream_consumer.go:130-144`) — so adding the method to `consumerHandle` would force the super adapter to fake a method the vendor type does not have, whereas the assertion keeps the asymmetry exactly where the vendor put it and adds no new interface. A failed assertion yields a nil `offsetStorer`, which `offsetTracker.storeLocked` already answers with `errNoOffsetStorer` (`runner.go:118-121`).
+
+**The in-flight commit target still arrives with the delivery.** `runner.messagesHandler` passes the delivering `*stream.Consumer` straight into `deliver` today (`runner.go:233-236`), and `*stream.Consumer` implements `StoreCustomOffset` (`pkg/stream/consumer.go:521`). The port's handler therefore carries it: `type messageHandler func(streamName string, offset int64, msg *amqp.Message, store offsetStorer)`. The vendor adapter unwraps `consumerContext.Consumer` and passes it as `store`; `deliver`'s signature does not change; nothing in `runner.go` resolves a storer. An in-flight commit lands on the same object it lands on today, on the same connection.
+
+**The shutdown flush is the only thing `storerFor` resolves — unchanged.** `trackConsumer` keeps storing the resolver on `runningConsumer` exactly as it does now (`manager.go:415-430`), and `runningConsumer.storerFor`'s existing doc comment ("Only the shutdown flush needs it; every in-flight commit goes through the consumer the client hands to the delivery callback", `manager.go:84-87`) stays true and stays put. Plain: the handle, via the type assertion. Super: `envOffsetStorer` per partition, through the port — which is already what it does (`manager.go:396-398`).
+
+---
+
+### Task 1: The Environment port, the vendor adapter, and the manager on top of it
+
+**Files:**
+
+- Create: `messaging/streams/environment.go`
+- Create: `messaging/streams/environment_fake_test.go`
+- Modify: `messaging/streams/manager.go` (struct `94-119`, `NewManager` `129-146`, `Start` `165-241`, `declareStreams` `273-283`, `declareSuperStreams` `290-300`, `startConsumer` `325-330`, `startStreamConsumer` `333-365`, `startSuperStreamConsumer` `369-400`, `bindPublisher` `465-479`, `constructProducer` `483-488`, factories `517-551`, `envOffsetStorer` `553-563`, `resolveOffset` `582-587`)
+- Modify: `messaging/streams/runner.go` (delete `messagesHandler` `225-236`, move its concurrency prose onto `deliver`)
+- Modify: `messaging/streams/manager_test.go` (the `*stream.Environment` literals and the four producer-factory tests)
+
+**Interfaces:**
+
+- Produces, consumed by Tasks 2–4:
+  - `type messageHandler func(streamName string, offset int64, msg *amqp.Message, store offsetStorer)`
+  - `type environment interface { DeclareStream(name string, opts *stream.StreamOptions) error; DeclareSuperStream(name string, opts *stream.PartitionsOptions) error; QueryOffset(consumer, streamName string) (int64, error); StoreOffset(consumer, streamName string, offset int64) error; NewConsumer(streamName string, opts *stream.ConsumerOptions, handler messageHandler) (consumerHandle, error); NewSuperStreamConsumer(superStream string, opts *stream.SuperStreamConsumerOptions, handler messageHandler) (consumerHandle, error); NewProducer(streamName string, opts *stream.ProducerOptions, confirmed ha.ConfirmMessageHandler) (producerHandle, error); NewSuperStreamProducer(superStream string, opts *stream.SuperStreamProducerOptions, confirmed ha.PartitionConfirmMessageHandler) (producerHandle, error); Close() error }`
+  - `Manager.dialEnvironment func(*stream.EnvironmentOptions) (environment, error)`
+  - test helpers: `newFakeEnvironment() *fakeEnvironment`, `dialFake(m *Manager, fake *fakeEnvironment)`, `fakeEnvironment.failOn(key string, err error)`, `fakeEnvironment.setOffset` / `storedOffset` / `recorded` / `consumer` / `consumerOptions` / `producer` / `superProducerOptions` / `useProducer`, `fakeConsumer.deliver(streamName string, offset int64, msg *amqp.Message)`, `fakeConsumer.promote(streamName string) stream.OffsetSpecification`
+- Consumes, **unchanged**: `consumerHandle` (`manager.go:70-73`), `producerHandle` (`publisher.go:41-45`), `offsetStorer` (`runner.go:39-41`), `consumerRunner.deliver(streamName string, offset int64, message *amqp.Message, store offsetStorer)` (`runner.go:239`), `fakeHandle` / `fakeProducer` (existing test doubles).
+
+- [ ] **Step 1: Write the failing test — the manager must dial through a swappable seam**
+
+Create `messaging/streams/environment_fake_test.go` with the first cut of the fake. Everything here is used by this task; Task 2 grows it.
+
+```go
+package streams
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/ha"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
+)
+
+// The calls a fakeEnvironment records, in the order it made them. A target is
+// appended after a colon so a test asserts WHICH stream a phase reached, not only
+// that the phase ran. consumer_store and store_offset are deliberately separate:
+// an in-flight commit goes through the consumer that delivered the message, a
+// shutdown flush of a super stream through the Environment port, and a test that
+// could not tell them apart could not catch one turning into the other.
+const (
+	callDeclareStream      = "declare_stream"
+	callDeclareSuperStream = "declare_super_stream"
+	callNewProducer        = "new_producer"
+	callNewSuperProducer   = "new_super_producer"
+	callNewConsumer        = "new_consumer"
+	callNewSuperConsumer   = "new_super_consumer"
+	callQueryOffset        = "query_offset"
+	callStoreOffset        = "store_offset"
+	callConsumerStore      = "consumer_store"
+	callClose              = "close"
+)
+
+// errDeclareFailed, errConsumerStart and errProducerConstruction are the broker
+// failures a test injects at the port.
+var (
+	errDeclareFailed        = errors.New("declaration refused")
+	errConsumerStart        = errors.New("consumer start refused")
+	errProducerConstruction = errors.New("producer construction failed")
+)
+
+// deliveryStorer is the commit target the fake hands each delivery, standing in
+// for the *stream.Consumer the client passes its own callback: an in-flight
+// commit goes through the consumer that delivered the message, on ITS connection,
+// never through the Environment port or the reliable handle above it. It writes
+// where QueryOffset answers from, so a committed position is observable.
+type deliveryStorer struct {
+	env      *fakeEnvironment
+	consumer string
+	stream   string
+}
+
+func (s deliveryStorer) StoreCustomOffset(offset int64) error {
+	return s.env.storeFromConsumer(s.consumer, s.stream, offset)
+}
+
+// fakeConsumer is one consumer the fake environment handed back: the handle the
+// manager tracks, plus the callbacks a test drives it through.
+type fakeConsumer struct {
+	env *fakeEnvironment
+	// name is the consumer name the manager asked for, which is the key the
+	// broker stores offsets under.
+	name string
+	// handle is what the port returned: a *fakeHandle for a plain stream, because
+	// *ha.ReliableConsumer is an offsetStorer, and a *fakeSuperHandle for a super
+	// stream, because *ha.ReliableSuperStreamConsumer is not.
+	handle consumerHandle
+	// events is that handle's shared event log, so a test asserts store and close
+	// without caring which handle kind it got.
+	events  *fakeHandle
+	handler messageHandler
+	// sac is the promotion callback the manager installed, nil when the
+	// declaration did not ask for single active consumer.
+	sac stream.ConsumerUpdate
+}
+
+// deliver pushes one message through the runner exactly as the client's read
+// loop would, including the delivering consumer it commits through.
+func (c *fakeConsumer) deliver(streamName string, offset int64, msg *amqp.Message) {
+	c.handler(streamName, offset, msg,
+		deliveryStorer{env: c.env, consumer: c.name, stream: streamName})
+}
+
+// promote fires the single-active-consumer promotion callback, which is where a
+// per-partition stored offset is restored.
+func (c *fakeConsumer) promote(streamName string) stream.OffsetSpecification {
+	return c.sac(streamName, true)
+}
+
+// fakeSuperHandle stands in for *ha.ReliableSuperStreamConsumer. It delegates to
+// a fakeHandle rather than embedding one: embedding would promote
+// StoreCustomOffset, and the vendor type has none — that absence is exactly what
+// routes a super stream's shutdown flush through the Environment port.
+type fakeSuperHandle struct{ h *fakeHandle }
+
+func (f *fakeSuperHandle) Close() error   { return f.h.Close() }
+func (f *fakeSuperHandle) GetStatus() int { return f.h.GetStatus() }
+
+// fakeEnvironment is the in-memory adapter behind the Environment port.
+type fakeEnvironment struct {
+	mu sync.Mutex
+
+	calls []string
+	// errs injects one failure per port call, keyed either by method
+	// ("new_producer") or by method and target ("new_producer:orders").
+	errs map[string]error
+	// offsets is the broker's server-side offset store, keyed "<consumer>/<stream>".
+	offsets map[string]int64
+
+	consumers     map[string]*fakeConsumer
+	consumerOpts  map[string]*stream.ConsumerOptions
+	producers     map[string]*fakeProducer
+	superProdOpts map[string]*stream.SuperStreamProducerOptions
+	preparedProds map[string]*fakeProducer
+}
+
+var _ environment = (*fakeEnvironment)(nil)
+
+func newFakeEnvironment() *fakeEnvironment {
+	return &fakeEnvironment{
+		errs:          map[string]error{},
+		offsets:       map[string]int64{},
+		consumers:     map[string]*fakeConsumer{},
+		consumerOpts:  map[string]*stream.ConsumerOptions{},
+		producers:     map[string]*fakeProducer{},
+		superProdOpts: map[string]*stream.SuperStreamProducerOptions{},
+		preparedProds: map[string]*fakeProducer{},
+	}
+}
+
+// failOn makes one port call fail. key is a method name or "<method>:<target>".
+func (f *fakeEnvironment) failOn(key string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.errs[key] = err
+}
+
+// useProducer makes the fake hand back p for streamName instead of a default
+// open producer, so a test can start a manager on a producer that blocks, that
+// refuses to close, or that reports a status of its choosing.
+func (f *fakeEnvironment) useProducer(streamName string, p *fakeProducer) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.preparedProds[streamName] = p
+}
+
+// setOffset seeds the broker's stored offset for one consumer and stream.
+func (f *fakeEnvironment) setOffset(consumer, streamName string, offset int64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.offsets[consumer+"/"+streamName] = offset
+}
+
+// storedOffset reports what the broker holds, whichever path committed it.
+func (f *fakeEnvironment) storedOffset(consumer, streamName string) (int64, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	offset, ok := f.offsets[consumer+"/"+streamName]
+	return offset, ok
+}
+
+func (f *fakeEnvironment) recorded() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
+
+func (f *fakeEnvironment) consumer(streamName string) *fakeConsumer {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.consumers[streamName]
+}
+
+func (f *fakeEnvironment) consumerOptions(streamName string) *stream.ConsumerOptions {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.consumerOpts[streamName]
+}
+
+func (f *fakeEnvironment) producer(streamName string) *fakeProducer {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.producers[streamName]
+}
+
+func (f *fakeEnvironment) superProducerOptions(superStream string) *stream.SuperStreamProducerOptions {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.superProdOpts[superStream]
+}
+
+// recordLocked and errForLocked are called with f.mu held.
+func (f *fakeEnvironment) recordLocked(entry string) { f.calls = append(f.calls, entry) }
+
+func (f *fakeEnvironment) errForLocked(method, target string) error {
+	if err, ok := f.errs[method+":"+target]; ok {
+		return err
+	}
+	return f.errs[method]
+}
+
+// storeFromConsumer records a commit made through a delivering consumer rather
+// than through the port, and writes it where QueryOffset answers from.
+func (f *fakeEnvironment) storeFromConsumer(consumer, streamName string, offset int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	key := consumer + "/" + streamName
+	f.recordLocked(fmt.Sprintf("%s:%s=%d", callConsumerStore, key, offset))
+	if err := f.errForLocked(callConsumerStore, key); err != nil {
+		return err
+	}
+	f.offsets[key] = offset
+	return nil
+}
+
+func (f *fakeEnvironment) DeclareStream(name string, _ *stream.StreamOptions) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordLocked(callDeclareStream + ":" + name)
+	return f.errForLocked(callDeclareStream, name)
+}
+
+func (f *fakeEnvironment) DeclareSuperStream(name string, _ *stream.PartitionsOptions) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordLocked(callDeclareSuperStream + ":" + name)
+	return f.errForLocked(callDeclareSuperStream, name)
+}
+
+func (f *fakeEnvironment) QueryOffset(consumer, streamName string) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	key := consumer + "/" + streamName
+	f.recordLocked(callQueryOffset + ":" + key)
+	if err := f.errForLocked(callQueryOffset, key); err != nil {
+		return 0, err
+	}
+	offset, ok := f.offsets[key]
+	if !ok {
+		// The client answers a name it has never stored with this sentinel, and
+		// offsetSpecFor is the only place that tells it apart from a real failure.
+		return 0, stream.OffsetNotFoundError
+	}
+	return offset, nil
+}
+
+func (f *fakeEnvironment) StoreOffset(consumer, streamName string, offset int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	key := consumer + "/" + streamName
+	f.recordLocked(fmt.Sprintf("%s:%s=%d", callStoreOffset, key, offset))
+	if err := f.errForLocked(callStoreOffset, key); err != nil {
+		return err
+	}
+	f.offsets[key] = offset
+	return nil
+}
+
+func (f *fakeEnvironment) NewConsumer(streamName string, opts *stream.ConsumerOptions,
+	handler messageHandler,
+) (consumerHandle, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.recordLocked(callNewConsumer + ":" + streamName)
+	if err := f.errForLocked(callNewConsumer, streamName); err != nil {
+		return nil, err
+	}
+	events := &fakeHandle{status: ha.StatusOpen}
+	f.consumerOpts[streamName] = opts
+	f.consumers[streamName] = &fakeConsumer{
+		env:     f,
+		name:    opts.ConsumerName,
+		handle:  events,
+		events:  events,
+		handler: handler,
+		sac:     consumerUpdateOf(opts.SingleActiveConsumer),
+	}
+	return events, nil
+}
+
+func (f *fakeEnvironment) NewSuperStreamConsumer(superStream string, opts *stream.SuperStreamConsumerOptions,
+	handler messageHandler,
+) (consumerHandle, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.recordLocked(callNewSuperConsumer + ":" + superStream)
+	if err := f.errForLocked(callNewSuperConsumer, superStream); err != nil {
+		return nil, err
+	}
+	events := &fakeHandle{status: ha.StatusOpen}
+	handle := &fakeSuperHandle{h: events}
+	f.consumers[superStream] = &fakeConsumer{
+		env:     f,
+		name:    opts.ConsumerName,
+		handle:  handle,
+		events:  events,
+		handler: handler,
+		sac:     consumerUpdateOf(opts.SingleActiveConsumer),
+	}
+	return handle, nil
+}
+
+// consumerUpdateOf reads the promotion callback out of either options type's
+// single-active-consumer block, which the client leaves nil when SAC is off.
+func consumerUpdateOf(sac *stream.SingleActiveConsumer) stream.ConsumerUpdate {
+	if sac == nil {
+		return nil
+	}
+	return sac.ConsumerUpdate
+}
+
+func (f *fakeEnvironment) NewProducer(streamName string, _ *stream.ProducerOptions,
+	_ ha.ConfirmMessageHandler,
+) (producerHandle, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.recordLocked(callNewProducer + ":" + streamName)
+	if err := f.errForLocked(callNewProducer, streamName); err != nil {
+		return nil, err
+	}
+	return f.newProducerLocked(streamName), nil
+}
+
+func (f *fakeEnvironment) NewSuperStreamProducer(superStream string, opts *stream.SuperStreamProducerOptions,
+	_ ha.PartitionConfirmMessageHandler,
+) (producerHandle, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.recordLocked(callNewSuperProducer + ":" + superStream)
+	if err := f.errForLocked(callNewSuperProducer, superStream); err != nil {
+		return nil, err
+	}
+	f.superProdOpts[superStream] = opts
+	return f.newProducerLocked(superStream), nil
+}
+
+func (f *fakeEnvironment) newProducerLocked(streamName string) *fakeProducer {
+	p, ok := f.preparedProds[streamName]
+	if !ok {
+		p = openProducer()
+	}
+	f.producers[streamName] = p
+	return p
+}
+
+func (f *fakeEnvironment) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordLocked(callClose)
+	return f.errForLocked(callClose, "")
+}
+
+// dialFake makes m.Start open fake instead of a broker.
+func dialFake(m *Manager, fake *fakeEnvironment) {
+	m.dialEnvironment = func(*stream.EnvironmentOptions) (environment, error) { return fake, nil }
+}
+```
+
+Now append the RED test to `messaging/streams/manager_test.go`:
+
+```go
+// TestManagerStartDeclaresThroughTheEnvironmentPort is the whole point of the
+// port: Start's declare phase reaches the broker seam in a unit test. Before the
+// port there was no way in — the phase was only ever reached with a nil
+// environment, by a test that asserted through a panic.
+func TestManagerStartDeclaresThroughTheEnvironmentPort(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	dialFake(m, fake)
+
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+
+	require.NoError(t, m.Start(context.Background(), decls))
+
+	assert.Equal(t, []string{callDeclareStream + ":" + testStream}, fake.recorded())
+	assert.True(t, m.started)
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./messaging/streams/ -run TestManagerStartDeclaresThroughTheEnvironmentPort`
+
+Expected: FAIL — a build failure, which is Go's red for a seam that does not exist yet:
+
+```text
+# github.com/gaborage/go-bricks/messaging/streams [github.com/gaborage/go-bricks/messaging/streams.test]
+messaging/streams/environment_fake_test.go:...: undefined: environment
+messaging/streams/environment_fake_test.go:...: undefined: messageHandler
+messaging/streams/manager_test.go:...: m.dialEnvironment undefined (type *Manager has no field or method dialEnvironment)
+FAIL	github.com/gaborage/go-bricks/messaging/streams [build failed]
+```
+
+- [ ] **Step 3: Create the Environment port and its vendor adapter**
+
+Create `messaging/streams/environment.go`:
+
+```go
+package streams
+
+import (
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/ha"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
+)
+
+// messageHandler receives one delivery in the framework's own vocabulary. store
+// is the consumer that delivered the message, which is what an in-flight commit
+// goes through: the client's callback carries a stream.ConsumerContext whose
+// Consumer is a vendor struct of unexported fields that no test can populate, so
+// the unwrapping stays in the adapter and everything above this line is reachable
+// without a broker.
+type messageHandler func(streamName string, offset int64, msg *amqp.Message, store offsetStorer)
+
+// environment is the Environment port: the seam through which the streams lane
+// reaches the broker. One method per vendor call the manager makes, with the
+// vendor environment as its production adapter and an in-memory fake for tests.
+//
+// Unexported on purpose: nothing outside this package varies across the seam —
+// one production adapter, one test fake — so there is no consumer-facing
+// interface to export and no second implementation to abstract over.
+type environment interface {
+	DeclareStream(name string, opts *stream.StreamOptions) error
+	DeclareSuperStream(name string, opts *stream.PartitionsOptions) error
+	QueryOffset(consumer, streamName string) (int64, error)
+	StoreOffset(consumer, streamName string, offset int64) error
+	NewConsumer(streamName string, opts *stream.ConsumerOptions, handler messageHandler) (consumerHandle, error)
+	NewSuperStreamConsumer(superStream string, opts *stream.SuperStreamConsumerOptions, handler messageHandler) (consumerHandle, error)
+	NewProducer(streamName string, opts *stream.ProducerOptions, confirmed ha.ConfirmMessageHandler) (producerHandle, error)
+	NewSuperStreamProducer(superStream string, opts *stream.SuperStreamProducerOptions, confirmed ha.PartitionConfirmMessageHandler) (producerHandle, error)
+	Close() error
+}
+
+// vendorEnvironment is the production adapter over the stream client.
+type vendorEnvironment struct{ env *stream.Environment }
+
+var _ environment = vendorEnvironment{}
+
+// dialVendorEnvironment opens the port against a real broker.
+//
+// NewEnvironment returns a non-nil Environment BESIDE a non-nil error, so the
+// failure path has something to dispose and `env != nil` is not a success test.
+// v1.8.3 does tear the locator socket down itself, but only through an internal
+// `defer client.Close()` it documents nowhere, and Client.connect opens the
+// socket and starts its read goroutine before authentication — so disposing it
+// here is what keeps a rejected credential from depending on that detail.
+func dialVendorEnvironment(opts *stream.EnvironmentOptions) (environment, error) {
+	env, err := stream.NewEnvironment(opts)
+	if err != nil {
+		if env != nil {
+			_ = env.Close()
+		}
+		return nil, err
+	}
+	return vendorEnvironment{env: env}, nil
+}
+
+func (e vendorEnvironment) DeclareStream(name string, opts *stream.StreamOptions) error {
+	return e.env.DeclareStream(name, opts)
+}
+
+func (e vendorEnvironment) DeclareSuperStream(name string, opts *stream.PartitionsOptions) error {
+	return e.env.DeclareSuperStream(name, opts)
+}
+
+func (e vendorEnvironment) QueryOffset(consumer, streamName string) (int64, error) {
+	return e.env.QueryOffset(consumer, streamName)
+}
+
+func (e vendorEnvironment) StoreOffset(consumer, streamName string, offset int64) error {
+	return e.env.StoreOffset(consumer, streamName, offset)
+}
+
+// NewConsumer returns the reliable consumer itself rather than a wrapper: it
+// satisfies consumerHandle AND offsetStorer, which is what lets a plain stream's
+// SHUTDOWN flush commit through its own handle. The nil-on-error return matters —
+// the client hands back a non-nil consumer beside a non-nil error, and a typed
+// nil in a consumerHandle would read as a live handle.
+func (e vendorEnvironment) NewConsumer(streamName string, opts *stream.ConsumerOptions,
+	handler messageHandler,
+) (consumerHandle, error) {
+	consumer, err := ha.NewReliableConsumer(e.env, streamName, opts, vendorMessagesHandler(handler))
+	if err != nil {
+		return nil, err
+	}
+	return consumer, nil
+}
+
+// NewSuperStreamConsumer's handle is deliberately NOT an offsetStorer:
+// *ha.ReliableSuperStreamConsumer has no StoreCustomOffset, so a super stream's
+// shutdown flush goes through this port's StoreOffset, per partition.
+func (e vendorEnvironment) NewSuperStreamConsumer(superStream string, opts *stream.SuperStreamConsumerOptions,
+	handler messageHandler,
+) (consumerHandle, error) {
+	consumer, err := ha.NewReliableSuperStreamConsumer(e.env, superStream, vendorMessagesHandler(handler), opts)
+	if err != nil {
+		return nil, err
+	}
+	return consumer, nil
+}
+
+func (e vendorEnvironment) NewProducer(streamName string, opts *stream.ProducerOptions,
+	confirmed ha.ConfirmMessageHandler,
+) (producerHandle, error) {
+	producer, err := ha.NewReliableProducer(e.env, streamName, opts, confirmed)
+	if err != nil {
+		return nil, err
+	}
+	return producer, nil
+}
+
+func (e vendorEnvironment) NewSuperStreamProducer(superStream string, opts *stream.SuperStreamProducerOptions,
+	confirmed ha.PartitionConfirmMessageHandler,
+) (producerHandle, error) {
+	producer, err := ha.NewReliableSuperStreamProducer(e.env, superStream, opts, confirmed)
+	if err != nil {
+		return nil, err
+	}
+	return producer, nil
+}
+
+func (e vendorEnvironment) Close() error { return e.env.Close() }
+
+// vendorMessagesHandler adapts the port's handler to the client's callback. The
+// consumer it unwraps is both the source of the position and the target of the
+// in-flight commit, exactly as the client hands it over.
+func vendorMessagesHandler(handler messageHandler) stream.MessagesHandler {
+	return func(consumerContext stream.ConsumerContext, msg *amqp.Message) {
+		consumer := consumerContext.Consumer
+		handler(consumer.GetStreamName(), consumer.GetOffset(), msg, consumer)
+	}
+}
+```
+
+- [ ] **Step 4: Rewire `Manager` onto the port**
+
+In `messaging/streams/manager.go`, replace the producer-factory fields and the environment field (lines `104-119`) with:
+
+```go
+	// dialEnvironment opens the Environment port. A field rather than a direct
+	// call so an in-package test can hand the manager a fake: the dial is the only
+	// thing between Start and every phase it drives. Same seam as the AMQP lane's
+	// amqpDialFunc (messaging/amqp_adapters.go:47), minus the process-global — a
+	// Manager owns its own dialer, so tests need no save-and-restore.
+	dialEnvironment func(*stream.EnvironmentOptions) (environment, error)
+
+	mu         sync.Mutex
+	env        environment
+	consumers  []*runningConsumer
+	publishers []*Publisher
+	started    bool
+	cancel     context.CancelFunc
+```
+
+In `NewManager` (`139-145`), replace the two factory assignments:
+
+```go
+	return &Manager{
+		opts:            opts,
+		log:             opts.Logger,
+		flushBudget:     shutdownFlushBudget,
+		dialEnvironment: dialVendorEnvironment,
+	}
+```
+
+In `Start`, replace the dial block (`180-193`) with:
+
+```go
+	env, err := m.dialEnvironment(m.environmentOptions())
+	if err != nil {
+		return fmt.Errorf("failed to connect to stream endpoint %s: %w", redactStreamURI(m.opts.URI), safeEnvError(err))
+	}
+	m.env = env
+```
+
+Retype every environment parameter — `declareStreams`, `declareSuperStreams`, `startConsumer`, `startStreamConsumer`, `startSuperStreamConsumer`, `bindPublisher`, `constructProducer`, `resolveOffset` — from `env *stream.Environment` to `env environment`, and `envOffsetStorer.env` likewise:
+
+```go
+// envOffsetStorer commits one stream's offset through the Environment port
+// instead of through a consumer.
+type envOffsetStorer struct {
+	env      environment
+	consumer string
+	stream   string
+}
+```
+
+Replace the two consumer constructions. `startStreamConsumer` (`357-364`) — `runner.deliver` is a `messageHandler` as it stands, so the handler argument is a plain method value:
+
+```go
+	handle, err := env.NewConsumer(decl.Stream, opts, runner.deliver)
+	if err != nil {
+		return fmt.Errorf("failed to start consumer %q on stream %q: %w", decl.Name, decl.Stream, err)
+	}
+
+	// One stream, so one flush target: the reliable consumer itself. The assertion
+	// is what keeps consumerHandle narrower than offset storage — the super-stream
+	// handle has no StoreCustomOffset at all — and a handle that is not a storer
+	// commits nothing rather than panicking (errNoOffsetStorer).
+	storer, _ := handle.(offsetStorer)
+	m.trackConsumer(decl, handle, runner, func(string) offsetStorer { return storer })
+	return nil
+```
+
+`startSuperStreamConsumer` (`387-399`) — the comment is today's, unchanged but for naming the port:
+
+```go
+	handle, err := env.NewSuperStreamConsumer(decl.Stream, opts, runner.deliver)
+	if err != nil {
+		return fmt.Errorf("failed to start consumer %q on super stream %q: %w", decl.Name, decl.Stream, err)
+	}
+
+	// The shutdown flush goes through the Environment port, per partition:
+	// *ha.ReliableSuperStreamConsumer has no StoreCustomOffset, and the partition
+	// consumer that delivered the last message may already have been replaced by a
+	// reconnect.
+	m.trackConsumer(decl, handle, runner, func(partition string) offsetStorer {
+		return envOffsetStorer{env: env, consumer: decl.Name, stream: partition}
+	})
+	return nil
+```
+
+`trackConsumer` (`415-430`) and `runningConsumer` (`78-88`) are **not** modified: the resolver they carry is still the shutdown flush's alone, and the existing doc comments already say so.
+
+Replace `constructProducer` (`483-488`) and delete `producerFactory`, `superProducerFactory`, `newReliableProducer` and `newReliableSuperProducer` (`517-551`) entirely:
+
+```go
+// constructProducer builds one declaration's producer through the Environment
+// port, on the API its kind requires.
+//
+// The plain producer options are the client's defaults on purpose: deduplication,
+// sub-entry batching and compression are all deferred, and the default
+// SubEntrySize of 1 is what makes the confirmation's message pointer a valid
+// correlation key. Hash routing is the only strategy offered for a super stream:
+// it is murmur3 with RabbitMQ's shared seed, so a partition assignment made here
+// matches what the Java, .NET and Python clients compute for the same key. Key
+// routing — which asks the broker to resolve a key to partitions — is deferred.
+func (m *Manager) constructProducer(env environment, decl *publisherDeclaration) (producerHandle, error) {
+	if decl.Super {
+		opts := stream.NewSuperStreamProducerOptions(
+			stream.NewHashRoutingStrategy(m.routingKeyExtractor(decl.Publisher)))
+		return env.NewSuperStreamProducer(decl.Stream, opts, decl.Publisher.partitionsConfirmed)
+	}
+	return env.NewProducer(decl.Stream, stream.NewProducerOptions(), decl.Publisher.confirmed)
+}
+```
+
+Keep `manager.go`'s `message` import (`routingKeyExtractor` still returns `func(message.StreamMessage) string`) and its `ha` import (`readyLocked` uses `ha.StatusOpen`).
+
+- [ ] **Step 5: Move the vendor callback out of the runner**
+
+In `messaging/streams/runner.go`, delete `messagesHandler` (`225-236`) and move its concurrency prose onto `deliver`, whose signature and body are otherwise untouched:
+
+```go
+// deliver runs the handler for one message, then applies the commit policy.
+// store is the consumer that delivered it, which is what the in-flight commit
+// goes through.
+//
+// The client invokes this sequentially per STREAM — which for a super stream
+// means per partition, where one runner serves every partition and the client
+// calls it from one goroutine each, concurrently. The framework keeps that shape:
+// handlers run inline with no worker pool, because a stream is an ordered log and
+// parallelism *within* one would break that order and make a committed offset
+// claim messages behind it were handled. Anything reachable from here that is not
+// per-stream state must therefore be safe for concurrent use — the offset book
+// is, precisely because it hands each stream its own tracker.
+func (r *consumerRunner) deliver(streamName string, offset int64, message *amqp.Message, store offsetStorer) {
+```
+
+`consumerRunner`'s fields, `invoke`, `offsetTracker` and `offsetBook` are unchanged. The `stream` import may now be unused in `runner.go` — remove it only if the compiler says so.
+
+- [ ] **Step 6: Run the new test to verify it passes**
+
+Run: `go test ./messaging/streams/ -run TestManagerStartDeclaresThroughTheEnvironmentPort -v`
+Expected: `--- PASS: TestManagerStartDeclaresThroughTheEnvironmentPort` then `ok  github.com/gaborage/go-bricks/messaging/streams`
+
+- [ ] **Step 7: Move the producer-construction tests onto the port**
+
+In `messaging/streams/manager_test.go`: delete `errProducerConstruction` (line `39` — it now lives in `environment_fake_test.go`), `unreachableProducer` (`1340-1342`), `unreachableSuperProducer` (`1345-1349`), and the `"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/message"` import (line `14`), which no test needs after this step.
+
+Replace the two `m.env = &stream.Environment{}` literals — `TestManagerStartRejectsSecondStart` (line `465`) and `TestManagerStartRefusesRestartAfterStopConsumers` (line `1137-1138`) — with the fake, which is now what the field's type admits:
+
+```go
+	m.env = newFakeEnvironment()
+```
+
+```go
+	env := newFakeEnvironment()
+	m.env = env
+```
+
+Replace the four producer-factory tests (`1268-1410`) with these five, which drive the same paths through the port:
+
+```go
+// TestManagerBindPublisherWrapsAConstructionFailure exercises the construction
+// failure through the Environment port: against a real broker it dials, so this
+// is the only way a broker-free test can reach it.
+func TestManagerBindPublisherWrapsAConstructionFailure(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	fake.failOn(callNewProducer, errProducerConstruction)
+	decl := onePublisherDeclaration(t)
+
+	err := m.bindPublisher(fake, decl)
+
+	require.ErrorIs(t, err, errProducerConstruction, "the client's own cause reaches the caller")
+	assert.Contains(t, err.Error(), `failed to start the publisher on stream "`+testStream+`"`)
+	assert.Empty(t, m.publishers, "a publisher that could not be constructed is not tracked")
+	assert.ErrorIs(t, decl.Publisher.Publish(context.Background(), &PublishMessage{Data: []byte(testBody)}),
+		ErrPublisherNotStarted, "and its handle stays unbound")
+}
+
+// TestManagerBindPublisherTracksAConstructedProducer is the success half: the
+// producer is built for the declared stream, bound, and tracked.
+func TestManagerBindPublisherTracksAConstructedProducer(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	decl := onePublisherDeclaration(t)
+
+	require.NoError(t, m.bindPublisher(fake, decl))
+
+	assert.Equal(t, []string{callNewProducer + ":" + testStream}, fake.recorded(),
+		"the producer is built for the declared stream, through the plain constructor")
+	assert.Equal(t, []*Publisher{decl.Publisher}, m.publishers)
+	assert.Equal(t, ha.StatusOpen, decl.Publisher.status(), "the handle is bound to the new producer")
+}
+
+// TestManagerBindPublisherWrapsASuperConstructionFailure is the super-stream half
+// of the construction-failure path, and pins that the failure names the kind of
+// target the declaration asked for rather than calling every target a stream.
+func TestManagerBindPublisherWrapsASuperConstructionFailure(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	fake.failOn(callNewSuperProducer, errProducerConstruction)
+	decl := oneSuperPublisherDeclaration(t)
+
+	err := m.bindPublisher(fake, decl)
+
+	require.ErrorIs(t, err, errProducerConstruction)
+	assert.Contains(t, err.Error(), `failed to start the publisher on super stream "`+testSuperStream+`"`)
+	assert.Empty(t, m.publishers)
+}
+
+// TestManagerBindPublisherBuildsASuperProducerForASuperTarget pins the dispatch: a
+// super declaration must reach the port's super-stream constructor, with the hash
+// routing strategy that constructor requires and an extractor that answers the key
+// the caller registered. Binding it through the plain constructor would compile and
+// then fail at the broker, because a super stream is not a stream.
+func TestManagerBindPublisherBuildsASuperProducerForASuperTarget(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	// A plain bind here is the defect under test: it must never be reached.
+	fake.failOn(callNewProducer, errProducerConstruction)
+	decl := oneSuperPublisherDeclaration(t)
+
+	require.NoError(t, m.bindPublisher(fake, decl))
+
+	assert.Equal(t, []string{callNewSuperProducer + ":" + testSuperStream}, fake.recorded())
+	opts := fake.superProducerOptions(testSuperStream)
+	require.NotNil(t, opts)
+	strategy, ok := opts.RoutingStrategy.(*stream.HashRoutingStrategy)
+	require.True(t, ok, "hash routing is the only strategy offered")
+
+	registered := amqp.NewMessage([]byte(testBody))
+	decl.Publisher.pending.add(registered, testRoutingKey)
+	assert.Equal(t, testRoutingKey, strategy.RoutingKeyExtractor(registered),
+		"the extractor answers the key the caller registered with that exact message")
+
+	assert.Equal(t, []*Publisher{decl.Publisher}, m.publishers)
+	assert.Equal(t, ha.StatusOpen, decl.Publisher.status())
+}
+
+// TestManagerBindPublisherBuildsAPlainProducerForAPlainTarget is the other half of
+// that dispatch, and would fail if the two constructors were ever swapped.
+func TestManagerBindPublisherBuildsAPlainProducerForAPlainTarget(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	// A super bind here is the defect under test: it must never be reached.
+	fake.failOn(callNewSuperProducer, errProducerConstruction)
+
+	require.NoError(t, m.bindPublisher(fake, onePublisherDeclaration(t)))
+
+	assert.Equal(t, []string{callNewProducer + ":" + testStream}, fake.recorded())
+	require.Len(t, m.publishers, 1)
+	assert.Equal(t, ha.StatusOpen, m.publishers[0].status())
+}
+```
+
+- [ ] **Step 8: Run the whole package to verify it is green**
+
+Run: `go test -race ./messaging/streams/`
+Expected: `ok  github.com/gaborage/go-bricks/messaging/streams` with no `DATA RACE` and no build errors. `runner_test.go` must compile untouched — if it does not, `deliver`'s signature was changed and the change must be reverted. If `TestManagerDeclareProceedsOnALiveContext` fails, leave it — Task 3 replaces it; if it *passes*, it still asserts through a panic on a nil interface, which Task 3 removes.
+
+Run: `go vet ./messaging/streams/`
+Expected: no output. (`go build` alone will not compile the test doubles — a new interface method is only caught by `vet`/`test`.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+cat > /tmp/streams-port-msg.txt <<'EOF'
+refactor(streams): route the manager through an Environment port
+
+Manager threaded the concrete *stream.Environment through ten methods, so
+Start never reached declareStreams in a unit test and startStreamConsumer,
+startSuperStreamConsumer, resolveOffset, trackConsumer and newRunner had
+zero unit hits.
+
+Introduce an unexported environment interface -- one method per vendor call
+the manager makes -- with vendorEnvironment as its production adapter and a
+dialEnvironment field tests overwrite, mirroring the AMQP lane's
+amqpDialFunc minus the process-global. producerFactory and
+superProducerFactory fold into the port.
+
+The vendor stream.MessagesHandler unwrapping moves into the adapter, which
+passes the delivering consumer through as the port handler's store argument,
+so consumerRunner.deliver keeps its signature and every commit path is
+byte-for-byte what it was: in flight through the consumer that delivered the
+message, at shutdown through trackConsumer's storerFor -- the handle on a
+plain stream, the port per partition on a super stream.
+
+No exported API change.
+EOF
+git add messaging/streams/environment.go messaging/streams/environment_fake_test.go \
+        messaging/streams/manager.go messaging/streams/runner.go \
+        messaging/streams/manager_test.go
+git commit -F /tmp/streams-port-msg.txt
+```
+
+---
+
+### Task 2: The full fake and the in-process `Start` suite
+
+**Files:**
+
+- Modify: `messaging/streams/environment_fake_test.go` (add the blocking-store hook and the shared declaration/start helpers)
+- Modify: `messaging/streams/manager_test.go` (add the `Start` suite)
+
+**Interfaces:**
+
+- Consumes from Task 1: `environment`, `messageHandler`, `fakeEnvironment`, `fakeConsumer`, `dialFake`, `Manager.dialEnvironment`, `consumerRunner.deliver`.
+- Produces, consumed by Task 3:
+  - `func startOnFake(t *testing.T, m *Manager, fake *fakeEnvironment, decls *Declarations)`
+  - `func oneConsumerDecls() *Declarations` · `func superConsumerDecls() *Declarations`
+  - `func (f *fakeEnvironment) blockStoreOn(key string) (entered <-chan struct{}, release chan<- struct{})`
+  - `func ptrTo[T any](v T) *T`
+
+- [ ] **Step 1: Write the failing tests — the `Start` suite**
+
+First add the helpers to `messaging/streams/environment_fake_test.go`. The blocking hook needs new fields on `fakeEnvironment`:
+
+```go
+	// blockedStore parks one StoreOffset key until release closes, standing in for
+	// the client's locator reconnect loop against a broker that is down: it has no
+	// attempt cap and no deadline, so such a commit never returns on its own.
+	blockedStore string
+	storeEntered chan struct{}
+	storeRelease chan struct{}
+	storeOnce    sync.Once
+```
+
+```go
+func (f *fakeEnvironment) blockStoreOn(key string) (entered <-chan struct{}, release chan<- struct{}) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.blockedStore = key
+	f.storeEntered = make(chan struct{})
+	f.storeRelease = make(chan struct{})
+	return f.storeEntered, f.storeRelease
+}
+```
+
+and `StoreOffset` becomes (replacing the Task 1 body):
+
+```go
+func (f *fakeEnvironment) StoreOffset(consumer, streamName string, offset int64) error {
+	key := consumer + "/" + streamName
+
+	f.mu.Lock()
+	f.recordLocked(fmt.Sprintf("%s:%s=%d", callStoreOffset, key, offset))
+	injected := f.errForLocked(callStoreOffset, key)
+	blocked := f.blockedStore == key
+	entered, release := f.storeEntered, f.storeRelease
+	f.mu.Unlock()
+
+	// Parked OUTSIDE the lock on purpose: the shutdown flush budget exists to walk
+	// away from a commit that cannot finish, and holding this mutex would stall the
+	// consumer behind it on the mutex instead of letting the budget skip it.
+	if blocked {
+		f.storeOnce.Do(func() { close(entered) })
+		<-release
+	}
+
+	if injected != nil {
+		return injected
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.offsets[key] = offset
+	return nil
+}
+```
+
+Then the shared start helpers, at the end of the same file:
+
+```go
+// startOnFake runs a real Start against fake, so a test asserts on state Start
+// actually produced instead of state a helper fabricated.
+func startOnFake(t *testing.T, m *Manager, fake *fakeEnvironment, decls *Declarations) {
+	t.Helper()
+	dialFake(m, fake)
+	require.NoError(t, m.Start(context.Background(), decls))
+}
+
+// oneConsumerDecls is the plain lane's minimum: one stream, one consumer on it.
+func oneConsumerDecls() *Declarations {
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	decls.DeclareConsumer(&ConsumerOptions{Stream: testStream, Name: testConsumerName, Handler: noopHandler})
+	return decls
+}
+
+// superConsumerDecls is the partitioned lane's minimum: one super stream, one
+// consumer across every partition of it.
+func superConsumerDecls() *Declarations {
+	decls := NewDeclarations()
+	decls.DeclareSuperStream(testSuperStream, testPartitions, nil)
+	decls.DeclareSuperStreamConsumer(&SuperStreamConsumerOptions{
+		SuperStream: testSuperStream, Name: testConsumerName, Handler: noopHandler,
+	})
+	return decls
+}
+
+// ptrTo is how a table tells "no stored offset" from "stored offset 0".
+func ptrTo[T any](v T) *T { return &v }
+```
+
+Add `"context"`, `"testing"` and `"github.com/stretchr/testify/require"` to that file's imports.
+
+Now append the suite to `messaging/streams/manager_test.go`:
+
+```go
+// TestManagerStartDeclaresBindsThenStarts pins Start's phase order against the
+// port. Publishers bind BEFORE consumers start because a handler may publish from
+// its very first delivery, and an unbound publisher would reject it with
+// ErrPublisherNotStarted; both declare phases come first because neither a
+// producer nor a consumer can attach to a stream that does not exist.
+func TestManagerStartDeclaresBindsThenStarts(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	decls.DeclareSuperStream(testSuperStream, testPartitions, nil)
+	decls.DeclarePublisher(&PublisherOptions{Stream: testStream})
+	decls.DeclareConsumer(&ConsumerOptions{Stream: testStream, Name: testConsumerName, Handler: noopHandler})
+
+	startOnFake(t, m, fake, decls)
+
+	assert.Equal(t, []string{
+		callDeclareStream + ":" + testStream,
+		callDeclareSuperStream + ":" + testSuperStream,
+		callNewProducer + ":" + testStream,
+		callQueryOffset + ":" + testConsumerName + "/" + testStream,
+		callNewConsumer + ":" + testStream,
+	}, fake.recorded())
+	assert.True(t, m.started)
+	assert.Len(t, m.consumers, 1)
+	assert.Len(t, m.publishers, 1)
+}
+
+// TestManagerStartUnwindsAFailedDeclaration is abortStartLocked in process: the
+// environment was already dialed, so a caller that treats the error as fatal
+// without calling Close must leak nothing, and a retried Start must not orphan
+// the previous connection pool.
+func TestManagerStartUnwindsAFailedDeclaration(t *testing.T) {
+	m := testManager(t)
+	failing := newFakeEnvironment()
+	failing.failOn(callDeclareStream+":"+testStream, errDeclareFailed)
+	dialFake(m, failing)
+
+	err := m.Start(context.Background(), oneConsumerDecls())
+
+	require.ErrorIs(t, err, errDeclareFailed)
+	assert.Contains(t, err.Error(), `failed to declare stream "`+testStream+`"`)
+	assert.Contains(t, failing.recorded(), callClose, "the dialed environment is disposed by the failed Start itself")
+	assert.Nil(t, m.env)
+	assert.Empty(t, m.consumers)
+	assert.Empty(t, m.publishers)
+	assert.False(t, m.started)
+
+	// The unwind has to leave the manager startable, or a retry would be refused
+	// by the already-started guard for the rest of the process's life.
+	healthy := newFakeEnvironment()
+	startOnFake(t, m, healthy, oneConsumerDecls())
+	assert.True(t, m.started)
+}
+
+// TestManagerStartUnwindsAFailedConsumerStart is the unwind's other entry point,
+// and the one with something to undo: a publisher was already bound, so the
+// unwind has to close it rather than leave a producer attached to an environment
+// it is about to dispose.
+func TestManagerStartUnwindsAFailedConsumerStart(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	fake.failOn(callNewConsumer+":"+testStream, errConsumerStart)
+	dialFake(m, fake)
+
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	publisher := decls.DeclarePublisher(&PublisherOptions{Stream: testStream})
+	decls.DeclareConsumer(&ConsumerOptions{Stream: testStream, Name: testConsumerName, Handler: noopHandler})
+
+	err := m.Start(context.Background(), decls)
+
+	require.ErrorIs(t, err, errConsumerStart)
+	assert.Contains(t, err.Error(), `failed to start consumer "`+testConsumerName+`" on stream "`+testStream+`"`)
+	assert.True(t, fake.producer(testStream).isClosed(), "the publisher bound before the failure is closed")
+	assert.ErrorIs(t, publisher.Publish(context.Background(), &PublishMessage{Data: []byte(testBody)}),
+		ErrPublisherClosed)
+	assert.Contains(t, fake.recorded(), callClose)
+	assert.Nil(t, m.env)
+	assert.False(t, m.started)
+}
+
+// TestManagerStartResolvesTheAttachPosition drives resolveOffset through Start.
+// Only a MISSING offset may fall back to the declared start: any other query
+// failure answered with a start position would SKIP, fatally so for the
+// zero-value OffsetNext, and streams have no redelivery to get it back.
+func TestManagerStartResolvesTheAttachPosition(t *testing.T) {
+	tests := []struct {
+		name     string
+		stored   *int64
+		queryErr error
+		start    OffsetStart
+		want     stream.OffsetSpecification
+	}{
+		{
+			name:   "stored_offset_resumes_one_past_it",
+			stored: ptrTo(int64(17)),
+			start:  OffsetFirst(),
+			want:   stream.OffsetSpecification{}.Offset(18),
+		},
+		{
+			name:  "no_stored_offset_uses_the_declared_start",
+			start: OffsetFirst(),
+			want:  stream.OffsetSpecification{}.First(),
+		},
+		{
+			name:     "query_failure_without_a_local_commit_replays_from_first",
+			queryErr: errors.New("boom"),
+			start:    OffsetNext(),
+			want:     stream.OffsetSpecification{}.First(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := testManager(t)
+			fake := newFakeEnvironment()
+			if tt.stored != nil {
+				fake.setOffset(testConsumerName, testStream, *tt.stored)
+			}
+			if tt.queryErr != nil {
+				fake.failOn(callQueryOffset, tt.queryErr)
+			}
+
+			decls := NewDeclarations()
+			decls.DeclareStream(testStream, nil)
+			decls.DeclareConsumer(&ConsumerOptions{
+				Stream: testStream, Name: testConsumerName, Start: tt.start, Handler: noopHandler,
+			})
+			startOnFake(t, m, fake, decls)
+
+			opts := fake.consumerOptions(testStream)
+			require.NotNil(t, opts)
+			assert.Equal(t, tt.want, opts.Offset)
+		})
+	}
+}
+
+// TestManagerStartPromotionResolvesTheOffsetAgain exercises the single active
+// consumer promotion callback the client fires from its own goroutine: another
+// group member may have advanced the offset while this one was passive, so the
+// position is resolved again rather than reused from attach time.
+func TestManagerStartPromotionResolvesTheOffsetAgain(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	decls.DeclareConsumer(&ConsumerOptions{
+		Stream: testStream, Name: testConsumerName, SAC: true, Start: OffsetFirst(), Handler: noopHandler,
+	})
+	startOnFake(t, m, fake, decls)
+
+	require.Equal(t, stream.OffsetSpecification{}.First(), fake.consumerOptions(testStream).Offset,
+		"the premise: nothing was stored when the consumer attached")
+
+	// Another member committed while this one was passive.
+	fake.setOffset(testConsumerName, testStream, 41)
+
+	assert.Equal(t, stream.OffsetSpecification{}.Offset(42), fake.consumer(testStream).promote(testStream))
+}
+
+// TestManagerStartPromotionFallsBackToTheLocalCommit is resolveOffset's third
+// branch, which only a promotion can reach: the broker cannot be asked, but this
+// process committed a position for the stream itself, so that is the closest
+// truth available and is no older than the broker's.
+func TestManagerStartPromotionFallsBackToTheLocalCommit(t *testing.T) {
+	m := NewManager(ManagerOptions{
+		URI: unreachableTestURI, OffsetStoreCount: 1, Logger: logger.New("error", false),
+	})
+	fake := newFakeEnvironment()
+
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	decls.DeclareConsumer(&ConsumerOptions{
+		Stream: testStream, Name: testConsumerName, SAC: true, Start: OffsetNext(), Handler: noopHandler,
+	})
+	startOnFake(t, m, fake, decls)
+
+	consumer := fake.consumer(testStream)
+	consumer.deliver(testStream, 41, amqpMessage("payload"))
+	require.Equal(t, map[string]int64{testStream: 41}, m.consumers[0].offsets.stored(),
+		"the premise: this process committed 41")
+
+	fake.failOn(callQueryOffset, errors.New("boom"))
+
+	assert.Equal(t, stream.OffsetSpecification{}.Offset(42), consumer.promote(testStream),
+		"a broker that cannot be asked resumes from the local commit, never from the declared start")
+}
+
+// TestManagerStartCommitsInFlightThroughTheDeliveringConsumer pins the commit
+// path the Environment port must NOT have moved: an in-flight commit goes through
+// the consumer that delivered the message, on its connection — neither through
+// the reliable handle above it nor through the port's locator. Both kinds behave
+// identically here; the asymmetry is the shutdown flush's alone.
+func TestManagerStartCommitsInFlightThroughTheDeliveringConsumer(t *testing.T) {
+	tests := []struct {
+		name         string
+		decls        func() *Declarations
+		trackedName  string
+		deliverOn    string
+	}{
+		{name: "plain_stream", decls: oneConsumerDecls, trackedName: testStream, deliverOn: testStream},
+		{name: "super_stream_partition", decls: superConsumerDecls, trackedName: testSuperStream, deliverOn: testPartition0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewManager(ManagerOptions{
+				URI: unreachableTestURI, OffsetStoreCount: 1, Logger: logger.New("error", false),
+			})
+			fake := newFakeEnvironment()
+			startOnFake(t, m, fake, tt.decls())
+
+			consumer := fake.consumer(tt.trackedName)
+			consumer.deliver(tt.deliverOn, 7, amqpMessage("payload"))
+
+			key := testConsumerName + "/" + tt.deliverOn
+			assert.Contains(t, fake.recorded(), callConsumerStore+":"+key+"=7")
+			assert.NotContains(t, fake.recorded(), callStoreOffset+":"+key+"=7",
+				"an in-flight commit never goes through the Environment port")
+			assert.Empty(t, consumer.events.recorded(),
+				"nor through the reliable handle the manager tracks")
+
+			offset, ok := fake.storedOffset(testConsumerName, tt.deliverOn)
+			require.True(t, ok, "the commit reaches the broker's offset store")
+			assert.Equal(t, int64(7), offset)
+			assert.Equal(t, map[string]int64{tt.deliverOn: 7}, m.consumers[0].offsets.stored())
+		})
+	}
+}
+
+// TestManagerStartFlushesPlainThroughTheHandleAndSuperThroughThePort is the
+// offset-storer asymmetry, which lives entirely in the SHUTDOWN flush: a plain
+// consumer's handle is an offsetStorer, while *ha.ReliableSuperStreamConsumer has
+// no StoreCustomOffset at all, so its partitions commit through the port.
+func TestManagerStartFlushesPlainThroughTheHandleAndSuperThroughThePort(t *testing.T) {
+	tests := []struct {
+		name        string
+		decls       func() *Declarations
+		trackedName string
+		deliverOn   string
+		wantHandle  []string
+		wantPort    bool
+	}{
+		{
+			name: "plain_stream_flushes_through_its_own_handle",
+			decls: oneConsumerDecls, trackedName: testStream, deliverOn: testStream,
+			wantHandle: []string{"store:7", "close"}, wantPort: false,
+		},
+		{
+			name: "super_stream_flushes_through_the_port",
+			decls: superConsumerDecls, trackedName: testSuperStream, deliverOn: testPartition0,
+			wantHandle: []string{"close"}, wantPort: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// A high threshold leaves the delivery pending, so the flush has work.
+			m := NewManager(ManagerOptions{
+				URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: logger.New("error", false),
+			})
+			fake := newFakeEnvironment()
+			startOnFake(t, m, fake, tt.decls())
+
+			consumer := fake.consumer(tt.trackedName)
+			consumer.deliver(tt.deliverOn, 7, amqpMessage("payload"))
+			require.Empty(t, consumer.events.recorded(), "the premise: the offset is still pending")
+
+			m.StopConsumers()
+
+			assert.Equal(t, tt.wantHandle, consumer.events.recorded())
+			portEntry := callStoreOffset + ":" + testConsumerName + "/" + tt.deliverOn + "=7"
+			if tt.wantPort {
+				assert.Contains(t, fake.recorded(), portEntry)
+			} else {
+				assert.NotContains(t, fake.recorded(), portEntry)
+			}
+		})
+	}
+}
+
+// TestManagerStartRunsTheHandlerForADeliveredMessage is the delivery path end to
+// end through Start: the port hands the runner a message, the module's handler
+// sees the framework's view of it, and the offset is committed after success.
+func TestManagerStartRunsTheHandlerForADeliveredMessage(t *testing.T) {
+	var got *Message
+	m := NewManager(ManagerOptions{
+		URI: unreachableTestURI, OffsetStoreCount: 1, Logger: logger.New("error", false),
+	})
+	fake := newFakeEnvironment()
+
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	decls.DeclareConsumer(&ConsumerOptions{
+		Stream: testStream, Name: testConsumerName,
+		Handler: func(_ context.Context, msg *Message) error {
+			got = msg
+			return nil
+		},
+	})
+	startOnFake(t, m, fake, decls)
+
+	fake.consumer(testStream).deliver(testStream, 55, amqpMessage("payload"))
+
+	require.NotNil(t, got)
+	assert.Equal(t, []byte("payload"), got.Data)
+	assert.Equal(t, int64(55), got.Offset)
+	assert.Equal(t, testStream, got.Stream)
+	assert.Equal(t, map[string]any{"kind": "test"}, got.Properties)
+	assert.Contains(t, fake.recorded(), callConsumerStore+":"+testConsumerName+"/"+testStream+"=55")
+}
+```
+
+- [ ] **Step 2: Run the suite to verify it fails**
+
+Run: `go test ./messaging/streams/ -run 'TestManagerStart(DeclaresBindsThenStarts|Unwinds|Resolves|Promotion|Commits|Flushes|RunsTheHandler)'`
+
+Expected: FAIL — a build failure naming the helpers that do not exist yet:
+
+```text
+messaging/streams/manager_test.go:...: undefined: startOnFake
+messaging/streams/manager_test.go:...: undefined: oneConsumerDecls
+messaging/streams/manager_test.go:...: undefined: superConsumerDecls
+messaging/streams/manager_test.go:...: undefined: ptrTo
+FAIL	github.com/gaborage/go-bricks/messaging/streams [build failed]
+```
+
+If you added the helpers in Step 1 as written, run the suite anyway before proceeding and confirm every one of the nine tests passes; if any fails, the failure is real and belongs to `manager.go` — fix it there, never by weakening the assertion.
+
+- [ ] **Step 3: Make the suite pass**
+
+The suite is written against the port Task 1 already built, so no production change should be needed. If a test fails, the likely causes and their fixes:
+
+- `TestManagerStartDeclaresBindsThenStarts` sees `new_consumer` before `new_producer` → `Start` is calling `startConsumers` before `bindPublishers`; restore the order at `manager.go:221-237`.
+- `TestManagerStartUnwindsAFailedConsumerStart` reports the publisher still open → `abortStartLocked` is not reaching `stopPublishersLocked`; check `stopLocked` (`manager.go:713-738`).
+- `TestManagerStartCommitsInFlightThroughTheDeliveringConsumer` records a `store_offset:` or a `store:` → a commit path moved; the adapter must pass `consumerContext.Consumer` as `store` and `deliver` must use its `store` argument untouched.
+- `TestManagerStartFlushesPlainThroughTheHandleAndSuperThroughThePort` fails on the super case → `startSuperStreamConsumer`'s `storerFor` is returning the handle instead of `envOffsetStorer`.
+- `TestManagerStartPromotionFallsBackToTheLocalCommit` returns `First()` → `resolveOffset` is not consulting `committed.stored()` (`manager.go:583-586`).
+
+- [ ] **Step 4: Run the suite to verify it passes**
+
+Run: `go test -race ./messaging/streams/ -run 'TestManagerStart' -v`
+Expected: every `TestManagerStart*` reports `--- PASS`, then `ok  github.com/gaborage/go-bricks/messaging/streams`.
+
+- [ ] **Step 5: Run the whole package**
+
+Run: `go test -race ./messaging/streams/`
+Expected: `ok  github.com/gaborage/go-bricks/messaging/streams`, no `DATA RACE`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cat > /tmp/streams-start-suite-msg.txt <<'EOF'
+test(streams): cover Manager.Start in process against the fake environment
+
+The fake environment records port calls in order, injects a failure per call,
+keeps offsets in memory and hands back consumer handles a test can push
+messages through, so the whole of Start is now reachable without a broker. A
+delivery driven through the fake commits through the consumer that delivered
+it, recorded under a label distinct from the port's own StoreOffset so a test
+can tell the two paths apart.
+
+New coverage: the declare/bind/start phase order, abortStartLocked's unwind
+from a failed declaration and from a failed consumer start (including the
+publisher bound before it), resolveOffset's fallbacks including the
+local-commit branch only a single-active-consumer promotion can reach, the
+in-flight commit target for both kinds, the shutdown-flush asymmetry, and one
+delivery running the module handler end to end.
+EOF
+git add messaging/streams/environment_fake_test.go messaging/streams/manager_test.go
+git commit -F /tmp/streams-start-suite-msg.txt
+```
+
+---
+
+### Task 3: Retire the `attach*` helpers — build every test's state through `Start`
+
+**Files:**
+
+- Modify: `messaging/streams/manager_test.go` (delete `attach` `240-253`, `attachPartitioned` `255-279`, `attachPublisher` `1163-1166`, `rebindPublisher` `1168-1175`; rewrite every caller)
+
+**Interfaces:**
+
+- Consumes from Task 2: `startOnFake`, `oneConsumerDecls`, `superConsumerDecls`, `fakeEnvironment.useProducer`, `fakeEnvironment.blockStoreOn`, `fakeConsumer.deliver`.
+
+This task ships as **two commits** so each diff stays reviewable: the consumer-side helpers first, the publisher-side helpers second.
+
+#### 3a — the consumer-side helpers
+
+- [ ] **Step 1: Write the failing test — the declare phase asserted by a call, not by a panic**
+
+Replace `TestManagerDeclareProceedsOnALiveContext` (`manager_test.go:539-547`) with:
+
+```go
+// A live context must not short-circuit the fan-out. Before the Environment port
+// this was asserted by panicking on a nil environment, which proved only that
+// SOMETHING was dereferenced; now it names the call that reached the broker.
+func TestManagerDeclareProceedsOnALiveContext(t *testing.T) {
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	m := testManager(t)
+	fake := newFakeEnvironment()
+
+	require.NoError(t, m.declareStreams(context.Background(), fake, decls))
+
+	assert.Equal(t, []string{callDeclareStream + ":" + testStream}, fake.recorded())
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `go test ./messaging/streams/ -run TestManagerDeclareProceedsOnALiveContext -v`
+Expected: PASS. This one is a *straight replacement* of an assertion, not a new behavior — the red here is the old test's `assert.Panics`, which you have just deleted. If instead it FAILS, `declareStreams` is not forwarding to the port; fix `manager.go:273-283`.
+
+- [ ] **Step 3: Rewrite the `attach`-based tests**
+
+Delete `attach` (`240-253`) and `attachPartitioned` (`255-279`), and rewrite `recordingManager` (`220-230`):
+
+```go
+// recordingManager starts a manager on fake with one plain consumer that has a
+// pending, uncommitted offset, so both shutdown guards are reachable. The count
+// threshold is deliberately high: the delivery must leave work for the shutdown
+// flush to do rather than commit it inline.
+func recordingManager(t *testing.T, fake *fakeEnvironment) (*Manager, *recordingLogger) {
+	t.Helper()
+	log := &recordingLogger{}
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: log})
+	startOnFake(t, m, fake, oneConsumerDecls())
+	fake.consumer(testStream).deliver(testStream, 4, amqpMessage("payload"))
+	return m, log
+}
+```
+
+Now each caller, in file order:
+
+`TestManagerStartRejectsSecondStart` (`462-474`) — drop the `attach` line; the fake environment installed in Task 1 Step 7 is the whole premise:
+
+```go
+func TestManagerStartRejectsSecondStart(t *testing.T) {
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: logger.New("error", false)})
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, oneConsumerDecls())
+
+	err := m.Start(context.Background(), oneConsumerDecls())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already started")
+}
+```
+
+`TestManagerStopConsumersFlushesEveryTrackedStream` (`285-296`):
+
+```go
+func TestManagerStopConsumersFlushesEveryTrackedStream(t *testing.T) {
+	m := NewManager(ManagerOptions{
+		URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: logger.New("error", false),
+	})
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, superConsumerDecls())
+
+	consumer := fake.consumer(testSuperStream)
+	consumer.deliver(testPartition0, 11, amqpMessage("a"))
+	consumer.deliver(testPartition1, 501, amqpMessage("b"))
+	require.NotContains(t, fake.recorded(), callStoreOffset+":"+testConsumerName+"/"+testPartition0+"=11",
+		"the premise: both offsets are still pending")
+
+	m.StopConsumers()
+
+	assert.Contains(t, fake.recorded(), callStoreOffset+":"+testConsumerName+"/"+testPartition0+"=11")
+	assert.Contains(t, fake.recorded(), callStoreOffset+":"+testConsumerName+"/"+testPartition1+"=501")
+	assert.Equal(t, []string{"close"}, consumer.events.recorded(), "the handle itself stores nothing")
+	assert.Empty(t, m.consumers)
+}
+```
+
+`TestManagerStopConsumersAbandonsFlushWhenBudgetSpent` (`328-385`) — the super stream is declared first so it is the consumer whose commit hangs, and the plain stream behind it is the one that must be skipped rather than attempted:
+
+```go
+func TestManagerStopConsumersAbandonsFlushWhenBudgetSpent(t *testing.T) {
+	log := &recordingLogger{}
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: log})
+	m.flushBudget = 50 * time.Millisecond
+
+	fake := newFakeEnvironment()
+	entered, release := fake.blockStoreOn(testConsumerName + "/" + testPartition0)
+	defer close(release)
+
+	decls := NewDeclarations()
+	decls.DeclareSuperStream(testSuperStream, testPartitions, nil)
+	decls.DeclareStream(testStream, nil)
+	decls.DeclareSuperStreamConsumer(&SuperStreamConsumerOptions{
+		SuperStream: testSuperStream, Name: testConsumerName, Handler: noopHandler,
+	})
+	decls.DeclareConsumer(&ConsumerOptions{Stream: testStream, Name: secondConsumerName, Handler: noopHandler})
+	startOnFake(t, m, fake, decls)
+
+	fake.consumer(testSuperStream).deliver(testPartition0, 11, amqpMessage("a"))
+	behind := fake.consumer(testStream)
+	behind.deliver(testStream, 501, amqpMessage("b"))
+	require.Empty(t, behind.events.recorded(), "the premise: the second consumer's offset is still pending")
+
+	returned := make(chan struct{})
+	go func() {
+		m.StopConsumers()
+		close(returned)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the blocked commit was never attempted, so this test is not exercising the hang it claims to")
+	}
+
+	select {
+	case <-returned:
+	case <-time.After(10 * time.Second):
+		t.Fatal("StopConsumers never returned: the flush budget did not bound a commit that cannot finish")
+	}
+
+	assert.Equal(t, []string{"close"}, behind.events.recorded(),
+		"a budget already spent must skip the remaining flush outright, not attempt one more")
+	assert.Equal(t, []string{testSuperStream, testStream}, log.warnStreams(msgFlushSkipped),
+		"every skipped flush is reported at WARN, naming its stream")
+	assert.Equal(t, []string{"close"}, fake.consumer(testSuperStream).events.recorded(),
+		"an abandoned flush must still let its consumer be closed")
+	assert.Empty(t, m.consumers)
+	assert.False(t, m.started)
+}
+```
+
+`TestManagerStopConsumersFlushesWithinBudget` (`391-402`):
+
+```go
+func TestManagerStopConsumersFlushesWithinBudget(t *testing.T) {
+	log := &recordingLogger{}
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: log})
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, superConsumerDecls())
+
+	consumer := fake.consumer(testSuperStream)
+	consumer.deliver(testPartition0, 11, amqpMessage("a"))
+	consumer.deliver(testPartition1, 501, amqpMessage("b"))
+
+	m.StopConsumers()
+
+	assert.Contains(t, fake.recorded(), callStoreOffset+":"+testConsumerName+"/"+testPartition0+"=11")
+	assert.Contains(t, fake.recorded(), callStoreOffset+":"+testConsumerName+"/"+testPartition1+"=501")
+	assert.Empty(t, log.warnStreams(msgFlushSkipped), "a flush that lands well inside the budget skips nothing")
+	assert.Equal(t, []string{"close"}, consumer.events.recorded())
+}
+```
+
+`TestManagerStatsKeysOffsetsByTrackedStream` (`407-418`):
+
+```go
+func TestManagerStatsKeysOffsetsByTrackedStream(t *testing.T) {
+	m := NewManager(ManagerOptions{
+		URI: unreachableTestURI, OffsetStoreCount: 1, Logger: logger.New("error", false),
+	})
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, superConsumerDecls())
+
+	consumer := fake.consumer(testSuperStream)
+	consumer.deliver(testPartition0, 11, amqpMessage("a"))
+	consumer.deliver(testPartition1, 501, amqpMessage("b"))
+
+	stats := m.Stats()
+
+	assert.Equal(t, map[string]int64{
+		testPartition0 + "/" + testConsumerName: 11,
+		testPartition1 + "/" + testConsumerName: 501,
+	}, stats["stored_offsets"])
+	assert.Equal(t, 1, stats["consumers"], "the two partitions are one consumer")
+}
+```
+
+`TestManagerStopConsumersFlushesBeforeClosing` (`591-604`):
+
+```go
+func TestManagerStopConsumersFlushesBeforeClosing(t *testing.T) {
+	m := NewManager(ManagerOptions{
+		URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: logger.New("error", false),
+	})
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, oneConsumerDecls())
+	fake.consumer(testStream).deliver(testStream, 88, amqpMessage("payload"))
+
+	m.StopConsumers()
+
+	assert.Equal(t, []string{"store:88", "close"}, fake.consumer(testStream).events.recorded(),
+		"a clean shutdown commits the last handled offset before the consumer goes away")
+	assert.False(t, m.started)
+	assert.Empty(t, m.consumers)
+}
+```
+
+`TestManagerStopConsumersIsIdempotent` (`606-615`):
+
+```go
+func TestManagerStopConsumersIsIdempotent(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, oneConsumerDecls())
+
+	m.StopConsumers()
+	m.StopConsumers()
+
+	assert.Equal(t, []string{"close"}, fake.consumer(testStream).events.recorded(),
+		"nothing pending, and no second close")
+}
+```
+
+`TestManagerStopConsumersCancelsConsumeContext` (`652-662`) — `Start` now installs `m.cancel` itself, so the test overwrites it with a context it owns and can observe:
+
+```go
+func TestManagerStopConsumersCancelsConsumeContext(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startOnFake(t, m, fake, oneConsumerDecls())
+	consumeCtx, consumeCancel := consumeContext(ctx)
+	m.cancel = consumeCancel
+
+	m.StopConsumers()
+
+	require.ErrorIs(t, consumeCtx.Err(), context.Canceled)
+	assert.Nil(t, m.cancel)
+}
+```
+
+`TestManagerStopConsumersStopsDetachedConsumeContext` (`683-698`):
+
+```go
+func TestManagerStopConsumersStopsDetachedConsumeContext(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	parent, cancelParent := context.WithCancel(context.Background())
+	startOnFake(t, m, fake, oneConsumerDecls())
+	consumeCtx, cancel := consumeContext(parent)
+	m.cancel = cancel
+
+	cancelParent()
+	require.NoError(t, consumeCtx.Err(), "the premise: the caller's context is canceled first")
+
+	m.StopConsumers()
+
+	require.ErrorIs(t, consumeCtx.Err(), context.Canceled)
+	assert.Nil(t, m.cancel)
+	assert.False(t, m.started)
+}
+```
+
+`TestManagerStats` (`707-726`):
+
+```go
+func TestManagerStats(t *testing.T) {
+	m := NewManager(ManagerOptions{
+		URI:                 unreachableTestURI,
+		OffsetStoreCount:    1,
+		OffsetStoreInterval: 2 * time.Second,
+		Logger:              logger.New("error", false),
+	})
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, oneConsumerDecls())
+	fake.consumer(testStream).deliver(testStream, 31, amqpMessage("payload"))
+
+	stats := m.Stats()
+
+	assert.Equal(t, true, stats["started"])
+	assert.Equal(t, 1, stats["consumers"])
+	assert.Equal(t, true, stats["ready"])
+	assert.Equal(t, map[string]int64{testStream + "/" + testConsumerName: 31}, stats["stored_offsets"])
+	assert.Equal(t, 1, stats["offset_store_count"])
+	assert.Equal(t, "2s", stats["offset_flush_interval"])
+}
+```
+
+`TestManagerStatsOmitsUncommittedOffsets` (`728-735`):
+
+```go
+func TestManagerStatsOmitsUncommittedOffsets(t *testing.T) {
+	m := NewManager(ManagerOptions{
+		URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: logger.New("error", false),
+	})
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, oneConsumerDecls())
+	fake.consumer(testStream).deliver(testStream, 31, amqpMessage("payload"))
+
+	stats := m.Stats()
+
+	assert.Empty(t, stats["stored_offsets"])
+}
+```
+
+`TestManagerReady` (`737-760`):
+
+```go
+func TestManagerReady(t *testing.T) {
+	tests := []struct {
+		name    string
+		started bool
+		status  int
+		want    bool
+	}{
+		{name: "open_consumer_is_ready", started: true, status: ha.StatusOpen, want: true},
+		{name: "reconnecting_consumer_is_not_ready", started: true, status: ha.StatusReconnecting, want: false},
+		{name: "closed_consumer_is_not_ready", started: true, status: ha.StatusClosed, want: false},
+		{name: "never_started_is_not_ready", started: false, status: ha.StatusOpen, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := testManager(t)
+			fake := newFakeEnvironment()
+			startOnFake(t, m, fake, oneConsumerDecls())
+			fake.consumer(testStream).events.status = tt.status
+			m.started = tt.started
+
+			assert.Equal(t, tt.want, m.Ready())
+			assert.Equal(t, tt.want, m.Stats()["ready"])
+		})
+	}
+}
+```
+
+`TestManagerStopConsumersToleratesFlushAndCloseErrors` (`621-638`):
+
+```go
+func TestManagerStopConsumersToleratesFlushAndCloseErrors(t *testing.T) {
+	fake := newFakeEnvironment()
+	m, log := recordingManager(t, fake)
+	handle := fake.consumer(testStream).events
+	handle.closeErr = errors.New("close failed")
+	handle.storeErr = errors.New("store failed")
+
+	assert.NotPanics(t, m.StopConsumers)
+	assert.False(t, m.started)
+
+	assert.ElementsMatch(t, []string{msgFlushFailed, msgCloseConsumerFailed}, log.warnMessages())
+	flushErr, ok := log.warnError(msgFlushFailed)
+	require.True(t, ok)
+	assert.Equal(t, "store failed", flushErr)
+	closeErr, ok := log.warnError(msgCloseConsumerFailed)
+	require.True(t, ok)
+	assert.Equal(t, "close failed", closeErr)
+}
+```
+
+`TestManagerStopConsumersIsSilentOnCleanShutdown` (`642-650`):
+
+```go
+func TestManagerStopConsumersIsSilentOnCleanShutdown(t *testing.T) {
+	fake := newFakeEnvironment()
+	m, log := recordingManager(t, fake)
+
+	m.StopConsumers()
+
+	assert.Equal(t, []string{"store:4", "close"}, fake.consumer(testStream).events.recorded())
+	assert.Empty(t, log.warnMessages(), "a clean shutdown reports nothing to the operator")
+}
+```
+
+`TestManagerAbortStartLockedDisposesEnvironment` (`1095-1108`):
+
+```go
+func TestManagerAbortStartLockedDisposesEnvironment(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, oneConsumerDecls())
+
+	m.abortStartLocked()
+
+	assert.Nil(t, m.env, "the environment is disposed, not just the consumers")
+	assert.Empty(t, m.consumers)
+	assert.False(t, m.started)
+	assert.Equal(t, []string{"close"}, fake.consumer(testStream).events.recorded())
+	assert.Contains(t, fake.recorded(), callClose)
+
+	require.NoError(t, m.Close(), "the follow-up Close short-circuits instead of closing twice")
+}
+```
+
+`TestManagerAbortStartLockedReportsOnlyRealDisposalFailures` (`1114-1123`) — the premise changes with the port: there IS an environment to dispose now, so the guard is exercised from both sides:
+
+```go
+// TestManagerAbortStartLockedReportsOnlyRealDisposalFailures pins the unwind's
+// own guard from both sides: a disposal that succeeded must not be reported as a
+// failure on every successful unwind, and one that failed must reach the operator
+// with its cause attached.
+func TestManagerAbortStartLockedReportsOnlyRealDisposalFailures(t *testing.T) {
+	t.Run("successful_disposal_is_silent", func(t *testing.T) {
+		fake := newFakeEnvironment()
+		m, log := recordingManager(t, fake)
+
+		m.abortStartLocked()
+
+		require.Contains(t, fake.recorded(), callClose, "the premise: there was an environment to dispose")
+		assert.Empty(t, log.warnMessages(), "the whole unwind is silent when every step succeeds")
+	})
+
+	t.Run("failed_disposal_is_reported", func(t *testing.T) {
+		fake := newFakeEnvironment()
+		m, log := recordingManager(t, fake)
+		fake.failOn(callClose, errors.New("close failed"))
+
+		m.abortStartLocked()
+
+		assert.Contains(t, log.warnMessages(), msgCloseEnvFailed)
+		closeErr, ok := log.warnError(msgCloseEnvFailed)
+		require.True(t, ok)
+		assert.Equal(t, "close failed", closeErr)
+	})
+}
+```
+
+`TestManagerStartRefusesRestartAfterStopConsumers` (`1133-1153`):
+
+```go
+func TestManagerStartRefusesRestartAfterStopConsumers(t *testing.T) {
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: logger.New("error", false)})
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, oneConsumerDecls())
+
+	m.StopConsumers()
+	require.False(t, m.started, "the premise: StopConsumers clears started")
+	require.Same(t, fake, m.env, "the premise: StopConsumers leaves the environment for Close")
+
+	err := m.Start(context.Background(), oneConsumerDecls())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already started",
+		"the restart is refused by the guard, not by a failed dial")
+	assert.Same(t, fake, m.env, "the first environment is still the one Close disposes, not an orphan")
+	assert.False(t, m.started)
+	assert.NotContains(t, fake.recorded(), callClose, "a refused restart disposes nothing")
+}
+```
+
+- [ ] **Step 4: Run the rewritten tests**
+
+Run: `go test -race ./messaging/streams/ -run 'TestManager(Stop|Stats|Ready|AbortStart|Start|Declare)' -v`
+Expected: every listed test reports `--- PASS`. Then `go test -race ./messaging/streams/` → `ok`.
+
+- [ ] **Step 5: Commit 3a**
+
+```bash
+cat > /tmp/streams-attach-consumers-msg.txt <<'EOF'
+test(streams): build consumer shutdown state through Start, not attach
+
+attach and attachPartitioned fabricated the runningConsumer state Start is
+supposed to produce, so every shutdown, stats and readiness test asserted
+against a hand-built shape rather than the one the manager builds. They now
+run a real Start against the fake environment and push deliveries through the
+handle it returns.
+
+TestManagerDeclareProceedsOnALiveContext stops asserting through a panic on a
+nil environment and names the port call the phase made instead.
+TestManagerAbortStartLockedReportsOnlyRealDisposalFailures gains the failing
+half, which was unreachable while there was never an environment to dispose.
+EOF
+git add messaging/streams/manager_test.go
+git commit -F /tmp/streams-attach-consumers-msg.txt
+```
+
+#### 3b — the publisher-side helpers
+
+- [ ] **Step 6: Rewrite the `attachPublisher`/`rebindPublisher` tests**
+
+Delete `attachPublisher` (`1163-1166`) and `rebindPublisher` (`1168-1175`), then rewrite their seven callers.
+
+`TestManagerStopClosesPublishersAfterConsumers` (`1448-1463`):
+
+```go
+func TestManagerStopClosesPublishersAfterConsumers(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+
+	var order []string
+	producer := openProducer()
+	producer.onClose = func() { order = append(order, "publisher") }
+	fake.useProducer(testStream, producer)
+
+	decls := oneConsumerDecls()
+	decls.DeclarePublisher(&PublisherOptions{Stream: testStream})
+	startOnFake(t, m, fake, decls)
+	fake.consumer(testStream).events.onClose = func() { order = append(order, "consumer") }
+
+	m.StopConsumers()
+
+	assert.Equal(t, []string{"consumer", "publisher"}, order)
+	assert.Empty(t, m.publishers)
+	assert.False(t, m.started)
+}
+```
+
+`TestManagerStopFailsAnInFlightPublish` (`1468-1481`):
+
+```go
+func TestManagerStopFailsAnInFlightPublish(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	producer := blockingProducer(t)
+	fake.useProducer(testStream, producer)
+
+	decls := onePublisher(t)
+	startOnFake(t, m, fake, decls)
+	p := decls.publishers[0].Publisher
+
+	done := publishAsync(context.Background(), p, &PublishMessage{Data: []byte(testBody)})
+	waitForSend(t, producer)
+
+	m.StopConsumers()
+
+	require.ErrorIs(t, <-done, ErrPublisherClosed)
+	assert.ErrorIs(t, p.Publish(context.Background(), &PublishMessage{Data: []byte(testBody)}), ErrPublisherClosed,
+		"the publisher stays closed for late callers")
+}
+```
+
+`TestManagerStopReportsAPublisherCloseFailure` (`1483-1496`):
+
+```go
+func TestManagerStopReportsAPublisherCloseFailure(t *testing.T) {
+	log := &recordingLogger{}
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: log})
+	fake := newFakeEnvironment()
+	producer := openProducer()
+	producer.closeErr = errors.New("close failed")
+	fake.useProducer(testStream, producer)
+	startOnFake(t, m, fake, onePublisher(t))
+
+	assert.NotPanics(t, m.StopConsumers)
+
+	assert.Equal(t, []string{msgClosePublisherFailed}, log.warnMessages())
+	closeErr, ok := log.warnError(msgClosePublisherFailed)
+	require.True(t, ok)
+	assert.Equal(t, "close failed", closeErr)
+}
+```
+
+`TestManagerStopIsSilentOnACleanPublisherClose` (`1498-1506`):
+
+```go
+func TestManagerStopIsSilentOnACleanPublisherClose(t *testing.T) {
+	log := &recordingLogger{}
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: log})
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, onePublisher(t))
+
+	m.StopConsumers()
+
+	assert.Empty(t, log.warnMessages(), "a clean publisher close reports nothing to the operator")
+}
+```
+
+`TestManagerReadyRequiresEveryPublisher` (`1510-1529`):
+
+```go
+func TestManagerReadyRequiresEveryPublisher(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		want   bool
+	}{
+		{name: "open_publisher_is_ready", status: ha.StatusOpen, want: true},
+		{name: "reconnecting_publisher_is_not_ready", status: ha.StatusReconnecting, want: false},
+		{name: "closed_publisher_is_not_ready", status: ha.StatusClosed, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := testManager(t)
+			fake := newFakeEnvironment()
+			fake.useProducer(testStream, &fakeProducer{status: tt.status})
+			startOnFake(t, m, fake, onePublisher(t))
+
+			assert.Equal(t, tt.want, m.Ready())
+		})
+	}
+}
+```
+
+`TestManagerStatsCountsPublishers` (`1531-1540`):
+
+```go
+func TestManagerStatsCountsPublishers(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, onePublisher(t))
+
+	stats := m.Stats()
+
+	assert.Equal(t, 1, stats["publishers"])
+	assert.Equal(t, 0, stats["consumers"])
+	assert.Equal(t, true, stats["ready"])
+}
+```
+
+`TestManagerRebindRevivesAPublisherAfterAStopCycle` (`1547-1563`) — this one no longer *simulates* the Start → Close → Start cycle, it runs it:
+
+```go
+// TestManagerRebindRevivesAPublisherAfterAStopCycle covers the Start → Close →
+// Start cycle Manager.Start allows: its guard is the environment, which Close
+// nils, and consumers survive it because each Start rebuilds them. A publisher
+// cannot be rebuilt — the module holds the same handle from declaration onwards —
+// so the rebind has to reopen it or the second Start comes up publishing nothing.
+func TestManagerRebindRevivesAPublisherAfterAStopCycle(t *testing.T) {
+	m := testManager(t)
+	decls := onePublisher(t)
+	p := decls.publishers[0].Publisher
+
+	firstEnv := newFakeEnvironment()
+	first := openProducer()
+	firstEnv.useProducer(testStream, first)
+	startOnFake(t, m, firstEnv, decls)
+
+	m.StopConsumers()
+	require.NoError(t, m.Close())
+
+	require.ErrorIs(t, p.Publish(context.Background(), &PublishMessage{Data: []byte(testBody)}), ErrPublisherClosed)
+	assert.False(t, m.Ready(), "a stopped manager is not ready")
+
+	secondEnv := newFakeEnvironment()
+	second := openProducer()
+	secondEnv.useProducer(testStream, second)
+	startOnFake(t, m, secondEnv, decls)
+
+	assert.True(t, m.Ready(), "the second start comes up ready")
+	publishConfirmed(t, p, second, &PublishMessage{Data: []byte(testBody)})
+	assert.Zero(t, first.sentCount(), "the revived publisher sends through the new producer, not the disposed one")
+}
+```
+
+- [ ] **Step 7: Run the rewritten tests**
+
+Run: `go test -race ./messaging/streams/ -run 'TestManager(Stop|Ready|Stats|Rebind)' -v`
+Expected: every listed test reports `--- PASS`.
+
+- [ ] **Step 8: Confirm the helpers are gone**
+
+Run: `git grep -n -E '(attach|attachPartitioned|attachPublisher|rebindPublisher)\(' -- messaging/streams`
+Expected: no output (exit status 1). `git grep -E` is used without PCRE escapes on purpose — `\b`, `\s`, `\d` and `\w` are silently ignored by it.
+
+- [ ] **Step 9: Run the whole package**
+
+Run: `go test -race ./messaging/streams/`
+Expected: `ok  github.com/gaborage/go-bricks/messaging/streams`.
+
+- [ ] **Step 10: Commit 3b**
+
+```bash
+cat > /tmp/streams-attach-publishers-msg.txt <<'EOF'
+test(streams): bind publishers through Start, not attachPublisher
+
+attachPublisher and rebindPublisher hand-built the binding Manager.Start
+installs, which meant the shutdown-order, in-flight-publish, close-failure and
+readiness tests never exercised bindPublisher at all. They now start a real
+manager on the fake environment, which hands back the producer the test
+prepared.
+
+TestManagerRebindRevivesAPublisherAfterAStopCycle stops simulating the
+Start-Close-Start cycle and runs it.
+EOF
+git add messaging/streams/manager_test.go
+git commit -F /tmp/streams-attach-publishers-msg.txt
+```
+
+---
+
+### Task 4: Container-test triage
+
+**Files:**
+
+- Modify: `messaging/streams/streams_integration_test.go` (one test)
+- Modify: `messaging/streams/manager_test.go` (one comment that points at it)
+
+Spec decision 6: a container assertion is deleted only when an in-process assertion replaced it. Verdict per test, all ten:
+
+| # | Integration test (line) | Verdict | Why |
+| --- | --- | --- | --- |
+| 1 | `TestStreamsManagerConsumesAndRestoresOffsetIntegration` (`:183`) | **Keep** | Proves the BROKER stores and returns the offset across a restart. The fake's offset map is our own code; it cannot stand in for that. |
+| 2 | `TestStreamsManagerSkipsFailedMessageIntegration` (`:227`) | **Keep** | Commit-only-after-success against a real broker, and the only proof that a skipped message is never redelivered. |
+| 3 | `TestStreamsManagerConsumesSuperStreamPartitionsIntegration` (`:415`) | **Keep** | Per-partition commit and per-partition resume are broker-side; the in-process asymmetry test covers which object the flush targets, not what the broker does with it. |
+| 4 | `TestStreamsManagerSuperStreamDistributesPartitionsIntegration` (`:468`) | **Keep** | Group distribution and hand-over are broker-side; nothing in-process replaces them. |
+| 5 | `TestStreamsManagerSuperStreamPartitionMismatchIsSilentIntegration` (`:535`) | **Keep** | Pins a VENDOR behavior (the client swallows `StreamAlreadyExists` for super streams). The fake implements our port, not the client's quirk. |
+| 6 | `TestStreamsManagerSingleActiveConsumerIntegration` (`:586`) | **Keep** | The in-process test proves the promotion callback re-resolves the position; only this one proves the broker fires it and attaches there. Its `-race` rationale for the environment snapshot is unchanged. |
+| 7 | `TestStreamsManagerDisposesEnvironmentOnDeclareFailureIntegration` (`:628`) | **Shrink** | `TestManagerStartUnwindsAFailedDeclaration` now covers the unwind in process — env disposed, `started` false, follow-up `Close` a no-op — with a dialed environment. What remains broker-only is that a retention mismatch really is rejected. |
+| 8 | `TestStreamsPublisherRoundTripIntegration` (`:662`) | **Keep** | The pointer-identity correlation the publisher is built on is a vendor contract. |
+| 9 | `TestStreamsSuperStreamPublisherPartitionsIntegration` (`:842`) | **Keep** | murmur3 partition agreement with the broker. |
+| 10 | `TestStreamsPublisherRejectedAfterStopIntegration` (`:882`) | **Keep** | End-to-end shutdown contract; cheap, and no in-process assertion covers publishing into a disposed environment. |
+
+- [ ] **Step 1: Shrink the one test an in-process assertion replaced**
+
+Replace `TestStreamsManagerDisposesEnvironmentOnDeclareFailureIntegration` (`streams_integration_test.go:623-651`) with:
+
+```go
+// TestStreamsManagerRejectsAConflictingRetentionIntegration is what only a broker
+// can answer: re-declaring an existing stream with different retention really is
+// answered with precondition-failed, so Start fails after the dial.
+//
+// The unwind that failure triggers — environment disposed, started false, the
+// caller's follow-up Close a no-op — is asserted in process against the
+// Environment port by TestManagerStartUnwindsAFailedDeclaration, so it is not
+// repeated here.
+func TestStreamsManagerRejectsAConflictingRetentionIntegration(t *testing.T) {
+	ctx := context.Background()
+	opts := streamsTestEnv(ctx, t)
+
+	first := NewManager(opts)
+	firstDecls := NewDeclarations()
+	firstDecls.DeclareStream(itStream, &StreamSpec{MaxAge: time.Hour})
+	require.NoError(t, first.Start(ctx, firstDecls))
+	first.StopConsumers()
+	require.NoError(t, first.Close())
+
+	// Same stream, different retention: the broker rejects the declaration.
+	second := NewManager(opts)
+	conflicting := NewDeclarations()
+	conflicting.DeclareStream(itStream, &StreamSpec{MaxAge: 48 * time.Hour})
+
+	err := second.Start(ctx, conflicting)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to declare stream")
+	require.NoError(t, second.Close())
+}
+```
+
+- [ ] **Step 2: Repoint the comment that named it**
+
+In `messaging/streams/manager_test.go`, `TestManagerStartFailedDialLeavesNothingToDispose`'s comment (`1078-1082`) claims the post-dial half needs a broker. That stopped being true. Replace the comment with:
+
+```go
+// TestManagerStartFailedDialLeavesNothingToDispose is the pre-dial half: the
+// environment was never stored, so Close is a no-op. The post-dial half — where
+// the environment exists and must be disposed — is
+// TestManagerStartUnwindsAFailedDeclaration, in process against the Environment
+// port.
+```
+
+- [ ] **Step 3: Verify the integration file still builds**
+
+Run: `go vet -tags=integration ./messaging/streams/`
+Expected: no output. (Do **not** run `make test-integration`; the controller decides whether a Docker run is warranted — Task 5.)
+
+- [ ] **Step 4: Verify the unit suite is untouched by the edit**
+
+Run: `go test -race ./messaging/streams/`
+Expected: `ok  github.com/gaborage/go-bricks/messaging/streams`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cat > /tmp/streams-container-triage-msg.txt <<'EOF'
+test(streams): shrink the declare-failure container test to its broker half
+
+The Environment port makes the post-dial unwind reachable in process, so
+TestStreamsManagerDisposesEnvironmentOnDeclareFailureIntegration no longer has
+to spend a container on asserting that the environment was disposed, that
+started is false and that the follow-up Close short-circuits.
+
+What is left is the half only a broker can answer -- a retention mismatch on an
+existing stream really is precondition-failed -- renamed for what it now
+asserts. The other nine container tests are unchanged: each still covers a
+broker-side or vendor-side property no in-process assertion replaced.
+EOF
+git add messaging/streams/streams_integration_test.go messaging/streams/manager_test.go
+git commit -F /tmp/streams-container-triage-msg.txt
+```
+
+---
+
+### Task 5: Gates (controller only)
+
+Implementers stop after Task 4. The controller runs everything below, in this order, and never delegates it.
+
+- [ ] **Step 1: `make check`, backgrounded**
+
+```bash
+make check
+```
+
+Run with `run_in_background: true` (CLAUDE.md workflow rule). Expected: exits 0. Watch for:
+
+- `gofmt`/`gci` import ordering in the new `environment.go` and `environment_fake_test.go` — `gofmt -l` is silent on gofumpt/gci rules, so after `make fmt` always check `git status --porcelain`.
+- `gocritic`/`staticcheck` on the type assertion `storer, _ := handle.(offsetStorer)` — the blank is deliberate; the nil result is the documented `errNoOffsetStorer` path.
+
+- [ ] **Step 2: `/simplify`**
+
+Runs first because it mutates the diff. Likely targets: the nine one-line delegations in `vendorEnvironment` (they are irreducible — resist a reflective or generic "simplification"), and duplication between `oneConsumerDecls`/`superConsumerDecls` and the ad-hoc declaration builders in the `Start` suite. If it changes code, re-run `make check`.
+
+- [ ] **Step 3: `/security-audit`**
+
+Focus areas for this diff: `safeEnvError` and `redactStreamURI` still wrap every dial failure (the URI-credential path moved into `dialVendorEnvironment` — confirm the error still reaches `Start`'s `fmt.Errorf` with `safeEnvError` applied, and that `TestManagerStartDoesNotLeakURIOnParseFailure` still passes); the fake's `StoreOffset` parks outside its own mutex, so confirm no shutdown path can deadlock. If it changes code, re-run `make check`.
+
+- [ ] **Step 4: `/code-review` (CodeRabbit)**
+
+Must see the final diff. If findings are applied afterwards, re-run it. Expect it to ask for an ADR — answer that nothing exported changes (`environment`, `messageHandler`, `vendorEnvironment`, `dialEnvironment` are all unexported; `NewManager`/`ManagerOptions`/`Manager`'s method set are byte-identical) and no behavior changes (no commit path moves), so ADR-and-atom does not apply.
+
+- [ ] **Step 5: `make mutate`, backgrounded, after committing**
+
+```bash
+make mutate
+```
+
+`run_in_background: true`. The scope is `merge-base..HEAD`, so **commit first** — uncommitted work yields `no mutatable changes` and a misleading exit 0. Proof it ran is a `(N mutants on changed lines)` line with N > 0. Surviving mutants on changed lines block the push. The lines most likely to survive:
+
+- `vendorEnvironment`'s nil-on-error returns — nothing unit-tests the vendor adapter, since constructing one needs a broker. If they survive, note it rather than inventing a test that cannot attribute its failure to those lines.
+- `startStreamConsumer`'s `storer, _ := handle.(offsetStorer)` — killed by the plain case of `TestManagerStartFlushesPlainThroughTheHandleAndSuperThroughThePort`.
+- `vendorMessagesHandler`'s `store` argument — not reachable by unit tests either; the fake supplies its own. `TestStreamsManagerSkipsFailedMessageIntegration` is the container-side guard.
+
+- [ ] **Step 6: Integration suite (optional, Docker required)**
+
+```bash
+make test-integration
+```
+
+Worth one run because Task 4 renamed a test. No commit path changed, so no behavioral surprise is expected.
+
+- [ ] **Step 7: Push and open the PR**
+
+Confirm the branch is not `main`, push, then open the PR with the three-heading body (`## What` / `## Impact` / `## Verification`, ≤3 sentences each, whole body under 150 words). `## Impact` is `None.` — no exported API change, no config key, no behavior a consumer configures. `## Verification` names only what CI cannot show: that `make mutate` ran clean on the changed lines and, if it was run, that the container suite passed against a real broker.
+
+---
+
+## Self-review
+
+**Spec coverage (decisions 1–6).**
+
+| Spec decision | Where |
+| --- | --- |
+| 1 — seam mirrors `amqp_adapters.go`; unexported interface + `dialEnvironment` field; tests swap the field | Task 1 Steps 3–4; `dialFake` in Step 1 |
+| 2 — nine port methods, one per vendor call; constructors return the existing handles; factories fold in | Task 1 Step 3 (interface), Step 4 (`constructProducer`, factories deleted) |
+| 3 — offset-storer asymmetry preserved; `storerFor` stays and is exercised in process | Task 1 Step 4 (both `storerFor` closures, `trackConsumer` untouched); Task 2 `TestManagerStartFlushesPlainThroughTheHandleAndSuperThroughThePort` |
+| 4 — go-bricks-shaped handler; adapter does the `ConsumerContext` unwrapping | Task 1 Step 3 (`messageHandler`, `vendorMessagesHandler`), Step 5 (`messagesHandler` deleted from the runner). The handler carries the delivering consumer as `store`, so the in-flight commit path is unchanged. |
+| 5 — fake records call order, injects errors, drives deliveries, stores offsets in memory | Task 1 Step 1 + Task 2 Step 1 |
+| 6 — container tests shrink only where an in-process assertion replaced them | Task 4, all ten listed |
+
+Spec items *not* covered, by design: decisions 7–13 (delivery pipeline, `messaging/internal/delivery`, `StartConsumeSpan` removal, ADR-068) — PR2/PR3.
+
+**Placeholder scan.** No `TBD`, no "similar to Task N", no "add error handling". Every code step carries the code; every run step carries the command and the expected output. The one judgement call left open is Task 5 Step 5's mutant triage, which is explicitly a controller decision with named candidates.
+
+**Type consistency.**
+
+- `messageHandler` is `func(streamName string, offset int64, msg *amqp.Message, store offsetStorer)` in the interface (Task 1 Step 3), in the fake's field and both constructors (Step 1), and matches `consumerRunner.deliver`'s **unchanged** signature (`runner.go:239`) so `runner.deliver` is assignable as a method value in `startStreamConsumer` and `startSuperStreamConsumer` (Step 4).
+- `vendorMessagesHandler` passes `consumerContext.Consumer` (a `*stream.Consumer`, which has `StoreCustomOffset(int64) error`, `pkg/stream/consumer.go:521`) as `store`; `fakeConsumer.deliver` passes `deliveryStorer`, which has the same method. Both satisfy `offsetStorer`.
+- `consumerHandle` stays `{Close() error; GetStatus() int}` everywhere; `*fakeHandle` satisfies it plus `offsetStorer`, `*fakeSuperHandle` satisfies only it — mirroring `*ha.ReliableConsumer` vs `*ha.ReliableSuperStreamConsumer`.
+- `environment.Close() error` is what `closeEnvLocked` calls and what `fakeEnvironment.Close` records as `callClose`.
+- `storerFor func(streamName string) offsetStorer` keeps the same signature on `runningConsumer`, on `trackConsumer`'s parameter, and as `offsetBook.flush`'s argument — none of them modified.
+- Fake method names used by tests: `recorded`, `consumer`, `consumerOptions`, `producer`, `superProducerOptions`, `failOn`, `useProducer`, `setOffset`, `storedOffset`, `blockStoreOn`; consumer-level: `deliver`, `promote`, `events`. Every call site in Tasks 1–4 uses exactly these.
+- `runner_test.go` is untouched by every task, and `deliverWith` / `bindStorers` / `runner.storerFor` appear nowhere in this plan.

--- a/messaging/streams/environment.go
+++ b/messaging/streams/environment.go
@@ -1,0 +1,134 @@
+package streams
+
+import (
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/ha"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
+)
+
+// messageHandler receives one delivery in the framework's own vocabulary. store
+// is the consumer that delivered the message, which is what an in-flight commit
+// goes through: the client's callback carries a stream.ConsumerContext whose
+// Consumer is a vendor struct of unexported fields that no test can populate, so
+// the unwrapping stays in the adapter and everything above this line is reachable
+// without a broker.
+type messageHandler func(streamName string, offset int64, msg *amqp.Message, store offsetStorer)
+
+// environment is the Environment port: the seam through which the streams lane
+// reaches the broker. One method per vendor call the manager makes, with the
+// vendor environment as its production adapter and an in-memory fake for tests.
+//
+// Unexported on purpose: nothing outside this package varies across the seam —
+// one production adapter, one test fake — so there is no consumer-facing
+// interface to export and no second implementation to abstract over.
+type environment interface {
+	DeclareStream(name string, opts *stream.StreamOptions) error
+	DeclareSuperStream(name string, opts *stream.PartitionsOptions) error
+	QueryOffset(consumer, streamName string) (int64, error)
+	StoreOffset(consumer, streamName string, offset int64) error
+	NewConsumer(streamName string, opts *stream.ConsumerOptions, handler messageHandler) (consumerHandle, error)
+	NewSuperStreamConsumer(superStream string, opts *stream.SuperStreamConsumerOptions, handler messageHandler) (consumerHandle, error)
+	NewProducer(streamName string, opts *stream.ProducerOptions, confirmed ha.ConfirmMessageHandler) (producerHandle, error)
+	NewSuperStreamProducer(superStream string, opts *stream.SuperStreamProducerOptions, confirmed ha.PartitionConfirmMessageHandler) (producerHandle, error)
+	Close() error
+}
+
+// vendorEnvironment is the production adapter over the stream client.
+type vendorEnvironment struct{ env *stream.Environment }
+
+var _ environment = vendorEnvironment{}
+
+// dialVendorEnvironment opens the port against a real broker.
+//
+// NewEnvironment returns a non-nil Environment BESIDE a non-nil error, so the
+// failure path has something to dispose and `env != nil` is not a success test.
+// v1.8.3 does tear the locator socket down itself, but only through an internal
+// `defer client.Close()` it documents nowhere, and Client.connect opens the
+// socket and starts its read goroutine before authentication — so disposing it
+// here is what keeps a rejected credential from depending on that detail.
+func dialVendorEnvironment(opts *stream.EnvironmentOptions) (environment, error) {
+	env, err := stream.NewEnvironment(opts)
+	if err != nil {
+		if env != nil {
+			_ = env.Close()
+		}
+		return nil, err
+	}
+	return vendorEnvironment{env: env}, nil
+}
+
+func (e vendorEnvironment) DeclareStream(name string, opts *stream.StreamOptions) error {
+	return e.env.DeclareStream(name, opts)
+}
+
+func (e vendorEnvironment) DeclareSuperStream(name string, opts *stream.PartitionsOptions) error {
+	return e.env.DeclareSuperStream(name, opts)
+}
+
+func (e vendorEnvironment) QueryOffset(consumer, streamName string) (int64, error) {
+	return e.env.QueryOffset(consumer, streamName)
+}
+
+func (e vendorEnvironment) StoreOffset(consumer, streamName string, offset int64) error {
+	return e.env.StoreOffset(consumer, streamName, offset)
+}
+
+// NewConsumer returns the reliable consumer itself rather than a wrapper: it
+// satisfies consumerHandle AND offsetStorer, which is what lets a plain stream's
+// SHUTDOWN flush commit through its own handle. The nil-on-error return matters —
+// the client hands back a non-nil consumer beside a non-nil error, and a typed
+// nil in a consumerHandle would read as a live handle.
+func (e vendorEnvironment) NewConsumer(streamName string, opts *stream.ConsumerOptions,
+	handler messageHandler,
+) (consumerHandle, error) {
+	consumer, err := ha.NewReliableConsumer(e.env, streamName, opts, vendorMessagesHandler(handler))
+	if err != nil {
+		return nil, err
+	}
+	return consumer, nil
+}
+
+// NewSuperStreamConsumer's handle is deliberately NOT an offsetStorer:
+// *ha.ReliableSuperStreamConsumer has no StoreCustomOffset, so a super stream's
+// shutdown flush goes through this port's StoreOffset, per partition.
+func (e vendorEnvironment) NewSuperStreamConsumer(superStream string, opts *stream.SuperStreamConsumerOptions,
+	handler messageHandler,
+) (consumerHandle, error) {
+	consumer, err := ha.NewReliableSuperStreamConsumer(e.env, superStream, vendorMessagesHandler(handler), opts)
+	if err != nil {
+		return nil, err
+	}
+	return consumer, nil
+}
+
+func (e vendorEnvironment) NewProducer(streamName string, opts *stream.ProducerOptions,
+	confirmed ha.ConfirmMessageHandler,
+) (producerHandle, error) {
+	producer, err := ha.NewReliableProducer(e.env, streamName, opts, confirmed)
+	if err != nil {
+		return nil, err
+	}
+	return producer, nil
+}
+
+func (e vendorEnvironment) NewSuperStreamProducer(superStream string, opts *stream.SuperStreamProducerOptions,
+	confirmed ha.PartitionConfirmMessageHandler,
+) (producerHandle, error) {
+	producer, err := ha.NewReliableSuperStreamProducer(e.env, superStream, opts, confirmed)
+	if err != nil {
+		return nil, err
+	}
+	return producer, nil
+}
+
+func (e vendorEnvironment) Close() error { return e.env.Close() }
+
+// vendorMessagesHandler adapts the port's handler to the client's callback. The
+// consumer it unwraps is both the source of the position and the target of the
+// in-flight commit, exactly as the client hands it over.
+func vendorMessagesHandler(handler messageHandler) stream.MessagesHandler {
+	return func(consumerContext stream.ConsumerContext, msg *amqp.Message) {
+		consumer := consumerContext.Consumer
+		handler(consumer.GetStreamName(), consumer.GetOffset(), msg, consumer)
+	}
+}

--- a/messaging/streams/environment.go
+++ b/messaging/streams/environment.go
@@ -36,7 +36,13 @@ type environment interface {
 // vendorEnvironment is the production adapter over the stream client.
 type vendorEnvironment struct{ env *stream.Environment }
 
-var _ environment = vendorEnvironment{}
+// A vendor bump that drops StoreCustomOffset from the plain consumer must fail
+// the build here, not silently stop the shutdown flush's runtime assertion in
+// manager.go.
+var (
+	_ environment  = vendorEnvironment{}
+	_ offsetStorer = (*ha.ReliableConsumer)(nil)
+)
 
 // dialVendorEnvironment opens the port against a real broker.
 //

--- a/messaging/streams/environment_fake_test.go
+++ b/messaging/streams/environment_fake_test.go
@@ -179,6 +179,7 @@ func (f *fakeEnvironment) blockStoreOn(key string) (entered <-chan struct{}, rel
 	f.blockedStore = key
 	f.storeEntered = make(chan struct{})
 	f.storeRelease = make(chan struct{})
+	f.storeOnce = sync.Once{} // a second hook in one test gets a fresh one-shot
 	return f.storeEntered, f.storeRelease
 }
 

--- a/messaging/streams/environment_fake_test.go
+++ b/messaging/streams/environment_fake_test.go
@@ -129,6 +129,14 @@ type fakeEnvironment struct {
 	// so superProdOpts and its existing accessor stay untouched.
 	superProdConfirmed map[string]ha.PartitionConfirmMessageHandler
 	preparedProds      map[string]*fakeProducer
+
+	// blockedStore parks one StoreOffset key until release closes, standing in for
+	// the client's locator reconnect loop against a broker that is down: it has no
+	// attempt cap and no deadline, so such a commit never returns on its own.
+	blockedStore string
+	storeEntered chan struct{}
+	storeRelease chan struct{}
+	storeOnce    sync.Once
 }
 
 var _ environment = (*fakeEnvironment)(nil)
@@ -152,6 +160,15 @@ func (f *fakeEnvironment) failOn(key string, err error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.errs[key] = err
+}
+
+func (f *fakeEnvironment) blockStoreOn(key string) (entered <-chan struct{}, release chan<- struct{}) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.blockedStore = key
+	f.storeEntered = make(chan struct{})
+	f.storeRelease = make(chan struct{})
+	return f.storeEntered, f.storeRelease
 }
 
 // setOffset seeds the broker's stored offset for one consumer and stream.
@@ -273,14 +290,29 @@ func (f *fakeEnvironment) QueryOffset(consumer, streamName string) (int64, error
 }
 
 func (f *fakeEnvironment) StoreOffset(consumer, streamName string, offset int64) error {
+	key := consumer + "/" + streamName
+
+	f.mu.Lock()
+	f.recordLocked(fmt.Sprintf("%s:%s=%d", callStoreOffset, key, offset))
+	injected := f.errForLocked(callStoreOffset, key)
+	blocked := f.blockedStore == key
+	entered, release := f.storeEntered, f.storeRelease
+	f.mu.Unlock()
+
+	// Parked OUTSIDE the lock on purpose: the shutdown flush budget exists to walk
+	// away from a commit that cannot finish, and holding this mutex would stall the
+	// consumer behind it on the mutex instead of letting the budget skip it.
+	if blocked {
+		f.storeOnce.Do(func() { close(entered) })
+		<-release
+	}
+
+	if injected != nil {
+		return injected
+	}
+
 	f.mu.Lock()
 	defer f.mu.Unlock()
-
-	key := consumer + "/" + streamName
-	f.recordLocked(fmt.Sprintf("%s:%s=%d", callStoreOffset, key, offset))
-	if err := f.errForLocked(callStoreOffset, key); err != nil {
-		return err
-	}
 	f.offsets[key] = offset
 	return nil
 }

--- a/messaging/streams/environment_fake_test.go
+++ b/messaging/streams/environment_fake_test.go
@@ -57,6 +57,17 @@ type fakeConsumer struct {
 // routes a super stream's shutdown flush through the Environment port.
 type fakeSuperHandle struct{ h *fakeHandle }
 
+// producerCall captures what the plain producer constructor received for one
+// stream: the options a test asserts stream.NewProducerOptions() reached the
+// port with, and the confirmation handler the publisher bound to correlate its
+// own sends. The super lane captures the same two things in superProdOpts and
+// superProdConfirmed instead, because it already had the options half before
+// this struct existed.
+type producerCall struct {
+	opts      *stream.ProducerOptions
+	confirmed ha.ConfirmMessageHandler
+}
+
 func (f *fakeSuperHandle) Close() error   { return f.h.Close() }
 func (f *fakeSuperHandle) GetStatus() int { return f.h.GetStatus() }
 
@@ -74,21 +85,28 @@ type fakeEnvironment struct {
 	consumers     map[string]*fakeConsumer
 	consumerOpts  map[string]*stream.ConsumerOptions
 	producers     map[string]*fakeProducer
+	producerCalls map[string]*producerCall
 	superProdOpts map[string]*stream.SuperStreamProducerOptions
-	preparedProds map[string]*fakeProducer
+	// superProdConfirmed is superProdOpts' sibling for the confirmation handler:
+	// kept as its own map, keyed the same way, rather than folded into a struct,
+	// so superProdOpts and its existing accessor stay untouched.
+	superProdConfirmed map[string]ha.PartitionConfirmMessageHandler
+	preparedProds      map[string]*fakeProducer
 }
 
 var _ environment = (*fakeEnvironment)(nil)
 
 func newFakeEnvironment() *fakeEnvironment {
 	return &fakeEnvironment{
-		errs:          map[string]error{},
-		offsets:       map[string]int64{},
-		consumers:     map[string]*fakeConsumer{},
-		consumerOpts:  map[string]*stream.ConsumerOptions{},
-		producers:     map[string]*fakeProducer{},
-		superProdOpts: map[string]*stream.SuperStreamProducerOptions{},
-		preparedProds: map[string]*fakeProducer{},
+		errs:               map[string]error{},
+		offsets:            map[string]int64{},
+		consumers:          map[string]*fakeConsumer{},
+		consumerOpts:       map[string]*stream.ConsumerOptions{},
+		producers:          map[string]*fakeProducer{},
+		producerCalls:      map[string]*producerCall{},
+		superProdOpts:      map[string]*stream.SuperStreamProducerOptions{},
+		superProdConfirmed: map[string]ha.PartitionConfirmMessageHandler{},
+		preparedProds:      map[string]*fakeProducer{},
 	}
 }
 
@@ -109,6 +127,22 @@ func (f *fakeEnvironment) superProducerOptions(superStream string) *stream.Super
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.superProdOpts[superStream]
+}
+
+// producerCall reads back what NewProducer received for one stream, or nil if
+// the plain constructor was never reached for it.
+func (f *fakeEnvironment) producerCall(streamName string) *producerCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.producerCalls[streamName]
+}
+
+// superProducerConfirmed is superProducerOptions' sibling for the confirmation
+// handler NewSuperStreamProducer received for one super stream.
+func (f *fakeEnvironment) superProducerConfirmed(superStream string) ha.PartitionConfirmMessageHandler {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.superProdConfirmed[superStream]
 }
 
 // recordLocked and errForLocked are called with f.mu held.
@@ -221,8 +255,8 @@ func consumerUpdateOf(sac *stream.SingleActiveConsumer) stream.ConsumerUpdate {
 	return sac.ConsumerUpdate
 }
 
-func (f *fakeEnvironment) NewProducer(streamName string, _ *stream.ProducerOptions,
-	_ ha.ConfirmMessageHandler,
+func (f *fakeEnvironment) NewProducer(streamName string, opts *stream.ProducerOptions,
+	confirmed ha.ConfirmMessageHandler,
 ) (producerHandle, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -231,11 +265,12 @@ func (f *fakeEnvironment) NewProducer(streamName string, _ *stream.ProducerOptio
 	if err := f.errForLocked(callNewProducer, streamName); err != nil {
 		return nil, err
 	}
+	f.producerCalls[streamName] = &producerCall{opts: opts, confirmed: confirmed}
 	return f.newProducerLocked(streamName), nil
 }
 
 func (f *fakeEnvironment) NewSuperStreamProducer(superStream string, opts *stream.SuperStreamProducerOptions,
-	_ ha.PartitionConfirmMessageHandler,
+	confirmed ha.PartitionConfirmMessageHandler,
 ) (producerHandle, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -245,6 +280,7 @@ func (f *fakeEnvironment) NewSuperStreamProducer(superStream string, opts *strea
 		return nil, err
 	}
 	f.superProdOpts[superStream] = opts
+	f.superProdConfirmed[superStream] = confirmed
 	return f.newProducerLocked(superStream), nil
 }
 

--- a/messaging/streams/environment_fake_test.go
+++ b/messaging/streams/environment_fake_test.go
@@ -1,16 +1,17 @@
 package streams
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
+	"testing"
 
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/ha"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
+	"github.com/stretchr/testify/require"
 )
-
-// errProducerConstruction is the broker failure a test injects at the port.
-var errProducerConstruction = errors.New("producer construction failed")
 
 // The calls a fakeEnvironment records, in the order it made them. A target is
 // appended after a colon so a test asserts WHICH stream a phase reached, not only
@@ -31,6 +32,29 @@ const (
 	callClose              = "close"
 )
 
+// errDeclareFailed, errConsumerStart and errProducerConstruction are the broker
+// failures a test injects at the port.
+var (
+	errDeclareFailed        = errors.New("declaration refused")
+	errConsumerStart        = errors.New("consumer start refused")
+	errProducerConstruction = errors.New("producer construction failed")
+)
+
+// deliveryStorer is the commit target the fake hands each delivery, standing in
+// for the *stream.Consumer the client passes its own callback: an in-flight
+// commit goes through the consumer that delivered the message, on ITS connection,
+// never through the Environment port or the reliable handle above it. It writes
+// where QueryOffset answers from, so a committed position is observable.
+type deliveryStorer struct {
+	env      *fakeEnvironment
+	consumer string
+	stream   string
+}
+
+func (s deliveryStorer) StoreCustomOffset(offset int64) error {
+	return s.env.storeFromConsumer(s.consumer, s.stream, offset)
+}
+
 // fakeConsumer is one consumer the fake environment handed back: the handle the
 // manager tracks, plus the callbacks a test drives it through.
 type fakeConsumer struct {
@@ -49,6 +73,19 @@ type fakeConsumer struct {
 	// sac is the promotion callback the manager installed, nil when the
 	// declaration did not ask for single active consumer.
 	sac stream.ConsumerUpdate
+}
+
+// deliver pushes one message through the runner exactly as the client's read
+// loop would, including the delivering consumer it commits through.
+func (c *fakeConsumer) deliver(streamName string, offset int64, msg *amqp.Message) {
+	c.handler(streamName, offset, msg,
+		deliveryStorer{env: c.env, consumer: c.name, stream: streamName})
+}
+
+// promote fires the single-active-consumer promotion callback, which is where a
+// per-partition stored offset is restored.
+func (c *fakeConsumer) promote(streamName string) stream.OffsetSpecification {
+	return c.sac(streamName, true)
 }
 
 // fakeSuperHandle stands in for *ha.ReliableSuperStreamConsumer. It delegates to
@@ -117,10 +154,43 @@ func (f *fakeEnvironment) failOn(key string, err error) {
 	f.errs[key] = err
 }
 
+// setOffset seeds the broker's stored offset for one consumer and stream.
+func (f *fakeEnvironment) setOffset(consumer, streamName string, offset int64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.offsets[consumer+"/"+streamName] = offset
+}
+
+// storedOffset reports what the broker holds, whichever path committed it.
+func (f *fakeEnvironment) storedOffset(consumer, streamName string) (int64, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	offset, ok := f.offsets[consumer+"/"+streamName]
+	return offset, ok
+}
+
 func (f *fakeEnvironment) recorded() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]string(nil), f.calls...)
+}
+
+func (f *fakeEnvironment) consumer(streamName string) *fakeConsumer {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.consumers[streamName]
+}
+
+func (f *fakeEnvironment) consumerOptions(streamName string) *stream.ConsumerOptions {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.consumerOpts[streamName]
+}
+
+func (f *fakeEnvironment) producer(streamName string) *fakeProducer {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.producers[streamName]
 }
 
 func (f *fakeEnvironment) superProducerOptions(superStream string) *stream.SuperStreamProducerOptions {
@@ -153,6 +223,21 @@ func (f *fakeEnvironment) errForLocked(method, target string) error {
 		return err
 	}
 	return f.errs[method]
+}
+
+// storeFromConsumer records a commit made through a delivering consumer rather
+// than through the port, and writes it where QueryOffset answers from.
+func (f *fakeEnvironment) storeFromConsumer(consumer, streamName string, offset int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	key := consumer + "/" + streamName
+	f.recordLocked(fmt.Sprintf("%s:%s=%d", callConsumerStore, key, offset))
+	if err := f.errForLocked(callConsumerStore, key); err != nil {
+		return err
+	}
+	f.offsets[key] = offset
+	return nil
 }
 
 func (f *fakeEnvironment) DeclareStream(name string, _ *stream.StreamOptions) error {
@@ -304,3 +389,33 @@ func (f *fakeEnvironment) Close() error {
 func dialFake(m *Manager, fake *fakeEnvironment) {
 	m.dialEnvironment = func(*stream.EnvironmentOptions) (environment, error) { return fake, nil }
 }
+
+// startOnFake runs a real Start against fake, so a test asserts on state Start
+// actually produced instead of state a helper fabricated.
+func startOnFake(t *testing.T, m *Manager, fake *fakeEnvironment, decls *Declarations) {
+	t.Helper()
+	dialFake(m, fake)
+	require.NoError(t, m.Start(context.Background(), decls))
+}
+
+// oneConsumerDecls is the plain lane's minimum: one stream, one consumer on it.
+func oneConsumerDecls() *Declarations {
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	decls.DeclareConsumer(&ConsumerOptions{Stream: testStream, Name: testConsumerName, Handler: noopHandler})
+	return decls
+}
+
+// superConsumerDecls is the partitioned lane's minimum: one super stream, one
+// consumer across every partition of it.
+func superConsumerDecls() *Declarations {
+	decls := NewDeclarations()
+	decls.DeclareSuperStream(testSuperStream, testPartitions, nil)
+	decls.DeclareSuperStreamConsumer(&SuperStreamConsumerOptions{
+		SuperStream: testSuperStream, Name: testConsumerName, Handler: noopHandler,
+	})
+	return decls
+}
+
+// ptrTo is how a table tells "no stored offset" from "stored offset 0".
+func ptrTo[T any](v T) *T { return &v }

--- a/messaging/streams/environment_fake_test.go
+++ b/messaging/streams/environment_fake_test.go
@@ -73,6 +73,10 @@ type fakeConsumer struct {
 	// sac is the promotion callback the manager installed, nil when the
 	// declaration did not ask for single active consumer.
 	sac stream.ConsumerUpdate
+	// opts is what NewConsumer received for this consumer, or nil for a super
+	// consumer, which the port constructs from *stream.SuperStreamConsumerOptions
+	// instead.
+	opts *stream.ConsumerOptions
 }
 
 // deliver pushes one message through the runner exactly as the client's read
@@ -97,12 +101,19 @@ type fakeSuperHandle struct{ h *fakeHandle }
 // producerCall captures what the plain producer constructor received for one
 // stream: the options a test asserts stream.NewProducerOptions() reached the
 // port with, and the confirmation handler the publisher bound to correlate its
-// own sends. The super lane captures the same two things in superProdOpts and
-// superProdConfirmed instead, because it already had the options half before
-// this struct existed.
+// own sends. The super lane's counterpart is superProducerCall.
 type producerCall struct {
 	opts      *stream.ProducerOptions
 	confirmed ha.ConfirmMessageHandler
+}
+
+// superProducerCall is producerCall's counterpart for the super-stream producer
+// constructor: the options a test asserts stream.NewSuperStreamProducerOptions()
+// reached the port with, and the partition confirmation handler the publisher
+// bound to correlate its own sends.
+type superProducerCall struct {
+	opts      *stream.SuperStreamProducerOptions
+	confirmed ha.PartitionConfirmMessageHandler
 }
 
 func (f *fakeSuperHandle) Close() error   { return f.h.Close() }
@@ -120,14 +131,11 @@ type fakeEnvironment struct {
 	offsets map[string]int64
 
 	consumers     map[string]*fakeConsumer
-	consumerOpts  map[string]*stream.ConsumerOptions
 	producers     map[string]*fakeProducer
 	producerCalls map[string]*producerCall
-	superProdOpts map[string]*stream.SuperStreamProducerOptions
-	// superProdConfirmed is superProdOpts' sibling for the confirmation handler:
-	// kept as its own map, keyed the same way, rather than folded into a struct,
-	// so superProdOpts and its existing accessor stay untouched.
-	superProdConfirmed map[string]ha.PartitionConfirmMessageHandler
+	// superProducerCalls is producerCalls' counterpart for the super-stream
+	// producer constructor, keyed by super stream.
+	superProducerCalls map[string]*superProducerCall
 	// preparedProd is handed back by every producer construction, plain or super,
 	// rather than one per stream: every test that prepares a producer starts a
 	// single publisher. Key it by stream the day one of them starts two.
@@ -149,11 +157,9 @@ func newFakeEnvironment() *fakeEnvironment {
 		errs:               map[string]error{},
 		offsets:            map[string]int64{},
 		consumers:          map[string]*fakeConsumer{},
-		consumerOpts:       map[string]*stream.ConsumerOptions{},
 		producers:          map[string]*fakeProducer{},
 		producerCalls:      map[string]*producerCall{},
-		superProdOpts:      map[string]*stream.SuperStreamProducerOptions{},
-		superProdConfirmed: map[string]ha.PartitionConfirmMessageHandler{},
+		superProducerCalls: map[string]*superProducerCall{},
 	}
 }
 
@@ -213,7 +219,11 @@ func (f *fakeEnvironment) consumer(streamName string) *fakeConsumer {
 func (f *fakeEnvironment) consumerOptions(streamName string) *stream.ConsumerOptions {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.consumerOpts[streamName]
+	c := f.consumers[streamName]
+	if c == nil {
+		return nil
+	}
+	return c.opts
 }
 
 func (f *fakeEnvironment) producer(streamName string) *fakeProducer {
@@ -225,7 +235,11 @@ func (f *fakeEnvironment) producer(streamName string) *fakeProducer {
 func (f *fakeEnvironment) superProducerOptions(superStream string) *stream.SuperStreamProducerOptions {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.superProdOpts[superStream]
+	call := f.superProducerCalls[superStream]
+	if call == nil {
+		return nil
+	}
+	return call.opts
 }
 
 // producerCall reads back what NewProducer received for one stream, or nil if
@@ -241,7 +255,11 @@ func (f *fakeEnvironment) producerCall(streamName string) *producerCall {
 func (f *fakeEnvironment) superProducerConfirmed(superStream string) ha.PartitionConfirmMessageHandler {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.superProdConfirmed[superStream]
+	call := f.superProducerCalls[superStream]
+	if call == nil {
+		return nil
+	}
+	return call.confirmed
 }
 
 // recordLocked and errForLocked are called with f.mu held.
@@ -340,7 +358,6 @@ func (f *fakeEnvironment) NewConsumer(streamName string, opts *stream.ConsumerOp
 		return nil, err
 	}
 	events := &fakeHandle{status: ha.StatusOpen}
-	f.consumerOpts[streamName] = opts
 	f.consumers[streamName] = &fakeConsumer{
 		env:     f,
 		name:    opts.ConsumerName,
@@ -348,6 +365,7 @@ func (f *fakeEnvironment) NewConsumer(streamName string, opts *stream.ConsumerOp
 		events:  events,
 		handler: handler,
 		sac:     consumerUpdateOf(opts.SingleActiveConsumer),
+		opts:    opts,
 	}
 	return events, nil
 }
@@ -408,8 +426,7 @@ func (f *fakeEnvironment) NewSuperStreamProducer(superStream string, opts *strea
 	if err := f.errForLocked(callNewSuperProducer, superStream); err != nil {
 		return nil, err
 	}
-	f.superProdOpts[superStream] = opts
-	f.superProdConfirmed[superStream] = confirmed
+	f.superProducerCalls[superStream] = &superProducerCall{opts: opts, confirmed: confirmed}
 	return f.newProducerLocked(superStream), nil
 }
 
@@ -460,6 +477,3 @@ func superConsumerDecls() *Declarations {
 	})
 	return decls
 }
-
-// ptrTo is how a table tells "no stored offset" from "stored offset 0".
-func ptrTo[T any](v T) *T { return &v }

--- a/messaging/streams/environment_fake_test.go
+++ b/messaging/streams/environment_fake_test.go
@@ -1,0 +1,270 @@
+package streams
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/ha"
+	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
+)
+
+// errProducerConstruction is the broker failure a test injects at the port.
+var errProducerConstruction = errors.New("producer construction failed")
+
+// The calls a fakeEnvironment records, in the order it made them. A target is
+// appended after a colon so a test asserts WHICH stream a phase reached, not only
+// that the phase ran. consumer_store and store_offset are deliberately separate:
+// an in-flight commit goes through the consumer that delivered the message, a
+// shutdown flush of a super stream through the Environment port, and a test that
+// could not tell them apart could not catch one turning into the other.
+const (
+	callDeclareStream      = "declare_stream"
+	callDeclareSuperStream = "declare_super_stream"
+	callNewProducer        = "new_producer"
+	callNewSuperProducer   = "new_super_producer"
+	callNewConsumer        = "new_consumer"
+	callNewSuperConsumer   = "new_super_consumer"
+	callQueryOffset        = "query_offset"
+	callStoreOffset        = "store_offset"
+	callConsumerStore      = "consumer_store"
+	callClose              = "close"
+)
+
+// fakeConsumer is one consumer the fake environment handed back: the handle the
+// manager tracks, plus the callbacks a test drives it through.
+type fakeConsumer struct {
+	env *fakeEnvironment
+	// name is the consumer name the manager asked for, which is the key the
+	// broker stores offsets under.
+	name string
+	// handle is what the port returned: a *fakeHandle for a plain stream, because
+	// *ha.ReliableConsumer is an offsetStorer, and a *fakeSuperHandle for a super
+	// stream, because *ha.ReliableSuperStreamConsumer is not.
+	handle consumerHandle
+	// events is that handle's shared event log, so a test asserts store and close
+	// without caring which handle kind it got.
+	events  *fakeHandle
+	handler messageHandler
+	// sac is the promotion callback the manager installed, nil when the
+	// declaration did not ask for single active consumer.
+	sac stream.ConsumerUpdate
+}
+
+// fakeSuperHandle stands in for *ha.ReliableSuperStreamConsumer. It delegates to
+// a fakeHandle rather than embedding one: embedding would promote
+// StoreCustomOffset, and the vendor type has none — that absence is exactly what
+// routes a super stream's shutdown flush through the Environment port.
+type fakeSuperHandle struct{ h *fakeHandle }
+
+func (f *fakeSuperHandle) Close() error   { return f.h.Close() }
+func (f *fakeSuperHandle) GetStatus() int { return f.h.GetStatus() }
+
+// fakeEnvironment is the in-memory adapter behind the Environment port.
+type fakeEnvironment struct {
+	mu sync.Mutex
+
+	calls []string
+	// errs injects one failure per port call, keyed either by method
+	// ("new_producer") or by method and target ("new_producer:orders").
+	errs map[string]error
+	// offsets is the broker's server-side offset store, keyed "<consumer>/<stream>".
+	offsets map[string]int64
+
+	consumers     map[string]*fakeConsumer
+	consumerOpts  map[string]*stream.ConsumerOptions
+	producers     map[string]*fakeProducer
+	superProdOpts map[string]*stream.SuperStreamProducerOptions
+	preparedProds map[string]*fakeProducer
+}
+
+var _ environment = (*fakeEnvironment)(nil)
+
+func newFakeEnvironment() *fakeEnvironment {
+	return &fakeEnvironment{
+		errs:          map[string]error{},
+		offsets:       map[string]int64{},
+		consumers:     map[string]*fakeConsumer{},
+		consumerOpts:  map[string]*stream.ConsumerOptions{},
+		producers:     map[string]*fakeProducer{},
+		superProdOpts: map[string]*stream.SuperStreamProducerOptions{},
+		preparedProds: map[string]*fakeProducer{},
+	}
+}
+
+// failOn makes one port call fail. key is a method name or "<method>:<target>".
+func (f *fakeEnvironment) failOn(key string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.errs[key] = err
+}
+
+func (f *fakeEnvironment) recorded() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
+
+func (f *fakeEnvironment) superProducerOptions(superStream string) *stream.SuperStreamProducerOptions {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.superProdOpts[superStream]
+}
+
+// recordLocked and errForLocked are called with f.mu held.
+func (f *fakeEnvironment) recordLocked(entry string) { f.calls = append(f.calls, entry) }
+
+func (f *fakeEnvironment) errForLocked(method, target string) error {
+	if err, ok := f.errs[method+":"+target]; ok {
+		return err
+	}
+	return f.errs[method]
+}
+
+func (f *fakeEnvironment) DeclareStream(name string, _ *stream.StreamOptions) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordLocked(callDeclareStream + ":" + name)
+	return f.errForLocked(callDeclareStream, name)
+}
+
+func (f *fakeEnvironment) DeclareSuperStream(name string, _ *stream.PartitionsOptions) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordLocked(callDeclareSuperStream + ":" + name)
+	return f.errForLocked(callDeclareSuperStream, name)
+}
+
+func (f *fakeEnvironment) QueryOffset(consumer, streamName string) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	key := consumer + "/" + streamName
+	f.recordLocked(callQueryOffset + ":" + key)
+	if err := f.errForLocked(callQueryOffset, key); err != nil {
+		return 0, err
+	}
+	offset, ok := f.offsets[key]
+	if !ok {
+		// The client answers a name it has never stored with this sentinel, and
+		// offsetSpecFor is the only place that tells it apart from a real failure.
+		return 0, stream.OffsetNotFoundError
+	}
+	return offset, nil
+}
+
+func (f *fakeEnvironment) StoreOffset(consumer, streamName string, offset int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	key := consumer + "/" + streamName
+	f.recordLocked(fmt.Sprintf("%s:%s=%d", callStoreOffset, key, offset))
+	if err := f.errForLocked(callStoreOffset, key); err != nil {
+		return err
+	}
+	f.offsets[key] = offset
+	return nil
+}
+
+func (f *fakeEnvironment) NewConsumer(streamName string, opts *stream.ConsumerOptions,
+	handler messageHandler,
+) (consumerHandle, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.recordLocked(callNewConsumer + ":" + streamName)
+	if err := f.errForLocked(callNewConsumer, streamName); err != nil {
+		return nil, err
+	}
+	events := &fakeHandle{status: ha.StatusOpen}
+	f.consumerOpts[streamName] = opts
+	f.consumers[streamName] = &fakeConsumer{
+		env:     f,
+		name:    opts.ConsumerName,
+		handle:  events,
+		events:  events,
+		handler: handler,
+		sac:     consumerUpdateOf(opts.SingleActiveConsumer),
+	}
+	return events, nil
+}
+
+func (f *fakeEnvironment) NewSuperStreamConsumer(superStream string, opts *stream.SuperStreamConsumerOptions,
+	handler messageHandler,
+) (consumerHandle, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.recordLocked(callNewSuperConsumer + ":" + superStream)
+	if err := f.errForLocked(callNewSuperConsumer, superStream); err != nil {
+		return nil, err
+	}
+	events := &fakeHandle{status: ha.StatusOpen}
+	handle := &fakeSuperHandle{h: events}
+	f.consumers[superStream] = &fakeConsumer{
+		env:     f,
+		name:    opts.ConsumerName,
+		handle:  handle,
+		events:  events,
+		handler: handler,
+		sac:     consumerUpdateOf(opts.SingleActiveConsumer),
+	}
+	return handle, nil
+}
+
+// consumerUpdateOf reads the promotion callback out of either options type's
+// single-active-consumer block, which the client leaves nil when SAC is off.
+func consumerUpdateOf(sac *stream.SingleActiveConsumer) stream.ConsumerUpdate {
+	if sac == nil {
+		return nil
+	}
+	return sac.ConsumerUpdate
+}
+
+func (f *fakeEnvironment) NewProducer(streamName string, _ *stream.ProducerOptions,
+	_ ha.ConfirmMessageHandler,
+) (producerHandle, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.recordLocked(callNewProducer + ":" + streamName)
+	if err := f.errForLocked(callNewProducer, streamName); err != nil {
+		return nil, err
+	}
+	return f.newProducerLocked(streamName), nil
+}
+
+func (f *fakeEnvironment) NewSuperStreamProducer(superStream string, opts *stream.SuperStreamProducerOptions,
+	_ ha.PartitionConfirmMessageHandler,
+) (producerHandle, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.recordLocked(callNewSuperProducer + ":" + superStream)
+	if err := f.errForLocked(callNewSuperProducer, superStream); err != nil {
+		return nil, err
+	}
+	f.superProdOpts[superStream] = opts
+	return f.newProducerLocked(superStream), nil
+}
+
+func (f *fakeEnvironment) newProducerLocked(streamName string) *fakeProducer {
+	p, ok := f.preparedProds[streamName]
+	if !ok {
+		p = openProducer()
+	}
+	f.producers[streamName] = p
+	return p
+}
+
+func (f *fakeEnvironment) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.recordLocked(callClose)
+	return f.errForLocked(callClose, "")
+}
+
+// dialFake makes m.Start open fake instead of a broker.
+func dialFake(m *Manager, fake *fakeEnvironment) {
+	m.dialEnvironment = func(*stream.EnvironmentOptions) (environment, error) { return fake, nil }
+}

--- a/messaging/streams/environment_fake_test.go
+++ b/messaging/streams/environment_fake_test.go
@@ -128,7 +128,10 @@ type fakeEnvironment struct {
 	// kept as its own map, keyed the same way, rather than folded into a struct,
 	// so superProdOpts and its existing accessor stay untouched.
 	superProdConfirmed map[string]ha.PartitionConfirmMessageHandler
-	preparedProds      map[string]*fakeProducer
+	// preparedProd is handed back by every producer construction, plain or super,
+	// rather than one per stream: every test that prepares a producer starts a
+	// single publisher. Key it by stream the day one of them starts two.
+	preparedProd *fakeProducer
 
 	// blockedStore parks one StoreOffset key until release closes, standing in for
 	// the client's locator reconnect loop against a broker that is down: it has no
@@ -151,7 +154,6 @@ func newFakeEnvironment() *fakeEnvironment {
 		producerCalls:      map[string]*producerCall{},
 		superProdOpts:      map[string]*stream.SuperStreamProducerOptions{},
 		superProdConfirmed: map[string]ha.PartitionConfirmMessageHandler{},
-		preparedProds:      map[string]*fakeProducer{},
 	}
 }
 
@@ -160,6 +162,15 @@ func (f *fakeEnvironment) failOn(key string, err error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.errs[key] = err
+}
+
+// useProducer makes the fake hand back p instead of a default open producer, so
+// a test can start a manager on a producer that blocks, that refuses to close,
+// or that reports a status of its choosing.
+func (f *fakeEnvironment) useProducer(p *fakeProducer) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.preparedProd = p
 }
 
 func (f *fakeEnvironment) blockStoreOn(key string) (entered <-chan struct{}, release chan<- struct{}) {
@@ -402,8 +413,8 @@ func (f *fakeEnvironment) NewSuperStreamProducer(superStream string, opts *strea
 }
 
 func (f *fakeEnvironment) newProducerLocked(streamName string) *fakeProducer {
-	p, ok := f.preparedProds[streamName]
-	if !ok {
+	p := f.preparedProd
+	if p == nil {
 		p = openProducer()
 	}
 	f.producers[streamName] = p

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -73,8 +73,8 @@ type consumerHandle interface {
 }
 
 // runningConsumer pairs a live client consumer with the offset bookkeeping its
-// runner owns. The runner itself is retained by the client through the
-// messagesHandler callback, so only the book is kept here.
+// runner owns. The runner itself is retained by the client through the delivery
+// callback, so only the book is kept here.
 type runningConsumer struct {
 	stream string
 	name   string
@@ -101,17 +101,15 @@ type Manager struct {
 	// is already gone.
 	flushBudget time.Duration
 
-	// newProducer and newSuperProducer construct the client producer bindPublisher
-	// installs, one per declaration kind. Held as fields for the same reason as
-	// flushBudget, so a test can make construction fail: they dial, so no
-	// broker-free test could otherwise reach that path. Deliberately not
-	// ManagerOptions fields — an operator has no reason to substitute the client's
-	// own constructors.
-	newProducer      producerFactory
-	newSuperProducer superProducerFactory
+	// dialEnvironment opens the Environment port. A field rather than a direct
+	// call so an in-package test can hand the manager a fake: the dial is the only
+	// thing between Start and every phase it drives. Same seam as the AMQP lane's
+	// amqpDialFunc (messaging/amqp_adapters.go:47), minus the process-global — a
+	// Manager owns its own dialer, so tests need no save-and-restore.
+	dialEnvironment func(*stream.EnvironmentOptions) (environment, error)
 
 	mu         sync.Mutex
-	env        *stream.Environment
+	env        environment
 	consumers  []*runningConsumer
 	publishers []*Publisher
 	started    bool
@@ -137,11 +135,10 @@ func NewManager(opts ManagerOptions) *Manager {
 		opts.OffsetStoreInterval = defaultOffsetStoreInterval
 	}
 	return &Manager{
-		opts:             opts,
-		log:              opts.Logger,
-		flushBudget:      shutdownFlushBudget,
-		newProducer:      newReliableProducer,
-		newSuperProducer: newReliableSuperProducer,
+		opts:            opts,
+		log:             opts.Logger,
+		flushBudget:     shutdownFlushBudget,
+		dialEnvironment: dialVendorEnvironment,
 	}
 }
 
@@ -177,17 +174,8 @@ func (m *Manager) Start(ctx context.Context, decls *Declarations) error {
 		return errors.New("streams manager already started: Close it before starting again")
 	}
 
-	// NewEnvironment returns a non-nil Environment BESIDE a non-nil error, so the
-	// failure path has something to dispose and `env != nil` is not a success test.
-	// v1.8.3 does tear the locator socket down itself, but only through an internal
-	// `defer client.Close()` it documents nowhere, and Client.connect opens the
-	// socket and starts its read goroutine before authentication — so disposing it
-	// here is what keeps a rejected credential from depending on that detail.
-	env, err := stream.NewEnvironment(m.environmentOptions())
+	env, err := m.dialEnvironment(m.environmentOptions())
 	if err != nil {
-		if env != nil {
-			_ = env.Close()
-		}
 		return fmt.Errorf("failed to connect to stream endpoint %s: %w", redactStreamURI(m.opts.URI), safeEnvError(err))
 	}
 	m.env = env
@@ -270,7 +258,7 @@ func (m *Manager) environmentOptions() *stream.EnvironmentOptions {
 // Each declaration is a blocking broker round trip the client gives no context of
 // its own, so ctx is checked between them: a caller that gave up on startup stops
 // paying for the rest of the fan-out.
-func (m *Manager) declareStreams(ctx context.Context, env *stream.Environment, decls *Declarations) error {
+func (m *Manager) declareStreams(ctx context.Context, env environment, decls *Declarations) error {
 	for _, s := range decls.streams {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("startup canceled before declaring stream %q: %w", s.Name, err)
@@ -287,7 +275,7 @@ func (m *Manager) declareStreams(ctx context.Context, env *stream.Environment, d
 // that already exists with a DIFFERENT partition count or retention is accepted
 // silently — see wiki/streams.md.
 // Like declareStreams, it checks ctx between round trips.
-func (m *Manager) declareSuperStreams(ctx context.Context, env *stream.Environment, decls *Declarations) error {
+func (m *Manager) declareSuperStreams(ctx context.Context, env environment, decls *Declarations) error {
 	for _, s := range decls.superStreams {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("startup canceled before declaring super stream %q: %w", s.Name, err)
@@ -305,9 +293,8 @@ func (m *Manager) declareSuperStreams(ctx context.Context, env *stream.Environme
 // already-started ones for the caller to unwind.
 //
 // start is a parameter rather than a method call because it is the only part that
-// reaches the broker — *stream.Environment is a concrete vendor type with no seam
-// to fake — so keeping it out is what lets this loop's cancellation and fail-fast
-// policy be exercised without one.
+// reaches the broker, so keeping it out is what lets this loop's cancellation and
+// fail-fast policy be exercised on a bare function.
 func startConsumers(ctx context.Context, decls []*consumerDeclaration, start func(*consumerDeclaration) error) error {
 	for _, decl := range decls {
 		if err := ctx.Err(); err != nil {
@@ -322,7 +309,7 @@ func startConsumers(ctx context.Context, decls []*consumerDeclaration, start fun
 
 // startConsumer starts one consumer for a declaration, on the client API its kind
 // requires. env is the caller's snapshot of m.env, taken under m.mu.
-func (m *Manager) startConsumer(ctx context.Context, env *stream.Environment, decl *consumerDeclaration) error {
+func (m *Manager) startConsumer(ctx context.Context, env environment, decl *consumerDeclaration) error {
 	if decl.Super {
 		return m.startSuperStreamConsumer(ctx, env, decl)
 	}
@@ -330,7 +317,7 @@ func (m *Manager) startConsumer(ctx context.Context, env *stream.Environment, de
 }
 
 // startStreamConsumer starts one reliable consumer on a plain stream.
-func (m *Manager) startStreamConsumer(ctx context.Context, env *stream.Environment, decl *consumerDeclaration) error {
+func (m *Manager) startStreamConsumer(ctx context.Context, env environment, decl *consumerDeclaration) error {
 	runner := m.newRunner(ctx, decl)
 
 	opts := stream.NewConsumerOptions().
@@ -354,19 +341,23 @@ func (m *Manager) startStreamConsumer(ctx context.Context, env *stream.Environme
 			}))
 	}
 
-	consumer, err := ha.NewReliableConsumer(env, decl.Stream, opts, runner.messagesHandler)
+	handle, err := env.NewConsumer(decl.Stream, opts, runner.deliver)
 	if err != nil {
 		return fmt.Errorf("failed to start consumer %q on stream %q: %w", decl.Name, decl.Stream, err)
 	}
 
-	// One stream, so one flush target: the reliable consumer itself.
-	m.trackConsumer(decl, consumer, runner, func(string) offsetStorer { return consumer })
+	// One stream, so one flush target: the reliable consumer itself. The assertion
+	// is what keeps consumerHandle narrower than offset storage — the super-stream
+	// handle has no StoreCustomOffset at all — and a handle that is not a storer
+	// commits nothing rather than panicking (errNoOffsetStorer).
+	storer, _ := handle.(offsetStorer)
+	m.trackConsumer(decl, handle, runner, func(string) offsetStorer { return storer })
 	return nil
 }
 
 // startSuperStreamConsumer starts one reliable consumer across every partition of
 // a super stream. env is the caller's snapshot of m.env, taken under m.mu.
-func (m *Manager) startSuperStreamConsumer(ctx context.Context, env *stream.Environment, decl *consumerDeclaration) error {
+func (m *Manager) startSuperStreamConsumer(ctx context.Context, env environment, decl *consumerDeclaration) error {
 	runner := m.newRunner(ctx, decl)
 
 	// Always a single active consumer group. The client attaches every partition
@@ -384,16 +375,16 @@ func (m *Manager) startSuperStreamConsumer(ctx context.Context, env *stream.Envi
 				return m.resolveOffset(env, decl.Name, partition, decl.Start, runner.offsets)
 			}))
 
-	consumer, err := ha.NewReliableSuperStreamConsumer(env, decl.Stream, runner.messagesHandler, opts)
+	handle, err := env.NewSuperStreamConsumer(decl.Stream, opts, runner.deliver)
 	if err != nil {
 		return fmt.Errorf("failed to start consumer %q on super stream %q: %w", decl.Name, decl.Stream, err)
 	}
 
-	// The shutdown flush goes through the environment, per partition:
+	// The shutdown flush goes through the Environment port, per partition:
 	// *ha.ReliableSuperStreamConsumer has no StoreCustomOffset, and the partition
 	// consumer that delivered the last message may already have been replaced by a
 	// reconnect.
-	m.trackConsumer(decl, consumer, runner, func(partition string) offsetStorer {
+	m.trackConsumer(decl, handle, runner, func(partition string) offsetStorer {
 		return envOffsetStorer{env: env, consumer: decl.Name, stream: partition}
 	})
 	return nil
@@ -462,7 +453,7 @@ func bindPublishers(ctx context.Context, decls []*publisherDeclaration, bind fun
 }
 
 // bindPublisher constructs one client producer and hands it to its Publisher.
-func (m *Manager) bindPublisher(env *stream.Environment, decl *publisherDeclaration) error {
+func (m *Manager) bindPublisher(env environment, decl *publisherDeclaration) error {
 	producer, err := m.constructProducer(env, decl)
 	if err != nil {
 		return fmt.Errorf("failed to start the publisher on %s %q: %w", streamKindLabel(decl.Super), decl.Stream, err)
@@ -478,13 +469,23 @@ func (m *Manager) bindPublisher(env *stream.Environment, decl *publisherDeclarat
 	return nil
 }
 
-// constructProducer builds one declaration's client producer, on the client API
-// its kind requires.
-func (m *Manager) constructProducer(env *stream.Environment, decl *publisherDeclaration) (producerHandle, error) {
+// constructProducer builds one declaration's producer through the Environment
+// port, on the API its kind requires.
+//
+// The plain producer options are the client's defaults on purpose: deduplication,
+// sub-entry batching and compression are all deferred, and the default
+// SubEntrySize of 1 is what makes the confirmation's message pointer a valid
+// correlation key. Hash routing is the only strategy offered for a super stream:
+// it is murmur3 with RabbitMQ's shared seed, so a partition assignment made here
+// matches what the Java, .NET and Python clients compute for the same key. Key
+// routing — which asks the broker to resolve a key to partitions — is deferred.
+func (m *Manager) constructProducer(env environment, decl *publisherDeclaration) (producerHandle, error) {
 	if decl.Super {
-		return m.newSuperProducer(env, decl.Stream, m.routingKeyExtractor(decl.Publisher), decl.Publisher.partitionsConfirmed)
+		opts := stream.NewSuperStreamProducerOptions(
+			stream.NewHashRoutingStrategy(m.routingKeyExtractor(decl.Publisher)))
+		return env.NewSuperStreamProducer(decl.Stream, opts, decl.Publisher.partitionsConfirmed)
 	}
-	return m.newProducer(env, decl.Stream, decl.Publisher.confirmed)
+	return env.NewProducer(decl.Stream, stream.NewProducerOptions(), decl.Publisher.confirmed)
 }
 
 // routingKeyExtractor builds the hash-routing extractor of one super-stream
@@ -514,46 +515,10 @@ func (m *Manager) routingKeyExtractor(p *Publisher) func(message.StreamMessage) 
 	}
 }
 
-// producerFactory constructs the client producer one plain-stream publisher sends
-// through.
-//
-// It is the constructor half of the producerHandle seam: producerHandle makes the
-// publish and confirmation policy testable without a broker, and this makes the
-// FAILURE of construction testable too — ha.NewReliableProducer dials, so nothing
-// broker-free could otherwise reach the path where that fails.
-type producerFactory func(env *stream.Environment, streamName string, confirmed ha.ConfirmMessageHandler) (producerHandle, error)
-
-// superProducerFactory is the same seam for a super-stream publisher. It is a
-// separate type because the client's two reliable producers take neither the same
-// options nor the same confirmation shape: this one needs a routing strategy, and
-// confirms per partition.
-type superProducerFactory func(env *stream.Environment, superStream string,
-	routingKeyFor func(message.StreamMessage) string, confirmed ha.PartitionConfirmMessageHandler) (producerHandle, error)
-
-// newReliableProducer is the production factory. The producer options are the
-// client's defaults on purpose: deduplication, sub-entry batching and compression
-// are all deferred, and the default SubEntrySize of 1 is what makes the
-// confirmation's message pointer a valid correlation key.
-func newReliableProducer(env *stream.Environment, streamName string, confirmed ha.ConfirmMessageHandler) (producerHandle, error) {
-	return ha.NewReliableProducer(env, streamName, stream.NewProducerOptions(), confirmed)
-}
-
-// newReliableSuperProducer is the production factory for a super stream. Hash
-// routing is the only strategy offered: it is murmur3 with RabbitMQ's shared seed,
-// so a partition assignment made here matches what the Java, .NET and Python
-// clients compute for the same key. Key routing — which asks the broker to resolve
-// a key to partitions — is deferred.
-func newReliableSuperProducer(env *stream.Environment, superStream string,
-	routingKeyFor func(message.StreamMessage) string, confirmed ha.PartitionConfirmMessageHandler,
-) (producerHandle, error) {
-	opts := stream.NewSuperStreamProducerOptions(stream.NewHashRoutingStrategy(routingKeyFor))
-	return ha.NewReliableSuperStreamProducer(env, superStream, opts, confirmed)
-}
-
-// envOffsetStorer commits one stream's offset through the environment's locator
-// connection instead of through a consumer.
+// envOffsetStorer commits one stream's offset through the Environment port
+// instead of through a consumer.
 type envOffsetStorer struct {
-	env      *stream.Environment
+	env      environment
 	consumer string
 	stream   string
 }
@@ -579,7 +544,7 @@ func (m *Manager) newOffsetBook() *offsetBook {
 // the SAC promotion callback the client invokes from its own goroutine — can read
 // that guarded field without m.mu. m.log is immutable after NewManager, and the
 // book takes only its own lock, so neither is a route back to m.mu.
-func (m *Manager) resolveOffset(env *stream.Environment, consumerName, streamName string, start OffsetStart, committed *offsetBook) stream.OffsetSpecification {
+func (m *Manager) resolveOffset(env environment, consumerName, streamName string, start OffsetStart, committed *offsetBook) stream.OffsetSpecification {
 	stored, err := env.QueryOffset(consumerName, streamName)
 	localOffset, hasLocal := committed.stored()[streamName]
 	m.reportOffsetQuery(err, consumerName, streamName, hasLocal)

--- a/messaging/streams/manager.go
+++ b/messaging/streams/manager.go
@@ -174,6 +174,13 @@ func (m *Manager) Start(ctx context.Context, decls *Declarations) error {
 		return errors.New("streams manager already started: Close it before starting again")
 	}
 
+	// The dial is a blocking broker round trip the client gives no context for —
+	// the same rule the declare loops below apply between round trips: a caller
+	// that already gave up on startup must not pay for it.
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("startup canceled before dialing stream endpoint %s: %w", redactStreamURI(m.opts.URI), err)
+	}
+
 	env, err := m.dialEnvironment(m.environmentOptions())
 	if err != nil {
 		return fmt.Errorf("failed to connect to stream endpoint %s: %w", redactStreamURI(m.opts.URI), safeEnvError(err))

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -236,6 +236,19 @@ func testManager(t *testing.T) *Manager {
 	})
 }
 
+// countOf reports how many times want appears in entries. assert.Contains alone
+// cannot see a duplicate: a partition flushed twice still contains its entry
+// once, so the shutdown-flush tests below count occurrences instead.
+func countOf(entries []string, want string) int {
+	n := 0
+	for _, e := range entries {
+		if e == want {
+			n++
+		}
+	}
+	return n
+}
+
 // TestManagerStopConsumersFlushesEveryTrackedStream extends the shutdown flush to
 // a consumer that tracks more than one stream: every partition's pending offset is
 // committed through the storer that reaches it, and only then is the consumer
@@ -256,8 +269,11 @@ func TestManagerStopConsumersFlushesEveryTrackedStream(t *testing.T) {
 
 	m.StopConsumers()
 
-	assert.Contains(t, fake.recorded(), callStoreOffset+":"+testConsumerName+"/"+testPartition0+"=11")
-	assert.Contains(t, fake.recorded(), callStoreOffset+":"+testConsumerName+"/"+testPartition1+"=501")
+	recorded := fake.recorded()
+	assert.Equal(t, 1, countOf(recorded, callStoreOffset+":"+testConsumerName+"/"+testPartition0+"=11"),
+		"partition 0 flushed exactly once")
+	assert.Equal(t, 1, countOf(recorded, callStoreOffset+":"+testConsumerName+"/"+testPartition1+"=501"),
+		"partition 1 flushed exactly once")
 	assert.Equal(t, []string{"close"}, consumer.events.recorded(), "the handle itself stores nothing")
 	assert.Empty(t, m.consumers)
 }
@@ -343,8 +359,11 @@ func TestManagerStopConsumersFlushesWithinBudget(t *testing.T) {
 
 	m.StopConsumers()
 
-	assert.Contains(t, fake.recorded(), callStoreOffset+":"+testConsumerName+"/"+testPartition0+"=11")
-	assert.Contains(t, fake.recorded(), callStoreOffset+":"+testConsumerName+"/"+testPartition1+"=501")
+	recorded := fake.recorded()
+	assert.Equal(t, 1, countOf(recorded, callStoreOffset+":"+testConsumerName+"/"+testPartition0+"=11"),
+		"partition 0 flushed exactly once")
+	assert.Equal(t, 1, countOf(recorded, callStoreOffset+":"+testConsumerName+"/"+testPartition1+"=501"),
+		"partition 1 flushed exactly once")
 	assert.Empty(t, log.warnStreams(msgFlushSkipped), "a flush that lands well inside the budget skips nothing")
 	assert.Equal(t, []string{"close"}, consumer.events.recorded())
 }
@@ -691,10 +710,14 @@ func TestManagerCloseWithoutEnvironmentIsIdempotent(t *testing.T) {
 	require.NoError(t, m.Close())
 }
 
+// TestManagerStats keeps offset_store_count at 9, distinct from the single
+// declared consumer: a threshold of 1 would equal stats["consumers"] and hide a
+// guard that swapped the two keys. Nine deliveries hit that threshold so the
+// last one still commits inline, leaving stored_offsets non-empty below.
 func TestManagerStats(t *testing.T) {
 	m := NewManager(ManagerOptions{
 		URI:                 unreachableTestURI,
-		OffsetStoreCount:    1,
+		OffsetStoreCount:    9,
 		OffsetStoreInterval: 2 * time.Second,
 		Logger:              logger.New("error", false),
 	})
@@ -702,7 +725,9 @@ func TestManagerStats(t *testing.T) {
 	startOnFake(t, m, fake, oneConsumerDecls())
 	consumer := fake.consumer(testStream)
 	require.NotNil(t, consumer)
-	consumer.deliver(testStream, 31, amqpMessage("payload"))
+	for offset := int64(23); offset <= 31; offset++ {
+		consumer.deliver(testStream, offset, amqpMessage("payload"))
+	}
 
 	stats := m.Stats()
 
@@ -710,7 +735,7 @@ func TestManagerStats(t *testing.T) {
 	assert.Equal(t, 1, stats["consumers"])
 	assert.Equal(t, true, stats["ready"])
 	assert.Equal(t, map[string]int64{testStream + "/" + testConsumerName: 31}, stats["stored_offsets"])
-	assert.Equal(t, 1, stats["offset_store_count"])
+	assert.Equal(t, 9, stats["offset_store_count"])
 	assert.Equal(t, "2s", stats["offset_flush_interval"])
 }
 
@@ -1759,6 +1784,10 @@ func TestManagerStartPromotionFallsBackToTheLocalCommit(t *testing.T) {
 	})
 	startOnFake(t, m, fake, decls)
 
+	opts := fake.consumerOptions(testStream)
+	require.NotNil(t, opts)
+	require.NotNil(t, opts.SingleActiveConsumer, "the premise: the SAC block reached the port")
+
 	consumer := fake.consumer(testStream)
 	require.NotNil(t, consumer)
 	consumer.deliver(testStream, 41, amqpMessage("payload"))
@@ -1857,10 +1886,11 @@ func TestManagerStartFlushesPlainThroughTheHandleAndSuperThroughThePort(t *testi
 
 			assert.Equal(t, tt.wantHandle, consumer.events.recorded())
 			portEntry := callStoreOffset + ":" + testConsumerName + "/" + tt.deliverOn + "=7"
+			recorded := fake.recorded()
 			if tt.wantPort {
-				assert.Contains(t, fake.recorded(), portEntry)
+				assert.Equal(t, 1, countOf(recorded, portEntry), "flushed exactly once through the port")
 			} else {
-				assert.NotContains(t, fake.recorded(), portEntry)
+				assert.NotContains(t, recorded, portEntry)
 			}
 		})
 	}

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -1101,8 +1101,9 @@ func TestSafeEnvError(t *testing.T) {
 
 // TestManagerStartFailedDialLeavesNothingToDispose is the pre-dial half: the
 // environment was never stored, so Close is a no-op. The post-dial half — where
-// the environment exists and must be disposed — needs a broker and lives in
-// TestStreamsManagerDisposesEnvironmentOnDeclareFailureIntegration.
+// the environment exists and must be disposed — is
+// TestManagerStartUnwindsAFailedDeclaration, in process against the Environment
+// port.
 func TestManagerStartFailedDialLeavesNothingToDispose(t *testing.T) {
 	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: logger.New("error", false)})
 	decls := NewDeclarations()

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -213,15 +213,18 @@ func (e *recordedEvent) Bytes(_ string, _ []byte) logger.LogEvent      { return 
 func (e *recordedEvent) Bool(_ string, _ bool) logger.LogEvent         { return e }
 func (e *recordedEvent) Enabled() bool                                 { return true }
 
-// recordingManager builds a manager with one attached fake consumer whose tracker
-// already has a pending offset, so both shutdown guards are reachable.
-func recordingManager(t *testing.T, handle *fakeHandle) (*Manager, *recordingLogger) {
+// recordingManager starts a manager on fake with one plain consumer that has a
+// pending, uncommitted offset, so both shutdown guards are reachable. The count
+// threshold is deliberately high: the delivery must leave work for the shutdown
+// flush to do rather than commit it inline.
+func recordingManager(t *testing.T, fake *fakeEnvironment) (*Manager, *recordingLogger) {
 	t.Helper()
 	log := &recordingLogger{}
-	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: log})
-	tracker := newOffsetTracker(1000, time.Hour, nil)
-	require.NoError(t, tracker.record(4, nil, &fakeStorer{}))
-	attach(m, handle, tracker)
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: log})
+	startOnFake(t, m, fake, oneConsumerDecls())
+	consumer := fake.consumer(testStream)
+	require.NotNil(t, consumer)
+	consumer.deliver(testStream, 4, amqpMessage("payload"))
 	return m, log
 }
 
@@ -234,7 +237,8 @@ func testManager(t *testing.T) *Manager {
 }
 
 // attach wires a fake consumer into a manager as if Start had created it: one
-// stream, whose flush target is the handle itself — the plain lane's shape.
+// stream, whose flush target is the handle itself — the plain lane's shape. Its
+// last caller is a publisher test, retired in the follow-up commit.
 func attach(m *Manager, handle *fakeHandle, tracker *offsetTracker) {
 	book := bookOf(tracker)
 	book.trackerFor(testStream)
@@ -248,67 +252,30 @@ func attach(m *Manager, handle *fakeHandle, tracker *offsetTracker) {
 	m.started = true
 }
 
-// attachPartitioned wires one consumer that tracks two streams, the shape a super
-// stream produces: one book, one flush target per partition.
-// countBeforeStorage decides whether the two recorded offsets are still pending
-// (a high threshold) or already committed (1).
-func attachPartitioned(t *testing.T, m *Manager, countBeforeStorage int) (handle *fakeHandle, storer0, storer1 *fakeStorer) {
-	t.Helper()
-	handle = &fakeHandle{status: ha.StatusOpen}
-	storer0, storer1 = &fakeStorer{}, &fakeStorer{}
-	book := newOffsetBook(func() *offsetTracker { return newOffsetTracker(countBeforeStorage, time.Hour, nil) })
-	require.NoError(t, book.trackerFor(testPartition0).record(11, nil, storer0))
-	require.NoError(t, book.trackerFor(testPartition1).record(501, nil, storer1))
-
-	m.consumers = append(m.consumers, &runningConsumer{
-		stream:  testSuperStream,
-		name:    testConsumerName,
-		handle:  handle,
-		offsets: book,
-		storerFor: storerByStream(map[string]offsetStorer{
-			testPartition0: storer0,
-			testPartition1: storer1,
-		}),
-	})
-	m.started = true
-	return handle, storer0, storer1
-}
-
 // TestManagerStopConsumersFlushesEveryTrackedStream extends the shutdown flush to
 // a consumer that tracks more than one stream: every partition's pending offset is
 // committed through the storer that reaches it, and only then is the consumer
 // closed.
 func TestManagerStopConsumersFlushesEveryTrackedStream(t *testing.T) {
-	m := testManager(t)
-	handle, storer0, storer1 := attachPartitioned(t, m, 1000)
-	require.Empty(t, storer0.offsets(), "the premise: both offsets are still pending")
+	m := NewManager(ManagerOptions{
+		URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: logger.New("error", false),
+	})
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, superConsumerDecls())
+
+	consumer := fake.consumer(testSuperStream)
+	require.NotNil(t, consumer)
+	consumer.deliver(testPartition0, 11, amqpMessage("a"))
+	consumer.deliver(testPartition1, 501, amqpMessage("b"))
+	require.NotContains(t, fake.recorded(), callStoreOffset+":"+testConsumerName+"/"+testPartition0+"=11",
+		"the premise: both offsets are still pending")
 
 	m.StopConsumers()
 
-	assert.Equal(t, []int64{11}, storer0.offsets())
-	assert.Equal(t, []int64{501}, storer1.offsets())
-	assert.Equal(t, []string{"close"}, handle.recorded(), "the handle itself stores nothing")
+	assert.Contains(t, fake.recorded(), callStoreOffset+":"+testConsumerName+"/"+testPartition0+"=11")
+	assert.Contains(t, fake.recorded(), callStoreOffset+":"+testConsumerName+"/"+testPartition1+"=501")
+	assert.Equal(t, []string{"close"}, consumer.events.recorded(), "the handle itself stores nothing")
 	assert.Empty(t, m.consumers)
-}
-
-// blockingStorer stands in for a commit against a broker that is down. The
-// client's locator reconnect loop has no attempt cap and no deadline, so such a
-// call never returns on its own; release is how the test ends it once the
-// assertions are made.
-type blockingStorer struct {
-	entered chan struct{}
-	release chan struct{}
-	once    sync.Once
-}
-
-func newBlockingStorer() *blockingStorer {
-	return &blockingStorer{entered: make(chan struct{}), release: make(chan struct{})}
-}
-
-func (b *blockingStorer) StoreCustomOffset(int64) error {
-	b.once.Do(func() { close(b.entered) })
-	<-b.release
-	return nil
 }
 
 // TestManagerStopConsumersAbandonsFlushWhenBudgetSpent pins the shutdown flush
@@ -323,33 +290,29 @@ func (b *blockingStorer) StoreCustomOffset(int64) error {
 // already spent, and that both are named at WARN so the replay is not silent.
 func TestManagerStopConsumersAbandonsFlushWhenBudgetSpent(t *testing.T) {
 	log := &recordingLogger{}
-	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: log})
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: log})
 	m.flushBudget = 50 * time.Millisecond
 
-	blocked := newBlockingStorer()
-	defer close(blocked.release)
+	fake := newFakeEnvironment()
+	entered, release := fake.blockStoreOn(testConsumerName + "/" + testPartition0)
+	defer close(release)
 
-	stuck := &fakeHandle{status: ha.StatusOpen}
-	stuckBook := newOffsetBook(func() *offsetTracker { return newOffsetTracker(1000, time.Hour, nil) })
-	require.NoError(t, stuckBook.trackerFor(testPartition0).record(11, nil, blocked))
+	decls := NewDeclarations()
+	decls.DeclareSuperStream(testSuperStream, testPartitions, nil)
+	decls.DeclareStream(testStream, nil)
+	decls.DeclareSuperStreamConsumer(&SuperStreamConsumerOptions{
+		SuperStream: testSuperStream, Name: testConsumerName, Handler: noopHandler,
+	})
+	decls.DeclareConsumer(&ConsumerOptions{Stream: testStream, Name: secondConsumerName, Handler: noopHandler})
+	startOnFake(t, m, fake, decls)
 
-	behind := &fakeHandle{status: ha.StatusOpen}
-	behindStorer := &fakeStorer{}
-	behindBook := newOffsetBook(func() *offsetTracker { return newOffsetTracker(1000, time.Hour, nil) })
-	require.NoError(t, behindBook.trackerFor(testPartition1).record(501, nil, behindStorer))
-	require.Empty(t, behindStorer.offsets(), "the premise: the second consumer's offset is still pending")
-
-	m.consumers = append(m.consumers,
-		&runningConsumer{
-			stream: testSuperStream, name: testConsumerName, handle: stuck, offsets: stuckBook,
-			storerFor: func(string) offsetStorer { return blocked },
-		},
-		&runningConsumer{
-			stream: testStream, name: secondConsumerName, handle: behind, offsets: behindBook,
-			storerFor: func(string) offsetStorer { return behindStorer },
-		},
-	)
-	m.started = true
+	stuck := fake.consumer(testSuperStream)
+	require.NotNil(t, stuck)
+	stuck.deliver(testPartition0, 11, amqpMessage("a"))
+	behind := fake.consumer(testStream)
+	require.NotNil(t, behind)
+	behind.deliver(testStream, 501, amqpMessage("b"))
+	require.Empty(t, behind.events.recorded(), "the premise: the second consumer's offset is still pending")
 
 	returned := make(chan struct{})
 	go func() {
@@ -358,7 +321,7 @@ func TestManagerStopConsumersAbandonsFlushWhenBudgetSpent(t *testing.T) {
 	}()
 
 	select {
-	case <-blocked.entered:
+	case <-entered:
 	case <-time.After(5 * time.Second):
 		t.Fatal("the blocked commit was never attempted, so this test is not exercising the hang it claims to")
 	}
@@ -369,13 +332,12 @@ func TestManagerStopConsumersAbandonsFlushWhenBudgetSpent(t *testing.T) {
 		t.Fatal("StopConsumers never returned: the flush budget did not bound a commit that cannot finish")
 	}
 
-	assert.Empty(t, behindStorer.offsets(),
+	assert.Equal(t, []string{"close"}, behind.events.recorded(),
 		"a budget already spent must skip the remaining flush outright, not attempt one more")
 	assert.Equal(t, []string{testSuperStream, testStream}, log.warnStreams(msgFlushSkipped),
 		"every skipped flush is reported at WARN, naming its stream")
-	assert.Equal(t, []string{"close"}, stuck.recorded(),
+	assert.Equal(t, []string{"close"}, stuck.events.recorded(),
 		"an abandoned flush must still let its consumer be closed")
-	assert.Equal(t, []string{"close"}, behind.recorded())
 	assert.Empty(t, m.consumers)
 	assert.False(t, m.started)
 }
@@ -386,23 +348,37 @@ func TestManagerStopConsumersAbandonsFlushWhenBudgetSpent(t *testing.T) {
 // abandonment test above.
 func TestManagerStopConsumersFlushesWithinBudget(t *testing.T) {
 	log := &recordingLogger{}
-	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: log})
-	handle, storer0, storer1 := attachPartitioned(t, m, 1000)
+	m := NewManager(ManagerOptions{URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: log})
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, superConsumerDecls())
+
+	consumer := fake.consumer(testSuperStream)
+	require.NotNil(t, consumer)
+	consumer.deliver(testPartition0, 11, amqpMessage("a"))
+	consumer.deliver(testPartition1, 501, amqpMessage("b"))
 
 	m.StopConsumers()
 
-	assert.Equal(t, []int64{11}, storer0.offsets())
-	assert.Equal(t, []int64{501}, storer1.offsets())
+	assert.Contains(t, fake.recorded(), callStoreOffset+":"+testConsumerName+"/"+testPartition0+"=11")
+	assert.Contains(t, fake.recorded(), callStoreOffset+":"+testConsumerName+"/"+testPartition1+"=501")
 	assert.Empty(t, log.warnStreams(msgFlushSkipped), "a flush that lands well inside the budget skips nothing")
-	assert.Equal(t, []string{"close"}, handle.recorded())
+	assert.Equal(t, []string{"close"}, consumer.events.recorded())
 }
 
 // TestManagerStatsKeysOffsetsByTrackedStream pins the /ready body's key: a position
 // is reported under the stream it belongs to, which for a super stream is the
 // partition rather than the declared name.
 func TestManagerStatsKeysOffsetsByTrackedStream(t *testing.T) {
-	m := testManager(t)
-	attachPartitioned(t, m, 1)
+	m := NewManager(ManagerOptions{
+		URI: unreachableTestURI, OffsetStoreCount: 1, Logger: logger.New("error", false),
+	})
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, superConsumerDecls())
+
+	consumer := fake.consumer(testSuperStream)
+	require.NotNil(t, consumer)
+	consumer.deliver(testPartition0, 11, amqpMessage("a"))
+	consumer.deliver(testPartition1, 501, amqpMessage("b"))
 
 	stats := m.Stats()
 
@@ -469,19 +445,14 @@ func TestManagerStartDeclaresThroughTheEnvironmentPort(t *testing.T) {
 	assert.True(t, m.started)
 }
 
-// The environment is installed alongside the consumer because Start sets it
-// before it sets started; attach alone would leave a state Start never produces.
 // The URI is unreachable so a guard that stopped holding surfaces as a dial
 // failure the message assertion rejects, rather than as a lucky local broker.
 func TestManagerStartRejectsSecondStart(t *testing.T) {
 	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: logger.New("error", false)})
-	attach(m, &fakeHandle{status: ha.StatusOpen}, newOffsetTracker(1, time.Hour, nil))
-	m.env = newFakeEnvironment()
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, oneConsumerDecls())
 
-	decls := NewDeclarations()
-	decls.DeclareStream(testStream, nil)
-
-	err := m.Start(context.Background(), decls)
+	err := m.Start(context.Background(), oneConsumerDecls())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already started")
@@ -550,14 +521,18 @@ func TestManagerStartupAbortsOnACanceledContext(t *testing.T) {
 	}
 }
 
-// A live context must not short-circuit the fan-out: the nil environment proves
-// the broker call is attempted by panicking, which the guard would have prevented.
+// A live context must not short-circuit the fan-out. Before the Environment port
+// this was asserted by panicking on a nil environment, which proved only that
+// SOMETHING was dereferenced; now it names the call that reached the broker.
 func TestManagerDeclareProceedsOnALiveContext(t *testing.T) {
 	decls := NewDeclarations()
 	decls.DeclareStream(testStream, nil)
 	m := testManager(t)
+	fake := newFakeEnvironment()
 
-	assert.Panics(t, func() { _ = m.declareStreams(context.Background(), nil, decls) })
+	require.NoError(t, m.declareStreams(context.Background(), fake, decls))
+
+	assert.Equal(t, []string{callDeclareStream + ":" + testStream}, fake.recorded())
 }
 
 // twoConsumers declares a pair so the fan-out has a second iteration to reach —
@@ -603,15 +578,18 @@ func TestStartConsumersStopsAtTheFirstFailure(t *testing.T) {
 }
 
 func TestManagerStopConsumersFlushesBeforeClosing(t *testing.T) {
-	m := testManager(t)
-	handle := &fakeHandle{status: ha.StatusOpen}
-	tracker := newOffsetTracker(1000, time.Hour, nil)
-	require.NoError(t, tracker.record(88, nil, &fakeStorer{}))
-	attach(m, handle, tracker)
+	m := NewManager(ManagerOptions{
+		URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: logger.New("error", false),
+	})
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, oneConsumerDecls())
+	consumer := fake.consumer(testStream)
+	require.NotNil(t, consumer)
+	consumer.deliver(testStream, 88, amqpMessage("payload"))
 
 	m.StopConsumers()
 
-	assert.Equal(t, []string{"store:88", "close"}, handle.recorded(),
+	assert.Equal(t, []string{"store:88", "close"}, consumer.events.recorded(),
 		"a clean shutdown commits the last handled offset before the consumer goes away")
 	assert.False(t, m.started)
 	assert.Empty(t, m.consumers)
@@ -619,13 +597,16 @@ func TestManagerStopConsumersFlushesBeforeClosing(t *testing.T) {
 
 func TestManagerStopConsumersIsIdempotent(t *testing.T) {
 	m := testManager(t)
-	handle := &fakeHandle{status: ha.StatusOpen}
-	attach(m, handle, newOffsetTracker(1000, time.Hour, nil))
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, oneConsumerDecls())
+	consumer := fake.consumer(testStream)
+	require.NotNil(t, consumer)
 
 	m.StopConsumers()
 	m.StopConsumers()
 
-	assert.Equal(t, []string{"close"}, handle.recorded(), "nothing pending, and no second close")
+	assert.Equal(t, []string{"close"}, consumer.events.recorded(),
+		"nothing pending, and no second close")
 }
 
 // TestManagerStopConsumersToleratesFlushAndCloseErrors pins both shutdown
@@ -633,11 +614,13 @@ func TestManagerStopConsumersIsIdempotent(t *testing.T) {
 // consumer that would not close each surface to the operator with the underlying
 // error attached, and neither aborts the rest of the teardown.
 func TestManagerStopConsumersToleratesFlushAndCloseErrors(t *testing.T) {
-	m, log := recordingManager(t, &fakeHandle{
-		status:   ha.StatusOpen,
-		closeErr: errors.New("close failed"),
-		storeErr: errors.New("store failed"),
-	})
+	fake := newFakeEnvironment()
+	m, log := recordingManager(t, fake)
+	consumer := fake.consumer(testStream)
+	require.NotNil(t, consumer)
+	handle := consumer.events
+	handle.closeErr = errors.New("close failed")
+	handle.storeErr = errors.New("store failed")
 
 	assert.NotPanics(t, m.StopConsumers)
 	assert.False(t, m.started)
@@ -654,24 +637,29 @@ func TestManagerStopConsumersToleratesFlushAndCloseErrors(t *testing.T) {
 // TestManagerStopConsumersIsSilentOnCleanShutdown is the other side of the same
 // two guards: a teardown whose flush and close both succeed reports no failure.
 func TestManagerStopConsumersIsSilentOnCleanShutdown(t *testing.T) {
-	handle := &fakeHandle{status: ha.StatusOpen}
-	m, log := recordingManager(t, handle)
+	fake := newFakeEnvironment()
+	m, log := recordingManager(t, fake)
+	consumer := fake.consumer(testStream)
+	require.NotNil(t, consumer)
 
 	m.StopConsumers()
 
-	assert.Equal(t, []string{"store:4", "close"}, handle.recorded())
+	assert.Equal(t, []string{"store:4", "close"}, consumer.events.recorded())
 	assert.Empty(t, log.warnMessages(), "a clean shutdown reports nothing to the operator")
 }
 
 func TestManagerStopConsumersCancelsConsumeContext(t *testing.T) {
 	m := testManager(t)
+	fake := newFakeEnvironment()
 	ctx, cancel := context.WithCancel(context.Background())
-	m.cancel = cancel
-	attach(m, &fakeHandle{status: ha.StatusOpen}, newOffsetTracker(1, time.Hour, nil))
+	defer cancel()
+	startOnFake(t, m, fake, oneConsumerDecls())
+	consumeCtx, consumeCancel := consumeContext(ctx)
+	m.cancel = consumeCancel
 
 	m.StopConsumers()
 
-	require.Error(t, ctx.Err())
+	require.ErrorIs(t, consumeCtx.Err(), context.Canceled)
 	assert.Nil(t, m.cancel)
 }
 
@@ -696,10 +684,11 @@ func TestConsumeContextInheritsValuesWithoutCancellation(t *testing.T) {
 // severing the caller's cancellation must not cost StopConsumers its own.
 func TestManagerStopConsumersStopsDetachedConsumeContext(t *testing.T) {
 	m := testManager(t)
+	fake := newFakeEnvironment()
 	parent, cancelParent := context.WithCancel(context.Background())
+	startOnFake(t, m, fake, oneConsumerDecls())
 	consumeCtx, cancel := consumeContext(parent)
 	m.cancel = cancel
-	attach(m, &fakeHandle{status: ha.StatusOpen}, newOffsetTracker(1, time.Hour, nil))
 
 	cancelParent()
 	require.NoError(t, consumeCtx.Err(), "the premise: the caller's context is canceled first")
@@ -720,14 +709,16 @@ func TestManagerCloseWithoutEnvironmentIsIdempotent(t *testing.T) {
 
 func TestManagerStats(t *testing.T) {
 	m := NewManager(ManagerOptions{
-		URI:                 "rabbitmq-stream://localhost:5552/",
-		OffsetStoreCount:    9,
+		URI:                 unreachableTestURI,
+		OffsetStoreCount:    1,
 		OffsetStoreInterval: 2 * time.Second,
 		Logger:              logger.New("error", false),
 	})
-	tracker := newOffsetTracker(1, time.Hour, nil)
-	require.NoError(t, tracker.record(31, nil, &fakeStorer{}))
-	attach(m, &fakeHandle{status: ha.StatusOpen}, tracker)
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, oneConsumerDecls())
+	consumer := fake.consumer(testStream)
+	require.NotNil(t, consumer)
+	consumer.deliver(testStream, 31, amqpMessage("payload"))
 
 	stats := m.Stats()
 
@@ -735,13 +726,19 @@ func TestManagerStats(t *testing.T) {
 	assert.Equal(t, 1, stats["consumers"])
 	assert.Equal(t, true, stats["ready"])
 	assert.Equal(t, map[string]int64{testStream + "/" + testConsumerName: 31}, stats["stored_offsets"])
-	assert.Equal(t, 9, stats["offset_store_count"])
+	assert.Equal(t, 1, stats["offset_store_count"])
 	assert.Equal(t, "2s", stats["offset_flush_interval"])
 }
 
 func TestManagerStatsOmitsUncommittedOffsets(t *testing.T) {
-	m := testManager(t)
-	attach(m, &fakeHandle{status: ha.StatusOpen}, newOffsetTracker(1000, time.Hour, nil))
+	m := NewManager(ManagerOptions{
+		URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: logger.New("error", false),
+	})
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, oneConsumerDecls())
+	consumer := fake.consumer(testStream)
+	require.NotNil(t, consumer)
+	consumer.deliver(testStream, 31, amqpMessage("payload"))
 
 	stats := m.Stats()
 
@@ -764,7 +761,11 @@ func TestManagerReady(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := testManager(t)
-			attach(m, &fakeHandle{status: tt.status}, newOffsetTracker(1, time.Hour, nil))
+			fake := newFakeEnvironment()
+			startOnFake(t, m, fake, oneConsumerDecls())
+			consumer := fake.consumer(testStream)
+			require.NotNil(t, consumer)
+			consumer.events.status = tt.status
 			m.started = tt.started
 
 			assert.Equal(t, tt.want, m.Ready())
@@ -1108,32 +1109,49 @@ func TestManagerStartFailedDialLeavesNothingToDispose(t *testing.T) {
 // Close leaked it and a second Start orphaned it beyond any later Close.
 func TestManagerAbortStartLockedDisposesEnvironment(t *testing.T) {
 	m := testManager(t)
-	handle := &fakeHandle{status: ha.StatusOpen}
-	attach(m, handle, newOffsetTracker(1000, time.Hour, nil))
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, oneConsumerDecls())
+	consumer := fake.consumer(testStream)
+	require.NotNil(t, consumer)
 
 	m.abortStartLocked()
 
 	assert.Nil(t, m.env, "the environment is disposed, not just the consumers")
 	assert.Empty(t, m.consumers)
 	assert.False(t, m.started)
-	assert.Equal(t, []string{"close"}, handle.recorded())
+	assert.Equal(t, []string{"close"}, consumer.events.recorded())
+	assert.Contains(t, fake.recorded(), callClose)
 
 	require.NoError(t, m.Close(), "the follow-up Close short-circuits instead of closing twice")
 }
 
 // TestManagerAbortStartLockedReportsOnlyRealDisposalFailures pins the unwind's
-// own guard: nothing was dialed, so closeEnvLocked has nothing to close and
-// returns nil. A guard reading that the wrong way round would tell the operator
-// the environment failed to close on every successful unwind.
+// own guard from both sides: a disposal that succeeded must not be reported as a
+// failure on every successful unwind, and one that failed must reach the operator
+// with its cause attached.
 func TestManagerAbortStartLockedReportsOnlyRealDisposalFailures(t *testing.T) {
-	m, log := recordingManager(t, &fakeHandle{status: ha.StatusOpen})
+	t.Run("successful_disposal_is_silent", func(t *testing.T) {
+		fake := newFakeEnvironment()
+		m, log := recordingManager(t, fake)
 
-	m.abortStartLocked()
+		m.abortStartLocked()
 
-	require.Nil(t, m.env, "the premise: there was no environment to dispose")
-	assert.NotContains(t, log.warnMessages(), msgCloseEnvFailed,
-		"a disposal that succeeded is not reported as a failure")
-	assert.Empty(t, log.warnMessages(), "the whole unwind is silent when every step succeeds")
+		require.Contains(t, fake.recorded(), callClose, "the premise: there was an environment to dispose")
+		assert.Empty(t, log.warnMessages(), "the whole unwind is silent when every step succeeds")
+	})
+
+	t.Run("failed_disposal_is_reported", func(t *testing.T) {
+		fake := newFakeEnvironment()
+		m, log := recordingManager(t, fake)
+		fake.failOn(callClose, errors.New("close failed"))
+
+		m.abortStartLocked()
+
+		assert.Contains(t, log.warnMessages(), msgCloseEnvFailed)
+		closeErr, ok := log.warnError(msgCloseEnvFailed)
+		require.True(t, ok)
+		assert.Equal(t, "close failed", closeErr)
+	})
 }
 
 // TestManagerStartRefusesRestartAfterStopConsumers is the restart variant of the
@@ -1146,24 +1164,21 @@ func TestManagerAbortStartLockedReportsOnlyRealDisposalFailures(t *testing.T) {
 // message assertion below separates from a genuine refusal.
 func TestManagerStartRefusesRestartAfterStopConsumers(t *testing.T) {
 	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: logger.New("error", false)})
-	handle := &fakeHandle{status: ha.StatusOpen}
-	attach(m, handle, newOffsetTracker(1000, time.Hour, nil))
-	env := newFakeEnvironment()
-	m.env = env
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, oneConsumerDecls())
 
 	m.StopConsumers()
 	require.False(t, m.started, "the premise: StopConsumers clears started")
-	require.Same(t, env, m.env, "the premise: StopConsumers leaves the environment for Close")
+	require.Same(t, fake, m.env, "the premise: StopConsumers leaves the environment for Close")
 
-	decls := NewDeclarations()
-	decls.DeclareStream(testStream, nil)
-	err := m.Start(context.Background(), decls)
+	err := m.Start(context.Background(), oneConsumerDecls())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already started",
 		"the restart is refused by the guard, not by a failed dial")
-	assert.Same(t, env, m.env, "the first environment is still the one Close disposes, not an orphan")
+	assert.Same(t, fake, m.env, "the first environment is still the one Close disposes, not an orphan")
 	assert.False(t, m.started)
+	assert.NotContains(t, fake.recorded(), callClose, "a refused restart disposes nothing")
 }
 
 func TestManagerCloseEnvLockedIsIdempotent(t *testing.T) {
@@ -1637,7 +1652,9 @@ func TestManagerStartUnwindsAFailedConsumerStart(t *testing.T) {
 
 	require.ErrorIs(t, err, errConsumerStart)
 	assert.Contains(t, err.Error(), `failed to start consumer "`+testConsumerName+`" on stream "`+testStream+`"`)
-	assert.True(t, fake.producer(testStream).isClosed(), "the publisher bound before the failure is closed")
+	producer := fake.producer(testStream)
+	require.NotNil(t, producer)
+	assert.True(t, producer.isClosed(), "the publisher bound before the failure is closed")
 	assert.ErrorIs(t, publisher.Publish(context.Background(), &PublishMessage{Data: []byte(testBody)}),
 		ErrPublisherClosed)
 	assert.Contains(t, fake.recorded(), callClose)
@@ -1716,13 +1733,18 @@ func TestManagerStartPromotionResolvesTheOffsetAgain(t *testing.T) {
 	})
 	startOnFake(t, m, fake, decls)
 
-	require.Equal(t, stream.OffsetSpecification{}.First(), fake.consumerOptions(testStream).Offset,
+	opts := fake.consumerOptions(testStream)
+	require.NotNil(t, opts)
+	require.NotNil(t, opts.SingleActiveConsumer, "the premise: the SAC block reached the port")
+	require.Equal(t, stream.OffsetSpecification{}.First(), opts.Offset,
 		"the premise: nothing was stored when the consumer attached")
 
 	// Another member committed while this one was passive.
 	fake.setOffset(testConsumerName, testStream, 41)
 
-	assert.Equal(t, stream.OffsetSpecification{}.Offset(42), fake.consumer(testStream).promote(testStream))
+	consumer := fake.consumer(testStream)
+	require.NotNil(t, consumer)
+	assert.Equal(t, stream.OffsetSpecification{}.Offset(42), consumer.promote(testStream))
 }
 
 // TestManagerStartPromotionFallsBackToTheLocalCommit is resolveOffset's third
@@ -1743,6 +1765,7 @@ func TestManagerStartPromotionFallsBackToTheLocalCommit(t *testing.T) {
 	startOnFake(t, m, fake, decls)
 
 	consumer := fake.consumer(testStream)
+	require.NotNil(t, consumer)
 	consumer.deliver(testStream, 41, amqpMessage("payload"))
 	require.Equal(t, map[string]int64{testStream: 41}, m.consumers[0].offsets.stored(),
 		"the premise: this process committed 41")
@@ -1778,6 +1801,7 @@ func TestManagerStartCommitsInFlightThroughTheDeliveringConsumer(t *testing.T) {
 			startOnFake(t, m, fake, tt.decls())
 
 			consumer := fake.consumer(tt.trackedName)
+			require.NotNil(t, consumer)
 			consumer.deliver(tt.deliverOn, 7, amqpMessage("payload"))
 
 			key := testConsumerName + "/" + tt.deliverOn
@@ -1830,6 +1854,7 @@ func TestManagerStartFlushesPlainThroughTheHandleAndSuperThroughThePort(t *testi
 			startOnFake(t, m, fake, tt.decls())
 
 			consumer := fake.consumer(tt.trackedName)
+			require.NotNil(t, consumer)
 			consumer.deliver(tt.deliverOn, 7, amqpMessage("payload"))
 			require.Empty(t, consumer.events.recorded(), "the premise: the offset is still pending")
 
@@ -1867,7 +1892,9 @@ func TestManagerStartRunsTheHandlerForADeliveredMessage(t *testing.T) {
 	})
 	startOnFake(t, m, fake, decls)
 
-	fake.consumer(testStream).deliver(testStream, 55, amqpMessage("payload"))
+	consumer := fake.consumer(testStream)
+	require.NotNil(t, consumer)
+	consumer.deliver(testStream, 55, amqpMessage("payload"))
 
 	require.NotNil(t, got)
 	assert.Equal(t, []byte("payload"), got.Data)

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -1310,6 +1310,12 @@ func TestManagerBindPublisherTracksAConstructedProducer(t *testing.T) {
 		"the producer is built for the declared stream, through the plain constructor")
 	assert.Equal(t, []*Publisher{decl.Publisher}, m.publishers)
 	assert.Equal(t, ha.StatusOpen, decl.Publisher.status(), "the handle is bound to the new producer")
+
+	call := fake.producerCall(testStream)
+	require.NotNil(t, call, "the port must have captured the plain producer's construction call")
+	assert.NotNil(t, call.opts, "stream.NewProducerOptions() must reach the constructor")
+	assert.NotNil(t, call.confirmed,
+		"the confirmation handler must reach the constructor, or the publisher's sends are never correlated")
 }
 
 // onePublisher declares a single publisher — the shape where a cancellation
@@ -1376,6 +1382,8 @@ func TestManagerBindPublisherBuildsASuperProducerForASuperTarget(t *testing.T) {
 	require.NotNil(t, opts)
 	strategy, ok := opts.RoutingStrategy.(*stream.HashRoutingStrategy)
 	require.True(t, ok, "hash routing is the only strategy offered")
+	assert.NotNil(t, fake.superProducerConfirmed(testSuperStream),
+		"the partition confirmation handler must reach the constructor, or the publisher's sends are never correlated")
 
 	registered := amqp.NewMessage([]byte(testBody))
 	decl.Publisher.pending.add(registered, testRoutingKey)

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -649,13 +649,12 @@ func TestManagerStopConsumersIsSilentOnCleanShutdown(t *testing.T) {
 	assert.Empty(t, log.warnMessages(), "a clean shutdown reports nothing to the operator")
 }
 
-// TestManagerStopConsumersCancelsConsumeContext pins the context StopConsumers
-// actually cancels: the one Start built and handed down to the handler, not one
-// a test wires up and assigns to m.cancel itself.
-func TestManagerStopConsumersCancelsConsumeContext(t *testing.T) {
-	m := testManager(t)
-	fake := newFakeEnvironment()
-
+// startWithCapturedHandlerCtx runs a real Start on parent with one consumer
+// whose handler records the context it receives, delivers one message, and
+// returns that context: the one Start actually built and handed down, not one a
+// test wires up and assigns to m.cancel itself.
+func startWithCapturedHandlerCtx(parent context.Context, t *testing.T, m *Manager, fake *fakeEnvironment) context.Context {
+	t.Helper()
 	var capturedCtx context.Context
 	decls := NewDeclarations()
 	decls.DeclareStream(testStream, nil)
@@ -666,17 +665,46 @@ func TestManagerStopConsumersCancelsConsumeContext(t *testing.T) {
 			return nil
 		},
 	})
-	startOnFake(t, m, fake, decls)
+	dialFake(m, fake)
+	require.NoError(t, m.Start(parent, decls))
 
 	consumer := fake.consumer(testStream)
 	require.NotNil(t, consumer)
 	consumer.deliver(testStream, 4, amqpMessage("payload"))
 	require.NotNil(t, capturedCtx, "the premise: the handler ran and captured the context it received")
+	return capturedCtx
+}
+
+// TestManagerStopConsumersCancelsConsumeContext pins the context StopConsumers
+// actually cancels: the one Start built and handed down to the handler.
+func TestManagerStopConsumersCancelsConsumeContext(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	capturedCtx := startWithCapturedHandlerCtx(context.Background(), t, m, fake)
 
 	m.StopConsumers()
 
 	require.ErrorIs(t, capturedCtx.Err(), context.Canceled)
 	assert.Nil(t, m.cancel)
+}
+
+// TestManagerStartRefusesACanceledContext pins the pre-dial gate: the dial is a
+// blocking broker round trip the client gives no context for, so a caller that
+// gave up before Start must not pay for it.
+func TestManagerStartRefusesACanceledContext(t *testing.T) {
+	m := testManager(t)
+	dialed := false
+	m.dialEnvironment = func(*stream.EnvironmentOptions) (environment, error) {
+		dialed = true
+		return newFakeEnvironment(), nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := m.Start(ctx, oneConsumerDecls())
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, dialed, "a canceled caller must not pay for the dial")
 }
 
 // TestConsumeContextInheritsValuesWithoutCancellation is the first half of the
@@ -697,21 +725,21 @@ func TestConsumeContextInheritsValuesWithoutCancellation(t *testing.T) {
 }
 
 // TestManagerStopConsumersStopsDetachedConsumeContext is the second half:
-// severing the caller's cancellation must not cost StopConsumers its own.
+// severing the caller's cancellation must not cost StopConsumers its own. The
+// consume context comes out of a real Start on a cancelable parent, so the
+// cancel path under test is the one Start owns.
 func TestManagerStopConsumersStopsDetachedConsumeContext(t *testing.T) {
 	m := testManager(t)
 	fake := newFakeEnvironment()
 	parent, cancelParent := context.WithCancel(context.Background())
-	startOnFake(t, m, fake, oneConsumerDecls())
-	consumeCtx, cancel := consumeContext(parent)
-	m.cancel = cancel
+	capturedCtx := startWithCapturedHandlerCtx(parent, t, m, fake)
 
 	cancelParent()
-	require.NoError(t, consumeCtx.Err(), "the premise: the caller's context is canceled first")
+	require.NoError(t, capturedCtx.Err(), "the premise: the caller's cancellation must not reach the consume context")
 
 	m.StopConsumers()
 
-	require.ErrorIs(t, consumeCtx.Err(), context.Canceled)
+	require.ErrorIs(t, capturedCtx.Err(), context.Canceled)
 	assert.Nil(t, m.cancel)
 	assert.False(t, m.started)
 }

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -1561,3 +1561,318 @@ func TestManagerRebindRevivesAPublisherAfterAStopCycle(t *testing.T) {
 	publishConfirmed(t, p, second, &PublishMessage{Data: []byte(testBody)})
 	assert.Zero(t, first.sentCount(), "the revived publisher sends through the new producer, not the disposed one")
 }
+
+// TestManagerStartDeclaresBindsThenStarts pins Start's phase order against the
+// port. Publishers bind BEFORE consumers start because a handler may publish from
+// its very first delivery, and an unbound publisher would reject it with
+// ErrPublisherNotStarted; both declare phases come first because neither a
+// producer nor a consumer can attach to a stream that does not exist.
+func TestManagerStartDeclaresBindsThenStarts(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	decls.DeclareSuperStream(testSuperStream, testPartitions, nil)
+	decls.DeclarePublisher(&PublisherOptions{Stream: testStream})
+	decls.DeclareConsumer(&ConsumerOptions{Stream: testStream, Name: testConsumerName, Handler: noopHandler})
+
+	startOnFake(t, m, fake, decls)
+
+	assert.Equal(t, []string{
+		callDeclareStream + ":" + testStream,
+		callDeclareSuperStream + ":" + testSuperStream,
+		callNewProducer + ":" + testStream,
+		callQueryOffset + ":" + testConsumerName + "/" + testStream,
+		callNewConsumer + ":" + testStream,
+	}, fake.recorded())
+	assert.True(t, m.started)
+	assert.Len(t, m.consumers, 1)
+	assert.Len(t, m.publishers, 1)
+}
+
+// TestManagerStartUnwindsAFailedDeclaration is abortStartLocked in process: the
+// environment was already dialed, so a caller that treats the error as fatal
+// without calling Close must leak nothing, and a retried Start must not orphan
+// the previous connection pool.
+func TestManagerStartUnwindsAFailedDeclaration(t *testing.T) {
+	m := testManager(t)
+	failing := newFakeEnvironment()
+	failing.failOn(callDeclareStream+":"+testStream, errDeclareFailed)
+	dialFake(m, failing)
+
+	err := m.Start(context.Background(), oneConsumerDecls())
+
+	require.ErrorIs(t, err, errDeclareFailed)
+	assert.Contains(t, err.Error(), `failed to declare stream "`+testStream+`"`)
+	assert.Contains(t, failing.recorded(), callClose, "the dialed environment is disposed by the failed Start itself")
+	assert.Nil(t, m.env)
+	assert.Empty(t, m.consumers)
+	assert.Empty(t, m.publishers)
+	assert.False(t, m.started)
+
+	// The unwind has to leave the manager startable, or a retry would be refused
+	// by the already-started guard for the rest of the process's life.
+	healthy := newFakeEnvironment()
+	startOnFake(t, m, healthy, oneConsumerDecls())
+	assert.True(t, m.started)
+}
+
+// TestManagerStartUnwindsAFailedConsumerStart is the unwind's other entry point,
+// and the one with something to undo: a publisher was already bound, so the
+// unwind has to close it rather than leave a producer attached to an environment
+// it is about to dispose.
+func TestManagerStartUnwindsAFailedConsumerStart(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	fake.failOn(callNewConsumer+":"+testStream, errConsumerStart)
+	dialFake(m, fake)
+
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	publisher := decls.DeclarePublisher(&PublisherOptions{Stream: testStream})
+	decls.DeclareConsumer(&ConsumerOptions{Stream: testStream, Name: testConsumerName, Handler: noopHandler})
+
+	err := m.Start(context.Background(), decls)
+
+	require.ErrorIs(t, err, errConsumerStart)
+	assert.Contains(t, err.Error(), `failed to start consumer "`+testConsumerName+`" on stream "`+testStream+`"`)
+	assert.True(t, fake.producer(testStream).isClosed(), "the publisher bound before the failure is closed")
+	assert.ErrorIs(t, publisher.Publish(context.Background(), &PublishMessage{Data: []byte(testBody)}),
+		ErrPublisherClosed)
+	assert.Contains(t, fake.recorded(), callClose)
+	assert.Nil(t, m.env)
+	assert.False(t, m.started)
+}
+
+// TestManagerStartResolvesTheAttachPosition drives resolveOffset through Start.
+// Only a MISSING offset may fall back to the declared start: any other query
+// failure answered with a start position would SKIP, fatally so for the
+// zero-value OffsetNext, and streams have no redelivery to get it back.
+func TestManagerStartResolvesTheAttachPosition(t *testing.T) {
+	tests := []struct {
+		name     string
+		stored   *int64
+		queryErr error
+		start    OffsetStart
+		want     stream.OffsetSpecification
+	}{
+		{
+			name:   "stored_offset_resumes_one_past_it",
+			stored: ptrTo(int64(17)),
+			start:  OffsetFirst(),
+			want:   stream.OffsetSpecification{}.Offset(18),
+		},
+		{
+			name:  "no_stored_offset_uses_the_declared_start",
+			start: OffsetFirst(),
+			want:  stream.OffsetSpecification{}.First(),
+		},
+		{
+			name:     "query_failure_without_a_local_commit_replays_from_first",
+			queryErr: errors.New("boom"),
+			start:    OffsetNext(),
+			want:     stream.OffsetSpecification{}.First(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := testManager(t)
+			fake := newFakeEnvironment()
+			if tt.stored != nil {
+				fake.setOffset(testConsumerName, testStream, *tt.stored)
+			}
+			if tt.queryErr != nil {
+				fake.failOn(callQueryOffset, tt.queryErr)
+			}
+
+			decls := NewDeclarations()
+			decls.DeclareStream(testStream, nil)
+			decls.DeclareConsumer(&ConsumerOptions{
+				Stream: testStream, Name: testConsumerName, Start: tt.start, Handler: noopHandler,
+			})
+			startOnFake(t, m, fake, decls)
+
+			opts := fake.consumerOptions(testStream)
+			require.NotNil(t, opts)
+			assert.Equal(t, tt.want, opts.Offset)
+		})
+	}
+}
+
+// TestManagerStartPromotionResolvesTheOffsetAgain exercises the single active
+// consumer promotion callback the client fires from its own goroutine: another
+// group member may have advanced the offset while this one was passive, so the
+// position is resolved again rather than reused from attach time.
+func TestManagerStartPromotionResolvesTheOffsetAgain(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	decls.DeclareConsumer(&ConsumerOptions{
+		Stream: testStream, Name: testConsumerName, SAC: true, Start: OffsetFirst(), Handler: noopHandler,
+	})
+	startOnFake(t, m, fake, decls)
+
+	require.Equal(t, stream.OffsetSpecification{}.First(), fake.consumerOptions(testStream).Offset,
+		"the premise: nothing was stored when the consumer attached")
+
+	// Another member committed while this one was passive.
+	fake.setOffset(testConsumerName, testStream, 41)
+
+	assert.Equal(t, stream.OffsetSpecification{}.Offset(42), fake.consumer(testStream).promote(testStream))
+}
+
+// TestManagerStartPromotionFallsBackToTheLocalCommit is resolveOffset's third
+// branch, which only a promotion can reach: the broker cannot be asked, but this
+// process committed a position for the stream itself, so that is the closest
+// truth available and is no older than the broker's.
+func TestManagerStartPromotionFallsBackToTheLocalCommit(t *testing.T) {
+	m := NewManager(ManagerOptions{
+		URI: unreachableTestURI, OffsetStoreCount: 1, Logger: logger.New("error", false),
+	})
+	fake := newFakeEnvironment()
+
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	decls.DeclareConsumer(&ConsumerOptions{
+		Stream: testStream, Name: testConsumerName, SAC: true, Start: OffsetNext(), Handler: noopHandler,
+	})
+	startOnFake(t, m, fake, decls)
+
+	consumer := fake.consumer(testStream)
+	consumer.deliver(testStream, 41, amqpMessage("payload"))
+	require.Equal(t, map[string]int64{testStream: 41}, m.consumers[0].offsets.stored(),
+		"the premise: this process committed 41")
+
+	fake.failOn(callQueryOffset, errors.New("boom"))
+
+	assert.Equal(t, stream.OffsetSpecification{}.Offset(42), consumer.promote(testStream),
+		"a broker that cannot be asked resumes from the local commit, never from the declared start")
+}
+
+// TestManagerStartCommitsInFlightThroughTheDeliveringConsumer pins the commit
+// path the Environment port must NOT have moved: an in-flight commit goes through
+// the consumer that delivered the message, on its connection — neither through
+// the reliable handle above it nor through the port's locator. Both kinds behave
+// identically here; the asymmetry is the shutdown flush's alone.
+func TestManagerStartCommitsInFlightThroughTheDeliveringConsumer(t *testing.T) {
+	tests := []struct {
+		name        string
+		decls       func() *Declarations
+		trackedName string
+		deliverOn   string
+	}{
+		{name: "plain_stream", decls: oneConsumerDecls, trackedName: testStream, deliverOn: testStream},
+		{name: "super_stream_partition", decls: superConsumerDecls, trackedName: testSuperStream, deliverOn: testPartition0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewManager(ManagerOptions{
+				URI: unreachableTestURI, OffsetStoreCount: 1, Logger: logger.New("error", false),
+			})
+			fake := newFakeEnvironment()
+			startOnFake(t, m, fake, tt.decls())
+
+			consumer := fake.consumer(tt.trackedName)
+			consumer.deliver(tt.deliverOn, 7, amqpMessage("payload"))
+
+			key := testConsumerName + "/" + tt.deliverOn
+			assert.Contains(t, fake.recorded(), callConsumerStore+":"+key+"=7")
+			assert.NotContains(t, fake.recorded(), callStoreOffset+":"+key+"=7",
+				"an in-flight commit never goes through the Environment port")
+			assert.Empty(t, consumer.events.recorded(),
+				"nor through the reliable handle the manager tracks")
+
+			offset, ok := fake.storedOffset(testConsumerName, tt.deliverOn)
+			require.True(t, ok, "the commit reaches the broker's offset store")
+			assert.Equal(t, int64(7), offset)
+			assert.Equal(t, map[string]int64{tt.deliverOn: 7}, m.consumers[0].offsets.stored())
+		})
+	}
+}
+
+// TestManagerStartFlushesPlainThroughTheHandleAndSuperThroughThePort is the
+// offset-storer asymmetry, which lives entirely in the SHUTDOWN flush: a plain
+// consumer's handle is an offsetStorer, while *ha.ReliableSuperStreamConsumer has
+// no StoreCustomOffset at all, so its partitions commit through the port.
+func TestManagerStartFlushesPlainThroughTheHandleAndSuperThroughThePort(t *testing.T) {
+	tests := []struct {
+		name        string
+		decls       func() *Declarations
+		trackedName string
+		deliverOn   string
+		wantHandle  []string
+		wantPort    bool
+	}{
+		{
+			name:  "plain_stream_flushes_through_its_own_handle",
+			decls: oneConsumerDecls, trackedName: testStream, deliverOn: testStream,
+			wantHandle: []string{"store:7", "close"}, wantPort: false,
+		},
+		{
+			name:  "super_stream_flushes_through_the_port",
+			decls: superConsumerDecls, trackedName: testSuperStream, deliverOn: testPartition0,
+			wantHandle: []string{"close"}, wantPort: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// A high threshold leaves the delivery pending, so the flush has work.
+			m := NewManager(ManagerOptions{
+				URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: logger.New("error", false),
+			})
+			fake := newFakeEnvironment()
+			startOnFake(t, m, fake, tt.decls())
+
+			consumer := fake.consumer(tt.trackedName)
+			consumer.deliver(tt.deliverOn, 7, amqpMessage("payload"))
+			require.Empty(t, consumer.events.recorded(), "the premise: the offset is still pending")
+
+			m.StopConsumers()
+
+			assert.Equal(t, tt.wantHandle, consumer.events.recorded())
+			portEntry := callStoreOffset + ":" + testConsumerName + "/" + tt.deliverOn + "=7"
+			if tt.wantPort {
+				assert.Contains(t, fake.recorded(), portEntry)
+			} else {
+				assert.NotContains(t, fake.recorded(), portEntry)
+			}
+		})
+	}
+}
+
+// TestManagerStartRunsTheHandlerForADeliveredMessage is the delivery path end to
+// end through Start: the port hands the runner a message, the module's handler
+// sees the framework's view of it, and the offset is committed after success.
+func TestManagerStartRunsTheHandlerForADeliveredMessage(t *testing.T) {
+	var got *Message
+	m := NewManager(ManagerOptions{
+		URI: unreachableTestURI, OffsetStoreCount: 1, Logger: logger.New("error", false),
+	})
+	fake := newFakeEnvironment()
+
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	decls.DeclareConsumer(&ConsumerOptions{
+		Stream: testStream, Name: testConsumerName,
+		Handler: func(_ context.Context, msg *Message) error {
+			got = msg
+			return nil
+		},
+	})
+	startOnFake(t, m, fake, decls)
+
+	fake.consumer(testStream).deliver(testStream, 55, amqpMessage("payload"))
+
+	require.NotNil(t, got)
+	assert.Equal(t, []byte("payload"), got.Data)
+	assert.Equal(t, int64(55), got.Offset)
+	assert.Equal(t, testStream, got.Stream)
+	assert.Equal(t, map[string]any{"kind": "test"}, got.Properties)
+	assert.Contains(t, fake.recorded(), callConsumerStore+":"+testConsumerName+"/"+testStream+"=55")
+}

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -228,6 +228,22 @@ func recordingManager(t *testing.T, fake *fakeEnvironment) (*Manager, *recording
 	return m, log
 }
 
+// twoPartitionSuperConsumer starts m on a fresh fake with the super-stream
+// consumer declared by superConsumerDecls, then delivers offset 11 on partition0
+// and 501 on partition1, leaving both pending — the fixture shared by every test
+// that needs a two-partition super consumer in that state.
+func twoPartitionSuperConsumer(t *testing.T, m *Manager) (*fakeEnvironment, *fakeConsumer) {
+	t.Helper()
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, superConsumerDecls())
+
+	consumer := fake.consumer(testSuperStream)
+	require.NotNil(t, consumer)
+	consumer.deliver(testPartition0, 11, amqpMessage("a"))
+	consumer.deliver(testPartition1, 501, amqpMessage("b"))
+	return fake, consumer
+}
+
 func testManager(t *testing.T) *Manager {
 	t.Helper()
 	return NewManager(ManagerOptions{
@@ -257,13 +273,7 @@ func TestManagerStopConsumersFlushesEveryTrackedStream(t *testing.T) {
 	m := NewManager(ManagerOptions{
 		URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: logger.New("error", false),
 	})
-	fake := newFakeEnvironment()
-	startOnFake(t, m, fake, superConsumerDecls())
-
-	consumer := fake.consumer(testSuperStream)
-	require.NotNil(t, consumer)
-	consumer.deliver(testPartition0, 11, amqpMessage("a"))
-	consumer.deliver(testPartition1, 501, amqpMessage("b"))
+	fake, consumer := twoPartitionSuperConsumer(t, m)
 	require.NotContains(t, fake.recorded(), callStoreOffset+":"+testConsumerName+"/"+testPartition0+"=11",
 		"the premise: both offsets are still pending")
 
@@ -349,13 +359,7 @@ func TestManagerStopConsumersAbandonsFlushWhenBudgetSpent(t *testing.T) {
 func TestManagerStopConsumersFlushesWithinBudget(t *testing.T) {
 	log := &recordingLogger{}
 	m := NewManager(ManagerOptions{URI: unreachableTestURI, OffsetStoreCount: 1000, Logger: log})
-	fake := newFakeEnvironment()
-	startOnFake(t, m, fake, superConsumerDecls())
-
-	consumer := fake.consumer(testSuperStream)
-	require.NotNil(t, consumer)
-	consumer.deliver(testPartition0, 11, amqpMessage("a"))
-	consumer.deliver(testPartition1, 501, amqpMessage("b"))
+	fake, consumer := twoPartitionSuperConsumer(t, m)
 
 	m.StopConsumers()
 
@@ -375,13 +379,7 @@ func TestManagerStatsKeysOffsetsByTrackedStream(t *testing.T) {
 	m := NewManager(ManagerOptions{
 		URI: unreachableTestURI, OffsetStoreCount: 1, Logger: logger.New("error", false),
 	})
-	fake := newFakeEnvironment()
-	startOnFake(t, m, fake, superConsumerDecls())
-
-	consumer := fake.consumer(testSuperStream)
-	require.NotNil(t, consumer)
-	consumer.deliver(testPartition0, 11, amqpMessage("a"))
-	consumer.deliver(testPartition1, 501, amqpMessage("b"))
+	twoPartitionSuperConsumer(t, m)
 
 	stats := m.Stats()
 
@@ -651,18 +649,33 @@ func TestManagerStopConsumersIsSilentOnCleanShutdown(t *testing.T) {
 	assert.Empty(t, log.warnMessages(), "a clean shutdown reports nothing to the operator")
 }
 
+// TestManagerStopConsumersCancelsConsumeContext pins the context StopConsumers
+// actually cancels: the one Start built and handed down to the handler, not one
+// a test wires up and assigns to m.cancel itself.
 func TestManagerStopConsumersCancelsConsumeContext(t *testing.T) {
 	m := testManager(t)
 	fake := newFakeEnvironment()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	startOnFake(t, m, fake, oneConsumerDecls())
-	consumeCtx, consumeCancel := consumeContext(ctx)
-	m.cancel = consumeCancel
+
+	var capturedCtx context.Context
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+	decls.DeclareConsumer(&ConsumerOptions{
+		Stream: testStream, Name: testConsumerName,
+		Handler: func(ctx context.Context, _ *Message) error {
+			capturedCtx = ctx
+			return nil
+		},
+	})
+	startOnFake(t, m, fake, decls)
+
+	consumer := fake.consumer(testStream)
+	require.NotNil(t, consumer)
+	consumer.deliver(testStream, 4, amqpMessage("payload"))
+	require.NotNil(t, capturedCtx, "the premise: the handler ran and captured the context it received")
 
 	m.StopConsumers()
 
-	require.ErrorIs(t, consumeCtx.Err(), context.Canceled)
+	require.ErrorIs(t, capturedCtx.Err(), context.Canceled)
 	assert.Nil(t, m.cancel)
 }
 
@@ -1689,17 +1702,19 @@ func TestManagerStartUnwindsAFailedConsumerStart(t *testing.T) {
 // zero-value OffsetNext, and streams have no redelivery to get it back.
 func TestManagerStartResolvesTheAttachPosition(t *testing.T) {
 	tests := []struct {
-		name     string
-		stored   *int64
-		queryErr error
-		start    OffsetStart
-		want     stream.OffsetSpecification
+		name      string
+		stored    int64
+		hasStored bool
+		queryErr  error
+		start     OffsetStart
+		want      stream.OffsetSpecification
 	}{
 		{
-			name:   "stored_offset_resumes_one_past_it",
-			stored: ptrTo(int64(17)),
-			start:  OffsetFirst(),
-			want:   stream.OffsetSpecification{}.Offset(18),
+			name:      "stored_offset_resumes_one_past_it",
+			stored:    17,
+			hasStored: true,
+			start:     OffsetFirst(),
+			want:      stream.OffsetSpecification{}.Offset(18),
 		},
 		{
 			name:  "no_stored_offset_uses_the_declared_start",
@@ -1718,8 +1733,8 @@ func TestManagerStartResolvesTheAttachPosition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			m := testManager(t)
 			fake := newFakeEnvironment()
-			if tt.stored != nil {
-				fake.setOffset(testConsumerName, testStream, *tt.stored)
+			if tt.hasStored {
+				fake.setOffset(testConsumerName, testStream, tt.stored)
 			}
 			if tt.queryErr != nil {
 				fake.failOn(callQueryOffset, tt.queryErr)

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/ha"
-	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/message"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,9 +33,6 @@ func failingStart(*consumerDeclaration) error { return errStartAttempted }
 var errBindAttempted = errors.New("publisher bind attempted")
 
 func failingBind(*publisherDeclaration) error { return errBindAttempted }
-
-// errProducerConstruction is the client constructor's failure, faked.
-var errProducerConstruction = errors.New("producer construction failed")
 
 // fakeHandle stands in for *ha.ReliableConsumer so shutdown bookkeeping is
 // testable without a broker.
@@ -455,6 +451,24 @@ func TestManagerStartWithoutDeclarationsDoesNotDial(t *testing.T) {
 	assert.False(t, m.started)
 }
 
+// TestManagerStartDeclaresThroughTheEnvironmentPort is the whole point of the
+// port: Start's declare phase reaches the broker seam in a unit test. Before the
+// port there was no way in — the phase was only ever reached with a nil
+// environment, by a test that asserted through a panic.
+func TestManagerStartDeclaresThroughTheEnvironmentPort(t *testing.T) {
+	m := testManager(t)
+	fake := newFakeEnvironment()
+	dialFake(m, fake)
+
+	decls := NewDeclarations()
+	decls.DeclareStream(testStream, nil)
+
+	require.NoError(t, m.Start(context.Background(), decls))
+
+	assert.Equal(t, []string{callDeclareStream + ":" + testStream}, fake.recorded())
+	assert.True(t, m.started)
+}
+
 // The environment is installed alongside the consumer because Start sets it
 // before it sets started; attach alone would leave a state Start never produces.
 // The URI is unreachable so a guard that stopped holding surfaces as a dial
@@ -462,7 +476,7 @@ func TestManagerStartWithoutDeclarationsDoesNotDial(t *testing.T) {
 func TestManagerStartRejectsSecondStart(t *testing.T) {
 	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: logger.New("error", false)})
 	attach(m, &fakeHandle{status: ha.StatusOpen}, newOffsetTracker(1, time.Hour, nil))
-	m.env = &stream.Environment{}
+	m.env = newFakeEnvironment()
 
 	decls := NewDeclarations()
 	decls.DeclareStream(testStream, nil)
@@ -1134,7 +1148,7 @@ func TestManagerStartRefusesRestartAfterStopConsumers(t *testing.T) {
 	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: logger.New("error", false)})
 	handle := &fakeHandle{status: ha.StatusOpen}
 	attach(m, handle, newOffsetTracker(1000, time.Hour, nil))
-	env := &stream.Environment{}
+	env := newFakeEnvironment()
 	m.env = env
 
 	m.StopConsumers()
@@ -1265,17 +1279,16 @@ func TestBindPublishersStopsAtTheFirstFailure(t *testing.T) {
 	assert.Equal(t, []string{testStream}, attempted, "the fan-out stops at the first failure")
 }
 
-// TestManagerBindPublisherWrapsAConstructionFailure exercises the vendor
-// constructor's failure path through the producerFactory seam: it dials, so this
+// TestManagerBindPublisherWrapsAConstructionFailure exercises the construction
+// failure through the Environment port: against a real broker it dials, so this
 // is the only way a broker-free test can reach it.
 func TestManagerBindPublisherWrapsAConstructionFailure(t *testing.T) {
 	m := testManager(t)
-	m.newProducer = func(*stream.Environment, string, ha.ConfirmMessageHandler) (producerHandle, error) {
-		return nil, errProducerConstruction
-	}
+	fake := newFakeEnvironment()
+	fake.failOn(callNewProducer, errProducerConstruction)
 	decl := onePublisherDeclaration(t)
 
-	err := m.bindPublisher(nil, decl)
+	err := m.bindPublisher(fake, decl)
 
 	require.ErrorIs(t, err, errProducerConstruction, "the client's own cause reaches the caller")
 	assert.Contains(t, err.Error(), `failed to start the publisher on stream "`+testStream+`"`)
@@ -1285,23 +1298,16 @@ func TestManagerBindPublisherWrapsAConstructionFailure(t *testing.T) {
 }
 
 // TestManagerBindPublisherTracksAConstructedProducer is the success half: the
-// producer is built for the declared stream, wired to that publisher's own
-// confirmation handler, bound, and tracked.
+// producer is built for the declared stream, bound, and tracked.
 func TestManagerBindPublisherTracksAConstructedProducer(t *testing.T) {
 	m := testManager(t)
-	handle := openProducer()
-	var gotStream string
-	var gotConfirmed ha.ConfirmMessageHandler
-	m.newProducer = func(_ *stream.Environment, streamName string, confirmed ha.ConfirmMessageHandler) (producerHandle, error) {
-		gotStream, gotConfirmed = streamName, confirmed
-		return handle, nil
-	}
+	fake := newFakeEnvironment()
 	decl := onePublisherDeclaration(t)
 
-	require.NoError(t, m.bindPublisher(nil, decl))
+	require.NoError(t, m.bindPublisher(fake, decl))
 
-	assert.Equal(t, testStream, gotStream, "the producer is built for the declared stream")
-	require.NotNil(t, gotConfirmed, "the client is given a confirmation handler")
+	assert.Equal(t, []string{callNewProducer + ":" + testStream}, fake.recorded(),
+		"the producer is built for the declared stream, through the plain constructor")
 	assert.Equal(t, []*Publisher{decl.Publisher}, m.publishers)
 	assert.Equal(t, ha.StatusOpen, decl.Publisher.status(), "the handle is bound to the new producer")
 }
@@ -1335,29 +1341,16 @@ func oneSuperPublisherDeclaration(t *testing.T) *publisherDeclaration {
 	return decls.publishers[0]
 }
 
-// unreachableProducer fails every construction, so a bind reaches its error path
-// without a broker.
-func unreachableProducer(*stream.Environment, string, ha.ConfirmMessageHandler) (producerHandle, error) {
-	return nil, errProducerConstruction
-}
-
-// unreachableSuperProducer is its super-stream twin.
-func unreachableSuperProducer(*stream.Environment, string, func(message.StreamMessage) string,
-	ha.PartitionConfirmMessageHandler,
-) (producerHandle, error) {
-	return nil, errProducerConstruction
-}
-
 // TestManagerBindPublisherWrapsASuperConstructionFailure is the super-stream half
 // of the construction-failure path, and pins that the failure names the kind of
 // target the declaration asked for rather than calling every target a stream.
 func TestManagerBindPublisherWrapsASuperConstructionFailure(t *testing.T) {
 	m := testManager(t)
-	m.newProducer = unreachableProducer
-	m.newSuperProducer = unreachableSuperProducer
+	fake := newFakeEnvironment()
+	fake.failOn(callNewSuperProducer, errProducerConstruction)
 	decl := oneSuperPublisherDeclaration(t)
 
-	err := m.bindPublisher(nil, decl)
+	err := m.bindPublisher(fake, decl)
 
 	require.ErrorIs(t, err, errProducerConstruction)
 	assert.Contains(t, err.Error(), `failed to start the publisher on super stream "`+testSuperStream+`"`)
@@ -1365,30 +1358,30 @@ func TestManagerBindPublisherWrapsASuperConstructionFailure(t *testing.T) {
 }
 
 // TestManagerBindPublisherBuildsASuperProducerForASuperTarget pins the dispatch: a
-// super declaration must reach the client's super-stream constructor, with a
-// routing extractor and the per-partition confirmation handler that constructor
-// requires. Binding it through the plain constructor would compile and then fail at
-// the broker, because a super stream is not a stream.
+// super declaration must reach the port's super-stream constructor, with the hash
+// routing strategy that constructor requires and an extractor that answers the key
+// the caller registered. Binding it through the plain constructor would compile and
+// then fail at the broker, because a super stream is not a stream.
 func TestManagerBindPublisherBuildsASuperProducerForASuperTarget(t *testing.T) {
 	m := testManager(t)
-	m.newProducer = unreachableProducer // a plain bind here is the defect under test
-	handle := openProducer()
-	var gotStream string
-	var gotExtractor func(message.StreamMessage) string
-	var gotConfirmed ha.PartitionConfirmMessageHandler
-	m.newSuperProducer = func(_ *stream.Environment, superStream string,
-		routingKeyFor func(message.StreamMessage) string, confirmed ha.PartitionConfirmMessageHandler,
-	) (producerHandle, error) {
-		gotStream, gotExtractor, gotConfirmed = superStream, routingKeyFor, confirmed
-		return handle, nil
-	}
+	fake := newFakeEnvironment()
+	// A plain bind here is the defect under test: it must never be reached.
+	fake.failOn(callNewProducer, errProducerConstruction)
 	decl := oneSuperPublisherDeclaration(t)
 
-	require.NoError(t, m.bindPublisher(nil, decl))
+	require.NoError(t, m.bindPublisher(fake, decl))
 
-	assert.Equal(t, testSuperStream, gotStream, "the producer is built for the declared super stream")
-	require.NotNil(t, gotExtractor, "hash routing needs an extractor")
-	require.NotNil(t, gotConfirmed, "a super stream confirms per partition")
+	assert.Equal(t, []string{callNewSuperProducer + ":" + testSuperStream}, fake.recorded())
+	opts := fake.superProducerOptions(testSuperStream)
+	require.NotNil(t, opts)
+	strategy, ok := opts.RoutingStrategy.(*stream.HashRoutingStrategy)
+	require.True(t, ok, "hash routing is the only strategy offered")
+
+	registered := amqp.NewMessage([]byte(testBody))
+	decl.Publisher.pending.add(registered, testRoutingKey)
+	assert.Equal(t, testRoutingKey, strategy.RoutingKeyExtractor(registered),
+		"the extractor answers the key the caller registered with that exact message")
+
 	assert.Equal(t, []*Publisher{decl.Publisher}, m.publishers)
 	assert.Equal(t, ha.StatusOpen, decl.Publisher.status())
 }
@@ -1397,14 +1390,13 @@ func TestManagerBindPublisherBuildsASuperProducerForASuperTarget(t *testing.T) {
 // that dispatch, and would fail if the two constructors were ever swapped.
 func TestManagerBindPublisherBuildsAPlainProducerForAPlainTarget(t *testing.T) {
 	m := testManager(t)
-	m.newSuperProducer = unreachableSuperProducer // a super bind here is the defect under test
-	handle := openProducer()
-	m.newProducer = func(*stream.Environment, string, ha.ConfirmMessageHandler) (producerHandle, error) {
-		return handle, nil
-	}
+	fake := newFakeEnvironment()
+	// A super bind here is the defect under test: it must never be reached.
+	fake.failOn(callNewSuperProducer, errProducerConstruction)
 
-	require.NoError(t, m.bindPublisher(nil, onePublisherDeclaration(t)))
+	require.NoError(t, m.bindPublisher(fake, onePublisherDeclaration(t)))
 
+	assert.Equal(t, []string{callNewProducer + ":" + testStream}, fake.recorded())
 	require.Len(t, m.publishers, 1)
 	assert.Equal(t, ha.StatusOpen, m.publishers[0].status())
 }

--- a/messaging/streams/manager_test.go
+++ b/messaging/streams/manager_test.go
@@ -236,22 +236,6 @@ func testManager(t *testing.T) *Manager {
 	})
 }
 
-// attach wires a fake consumer into a manager as if Start had created it: one
-// stream, whose flush target is the handle itself — the plain lane's shape. Its
-// last caller is a publisher test, retired in the follow-up commit.
-func attach(m *Manager, handle *fakeHandle, tracker *offsetTracker) {
-	book := bookOf(tracker)
-	book.trackerFor(testStream)
-	m.consumers = append(m.consumers, &runningConsumer{
-		stream:    testStream,
-		name:      testConsumerName,
-		handle:    handle,
-		offsets:   book,
-		storerFor: func(string) offsetStorer { return handle },
-	})
-	m.started = true
-}
-
 // TestManagerStopConsumersFlushesEveryTrackedStream extends the shutdown flush to
 // a consumer that tracks more than one stream: every partition's pending offset is
 // committed through the storer that reaches it, and only then is the consumer
@@ -1189,20 +1173,6 @@ func TestManagerCloseEnvLockedIsIdempotent(t *testing.T) {
 	assert.Nil(t, m.env)
 }
 
-// attachPublisher wires a fake producer into a manager as if Start had bound it.
-func attachPublisher(m *Manager, handle *fakeProducer) *Publisher {
-	return rebindPublisher(m, newPublisher(testStream, false), handle)
-}
-
-// rebindPublisher binds an EXISTING publisher to a new producer, which is what a
-// second Manager.Start does to the handle a module has held since declaration.
-func rebindPublisher(m *Manager, p *Publisher, handle *fakeProducer) *Publisher {
-	p.bind(handle)
-	m.publishers = append(m.publishers, p)
-	m.started = true
-	return p
-}
-
 // twoPublishers declares a pair so the fan-out has a second iteration to reach —
 // with one declaration, stopping early and running to completion look identical.
 func twoPublishers(t *testing.T) *Declarations {
@@ -1462,13 +1432,19 @@ func TestManagerRoutingKeyExtractorReportsAnUnregisteredMessage(t *testing.T) {
 // the consumers rather than the other way round.
 func TestManagerStopClosesPublishersAfterConsumers(t *testing.T) {
 	m := testManager(t)
+	fake := newFakeEnvironment()
 
 	var order []string
-	consumer := &fakeHandle{status: ha.StatusOpen, onClose: func() { order = append(order, "consumer") }}
-	attach(m, consumer, newOffsetTracker(1000, time.Hour, nil))
 	producer := openProducer()
 	producer.onClose = func() { order = append(order, "publisher") }
-	attachPublisher(m, producer)
+	fake.useProducer(producer)
+
+	decls := oneConsumerDecls()
+	decls.DeclarePublisher(&PublisherOptions{Stream: testStream})
+	startOnFake(t, m, fake, decls)
+	consumer := fake.consumer(testStream)
+	require.NotNil(t, consumer)
+	consumer.events.onClose = func() { order = append(order, "consumer") }
 
 	m.StopConsumers()
 
@@ -1482,8 +1458,13 @@ func TestManagerStopClosesPublishersAfterConsumers(t *testing.T) {
 // sweep the caller would hang for the whole shutdown.
 func TestManagerStopFailsAnInFlightPublish(t *testing.T) {
 	m := testManager(t)
+	fake := newFakeEnvironment()
 	producer := blockingProducer(t)
-	p := attachPublisher(m, producer)
+	fake.useProducer(producer)
+
+	decls := onePublisher(t)
+	startOnFake(t, m, fake, decls)
+	p := decls.publishers[0].Publisher
 
 	done := publishAsync(context.Background(), p, &PublishMessage{Data: []byte(testBody)})
 	waitForSend(t, producer)
@@ -1498,9 +1479,11 @@ func TestManagerStopFailsAnInFlightPublish(t *testing.T) {
 func TestManagerStopReportsAPublisherCloseFailure(t *testing.T) {
 	log := &recordingLogger{}
 	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: log})
+	fake := newFakeEnvironment()
 	producer := openProducer()
 	producer.closeErr = errors.New("close failed")
-	attachPublisher(m, producer)
+	fake.useProducer(producer)
+	startOnFake(t, m, fake, onePublisher(t))
 
 	assert.NotPanics(t, m.StopConsumers)
 
@@ -1513,7 +1496,8 @@ func TestManagerStopReportsAPublisherCloseFailure(t *testing.T) {
 func TestManagerStopIsSilentOnACleanPublisherClose(t *testing.T) {
 	log := &recordingLogger{}
 	m := NewManager(ManagerOptions{URI: unreachableTestURI, Logger: log})
-	attachPublisher(m, openProducer())
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, onePublisher(t))
 
 	m.StopConsumers()
 
@@ -1536,7 +1520,9 @@ func TestManagerReadyRequiresEveryPublisher(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := testManager(t)
-			attachPublisher(m, &fakeProducer{status: tt.status})
+			fake := newFakeEnvironment()
+			fake.useProducer(&fakeProducer{status: tt.status})
+			startOnFake(t, m, fake, onePublisher(t))
 
 			assert.Equal(t, tt.want, m.Ready())
 		})
@@ -1545,7 +1531,8 @@ func TestManagerReadyRequiresEveryPublisher(t *testing.T) {
 
 func TestManagerStatsCountsPublishers(t *testing.T) {
 	m := testManager(t)
-	attachPublisher(m, openProducer())
+	fake := newFakeEnvironment()
+	startOnFake(t, m, fake, onePublisher(t))
 
 	stats := m.Stats()
 
@@ -1561,16 +1548,24 @@ func TestManagerStatsCountsPublishers(t *testing.T) {
 // so the rebind has to reopen it or the second Start comes up publishing nothing.
 func TestManagerRebindRevivesAPublisherAfterAStopCycle(t *testing.T) {
 	m := testManager(t)
+	decls := onePublisher(t)
+	p := decls.publishers[0].Publisher
+
+	firstEnv := newFakeEnvironment()
 	first := openProducer()
-	p := attachPublisher(m, first)
+	firstEnv.useProducer(first)
+	startOnFake(t, m, firstEnv, decls)
 
 	m.StopConsumers()
+	require.NoError(t, m.Close())
 
 	require.ErrorIs(t, p.Publish(context.Background(), &PublishMessage{Data: []byte(testBody)}), ErrPublisherClosed)
 	assert.False(t, m.Ready(), "a stopped manager is not ready")
 
+	secondEnv := newFakeEnvironment()
 	second := openProducer()
-	rebindPublisher(m, p, second)
+	secondEnv.useProducer(second)
+	startOnFake(t, m, secondEnv, decls)
 
 	assert.True(t, m.Ready(), "the second start comes up ready")
 	publishConfirmed(t, p, second, &PublishMessage{Data: []byte(testBody)})

--- a/messaging/streams/runner.go
+++ b/messaging/streams/runner.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
-	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
@@ -221,21 +220,18 @@ type consumerRunner struct {
 	baseCtx context.Context // NOSONAR S8242: no parameter to pass it through - the vendor callback signature is fixed
 }
 
-// messagesHandler is the callback handed to the stream client. The client invokes
-// it sequentially per STREAM — which for a super stream means per partition, where
-// one runner serves every partition and the client calls this from one goroutine
-// each, concurrently. The framework keeps that shape: handlers run inline with no
-// worker pool, because a stream is an ordered log and parallelism *within* one
-// would break that order and make a committed offset claim messages behind it were
-// handled. Anything reachable from here that is not per-stream state must
-// therefore be safe for concurrent use — the offset book is, precisely because it
-// hands each stream its own tracker.
-func (r *consumerRunner) messagesHandler(consumerContext stream.ConsumerContext, message *amqp.Message) {
-	consumer := consumerContext.Consumer
-	r.deliver(consumer.GetStreamName(), consumer.GetOffset(), message, consumer)
-}
-
 // deliver runs the handler for one message, then applies the commit policy.
+// store is the consumer that delivered it, which is what the in-flight commit
+// goes through.
+//
+// The client invokes this sequentially per STREAM — which for a super stream
+// means per partition, where one runner serves every partition and the client
+// calls it from one goroutine each, concurrently. The framework keeps that shape:
+// handlers run inline with no worker pool, because a stream is an ordered log and
+// parallelism *within* one would break that order and make a committed offset
+// claim messages behind it were handled. Anything reachable from here that is not
+// per-stream state must therefore be safe for concurrent use — the offset book
+// is, precisely because it hands each stream its own tracker.
 func (r *consumerRunner) deliver(streamName string, offset int64, message *amqp.Message, store offsetStorer) {
 	ctx, span := r.tracer.Start(r.baseCtx, streamName+" "+spanOperationReceive,
 		trace.WithSpanKind(trace.SpanKindConsumer))

--- a/messaging/streams/streams_integration_test.go
+++ b/messaging/streams/streams_integration_test.go
@@ -620,12 +620,15 @@ func TestStreamsManagerSingleActiveConsumerIntegration(t *testing.T) {
 		"promotion resolves the stored offset, not the declared start position")
 }
 
-// TestStreamsManagerDisposesEnvironmentOnDeclareFailureIntegration exercises a real
-// post-dial failure: re-declaring an existing stream with different retention makes
-// the broker answer precondition-failed, so Start fails with the environment already
-// dialed. Manager is exported API, so a caller that treats that error as fatal
-// without calling Close must not leak the connection pool.
-func TestStreamsManagerDisposesEnvironmentOnDeclareFailureIntegration(t *testing.T) {
+// TestStreamsManagerRejectsAConflictingRetentionIntegration is what only a broker
+// can answer: re-declaring an existing stream with different retention really is
+// answered with precondition-failed, so Start fails after the dial.
+//
+// The unwind that failure triggers — environment disposed, started false, the
+// caller's follow-up Close a no-op — is asserted in process against the
+// Environment port by TestManagerStartUnwindsAFailedDeclaration, so it is not
+// repeated here.
+func TestStreamsManagerRejectsAConflictingRetentionIntegration(t *testing.T) {
 	ctx := context.Background()
 	opts := streamsTestEnv(ctx, t)
 
@@ -645,9 +648,7 @@ func TestStreamsManagerDisposesEnvironmentOnDeclareFailureIntegration(t *testing
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to declare stream")
-	assert.Nil(t, second.env, "the dialed environment is disposed by the failed Start itself")
-	assert.False(t, second.started)
-	require.NoError(t, second.Close(), "the caller's follow-up Close short-circuits instead of double-closing")
+	require.NoError(t, second.Close())
 }
 
 // TestStreamsPublisherRoundTripIntegration is the proof of the correlation

--- a/wiki/adr_063_streams_native_publishing.md
+++ b/wiki/adr_063_streams_native_publishing.md
@@ -58,7 +58,7 @@ publishing ID is needed.
 This holds **only at the client's default `SubEntrySize` of 1** (`producer.go:219`). Sub-entry
 aggregation would batch several messages behind one entry and break the one-to-one mapping, so on the
 plain lane the production producer options are the client's defaults verbatim — no `Name`, no
-`SubEntrySize`, no compression — and `messaging/streams/manager.go`'s `newReliableProducer` carries
+`SubEntrySize`, no compression — and `messaging/streams/manager.go`'s `constructProducer` carries
 that note at the call site.
 
 The super lane reaches the same guarantee by a different route, which is worth stating because the
@@ -186,7 +186,7 @@ which is the known limitation above.
 `context.Background()` to `Publish` can wait for as long as the broker takes. Only an HTTP handler
 inherits a deadline for free — `server.timeout.middleware`, 5 s by default. Every other caller this
 lane attracts carries none: a stream consumer handler runs under `consumeContext`
-(`manager.go:249-251`), which is `context.WithCancel(context.WithoutCancel(ctx))` and therefore has no
+(`manager.go`'s `consumeContext`), which is `context.WithCancel(context.WithoutCancel(ctx))` and therefore has no
 deadline at all, and scheduled jobs and relays are the same. A consumer republishing downstream is the
 likeliest publisher on this lane and the one with nothing to inherit, so it must pass a deadline of
 its own.

--- a/wiki/adr_063_streams_native_publishing.md
+++ b/wiki/adr_063_streams_native_publishing.md
@@ -154,8 +154,9 @@ the reason it is the only strategy offered.
 ### Shape follows the consume side
 
 Publishers reach the broker through the same `producerHandle` seam pattern the consumers use, so the
-confirmation-correlation policy is testable without a broker; the vendor constructors sit behind
-factory fields for the same reason. No `ModuleDeps` field is added — a module holds the handle its own
+confirmation-correlation policy is testable without a broker; the vendor constructors are reached
+through the manager's Environment port for the same reason (originally two factory fields, folded
+into the port when it landed). No `ModuleDeps` field is added — a module holds the handle its own
 `DeclareStreams` returned. Publishers count towards `Manager.Ready()` and `Stats()` alongside
 consumers, on the same non-critical probe. Metrics and spans reuse the AMQP lane's instruments and the
 `go-bricks/messaging` tracer, and trace context is injected through the framework's own `trace`


### PR DESCRIPTION
## What

`messaging/streams.Manager` called the vendor `*stream.Environment` directly, so lifecycle assertions needed a broker or the `attach*` helpers that built manager state by hand. The manager now goes through an unexported Environment port (`environment.go`: declare, query/store offset, consumer and producer construction, close), with the vendor adapter behind it and a scriptable fake in tests. No commit path moves — the delivering consumer still travels with each delivery as the in-flight offset storer, and the shutdown flush still resolves through the tracked consumer.

## Impact

No consumer change: no exported symbol moves; ADR-059/063 semantics untouched. The `attach*` helpers are gone — every test builds state through `Start`; one container test shrank to its broker-only half.

## Verification

Diff-scoped mutation gate on the changed lines; the in-process `Start` suite ran `-race -count=3`; commit paths checked against the vendor source (`consumerContext.Consumer`, `ha.ReliableConsumer.StoreCustomOffset`) with a compile-time guard added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream startup and shutdown cleanup when initialization or declarations fail.
  * Improved offset handling during active processing and shutdown, including timeout and cancellation scenarios.
  * Improved cancellation handling during stream startup.
  * Clarified delivery behavior across streams and partitions.

* **Documentation**
  * Updated stream architecture documentation to reflect current publishing and consumption behavior.

* **Tests**
  * Expanded coverage for stream lifecycle management, offset handling, publishing, rebinding, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->