### PR TITLE
feat(messaging): add the delivery pipeline both consume lanes will share

### DIFF
--- a/messaging/internal/delivery/delivery.go
+++ b/messaging/internal/delivery/delivery.go
@@ -59,8 +59,15 @@ func tracer() trace.Tracer {
 		return *t
 	}
 	t := otel.Tracer(tracerName)
-	sharedTracer.CompareAndSwap(nil, &t) // the first resolver wins; a loser reads the winner's
-	return *sharedTracer.Load()
+	if sharedTracer.CompareAndSwap(nil, &t) {
+		return t
+	}
+	// A concurrent resolver won; use its tracer — unless a concurrent reset already
+	// cleared it again, in which case this delivery keeps the one it resolved.
+	if winner := sharedTracer.Load(); winner != nil {
+		return *winner
+	}
+	return t
 }
 
 // Outcome names how one delivery ended.

--- a/messaging/internal/delivery/delivery.go
+++ b/messaging/internal/delivery/delivery.go
@@ -35,6 +35,9 @@ const (
 	messagingSystem      = "rabbitmq"
 
 	panicMessage = "panic in message handler: %v"
+
+	// spanAttrCap is the four common attributes plus the AMQP lane's four extras.
+	spanAttrCap = 8
 )
 
 // Outcome names how one delivery ended.
@@ -101,9 +104,10 @@ type Result struct {
 }
 
 // Run puts one message through the delivery pipeline and returns the outcome for
-// the lane to settle. It never returns nil and never panics: a handler panic
+// the lane to settle. It never returns nil, and a handler panic never escapes: it
 // becomes a Panicked result carrying the recovered value, its stack, and an
-// error.
+// error. A panic in the lane's own LogOutcome or Log is the lane's bug and does
+// propagate — the span still ends and the lease scope still drains, both deferred.
 func Run(ctx context.Context, req *Request) *Result {
 	start := time.Now()
 
@@ -145,7 +149,7 @@ func Run(ctx context.Context, req *Request) *Result {
 
 // spanAttributes renders the four attributes both lanes set, then the lane's own.
 func spanAttributes(req *Request) []attribute.KeyValue {
-	attrs := make([]attribute.KeyValue, 0, 4+len(req.SpanExtras))
+	attrs := make([]attribute.KeyValue, 0, spanAttrCap)
 	attrs = append(attrs,
 		attribute.String(string(semconv.MessagingSystemKey), messagingSystem),
 		semconv.MessagingOperationName(spanOperationReceive),

--- a/messaging/internal/delivery/delivery.go
+++ b/messaging/internal/delivery/delivery.go
@@ -13,7 +13,7 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -45,18 +45,22 @@ const (
 // inline variadic would heap-allocate both the slice and the option per message.
 var consumerSpanOpts = []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindConsumer)}
 
-var (
-	sharedTracer     trace.Tracer
-	sharedTracerOnce sync.Once
-)
+// sharedTracer holds the resolved tracer; nil until the first delivery. An
+// atomic pointer keeps the hot path lock-free and lets the test hook reset it
+// safely against a concurrent Run.
+var sharedTracer atomic.Pointer[trace.Tracer]
 
 // tracer returns the one tracer both lanes' deliveries report under. otel.Tracer
 // takes the global provider's lock and re-resolves the scope on every call, so
 // the hot path resolves it once — the streams lane caches its tracer per runner
 // today, and routing it through this seam must not regress that.
 func tracer() trace.Tracer {
-	sharedTracerOnce.Do(func() { sharedTracer = otel.Tracer(tracerName) })
-	return sharedTracer
+	if t := sharedTracer.Load(); t != nil {
+		return *t
+	}
+	t := otel.Tracer(tracerName)
+	sharedTracer.CompareAndSwap(nil, &t) // the first resolver wins; a loser reads the winner's
+	return *sharedTracer.Load()
 }
 
 // Outcome names how one delivery ended.

--- a/messaging/internal/delivery/delivery.go
+++ b/messaging/internal/delivery/delivery.go
@@ -1,0 +1,177 @@
+// Package delivery runs the delivery pipeline both messaging lanes share:
+// everything that happens to one consumed message between "bytes arrived" and
+// "outcome recorded" — trace extraction from the lane's carrier, the consumer
+// span, the per-message lease scope, handler invocation, panic-to-error, one
+// consumed record at completion, and the lane's own outcome line.
+//
+// Settlement is not here. Turning an outcome into a broker action — ack or
+// nack-without-requeue on the classic lane, commit-offset or skip on the streams
+// lane — is the lane's, and so is the policy behind it.
+package delivery
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/gaborage/go-bricks/internal/leasescope"
+	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/messaging/internal/tracking"
+	gobrickstrace "github.com/gaborage/go-bricks/trace"
+)
+
+const (
+	// tracerName is the one instrumentation scope both lanes report under.
+	tracerName = "go-bricks/messaging"
+
+	spanOperationReceive = "receive"
+	messagingSystem      = "rabbitmq"
+
+	panicMessage = "panic in message handler: %v"
+)
+
+// Outcome names how one delivery ended.
+type Outcome int
+
+// The three outcomes of one delivery. Succeeded is the zero value, so a result
+// is built as a success and only overwritten when the handler says otherwise.
+const (
+	Succeeded Outcome = iota
+	HandlerError
+	Panicked
+)
+
+// Handler invokes the module's handler for one message. The pipeline owns the
+// per-message context, so it hands over the two things derived from it that a
+// lane needs before its own handler runs: the context-bound logger and the
+// trace ID.
+type Handler func(ctx context.Context, log logger.Logger, traceID string) error
+
+// Request is what one lane hands the pipeline for one message. Handle and
+// LogOutcome are required.
+type Request struct {
+	// Carrier is where the trace context traveled: AMQP 0.9.1 headers on the
+	// classic lane, AMQP 1.0 application properties on the streams lane.
+	Carrier gobrickstrace.HeaderAccessor
+
+	// Destination is the queue or stream the message arrived on — the span
+	// name's prefix and messaging.destination.name.
+	Destination string
+
+	// BodySize is the payload length for messaging.message.body.size.
+	BodySize int
+
+	// SpanExtras are the lane's span attributes, set after the four both lanes
+	// share.
+	SpanExtras []attribute.KeyValue
+
+	// Metrics identifies this message on the receive instruments.
+	Metrics tracking.ConsumeAttributes
+
+	// Log is the consumer's logger. The pipeline binds it to the per-message
+	// context and hands the bound one back on Result.
+	Log logger.Logger
+
+	Handle Handler
+
+	// LogOutcome writes the lane's own line for the finished delivery. It runs
+	// while the span is open and the lease scope still holds, so a handle the
+	// handler borrowed outlives the line.
+	LogOutcome func(*Result)
+}
+
+// Result is what the lane settles on. Panic and Stack are set only when Outcome
+// is Panicked; Err is nil only when Outcome is Succeeded. A pointer, not a
+// value, so the lane's LogOutcome does not copy it per message.
+type Result struct {
+	Outcome  Outcome
+	Err      error
+	Duration time.Duration
+	TraceID  string
+	Log      logger.Logger
+	Panic    any
+	Stack    []byte
+}
+
+// Run puts one message through the delivery pipeline and returns the outcome for
+// the lane to settle. It never returns nil and never panics: a handler panic
+// becomes a Panicked result carrying the recovered value, its stack, and an
+// error.
+func Run(ctx context.Context, req *Request) *Result {
+	start := time.Now()
+
+	msgCtx := gobrickstrace.ExtractFromHeaders(ctx, req.Carrier)
+
+	msgCtx, span := otel.Tracer(tracerName).Start(msgCtx, req.Destination+" "+spanOperationReceive,
+		trace.WithSpanKind(trace.SpanKindConsumer))
+	span.SetAttributes(spanAttributes(req)...)
+
+	// Install the per-message lease scope (ADR-032): per-tenant handles borrowed
+	// via deps.DB/Cache/Messaging while this message is handled (including inbox
+	// ProcessOnce, which runs inside the handler and inherits msgCtx) are
+	// released when the message is done, so a handle evicted mid-handling is not
+	// closed under it. Deferred before span.End so the span closes first and
+	// ReleaseAll runs last.
+	msgCtx, scope := leasescope.Install(msgCtx)
+	defer scope.ReleaseAll()
+	defer span.End()
+
+	log := req.Log.WithContext(msgCtx)
+	traceID := gobrickstrace.EnsureTraceID(msgCtx)
+
+	res := invoke(msgCtx, log, traceID, req.Handle)
+	res.Duration = time.Since(start)
+	res.TraceID = traceID
+	res.Log = log
+
+	req.LogOutcome(res)
+
+	if res.Err != nil {
+		span.RecordError(res.Err)
+		span.SetStatus(codes.Error, res.Err.Error())
+	}
+
+	tracking.RecordConsume(msgCtx, req.Metrics, res.Duration, res.Err)
+
+	return res
+}
+
+// spanAttributes renders the four attributes both lanes set, then the lane's own.
+func spanAttributes(req *Request) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 4+len(req.SpanExtras))
+	attrs = append(attrs,
+		attribute.String(string(semconv.MessagingSystemKey), messagingSystem),
+		semconv.MessagingOperationName(spanOperationReceive),
+		semconv.MessagingDestinationName(req.Destination),
+		semconv.MessagingMessageBodySize(req.BodySize),
+	)
+	return append(attrs, req.SpanExtras...)
+}
+
+// invoke runs the lane's handler, turning a panic into an error so one tail
+// logs, marks and records every outcome.
+func invoke(ctx context.Context, log logger.Logger, traceID string, handle Handler) (res *Result) {
+	res = &Result{}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			res.Outcome = Panicked
+			res.Panic = recovered
+			res.Stack = debug.Stack()
+			res.Err = fmt.Errorf(panicMessage, recovered)
+		}
+	}()
+
+	if err := handle(ctx, log, traceID); err != nil {
+		res.Outcome = HandlerError
+		res.Err = err
+	}
+	return res
+}

