### PR TITLE
feat(messaging): add the fixture that drives the lane contract

### DIFF
--- a/messaging/internal/lanecontract/fixture.go
+++ b/messaging/internal/lanecontract/fixture.go
@@ -1,0 +1,197 @@
+package lanecontract
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/messaging/internal/delivery"
+	"github.com/gaborage/go-bricks/messaging/internal/tracking"
+	obtest "github.com/gaborage/go-bricks/observability/testing"
+)
+
+// SetupTelemetry installs a test tracer and meter provider, both restored on
+// cleanup. The tracking meter and the pipeline's tracer are package singletons,
+// so both resets bracket the test on both sides: without the reset a provider
+// swapped in here is never observed, since the singleton still holds the
+// previous one.
+//
+// Call it before constructing anything that caches a tracer. The streams lane
+// resolves its tracer at manager construction, not per delivery, so a lane built
+// first pins the previous provider and reports zero spans — a false failure that
+// looks like a broken assertion.
+func SetupTelemetry(t *testing.T) (*tracetest.InMemoryExporter, *obtest.TestMeterProvider) {
+	t.Helper()
+
+	prevTP := otel.GetTracerProvider()
+	prevProp := otel.GetTextMapPropagator()
+	prevMP := otel.GetMeterProvider()
+
+	ttp := obtest.NewTestTraceProvider()
+	otel.SetTracerProvider(ttp)
+	// Defensive only: nothing in the delivery path reads the global propagator —
+	// trace.ExtractFromHeaders parses the carrier into context values by hand, so
+	// the consume span is a root on both lanes and no family can assert otherwise.
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	mp := obtest.NewTestMeterProvider()
+	otel.SetMeterProvider(mp)
+	tracking.ResetMeterForTesting()
+	delivery.ResetTracerForTesting()
+
+	t.Cleanup(func() {
+		// Restore and reset BEFORE asserting: require.NoError runs Goexit on
+		// failure, which would skip everything after it and leave a shut-down
+		// provider installed process-wide, so every later test in the binary
+		// would silently record nothing.
+		otel.SetTracerProvider(prevTP)
+		otel.SetTextMapPropagator(prevProp)
+		otel.SetMeterProvider(prevMP)
+		tracking.ResetMeterForTesting()
+		delivery.ResetTracerForTesting()
+		require.NoError(t, ttp.Shutdown(context.Background()))
+		require.NoError(t, mp.Shutdown(context.Background()))
+	})
+
+	return ttp.Exporter, mp
+}
+
+// Outcomes records every Result a lane's LogOutcome was handed. The mutex is
+// load-bearing, not defensive: the streams lane invokes handlers from one
+// goroutine per partition, so the unsynchronized recorder this was lifted from
+// would race there.
+type Outcomes struct {
+	mu   sync.Mutex
+	seen []*delivery.Result
+}
+
+// Log is the LogOutcome hook: hand it to delivery.Request.LogOutcome directly.
+func (o *Outcomes) Log(res *delivery.Result) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.seen = append(o.seen, res)
+}
+
+// Seen copies the recorded results, so reading them cannot race a delivery still
+// in flight on another partition.
+func (o *Outcomes) Seen() []*delivery.Result {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	out := make([]*delivery.Result, len(o.seen))
+	copy(out, o.seen)
+	return out
+}
+
+// RecordingLogger captures every emitted line with its fields in order and
+// records the context each derived logger was bound to, so a family can assert
+// WHICH logger a lane received. Derived loggers share the parent's buffer and
+// mutex, so a lane's per-message logger records into the same place.
+type RecordingLogger struct {
+	mu     *sync.Mutex
+	lines  *[]LogLine
+	fields [][2]string // context-level fields prepended to every event
+
+	// BoundTo is the context passed to the WithContext call that produced this
+	// logger; nil on a logger nobody bound.
+	BoundTo context.Context
+}
+
+// NewRecordingLogger returns a logger recording into a fresh buffer.
+func NewRecordingLogger() *RecordingLogger {
+	return &RecordingLogger{mu: &sync.Mutex{}, lines: &[]LogLine{}}
+}
+
+// Lines copies every line recorded so far, including through derived loggers.
+func (l *RecordingLogger) Lines() []LogLine {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]LogLine, len(*l.lines))
+	copy(out, *l.lines)
+	return out
+}
+
+// WithContext returns a logger sharing this one's buffer and remembering ctx.
+func (l *RecordingLogger) WithContext(ctx any) logger.Logger {
+	msgCtx, _ := ctx.(context.Context)
+	return &RecordingLogger{mu: l.mu, lines: l.lines, fields: l.fields, BoundTo: msgCtx}
+}
+
+// WithFields returns a logger carrying f on every later event.
+func (l *RecordingLogger) WithFields(f map[string]any) logger.Logger {
+	merged := make([][2]string, 0, len(l.fields)+len(f))
+	merged = append(merged, l.fields...)
+	keys := make([]string, 0, len(f))
+	for k := range f {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys) // map order is random; sort so the recorded shape is stable
+	for _, k := range keys {
+		merged = append(merged, [2]string{k, fmt.Sprint(f[k])})
+	}
+	return &RecordingLogger{mu: l.mu, lines: l.lines, fields: merged, BoundTo: l.BoundTo}
+}
+
+func (l *RecordingLogger) Info() logger.LogEvent  { return l.event(LevelInfo) }
+func (l *RecordingLogger) Error() logger.LogEvent { return l.event(LevelError) }
+func (l *RecordingLogger) Debug() logger.LogEvent { return l.event(LevelDebug) }
+func (l *RecordingLogger) Warn() logger.LogEvent  { return l.event(LevelWarn) }
+func (l *RecordingLogger) Fatal() logger.LogEvent { return l.event(LevelFatal) }
+
+func (l *RecordingLogger) event(level string) *recordingEvent {
+	fields := make([][2]string, len(l.fields), len(l.fields)+8)
+	copy(fields, l.fields)
+	return &recordingEvent{log: l, level: level, fields: fields}
+}
+
+// recordingEvent records every field write in order. Every setter stringifies,
+// so a family can read an Int64 offset or a Uint64 delivery tag as readily as a
+// Str — unlike the streams lane's own recorder, which keeps only Str.
+type recordingEvent struct {
+	log    *RecordingLogger
+	level  string
+	fields [][2]string
+}
+
+func (e *recordingEvent) add(key string, value any) logger.LogEvent {
+	e.fields = append(e.fields, [2]string{key, fmt.Sprint(value)})
+	return e
+}
+
+func (e *recordingEvent) Str(k, v string) logger.LogEvent               { return e.add(k, v) }
+func (e *recordingEvent) Int(k string, v int) logger.LogEvent           { return e.add(k, v) }
+func (e *recordingEvent) Int64(k string, v int64) logger.LogEvent       { return e.add(k, v) }
+func (e *recordingEvent) Uint64(k string, v uint64) logger.LogEvent     { return e.add(k, v) }
+func (e *recordingEvent) Dur(k string, v time.Duration) logger.LogEvent { return e.add(k, v) }
+func (e *recordingEvent) Interface(k string, v any) logger.LogEvent     { return e.add(k, v) }
+func (e *recordingEvent) Bytes(k string, v []byte) logger.LogEvent      { return e.add(k, string(v)) }
+func (e *recordingEvent) Bool(k string, v bool) logger.LogEvent         { return e.add(k, v) }
+func (e *recordingEvent) Enabled() bool                                 { return true }
+
+func (e *recordingEvent) Err(err error) logger.LogEvent {
+	if err == nil {
+		return e
+	}
+	return e.add("error", err.Error())
+}
+
+func (e *recordingEvent) Msg(msg string) {
+	e.log.mu.Lock()
+	defer e.log.mu.Unlock()
+	*e.log.lines = append(*e.log.lines, LogLine{Level: e.level, Msg: msg, Fields: e.fields})
+}
+
+func (e *recordingEvent) Msgf(format string, args ...any) { e.Msg(fmt.Sprintf(format, args...)) }
+
+var (
+	_ logger.Logger   = (*RecordingLogger)(nil)
+	_ logger.LogEvent = (*recordingEvent)(nil)
+)

