### PR TITLE
feat(messaging): add the identity family and its counter-example lane

### DIFF
--- a/messaging/internal/delivery/delivery_test.go
+++ b/messaging/internal/delivery/delivery_test.go
@@ -82,12 +82,16 @@ func setupTelemetry(t *testing.T, processors ...sdktrace.SpanProcessor) (*tracet
 	ResetTracerForTesting()
 
 	t.Cleanup(func() {
-		require.NoError(t, ttp.Shutdown(context.Background()))
+		// Restore and reset BEFORE asserting: require.NoError runs Goexit on
+		// failure, which would skip everything after it and leave a shut-down
+		// provider installed process-wide, with sharedTracer still pinned to it —
+		// so every later test in the binary would silently record nothing.
 		otel.SetTracerProvider(prevTP)
 		otel.SetTextMapPropagator(prevProp)
 		otel.SetMeterProvider(prevMP)
 		tracking.ResetMeterForTesting()
 		ResetTracerForTesting()
+		require.NoError(t, ttp.Shutdown(context.Background()))
 		require.NoError(t, mp.Shutdown(context.Background()))
 	})
 

--- a/messaging/internal/lanecontract/brokenlane.go
+++ b/messaging/internal/lanecontract/brokenlane.go
@@ -1,0 +1,129 @@
+package lanecontract
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gaborage/go-bricks/messaging/internal/delivery"
+	gobrickstrace "github.com/gaborage/go-bricks/trace"
+)
+
+// The broken lane's vocabulary. Its destination and settle words are
+// deliberately real-looking: a family must fail it on what it DOES, never on an
+// obviously fake string.
+const (
+	BrokenLaneName        = "broken"
+	brokenDestination     = "broken.queue"
+	brokenSettleOnSuccess = "ack"
+	brokenSettleOnFailure = "nack-no-requeue"
+
+	// What the lane DECLARES it emits. Each is contradicted by what it actually
+	// emits, and each contradiction is one assertion's proof that it bites.
+	brokenSuccessMsg = "Message processed successfully"
+	brokenFailureMsg = "Message processing failed - discarding without requeue"
+	brokenPanicMsg   = "Panic recovered in message handler - discarding without requeue"
+	brokenOutcomeKey = "queue"
+)
+
+// BrokenLane returns a Lane whose delivery breaks every rule the contract
+// enforces while its DECLARATION stays honest about what a conforming lane would
+// do — each gap between the two is what an assertion catches, and the DEFECT
+// markers below enumerate them.
+//
+// Every assertion family must FAIL against it. That is also the half of the proof
+// that survives: once both lanes conform, the red run against an un-migrated lane
+// can no longer be reproduced, but this lane stays broken forever.
+func BrokenLane() Lane {
+	return Lane{
+		Name:        BrokenLaneName,
+		Destination: brokenDestination,
+		Deliver:     deliverBroken,
+		OutcomeLines: map[delivery.Outcome]OutcomeLine{
+			delivery.Succeeded: {
+				Level: LevelInfo, Msg: brokenSuccessMsg,
+				ExtraKeys: []string{brokenOutcomeKey},
+			},
+			delivery.HandlerError: {
+				Level: LevelError, Msg: brokenFailureMsg,
+				ExtraKeys: []string{brokenOutcomeKey},
+			},
+			delivery.Panicked: {
+				Level: LevelError, Msg: brokenPanicMsg,
+				ExtraKeys: []string{brokenOutcomeKey},
+			},
+		},
+		SettleOnSuccess: brokenSettleOnSuccess,
+		SettleOnFailure: brokenSettleOnFailure,
+	}
+}
+
+// deliverBroken hand-rolls a non-conforming delivery. Each defect is marked so a
+// later reader does not "fix" one and quietly turn the proof into a tautology.
+func deliverBroken(t *testing.T, scenario Scenario) Observed {
+	t.Helper()
+
+	exporter, meter := SetupTelemetry(t)
+	log := NewRecordingLogger()
+
+	// DEFECT 1: the carrier is dropped — no trace extraction, so nothing that
+	// traveled with the message reaches the context or the Result.
+	// DEFECT 2: no lease scope, so a handle the handler borrows is released the
+	// moment it registers. No span and no consume either: there is no pipeline.
+	res, handlerTraceID := invokeBroken(context.Background(), scenario.Handle)
+	// DEFECT 3: the Result hands back the root logger, not one bound to the
+	// per-message context, so its BoundTo is nil.
+	res.Log = log
+
+	// DEFECT 4: none of the shared spine — no correlation_id, no processing_time,
+	// and no panic or stack even when the handler panicked.
+	// DEFECT 5: the failure text on a success too, so a success scenario cannot
+	// find the line it declared. The panic text IS emitted, deliberately: an
+	// unlocatable line short-circuits every later assertion, so the panic outcome
+	// is what carries the family past location to the spine.
+	// DEFECT 6: at WARN, where every outcome it declares says ERROR.
+	// DEFECT 7: an undeclared key, and not the one it did declare.
+	emitted := brokenFailureMsg
+	if res.Outcome == delivery.Panicked {
+		emitted = brokenPanicMsg
+	}
+	log.Warn().Str("exchange", brokenDestination).Msg(emitted)
+
+	// DEFECT 8: settled twice. On a real broker that is a double ack.
+	settles := []string{brokenSettleOnSuccess, brokenSettleOnSuccess}
+	if res.Outcome != delivery.Succeeded {
+		settles = []string{brokenSettleOnFailure, brokenSettleOnFailure}
+	}
+
+	return Observed{
+		Result:         res,
+		HandlerTraceID: handlerTraceID,
+		Settles:        settles,
+		Lines:          log.Lines(),
+		Spans:          exporter.GetSpans(),
+		Metrics:        meter.Collect(t),
+	}
+}
+
+// invokeBroken runs the handler body, classifies the outcome, and reports what
+// the handler saw of the context. It recovers a panic only because letting one
+// escape would take the test process down.
+func invokeBroken(ctx context.Context, handle func(context.Context) error) (res *delivery.Result, handlerTraceID string) {
+	res = &delivery.Result{}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			res.Outcome = delivery.Panicked
+			res.Err = fmt.Errorf("panic in message handler: %v", recovered)
+			// Panic and Stack are deliberately left unset — DEFECT 4.
+		}
+	}()
+
+	handlerTraceID, _ = gobrickstrace.IDFromContext(ctx)
+
+	if err := handle(ctx); err != nil {
+		res.Outcome = delivery.HandlerError
+		res.Err = err
+	}
+	return res, handlerTraceID
+}

