### PR TITLE
feat(messaging): add the telemetry family to the lane contract

### DIFF
--- a/messaging/internal/lanecontract/brokenlane.go
+++ b/messaging/internal/lanecontract/brokenlane.go
@@ -4,8 +4,14 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/gaborage/go-bricks/messaging/internal/delivery"
+	"github.com/gaborage/go-bricks/messaging/internal/tracking"
 	gobrickstrace "github.com/gaborage/go-bricks/trace"
 )
 
@@ -24,6 +30,17 @@ const (
 	brokenFailureMsg = "Message processing failed - discarding without requeue"
 	brokenPanicMsg   = "Panic recovered in message handler - discarding without requeue"
 	brokenOutcomeKey = "queue"
+
+	// Telemetry the lane reports, all wrong. The span name, kind and attributes
+	// are wrong rather than absent, and there is exactly ONE span: emitting none
+	// (or three) would trip the family's first gate and leave every assertion
+	// after it unproven.
+	brokenSpanName = "not.the.destination receive"
+
+	// BrokenCarrierTraceID is what a scenario should put on this lane's carrier:
+	// the lane stamps it onto a metric attribute, so a test can prove the
+	// per-message-value check catches it.
+	BrokenCarrierTraceID = "req-broken"
 )
 
 // BrokenLane returns a Lane whose delivery breaks every rule the contract
@@ -89,6 +106,8 @@ func deliverBroken(t *testing.T, scenario Scenario) Observed {
 	}
 	log.Warn().Str("exchange", brokenDestination).Msg(emitted)
 
+	reportBrokenTelemetry()
+
 	// DEFECT 8: settled twice. On a real broker that is a double ack.
 	settles := []string{brokenSettleOnSuccess, brokenSettleOnSuccess}
 	if res.Outcome != delivery.Succeeded {
@@ -127,3 +146,51 @@ func invokeBroken(ctx context.Context, handle func(context.Context) error) (res 
 	}
 	return res, handlerTraceID
 }
+
+// reportBrokenTelemetry emits one span and one consume record, each wrong in a
+// way one telemetry assertion catches. Exactly one span, deliberately: a lane
+// emitting none would fail the family's first gate and short-circuit every
+// assertion after it, proving only that gate.
+func reportBrokenTelemetry() {
+	tracer := otel.Tracer("lanecontract/broken")
+
+	// DEFECT 9: a parent, so the consume span is not a root. A REMOTE parent, so
+	// the lane still exports exactly one span.
+	parented := oteltrace.ContextWithRemoteSpanContext(context.Background(),
+		oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+			TraceID: brokenTraceID, SpanID: brokenSpanID, TraceFlags: oteltrace.FlagsSampled, Remote: true,
+		}))
+
+	// DEFECT 10: the wrong name, the wrong kind, an undeclared attribute, and a
+	// body size that matches no scenario.
+	_, span := tracer.Start(parented, brokenSpanName, oteltrace.WithSpanKind(oteltrace.SpanKindInternal))
+	span.SetAttributes(
+		attribute.String("messaging.system", "not-rabbitmq"),
+		attribute.String("undeclared.attribute", "x"),
+		attribute.Int64("messaging.message.body.size", 9999),
+	)
+	span.End()
+
+	// DEFECT 11: recorded from a DIFFERENT trace, so the exemplar names someone
+	// else's span rather than this delivery's.
+	// DEFECT 12: recorded twice, so the counter says two.
+	// DEFECT 13: never reports the error, so error.type is absent on a failure.
+	elsewhere := oteltrace.ContextWithRemoteSpanContext(context.Background(),
+		oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+			TraceID: brokenOtherTraceID, SpanID: brokenSpanID, TraceFlags: oteltrace.FlagsSampled, Remote: true,
+		}))
+	// DEFECT 14: the routing key carries the per-message trace ID, which is what
+	// blows the SDK's 2000-set cardinality limit in production.
+	attrs := tracking.AMQPConsumeAttributes("", BrokenCarrierTraceID, brokenDestination)
+	for range 2 {
+		tracking.RecordConsume(elsewhere, attrs, time.Millisecond, nil)
+	}
+}
+
+// Two fixed trace IDs: the span's parent, and the unrelated trace the record is
+// taken under.
+var (
+	brokenTraceID      = oteltrace.TraceID{0xb0, 0x0c}
+	brokenOtherTraceID = oteltrace.TraceID{0xe1, 0x5e}
+	brokenSpanID       = oteltrace.SpanID{0x0d, 0xed}
+)

