### PR TITLE
feat(messaging): declare the lane contract both messaging lanes must satisfy

### DIFF
--- a/messaging/internal/lanecontract/lanecontract.go
+++ b/messaging/internal/lanecontract/lanecontract.go
@@ -1,0 +1,222 @@
+// Package lanecontract holds the contract every messaging lane driving the
+// delivery pipeline must satisfy, and the fixture that drives it.
+//
+// It must import NEITHER messaging NOR messaging/streams: both lanes' tests are
+// in-package, so they import this one, and either import here is a hard cycle.
+// Everything lane-specific arrives through Lane's func fields.
+package lanecontract
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/gaborage/go-bricks/messaging/internal/delivery"
+)
+
+// Lane is one lane's self-description and the complete list of what two lanes
+// may legitimately differ on: a difference with no field here is drift, and a
+// field added here declares a new divergence that must justify itself. Fields
+// keyed by delivery.Outcome say the divergence is per-outcome, which is stricter
+// than one list across all outcomes, not looser.
+//
+// AutoAck is deliberately absent — it is classic-only, and a permanently-false
+// field for one lane is the creep this struct exists to prevent.
+type Lane struct {
+	Name string
+
+	// Destination is the queue name on the classic lane, the stream name on the
+	// streams lane — the span name's prefix either way.
+	Destination string
+
+	// Deliver puts one Scenario through this lane's real delivery path, wrapping
+	// the Scenario's handler body in this lane's own handler kind. It must not
+	// return until the delivery is complete and every write it made is visible to
+	// the caller: the streams lane delivers from one goroutine per partition, so
+	// without that edge a family reading Observed races the delivery.
+	//
+	// It must not call t.Run — the family owns the subtest, so the telemetry
+	// fixture's provider restore is scoped to the family's test, not a nested one.
+	Deliver func(*testing.T, Scenario) Observed
+
+	// SpanExtraKeys are the span attribute keys this lane may add on top of the
+	// four both lanes share.
+	SpanExtraKeys []string
+
+	// OutcomeLines is what this lane's outcome line looks like, per outcome. An
+	// outcome absent from the map expects no outcome line at all — the streams
+	// lane logs nothing on success — and a family asserts that negative rather
+	// than looking for a line. One map, one meaning: there is no second field
+	// whose absence means something else.
+	OutcomeLines map[delivery.Outcome]OutcomeLine
+
+	// SettleOnSuccess and SettleOnFailure name what settling does here:
+	// "ack"/"nack-no-requeue" on the classic lane, "commit"/"skip" on streams.
+	SettleOnSuccess string
+	SettleOnFailure string
+}
+
+// Scenario is one delivery to put through a lane, described without naming
+// either lane's message type. Handle is lane-agnostic because the two handler
+// kinds differ — a two-method interface versus a bare func type — so each
+// adapter wraps this rather than the harness building either.
+type Scenario struct {
+	Name string
+
+	// Carrier is what traveled with the message; nil is the nothing-traveled
+	// case, which every lane must also survive.
+	Carrier map[string]any
+
+	// Body is the payload, so a family can assert the shared
+	// messaging.message.body.size attribute by value rather than by presence.
+	Body []byte
+
+	// Handle returns nil to succeed, an error to fail, or panics.
+	Handle func(ctx context.Context) error
+}
+
+// Observed is everything a lane's delivery produced, in the form the assertion
+// families read it.
+type Observed struct {
+	// Result is captured through the pipeline's LogOutcome hook, so no production
+	// signature gains a test-only parameter.
+	Result *delivery.Result
+
+	// Settles records each settlement in order, in Lane.SettleOnSuccess's
+	// vocabulary. More than one entry means the lane settled twice.
+	Settles []string
+
+	Lines   []LogLine
+	Spans   tracetest.SpanStubs
+	Metrics metricdata.ResourceMetrics
+}
+
+// OutcomeLine is the shape of one lane's outcome line for one outcome: the
+// level it logs at, the exact text it logs, and the fields it adds beyond the
+// spine delivery.AppendOutcome stamps.
+type OutcomeLine struct {
+	// Level is one of the Level constants below. It is declared rather than
+	// inferred because the lanes genuinely differ here, and a level the harness
+	// cannot compare against is a divergence it cannot catch.
+	Level string
+
+	// Msg is the exact message text. It is also the locator: a family finds this
+	// line among the lane's others by its text, since the streams lane emits a
+	// store-failure WARN and a panic line alongside its outcome line, and
+	// selecting by "the line carrying correlation_id" cannot tell a spine-less
+	// outcome line from a missing one.
+	Msg string
+
+	// ExtraKeys is the EXACT set of fields this line carries beyond the shared
+	// spine — not a permission list. A lane that quietly stops emitting a
+	// declared key has drifted exactly as much as one that adds an undeclared
+	// key, and only an exact-set comparison catches both. Per-outcome keying is
+	// what makes it viable: the classic lane's success line adds one field where
+	// its failure line adds eight.
+	ExtraKeys []string
+}
+
+// The levels a recorded line can carry. The two lanes differ here today — the
+// classic lane logs a successful delivery at Info, the streams lane logs no
+// success line at all — so a level-blind harness would hide exactly the kind of
+// divergence it exists to catch.
+const (
+	LevelInfo  = "info"
+	LevelError = "error"
+	LevelDebug = "debug"
+	LevelWarn  = "warn"
+	LevelFatal = "fatal"
+)
+
+// LogLine is one emitted log line: its level, its message, and every field write
+// in emission order. Duplicate keys are preserved — a lane stamping one key twice
+// is exactly the drift this harness catches.
+type LogLine struct {
+	Level  string
+	Msg    string
+	Fields [][2]string
+}
+
+// Values returns every value written under key, in order; nil when absent.
+func (l LogLine) Values(key string) []string {
+	var out []string
+	for _, field := range l.Fields {
+		if field[0] == key {
+			out = append(out, field[1])
+		}
+	}
+	return out
+}
+
+// outcomes is every delivery outcome in a fixed order, so Validate reports
+// deterministically instead of in map order.
+var outcomes = []delivery.Outcome{delivery.Succeeded, delivery.HandlerError, delivery.Panicked}
+
+// outcomeName renders an outcome for an error message; delivery.Outcome is a
+// bare int, and "Panicked" beats "2" in a failure a human has to read.
+func outcomeName(outcome delivery.Outcome) string {
+	switch outcome {
+	case delivery.Succeeded:
+		return "Succeeded"
+	case delivery.HandlerError:
+		return "HandlerError"
+	case delivery.Panicked:
+		return "Panicked"
+	default:
+		return fmt.Sprintf("Outcome(%d)", int(outcome))
+	}
+}
+
+// isLevel reports whether level is one of the levels the recorder stamps.
+func isLevel(level string) bool {
+	switch level {
+	case LevelInfo, LevelError, LevelDebug, LevelWarn, LevelFatal:
+		return true
+	default:
+		return false
+	}
+}
+
+// Validate reports every way this lane's declaration is unusable, joined, so a
+// lane author fixes them in one pass. The receiver is a pointer because Lane is
+// wide enough that copying it per call is wasteful, not because it mutates. A family calls it before asserting
+// anything: a declaration the harness cannot act on would otherwise pass every
+// assertion silently, which is the rubber stamp this package exists to prevent.
+func (l *Lane) Validate() error {
+	var problems []error
+	declaredBy := make(map[string]delivery.Outcome, len(l.OutcomeLines))
+
+	for _, outcome := range outcomes {
+		line, declared := l.OutcomeLines[outcome]
+		if !declared {
+			continue
+		}
+
+		if !isLevel(line.Level) {
+			problems = append(problems, fmt.Errorf(
+				"lane %q outcome %s: level %q is not a level the recorder stamps",
+				l.Name, outcomeName(outcome), line.Level))
+		}
+
+		if line.Msg == "" {
+			problems = append(problems, fmt.Errorf(
+				"lane %q outcome %s: declares %d extra keys but no message, so a family cannot locate its line",
+				l.Name, outcomeName(outcome), len(line.ExtraKeys)))
+			continue
+		}
+
+		if first, duplicate := declaredBy[line.Msg]; duplicate {
+			problems = append(problems, fmt.Errorf(
+				"lane %q outcome %s: message %q is already declared by %s, so a family cannot tell the two lines apart",
+				l.Name, outcomeName(outcome), line.Msg, outcomeName(first)))
+			continue
+		}
+		declaredBy[line.Msg] = outcome
+	}
+
+	return errors.Join(problems...)
+}

