### PR TITLE
refactor(app): run the start and stop phases through the slots

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -83,8 +83,10 @@ type App struct {
 	// Messaging declarations, collected once at startup and replayed per tenant
 	messagingDeclarations *messaging.Declarations
 
-	// streamsManager is created during prepareRuntime — never at build time — so
-	// its readiness probe and closer are registered there too (see streams_setup.go).
+	// streamsManager is created during prepareRuntime — never at build time — so its
+	// closer is registered by streamsSlot.start (slot.go) and its readiness probe by
+	// prepareRuntime's post-start probe re-collect (lifecycle.go), not by the build-time
+	// slot walks.
 	streamsManager *streams.Manager
 
 	closers      []namedCloser

--- a/app/app.go
+++ b/app/app.go
@@ -83,10 +83,8 @@ type App struct {
 	// Messaging declarations, collected once at startup and replayed per tenant
 	messagingDeclarations *messaging.Declarations
 
-	// streamsManager is created during prepareRuntime — never at build time — so its
-	// closer is registered by streamsSlot.start (slot.go) and its readiness probe by
-	// prepareRuntime's post-start probe re-collect (lifecycle.go), not by the build-time
-	// slot walks.
+	// streamsManager exists only from prepareRuntime onward; see streamsSlot in slot.go
+	// for why its probe and closer are registered separately from the build-time walks.
 	streamsManager *streams.Manager
 
 	closers      []namedCloser

--- a/app/app_builder.go
+++ b/app/app_builder.go
@@ -285,11 +285,11 @@ func (b *Builder) ConfigureRuntimeHelpers() *Builder {
 // should fail fast), while the cache stays best-effort, because an unreachable cache is a
 // runtime condition — cache *misconfiguration* already aborted earlier, at manager
 // construction (CreateCacheManager).
-// requireSlots is the precondition every slot walk shares: CreateApp installed the slot list.
-// An empty walk would silently register no probe, no closer and pre-initialize nothing.
+// requireSlots is the Builder-side half of App.requireSlots: it records the failure on
+// b.err (the Builder's error-accumulation convention) instead of returning it.
 func (b *Builder) requireSlots(step string) bool {
-	if len(b.app.slots) == 0 {
-		b.err = fmt.Errorf("slots not installed before %s — CreateApp must run first", step)
+	if err := b.app.requireSlots(step); err != nil {
+		b.err = err
 		return false
 	}
 	return true
@@ -330,7 +330,9 @@ func (b *Builder) performPreInitialization() {
 	}
 }
 
-// CreateHealthProbes creates health check probes for all managers.
+// CreateHealthProbes creates health check probes for all managers. prepareRuntime
+// re-collects the set after the start phase (streamsSlot.probe, slot.go), so this
+// build-time list is only what an App built but never Run would report.
 func (b *Builder) CreateHealthProbes() *Builder {
 	if b.err != nil {
 		return b

--- a/app/debug_handlers_test.go
+++ b/app/debug_handlers_test.go
@@ -314,6 +314,21 @@ func loggedMsgContains(rec *recLogger, substr string) bool {
 	return ok
 }
 
+// loggedCount reports how many log lines rec recorded whose message contains
+// substr — the "exactly once" form of loggedEvent, for call sites that must tell
+// one emission of a line apart from two.
+func loggedCount(rec *recLogger, substr string) int {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	n := 0
+	for _, e := range rec.events {
+		if strings.Contains(e.msg, substr) {
+			n++
+		}
+	}
+	return n
+}
+
 // debugProbe is one request issued against a registered debug group: the peer address and
 // Authorization header it carries, and the HTTP status the access-control chain must answer.
 type debugProbe struct {

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -69,11 +69,8 @@ func (a *App) warnIfCleanupIntervalTooLate(keyPrefix string, cleanupInterval, id
 // and are stopped by the messaging slot's stop phase (ADR-029), so they inherit
 // only ctx's values, never its cancellation — see messagingSlot.start.
 func (a *App) prepareRuntime(ctx context.Context) error {
-	// Mirrors Builder.requireSlots: an empty walk would start no kind at all and then
-	// overwrite the probe list with an empty one, booting a service green with no database,
-	// no consumers and a /ready body that reports nothing.
-	if len(a.slots) == 0 {
-		return errors.New("slots not installed before prepareRuntime — CreateApp must run first")
+	if err := a.requireSlots("prepareRuntime"); err != nil {
+		return err
 	}
 
 	if err := a.buildMessagingDeclarations(); err != nil {
@@ -88,9 +85,8 @@ func (a *App) prepareRuntime(ctx context.Context) error {
 		return err
 	}
 
-	// The streams slot only builds its manager in start, so the probe set is collected again
-	// here rather than at build time. Safe because prepareRuntime is single-threaded and
-	// completes before the server starts serving /ready.
+	// Re-collected here because the streams slot only builds its manager in start; see
+	// streamsSlot.probe in slot.go.
 	a.healthProbes = a.collectProbes()
 
 	// Register debug endpoints if enabled

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -66,37 +66,25 @@ func (a *App) warnIfCleanupIntervalTooLate(keyPrefix string, cleanupInterval, id
 // startup context: components it starts that outlive startup inherit that
 // context's values rather than beginning from a bare context.Background().
 // AMQP consumers are the one exception: they outlive prepareRuntime itself
-// and are stopped by shutdownConsumers (ADR-029), so they inherit only ctx's
-// values, never its cancellation.
+// and are stopped by the messaging slot's stop phase (ADR-029), so they inherit
+// only ctx's values, never its cancellation — see messagingSlot.start.
 func (a *App) prepareRuntime(ctx context.Context) error {
 	if err := a.buildMessagingDeclarations(); err != nil {
 		return err
 	}
 
-	decls := a.messagingDeclarations
-
-	if err := a.assertMessagingConfiguredIfDeclared(decls); err != nil {
+	if err := a.assertMessagingConfiguredIfDeclared(a.messagingDeclarations); err != nil {
 		return err
 	}
 
-	// Values only, no cancellation: consumers outlive prepareRuntime and are stopped by
-	// shutdownConsumers (ADR-029), never by the startup context.
-	if err := a.prepareRuntimeConsumers(context.WithoutCancel(ctx), decls); err != nil {
+	if err := a.startSlots(ctx); err != nil {
 		return err
 	}
 
-	if err := a.prepareStreamConsumers(ctx); err != nil {
-		return err
-	}
-
-	// Single-tenant only — preWarmSingleTenant is a safe no-op when neither manager
-	// was built (attemptDatabasePreWarm/attemptMessagingPreWarm nil-check their own
-	// manager and DEBUG-log "unavailable").
-	if !a.cfg.Multitenant.Enabled {
-		if err := a.preWarmSingleTenant(ctx, decls); err != nil {
-			a.logger.Warn().Err(err).Msg("Pre-warming completed with warnings")
-		}
-	}
+	// The streams slot only builds its manager in start, so the probe set is collected again
+	// here rather than at build time. Safe because prepareRuntime is single-threaded and
+	// completes before the server starts serving /ready.
+	a.healthProbes = a.collectProbes()
 
 	// Register debug endpoints if enabled
 	if err := a.registerDebugHandlers(); err != nil {
@@ -119,6 +107,38 @@ func (a *App) prepareRuntime(ctx context.Context) error {
 	a.startMaintenanceLoops()
 
 	return nil
+}
+
+// startSlots runs every kind's start phase in registration order. A fatal error aborts
+// startup at the kind that reported it, so nothing after it runs. Advisory errors — the
+// best-effort single-tenant pre-warms — are aggregated into the one WARN prepareRuntime has
+// always emitted, and never fail startup.
+func (a *App) startSlots(ctx context.Context) error {
+	var advisories []error
+	for _, slot := range a.slots {
+		advisory, fatal := slot.start(ctx)
+		if fatal != nil {
+			return fatal
+		}
+		if advisory != nil {
+			advisories = append(advisories, advisory)
+		}
+	}
+
+	if len(advisories) > 0 {
+		a.logger.Warn().
+			Err(fmt.Errorf("pre-warming issues (non-fatal): %w", errors.Join(advisories...))).
+			Msg("Pre-warming completed with warnings")
+	}
+	return nil
+}
+
+// stopSlots halts every kind's inbound work in registration order, before modules are torn
+// down (ADR-029). Connections stay open — the close phase, after module Shutdown, owns those.
+func (a *App) stopSlots(ctx context.Context) {
+	for _, slot := range a.slots {
+		slot.stop(ctx)
+	}
 }
 
 // checkRouteConflicts fails startup when two registrations claimed the same
@@ -492,11 +512,10 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}, &errs)
 	}
 
-	// 2. Stop AMQP consumers from accepting new messages (connections are closed later via
-	//    the messaging-manager closer). Done before module shutdown so the framework stops
-	//    delivering fresh messages to modules that are about to be torn down.
-	a.shutdownConsumers()
-	a.shutdownStreamConsumers()
+	// 2. Stop each kind's inbound work (connections are closed later, in step 6, via the
+	//    slots' closers). Done before module shutdown so the framework stops delivering fresh
+	//    messages to modules that are about to be torn down.
+	a.stopSlots(ctx)
 
 	// 3. Shut down modules — no new HTTP requests or AMQP deliveries are admitted at this
 	//    point. AMQP handlers already in flight may still be unwinding after cancellation.

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -113,17 +113,24 @@ func (a *App) prepareRuntime(ctx context.Context) error {
 }
 
 // startSlots runs every kind's start phase in registration order. A fatal error aborts
-// startup at the kind that reported it, so nothing after it runs. Advisory errors — the
-// best-effort single-tenant pre-warms — are aggregated into the one WARN prepareRuntime has
-// always emitted, and never fail startup. A fatal discards advisories already collected;
-// each kind logged its own WARN.
+// startup at the kind that reported it, so nothing after it runs, and the kinds already up
+// are stopped again before it is returned. Advisory errors — the best-effort single-tenant
+// pre-warms — are aggregated into the one WARN prepareRuntime has always emitted, and never
+// fail startup. A fatal discards advisories already collected; each kind logged its own WARN.
 func (a *App) startSlots(ctx context.Context) error {
 	var advisories []error
+	started := make([]resourceSlot, 0, len(a.slots))
 	for _, slot := range a.slots {
 		advisory, fatal := slot.start(ctx)
 		if fatal != nil {
+			// The kinds already up own live inbound work — the messaging slot's consumers run
+			// under context.WithoutCancel, so the aborting startup context never reaches them —
+			// and Run returns a prepareRuntime failure without calling Shutdown. Unwinding here
+			// is the only thing that stops them.
+			stopEach(ctx, started)
 			return fatal
 		}
+		started = append(started, slot)
 		if advisory != nil {
 			advisories = append(advisories, advisory)
 		}
@@ -140,7 +147,13 @@ func (a *App) startSlots(ctx context.Context) error {
 // stopSlots halts every kind's inbound work in registration order, before modules are torn
 // down (ADR-029). Connections stay open — the close phase, after module Shutdown, owns those.
 func (a *App) stopSlots(ctx context.Context) {
-	for _, slot := range a.slots {
+	stopEach(ctx, a.slots)
+}
+
+// stopEach runs the stop phase over slots in the order given. stop never fails, so there is
+// nothing to aggregate.
+func stopEach(ctx context.Context, slots []resourceSlot) {
+	for _, slot := range slots {
 		slot.stop(ctx)
 	}
 }

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -119,7 +119,8 @@ func (a *App) prepareRuntime(ctx context.Context) error {
 // startSlots runs every kind's start phase in registration order. A fatal error aborts
 // startup at the kind that reported it, so nothing after it runs. Advisory errors — the
 // best-effort single-tenant pre-warms — are aggregated into the one WARN prepareRuntime has
-// always emitted, and never fail startup.
+// always emitted, and never fail startup. A fatal discards advisories already collected;
+// each kind logged its own WARN.
 func (a *App) startSlots(ctx context.Context) error {
 	var advisories []error
 	for _, slot := range a.slots {

--- a/app/lifecycle.go
+++ b/app/lifecycle.go
@@ -69,6 +69,13 @@ func (a *App) warnIfCleanupIntervalTooLate(keyPrefix string, cleanupInterval, id
 // and are stopped by the messaging slot's stop phase (ADR-029), so they inherit
 // only ctx's values, never its cancellation — see messagingSlot.start.
 func (a *App) prepareRuntime(ctx context.Context) error {
+	// Mirrors Builder.requireSlots: an empty walk would start no kind at all and then
+	// overwrite the probe list with an empty one, booting a service green with no database,
+	// no consumers and a /ready body that reports nothing.
+	if len(a.slots) == 0 {
+		return errors.New("slots not installed before prepareRuntime — CreateApp must run first")
+	}
+
 	if err := a.buildMessagingDeclarations(); err != nil {
 		return err
 	}
@@ -515,6 +522,8 @@ func (a *App) Shutdown(ctx context.Context) error {
 	// 2. Stop each kind's inbound work (connections are closed later, in step 6, via the
 	//    slots' closers). Done before module shutdown so the framework stops delivering fresh
 	//    messages to modules that are about to be torn down.
+	//    Deliberately unguarded, unlike prepareRuntime: teardown is best-effort and must not
+	//    fail on a hand-built App that never installed slots.
 	a.stopSlots(ctx)
 
 	// 3. Shut down modules — no new HTTP requests or AMQP deliveries are admitted at this

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -313,6 +313,28 @@ func TestPrepareRuntimeAllowsEmptyDeclarationsWithMessagingUnconfigured(t *testi
 	require.NoError(t, app.prepareRuntime(context.Background()))
 }
 
+// TestPrepareRuntimeAbortsWhenDeclaredConsumersCannotStart pins the #907 grading end to
+// end, through the two arms that carry it: messagingSlot.start must return the bootstrap
+// failure as FATAL rather than advisory, and prepareRuntime must abort on it rather than
+// continue. A service that declared consumers and cannot start them would otherwise serve
+// HTTP while consuming nothing. The absent pre-warm WARN is the discriminator: graded as
+// advisory, the failure would be swallowed into that one line and startup would succeed.
+func TestPrepareRuntimeAbortsWhenDeclaredConsumersCannotStart(t *testing.T) {
+	rec := &recLogger{}
+	a := newLifecycleCheckAppWithLogger(t, defaultTestConfig(), rec)
+	a.messagingManager = newFailingConsumerManager(t, rec, &failingBrokerURLProvider{})
+	a.messagingDeclarations = declaredConsumerFixture(t)
+
+	err := a.prepareRuntime(context.Background())
+
+	require.Error(t, err, "a declared-but-unstartable consumer set must abort startup")
+	assert.Contains(t, err.Error(), "failed to start single-tenant consumers")
+	assert.ErrorIs(t, err, errBrokerLookupFailed)
+
+	_, emitted := loggedEvent(rec, preWarmWarnMsg)
+	assert.False(t, emitted, "a fatal bootstrap aborts startup; it is never demoted to the pre-warm WARN")
+}
+
 // TestPrepareRuntimeReCollectsProbesAfterTheStartPhase pins the re-collect that replaced
 // prepareStreamConsumers' probe append. It starts from an emptied probe list so a deleted
 // re-collect cannot pass on the set the Builder already snapshotted: only the re-collect

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -241,13 +241,15 @@ func newLifecycleCheckApp(t *testing.T, cfg *config.Config) *App {
 func newLifecycleCheckAppWithLogger(t *testing.T, cfg *config.Config, log logger.Logger) *App {
 	t.Helper()
 	deps := &ModuleDeps{Logger: log, Config: cfg}
-	return &App{
+	a := &App{
 		cfg:      cfg,
 		logger:   log,
 		registry: NewModuleRegistry(deps),
 		server:   newMockServer(),
 		closers:  []namedCloser{},
 	}
+	a.installSlots(slotInputs{})
+	return a
 }
 
 // TestPrepareRuntimeFailsWhenDeclarationsExistAndMessagingUnconfigured guards
@@ -285,7 +287,7 @@ func TestPrepareRuntimeAllowsEmptyDeclarationsWithMessagingUnconfigured(t *testi
 type preWarmCtxSentinelKey struct{}
 
 // ctxRecordingDBConfigProvider captures the sentinel carried by the context that
-// reaches DBConfig — the first ctx-aware seam below preWarmSingleTenant.
+// reaches DBConfig — the first ctx-aware seam below databaseSlot.start.
 type ctxRecordingDBConfigProvider struct {
 	mu   sync.Mutex
 	seen any
@@ -299,7 +301,7 @@ func (p *ctxRecordingDBConfigProvider) DBConfig(ctx context.Context, _ string) (
 }
 
 // TestPrepareRuntimePropagatesContextToPreWarm pins that prepareRuntime hands its
-// own ctx to preWarmSingleTenant instead of a fresh context.Background(): a
+// own ctx to the start phase instead of a fresh context.Background(): a
 // sentinel value on the caller's context must survive down to the pre-warm
 // database seam. The value is the right observable because resourcepool detaches
 // cancellation with context.WithoutCancel, which preserves values — so a deadline
@@ -327,7 +329,7 @@ func TestPrepareRuntimePropagatesContextToPreWarm(t *testing.T) {
 	provider.mu.Lock()
 	defer provider.mu.Unlock()
 	assert.Equal(t, "from-prepare-runtime", provider.seen,
-		"prepareRuntime must pass its own context to preWarmSingleTenant; context.Background() drops the sentinel")
+		"prepareRuntime must pass its own context to the start phase; context.Background() drops the sentinel")
 }
 
 const (
@@ -338,7 +340,7 @@ const (
 )
 
 // staticDBConfigProvider resolves a usable single-tenant config, or fails with err
-// when set — the two outcomes that make preWarmSingleTenant succeed or return an error.
+// when set — the two outcomes that make the database pre-warm succeed or return an error.
 type staticDBConfigProvider struct{ err error }
 
 func (p staticDBConfigProvider) DBConfig(context.Context, string) (*config.DatabaseConfig, error) {
@@ -392,7 +394,7 @@ func TestPrepareRuntimeWarnsOnlyWhenPreWarmFails(t *testing.T) {
 
 			if tt.messagingOnly {
 				// dbManager stays nil: this row isolates the messagingManager-only
-				// pre-warm failure path (attemptMessagingPreWarm in prewarm.go).
+				// pre-warm failure path (messagingSlot.start in slot.go).
 				source := &failingBrokerURLProvider{}
 				a.messagingManager = newFailingConsumerManager(t, rec, source)
 				wantErrSubstring = errBrokerLookupFailed.Error()

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -313,6 +313,30 @@ func TestPrepareRuntimeAllowsEmptyDeclarationsWithMessagingUnconfigured(t *testi
 	require.NoError(t, app.prepareRuntime(context.Background()))
 }
 
+// TestStartSlotsStopsAlreadyStartedKindsOnFatal pins the unwind on a failed start phase.
+// The kinds that came up own live inbound work — the messaging slot's consumers run under
+// context.WithoutCancel, so the aborting startup context never stops them — and Run returns
+// a prepareRuntime failure straight to the caller without calling Shutdown. Without this
+// unwind a service that failed to start would keep consuming after startup gave up.
+func TestStartSlotsStopsAlreadyStartedKindsOnFatal(t *testing.T) {
+	order := []string{}
+	a := &App{logger: logger.New("error", false)}
+	a.slots = []resourceSlot{
+		&recordingSlot{kind: componentDatabase, order: &order},
+		&recordingSlot{kind: componentMessaging, order: &order},
+		&recordingSlot{kind: componentCache, order: &order},
+		&recordingSlot{kind: componentStreams, order: &order, startFatal: assert.AnError},
+	}
+
+	err := a.startSlots(context.Background())
+
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Equal(t, []string{
+		"start:database", "start:messaging", "start:cache", "start:streams",
+		"stop:database", "stop:messaging", "stop:cache",
+	}, order, "every kind that started is stopped in registration order; the kind that failed is not")
+}
+
 // TestPrepareRuntimeAbortsWhenDeclaredConsumersCannotStart pins the #907 grading end to
 // end, through the two arms that carry it: messagingSlot.start must return the bootstrap
 // failure as FATAL rather than advisory, and prepareRuntime must abort on it rather than

--- a/app/lifecycle_test.go
+++ b/app/lifecycle_test.go
@@ -112,6 +112,34 @@ func TestShutdownStopsServerBeforeModules(t *testing.T) {
 		"server must shut down before modules")
 }
 
+// TestShutdownStopsSlotsBeforeModules pins that the stop walk is wired into Shutdown at
+// all, and that ADR-029's order survives: every kind's inbound work is halted before any
+// module is torn down, so no module receives fresh work while it is shutting down. The
+// recording slots stand in for the real kinds because the property under test is the ORDER
+// of the two phases, not what either one does.
+func TestShutdownStopsSlotsBeforeModules(t *testing.T) {
+	order := []string{}
+	log := logger.New("error", false)
+	cfg := &config.Config{App: config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"}}
+	a := &App{
+		cfg:      cfg,
+		logger:   log,
+		registry: NewModuleRegistry(&ModuleDeps{Logger: log, Config: cfg}),
+		closers:  []namedCloser{},
+	}
+	a.slots = []resourceSlot{
+		&recordingSlot{kind: componentMessaging, order: &order},
+		&recordingSlot{kind: componentStreams, order: &order},
+	}
+	require.NoError(t, a.registry.Register(&recordingModule{onShutdown: func() {
+		order = append(order, "modules")
+	}}))
+
+	require.NoError(t, a.Shutdown(context.Background()))
+
+	assert.Equal(t, []string{"stop:messaging", "stop:streams", "modules"}, order)
+}
+
 func TestShutdownTiming(t *testing.T) {
 	// Test that the shutdown process completes within reasonable time
 	cfg := &config.Config{
@@ -199,6 +227,7 @@ func TestPrepareRuntimeWithScheduler(t *testing.T) {
 		server:   mockSrv,
 		closers:  []namedCloser{},
 	}
+	app.installSlots(slotInputs{})
 
 	// Call prepareRuntime
 	err = app.prepareRuntime(context.Background())
@@ -282,6 +311,47 @@ func TestPrepareRuntimeAllowsEmptyDeclarationsWithMessagingUnconfigured(t *testi
 	app := newLifecycleCheckApp(t, cfg)
 
 	require.NoError(t, app.prepareRuntime(context.Background()))
+}
+
+// TestPrepareRuntimeReCollectsProbesAfterTheStartPhase pins the re-collect that replaced
+// prepareStreamConsumers' probe append. It starts from an emptied probe list so a deleted
+// re-collect cannot pass on the set the Builder already snapshotted: only the re-collect
+// can put the classic kinds back.
+func TestPrepareRuntimeReCollectsProbesAfterTheStartPhase(t *testing.T) {
+	cfg := &config.Config{
+		App:         config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"},
+		Multitenant: config.MultitenantConfig{Enabled: false},
+	}
+	a := newLifecycleCheckApp(t, cfg)
+	a.healthProbes = nil
+
+	require.NoError(t, a.prepareRuntime(context.Background()))
+
+	assert.Equal(t,
+		[]string{componentDatabase, componentMessaging, componentCache},
+		probeNames(t, a.healthProbes),
+		"the start phase must be followed by a fresh probe collection")
+}
+
+// TestPrepareRuntimeRequiresInstalledSlots pins the fail-fast half of the walk's
+// precondition, mirroring Builder.requireSlots. Without it a slot-less App would start no
+// kind at all and then overwrite its probe list with an empty one — a service booting green
+// with no database, no consumers and a /ready body that reports nothing.
+func TestPrepareRuntimeRequiresInstalledSlots(t *testing.T) {
+	cfg := &config.Config{App: config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"}}
+	log := logger.New("error", false)
+	a := &App{
+		cfg:      cfg,
+		logger:   log,
+		registry: NewModuleRegistry(&ModuleDeps{Logger: log, Config: cfg}),
+		server:   newMockServer(),
+		closers:  []namedCloser{},
+	} // deliberately no installSlots
+
+	err := a.prepareRuntime(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "slots not installed before prepareRuntime")
 }
 
 type preWarmCtxSentinelKey struct{}
@@ -972,9 +1042,9 @@ func runReadyCheck(t *testing.T, app *App, cfg *config.Config) (body map[string]
 }
 
 // TestReadyCheckOmitsStreamsWhenNoneDeclared pins that a streams-free probe set renders
-// neither streams key: the kind reaches the body only where prepareStreamConsumers
-// registered its probe. The probe set is the real one, so the classic kinds render and the
-// two assertions below are not passing on an empty body.
+// neither streams key: the kind reaches the body only via the probe re-collect that
+// prepareRuntime runs after the start phase. The probe set is the real one, so the classic
+// kinds render and the two assertions below are not passing on an empty body.
 func TestReadyCheckOmitsStreamsWhenNoneDeclared(t *testing.T) {
 	cfg := &config.Config{App: config.AppConfig{Name: testApp, Env: "test", Version: "1.0.0"}}
 	app := &App{cfg: cfg, logger: logger.New("error", false)}

--- a/app/messaging_setup_test.go
+++ b/app/messaging_setup_test.go
@@ -25,13 +25,16 @@ func (m *simpleTestModule) Shutdown() error          { return nil }
 
 // newMinimalMessagingApp builds the minimal App shared by the pre-warm and
 // consumer-bootstrap test suites: a logger, the messaging manager under test,
-// and the config each call site cares about.
+// and the config each call site cares about, with the slots installed so the
+// start phase is reachable.
 func newMinimalMessagingApp(log logger.Logger, manager *messaging.Manager, cfg *config.Config) *App {
-	return &App{
+	a := &App{
 		logger:           log,
 		messagingManager: manager,
 		cfg:              cfg,
 	}
+	a.installSlots(slotInputs{})
+	return a
 }
 
 // errBrokerLookupFailed stands in for the broker-config and broker-availability

--- a/app/prewarm.go
+++ b/app/prewarm.go
@@ -34,17 +34,11 @@ func (a *App) preWarmDatabase(ctx context.Context) error {
 	return nil
 }
 
-// preWarmMessaging ensures consumers for the fixed "" key and waits, bounded, for the
-// publisher to report ready. messagingSlot.start holds the manager nil check and the
-// deployment-mode gate.
-func (a *App) preWarmMessaging(ctx context.Context, decls *messaging.Declarations) error {
-	if decls != nil {
-		if err := a.messagingManager.EnsureConsumers(ctx, "", decls); err != nil {
-			return fmt.Errorf("failed to ensure consumers: %w", err)
-		}
-		a.logger.Info().Msg("Ensured messaging consumers")
-	}
-
+// preWarmMessaging waits, bounded, for the fixed "" key's publisher to report ready. It
+// verifies publisher connectivity only: the consumer bootstrap lives once, in
+// prepareRuntimeConsumers, which the messaging slot's start runs before this.
+// messagingSlot.start holds the manager nil check and the deployment-mode gate.
+func (a *App) preWarmMessaging(ctx context.Context) error {
 	client, release, err := a.messagingManager.Publisher(ctx, "")
 	if err != nil {
 		return fmt.Errorf("failed to get publisher: %w", err)

--- a/app/prewarm.go
+++ b/app/prewarm.go
@@ -2,11 +2,9 @@ package app
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
-	"github.com/gaborage/go-bricks/config"
 	"github.com/gaborage/go-bricks/messaging"
 )
 
@@ -25,69 +23,8 @@ const defaultPreWarmReadinessTimeout = 5 * time.Second
 // constant just for this.
 const preWarmReadinessPollInterval = 100 * time.Millisecond
 
-// preWarmSingleTenant pre-warms connections for single-tenant deployments.
-// It establishes database connections and messaging consumers/publishers upfront.
-// Errors are logged as warnings and don't cause startup failure.
-func (a *App) preWarmSingleTenant(ctx context.Context, decls *messaging.Declarations) error {
-	var errs []error
-
-	errs = a.attemptDatabasePreWarm(ctx, errs)
-	errs = a.attemptMessagingPreWarm(ctx, decls, errs)
-
-	// Return combined errors but don't fail startup
-	if len(errs) > 0 {
-		return fmt.Errorf("pre-warming issues (non-fatal): %w", errors.Join(errs...))
-	}
-
-	return nil
-}
-
-// attemptDatabasePreWarm attempts to pre-warm the database connection.
-func (a *App) attemptDatabasePreWarm(ctx context.Context, errs []error) []error {
-	if a.dbManager == nil {
-		a.logger.Debug().Msg("Skipping single-tenant database pre-warming: manager unavailable")
-		return errs
-	}
-
-	if err := a.preWarmDatabase(ctx); err != nil {
-		// Check if error is due to database not being configured
-		if config.IsNotConfigured(err) {
-			a.logger.Debug().Msg("Skipping single-tenant database pre-warming: not configured")
-		} else {
-			a.logger.Warn().Err(err).Msg("Failed to pre-warm single-tenant database connection")
-			errs = append(errs, fmt.Errorf("database pre-warming failed: %w", err))
-		}
-	} else {
-		a.logger.Info().Msg("Pre-warmed single-tenant database connection")
-	}
-
-	return errs
-}
-
-// attemptMessagingPreWarm attempts to pre-warm messaging components.
-func (a *App) attemptMessagingPreWarm(ctx context.Context, decls *messaging.Declarations, errs []error) []error {
-	if a.messagingManager == nil {
-		a.logger.Debug().Msg("Skipping single-tenant messaging pre-warming: manager unavailable")
-		return errs
-	}
-
-	if err := a.preWarmMessaging(ctx, decls); err != nil {
-		// Check if error is due to messaging not being configured
-		if config.IsNotConfigured(err) {
-			a.logger.Debug().Msg("Skipping single-tenant messaging pre-warming: not configured")
-		} else {
-			a.logger.Warn().Err(err).Msg("Failed to pre-warm single-tenant messaging")
-			errs = append(errs, fmt.Errorf("messaging pre-warming failed: %w", err))
-		}
-	} else {
-		a.logger.Info().Msg("Pre-warmed single-tenant messaging")
-	}
-
-	return errs
-}
-
 // preWarmDatabase leases the fixed "" key to verify connectivity and releases it
-// immediately. attemptDatabasePreWarm holds the manager nil check.
+// immediately. databaseSlot.start holds the manager nil check and the deployment-mode gate.
 func (a *App) preWarmDatabase(ctx context.Context) error {
 	_, release, err := a.dbManager.Get(ctx, "")
 	if err != nil {
@@ -98,7 +35,8 @@ func (a *App) preWarmDatabase(ctx context.Context) error {
 }
 
 // preWarmMessaging ensures consumers for the fixed "" key and waits, bounded, for the
-// publisher to report ready. attemptMessagingPreWarm holds the manager nil check.
+// publisher to report ready. messagingSlot.start holds the manager nil check and the
+// deployment-mode gate.
 func (a *App) preWarmMessaging(ctx context.Context, decls *messaging.Declarations) error {
 	if decls != nil {
 		if err := a.messagingManager.EnsureConsumers(ctx, "", decls); err != nil {

--- a/app/prewarm_test.go
+++ b/app/prewarm_test.go
@@ -145,7 +145,7 @@ func TestMessagingSlotStartAwaitsPublisherReadiness(t *testing.T) {
 	}()
 
 	start := time.Now()
-	err, fatal := a.slots[1].start(context.Background())
+	err, fatal := slotOf(t, a, componentMessaging).start(context.Background())
 	elapsed := time.Since(start)
 
 	require.NoError(t, fatal, "pre-warming is never fatal")
@@ -167,7 +167,7 @@ func TestMessagingSlotStartContinuesWhenPublisherNeverReady(t *testing.T) {
 	})
 
 	start := time.Now()
-	err, fatal := a.slots[1].start(context.Background())
+	err, fatal := slotOf(t, a, componentMessaging).start(context.Background())
 	elapsed := time.Since(start)
 
 	// Not-ready-in-time is a WARN, not a startup failure — pre-warm must not
@@ -190,7 +190,7 @@ func TestMessagingSlotStartPropagatesContextCancellation(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	err, fatal := a.slots[1].start(ctx)
+	err, fatal := slotOf(t, a, componentMessaging).start(ctx)
 	elapsed := time.Since(start)
 
 	// Cancellation means shutdown/startup abort, not a broker-readiness problem —
@@ -214,7 +214,7 @@ func declaredConsumerFixture(t *testing.T) *messaging.Declarations {
 }
 
 // TestPreWarmMessagingEnsuresDeclaredConsumers pins the success half of the
-// consumer-ensure branch in preWarmMessaging (prewarm.go:104): a manager whose
+// consumer-ensure branch in preWarmMessaging: a manager whose
 // EnsureConsumers actually succeeds must return nil and log the "Ensured
 // messaging consumers" INFO line before ever reaching the publisher. Negating
 // `err != nil` to `err == nil` there would turn this success into a spurious

--- a/app/prewarm_test.go
+++ b/app/prewarm_test.go
@@ -203,8 +203,8 @@ func TestMessagingSlotStartPropagatesContextCancellation(t *testing.T) {
 // declaredConsumerFixture returns declarationsWithConsumer() (see
 // messaging_setup_test.go) plus the queue its one consumer references, so
 // Declarations.Validate() — which rejects a consumer pointing at an
-// unregistered queue — accepts it. Shared by both preWarmMessaging tests
-// below, which need a non-nil, non-empty, genuinely valid declaration set.
+// unregistered queue — accepts it. Shared by every call site that needs a
+// non-nil, non-empty, genuinely valid declaration set.
 func declaredConsumerFixture(t *testing.T) *messaging.Declarations {
 	t.Helper()
 	decls := declarationsWithConsumer()
@@ -213,13 +213,24 @@ func declaredConsumerFixture(t *testing.T) *messaging.Declarations {
 	return decls
 }
 
-// TestPreWarmMessagingEnsuresDeclaredConsumers pins the success half of the
-// consumer-ensure branch in preWarmMessaging: a manager whose
-// EnsureConsumers actually succeeds must return nil and log the "Ensured
-// messaging consumers" INFO line before ever reaching the publisher. Negating
-// `err != nil` to `err == nil` there would turn this success into a spurious
-// error and skip the log line — see also the failure-side pin below.
-func TestPreWarmMessagingEnsuresDeclaredConsumers(t *testing.T) {
+// consumerBootstrapAnnouncements counts the app-layer lines announcing a consumer
+// bootstrap: the surviving one prepareRuntimeConsumers emits, plus the retired one
+// preWarmMessaging emitted from its own second EnsureConsumers call. The mock client's
+// ConsumeFromQueue count cannot stand in for it — the manager's replay cache absorbs a
+// duplicate EnsureConsumers silently, so the broker-facing calls read 1 whether the
+// bootstrap ran once or twice.
+func consumerBootstrapAnnouncements(rec *recLogger) int {
+	return loggedCount(rec, "Single-tenant consumers started successfully") +
+		loggedCount(rec, "Ensured messaging consumers")
+}
+
+// TestMessagingSlotStartBootstrapsConsumersOnce pins where the consumer bootstrap lives:
+// once, in prepareRuntimeConsumers. preWarmMessaging used to run EnsureConsumers a second
+// time on the way to the publisher, which announced the same bootstrap twice and left one
+// failure reachable under two different gradings — fatal from the bootstrap, advisory from
+// the pre-warm. The slot's start must now bootstrap exactly once and go straight on to
+// publisher readiness.
+func TestMessagingSlotStartBootstrapsConsumersOnce(t *testing.T) {
 	rec := &recLogger{}
 	client := testmocks.NewMockAMQPClient() // defaults to ready
 	client.ExpectClose(nil)
@@ -230,36 +241,14 @@ func TestPreWarmMessagingEnsuresDeclaredConsumers(t *testing.T) {
 	defer func() { _ = manager.Close() }()
 
 	a := newMinimalMessagingApp(rec, manager, &config.Config{})
+	a.messagingDeclarations = declaredConsumerFixture(t)
 
-	require.NoError(t, a.preWarmMessaging(context.Background(), declaredConsumerFixture(t)))
+	advisory, fatal := slotOf(t, a, componentMessaging).start(context.Background())
 
-	event, emitted := loggedEvent(rec, "Ensured messaging consumers")
-	require.True(t, emitted, "preWarmMessaging must log once EnsureConsumers succeeds")
-	assert.Equal(t, "info", event.level)
-}
-
-// TestPreWarmMessagingWrapsEnsureConsumersFailure pins the failure half of the
-// same branch: a manager whose EnsureConsumers fails must return an error
-// wrapping "failed to ensure consumers" and must never reach the publisher —
-// Publisher() re-resolves the broker URL on a cold key, so a call count stuck
-// at 1 proves it was never invoked. Negating `err != nil` to `err == nil`
-// there would swallow the failure, log the success line anyway, and fall
-// through into Publisher.
-func TestPreWarmMessagingWrapsEnsureConsumersFailure(t *testing.T) {
-	rec := &recLogger{}
-	source := &failingBrokerURLProvider{}
-	manager := newFailingConsumerManager(t, rec, source)
-	defer func() { _ = manager.Close() }()
-
-	a := newMinimalMessagingApp(rec, manager, &config.Config{})
-
-	err := a.preWarmMessaging(context.Background(), declaredConsumerFixture(t))
-
-	require.Error(t, err)
-	assert.ErrorIs(t, err, errBrokerLookupFailed)
-	assert.ErrorContains(t, err, "failed to ensure consumers")
-	assert.Equal(t, 1, source.callCount(), "Publisher must never be reached once EnsureConsumers fails")
-
-	_, emitted := loggedEvent(rec, "Ensured messaging consumers")
-	assert.False(t, emitted, "the success log must not fire when EnsureConsumers fails")
+	require.NoError(t, fatal)
+	require.NoError(t, advisory)
+	assert.Equal(t, 1, consumerBootstrapAnnouncements(rec),
+		"the consumer bootstrap runs once per start, in prepareRuntimeConsumers")
+	assert.Equal(t, 1, loggedCount(rec, "Pre-warmed messaging publisher"),
+		"the pre-warm still reaches the publisher it exists to warm")
 }

--- a/app/prewarm_test.go
+++ b/app/prewarm_test.go
@@ -40,13 +40,21 @@ func newPrewarmTestManager(log logger.Logger, client *testmocks.MockAMQPClient) 
 		messaging.ManagerOptions{MaxPublishers: 5, IdleTTL: time.Hour}, factory)
 }
 
-// TestPreWarmSingleTenantSkipsAbsentManagers pins the absence guard: with neither
-// manager built, pre-warming is a silent no-op and never reports a problem.
-func TestPreWarmSingleTenantSkipsAbsentManagers(t *testing.T) {
-	a := &App{logger: logger.New("debug", true), cfg: &config.Config{}}
+// TestSlotStartSkipsAbsentManagers pins the absence guard: with neither manager built, the
+// start phase is a silent no-op and never reports a problem.
+func TestSlotStartSkipsAbsentManagers(t *testing.T) {
+	log := logger.New("debug", true)
+	cfg := &config.Config{}
+	// The streams kind's "absent" is a registry that declares no stream, so it gets one:
+	// its start delegates to prepareStreamConsumers, which refuses a nil registry outright.
+	a := &App{logger: log, cfg: cfg, registry: NewModuleRegistry(&ModuleDeps{Logger: log, Config: cfg})}
+	a.installSlots(slotInputs{})
 
-	require.NoError(t, a.preWarmSingleTenant(context.Background(), messaging.NewDeclarations()))
-	require.NoError(t, a.preWarmSingleTenant(context.Background(), nil))
+	for _, slot := range a.slots {
+		advisory, fatal := slot.start(context.Background())
+		require.NoError(t, fatal, slot.name())
+		require.NoError(t, advisory, slot.name())
+	}
 }
 
 func TestAppAwaitPublisherReady(t *testing.T) {
@@ -123,7 +131,7 @@ func TestAppPublisherReadinessTimeout(t *testing.T) {
 	}
 }
 
-func TestPreWarmSingleTenantAwaitsPublisherReadiness(t *testing.T) {
+func TestMessagingSlotStartAwaitsPublisherReadiness(t *testing.T) {
 	log := logger.New("debug", true)
 	client := newPrewarmMockClient()
 	manager := newPrewarmTestManager(log, client)
@@ -137,15 +145,16 @@ func TestPreWarmSingleTenantAwaitsPublisherReadiness(t *testing.T) {
 	}()
 
 	start := time.Now()
-	err := a.preWarmSingleTenant(context.Background(), nil)
+	err, fatal := a.slots[1].start(context.Background())
 	elapsed := time.Since(start)
 
+	require.NoError(t, fatal, "pre-warming is never fatal")
 	assert.NoError(t, err)
 	assert.Less(t, elapsed, defaultPreWarmReadinessTimeout,
 		"must return once the client reports ready, not wait out the full budget")
 }
 
-func TestPreWarmSingleTenantContinuesWhenPublisherNeverReady(t *testing.T) {
+func TestMessagingSlotStartContinuesWhenPublisherNeverReady(t *testing.T) {
 	log := logger.New("debug", true)
 	client := newPrewarmMockClient() // never flips ready
 	manager := newPrewarmTestManager(log, client)
@@ -158,17 +167,18 @@ func TestPreWarmSingleTenantContinuesWhenPublisherNeverReady(t *testing.T) {
 	})
 
 	start := time.Now()
-	err := a.preWarmSingleTenant(context.Background(), nil)
+	err, fatal := a.slots[1].start(context.Background())
 	elapsed := time.Since(start)
 
 	// Not-ready-in-time is a WARN, not a startup failure — pre-warm must not
 	// propagate an error; PublishToExchange's own readytimeout pre-flight will
 	// still absorb a slow first publish later.
+	require.NoError(t, fatal, "pre-warming is never fatal")
 	assert.NoError(t, err)
 	assert.Less(t, elapsed, time.Second, "must return once the configured budget elapses, not the 5s fallback")
 }
 
-func TestPreWarmSingleTenantPropagatesContextCancellation(t *testing.T) {
+func TestMessagingSlotStartPropagatesContextCancellation(t *testing.T) {
 	log := logger.New("debug", true)
 	client := newPrewarmMockClient() // never flips ready
 	manager := newPrewarmTestManager(log, client)
@@ -180,11 +190,12 @@ func TestPreWarmSingleTenantPropagatesContextCancellation(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	err := a.preWarmSingleTenant(ctx, nil)
+	err, fatal := a.slots[1].start(ctx)
 	elapsed := time.Since(start)
 
 	// Cancellation means shutdown/startup abort, not a broker-readiness problem —
 	// it propagates instead of being mislabeled by the generic not-ready WARN.
+	require.NoError(t, fatal, "pre-warming is never fatal")
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.Less(t, elapsed, time.Second, "must return once ctx expires")
 }

--- a/app/slot.go
+++ b/app/slot.go
@@ -2,14 +2,15 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/gaborage/go-bricks/config"
 )
 
 // A slot is the framework-side module that owns one resource kind's application lifecycle —
-// probe, pre-init, close — so that adding a kind is one slot, not an edit in every place
-// that enumerates kinds (CONTEXT.md, ADR-067).
+// probe, pre-init, start, stop, close — so that adding a kind is one slot, not an edit in
+// every place that enumerates kinds (CONTEXT.md, ADR-067).
 //
 // ADR-045: the interface lives in app/ and names only what app calls. The managers behind
 // it (database.DbManager, messaging.Manager, cache.CacheManager, streams.Manager) know
@@ -30,6 +31,14 @@ type resourceSlot interface {
 
 	// preInitFatal reports whether a preInit failure aborts startup.
 	preInitFatal() bool
+
+	// start brings the kind up in prepareRuntime. A non-nil fatal aborts startup at once; a
+	// non-nil advisory is aggregated into the single pre-warm WARN and never fails startup.
+	start(ctx context.Context) (advisory, fatal error)
+
+	// stop halts the kind's inbound work before module Shutdown (ADR-029). It never closes
+	// connections — that is the close phase, which runs after modules are torn down.
+	stop(ctx context.Context)
 
 	// closer hands over the resource the close phase must Close. ok is false when the kind
 	// has nothing to close yet, which is how an unconfigured kind and a streams manager that
@@ -116,6 +125,33 @@ func (s *databaseSlot) preInit(ctx context.Context) error {
 		})
 }
 
+// start pre-warms the single-tenant connection so the first request does not pay the dial.
+// Advisory only: a cold database is a runtime condition, and pre-init has already made a
+// *misconfigured* one fatal.
+func (s *databaseSlot) start(ctx context.Context) (advisory, fatal error) {
+	if s.app.multiTenant() {
+		return nil, nil
+	}
+	if s.app.dbManager == nil {
+		s.app.logger.Debug().Msg("Skipping single-tenant database pre-warming: manager unavailable")
+		return nil, nil
+	}
+
+	if err := s.app.preWarmDatabase(ctx); err != nil {
+		if config.IsNotConfigured(err) {
+			s.app.logger.Debug().Msg("Skipping single-tenant database pre-warming: not configured")
+			return nil, nil
+		}
+		s.app.logger.Warn().Err(err).Msg("Failed to pre-warm single-tenant database connection")
+		return fmt.Errorf("database pre-warming failed: %w", err), nil
+	}
+
+	s.app.logger.Info().Msg("Pre-warmed single-tenant database connection")
+	return nil, nil
+}
+
+func (s *databaseSlot) stop(context.Context) {}
+
 func (s *databaseSlot) closer() (namedCloser, bool) {
 	return slotCloser("database manager", s.app.dbManager)
 }
@@ -144,6 +180,41 @@ func (s *messagingSlot) preInit(ctx context.Context) error {
 			return release, err
 		})
 }
+
+// start runs the kind's two runtime steps in the order prepareRuntime always ran them: the
+// consumer bootstrap, whose failure is fatal once consumers were declared (#907), then the
+// single-tenant pre-warm, which is advisory.
+func (s *messagingSlot) start(ctx context.Context) (advisory, fatal error) {
+	decls := s.app.messagingDeclarations
+
+	// Values only, no cancellation: consumers outlive prepareRuntime and are stopped by
+	// shutdownConsumers (ADR-029), never by the startup context.
+	if err := s.app.prepareRuntimeConsumers(context.WithoutCancel(ctx), decls); err != nil {
+		return nil, err
+	}
+
+	if s.app.multiTenant() {
+		return nil, nil
+	}
+	if s.app.messagingManager == nil {
+		s.app.logger.Debug().Msg("Skipping single-tenant messaging pre-warming: manager unavailable")
+		return nil, nil
+	}
+
+	if err := s.app.preWarmMessaging(ctx, decls); err != nil {
+		if config.IsNotConfigured(err) {
+			s.app.logger.Debug().Msg("Skipping single-tenant messaging pre-warming: not configured")
+			return nil, nil
+		}
+		s.app.logger.Warn().Err(err).Msg("Failed to pre-warm single-tenant messaging")
+		return fmt.Errorf("messaging pre-warming failed: %w", err), nil
+	}
+
+	s.app.logger.Info().Msg("Pre-warmed single-tenant messaging")
+	return nil, nil
+}
+
+func (s *messagingSlot) stop(context.Context) { s.app.shutdownConsumers() }
 
 func (s *messagingSlot) closer() (namedCloser, bool) {
 	return slotCloser("messaging manager", s.app.messagingManager)
@@ -185,6 +256,12 @@ func (s *cacheSlot) preInit(ctx context.Context) error {
 	return err
 }
 
+// start is a no-op: the cache has no runtime bootstrap and no single-tenant pre-warm —
+// preInit already leased the fixed "" key during Builder construction.
+func (s *cacheSlot) start(context.Context) (advisory, fatal error) { return nil, nil }
+
+func (s *cacheSlot) stop(context.Context) {}
+
 func (s *cacheSlot) closer() (namedCloser, bool) {
 	return slotCloser("cache manager", s.app.cacheManager)
 }
@@ -198,8 +275,8 @@ func (s *streamsSlot) name() string { return componentStreams }
 // probe withholds a description until the manager exists. Registering a disabled one at
 // build time would add "streams" and "streams_stats" to the /ready body of every service in
 // the fleet, the overwhelming majority of which never declared a stream (ADR-066 rule 5
-// renders every registered kind). prepareStreamConsumers registers the description once it
-// has produced the manager, so it appears exactly where the runtime registration put it.
+// renders every registered kind). prepareRuntime re-collects after the start phase, so the
+// description appears exactly where the runtime registration put it.
 func (s *streamsSlot) probe() (probeDescription, bool) {
 	if s.app.streamsManager == nil {
 		return probeDescription{}, false
@@ -210,6 +287,20 @@ func (s *streamsSlot) probe() (probeDescription, bool) {
 func (s *streamsSlot) preInit(context.Context) error { return nil }
 
 func (s *streamsSlot) preInitFatal() bool { return false }
+
+// start builds the stream environment and starts the declared consumers and publishers,
+// then puts the manager on the FIFO close list. A service that declared streams and cannot
+// start them would serve HTTP while consuming nothing and publishing nowhere, so the failure
+// is fatal. PR5 folds prepareStreamConsumers' body in here.
+func (s *streamsSlot) start(ctx context.Context) (advisory, fatal error) {
+	if err := s.app.prepareStreamConsumers(ctx); err != nil {
+		return nil, err
+	}
+	s.app.registerSlotCloser(s)
+	return nil, nil
+}
+
+func (s *streamsSlot) stop(context.Context) { s.app.shutdownStreamConsumers() }
 
 func (s *streamsSlot) closer() (namedCloser, bool) {
 	return slotCloser("streams manager", s.app.streamsManager)

--- a/app/slot.go
+++ b/app/slot.go
@@ -146,7 +146,9 @@ func (s *databaseSlot) start(ctx context.Context) (advisory, fatal error) {
 		s.app.dbManager != nil, s.app.preWarmDatabase), nil
 }
 
-func (s *databaseSlot) stop(context.Context) {}
+func (s *databaseSlot) stop(context.Context) {
+	// no runtime teardown: the pool is released by the FIFO close list, via closer()
+}
 
 func (s *databaseSlot) closer() (namedCloser, bool) {
 	return slotCloser("database manager", s.app.dbManager)
@@ -238,7 +240,9 @@ func (s *cacheSlot) preInit(ctx context.Context) error {
 // preInit already leased the fixed "" key during Builder construction.
 func (s *cacheSlot) start(context.Context) (advisory, fatal error) { return nil, nil }
 
-func (s *cacheSlot) stop(context.Context) {}
+func (s *cacheSlot) stop(context.Context) {
+	// no runtime teardown: the manager is released by the FIFO close list, via closer()
+}
 
 func (s *cacheSlot) closer() (namedCloser, bool) {
 	return slotCloser("cache manager", s.app.cacheManager)

--- a/app/slot.go
+++ b/app/slot.go
@@ -181,19 +181,15 @@ func (s *messagingSlot) preInit(ctx context.Context) error {
 // consumer bootstrap, whose failure is fatal once consumers were declared (#907), then the
 // single-tenant pre-warm, which is advisory.
 func (s *messagingSlot) start(ctx context.Context) (advisory, fatal error) {
-	decls := s.app.messagingDeclarations
-
 	// Values only, no cancellation: consumers outlive prepareRuntime and are stopped by
 	// the messaging slot's stop phase (shutdownConsumers, ADR-029), never by the startup
 	// context.
-	if err := s.app.prepareRuntimeConsumers(context.WithoutCancel(ctx), decls); err != nil {
+	if err := s.app.prepareRuntimeConsumers(context.WithoutCancel(ctx), s.app.messagingDeclarations); err != nil {
 		return nil, err
 	}
 
 	return s.app.preWarmKind(ctx, s.name(), componentMessaging,
-		s.app.messagingManager != nil, func(ctx context.Context) error {
-			return s.app.preWarmMessaging(ctx, decls)
-		}), nil
+		s.app.messagingManager != nil, s.app.preWarmMessaging), nil
 }
 
 func (s *messagingSlot) stop(context.Context) { s.app.shutdownConsumers() }

--- a/app/slot.go
+++ b/app/slot.go
@@ -129,25 +129,8 @@ func (s *databaseSlot) preInit(ctx context.Context) error {
 // Advisory only: a cold database is a runtime condition, and pre-init has already made a
 // *misconfigured* one fatal.
 func (s *databaseSlot) start(ctx context.Context) (advisory, fatal error) {
-	if s.app.multiTenant() {
-		return nil, nil
-	}
-	if s.app.dbManager == nil {
-		s.app.logger.Debug().Msg("Skipping single-tenant database pre-warming: manager unavailable")
-		return nil, nil
-	}
-
-	if err := s.app.preWarmDatabase(ctx); err != nil {
-		if config.IsNotConfigured(err) {
-			s.app.logger.Debug().Msg("Skipping single-tenant database pre-warming: not configured")
-			return nil, nil
-		}
-		s.app.logger.Warn().Err(err).Msg("Failed to pre-warm single-tenant database connection")
-		return fmt.Errorf("database pre-warming failed: %w", err), nil
-	}
-
-	s.app.logger.Info().Msg("Pre-warmed single-tenant database connection")
-	return nil, nil
+	return s.app.preWarmKind(ctx, s.name(), "database connection",
+		s.app.dbManager != nil, s.app.preWarmDatabase), nil
 }
 
 func (s *databaseSlot) stop(context.Context) {}
@@ -194,25 +177,10 @@ func (s *messagingSlot) start(ctx context.Context) (advisory, fatal error) {
 		return nil, err
 	}
 
-	if s.app.multiTenant() {
-		return nil, nil
-	}
-	if s.app.messagingManager == nil {
-		s.app.logger.Debug().Msg("Skipping single-tenant messaging pre-warming: manager unavailable")
-		return nil, nil
-	}
-
-	if err := s.app.preWarmMessaging(ctx, decls); err != nil {
-		if config.IsNotConfigured(err) {
-			s.app.logger.Debug().Msg("Skipping single-tenant messaging pre-warming: not configured")
-			return nil, nil
-		}
-		s.app.logger.Warn().Err(err).Msg("Failed to pre-warm single-tenant messaging")
-		return fmt.Errorf("messaging pre-warming failed: %w", err), nil
-	}
-
-	s.app.logger.Info().Msg("Pre-warmed single-tenant messaging")
-	return nil, nil
+	return s.app.preWarmKind(ctx, s.name(), componentMessaging,
+		s.app.messagingManager != nil, func(ctx context.Context) error {
+			return s.app.preWarmMessaging(ctx, decls)
+		}), nil
 }
 
 func (s *messagingSlot) stop(context.Context) { s.app.shutdownConsumers() }
@@ -318,6 +286,36 @@ func slotCloser[T any, P interface {
 		return namedCloser{}, false
 	}
 	return namedCloser{name: name, closer: mgr}, true
+}
+
+// preWarmKind is the arm the two single-tenant pre-warming kinds share. subject names the
+// thing warmed in the two operator-facing lines, which is not the kind's own name for the
+// database ("database connection" vs "messaging"); present is the kind's manager-built
+// verdict, which only the slot can read. Multi-tenant deployments resolve per tenant, so
+// the fixed "" key is never warmed; a not-configured kind is a silent skip; anything else
+// is advisory, never fatal.
+func (a *App) preWarmKind(ctx context.Context, kind, subject string, present bool,
+	warm func(context.Context) error,
+) error {
+	if a.multiTenant() {
+		return nil
+	}
+	if !present {
+		a.logger.Debug().Msgf("Skipping single-tenant %s pre-warming: manager unavailable", kind)
+		return nil
+	}
+
+	if err := warm(ctx); err != nil {
+		if config.IsNotConfigured(err) {
+			a.logger.Debug().Msgf("Skipping single-tenant %s pre-warming: not configured", kind)
+			return nil
+		}
+		a.logger.Warn().Err(err).Msgf("Failed to pre-warm single-tenant %s", subject)
+		return fmt.Errorf("%s pre-warming failed: %w", kind, err)
+	}
+
+	a.logger.Info().Msgf("Pre-warmed single-tenant %s", subject)
+	return nil
 }
 
 // preInitLease is the arm the two startup-fatal kinds share: an unconfigured kind is skipped

--- a/app/slot.go
+++ b/app/slot.go
@@ -188,7 +188,8 @@ func (s *messagingSlot) start(ctx context.Context) (advisory, fatal error) {
 	decls := s.app.messagingDeclarations
 
 	// Values only, no cancellation: consumers outlive prepareRuntime and are stopped by
-	// shutdownConsumers (ADR-029), never by the startup context.
+	// the messaging slot's stop phase (shutdownConsumers, ADR-029), never by the startup
+	// context.
 	if err := s.app.prepareRuntimeConsumers(context.WithoutCancel(ctx), decls); err != nil {
 		return nil, err
 	}

--- a/app/slot.go
+++ b/app/slot.go
@@ -42,7 +42,9 @@ type resourceSlot interface {
 
 	// closer hands over the resource the close phase must Close. ok is false when the kind
 	// has nothing to close yet, which is how an unconfigured kind and a streams manager that
-	// has not started stay out of the FIFO close list.
+	// has not started stay out of the FIFO close list. Builder.RegisterClosers walks every
+	// slot's closer at build time, for the kinds whose manager exists by then; the streams
+	// slot calls its own again from start, once its manager exists.
 	closer() (namedCloser, bool)
 }
 
@@ -72,6 +74,17 @@ func (a *App) installSlots(inputs slotInputs) {
 		&cacheSlot{app: a, absent: inputs.cacheAbsent},
 		&streamsSlot{app: a},
 	}
+}
+
+// requireSlots is the precondition every slot walk shares: CreateApp installed the slot
+// list. An empty walk would silently register no probe, no closer, pre-initialize nothing,
+// and start no kind at all — Builder.requireSlots and prepareRuntime both call this rather
+// than each carrying their own copy of the check.
+func (a *App) requireSlots(step string) error {
+	if len(a.slots) == 0 {
+		return fmt.Errorf("slots not installed before %s — CreateApp must run first", step)
+	}
+	return nil
 }
 
 // collectProbes is the readiness walk: every slot that has a description to register, in
@@ -258,9 +271,8 @@ func (s *streamsSlot) preInit(context.Context) error { return nil }
 func (s *streamsSlot) preInitFatal() bool { return false }
 
 // start builds the stream environment and starts the declared consumers and publishers,
-// then puts the manager on the FIFO close list. A service that declared streams and cannot
-// start them would serve HTTP while consuming nothing and publishing nowhere, so the failure
-// is fatal. PR5 folds prepareStreamConsumers' body in here.
+// then puts the manager on the FIFO close list — see prepareStreamConsumers for why a
+// failure here is fatal. PR5 folds prepareStreamConsumers' body in here.
 func (s *streamsSlot) start(ctx context.Context) (advisory, fatal error) {
 	if err := s.app.prepareStreamConsumers(ctx); err != nil {
 		return nil, err
@@ -288,13 +300,18 @@ func slotCloser[T any, P interface {
 	return namedCloser{name: name, closer: mgr}, true
 }
 
+// preWarmSubject is the operator-facing name of the thing warmed, distinct from kind (a
+// plain string) so a slot's own name() cannot be passed into the subject parameter by
+// mistake — the two would otherwise be interchangeable positional strings.
+type preWarmSubject string
+
 // preWarmKind is the arm the two single-tenant pre-warming kinds share. subject names the
 // thing warmed in the two operator-facing lines, which is not the kind's own name for the
 // database ("database connection" vs "messaging"); present is the kind's manager-built
 // verdict, which only the slot can read. Multi-tenant deployments resolve per tenant, so
 // the fixed "" key is never warmed; a not-configured kind is a silent skip; anything else
 // is advisory, never fatal.
-func (a *App) preWarmKind(ctx context.Context, kind, subject string, present bool,
+func (a *App) preWarmKind(ctx context.Context, kind string, subject preWarmSubject, present bool,
 	warm func(context.Context) error,
 ) error {
 	if a.multiTenant() {

--- a/app/slot_test.go
+++ b/app/slot_test.go
@@ -35,9 +35,15 @@ var errNeverReachTheConnector = errors.New("the absent arm must never reach the 
 // only when asked for, because "absent kind" is half of what these walks decide.
 func newSlotTestApp(t *testing.T, withDB, withMessaging bool) *App {
 	t.Helper()
+	return newSlotTestAppWithLogger(t, logger.New("error", false), withDB, withMessaging)
+}
+
+// newSlotTestAppWithLogger is newSlotTestApp with the logger supplied, so tests can assert
+// on what the slots themselves log.
+func newSlotTestAppWithLogger(t *testing.T, log logger.Logger, withDB, withMessaging bool) *App {
+	t.Helper()
 
 	cfg := defaultTestConfig()
-	log := logger.New("error", false)
 	source := config.NewTenantStore(cfg)
 
 	a := &App{cfg: cfg, logger: log}
@@ -116,6 +122,19 @@ func closerNames(a *App) []string {
 		names = append(names, c.name)
 	}
 	return names
+}
+
+// slotOf returns the installed slot for kind, found by name() rather than a registration-
+// order index that would silently drift if installSlots' order ever changed.
+func slotOf(t *testing.T, a *App, kind string) resourceSlot {
+	t.Helper()
+	for _, s := range a.slots {
+		if s.name() == kind {
+			return s
+		}
+	}
+	require.FailNow(t, "no installed slot for kind "+kind)
+	return nil
 }
 
 // TestInstallSlotsCoversEveryKindInRegistrationOrder is the completeness pin: one slot per
@@ -468,13 +487,16 @@ func TestStopSlotsRunsEveryKindInRegistrationOrder(t *testing.T) {
 	assert.Equal(t, []string{"stop:messaging", "stop:streams"}, order)
 }
 
-// TestDatabaseSlotStartSkipsMultiTenant pins the deployment-mode check inside the slot:
-// multi-tenant resources resolve per tenant, so the fixed "" key is never warmed. The
-// provider always refuses, so warming it would surface as an advisory error.
-func TestDatabaseSlotStartSkipsMultiTenant(t *testing.T) {
+// newRefusingDBSlotApp builds an App wired to a database manager whose provider always
+// refuses the fixed "" key (errNeverReachTheConnector), so any lease attempt surfaces that
+// error. multiTenant sets cfg.Multitenant.Enabled, the one input the two start-phase tests
+// below differ on.
+func newRefusingDBSlotApp(t *testing.T, multiTenant bool) *App {
+	t.Helper()
+
 	log := logger.New("error", false)
 	cfg := defaultTestConfig()
-	cfg.Multitenant.Enabled = true
+	cfg.Multitenant.Enabled = multiTenant
 	dbManager := database.NewDbManager(staticDBConfigProvider{err: errNeverReachTheConnector}, log,
 		database.DbManagerOptions{MaxSize: 1, IdleTTL: time.Minute},
 		func(*config.DatabaseConfig, logger.Logger) (database.Interface, error) {
@@ -484,8 +506,16 @@ func TestDatabaseSlotStartSkipsMultiTenant(t *testing.T) {
 
 	a := &App{cfg: cfg, logger: log, dbManager: dbManager}
 	a.installSlots(slotInputs{})
+	return a
+}
 
-	advisory, fatal := a.slots[0].start(context.Background())
+// TestDatabaseSlotStartSkipsMultiTenant pins the deployment-mode check inside the slot:
+// multi-tenant resources resolve per tenant, so the fixed "" key is never warmed. The
+// provider always refuses, so warming it would surface as an advisory error.
+func TestDatabaseSlotStartSkipsMultiTenant(t *testing.T) {
+	a := newRefusingDBSlotApp(t, true)
+
+	advisory, fatal := slotOf(t, a, componentDatabase).start(context.Background())
 
 	assert.NoError(t, fatal)
 	assert.NoError(t, advisory, "multi-tenant startup must not pre-warm the fixed \"\" key")
@@ -494,18 +524,9 @@ func TestDatabaseSlotStartSkipsMultiTenant(t *testing.T) {
 // TestDatabaseSlotStartReportsPreWarmFailureAsAdvisory pins the other arm: a refused
 // pre-warm is reported, never fatal.
 func TestDatabaseSlotStartReportsPreWarmFailureAsAdvisory(t *testing.T) {
-	log := logger.New("error", false)
-	dbManager := database.NewDbManager(staticDBConfigProvider{err: errNeverReachTheConnector}, log,
-		database.DbManagerOptions{MaxSize: 1, IdleTTL: time.Minute},
-		func(*config.DatabaseConfig, logger.Logger) (database.Interface, error) {
-			return dbtesting.NewTestDB(dbTypePostgres), nil
-		})
-	t.Cleanup(func() { assert.NoError(t, dbManager.Close()) })
+	a := newRefusingDBSlotApp(t, false)
 
-	a := &App{cfg: defaultTestConfig(), logger: log, dbManager: dbManager}
-	a.installSlots(slotInputs{})
-
-	advisory, fatal := a.slots[0].start(context.Background())
+	advisory, fatal := slotOf(t, a, componentDatabase).start(context.Background())
 
 	assert.NoError(t, fatal, "pre-warming is never fatal")
 	require.Error(t, advisory)
@@ -521,7 +542,7 @@ func TestStreamsSlotStartRegistersItsCloser(t *testing.T) {
 		a := newStreamsApp(t, config.StreamsConfig{}, &minimalModule{name: "plain"})
 		a.installSlots(slotInputs{})
 
-		advisory, fatal := a.slots[3].start(context.Background())
+		advisory, fatal := slotOf(t, a, componentStreams).start(context.Background())
 
 		require.NoError(t, fatal)
 		require.NoError(t, advisory)
@@ -534,7 +555,7 @@ func TestStreamsSlotStartRegistersItsCloser(t *testing.T) {
 			&streamModule{name: "orders", declaration: declareOneConsumer})
 		a.installSlots(slotInputs{})
 
-		_, fatal := a.slots[3].start(context.Background())
+		_, fatal := slotOf(t, a, componentStreams).start(context.Background())
 
 		require.Error(t, fatal, "a service that declared streams and cannot start them must abort")
 		assert.Nil(t, a.streamsManager)
@@ -549,20 +570,11 @@ func newStopSlotTestApp(t *testing.T) (*App, *recLogger) {
 	t.Helper()
 
 	rec := &recLogger{}
-	cfg := defaultTestConfig()
+	a := newSlotTestAppWithLogger(t, rec, false, true)
 
-	client := testmocks.NewMockAMQPClient()
-	client.ExpectClose(nil)
-	messagingManager := messaging.NewMessagingManager(config.NewTenantStore(cfg), rec,
-		messaging.ManagerOptions{MaxPublishers: 1, IdleTTL: time.Hour},
-		func(string, logger.Logger) messaging.AMQPClient { return client })
-	t.Cleanup(func() { assert.NoError(t, messagingManager.Close()) })
+	a.streamsManager = streams.NewManager(streams.ManagerOptions{URI: unreachableStreamURI, Logger: rec})
+	t.Cleanup(func() { _ = a.streamsManager.Close() })
 
-	streamsManager := streams.NewManager(streams.ManagerOptions{URI: unreachableStreamURI, Logger: rec})
-	t.Cleanup(func() { _ = streamsManager.Close() })
-
-	a := &App{cfg: cfg, logger: rec, messagingManager: messagingManager, streamsManager: streamsManager}
-	a.installSlots(slotInputs{})
 	return a, rec
 }
 
@@ -579,7 +591,7 @@ func TestSlotStopDrivesItsOwnKindsTeardown(t *testing.T) {
 	t.Run("messaging_slot_stops_amqp_consumers_only", func(t *testing.T) {
 		a, rec := newStopSlotTestApp(t)
 
-		a.slots[1].stop(context.Background())
+		slotOf(t, a, componentMessaging).stop(context.Background())
 
 		assert.True(t, loggedMsgContains(rec, amqpStopLine), "the messaging slot must stop AMQP consumers")
 		assert.False(t, loggedMsgContains(rec, streamsStopLine), "it must not reach into the streams kind")
@@ -588,7 +600,7 @@ func TestSlotStopDrivesItsOwnKindsTeardown(t *testing.T) {
 	t.Run("streams_slot_stops_stream_consumers_only", func(t *testing.T) {
 		a, rec := newStopSlotTestApp(t)
 
-		a.slots[3].stop(context.Background())
+		slotOf(t, a, componentStreams).stop(context.Background())
 
 		assert.True(t, loggedMsgContains(rec, streamsStopLine), "the streams slot must stop stream consumers")
 		assert.False(t, loggedMsgContains(rec, amqpStopLine), "it must not reach into the AMQP kind")
@@ -597,8 +609,8 @@ func TestSlotStopDrivesItsOwnKindsTeardown(t *testing.T) {
 	t.Run("database_and_cache_stop_nothing", func(t *testing.T) {
 		a, rec := newStopSlotTestApp(t)
 
-		a.slots[0].stop(context.Background())
-		a.slots[2].stop(context.Background())
+		slotOf(t, a, componentDatabase).stop(context.Background())
+		slotOf(t, a, componentCache).stop(context.Background())
 
 		assert.False(t, loggedMsgContains(rec, amqpStopLine))
 		assert.False(t, loggedMsgContains(rec, streamsStopLine))

--- a/app/slot_test.go
+++ b/app/slot_test.go
@@ -542,6 +542,69 @@ func TestStreamsSlotStartRegistersItsCloser(t *testing.T) {
 	})
 }
 
+// newStopSlotTestApp builds an App holding BOTH inbound-work managers behind a recording
+// logger. Both are present on purpose: each kind's stop line is then the only thing that
+// tells the two apart, so a slot wired to the other kind's teardown fails here.
+func newStopSlotTestApp(t *testing.T) (*App, *recLogger) {
+	t.Helper()
+
+	rec := &recLogger{}
+	cfg := defaultTestConfig()
+
+	client := testmocks.NewMockAMQPClient()
+	client.ExpectClose(nil)
+	messagingManager := messaging.NewMessagingManager(config.NewTenantStore(cfg), rec,
+		messaging.ManagerOptions{MaxPublishers: 1, IdleTTL: time.Hour},
+		func(string, logger.Logger) messaging.AMQPClient { return client })
+	t.Cleanup(func() { assert.NoError(t, messagingManager.Close()) })
+
+	streamsManager := streams.NewManager(streams.ManagerOptions{URI: unreachableStreamURI, Logger: rec})
+	t.Cleanup(func() { _ = streamsManager.Close() })
+
+	a := &App{cfg: cfg, logger: rec, messagingManager: messagingManager, streamsManager: streamsManager}
+	a.installSlots(slotInputs{})
+	return a, rec
+}
+
+// TestSlotStopDrivesItsOwnKindsTeardown pins the slot→teardown mapping the stop walk relies
+// on. Each kind's stop must halt its OWN inbound work and nothing else: with the two bodies
+// swapped, every kind still gets stopped by the full walk, so only running one slot's stop
+// in isolation — and demanding the other kind stayed untouched — tells the wiring apart.
+func TestSlotStopDrivesItsOwnKindsTeardown(t *testing.T) {
+	const (
+		amqpStopLine    = "Stopping messaging consumers"
+		streamsStopLine = "Stopping stream consumers"
+	)
+
+	t.Run("messaging_slot_stops_amqp_consumers_only", func(t *testing.T) {
+		a, rec := newStopSlotTestApp(t)
+
+		a.slots[1].stop(context.Background())
+
+		assert.True(t, loggedMsgContains(rec, amqpStopLine), "the messaging slot must stop AMQP consumers")
+		assert.False(t, loggedMsgContains(rec, streamsStopLine), "it must not reach into the streams kind")
+	})
+
+	t.Run("streams_slot_stops_stream_consumers_only", func(t *testing.T) {
+		a, rec := newStopSlotTestApp(t)
+
+		a.slots[3].stop(context.Background())
+
+		assert.True(t, loggedMsgContains(rec, streamsStopLine), "the streams slot must stop stream consumers")
+		assert.False(t, loggedMsgContains(rec, amqpStopLine), "it must not reach into the AMQP kind")
+	})
+
+	t.Run("database_and_cache_stop_nothing", func(t *testing.T) {
+		a, rec := newStopSlotTestApp(t)
+
+		a.slots[0].stop(context.Background())
+		a.slots[2].stop(context.Background())
+
+		assert.False(t, loggedMsgContains(rec, amqpStopLine))
+		assert.False(t, loggedMsgContains(rec, streamsStopLine))
+	})
+}
+
 // recordingSlot is a resourceSlot stand-in that records which phase ran on which kind, so
 // the walks can be pinned on order and short-circuiting without standing up four real
 // managers. Every field defaults to "this phase succeeds and does nothing".

--- a/app/slot_test.go
+++ b/app/slot_test.go
@@ -382,12 +382,174 @@ func TestStreamsSlotPreInitIsANoop(t *testing.T) {
 	assert.NoError(t, a.slots[3].preInit(context.Background()))
 }
 
+// TestStartSlotsRunsEveryKindInRegistrationOrder pins the walk itself: one order for every
+// phase (spec decision 8), with no kind skipped.
+func TestStartSlotsRunsEveryKindInRegistrationOrder(t *testing.T) {
+	order := []string{}
+	a := &App{logger: logger.New("error", false)}
+	a.slots = []resourceSlot{
+		&recordingSlot{kind: componentDatabase, order: &order},
+		&recordingSlot{kind: componentMessaging, order: &order},
+		&recordingSlot{kind: componentCache, order: &order},
+		&recordingSlot{kind: componentStreams, order: &order},
+	}
+
+	require.NoError(t, a.startSlots(context.Background()))
+
+	assert.Equal(t,
+		[]string{"start:database", "start:messaging", "start:cache", "start:streams"},
+		order)
+}
+
+// TestStartSlotsStopsAtTheFirstFatalKind pins that a kind that cannot start aborts startup
+// there: a service that declared streams and cannot start them must not go on to serve HTTP.
+func TestStartSlotsStopsAtTheFirstFatalKind(t *testing.T) {
+	order := []string{}
+	a := &App{logger: logger.New("error", false)}
+	a.slots = []resourceSlot{
+		&recordingSlot{kind: componentMessaging, order: &order, startFatal: assert.AnError},
+		&recordingSlot{kind: componentStreams, order: &order},
+	}
+
+	err := a.startSlots(context.Background())
+
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Equal(t, []string{"start:messaging"}, order)
+}
+
+// TestStartSlotsAggregatesAdvisoriesIntoOneWarn pins the pre-warm contract: advisory
+// failures never fail startup and never multiply the operator's WARN count — both kinds'
+// causes arrive under the one line prepareRuntime has always emitted.
+func TestStartSlotsAggregatesAdvisoriesIntoOneWarn(t *testing.T) {
+	order := []string{}
+	rec := &recLogger{}
+	a := &App{logger: rec}
+	a.slots = []resourceSlot{
+		&recordingSlot{kind: componentDatabase, order: &order, startAdvice: errors.New("db-advisory")},
+		&recordingSlot{kind: componentMessaging, order: &order, startAdvice: errors.New("msg-advisory")},
+	}
+
+	require.NoError(t, a.startSlots(context.Background()),
+		"pre-warming trouble is advisory: startup completes either way")
+
+	event, emitted := loggedEvent(rec, preWarmWarnMsg)
+	require.True(t, emitted)
+	assert.Equal(t, "warn", event.level)
+	assert.Contains(t, event.err, "pre-warming issues (non-fatal)")
+	assert.Contains(t, event.err, "db-advisory")
+	assert.Contains(t, event.err, "msg-advisory")
+}
+
+// TestStartSlotsStaysSilentWithoutAdvisories is the negative half.
+func TestStartSlotsStaysSilentWithoutAdvisories(t *testing.T) {
+	order := []string{}
+	rec := &recLogger{}
+	a := &App{logger: rec}
+	a.slots = []resourceSlot{&recordingSlot{kind: componentDatabase, order: &order}}
+
+	require.NoError(t, a.startSlots(context.Background()))
+
+	_, emitted := loggedEvent(rec, preWarmWarnMsg)
+	assert.False(t, emitted, "a clean start must emit no pre-warm WARN")
+}
+
+// TestStopSlotsRunsEveryKindInRegistrationOrder pins the shutdown walk. ADR-029 places it
+// before module Shutdown, which TestShutdownStopsServerBeforeModules covers end to end.
+func TestStopSlotsRunsEveryKindInRegistrationOrder(t *testing.T) {
+	order := []string{}
+	a := &App{logger: logger.New("error", false)}
+	a.slots = []resourceSlot{
+		&recordingSlot{kind: componentMessaging, order: &order},
+		&recordingSlot{kind: componentStreams, order: &order},
+	}
+
+	a.stopSlots(context.Background())
+
+	assert.Equal(t, []string{"stop:messaging", "stop:streams"}, order)
+}
+
+// TestDatabaseSlotStartSkipsMultiTenant pins the deployment-mode check inside the slot:
+// multi-tenant resources resolve per tenant, so the fixed "" key is never warmed. The
+// provider always refuses, so warming it would surface as an advisory error.
+func TestDatabaseSlotStartSkipsMultiTenant(t *testing.T) {
+	log := logger.New("error", false)
+	cfg := defaultTestConfig()
+	cfg.Multitenant.Enabled = true
+	dbManager := database.NewDbManager(staticDBConfigProvider{err: errNeverReachTheConnector}, log,
+		database.DbManagerOptions{MaxSize: 1, IdleTTL: time.Minute},
+		func(*config.DatabaseConfig, logger.Logger) (database.Interface, error) {
+			return dbtesting.NewTestDB(dbTypePostgres), nil
+		})
+	t.Cleanup(func() { assert.NoError(t, dbManager.Close()) })
+
+	a := &App{cfg: cfg, logger: log, dbManager: dbManager}
+	a.installSlots(slotInputs{})
+
+	advisory, fatal := a.slots[0].start(context.Background())
+
+	assert.NoError(t, fatal)
+	assert.NoError(t, advisory, "multi-tenant startup must not pre-warm the fixed \"\" key")
+}
+
+// TestDatabaseSlotStartReportsPreWarmFailureAsAdvisory pins the other arm: a refused
+// pre-warm is reported, never fatal.
+func TestDatabaseSlotStartReportsPreWarmFailureAsAdvisory(t *testing.T) {
+	log := logger.New("error", false)
+	dbManager := database.NewDbManager(staticDBConfigProvider{err: errNeverReachTheConnector}, log,
+		database.DbManagerOptions{MaxSize: 1, IdleTTL: time.Minute},
+		func(*config.DatabaseConfig, logger.Logger) (database.Interface, error) {
+			return dbtesting.NewTestDB(dbTypePostgres), nil
+		})
+	t.Cleanup(func() { assert.NoError(t, dbManager.Close()) })
+
+	a := &App{cfg: defaultTestConfig(), logger: log, dbManager: dbManager}
+	a.installSlots(slotInputs{})
+
+	advisory, fatal := a.slots[0].start(context.Background())
+
+	assert.NoError(t, fatal, "pre-warming is never fatal")
+	require.Error(t, advisory)
+	assert.Contains(t, advisory.Error(), "database pre-warming failed")
+	assert.ErrorIs(t, advisory, errNeverReachTheConnector)
+}
+
+// TestStreamsSlotStartRegistersItsCloser pins the half of the runtime registration the slot
+// now owns: prepareStreamConsumers produces the manager, the slot puts it on the FIFO close
+// list. A streams-free service registers nothing.
+func TestStreamsSlotStartRegistersItsCloser(t *testing.T) {
+	t.Run("no_declarations_registers_nothing", func(t *testing.T) {
+		a := newStreamsApp(t, config.StreamsConfig{}, &minimalModule{name: "plain"})
+		a.installSlots(slotInputs{})
+
+		advisory, fatal := a.slots[3].start(context.Background())
+
+		require.NoError(t, fatal)
+		require.NoError(t, advisory)
+		assert.Nil(t, a.streamsManager)
+		assert.Empty(t, a.closers)
+	})
+
+	t.Run("failed_start_registers_nothing", func(t *testing.T) {
+		a := newStreamsApp(t, config.StreamsConfig{URI: unreachableStreamURI},
+			&streamModule{name: "orders", declaration: declareOneConsumer})
+		a.installSlots(slotInputs{})
+
+		_, fatal := a.slots[3].start(context.Background())
+
+		require.Error(t, fatal, "a service that declared streams and cannot start them must abort")
+		assert.Nil(t, a.streamsManager)
+		assert.Empty(t, a.closers)
+	})
+}
+
 // recordingSlot is a resourceSlot stand-in that records which phase ran on which kind, so
 // the walks can be pinned on order and short-circuiting without standing up four real
 // managers. Every field defaults to "this phase succeeds and does nothing".
 type recordingSlot struct {
 	order        *[]string
 	preInitErr   error
+	startAdvice  error
+	startFatal   error
 	kind         string
 	fatalPreInit bool
 }
@@ -404,6 +566,13 @@ func (s *recordingSlot) preInit(context.Context) error {
 }
 
 func (s *recordingSlot) preInitFatal() bool { return s.fatalPreInit }
+
+func (s *recordingSlot) start(context.Context) (advisory, fatal error) {
+	s.record("start")
+	return s.startAdvice, s.startFatal
+}
+
+func (s *recordingSlot) stop(context.Context) { s.record("stop") }
 
 func (s *recordingSlot) closer() (namedCloser, bool) { return namedCloser{}, false }
 

--- a/app/streams_setup.go
+++ b/app/streams_setup.go
@@ -18,11 +18,11 @@ const plaintextStreamScheme = "rabbitmq-stream"
 // declared publishers.
 //
 // Everything happens at RUNTIME on purpose: the manager does not exist while the
-// builder runs, so its readiness probe and its closer are both registered here
-// rather than by the build-time slot walks (Builder.CreateHealthProbes and
-// Builder.RegisterClosers), which are snapshotted before prepareRuntime runs.
-// This is safe because prepareRuntime is single-threaded and completes before the
-// server starts serving /ready.
+// build-time slot walks run (Builder.CreateHealthProbes and Builder.RegisterClosers
+// are snapshotted before prepareRuntime), so streamsSlot.start registers its closer
+// once this function has produced the manager, and prepareRuntime re-collects the
+// probe set after the start phase. This is safe because prepareRuntime is
+// single-threaded and completes before the server starts serving /ready.
 func (a *App) prepareStreamConsumers(ctx context.Context) error {
 	if a.registry == nil {
 		return errors.New("module registry not initialized")
@@ -68,8 +68,6 @@ func (a *App) prepareStreamConsumers(ctx context.Context) error {
 	}
 
 	a.streamsManager = mgr
-	a.registerCloser("streams manager", mgr)
-	a.healthProbes = append(a.healthProbes, streamsProbe(mgr))
 
 	return nil
 }

--- a/app/streams_setup.go
+++ b/app/streams_setup.go
@@ -17,12 +17,9 @@ const plaintextStreamScheme = "rabbitmq-stream"
 // when there are any, starts the stream-protocol consumers and binds the
 // declared publishers.
 //
-// Everything happens at RUNTIME on purpose: the manager does not exist while the
-// build-time slot walks run (Builder.CreateHealthProbes and Builder.RegisterClosers
-// are snapshotted before prepareRuntime), so streamsSlot.start registers its closer
-// once this function has produced the manager, and prepareRuntime re-collects the
-// probe set after the start phase. This is safe because prepareRuntime is
-// single-threaded and completes before the server starts serving /ready.
+// Everything happens at RUNTIME on purpose: the manager does not exist until this
+// function produces it — see streamsSlot in slot.go for why its probe and closer are
+// registered separately from the build-time walks.
 func (a *App) prepareStreamConsumers(ctx context.Context) error {
 	if a.registry == nil {
 		return errors.New("module registry not initialized")

--- a/app/streams_setup_test.go
+++ b/app/streams_setup_test.go
@@ -76,7 +76,6 @@ func TestPrepareStreamConsumersWithoutDeclarationsIsNoop(t *testing.T) {
 	require.NoError(t, a.prepareStreamConsumers(context.Background()))
 
 	assert.Nil(t, a.streamsManager)
-	assert.Empty(t, a.healthProbes, "a streams-free service keeps its probe list unchanged")
 	assert.Empty(t, a.closers)
 }
 
@@ -144,8 +143,7 @@ func TestPrepareStreamConsumersFailsWhenBrokerUnreachable(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to start stream consumers")
 	assert.NotContains(t, err.Error(), "guest:guest", "the stream URI's credentials must never reach an error message")
-	assert.Nil(t, a.streamsManager, "a failed start registers neither a probe nor a closer")
-	assert.Empty(t, a.healthProbes)
+	assert.Nil(t, a.streamsManager, "a failed start publishes no manager for the slot to register")
 	assert.Empty(t, a.closers)
 }
 
@@ -227,7 +225,6 @@ func TestPrepareStreamConsumersRejectsMultiTenantBypass(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "single-tenant only")
 	assert.Nil(t, a.streamsManager, "no Environment is built for a multi-tenant service")
-	assert.Empty(t, a.healthProbes)
 	assert.Empty(t, a.closers)
 }
 

--- a/wiki/adr_067_lifecycle_slots.md
+++ b/wiki/adr_067_lifecycle_slots.md
@@ -1,6 +1,6 @@
 # ADR-067: Slots Own the Per-Kind Lifecycle
 
-**Status:** Proposed — flips to Accepted when the last slot slice (the streams start phase) merges; the first slice (dead-surface removal, atom `[C60.4]`) is shipped
+**Status:** Proposed — flips to Accepted when the last slot slice (the streams fold, PR5) merges; the first slice (dead-surface removal, atom `[C60.4]`) is shipped
 **Date:** 2026-08-17
 **Builds on:** [ADR-066](adr_066_readiness_one_module.md) (readiness is one module — a
 *probe description* is what a slot hands readiness), [ADR-045](adr_045_no_producer_side_manager_interfaces.md)

--- a/wiki/migrations.md
+++ b/wiki/migrations.md
@@ -3311,7 +3311,7 @@ None of them is exhaustive — all three are line-oriented and blind to an impor
   internal helpers that happened to be exported. `MessagingInitializer` and
   `ConnectionPreWarmer` held a logger plus manager pointers `app.App` already holds and
   were each driven from a single startup line; they are now unexported `App` methods
-  (`prepareRuntimeConsumers`, `preWarmSingleTenant` and friends). `Options.Database` and
+  (`prepareRuntimeConsumers`, the slots' `start` phase and friends). `Options.Database` and
   `Options.MessagingClient` were read by no code path at all. The eight debug response
   types describe the JSON of `/_sys/health-debug`, `/_sys/goroutines` and `/_sys/gc`; they
   are unexported with their `json:` tags byte-identical. **No emitted JSON, status code or


### PR DESCRIPTION
## What

The slots gain `start(ctx) (advisory, fatal error)` and `stop(ctx)`; `prepareRuntime` walks them in the one registration order (database → messaging → cache → streams), aborts on the first fatal, joins advisories into the one WARN and re-collects probes; `Shutdown` runs `stopSlots` where the two stop calls were. `app/streams_setup.go` no longer registers the streams closer/probe at runtime — the slot does, once; the consumer bootstrap runs once, in the messaging slot's start.

## Impact

No consumer change (no exported symbol moves; `/ready` unchanged). Operators: the pre-warms now run before the AMQP bootstrap and the streams start (a failing streams start pays the pre-warm first); the duplicate `Ensured messaging consumers` INFO line retires. Second half of the slot slice; stacked on #1048.

## Verification

Diff-scoped mutation gate against the stack parent: all mutants on changed lines killed; the #907 grading, stop mapping, probe re-collect and ADR-029 order are pinned by named tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Lifecycle Improvements**
  * Standardized startup and shutdown across database, messaging, cache, and stream components.
  * Applications now validate required components before starting.
  * Shutdown stops inbound work in the correct order.
  * Startup failures halt initialization, while non-fatal readiness issues are reported as warnings.
* **Reliability**
  * Improved publisher readiness checks and consumer initialization.
  * Stream and messaging setup now register runtime resources consistently.
* **Documentation**
  * Updated lifecycle and migration documentation to reflect the revised startup process.
* **Tests**
  * Expanded coverage for startup, shutdown ordering, failures, readiness, cancellation, and resource cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->