--- a/messaging/internal/lanecontract/brokenlane_test.go
+++ b/messaging/internal/lanecontract/brokenlane_test.go
@@ -14,12 +14,21 @@ import (
 	gobrickstrace "github.com/gaborage/go-bricks/trace"
 )
 
-const brokenCarrierTraceID = "req-broken"
-
 // runIdentityAgainstBroken drives the broken lane through one scenario and
 // returns every assertion message AssertIdentity produced, without failing this
 // test.
 func runIdentityAgainstBroken(t *testing.T, scenario Scenario) string {
+	t.Helper()
+	return runAgainstBroken(t, scenario, AssertIdentity)
+}
+
+// runTelemetryAgainstBroken is the same for the telemetry family.
+func runTelemetryAgainstBroken(t *testing.T, scenario Scenario) string {
+	t.Helper()
+	return runAgainstBroken(t, scenario, AssertTelemetry)
+}
+
+func runAgainstBroken(t *testing.T, scenario Scenario, family func(T, *Lane, *Scenario, *Observed)) string {
 	t.Helper()
 
 	lane := BrokenLane()
@@ -34,7 +43,7 @@ func runIdentityAgainstBroken(t *testing.T, scenario Scenario) string {
 				}
 			}
 		}()
-		AssertIdentity(&recordingT{out: &failures}, &lane, &scenario, &observed)
+		family(&recordingT{out: &failures}, &lane, &scenario, &observed)
 	}()
 
 	return failures.String()