--- a/messaging/internal/lanecontract/lanecontract_test.go
+++ b/messaging/internal/lanecontract/lanecontract_test.go
@@ -1,0 +1,140 @@
+package lanecontract
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaborage/go-bricks/messaging/internal/delivery"
+)
+
+func TestLogLineValuesReturnsEveryWriteInOrder(t *testing.T) {
+	line := LogLine{Msg: "outcome", Fields: [][2]string{
+		{"correlation_id", "req-1"},
+		{"queue", "orders"},
+		{"correlation_id", "req-2"},
+	}}
+
+	tests := []struct {
+		name string
+		key  string
+		want []string
+	}{
+		{name: "written_twice", key: "correlation_id", want: []string{"req-1", "req-2"}},
+		{name: "written_once", key: "queue", want: []string{"orders"}},
+		{name: "absent", key: "exchange", want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, line.Values(tt.key))
+		})
+	}
+}
+
+// classicLane is the AMQP lane's real declared shape, read off registry.go
+// logOutcome/buildFailureLogEvent rather than from memory — the HandlerError
+// line chains .Err(res.Err), which the recorder files under "error", so it
+// carries eight extras where Panicked carries the same seven without it.
+func classicLane() Lane {
+	failureKeys := []string{
+		"message_id", "queue", "event_type", "amqp_correlation_id",
+		"consumer_tag", "routing_key", "exchange",
+	}
+	return Lane{
+		Name:        "classic",
+		Destination: "orders",
+		OutcomeLines: map[delivery.Outcome]OutcomeLine{
+			delivery.Succeeded: {
+				Level: LevelInfo, Msg: "Message processed successfully",
+				ExtraKeys: []string{"message_id"},
+			},
+			delivery.HandlerError: {
+				Level: LevelError, Msg: "Message processing failed - discarding without requeue",
+				ExtraKeys: append(append([]string{}, failureKeys...), "error"),
+			},
+			delivery.Panicked: {
+				Level: LevelError, Msg: "Panic recovered in message handler - discarding without requeue",
+				ExtraKeys: failureKeys,
+			},
+		},
+		SettleOnSuccess: "ack",
+		SettleOnFailure: "nack-no-requeue",
+	}
+}
+
+func TestLaneValidateAcceptsAConformingDeclaration(t *testing.T) {
+	lane := classicLane()
+	require.NoError(t, lane.Validate())
+
+	// An empty map declares no outcome line for any outcome, which is a lane the
+	// families assert negatively against, not a malformed one.
+	silent := Lane{Name: "silent"}
+	assert.NoError(t, silent.Validate())
+}
+
+func TestLaneValidateRejectsADeclarationAFamilyCannotActOn(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(Lane)
+		wantErr string
+	}{
+		{
+			name:    "level_the_recorder_never_stamps",
+			mutate:  func(l Lane) { l.OutcomeLines[delivery.Succeeded] = OutcomeLine{Level: "trace", Msg: "ok"} },
+			wantErr: `level "trace" is not a level the recorder stamps`,
+		},
+		{
+			name:    "empty_level",
+			mutate:  func(l Lane) { l.OutcomeLines[delivery.Succeeded] = OutcomeLine{Msg: "ok"} },
+			wantErr: `level "" is not a level the recorder stamps`,
+		},
+		{
+			name: "extras_but_no_message",
+			mutate: func(l Lane) {
+				l.OutcomeLines[delivery.Succeeded] = OutcomeLine{Level: LevelInfo, ExtraKeys: []string{"message_id"}}
+			},
+			wantErr: "declares 1 extra keys but no message, so a family cannot locate its line",
+		},
+		{
+			name: "message_duplicated_across_outcomes",
+			mutate: func(l Lane) {
+				line := l.OutcomeLines[delivery.Succeeded]
+				line.Msg = l.OutcomeLines[delivery.Panicked].Msg
+				l.OutcomeLines[delivery.Succeeded] = line
+			},
+			wantErr: "is already declared by",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lane := classicLane()
+			tt.mutate(lane)
+
+			err := lane.Validate()
+
+			require.Error(t, err, "a declaration a family cannot act on must not validate")
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Contains(t, err.Error(), `lane "classic"`, "the error names the lane")
+		})
+	}
+}
+
+// Every problem is reported in one pass, so a lane author is not fed them one
+// failing run at a time.
+func TestLaneValidateReportsEveryProblemAtOnce(t *testing.T) {
+	lane := classicLane()
+	lane.OutcomeLines[delivery.Succeeded] = OutcomeLine{Level: "trace", Msg: ""}
+	lane.OutcomeLines[delivery.HandlerError] = OutcomeLine{
+		Level: LevelError, Msg: lane.OutcomeLines[delivery.Panicked].Msg,
+	}
+
+	err := lane.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not a level the recorder stamps")
+	assert.Contains(t, err.Error(), "no message")
+	assert.Contains(t, err.Error(), "already declared by")
+}


### PR DESCRIPTION
## What

The two messaging lanes now share one delivery pipeline, but nothing checks that they behave alike — the cross-lane guarantees live only in prose, and `grep -rn trace_id messaging/` returns zero. This declares the contract instead: `Lane` enumerates what a lane may legitimately differ on (destination, span extras, and the level, message and exact extra-key set of each outcome line), so a divergence has to be a typed field somebody adds in review rather than something nobody notices.

## Impact

None. New internal test-support package; nothing in a production dependency graph imports it, and `internal/` blocks consumer import.

## Verification

CI gates only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lane-agnostic delivery contracts for defining scenarios, observed results, outcome logs, and metadata.
  * Added validation for declared outcome levels, required messages, and duplicate outcome entries.
  * Added support for retrieving repeated log-field values in their original order.

* **Bug Fixes**
  * Invalid lane declarations now report all detected validation errors together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->