--- a/messaging/internal/delivery/delivery.go
+++ b/messaging/internal/delivery/delivery.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -39,6 +40,24 @@ const (
 	// spanAttrCap is the four common attributes plus the AMQP lane's four extras.
 	spanAttrCap = 8
 )
+
+// consumerSpanOpts is built once and shared read-only by every delivery: a fresh
+// inline variadic would heap-allocate both the slice and the option per message.
+var consumerSpanOpts = []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindConsumer)}
+
+var (
+	sharedTracer     trace.Tracer
+	sharedTracerOnce sync.Once
+)
+
+// tracer returns the one tracer both lanes' deliveries report under. otel.Tracer
+// takes the global provider's lock and re-resolves the scope on every call, so
+// the hot path resolves it once — the streams lane caches its tracer per runner
+// today, and routing it through this seam must not regress that.
+func tracer() trace.Tracer {
+	sharedTracerOnce.Do(func() { sharedTracer = otel.Tracer(tracerName) })
+	return sharedTracer
+}
 
 // Outcome names how one delivery ended.
 type Outcome int
@@ -113,8 +132,7 @@ func Run(ctx context.Context, req *Request) *Result {
 
 	msgCtx := gobrickstrace.ExtractFromHeaders(ctx, req.Carrier)
 
-	msgCtx, span := otel.Tracer(tracerName).Start(msgCtx, req.Destination+" "+spanOperationReceive,
-		trace.WithSpanKind(trace.SpanKindConsumer))
+	msgCtx, span := tracer().Start(msgCtx, req.Destination+" "+spanOperationReceive, consumerSpanOpts...)
 	span.SetAttributes(spanAttributes(req)...)
 
 	// Install the per-message lease scope (ADR-032): per-tenant handles borrowed

--- a/messaging/internal/delivery/delivery_test.go
+++ b/messaging/internal/delivery/delivery_test.go
@@ -3,6 +3,7 @@ package delivery
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -480,4 +481,24 @@ func TestRunHandsTheLaneOneOutcomePerMessage(t *testing.T) {
 			assert.NotNil(t, res.Log)
 		})
 	}
+}
+
+// TestTracerCacheSurvivesAConcurrentReset pins the reset hook's contract: a
+// delivery that already resolved the tracer keeps it, one resolving alongside a
+// reset never sees nil, and -race stays quiet across the atomic pointer.
+func TestTracerCacheSurvivesAConcurrentReset(t *testing.T) {
+	setupTelemetry(t)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			for range 200 {
+				require.NotNil(t, tracer())
+			}
+		})
+	}
+	for range 50 {
+		ResetTracerForTesting()
+	}
+	wg.Wait()
 }

--- a/messaging/internal/delivery/delivery_test.go
+++ b/messaging/internal/delivery/delivery_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -492,10 +493,13 @@ func TestTracerCacheSurvivesAConcurrentReset(t *testing.T) {
 	setupTelemetry(t)
 
 	var wg sync.WaitGroup
+	var nilTracers atomic.Int64
 	for range 8 {
 		wg.Go(func() {
 			for range 200 {
-				require.NotNil(t, tracer())
+				if tracer() == nil { // no require in the worker: a Goexit there would hide the failure
+					nilTracers.Add(1)
+				}
 			}
 		})
 	}
@@ -503,4 +507,5 @@ func TestTracerCacheSurvivesAConcurrentReset(t *testing.T) {
 		ResetTracerForTesting()
 	}
 	wg.Wait()
+	assert.Zero(t, nilTracers.Load(), "a delivery racing a reset must never see a nil tracer")
 }