--- a/messaging/internal/lanecontract/fixture_test.go
+++ b/messaging/internal/lanecontract/fixture_test.go
@@ -1,0 +1,142 @@
+package lanecontract
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+
+	"github.com/gaborage/go-bricks/logger"
+	"github.com/gaborage/go-bricks/messaging/internal/delivery"
+)
+
+func TestSetupTelemetryInstallsProvidersAndRestoresThemOnCleanup(t *testing.T) {
+	beforeTracer := otel.GetTracerProvider()
+	beforeMeter := otel.GetMeterProvider()
+
+	t.Run("installed_for_the_test", func(t *testing.T) {
+		exporter, meter := SetupTelemetry(t)
+
+		require.NotNil(t, exporter)
+		require.NotNil(t, meter)
+		assert.NotSame(t, beforeTracer, otel.GetTracerProvider(), "the tracer provider must be swapped")
+		assert.NotSame(t, beforeMeter, otel.GetMeterProvider(), "the meter provider must be swapped")
+	})
+
+	// The subtest's cleanup has run by now. Both globals are process-wide, so a
+	// fixture that failed to restore them would silently corrupt every later test.
+	assert.Same(t, beforeTracer, otel.GetTracerProvider(), "cleanup must restore the tracer provider")
+	assert.Same(t, beforeMeter, otel.GetMeterProvider(), "cleanup must restore the meter provider")
+}
+
+// The streams lane runs one goroutine per partition, so this is what the mutex
+// is for: without it, -race fails here.
+func TestOutcomesRecordsConcurrentDeliveriesWithoutRacing(t *testing.T) {
+	const deliveries = 50
+	outcomes := &Outcomes{}
+
+	var wg sync.WaitGroup
+	wg.Add(deliveries)
+	for range deliveries {
+		go func() {
+			defer wg.Done()
+			outcomes.Log(&delivery.Result{})
+		}()
+	}
+	wg.Wait()
+
+	assert.Len(t, outcomes.Seen(), deliveries)
+}
+
+func TestRecordingLoggerCapturesEveryFieldTypeInEmissionOrder(t *testing.T) {
+	log := NewRecordingLogger()
+
+	log.Error().
+		Str("correlation_id", "req-1").
+		Int("body_size", 12).
+		Int64("offset", 7).
+		Uint64("delivery_tag", 123).
+		Dur("processing_time", 3*time.Millisecond).
+		Interface("panic", "boom").
+		Bytes("stack", []byte("goroutine 1")).
+		Bool("redelivered", true).
+		Err(errors.New("handler failed")).
+		Msg("outcome")
+
+	lines := log.Lines()
+	require.Len(t, lines, 1)
+	assert.Equal(t, "outcome", lines[0].Msg)
+	assert.Equal(t, [][2]string{
+		{"correlation_id", "req-1"},
+		{"body_size", "12"},
+		{"offset", "7"},
+		{"delivery_tag", "123"},
+		{"processing_time", "3ms"},
+		{"panic", "boom"},
+		{"stack", "goroutine 1"},
+		{"redelivered", "true"},
+		{"error", "handler failed"},
+	}, lines[0].Fields)
+}
+
+func TestRecordingLoggerDropsANilError(t *testing.T) {
+	log := NewRecordingLogger()
+
+	log.Info().Err(nil).Msg("outcome")
+
+	assert.Empty(t, log.Lines()[0].Fields)
+}
+
+func TestRecordingLoggerDerivedLoggersShareTheBuffer(t *testing.T) {
+	log := NewRecordingLogger()
+	ctx := context.Background()
+
+	bound := log.WithContext(ctx)
+	bound.Info().Msg("from the bound logger")
+	log.WithFields(map[string]any{"tenant": "acme", "consumer": "orders-worker"}).Info().Msg("from the fielded logger")
+
+	lines := log.Lines()
+	require.Len(t, lines, 2, "a derived logger must record into its parent's buffer")
+	assert.Equal(t, "from the bound logger", lines[0].Msg)
+	// Map iteration order is random, so WithFields sorts its keys.
+	assert.Equal(t, [][2]string{{"consumer", "orders-worker"}, {"tenant", "acme"}}, lines[1].Fields)
+
+	require.IsType(t, &RecordingLogger{}, bound)
+	assert.Equal(t, ctx, bound.(*RecordingLogger).BoundTo, "the bound context must be recorded")
+}
+
+// The two lanes differ on level today, so a family can only catch that if every
+// level method stamps its own.
+func TestRecordingLoggerStampsTheLevelOnEveryLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		emit  func(logger.Logger) logger.LogEvent
+		level string
+	}{
+		{name: "info", emit: logger.Logger.Info, level: LevelInfo},
+		{name: "error", emit: logger.Logger.Error, level: LevelError},
+		{name: "debug", emit: logger.Logger.Debug, level: LevelDebug},
+		{name: "warn", emit: logger.Logger.Warn, level: LevelWarn},
+		{name: "fatal", emit: logger.Logger.Fatal, level: LevelFatal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := NewRecordingLogger()
+
+			event := tt.emit(log)
+			assert.True(t, event.Enabled(), "the recorder never drops an event")
+			event.Msgf("emitted at %s", tt.level)
+
+			lines := log.Lines()
+			require.Len(t, lines, 1)
+			assert.Equal(t, tt.level, lines[0].Level)
+			assert.Equal(t, "emitted at "+tt.level, lines[0].Msg)
+		})
+	}
+}


### PR DESCRIPTION
## What

The lane contract needs one fixture both lanes drive: telemetry setup that installs and restores the tracer and meter providers, an outcome recorder, and a logger that captures every typed field in order. Lifted from `messaging/internal/delivery`'s private test fixture, which only that one package could reach.

## Impact

None. New internal test-support package; nothing in a production dependency graph imports it.

## Verification

The lifted `t.Cleanup` asserted provider shutdown *before* restoring the otel globals, so a shutdown failure would `Goexit` past every restore and leave a shut-down `TracerProvider` installed process-wide — every later test in the binary then records zero spans and blames its own lane. Restores and both singleton resets now run first, assertions last. The original in `delivery_test.go` has the same defect and is fixed in a later PR of this stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for telemetry setup and cleanup.
  * Added concurrency-safe verification for recording delivery outcomes.
  * Added logger tests covering field serialization, contextual logging, log levels, shared buffers, and nil-error handling.
* **Chores**
  * Added reusable testing utilities for validating messaging lane contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->