--- a/messaging/internal/lanecontract/brokenlane_test.go
+++ b/messaging/internal/lanecontract/brokenlane_test.go
@@ -1,0 +1,154 @@
+package lanecontract
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaborage/go-bricks/internal/leasescope"
+	"github.com/gaborage/go-bricks/messaging/internal/delivery"
+	gobrickstrace "github.com/gaborage/go-bricks/trace"
+)
+
+const brokenCarrierTraceID = "req-broken"
+
+// runIdentityAgainstBroken drives the broken lane through one scenario and
+// returns every assertion message AssertIdentity produced, without failing this
+// test.
+func runIdentityAgainstBroken(t *testing.T, scenario Scenario) string {
+	t.Helper()
+
+	lane := BrokenLane()
+	observed := lane.Deliver(t, scenario)
+
+	var failures strings.Builder
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				if _, stopped := recovered.(failNow); !stopped {
+					panic(recovered)
+				}
+			}
+		}()
+		AssertIdentity(&recordingT{out: &failures}, &lane, &scenario, &observed)
+	}()
+
+	return failures.String()
+}
+
+// recordingT captures what a family reported instead of failing the test.
+// FailNow panics with a sentinel the caller recovers, so require keeps its
+// contract of stopping the flow — a no-op would let the next require whose
+// failure leaves something nil panic here and nowhere else.
+type recordingT struct{ out *strings.Builder }
+
+type failNow struct{}
+
+func (r *recordingT) Errorf(format string, args ...any) {
+	fmt.Fprintf(r.out, format+"\n", args...)
+}
+func (r *recordingT) FailNow() { panic(failNow{}) }
+func (r *recordingT) Helper()  {}
+
+var _ T = (*recordingT)(nil)
+
+func TestBrokenLaneFailsTheTraceIdentityAssertions(t *testing.T) {
+	scenario := Scenario{
+		Name:    "succeeding_handler_with_a_carried_trace_id",
+		Carrier: map[string]any{gobrickstrace.HeaderXRequestID: brokenCarrierTraceID},
+		Handle:  func(context.Context) error { return nil },
+		Outcome: delivery.Succeeded,
+	}
+
+	failures := runIdentityAgainstBroken(t, scenario)
+
+	// Each of these is one identity assertion proving it bites. If a line stops
+	// appearing, either the assertion was weakened or the broken lane was
+	// "fixed" — both turn the family into a rubber stamp.
+	require.NotEmpty(t, failures, "the identity family must fail against the broken lane")
+	assert.Contains(t, failures, "trace.IDFromContext must return an id inside the handler",
+		"drops the carrier and writes nothing back")
+	assert.Contains(t, failures, "the id that traveled on the carrier must be the id the handler reads",
+		"drops the carrier")
+	assert.Contains(t, failures, "no line carries the declared message",
+		"logs the failure text on a success, so the declared line cannot be found")
+}
+
+// The success scenario cannot reach the level and key assertions, because the
+// line it declared is never emitted. The handler-error scenario can: the broken
+// lane's one line does carry the failure text, so the family gets far enough to
+// compare its level and its exact key set.
+func TestBrokenLaneFailsTheOutcomeLineShapeAssertions(t *testing.T) {
+	scenario := Scenario{
+		Name:    "failing_handler",
+		Carrier: map[string]any{gobrickstrace.HeaderXRequestID: brokenCarrierTraceID},
+		Handle:  func(context.Context) error { return assert.AnError },
+		Outcome: delivery.HandlerError,
+	}
+
+	failures := runIdentityAgainstBroken(t, scenario)
+
+	require.NotEmpty(t, failures)
+	assert.Contains(t, failures, "the outcome line must carry EXACTLY the extra keys the lane declared",
+		"emits an undeclared key and omits the one it declared")
+	assert.Contains(t, failures, "the outcome line must carry the handler's id under correlation_id",
+		"writes no correlation_id")
+	assert.Contains(t, failures, "the outcome line's level must be the one the lane declared",
+		"logs at WARN where every outcome it declares says ERROR")
+	assert.Contains(t, failures, "the shared spine stamps processing_time",
+		"writes none of the spine")
+}
+
+// The panic scenario reaches the spine's panic/stack assertions, which no other
+// scenario can: they are asserted present only for Panicked.
+func TestBrokenLaneFailsThePanicSpineAssertions(t *testing.T) {
+	failures := runIdentityAgainstBroken(t, Scenario{
+		Name:    "panicking_handler",
+		Carrier: map[string]any{gobrickstrace.HeaderXRequestID: brokenCarrierTraceID},
+		Handle:  func(context.Context) error { panic("boom") },
+		Outcome: delivery.Panicked,
+	})
+
+	require.NotEmpty(t, failures)
+	assert.Contains(t, failures, "a panicked delivery must log the recovered value")
+	assert.Contains(t, failures, "a panicked delivery must log its stack")
+}
+
+// The lease and settle defects are not identity's to catch — the failure family
+// owns them — but they must still be present, or the lane stops being a
+// counter-example for the families that land later.
+func TestBrokenLaneStillCarriesTheDefectsOtherFamiliesNeed(t *testing.T) {
+	lane := BrokenLane()
+	leaseReleased := false
+	releasedBeforeHandlerReturned := false
+
+	observed := lane.Deliver(t, Scenario{
+		Name: "borrows_a_handle",
+		Handle: func(ctx context.Context) error {
+			leasescope.Register(ctx, func() { leaseReleased = true })
+			releasedBeforeHandlerReturned = leaseReleased
+			return nil
+		},
+		Outcome: delivery.Succeeded,
+	})
+
+	assert.True(t, releasedBeforeHandlerReturned,
+		"installs no lease scope: leasescope.Register releases inline when none is present")
+	assert.Equal(t, []string{lane.SettleOnSuccess, lane.SettleOnSuccess}, observed.Settles,
+		"settles twice")
+	assert.Empty(t, observed.Spans, "opens no span")
+	assert.Empty(t, observed.Metrics.ScopeMetrics, "records no consume")
+}
+
+// The broken lane's DECLARATION is deliberately valid: it is broken by what it
+// emits, not by declaring something a family would reject up front. A lane that
+// failed Validate would short-circuit every family before they asserted anything.
+func TestBrokenLaneDeclarationItselfValidates(t *testing.T) {
+	lane := BrokenLane()
+
+	require.NoError(t, lane.Validate())
+}