@@ -59,7 +68,7 @@ var _ T = (*recordingT)(nil)
 func TestBrokenLaneFailsTheTraceIdentityAssertions(t *testing.T) {
 	scenario := Scenario{
 		Name:    "succeeding_handler_with_a_carried_trace_id",
-		Carrier: map[string]any{gobrickstrace.HeaderXRequestID: brokenCarrierTraceID},
+		Carrier: map[string]any{gobrickstrace.HeaderXRequestID: BrokenCarrierTraceID},
 		Handle:  func(context.Context) error { return nil },
 		Outcome: delivery.Succeeded,
 	}
@@ -85,7 +94,7 @@ func TestBrokenLaneFailsTheTraceIdentityAssertions(t *testing.T) {
 func TestBrokenLaneFailsTheOutcomeLineShapeAssertions(t *testing.T) {
 	scenario := Scenario{
 		Name:    "failing_handler",
-		Carrier: map[string]any{gobrickstrace.HeaderXRequestID: brokenCarrierTraceID},
+		Carrier: map[string]any{gobrickstrace.HeaderXRequestID: BrokenCarrierTraceID},
 		Handle:  func(context.Context) error { return assert.AnError },
 		Outcome: delivery.HandlerError,
 	}
@@ -108,7 +117,7 @@ func TestBrokenLaneFailsTheOutcomeLineShapeAssertions(t *testing.T) {
 func TestBrokenLaneFailsThePanicSpineAssertions(t *testing.T) {
 	failures := runIdentityAgainstBroken(t, Scenario{
 		Name:    "panicking_handler",
-		Carrier: map[string]any{gobrickstrace.HeaderXRequestID: brokenCarrierTraceID},
+		Carrier: map[string]any{gobrickstrace.HeaderXRequestID: BrokenCarrierTraceID},
 		Handle:  func(context.Context) error { panic("boom") },
 		Outcome: delivery.Panicked,
 	})
@@ -140,8 +149,38 @@ func TestBrokenLaneStillCarriesTheDefectsOtherFamiliesNeed(t *testing.T) {
 		"installs no lease scope: leasescope.Register releases inline when none is present")
 	assert.Equal(t, []string{lane.SettleOnSuccess, lane.SettleOnSuccess}, observed.Settles,
 		"settles twice")
-	assert.Empty(t, observed.Spans, "opens no span")
-	assert.Empty(t, observed.Metrics.ScopeMetrics, "records no consume")
+}
+
+func TestBrokenLaneFailsEveryTelemetryAssertion(t *testing.T) {
+	failures := runTelemetryAgainstBroken(t, Scenario{
+		Name:    "failing_handler",
+		Carrier: map[string]any{gobrickstrace.HeaderXRequestID: BrokenCarrierTraceID},
+		Body:    []byte("payload"),
+		Handle:  func(context.Context) error { return assert.AnError },
+		Outcome: delivery.HandlerError,
+	})
+
+	require.NotEmpty(t, failures, "the telemetry family must fail against the broken lane")
+	assert.Contains(t, failures, "the span is named <destination> receive on both lanes")
+	assert.Contains(t, failures, "a consume span is Consumer-kind")
+	assert.Contains(t, failures, "the consume span is a root")
+	assert.Contains(t, failures, "span attribute messaging.system has the wrong value")
+	assert.Contains(t, failures, "not-rabbitmq", "the failure names the value the lane actually set")
+	// The broken lane reports 9999 bytes for a seven-byte body. Without this the
+	// body-size comparison could be removed from the family entirely and every
+	// assertion here would still pass: no other line mentions that attribute.
+	assert.Contains(t, failures, "span attribute messaging.message.body.size has the wrong value")
+	// The broken lane sets neither of these, so a correct assertAttr reports them
+	// ABSENT. Matching only a wrong-value message would pass even if assertAttr
+	// matched the wrong key and compared some other attribute's value.
+	assert.Contains(t, failures, "span attribute messaging.operation.name is absent")
+	assert.Contains(t, failures, "span attribute messaging.destination.name is absent")
+	assert.Contains(t, failures, "carries the per-message trace ID")
+	assert.Contains(t, failures, "which the lane did not declare in SpanExtraKeys")
+	assert.Contains(t, failures, "the record counts the delivery once")
+	assert.Contains(t, failures, "error.type is present exactly when the delivery failed")
+	assert.Contains(t, failures, "the exemplar names the delivery's own span, not a sibling in the same trace")
+	assert.Contains(t, failures, "the exemplar names the delivery's own trace")
 }
 
 // The broken lane's DECLARATION is deliberately valid: it is broken by what it

--- a/messaging/internal/lanecontract/telemetry.go
+++ b/messaging/internal/lanecontract/telemetry.go
@@ -1,0 +1,174 @@
+package lanecontract
+
+import (
+	"encoding/hex"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/gaborage/go-bricks/messaging/internal/delivery"
+	obtest "github.com/gaborage/go-bricks/observability/testing"
+)
+
+// The metrics the pipeline records for one delivery, and the attributes both
+// lanes' spans and records carry.
+const (
+	metricConsumeDuration = "messaging.client.operation.duration"
+	metricConsumeCount    = "messaging.client.consumed.messages"
+
+	attrSystem      = "messaging.system"
+	attrOperation   = "messaging.operation.name"
+	attrDestination = "messaging.destination.name"
+	attrBodySize    = "messaging.message.body.size"
+	attrErrorType   = "error.type"
+
+	spanOperation = "receive"
+)
+
+// AssertTelemetry checks what one delivery reported to OpenTelemetry: one
+// consumer span of the shared shape, one consume record at completion, and an
+// exemplar tying the record back to that span.
+//
+// The exemplar resolves to a per-message ORPHAN trace, because the consume span
+// is deliberately a root on both lanes — re-parenting a consume trace onto its
+// producer is out of scope. So this asserts the exemplar EXISTS and names the
+// span, and nothing about what the trace contains.
+func AssertTelemetry(t T, lane *Lane, scenario *Scenario, observed *Observed) {
+	t.Helper()
+
+	require.Len(t, observed.Spans, 1, "one delivery opens exactly one consumer span")
+	span := observed.Spans[0]
+
+	assert.Equal(t, lane.Destination+" "+spanOperation, span.Name,
+		"the span is named <destination> receive on both lanes")
+	assert.Equal(t, oteltrace.SpanKindConsumer, span.SpanKind, "a consume span is Consumer-kind")
+	assert.False(t, span.Parent.IsValid(),
+		"the consume span is a root: re-parenting onto the producer is out of scope, so its exemplar names an orphan trace")
+
+	assertSpanAttributes(t, lane, scenario, &span)
+	assertConsumeRecord(t, scenario, observed, &span)
+}
+
+// assertSpanAttributes pins the four attributes both lanes set and confines the
+// lane's own to what it declared.
+func assertSpanAttributes(t T, lane *Lane, scenario *Scenario, span *sdktrace.SpanStub) {
+	t.Helper()
+
+	assertAttr(t, span.Attributes, attrSystem, "rabbitmq")
+	assertAttr(t, span.Attributes, attrOperation, spanOperation)
+	assertAttr(t, span.Attributes, attrDestination, lane.Destination)
+	assertAttr(t, span.Attributes, attrBodySize, int64(len(scenario.Body)))
+
+	shared := []string{attrSystem, attrOperation, attrDestination, attrBodySize}
+	var extras []string
+	for _, kv := range span.Attributes {
+		if key := string(kv.Key); !slices.Contains(shared, key) {
+			extras = append(extras, key)
+		}
+	}
+	for _, key := range extras {
+		assert.Contains(t, lane.SpanExtraKeys, key,
+			"the span carries attribute %q, which the lane did not declare in SpanExtraKeys", key)
+	}
+}
+
+// assertConsumeRecord pins one record at completion, error.type iff the delivery
+// failed, an exemplar naming the span, and no per-message value on any attribute.
+func assertConsumeRecord(t T, scenario *Scenario, observed *Observed, span *sdktrace.SpanStub) {
+	t.Helper()
+
+	points := consumeDataPoints(t, observed)
+	require.Len(t, points, 1, "one delivery records exactly one %s data point", metricConsumeCount)
+	assert.Equal(t, int64(1), points[0].Value, "the record counts the delivery once")
+
+	failed := scenario.Outcome != delivery.Succeeded
+	_, hasErrorType := points[0].Attributes.Value(attrErrorType)
+	assert.Equal(t, failed, hasErrorType, "error.type is present exactly when the delivery failed")
+	assertNoPerMessageValue(t, scenario, observed, points[0].Attributes)
+
+	// Exemplars are live by default (the SDK's zero-config filter is trace-based
+	// and the sampler is always-on here), so a missing one means the record was
+	// taken outside the span rather than at completion inside it.
+	exemplars := obtest.SumExemplars[int64](t, observed.Metrics, metricConsumeCount)
+	require.NotEmpty(t, exemplars, "the consume record carries an exemplar, so it was recorded inside the span")
+	// The span ID is the load-bearing half: a trace holds many spans, so matching
+	// only the trace would accept a record taken under a SIBLING span. Both IDs
+	// are []byte on the exemplar and fixed-size arrays on the span context, so
+	// compare hex renderings — assert.Equal across those types always fails.
+	assert.Equal(t, span.SpanContext.SpanID().String(), hex.EncodeToString(exemplars[0].SpanID),
+		"the exemplar names the delivery's own span, not a sibling in the same trace")
+	assert.Equal(t, span.SpanContext.TraceID().String(), hex.EncodeToString(exemplars[0].TraceID),
+		"the exemplar names the delivery's own trace")
+}
+
+// assertNoPerMessageValue keeps a per-message value off the metric attributes.
+// The trace ID is the one every lane has to hand and the one that would do the
+// damage: the SDK's cardinality limit is 2000 attribute sets, past which every
+// further set is silently replaced by otel.metric.overflow=true — no error, no
+// log, aggregation destroyed.
+func assertNoPerMessageValue(t T, scenario *Scenario, observed *Observed, attrs attribute.Set) {
+	t.Helper()
+
+	// Prefer the id the carrier declared over the one the handler read: a lane
+	// that drops the carrier reports an empty handler id, and comparing against
+	// that would make this check vacuous on exactly the lane it must catch.
+	perMessage := observed.HandlerTraceID
+	if carried, declared := carriedTraceID(scenario.Carrier); declared {
+		perMessage = carried
+	}
+	for _, kv := range attrs.ToSlice() {
+		assert.NotEqual(t, perMessage, kv.Value.String(),
+			"metric attribute %q carries the per-message trace ID, which would blow the SDK's cardinality limit", kv.Key)
+	}
+}
+
+// consumeDataPoints is the consume counter's data points, failing loudly when
+// the metric is absent or a different shape rather than yielding an empty slice
+// a caller would read as "nothing recorded".
+func consumeDataPoints(t T, observed *Observed) []metricdata.DataPoint[int64] {
+	t.Helper()
+
+	metric := obtest.FindMetric(observed.Metrics, metricConsumeCount)
+	require.NotNil(t, metric, "one delivery records one %s", metricConsumeCount)
+
+	data, ok := metric.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "metric %s is %T, not an int64 sum", metricConsumeCount, metric.Data)
+
+	return data.DataPoints
+}
+
+// RunTelemetry puts a lane through every identity scenario and asserts what it
+// reported. It reuses IdentityScenarios so the two families provably cover the
+// same deliveries rather than drifting into separate sets.
+func RunTelemetry(t *testing.T, lane *Lane) {
+	t.Helper()
+
+	for _, scenario := range IdentityScenarios() {
+		t.Run(scenario.Name, func(t *testing.T) {
+			observed := lane.Deliver(t, scenario)
+
+			AssertTelemetry(t, lane, &scenario, &observed)
+		})
+	}
+}
+
+// assertAttr reports the attribute's value, failing when it is absent rather
+// than when it merely differs — an absent attribute and a wrong one are
+// different defects and a lane can have either.
+func assertAttr(t T, attrs []attribute.KeyValue, key string, want any) {
+	t.Helper()
+
+	for _, kv := range attrs {
+		if string(kv.Key) == key {
+			assert.Equal(t, want, kv.Value.AsInterface(), "span attribute %s has the wrong value", key)
+			return
+		}
+	}
+	t.Errorf("span attribute %s is absent", key)
+}

--- a/messaging/lanecontract_test.go
+++ b/messaging/lanecontract_test.go
@@ -179,5 +179,9 @@ func TestClassicLaneMintsAFreshStableTraceIDPerDelivery(t *testing.T) {
 	// the Equal below would pass while asserting nothing.
 	require.NotEmpty(t, first.HandlerTraceID, "the pipeline plants an id the handler can read")
 	assert.Equal(t, first.HandlerTraceID, secondRead, "two reads in one delivery must agree")
+	// The sibling half: NotEqual also passes when the SECOND delivery mints
+	// nothing, so "each delivery mints its own" would hold vacuously the moment
+	// the second stopped planting an id at all.
+	require.NotEmpty(t, second.HandlerTraceID, "the second delivery plants an id too")
 	assert.NotEqual(t, first.HandlerTraceID, second.HandlerTraceID, "each delivery mints its own")
 }

--- a/messaging/lanecontract_test.go
+++ b/messaging/lanecontract_test.go
@@ -7,6 +7,7 @@ import (
 
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gaborage/go-bricks/messaging/internal/delivery"
 	"github.com/gaborage/go-bricks/messaging/internal/lanecontract"
@@ -47,6 +48,13 @@ func classicLane() lanecontract.Lane {
 				Level: lanecontract.LevelError, Msg: "Panic recovered in message handler - discarding without requeue",
 				ExtraKeys: failureKeys,
 			},
+		},
+		// consumeSpanExtras adds these four when the delivery carries them.
+		SpanExtraKeys: []string{
+			"messaging.rabbitmq.exchange",
+			"messaging.rabbitmq.destination.routing_key",
+			"messaging.message.id",
+			"messaging.message.conversation_id",
 		},
 		SettleOnSuccess: "ack",
 		SettleOnFailure: "nack-no-requeue",
@@ -139,6 +147,12 @@ func TestClassicLaneSatisfiesTheIdentityContract(t *testing.T) {
 	lanecontract.RunIdentity(t, &lane)
 }
 
+func TestClassicLaneSatisfiesTheTelemetryContract(t *testing.T) {
+	lane := classicLane()
+
+	lanecontract.RunTelemetry(t, &lane)
+}
+
 // Each delivery mints its own id, and a handler reading twice within one gets
 // the same one — EnsureTraceID mints without writing back, so without the
 // pipeline's write-back neither would hold.
@@ -160,6 +174,10 @@ func TestClassicLaneMintsAFreshStableTraceIDPerDelivery(t *testing.T) {
 		Outcome: delivery.Succeeded,
 	})
 
+	// Assert the precondition both comparisons rest on. If the pipeline stopped
+	// planting an id, first.HandlerTraceID and secondRead would both be "" and
+	// the Equal below would pass while asserting nothing.
+	require.NotEmpty(t, first.HandlerTraceID, "the pipeline plants an id the handler can read")
 	assert.Equal(t, first.HandlerTraceID, secondRead, "two reads in one delivery must agree")
 	assert.NotEqual(t, first.HandlerTraceID, second.HandlerTraceID, "each delivery mints its own")
 }

--- a/observability/testing/exemplars_test.go
+++ b/observability/testing/exemplars_test.go
@@ -15,7 +15,7 @@ import (
 
 // recordUnderASampledSpan records one counter and one histogram sample inside a
 // sampled span, which is what makes the SDK attach an exemplar at all.
-func recordUnderASampledSpan(t *testing.T) metricdata.ResourceMetrics {
+func recordUnderASampledSpan(t *testing.T) (metricdata.ResourceMetrics, oteltrace.TraceID) {
 	t.Helper()
 
 	tp := obtest.NewTestTraceProvider()
@@ -38,33 +38,36 @@ func recordUnderASampledSpan(t *testing.T) metricdata.ResourceMetrics {
 	histogram.Record(ctx, 0.5, metric.WithAttributes())
 
 	span.End()
-	return mp.Collect(t)
+	// Return the trace the metrics were recorded under. Asserting only that an
+	// exemplar HAS a trace id cannot tell "the right trace" from "a trace".
+	return mp.Collect(t), span.SpanContext().TraceID()
 }
 
 func TestSumExemplarsNamesTheRecordingSpan(t *testing.T) {
-	rm := recordUnderASampledSpan(t)
+	rm, recorded := recordUnderASampledSpan(t)
 
 	exemplars := obtest.SumExemplars[int64](t, rm, "things.counted")
 
 	require.NotEmpty(t, exemplars)
-	assert.NotEmpty(t, exemplars[0].TraceID, "the exemplar carries the trace it was recorded under")
-	assert.Len(t, exemplars[0].TraceID, len(oteltrace.TraceID{}))
+	assert.Equal(t, recorded[:], exemplars[0].TraceID,
+		"the exemplar names the trace it was recorded under, not merely some trace")
 }
 
 func TestHistogramExemplarsNamesTheRecordingSpan(t *testing.T) {
-	rm := recordUnderASampledSpan(t)
+	rm, recorded := recordUnderASampledSpan(t)
 
 	exemplars := obtest.HistogramExemplars[float64](t, rm, "things.timed")
 
 	require.NotEmpty(t, exemplars)
-	assert.NotEmpty(t, exemplars[0].TraceID)
+	assert.Equal(t, recorded[:], exemplars[0].TraceID,
+		"the exemplar names the trace it was recorded under, not merely some trace")
 }
 
 // Both helpers fail loudly rather than returning empty: an assertion helper that
 // yields nothing turns "the exemplar is missing" into "I guessed the shape
 // wrong", and both read as a passing zero-length result at the call site.
 func TestExemplarHelpersFailRatherThanYieldNothing(t *testing.T) {
-	rm := recordUnderASampledSpan(t)
+	rm, _ := recordUnderASampledSpan(t)
 
 	tests := []struct {
 		name string

--- a/observability/testing/exemplars_test.go
+++ b/observability/testing/exemplars_test.go
@@ -1,0 +1,120 @@
+package testing_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	obtest "github.com/gaborage/go-bricks/observability/testing"
+)
+
+// recordUnderASampledSpan records one counter and one histogram sample inside a
+// sampled span, which is what makes the SDK attach an exemplar at all.
+func recordUnderASampledSpan(t *testing.T) metricdata.ResourceMetrics {
+	t.Helper()
+
+	tp := obtest.NewTestTraceProvider()
+	mp := obtest.NewTestMeterProvider()
+	t.Cleanup(func() {
+		require.NoError(t, tp.Shutdown(context.Background()))
+		require.NoError(t, mp.Shutdown(context.Background()))
+	})
+
+	ctx, span := tp.Tracer("exemplars").Start(context.Background(), "work")
+	require.True(t, span.SpanContext().IsSampled(), "an unsampled span attaches no exemplar")
+
+	meter := mp.Meter("exemplars")
+	counter, err := meter.Int64Counter("things.counted")
+	require.NoError(t, err)
+	counter.Add(ctx, 1, metric.WithAttributes())
+
+	histogram, err := meter.Float64Histogram("things.timed")
+	require.NoError(t, err)
+	histogram.Record(ctx, 0.5, metric.WithAttributes())
+
+	span.End()
+	return mp.Collect(t)
+}
+
+func TestSumExemplarsNamesTheRecordingSpan(t *testing.T) {
+	rm := recordUnderASampledSpan(t)
+
+	exemplars := obtest.SumExemplars[int64](t, rm, "things.counted")
+
+	require.NotEmpty(t, exemplars)
+	assert.NotEmpty(t, exemplars[0].TraceID, "the exemplar carries the trace it was recorded under")
+	assert.Len(t, exemplars[0].TraceID, len(oteltrace.TraceID{}))
+}
+
+func TestHistogramExemplarsNamesTheRecordingSpan(t *testing.T) {
+	rm := recordUnderASampledSpan(t)
+
+	exemplars := obtest.HistogramExemplars[float64](t, rm, "things.timed")
+
+	require.NotEmpty(t, exemplars)
+	assert.NotEmpty(t, exemplars[0].TraceID)
+}
+
+// Both helpers fail loudly rather than returning empty: an assertion helper that
+// yields nothing turns "the exemplar is missing" into "I guessed the shape
+// wrong", and both read as a passing zero-length result at the call site.
+func TestExemplarHelpersFailRatherThanYieldNothing(t *testing.T) {
+	rm := recordUnderASampledSpan(t)
+
+	tests := []struct {
+		name string
+		call func(t obtest.TB)
+	}{
+		{
+			name: "sum_metric_absent",
+			call: func(t obtest.TB) { obtest.SumExemplars[int64](t, rm, "no.such.metric") },
+		},
+		{
+			name: "histogram_metric_absent",
+			call: func(t obtest.TB) { obtest.HistogramExemplars[float64](t, rm, "no.such.metric") },
+		},
+		{
+			name: "sum_asked_for_the_wrong_numeric_type",
+			call: func(t obtest.TB) { obtest.SumExemplars[float64](t, rm, "things.counted") },
+		},
+		{
+			name: "histogram_asked_for_a_sum",
+			call: func(t obtest.TB) { obtest.HistogramExemplars[float64](t, rm, "things.counted") },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := &failRecorder{}
+
+			recorder.run(func() { tt.call(recorder) })
+
+			assert.True(t, recorder.failed, "the helper must report rather than return empty")
+		})
+	}
+}
+
+// failRecorder captures a require failure instead of ending the test.
+type failRecorder struct{ failed bool }
+
+type stop struct{}
+
+func (r *failRecorder) Errorf(string, ...any) { r.failed = true }
+func (r *failRecorder) FailNow()              { panic(stop{}) }
+func (r *failRecorder) Helper()               {}
+
+func (r *failRecorder) run(fn func()) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			if _, stopped := recovered.(stop); !stopped {
+				panic(recovered)
+			}
+		}
+	}()
+	fn()
+}

--- a/observability/testing/helpers.go
+++ b/observability/testing/helpers.go
@@ -493,3 +493,68 @@ func GetMetricHistogramCount(rm metricdata.ResourceMetrics, metricName string) (
 		return 0, fmt.Errorf("metric %s is not a Histogram type", metricName)
 	}
 }