--- a/messaging/internal/delivery/delivery_test.go
+++ b/messaging/internal/delivery/delivery_test.go
@@ -492,10 +492,15 @@ func TestRunHandsTheLaneOneOutcomePerMessage(t *testing.T) {
 func TestTracerCacheSurvivesAConcurrentReset(t *testing.T) {
 	setupTelemetry(t)
 
+	// One gate releases workers and resetter together, and the resets run in a
+	// joined goroutine: without both, the scheduler can drain every reset before
+	// the first tracer() call and the test proves nothing about the race.
+	start := make(chan struct{})
 	var wg sync.WaitGroup
 	var nilTracers atomic.Int64
 	for range 8 {
 		wg.Go(func() {
+			<-start
 			for range 200 {
 				if tracer() == nil { // no require in the worker: a Goexit there would hide the failure
 					nilTracers.Add(1)
@@ -503,9 +508,13 @@ func TestTracerCacheSurvivesAConcurrentReset(t *testing.T) {
 			}
 		})
 	}
-	for range 50 {
-		ResetTracerForTesting()
-	}
+	wg.Go(func() {
+		<-start
+		for range 200 {
+			ResetTracerForTesting()
+		}
+	})
+	close(start)
 	wg.Wait()
 	assert.Zero(t, nilTracers.Load(), "a delivery racing a reset must never see a nil tracer")
 }

--- a/messaging/internal/delivery/delivery_test.go
+++ b/messaging/internal/delivery/delivery_test.go
@@ -386,6 +386,7 @@ func TestRunInstallsALeaseScopeAndDrainsItAfterTheHandler(t *testing.T) {
 			handle: func(released *bool) Handler {
 				return func(ctx context.Context, _ logger.Logger, _ string) error {
 					leasescope.Register(ctx, func() { *released = true })
+					time.Sleep(2 * time.Millisecond) // outlast Windows' coarse clock so Duration reads > 0
 					return nil
 				}
 			},
@@ -395,6 +396,7 @@ func TestRunInstallsALeaseScopeAndDrainsItAfterTheHandler(t *testing.T) {
 			handle: func(released *bool) Handler {
 				return func(ctx context.Context, _ logger.Logger, _ string) error {
 					leasescope.Register(ctx, func() { *released = true })
+					time.Sleep(2 * time.Millisecond)
 					panic("after borrowing")
 				}
 			},

--- a/messaging/internal/delivery/delivery_test.go
+++ b/messaging/internal/delivery/delivery_test.go
@@ -416,6 +416,11 @@ func TestRunInstallsALeaseScopeAndDrainsItAfterTheHandler(t *testing.T) {
 				// The lane logs and settles while the lease is still held: a
 				// handle borrowed by the handler must outlive the outcome line.
 				assert.False(t, released, "the scope drained before the lane saw the outcome")
+				// The lane's line reads these, so they must already be filled in
+				// by the time it runs — not after the outcome line.
+				assert.NotEmpty(t, res.TraceID)
+				assert.Positive(t, res.Duration)
+				assert.NotNil(t, res.Log)
 				rec.log(res)
 			}
 

--- a/messaging/internal/delivery/delivery_test.go
+++ b/messaging/internal/delivery/delivery_test.go
@@ -1,0 +1,492 @@
+package delivery
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	semconv "go.opentelemetry.io/otel/semconv/v1.32.0"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/gaborage/go-bricks/internal/leasescope"
+	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/messaging/internal/tracking"
+	obtest "github.com/gaborage/go-bricks/observability/testing"
+	gobrickstrace "github.com/gaborage/go-bricks/trace"
+)
+
+const (
+	testQueue       = "orders"
+	testTraceID     = "req-2026"
+	testTraceParent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+)
+
+// mapCarrier is a Carrier over a plain map: the pipeline only ever reads through
+// trace.HeaderAccessor, so a test does not need either lane's header type.
+type mapCarrier map[string]any
+
+func (c mapCarrier) Get(key string) any        { return c[key] }
+func (c mapCarrier) Set(key string, value any) { c[key] = value }
+
+// nopEvent satisfies logger.LogEvent without recording: the pipeline itself
+// writes no line, so there is nothing on an event to assert.
+type nopEvent struct{}
+
+func (nopEvent) Msg(string)                                  {}
+func (nopEvent) Msgf(string, ...any)                         {}
+func (e nopEvent) Err(error) logger.LogEvent                 { return e }
+func (e nopEvent) Str(_, _ string) logger.LogEvent           { return e }
+func (e nopEvent) Int(string, int) logger.LogEvent           { return e }
+func (e nopEvent) Int64(string, int64) logger.LogEvent       { return e }
+func (e nopEvent) Uint64(string, uint64) logger.LogEvent     { return e }
+func (e nopEvent) Dur(string, time.Duration) logger.LogEvent { return e }
+func (e nopEvent) Interface(string, any) logger.LogEvent     { return e }
+func (e nopEvent) Bytes(string, []byte) logger.LogEvent      { return e }
+func (e nopEvent) Bool(string, bool) logger.LogEvent         { return e }
+func (nopEvent) Enabled() bool                               { return true }
+
+// bindingLogger records the context it was bound to and the logger that binding
+// produced, so a test can assert WHICH logger the lane gets back.
+type bindingLogger struct {
+	boundTo context.Context
+	bound   *bindingLogger
+}
+
+func (l *bindingLogger) WithContext(ctx any) logger.Logger {
+	msgCtx, _ := ctx.(context.Context)
+	l.bound = &bindingLogger{boundTo: msgCtx}
+	return l.bound
+}
+func (l *bindingLogger) WithFields(map[string]any) logger.Logger { return l }
+func (l *bindingLogger) Info() logger.LogEvent                   { return nopEvent{} }
+func (l *bindingLogger) Error() logger.LogEvent                  { return nopEvent{} }
+func (l *bindingLogger) Debug() logger.LogEvent                  { return nopEvent{} }
+func (l *bindingLogger) Warn() logger.LogEvent                   { return nopEvent{} }
+func (l *bindingLogger) Fatal() logger.LogEvent                  { return nopEvent{} }
+
+var _ logger.Logger = (*bindingLogger)(nil)
+
+// setupTelemetry installs an in-memory span exporter and a test meter provider,
+// both restored on cleanup. The tracking instruments are package singletons, so
+// the reset brackets the test on both sides.
+func setupTelemetry(t *testing.T) (*tracetest.InMemoryExporter, *obtest.TestMeterProvider) {
+	t.Helper()
+
+	prevTP := otel.GetTracerProvider()
+	prevProp := otel.GetTextMapPropagator()
+	prevMP := otel.GetMeterProvider()
+
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	mp := obtest.NewTestMeterProvider()
+	otel.SetMeterProvider(mp)
+	tracking.ResetMeterForTesting()
+
+	t.Cleanup(func() {
+		require.NoError(t, tp.Shutdown(context.Background()))
+		otel.SetTracerProvider(prevTP)
+		otel.SetTextMapPropagator(prevProp)
+		otel.SetMeterProvider(prevMP)
+		tracking.ResetMeterForTesting()
+		require.NoError(t, mp.Shutdown(context.Background()))
+	})
+
+	return exporter, mp
+}
+
+// outcomes records every Result the lane's LogOutcome was handed.
+type outcomes struct {
+	seen []*Result
+}
+
+func (o *outcomes) log(res *Result) { o.seen = append(o.seen, res) }
+
+// newRequest builds a Request with the classic lane's shape and a handler the
+// test supplies. Fields a test cares about are overwritten by the caller.
+func newRequest(log logger.Logger, rec *outcomes, handle Handler) *Request {
+	return &Request{
+		Carrier:     mapCarrier{},
+		Destination: testQueue,
+		BodySize:    12,
+		Metrics:     tracking.AMQPConsumeAttributes("events", "orders.created", testQueue),
+		Log:         log,
+		Handle:      handle,
+		LogOutcome:  rec.log,
+	}
+}
+
+func succeedingHandler(context.Context, logger.Logger, string) error { return nil }
+
+func assertAttribute(t *testing.T, attrs []attribute.KeyValue, key string, want any) {
+	t.Helper()
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			assert.Equal(t, want, attr.Value.AsInterface(), "attribute %s", key)
+			return
+		}
+	}
+	t.Errorf("attribute %s not found", key)
+}
+
+func assertNoAttribute(t *testing.T, attrs []attribute.KeyValue, key string) {
+	t.Helper()
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			t.Errorf("attribute %s should be absent, got %v", key, attr.Value.AsInterface())
+		}
+	}
+}
+
+func TestRunReportsSucceededForAHandlerThatReturnsNil(t *testing.T) {
+	setupTelemetry(t)
+	rec := &outcomes{}
+
+	res := Run(context.Background(), newRequest(&bindingLogger{}, rec, func(context.Context, logger.Logger, string) error {
+		time.Sleep(time.Millisecond)
+		return nil
+	}))
+
+	require.NotNil(t, res)
+	assert.Equal(t, Succeeded, res.Outcome)
+	assert.NoError(t, res.Err)
+	assert.Nil(t, res.Panic)
+	assert.Nil(t, res.Stack)
+	assert.GreaterOrEqual(t, res.Duration, time.Millisecond)
+}
+
+func TestRunReportsHandlerErrorAndCarriesTheError(t *testing.T) {
+	setupTelemetry(t)
+	rec := &outcomes{}
+	handlerErr := errors.New("boom")
+
+	res := Run(context.Background(), newRequest(&bindingLogger{}, rec, func(context.Context, logger.Logger, string) error {
+		return handlerErr
+	}))
+
+	assert.Equal(t, HandlerError, res.Outcome)
+	assert.Same(t, handlerErr, res.Err)
+	assert.Nil(t, res.Panic)
+}
+
+func TestRunConvertsAPanicIntoAnError(t *testing.T) {
+	setupTelemetry(t)
+	rec := &outcomes{}
+
+	var res *Result
+	require.NotPanics(t, func() {
+		res = Run(context.Background(), newRequest(&bindingLogger{}, rec, func(context.Context, logger.Logger, string) error {
+			panic("handler exploded")
+		}))
+	})
+
+	assert.Equal(t, Panicked, res.Outcome)
+	require.Error(t, res.Err)
+	// The classic lane's wording, now both lanes'.
+	assert.Equal(t, "panic in message handler: handler exploded", res.Err.Error())
+	assert.Equal(t, "handler exploded", res.Panic)
+	assert.NotEmpty(t, res.Stack)
+}
+
+func TestRunBindsTheLoggerToThePerMessageContext(t *testing.T) {
+	setupTelemetry(t)
+	rec := &outcomes{}
+	base := &bindingLogger{}
+
+	var handleLog logger.Logger
+	var handleCtx context.Context
+	res := Run(context.Background(), newRequest(base, rec, func(ctx context.Context, log logger.Logger, _ string) error {
+		handleCtx, handleLog = ctx, log
+		return nil
+	}))
+
+	require.NotNil(t, base.bound)
+	assert.Same(t, base.bound, res.Log, "the lane settles through the context-bound logger")
+	assert.Same(t, base.bound, handleLog, "the handler adapter gets the same one")
+	assert.Same(t, base.bound.boundTo, handleCtx, "and it is bound to the context the handler ran under")
+}
+
+func TestRunCarriesTheCarrierTraceIDIntoTheContextAndTheResult(t *testing.T) {
+	setupTelemetry(t)
+	rec := &outcomes{}
+
+	req := newRequest(&bindingLogger{}, rec, func(ctx context.Context, _ logger.Logger, traceID string) error {
+		assert.Equal(t, testTraceID, traceID)
+		got, ok := gobrickstrace.IDFromContext(ctx)
+		assert.True(t, ok)
+		assert.Equal(t, testTraceID, got)
+		return nil
+	})
+	req.Carrier = mapCarrier{gobrickstrace.HeaderXRequestID: testTraceID}
+
+	res := Run(context.Background(), req)
+
+	assert.Equal(t, testTraceID, res.TraceID)
+}
+
+func TestRunGeneratesATraceIDWhenNoneTraveled(t *testing.T) {
+	setupTelemetry(t)
+	rec := &outcomes{}
+
+	first := Run(context.Background(), newRequest(&bindingLogger{}, rec, succeedingHandler))
+	second := Run(context.Background(), newRequest(&bindingLogger{}, rec, succeedingHandler))
+
+	assert.NotEmpty(t, first.TraceID)
+	assert.NotEqual(t, first.TraceID, second.TraceID)
+}
+
+func TestRunAcceptsANilCarrier(t *testing.T) {
+	setupTelemetry(t)
+	rec := &outcomes{}
+
+	req := newRequest(&bindingLogger{}, rec, succeedingHandler)
+	req.Carrier = nil
+
+	var res *Result
+	require.NotPanics(t, func() { res = Run(context.Background(), req) })
+	assert.Equal(t, Succeeded, res.Outcome)
+	assert.NotEmpty(t, res.TraceID)
+}
+
+func TestRunStartsARootSpanWhenOnlyAW3CHeaderTraveled(t *testing.T) {
+	exporter, _ := setupTelemetry(t)
+	rec := &outcomes{}
+
+	req := newRequest(&bindingLogger{}, rec, succeedingHandler)
+	req.Carrier = mapCarrier{gobrickstrace.HeaderTraceParent: testTraceParent}
+
+	Run(context.Background(), req)
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	// go-bricks extraction populates context VALUES, not the OTel span context,
+	// so a consume span has always been a root span. Changing that would
+	// re-parent every existing consumer span; ADR-068 keeps it out of scope.
+	assert.False(t, spans[0].Parent.IsValid())
+	tp, ok := gobrickstrace.ParentFromContext(rec.seen[0].Log.(*bindingLogger).boundTo)
+	require.True(t, ok)
+	assert.Equal(t, testTraceParent, tp)
+}
+
+func TestRunStartsOneConsumerSpanPerMessage(t *testing.T) {
+	exporter, _ := setupTelemetry(t)
+	rec := &outcomes{}
+
+	req := newRequest(&bindingLogger{}, rec, succeedingHandler)
+	req.SpanExtras = []attribute.KeyValue{attribute.String("messaging.rabbitmq.exchange", "events")}
+
+	Run(context.Background(), req)
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	span := spans[0]
+	assert.Equal(t, testQueue+" receive", span.Name)
+	assert.Equal(t, trace.SpanKindConsumer, span.SpanKind)
+	assertAttribute(t, span.Attributes, string(semconv.MessagingSystemKey), "rabbitmq")
+	assertAttribute(t, span.Attributes, string(semconv.MessagingOperationNameKey), "receive")
+	assertAttribute(t, span.Attributes, string(semconv.MessagingDestinationNameKey), testQueue)
+	assertAttribute(t, span.Attributes, string(semconv.MessagingMessageBodySizeKey), int64(12))
+	assertAttribute(t, span.Attributes, "messaging.rabbitmq.exchange", "events")
+	assert.Equal(t, codes.Unset, span.Status.Code)
+}
+
+func TestRunMarksTheSpanFailedForEveryFailingOutcome(t *testing.T) {
+	tests := []struct {
+		name    string
+		handle  Handler
+		wantMsg string
+	}{
+		{
+			name:    "handler_error",
+			handle:  func(context.Context, logger.Logger, string) error { return errors.New("nope") },
+			wantMsg: "nope",
+		},
+		{
+			name:    "panicked",
+			handle:  func(context.Context, logger.Logger, string) error { panic("nope") },
+			wantMsg: "panic in message handler: nope",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exporter, _ := setupTelemetry(t)
+			rec := &outcomes{}
+
+			Run(context.Background(), newRequest(&bindingLogger{}, rec, tt.handle))
+
+			spans := exporter.GetSpans()
+			require.Len(t, spans, 1)
+			assert.Equal(t, codes.Error, spans[0].Status.Code)
+			assert.Equal(t, tt.wantMsg, spans[0].Status.Description)
+			require.Len(t, spans[0].Events, 1)
+			assert.Equal(t, "exception", spans[0].Events[0].Name)
+		})
+	}
+}
+
+func TestRunRecordsOneConsumeAtCompletion(t *testing.T) {
+	_, mp := setupTelemetry(t)
+	rec := &outcomes{}
+
+	Run(context.Background(), newRequest(&bindingLogger{}, rec, func(context.Context, logger.Logger, string) error {
+		time.Sleep(time.Millisecond)
+		return nil
+	}))
+
+	rm := mp.Collect(t)
+	obtest.AssertMetricValue(t, rm, "messaging.client.consumed.messages", int64(1))
+
+	durationMetric := obtest.FindMetric(rm, "messaging.client.operation.duration")
+	require.NotNil(t, durationMetric)
+	histData, ok := durationMetric.Data.(metricdata.Histogram[float64])
+	require.True(t, ok)
+	require.Len(t, histData.DataPoints, 1)
+
+	attrs := histData.DataPoints[0].Attributes.ToSlice()
+	assertAttribute(t, attrs, "messaging.destination.name", "events:orders.created:orders")
+	assertNoAttribute(t, attrs, "error.type")
+}
+
+func TestRunRecordsAFailedDeliveryWithItsErrorType(t *testing.T) {
+	_, mp := setupTelemetry(t)
+	rec := &outcomes{}
+
+	Run(context.Background(), newRequest(&bindingLogger{}, rec, func(context.Context, logger.Logger, string) error {
+		time.Sleep(time.Millisecond)
+		return errors.New("nope")
+	}))
+
+	rm := mp.Collect(t)
+
+	consumed := obtest.FindMetric(rm, "messaging.client.consumed.messages")
+	require.NotNil(t, consumed)
+	sumData, ok := consumed.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, sumData.DataPoints, 1)
+	assert.Equal(t, int64(1), sumData.DataPoints[0].Value)
+	assertAttribute(t, sumData.DataPoints[0].Attributes.ToSlice(), "error.type", "*errors.errorString")
+}
+
+func TestRunInstallsALeaseScopeAndDrainsItAfterTheHandler(t *testing.T) {
+	tests := []struct {
+		name   string
+		handle func(released *bool) Handler
+	}{
+		{
+			name: "succeeded",
+			handle: func(released *bool) Handler {
+				return func(ctx context.Context, _ logger.Logger, _ string) error {
+					leasescope.Register(ctx, func() { *released = true })
+					return nil
+				}
+			},
+		},
+		{
+			name: "panicked",
+			handle: func(released *bool) Handler {
+				return func(ctx context.Context, _ logger.Logger, _ string) error {
+					leasescope.Register(ctx, func() { *released = true })
+					panic("after borrowing")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupTelemetry(t)
+			rec := &outcomes{}
+			released := false
+
+			req := newRequest(&bindingLogger{}, rec, tt.handle(&released))
+			req.LogOutcome = func(res *Result) {
+				// The lane logs and settles while the lease is still held: a
+				// handle borrowed by the handler must outlive the outcome line.
+				assert.False(t, released, "the scope drained before the lane saw the outcome")
+				rec.log(res)
+			}
+
+			Run(context.Background(), req)
+
+			assert.True(t, released, "the scope must drain once the message is done")
+		})
+	}
+}
+
+func TestRunEndsTheSpanBeforeItDrainsTheLeaseScope(t *testing.T) {
+	setupTelemetry(t)
+	rec := &outcomes{}
+
+	var order []string
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(onEndRecorder{onEnd: func() {
+		order = append(order, "span-end")
+	}}))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { require.NoError(t, tp.Shutdown(context.Background())) })
+
+	Run(context.Background(), newRequest(&bindingLogger{}, rec, func(ctx context.Context, _ logger.Logger, _ string) error {
+		leasescope.Register(ctx, func() { order = append(order, "release") })
+		return nil
+	}))
+
+	assert.Equal(t, []string{"span-end", "release"}, order)
+}
+
+// onEndRecorder is a span processor that only reports that a span ended, so the
+// pipeline's defer order can be asserted.
+type onEndRecorder struct {
+	onEnd func()
+}
+
+func (onEndRecorder) OnStart(context.Context, sdktrace.ReadWriteSpan) {}
+func (p onEndRecorder) OnEnd(sdktrace.ReadOnlySpan)                   { p.onEnd() }
+func (onEndRecorder) Shutdown(context.Context) error                  { return nil }
+func (onEndRecorder) ForceFlush(context.Context) error                { return nil }
+
+func TestRunHandsTheLaneOneOutcomePerMessage(t *testing.T) {
+	tests := []struct {
+		name   string
+		handle Handler
+		want   Outcome
+	}{
+		{name: "succeeded", handle: succeedingHandler, want: Succeeded},
+		{
+			name:   "handler_error",
+			handle: func(context.Context, logger.Logger, string) error { return errors.New("nope") },
+			want:   HandlerError,
+		},
+		{
+			name:   "panicked",
+			handle: func(context.Context, logger.Logger, string) error { panic("nope") },
+			want:   Panicked,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupTelemetry(t)
+			rec := &outcomes{}
+
+			res := Run(context.Background(), newRequest(&bindingLogger{}, rec, tt.handle))
+
+			require.Len(t, rec.seen, 1)
+			assert.Same(t, res, rec.seen[0], "the lane logs and settles the same Result")
+			assert.Equal(t, tt.want, res.Outcome)
+			assert.NotEmpty(t, res.TraceID)
+			assert.NotNil(t, res.Log)
+		})
+	}
+}