--- a/messaging/internal/lanecontract/identity.go
+++ b/messaging/internal/lanecontract/identity.go
@@ -1,0 +1,241 @@
+package lanecontract
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gaborage/go-bricks/messaging/internal/delivery"
+	gobrickstrace "github.com/gaborage/go-bricks/trace"
+)
+
+// T is require.TestingT plus Helper. It is an interface so the harness can prove
+// a family BITES by running it against a recorder: a family reports by calling
+// Errorf, so the live *testing.T would fail the suite doing the proving.
+type T interface {
+	require.TestingT
+	Helper()
+}
+
+// The spine delivery.AppendOutcome stamps on every lane's outcome line. A lane
+// declares only what it adds beyond these.
+const (
+	fieldCorrelationID  = "correlation_id"
+	fieldProcessingTime = "processing_time"
+	fieldPanic          = "panic"
+	fieldStack          = "stack"
+)
+
+// spineKeys is the whole spine, in one place: extraKeys strips it, and the
+// no-declared-line branch asserts a lane emits none of it.
+var spineKeys = []string{fieldCorrelationID, fieldProcessingTime, fieldPanic, fieldStack}
+
+// errHandlerFailed is the handler error the scenarios raise.
+var errHandlerFailed = errors.New("handler failed")
+
+// AssertIdentity checks the trace-identity contract for one delivery: the id that
+// traveled on the carrier is the id the handler reads and the id the lane logs,
+// on an outcome line whose shape matches what the lane declared.
+func AssertIdentity(t T, lane *Lane, scenario *Scenario, observed *Observed) {
+	t.Helper()
+
+	require.NoError(t, lane.Validate(), "a lane whose declaration is unusable cannot be asserted against")
+
+	handlerID := observed.HandlerTraceID
+	assert.NotEmpty(t, handlerID,
+		"trace.IDFromContext must return an id inside the handler; the pipeline writes one back even when nothing traveled")
+
+	if carried, declared := carriedTraceID(scenario.Carrier); declared {
+		assert.Equal(t, carried, handlerID,
+			"the id that traveled on the carrier must be the id the handler reads")
+	}
+
+	line := assertOutcomeLine(t, lane, scenario, observed)
+	if line == nil {
+		return
+	}
+
+	assert.Equal(t, []string{handlerID}, line.Values(fieldCorrelationID),
+		"the outcome line must carry the handler's id under correlation_id, exactly once")
+	assertSpine(t, scenario.Outcome, line)
+}
+
+// assertOutcomeLine finds the line this lane declared for the scenario's outcome
+// and checks its level and its exact extra-key set. Returns nil when there is no
+// line to assert against, so the caller stops rather than reading a zero value.
+func assertOutcomeLine(t T, lane *Lane, scenario *Scenario, observed *Observed) *LogLine {
+	t.Helper()
+
+	declared, ok := lane.OutcomeLines[scenario.Outcome]
+	if !ok {
+		// The lane declares no line for this outcome — the streams lane logs
+		// nothing on success. Assert the negative its declaration promises, or a
+		// lane exempts itself from every log assertion by declaring nothing.
+		for i := range observed.Lines {
+			for _, key := range spineKeys {
+				assert.Empty(t, observed.Lines[i].Values(key),
+					"the lane declares no outcome line here, so no line may carry the spine field %q", key)
+			}
+		}
+		return nil
+	}
+
+	var found *LogLine
+	for i := range observed.Lines {
+		if observed.Lines[i].Msg == declared.Msg {
+			require.Nil(t, found, "message %q was emitted more than once, so it cannot locate a line", declared.Msg)
+			found = &observed.Lines[i]
+		}
+	}
+	if !assert.NotNil(t, found, "no line carries the declared message %q", declared.Msg) {
+		return nil
+	}
+
+	assert.Equal(t, declared.Level, found.Level, "the outcome line's level must be the one the lane declared")
+	assert.ElementsMatch(t, declared.ExtraKeys, extraKeys(*found),
+		"the outcome line must carry EXACTLY the extra keys the lane declared: a key it stopped emitting is drift as much as one it added")
+
+	return found
+}
+
+// assertSpine checks the fields the pipeline stamps rather than the lane. Without
+// it the exact-set check above is exact only OUTSIDE the spine, so dropping
+// processing_time — or stamping a panic on a success — would pass.
+func assertSpine(t T, outcome delivery.Outcome, line *LogLine) {
+	t.Helper()
+
+	assert.NotEmpty(t, line.Values(fieldProcessingTime),
+		"the shared spine stamps processing_time on every outcome line")
+
+	if outcome == delivery.Panicked {
+		assert.NotEmpty(t, line.Values(fieldPanic), "a panicked delivery must log the recovered value")
+		assert.NotEmpty(t, line.Values(fieldStack), "a panicked delivery must log its stack")
+		return
+	}
+	assert.Empty(t, line.Values(fieldPanic), "panic belongs to the Panicked outcome only")
+	assert.Empty(t, line.Values(fieldStack), "stack belongs to the Panicked outcome only")
+}
+
+// extraKeys is the line's keys with the shared spine removed, so what is left is
+// what the lane itself contributed.
+func extraKeys(line LogLine) []string {
+	out := make([]string, 0, len(line.Fields))
+	for _, field := range line.Fields {
+		if !slices.Contains(spineKeys, field[0]) {
+			out = append(out, field[0])
+		}
+	}
+	return out
+}
+
+// carriedTraceID derives, independently of the pipeline, the id a carrier should
+// yield. declared reports whether the carrier names an id at all, so a carrier
+// the oracle cannot read fails rather than skipping the comparison it exists for.
+// Deliberately not trace.ExtractFromHeaders: asserting the pipeline against
+// itself would pass however wrong that function became.
+func carriedTraceID(carrier map[string]any) (id string, declared bool) {
+	if raw, ok := carrier[gobrickstrace.HeaderXRequestID]; ok {
+		return headerText(raw), true
+	}
+	if raw, ok := carrier[gobrickstrace.HeaderTraceParent]; ok {
+		return traceIDFromParent(headerText(raw)), true
+	}
+	return "", false
+}
+
+// headerText mirrors the production accessor: AMQP tables carry []byte in the
+// wild, and an oracle accepting only string would skip the comparison.
+func headerText(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case []byte:
+		return string(v)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+// traceIDFromParent takes the trace-id field of a W3C traceparent:
+// version-traceid-spanid-flags, where the trace-id is 32 hex characters.
+func traceIDFromParent(parent string) string {
+	if parts := strings.Split(parent, "-"); len(parts) >= 4 && len(parts[1]) == 32 {
+		return parts[1]
+	}
+	return ""
+}
+
+// IdentityScenarios is the set of deliveries every lane is put through. It lives
+// here rather than in an adapter because scenarios are not a Lane field: two
+// lanes facing different scenarios is drift the contract could not see.
+func IdentityScenarios() []Scenario {
+	const carriedID = "req-2026"
+	const carriedParent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	withID := func() map[string]any {
+		return map[string]any{gobrickstrace.HeaderXRequestID: carriedID}
+	}
+
+	return []Scenario{
+		{
+			Name:    "handler_returns_nil",
+			Carrier: withID(),
+			Body:    []byte(`{"id":1}`),
+			Handle:  func(context.Context) error { return nil },
+			Outcome: delivery.Succeeded,
+		},
+		{
+			Name:    "handler_returns_an_error",
+			Carrier: withID(),
+			Handle:  func(context.Context) error { return errHandlerFailed },
+			Outcome: delivery.HandlerError,
+		},
+		{
+			Name:    "handler_panics",
+			Carrier: withID(),
+			Handle:  func(context.Context) error { panic("boom") },
+			Outcome: delivery.Panicked,
+		},
+		{
+			// The id must come from the traceparent's trace-id field rather than a
+			// freshly minted UUID.
+			Name:    "carrier_carries_traceparent_only",
+			Carrier: map[string]any{gobrickstrace.HeaderTraceParent: carriedParent},
+			Handle:  func(context.Context) error { return nil },
+			Outcome: delivery.Succeeded,
+		},
+		{
+			// AMQP tables carry []byte, so a lane must read one as readily as a string.
+			Name:    "carrier_carries_x_request_id_as_bytes",
+			Carrier: map[string]any{gobrickstrace.HeaderXRequestID: []byte(carriedID)},
+			Handle:  func(context.Context) error { return nil },
+			Outcome: delivery.Succeeded,
+		},
+		{
+			// Nothing traveled: the pipeline mints an id and must write it back, or
+			// the handler reads none.
+			Name:    "carrier_is_nil",
+			Handle:  func(context.Context) error { return nil },
+			Outcome: delivery.Succeeded,
+		},
+	}
+}
+
+// RunIdentity puts a lane through every identity scenario. A lane's own test
+// calls this and nothing else, so both lanes provably face the same set.
+func RunIdentity(t *testing.T, lane *Lane) {
+	t.Helper()
+
+	for _, scenario := range IdentityScenarios() {
+		t.Run(scenario.Name, func(t *testing.T) {
+			observed := lane.Deliver(t, scenario)
+
+			AssertIdentity(t, lane, &scenario, &observed)
+		})
+	}
+}

--- a/messaging/internal/lanecontract/lanecontract.go
+++ b/messaging/internal/lanecontract/lanecontract.go
@@ -77,14 +77,27 @@ type Scenario struct {
 
 	// Handle returns nil to succeed, an error to fail, or panics.
 	Handle func(ctx context.Context) error
+
+	// Outcome is what Handle produces. The scenario declares it because it owns
+	// the handler body; a family uses it to pick the OutcomeLine the lane
+	// declared, and the failure family — not this one — is what checks the lane
+	// actually reported it.
+	Outcome delivery.Outcome
 }
 
 // Observed is everything a lane's delivery produced, in the form the assertion
 // families read it.
 type Observed struct {
 	// Result is captured through the pipeline's LogOutcome hook, so no production
-	// signature gains a test-only parameter.
+	// signature gains a test-only parameter. A lane driving its real settle path
+	// may leave it nil until that path can hand the result back — the classic
+	// lane builds its hook inside processMessage, where a test cannot reach it.
 	Result *delivery.Result
+
+	// HandlerTraceID is trace.IDFromContext read INSIDE the handler. It is the
+	// only place the per-message context is observable, and it is read
+	// independently of anything the lane logs, so the two can be compared.
+	HandlerTraceID string
 
 	// Settles records each settlement in order, in Lane.SettleOnSuccess's
 	// vocabulary. More than one entry means the lane settled twice.

--- a/messaging/lanecontract_test.go
+++ b/messaging/lanecontract_test.go
@@ -1,0 +1,165 @@
+package messaging
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gaborage/go-bricks/messaging/internal/delivery"
+	"github.com/gaborage/go-bricks/messaging/internal/lanecontract"
+	gobrickstrace "github.com/gaborage/go-bricks/trace"
+)
+
+// This file is in package messaging on purpose: processMessage is unexported, so
+// driving the REAL lane is only possible from inside it.
+
+const (
+	laneQueue    = "orders"
+	laneExchange = "events"
+)
+
+// classicLane describes the AMQP lane to the harness. The declared shapes are
+// read off logOutcome and buildFailureLogEvent: the success line adds message_id
+// alone, the failure line adds seven fields plus "error" from the chained
+// .Err(res.Err), and the panic line is the same seven without it.
+func classicLane() lanecontract.Lane {
+	failureKeys := []string{
+		"message_id", "queue", "event_type", "amqp_correlation_id",
+		"consumer_tag", "routing_key", "exchange",
+	}
+	return lanecontract.Lane{
+		Name:        "classic",
+		Destination: laneQueue,
+		Deliver:     deliverClassic,
+		OutcomeLines: map[delivery.Outcome]lanecontract.OutcomeLine{
+			delivery.Succeeded: {
+				Level: lanecontract.LevelInfo, Msg: "Message processed successfully",
+				ExtraKeys: []string{"message_id"},
+			},
+			delivery.HandlerError: {
+				Level: lanecontract.LevelError, Msg: "Message processing failed - discarding without requeue",
+				ExtraKeys: slices.Concat(failureKeys, []string{"error"}),
+			},
+			delivery.Panicked: {
+				Level: lanecontract.LevelError, Msg: "Panic recovered in message handler - discarding without requeue",
+				ExtraKeys: failureKeys,
+			},
+		},
+		SettleOnSuccess: "ack",
+		SettleOnFailure: "nack-no-requeue",
+	}
+}
+
+// laneHandler adapts the harness's lane-agnostic handler body to this lane's
+// two-method MessageHandler interface, and records what the handler saw of the
+// per-message context — the only place that context is observable.
+type laneHandler struct {
+	body    func(context.Context) error
+	traceID string
+}
+
+func (h *laneHandler) Handle(ctx context.Context, _ *amqp.Delivery) error {
+	h.traceID, _ = gobrickstrace.IDFromContext(ctx)
+	return h.body(ctx)
+}
+
+func (h *laneHandler) EventType() string { return "orders.created" }
+
+// deliverClassic drives the real processMessage. It does not rebuild the
+// pipeline request the lane builds, because a copy here would drift from the
+// lane silently — which is the failure this harness exists to catch.
+//
+// Observed.Result is left nil — see that field's doc for why the classic lane
+// cannot fill it yet.
+func deliverClassic(t *testing.T, scenario lanecontract.Scenario) lanecontract.Observed {
+	t.Helper()
+
+	exporter, meter := lanecontract.SetupTelemetry(t)
+	log := lanecontract.NewRecordingLogger()
+
+	handler := &laneHandler{body: scenario.Handle}
+	consumer := &ConsumerDeclaration{
+		Queue:     laneQueue,
+		EventType: "orders.created",
+		Handler:   handler,
+	}
+	acker := &settleRecorder{}
+	msg := &amqp.Delivery{
+		MessageId:     "msg-1",
+		CorrelationId: "amqp-corr-1",
+		RoutingKey:    "orders.created",
+		Exchange:      laneExchange,
+		DeliveryTag:   1,
+		Body:          scenario.Body,
+		Headers:       amqp.Table(scenario.Carrier),
+		Acknowledger:  acker,
+	}
+
+	registry := NewRegistry(&simpleMockAMQPClient{}, &stubLogger{})
+	registry.processMessage(context.Background(), consumer, msg, log)
+
+	return lanecontract.Observed{
+		HandlerTraceID: handler.traceID,
+		Settles:        acker.settles,
+		Lines:          log.Lines(),
+		Spans:          exporter.GetSpans(),
+		Metrics:        meter.Collect(t),
+	}
+}
+
+// settleRecorder records settlements in the harness's vocabulary, so "settled
+// exactly once" is observable rather than inferred from a pair of booleans.
+type settleRecorder struct{ settles []string }
+
+func (s *settleRecorder) Ack(uint64, bool) error {
+	s.settles = append(s.settles, "ack")
+	return nil
+}
+
+func (s *settleRecorder) Nack(_ uint64, _, requeue bool) error {
+	action := "nack-no-requeue"
+	if requeue {
+		action = "nack-requeue"
+	}
+	s.settles = append(s.settles, action)
+	return nil
+}
+
+func (s *settleRecorder) Reject(uint64, bool) error {
+	s.settles = append(s.settles, "reject")
+	return nil
+}
+
+func TestClassicLaneSatisfiesTheIdentityContract(t *testing.T) {
+	lane := classicLane()
+
+	lanecontract.RunIdentity(t, &lane)
+}
+
+// Each delivery mints its own id, and a handler reading twice within one gets
+// the same one — EnsureTraceID mints without writing back, so without the
+// pipeline's write-back neither would hold.
+func TestClassicLaneMintsAFreshStableTraceIDPerDelivery(t *testing.T) {
+	lane := classicLane()
+	var secondRead string
+
+	first := lane.Deliver(t, lanecontract.Scenario{
+		Name: "nothing_traveled",
+		Handle: func(ctx context.Context) error {
+			secondRead, _ = gobrickstrace.IDFromContext(ctx)
+			return nil
+		},
+		Outcome: delivery.Succeeded,
+	})
+	second := lane.Deliver(t, lanecontract.Scenario{
+		Name:    "nothing_traveled_again",
+		Handle:  func(context.Context) error { return nil },
+		Outcome: delivery.Succeeded,
+	})
+
+	assert.Equal(t, first.HandlerTraceID, secondRead, "two reads in one delivery must agree")
+	assert.NotEqual(t, first.HandlerTraceID, second.HandlerTraceID, "each delivery mints its own")
+}


### PR DESCRIPTION
## What

The lane contract declared what the two messaging lanes must agree on but asserted none of it. This adds the first family: the id that traveled on the carrier is the id the handler reads and the id the lane logs, and the outcome line is the level, message and exact extra-key set the lane declared. It ships with the counter-example lane that proves each assertion fails when it should, rather than only that it passes when it should.

## Impact

None at runtime. Internal test-support package plus the classic lane's adapter; nothing in a production dependency graph imports it, and `internal/` blocks consumer import.

## Verification

An adversarial pass running mutants against the real pipeline under `go test -overlay` found **three of six assertion sites dead or fail-open**: the spine was exempt from every check (dropping `Dur("processing_time", …)` passed, as did stamping `panic`/`stack` on a success line); a lane declaring no outcome line skipped every log assertion silently — which is the streams lane's dominant path; and the carrier oracle type-asserted `.(string)`, so an AMQP `[]byte` header made it return `""` and skip the comparison it exists to make. All three now assert. Perturbing the real lane confirms each direction: an undeclared key, a wrong level, and removing `processing_time` from `AppendOutcome` each fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Strengthened messaging delivery validation to help ensure consistent traceability, outcomes, logging, and settlement behavior.
  * Improved telemetry cleanup between operations, reducing the risk of stale monitoring state affecting subsequent processing.

* **Tests**
  * Added broader coverage for delivery identity, error handling, panic recovery, logging, metrics, and concurrent outcomes.
  * Added validation for both conforming and intentionally invalid delivery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->