+
+// TB is what the exemplar helpers need from *testing.T. It is an interface so a
+// caller that already abstracts over the test handle can pass its own.
+type TB interface {
+	require.TestingT
+	Helper()
+}
+
+// HistogramExemplars returns the exemplars attached to every data point of a
+// histogram metric.
+func HistogramExemplars[N int64 | float64](t TB, rm metricdata.ResourceMetrics, metricName string) []metricdata.Exemplar[N] {
+	t.Helper()
+	return exemplarsOf(t, rm, metricName, "histogram", histogramExemplars[N])
+}
+
+// SumExemplars is HistogramExemplars for a counter.
+func SumExemplars[N int64 | float64](t TB, rm metricdata.ResourceMetrics, metricName string) []metricdata.Exemplar[N] {
+	t.Helper()
+	return exemplarsOf(t, rm, metricName, "sum", sumExemplars[N])
+}
+
+func histogramExemplars[N int64 | float64](agg metricdata.Aggregation) ([]metricdata.Exemplar[N], bool) {
+	data, ok := agg.(metricdata.Histogram[N])
+	if !ok {
+		return nil, false
+	}
+	var out []metricdata.Exemplar[N]
+	for i := range data.DataPoints {
+		out = append(out, data.DataPoints[i].Exemplars...)
+	}
+	return out, true
+}
+
+func sumExemplars[N int64 | float64](agg metricdata.Aggregation) ([]metricdata.Exemplar[N], bool) {
+	data, ok := agg.(metricdata.Sum[N])
+	if !ok {
+		return nil, false
+	}
+	var out []metricdata.Exemplar[N]
+	for i := range data.DataPoints {
+		out = append(out, data.DataPoints[i].Exemplars...)
+	}
+	return out, true
+}
+
+// exemplarsOf looks the metric up and hands its aggregation to extract. It fails
+// the test when the metric is absent or a different shape, rather than returning
+// empty: a helper that silently yields nothing turns "the exemplar is missing"
+// into "I guessed the shape wrong", and both read as a passing zero-length
+// result at the call site.
+func exemplarsOf[N int64 | float64](
+	t TB,
+	rm metricdata.ResourceMetrics,
+	metricName, shape string,
+	extract func(metricdata.Aggregation) ([]metricdata.Exemplar[N], bool),
+) []metricdata.Exemplar[N] {
+	t.Helper()
+
+	metric := FindMetric(rm, metricName)
+	require.NotNil(t, metric, "metric %s not found", metricName)
+
+	out, ok := extract(metric.Data)
+	require.True(t, ok, "metric %s is %T, not a %s of the requested type", metricName, metric.Data, shape)
+	return out
+}