--- a/messaging/internal/delivery/delivery_test.go
+++ b/messaging/internal/delivery/delivery_test.go
@@ -38,73 +38,57 @@ type mapCarrier map[string]any
 func (c mapCarrier) Get(key string) any        { return c[key] }
 func (c mapCarrier) Set(key string, value any) { c[key] = value }
 
-// nopEvent satisfies logger.LogEvent without recording: the pipeline itself
-// writes no line, so there is nothing on an event to assert.
-type nopEvent struct{}
-
-func (nopEvent) Msg(string)                                  {}
-func (nopEvent) Msgf(string, ...any)                         {}
-func (e nopEvent) Err(error) logger.LogEvent                 { return e }
-func (e nopEvent) Str(_, _ string) logger.LogEvent           { return e }
-func (e nopEvent) Int(string, int) logger.LogEvent           { return e }
-func (e nopEvent) Int64(string, int64) logger.LogEvent       { return e }
-func (e nopEvent) Uint64(string, uint64) logger.LogEvent     { return e }
-func (e nopEvent) Dur(string, time.Duration) logger.LogEvent { return e }
-func (e nopEvent) Interface(string, any) logger.LogEvent     { return e }
-func (e nopEvent) Bytes(string, []byte) logger.LogEvent      { return e }
-func (e nopEvent) Bool(string, bool) logger.LogEvent         { return e }
-func (nopEvent) Enabled() bool                               { return true }
-
-// bindingLogger records the context it was bound to and the logger that binding
-// produced, so a test can assert WHICH logger the lane gets back.
+// bindingLogger records the logger a binding produced and the context it was bound
+// to, so a test can assert WHICH logger the lane gets back. Everything but
+// WithContext comes from the embedded real logger.
 type bindingLogger struct {
+	logger.Logger
 	boundTo context.Context
 	bound   *bindingLogger
 }
 
 func (l *bindingLogger) WithContext(ctx any) logger.Logger {
 	msgCtx, _ := ctx.(context.Context)
-	l.bound = &bindingLogger{boundTo: msgCtx}
+	l.bound = &bindingLogger{Logger: l.Logger, boundTo: msgCtx}
 	return l.bound
 }