### PR DESCRIPTION
## What

The lane contract asserted identity; this adds the telemetry family. Both lanes must produce a receive span with the same name shape, kind and exact attribute set, exactly one consume record at completion, `error.type` present iff the outcome failed, and a metric exemplar naming that span. It also adds the exemplar assertion helpers to `observability/testing`, which is a separate deliverable that happens to land here — the family itself is ~275 lines.

## Impact

None at runtime. Internal test-support package plus two exported helpers in `observability/testing`; nothing in a production dependency graph imports the harness.

## Verification

The mutation gate surfaced **two assertions that could not fail**, in code `make check`, `/simplify` and CodeRabbit had all already passed. One early-returned whenever the handler read no trace id — which the counter-example lane does by construction, so the check never ran against the one lane it exists to catch; it now derives the value from the carrier, which every lane sees, removing the guard rather than testing it. The other's must-fail test matched a substring the mutated code also emits; the discriminator is now a message only correct code can produce. Both mutants were hand-re-applied after fixing to confirm they die.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded messaging contract coverage for delivery outcomes, acknowledgements, rejections, lease handling, panic logging, and trace consistency.
  * Added validation for RabbitMQ telemetry, including consumer spans, metrics, error metadata, and exemplars.
  * Added tests confirming metric exemplars correctly link measurements to the recording trace.
  * Improved test utilities to report missing or invalid metrics clearly instead of silently passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->