-func (l *bindingLogger) WithFields(map[string]any) logger.Logger { return l }
-func (l *bindingLogger) Info() logger.LogEvent                   { return nopEvent{} }
-func (l *bindingLogger) Error() logger.LogEvent                  { return nopEvent{} }
-func (l *bindingLogger) Debug() logger.LogEvent                  { return nopEvent{} }
-func (l *bindingLogger) Warn() logger.LogEvent                   { return nopEvent{} }
-func (l *bindingLogger) Fatal() logger.LogEvent                  { return nopEvent{} }
 
 var _ logger.Logger = (*bindingLogger)(nil)
 
-// setupTelemetry installs an in-memory span exporter and a test meter provider,
-// both restored on cleanup. The tracking instruments are package singletons, so
-// the reset brackets the test on both sides.
-func setupTelemetry(t *testing.T) (*tracetest.InMemoryExporter, *obtest.TestMeterProvider) {
+// setupTelemetry installs a test tracer provider and a test meter provider, both
+// restored on cleanup, plus any span processor the test needs on that same
+// provider. The tracking meter and the pipeline's tracer are package singletons,
+// so both resets bracket the test on both sides.
+func setupTelemetry(t *testing.T, processors ...sdktrace.SpanProcessor) (*tracetest.InMemoryExporter, *obtest.TestMeterProvider) {
 	t.Helper()
 
 	prevTP := otel.GetTracerProvider()
 	prevProp := otel.GetTextMapPropagator()
 	prevMP := otel.GetMeterProvider()
 
-	exporter := tracetest.NewInMemoryExporter()
-	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
-	otel.SetTracerProvider(tp)
+	ttp := obtest.NewTestTraceProvider()
+	for _, processor := range processors {
+		ttp.RegisterSpanProcessor(processor)
+	}
+	otel.SetTracerProvider(ttp)
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 
 	mp := obtest.NewTestMeterProvider()
 	otel.SetMeterProvider(mp)
 	tracking.ResetMeterForTesting()
+	ResetTracerForTesting()
 
 	t.Cleanup(func() {
-		require.NoError(t, tp.Shutdown(context.Background()))
+		require.NoError(t, ttp.Shutdown(context.Background()))
 		otel.SetTracerProvider(prevTP)
 		otel.SetTextMapPropagator(prevProp)
 		otel.SetMeterProvider(prevMP)
 		tracking.ResetMeterForTesting()
+		ResetTracerForTesting()
 		require.NoError(t, mp.Shutdown(context.Background()))
 	})
 
-	return exporter, mp
+	return ttp.Exporter, mp
 }
 
 // outcomes records every Result the lane's LogOutcome was handed.
@@ -114,19 +98,43 @@ type outcomes struct {
 
 func (o *outcomes) log(res *Result) { o.seen = append(o.seen, res) }
 
-// newRequest builds a Request with the classic lane's shape and a handler the
-// test supplies. Fields a test cares about are overwritten by the caller.
-func newRequest(log logger.Logger, rec *outcomes, handle Handler) *Request {
+// harness owns one test's telemetry, outcome recorder and logger, so each test
+// states only what it is pinning.
+type harness struct {
+	exporter *tracetest.InMemoryExporter
+	mp       *obtest.TestMeterProvider
+	rec      *outcomes
+	log      *bindingLogger
+}
+
+func newHarness(t *testing.T, processors ...sdktrace.SpanProcessor) *harness {
+	t.Helper()
+	exporter, mp := setupTelemetry(t, processors...)
+	return &harness{
+		exporter: exporter,
+		mp:       mp,
+		rec:      &outcomes{},
+		log:      &bindingLogger{Logger: logger.New("error", false)},
+	}
+}
+
+// request builds a Request with the classic lane's shape; a test overwrites the
+// fields it cares about before handing it to runRequest.
+func (h *harness) request(handle Handler) *Request {
 	return &Request{
 		Carrier:     mapCarrier{},
 		Destination: testQueue,
 		BodySize:    12,
 		Metrics:     tracking.AMQPConsumeAttributes("events", "orders.created", testQueue),
-		Log:         log,
+		Log:         h.log,
 		Handle:      handle,
-		LogOutcome:  rec.log,
+		LogOutcome:  h.rec.log,
 	}
 }
+
+func (h *harness) run(handle Handler) *Result { return h.runRequest(h.request(handle)) }
+
+func (h *harness) runRequest(req *Request) *Result { return Run(context.Background(), req) }
 
 func succeedingHandler(context.Context, logger.Logger, string) error { return nil }
 
@@ -151,13 +159,12 @@ func assertNoAttribute(t *testing.T, attrs []attribute.KeyValue, key string) {
 }
 
 func TestRunReportsSucceededForAHandlerThatReturnsNil(t *testing.T) {
-	setupTelemetry(t)
-	rec := &outcomes{}
+	h := newHarness(t)
 
-	res := Run(context.Background(), newRequest(&bindingLogger{}, rec, func(context.Context, logger.Logger, string) error {
+	res := h.run(func(context.Context, logger.Logger, string) error {
 		time.Sleep(time.Millisecond)
 		return nil
-	}))
+	})
 
 	require.NotNil(t, res)
 	assert.Equal(t, Succeeded, res.Outcome)
@@ -168,13 +175,12 @@ func TestRunReportsSucceededForAHandlerThatReturnsNil(t *testing.T) {
 }
 
 func TestRunReportsHandlerErrorAndCarriesTheError(t *testing.T) {
-	setupTelemetry(t)
-	rec := &outcomes{}
+	h := newHarness(t)
 	handlerErr := errors.New("boom")
 
-	res := Run(context.Background(), newRequest(&bindingLogger{}, rec, func(context.Context, logger.Logger, string) error {
+	res := h.run(func(context.Context, logger.Logger, string) error {
 		return handlerErr
-	}))
+	})
 
 	assert.Equal(t, HandlerError, res.Outcome)
 	assert.Same(t, handlerErr, res.Err)
@@ -182,14 +188,13 @@ func TestRunReportsHandlerErrorAndCarriesTheError(t *testing.T) {
 }
 
 func TestRunConvertsAPanicIntoAnError(t *testing.T) {
-	setupTelemetry(t)
-	rec := &outcomes{}
+	h := newHarness(t)
 
 	var res *Result
 	require.NotPanics(t, func() {
-		res = Run(context.Background(), newRequest(&bindingLogger{}, rec, func(context.Context, logger.Logger, string) error {
+		res = h.run(func(context.Context, logger.Logger, string) error {
 			panic("handler exploded")
-		}))
+		})
 	})
 
 	assert.Equal(t, Panicked, res.Outcome)
@@ -201,28 +206,25 @@ func TestRunConvertsAPanicIntoAnError(t *testing.T) {
 }
 
 func TestRunBindsTheLoggerToThePerMessageContext(t *testing.T) {
-	setupTelemetry(t)
-	rec := &outcomes{}
-	base := &bindingLogger{}
+	h := newHarness(t)
 
 	var handleLog logger.Logger
 	var handleCtx context.Context
-	res := Run(context.Background(), newRequest(base, rec, func(ctx context.Context, log logger.Logger, _ string) error {
+	res := h.run(func(ctx context.Context, log logger.Logger, _ string) error {
 		handleCtx, handleLog = ctx, log
 		return nil
-	}))
+	})
 
-	require.NotNil(t, base.bound)
-	assert.Same(t, base.bound, res.Log, "the lane settles through the context-bound logger")
-	assert.Same(t, base.bound, handleLog, "the handler adapter gets the same one")
-	assert.Same(t, base.bound.boundTo, handleCtx, "and it is bound to the context the handler ran under")
+	require.NotNil(t, h.log.bound)
+	assert.Same(t, h.log.bound, res.Log, "the lane settles through the context-bound logger")
+	assert.Same(t, h.log.bound, handleLog, "the handler adapter gets the same one")
+	assert.Same(t, h.log.bound.boundTo, handleCtx, "and it is bound to the context the handler ran under")
 }
 
 func TestRunCarriesTheCarrierTraceIDIntoTheContextAndTheResult(t *testing.T) {
-	setupTelemetry(t)
-	rec := &outcomes{}
+	h := newHarness(t)
 
-	req := newRequest(&bindingLogger{}, rec, func(ctx context.Context, _ logger.Logger, traceID string) error {
+	req := h.request(func(ctx context.Context, _ logger.Logger, traceID string) error {
 		assert.Equal(t, testTraceID, traceID)
 		got, ok := gobrickstrace.IDFromContext(ctx)
 		assert.True(t, ok)
@@ -231,65 +233,61 @@ func TestRunCarriesTheCarrierTraceIDIntoTheContextAndTheResult(t *testing.T) {
 	})
 	req.Carrier = mapCarrier{gobrickstrace.HeaderXRequestID: testTraceID}
 
-	res := Run(context.Background(), req)
+	res := h.runRequest(req)
 
 	assert.Equal(t, testTraceID, res.TraceID)
 }
 
 func TestRunGeneratesATraceIDWhenNoneTraveled(t *testing.T) {
-	setupTelemetry(t)
-	rec := &outcomes{}
+	h := newHarness(t)
 
-	first := Run(context.Background(), newRequest(&bindingLogger{}, rec, succeedingHandler))
-	second := Run(context.Background(), newRequest(&bindingLogger{}, rec, succeedingHandler))
+	first := h.run(succeedingHandler)
+	second := h.run(succeedingHandler)
 
 	assert.NotEmpty(t, first.TraceID)
 	assert.NotEqual(t, first.TraceID, second.TraceID)
 }
 
 func TestRunAcceptsANilCarrier(t *testing.T) {
-	setupTelemetry(t)
-	rec := &outcomes{}
+	h := newHarness(t)
 
-	req := newRequest(&bindingLogger{}, rec, succeedingHandler)
+	req := h.request(succeedingHandler)
 	req.Carrier = nil
 
 	var res *Result
-	require.NotPanics(t, func() { res = Run(context.Background(), req) })
+	require.NotPanics(t, func() { res = h.runRequest(req) })
 	assert.Equal(t, Succeeded, res.Outcome)
 	assert.NotEmpty(t, res.TraceID)
 }
 
 func TestRunStartsARootSpanWhenOnlyAW3CHeaderTraveled(t *testing.T) {
-	exporter, _ := setupTelemetry(t)
-	rec := &outcomes{}
+	h := newHarness(t)
 
-	req := newRequest(&bindingLogger{}, rec, succeedingHandler)
+	req := h.request(succeedingHandler)
 	req.Carrier = mapCarrier{gobrickstrace.HeaderTraceParent: testTraceParent}
 
-	Run(context.Background(), req)
+	h.runRequest(req)
 
-	spans := exporter.GetSpans()
+	spans := h.exporter.GetSpans()
 	require.Len(t, spans, 1)
 	// go-bricks extraction populates context VALUES, not the OTel span context,
 	// so a consume span has always been a root span. Changing that would
 	// re-parent every existing consumer span; ADR-068 keeps it out of scope.
 	assert.False(t, spans[0].Parent.IsValid())
-	tp, ok := gobrickstrace.ParentFromContext(rec.seen[0].Log.(*bindingLogger).boundTo)
+	tp, ok := gobrickstrace.ParentFromContext(h.rec.seen[0].Log.(*bindingLogger).boundTo)
 	require.True(t, ok)
 	assert.Equal(t, testTraceParent, tp)
 }
 
 func TestRunStartsOneConsumerSpanPerMessage(t *testing.T) {
-	exporter, _ := setupTelemetry(t)
-	rec := &outcomes{}
+	h := newHarness(t)
 
-	req := newRequest(&bindingLogger{}, rec, succeedingHandler)
+	req := h.request(succeedingHandler)
 	req.SpanExtras = []attribute.KeyValue{attribute.String("messaging.rabbitmq.exchange", "events")}
 
-	Run(context.Background(), req)
+	h.runRequest(req)
 
-	spans := exporter.GetSpans()
+	spans := h.exporter.GetSpans()
 	require.Len(t, spans, 1)
 	span := spans[0]
 	assert.Equal(t, testQueue+" receive", span.Name)
@@ -322,12 +320,11 @@ func TestRunMarksTheSpanFailedForEveryFailingOutcome(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			exporter, _ := setupTelemetry(t)
-			rec := &outcomes{}
+			h := newHarness(t)
 
-			Run(context.Background(), newRequest(&bindingLogger{}, rec, tt.handle))
+			h.run(tt.handle)
 
-			spans := exporter.GetSpans()
+			spans := h.exporter.GetSpans()
 			require.Len(t, spans, 1)
 			assert.Equal(t, codes.Error, spans[0].Status.Code)
 			assert.Equal(t, tt.wantMsg, spans[0].Status.Description)
@@ -338,15 +335,14 @@ func TestRunMarksTheSpanFailedForEveryFailingOutcome(t *testing.T) {
 }
 
 func TestRunRecordsOneConsumeAtCompletion(t *testing.T) {
-	_, mp := setupTelemetry(t)
-	rec := &outcomes{}
+	h := newHarness(t)
 
-	Run(context.Background(), newRequest(&bindingLogger{}, rec, func(context.Context, logger.Logger, string) error {
+	h.run(func(context.Context, logger.Logger, string) error {
 		time.Sleep(time.Millisecond)
 		return nil
-	}))
+	})
 
-	rm := mp.Collect(t)
+	rm := h.mp.Collect(t)
 	obtest.AssertMetricValue(t, rm, "messaging.client.consumed.messages", int64(1))
 
 	durationMetric := obtest.FindMetric(rm, "messaging.client.operation.duration")
@@ -361,15 +357,14 @@ func TestRunRecordsOneConsumeAtCompletion(t *testing.T) {
 }
 
 func TestRunRecordsAFailedDeliveryWithItsErrorType(t *testing.T) {
-	_, mp := setupTelemetry(t)
-	rec := &outcomes{}
+	h := newHarness(t)
 
-	Run(context.Background(), newRequest(&bindingLogger{}, rec, func(context.Context, logger.Logger, string) error {
+	h.run(func(context.Context, logger.Logger, string) error {
 		time.Sleep(time.Millisecond)
 		return errors.New("nope")
-	}))
+	})
 
-	rm := mp.Collect(t)
+	rm := h.mp.Collect(t)
 
 	consumed := obtest.FindMetric(rm, "messaging.client.consumed.messages")
 	require.NotNil(t, consumed)
@@ -407,11 +402,10 @@ func TestRunInstallsALeaseScopeAndDrainsItAfterTheHandler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setupTelemetry(t)
-			rec := &outcomes{}
+			h := newHarness(t)
 			released := false
 
-			req := newRequest(&bindingLogger{}, rec, tt.handle(&released))
+			req := h.request(tt.handle(&released))
 			req.LogOutcome = func(res *Result) {
 				// The lane logs and settles while the lease is still held: a
 				// handle borrowed by the handler must outlive the outcome line.
@@ -421,10 +415,10 @@ func TestRunInstallsALeaseScopeAndDrainsItAfterTheHandler(t *testing.T) {
 				assert.NotEmpty(t, res.TraceID)
 				assert.Positive(t, res.Duration)
 				assert.NotNil(t, res.Log)
-				rec.log(res)
+				h.rec.log(res)
 			}
 
-			Run(context.Background(), req)
+			h.runRequest(req)
 
 			assert.True(t, released, "the scope must drain once the message is done")
 		})
@@ -432,20 +426,13 @@ func TestRunInstallsALeaseScopeAndDrainsItAfterTheHandler(t *testing.T) {
 }
 
 func TestRunEndsTheSpanBeforeItDrainsTheLeaseScope(t *testing.T) {
-	setupTelemetry(t)
-	rec := &outcomes{}
-
 	var order []string
-	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(onEndRecorder{onEnd: func() {
-		order = append(order, "span-end")
-	}}))
-	otel.SetTracerProvider(tp)
-	t.Cleanup(func() { require.NoError(t, tp.Shutdown(context.Background())) })
+	h := newHarness(t, onEndRecorder{onEnd: func() { order = append(order, "span-end") }})
 
-	Run(context.Background(), newRequest(&bindingLogger{}, rec, func(ctx context.Context, _ logger.Logger, _ string) error {
+	h.run(func(ctx context.Context, _ logger.Logger, _ string) error {
 		leasescope.Register(ctx, func() { order = append(order, "release") })
 		return nil
-	}))
+	})
 
 	assert.Equal(t, []string{"span-end", "release"}, order)
 }
@@ -482,13 +469,12 @@ func TestRunHandsTheLaneOneOutcomePerMessage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setupTelemetry(t)
-			rec := &outcomes{}
+			h := newHarness(t)
 
-			res := Run(context.Background(), newRequest(&bindingLogger{}, rec, tt.handle))
+			res := h.run(tt.handle)
 
-			require.Len(t, rec.seen, 1)
-			assert.Same(t, res, rec.seen[0], "the lane logs and settles the same Result")
+			require.Len(t, h.rec.seen, 1)
+			assert.Same(t, res, h.rec.seen[0], "the lane logs and settles the same Result")
 			assert.Equal(t, tt.want, res.Outcome)
 			assert.NotEmpty(t, res.TraceID)
 			assert.NotNil(t, res.Log)

--- a/messaging/internal/delivery/testing.go
+++ b/messaging/internal/delivery/testing.go
@@ -1,12 +1,10 @@
 package delivery
 
-import "sync"
-
 // ResetTracerForTesting drops the cached tracer so the next delivery binds to the
 // currently installed global TracerProvider. Mirrors tracking.ResetMeterForTesting,
 // and is exported for the same reason: the lane suites that swap in a test provider
-// live in other packages. Not safe against a concurrent Run.
+// live in other packages. Safe against a concurrent Run: a delivery in flight keeps
+// the tracer it already resolved.
 func ResetTracerForTesting() {
-	sharedTracerOnce = sync.Once{}
-	sharedTracer = nil
+	sharedTracer.Store(nil)
 }

--- a/messaging/internal/delivery/testing.go
+++ b/messaging/internal/delivery/testing.go
@@ -1,0 +1,12 @@
+package delivery
+
+import "sync"
+
+// ResetTracerForTesting drops the cached tracer so the next delivery binds to the
+// currently installed global TracerProvider. Mirrors tracking.ResetMeterForTesting,
+// and is exported for the same reason: the lane suites that swap in a test provider
+// live in other packages. Not safe against a concurrent Run.
+func ResetTracerForTesting() {
+	sharedTracerOnce = sync.Once{}
+	sharedTracer = nil
+}


### PR DESCRIPTION
## What

Both consume lanes carry the same per-message ceremony in two hand-written copies that drift. `messaging/internal/delivery` now owns it once: `Run(ctx, *Request) *Result` extracts the carrier, starts the consumer span, installs the lease scope, ensures the trace ID, invokes the handler (a panic becomes a `Panicked` outcome), records one consume metric with `error.type` and hands the lane a `Result`; the lane writes its outcome line and settles. No lane migrates here.

## Impact

None yet — an internal package with no caller; nothing exported by `messaging` changes. The AMQP lane moves onto it next (with the `StartConsumeSpan` removal and ADR-068), the streams lane after. Stacked on #1050.

## Verification

Diff-scoped mutation gate against the stack parent: 6/6 mutants killed; the suite runs `-race -count=3` against real OTel test providers; escape analysis shows one added allocation per delivery over today's AMQP path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared message delivery pipeline with per-message context, tracing, resource handling, and settlement results.
  * Added automatic reporting for successful deliveries, handler errors, and panics.
  * Added delivery metrics, outcome logging, and trace propagation or generation when needed.

* **Bug Fixes**
  * Improved failure visibility by marking unsuccessful deliveries in telemetry and preserving relevant error details.
  * Ensured message resources are released reliably after processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->