### PR TITLE
fix(outbox): bound the error text the relay persists

### DIFF
--- a/outbox/relay.go
+++ b/outbox/relay.go
@@ -368,12 +368,12 @@ func boundPersistedError(errMsg string) string {
 		return cleaned
 	}
 
+	// Slicing at a byte offset can land mid-rune; ToValidUTF8 drops the partial
+	// tail, so the column never receives a half-encoded character. Doing it this
+	// way rather than walking back to a rune start keeps the boundary out of the
+	// code: there is no index to be off by one on.
 	keep := maxPersistedErrorBytes - len(truncationMarker)
-	// Back off to a rune boundary so a multi-byte character is never split.
-	for keep > 0 && !utf8.RuneStart(cleaned[keep]) {
-		keep--
-	}
-	return cleaned[:keep] + truncationMarker
+	return strings.ToValidUTF8(cleaned[:keep], "") + truncationMarker
 }
 
 // markRecordFailed marks an outbox record as failed, logging any secondary errors.

--- a/outbox/relay.go
+++ b/outbox/relay.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
-	"unicode/utf8"
 
 	"github.com/gaborage/go-bricks/config"
 	dbtypes "github.com/gaborage/go-bricks/database/types"
@@ -353,12 +352,14 @@ const truncationMarker = "...[truncated]"
 //     because the framework could not write down why it failed.
 //   - Control bytes become spaces. This text is read back into logs and
 //     dashboards, and a broker-supplied newline should not be able to forge a
-//     log line there.
-//   - The result is capped, on a rune boundary so the column never receives a
-//     half-encoded character.
+//     log line there. Only control bytes: ToValidUTF8 has already removed every
+//     invalid sequence, so a U+FFFD reaching here is one the sender actually
+//     wrote, and substituting it would drop a character nothing is wrong with.
+//   - The result is capped without leaving a half-encoded character in the
+//     column.
 func boundPersistedError(errMsg string) string {
 	cleaned := strings.Map(func(r rune) rune {
-		if r == utf8.RuneError || unicode.IsControl(r) {
+		if unicode.IsControl(r) {
 			return ' '
 		}
 		return r

--- a/outbox/relay.go
+++ b/outbox/relay.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/gaborage/go-bricks/config"
 	dbtypes "github.com/gaborage/go-bricks/database/types"
@@ -306,7 +309,7 @@ func (r *Relay) publishRecord(ctx context.Context, log logger.Logger, db dbtypes
 // failures never reach here — they call markRecordFailed directly and are never parked.
 func (r *Relay) deadLetterPoison(ctx context.Context, log logger.Logger, db dbtypes.Interface, record *Record, errMsg string) publishOutcome {
 	if record.RetryCount+1 >= r.config.MaxRetries {
-		if err := r.store.MarkDeadLettered(ctx, db, record.ID, errMsg); err != nil {
+		if err := r.store.MarkDeadLettered(ctx, db, record.ID, boundPersistedError(errMsg)); err != nil {
 			log.Error().Err(err).Str("eventID", record.ID).Msg("Failed to dead-letter outbox event")
 			return outcomeFailed
 		}
@@ -320,9 +323,62 @@ func (r *Relay) deadLetterPoison(ctx context.Context, log logger.Logger, db dbty
 	return outcomeFailed
 }
 
+// maxPersistedErrorBytes bounds the diagnostic text the relay writes to a
+// record's error column. Both ledgers declare that column unbounded (`error
+// TEXT` on PostgreSQL, `error_msg CLOB` on Oracle), and the value written there
+// is not ours: it is err.Error() from a broker or driver, which can carry
+// server-supplied text of any length. A record that keeps failing rewrites the
+// column every cycle, so an unbounded error is unbounded storage per retry, on
+// the one table a service cannot drop.
+//
+// 1 KiB holds a broker error with its context and truncates only the pathological.
+const maxPersistedErrorBytes = 1024
+
+// truncationMarker is appended in place of the bytes dropped, so a reader can
+// tell a short error from a shortened one.
+const truncationMarker = "...[truncated]"
+
+// boundPersistedError makes an arbitrary error string safe to store.
+//
+// Unlike an inbound trace identifier — where truncation silently forges
+// correlation by mapping distinct upstream ids onto one, so a bad value is
+// DISCARDED — this text is diagnostic and nothing keys on it. A truncated error
+// still says what went wrong, while discarding one would throw away the only
+// record of why a record is stuck. So truncation is the right answer here, and
+// the marker keeps it honest.
+//
+// Three things happen, in order:
+//   - Invalid UTF-8 is dropped. PostgreSQL rejects it outright, which would fail
+//     the UPDATE and leave retry_count un-advanced — a record retrying forever
+//     because the framework could not write down why it failed.
+//   - Control bytes become spaces. This text is read back into logs and
+//     dashboards, and a broker-supplied newline should not be able to forge a
+//     log line there.
+//   - The result is capped, on a rune boundary so the column never receives a
+//     half-encoded character.
+func boundPersistedError(errMsg string) string {
+	cleaned := strings.Map(func(r rune) rune {
+		if r == utf8.RuneError || unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, strings.ToValidUTF8(errMsg, ""))
+
+	if len(cleaned) <= maxPersistedErrorBytes {
+		return cleaned
+	}
+
+	keep := maxPersistedErrorBytes - len(truncationMarker)
+	// Back off to a rune boundary so a multi-byte character is never split.
+	for keep > 0 && !utf8.RuneStart(cleaned[keep]) {
+		keep--
+	}
+	return cleaned[:keep] + truncationMarker
+}
+
 // markRecordFailed marks an outbox record as failed, logging any secondary errors.
 func (r *Relay) markRecordFailed(ctx context.Context, log logger.Logger, db dbtypes.Interface, eventID, errMsg string) {
-	if markErr := r.store.MarkFailed(ctx, db, eventID, errMsg); markErr != nil {
+	if markErr := r.store.MarkFailed(ctx, db, eventID, boundPersistedError(errMsg)); markErr != nil {
 		log.Error().
 			Err(markErr).
 			Str("eventID", eventID).

--- a/outbox/relay_test.go
+++ b/outbox/relay_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -566,4 +568,95 @@ func TestRelayContinuesBatchWhenNotConnectedButStillReady(t *testing.T) {
 	assert.Equal(t, "evt-2", store.MarkPublishedLastID)
 	assert.Equal(t, 1, store.MarkFailedCalls)
 	assert.Equal(t, "evt-1", store.MarkFailedLastID)
+}
+
+func TestBoundPersistedErrorMakesArbitraryTextSafeToStore(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		wantExact string
+		truncated bool
+	}{
+		{name: "short_text_passes_through", in: "broker rejected", wantExact: "broker rejected"},
+		{name: "empty_stays_empty", in: "", wantExact: ""},
+		// The column is read back into logs and dashboards, so a broker-supplied
+		// newline must not be able to forge a line there.
+		{
+			name:      "control_bytes_become_spaces",
+			in:        "publish failed\r\nlevel=error msg=\"forged\"\x00",
+			wantExact: "publish failed  level=error msg=\"forged\" ",
+		},
+		// PostgreSQL rejects invalid UTF-8 outright: the UPDATE would fail and
+		// retry_count would never advance, retrying forever over text nobody reads.
+		{name: "invalid_utf8_is_dropped", in: "err: " + string([]byte{0xff, 0xfe}) + " tail", wantExact: "err:  tail"},
+		{name: "at_the_cap_is_untouched", in: strings.Repeat("a", maxPersistedErrorBytes), wantExact: strings.Repeat("a", maxPersistedErrorBytes)},
+		{name: "one_over_the_cap_truncates", in: strings.Repeat("a", maxPersistedErrorBytes+1), truncated: true},
+		{name: "pathological_10kb_truncates", in: strings.Repeat("broker unreachable; ", 512), truncated: true},
+		{name: "multibyte_truncates_on_a_rune_boundary", in: strings.Repeat("日", 5000), truncated: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := boundPersistedError(tt.in)
+
+			assert.LessOrEqual(t, len(got), maxPersistedErrorBytes, "the ledger never receives more than the cap")
+			assert.True(t, utf8.ValidString(got), "invalid UTF-8 would be rejected by PostgreSQL and fail the UPDATE")
+			assert.NotContains(t, got, "\x00")
+			assert.NotContains(t, got, "\n")
+			assert.NotContains(t, got, "\r")
+
+			if tt.truncated {
+				assert.True(t, strings.HasSuffix(got, truncationMarker),
+					"a shortened error says so, or a reader cannot tell it from a short one")
+			} else {
+				assert.Equal(t, tt.wantExact, got)
+			}
+		})
+	}
+}
+
+// The helper being correct is not the property that matters: what matters is that
+// the value REACHING the ledger is bounded. This drives the real failure path and
+// asserts on what the store was handed, so removing the call from the relay fails
+// here even though the helper still passes its own tests.
+func TestPublishRecordBoundsTheErrorItPersists(t *testing.T) {
+	oversized := strings.Repeat("broker unreachable; ", 512) // ~10 KiB
+
+	store := &fakeStore{
+		FetchPendingResult: []Record{{ID: "evt-1", Exchange: "orders", RoutingKey: "created"}},
+	}
+	amqp := newFakeAMQP()
+	amqp.PublishErrFor = map[string]error{"orders:created": errors.New(oversized)}
+	r := newRelayWithFakes(store, amqp)
+	db := dbtesting.NewTestDB("postgresql")
+	ctx := newFakeJobCtx(db, amqp)
+
+	require.NoError(t, r.Execute(ctx))
+
+	require.Equal(t, 1, store.MarkFailedCalls)
+	assert.Greater(t, len(oversized), maxPersistedErrorBytes, "the fixture is actually oversized")
+	assert.LessOrEqual(t, len(store.MarkFailedLastErr), maxPersistedErrorBytes,
+		"the ledger receives the bounded error, not the broker's whole message")
+	assert.True(t, strings.HasSuffix(store.MarkFailedLastErr, truncationMarker))
+	assert.Contains(t, store.MarkFailedLastErr, "broker unreachable",
+		"and it is still diagnostic — truncated, not discarded")
+}
+
+// The dead-letter path writes to the same unbounded column, so bounding only the
+// failure path would leave the invariant untrue on the other half.
+func TestDeadLetterPoisonBoundsTheErrorItPersists(t *testing.T) {
+	oversized := strings.Repeat("x", 9000)
+
+	store := &fakeStore{}
+	amqp := newFakeAMQP()
+	r := newRelayWithFakes(store, amqp)
+	db := dbtesting.NewTestDB("postgresql")
+	ctx := newFakeJobCtx(db, amqp)
+
+	rec := &Record{ID: "evt-poison", RetryCount: r.config.MaxRetries}
+	r.deadLetterPoison(ctx, ctx.Logger(), db, rec, oversized)
+
+	require.Equal(t, 1, store.MarkDeadLetteredCalls)
+	assert.LessOrEqual(t, len(store.MarkDeadLetteredLastErr), maxPersistedErrorBytes)
+	assert.True(t, strings.HasSuffix(store.MarkDeadLetteredLastErr, truncationMarker))
 }

--- a/outbox/relay_test.go
+++ b/outbox/relay_test.go
@@ -660,3 +660,70 @@ func TestDeadLetterPoisonBoundsTheErrorItPersists(t *testing.T) {
 	assert.LessOrEqual(t, len(store.MarkDeadLetteredLastErr), maxPersistedErrorBytes)
 	assert.True(t, strings.HasSuffix(store.MarkDeadLetteredLastErr, truncationMarker))
 }
+
+// When the ledger write itself fails, the relay's only remaining job is to say
+// so. Nothing is returned and nothing else is stored, so the emitted line is the
+// whole observable — and its absence is how "we could not record why this record
+// failed" becomes silent.
+func TestMarkRecordFailedReportsAFailedLedgerWrite(t *testing.T) {
+	tests := []struct {
+		name      string
+		markErr   error
+		wantLines []string
+	}{
+		{name: "ledger_write_fails", markErr: errors.New("connection reset"), wantLines: []string{"Failed to mark outbox event as failed"}},
+		// The negative half: a successful write says nothing. Without this, a
+		// condition inverted to log on success would still look correct.
+		{name: "ledger_write_succeeds", wantLines: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &fakeStore{MarkFailedErr: tt.markErr}
+			r := newRelayWithFakes(store, newFakeAMQP())
+			log := newRecordingLogger()
+			db := dbtesting.NewTestDB("postgresql")
+
+			r.markRecordFailed(context.Background(), log, db, "evt-1", "boom")
+
+			assert.Equal(t, 1, store.MarkFailedCalls)
+			assert.Equal(t, tt.wantLines, log.messages())
+		})
+	}
+}
+
+// Same shape on the dead-letter path, which additionally reports the failure
+// through its return value: a record that could not be parked is NOT reported as
+// parked, or the relay would claim it had stopped retrying something it had not.
+func TestDeadLetterPoisonReportsAFailedLedgerWrite(t *testing.T) {
+	tests := []struct {
+		name      string
+		markErr   error
+		want      publishOutcome
+		wantLines []string
+	}{
+		{
+			name: "parking_fails", markErr: errors.New("connection reset"),
+			want: outcomeFailed, wantLines: []string{"Failed to dead-letter outbox event"},
+		},
+		{
+			name: "parking_succeeds",
+			want: outcomeDeadLettered, wantLines: []string{"Outbox event dead-lettered after exhausting retries"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &fakeStore{MarkDeadLetteredErr: tt.markErr}
+			r := newRelayWithFakes(store, newFakeAMQP())
+			log := newRecordingLogger()
+			db := dbtesting.NewTestDB("postgresql")
+			rec := &Record{ID: "evt-poison", RetryCount: r.config.MaxRetries}
+
+			got := r.deadLetterPoison(context.Background(), log, db, rec, "bad headers")
+
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantLines, log.messages())
+		})
+	}
+}

--- a/outbox/relay_test.go
+++ b/outbox/relay_test.go
@@ -589,6 +589,15 @@ func TestBoundPersistedErrorMakesArbitraryTextSafeToStore(t *testing.T) {
 		// PostgreSQL rejects invalid UTF-8 outright: the UPDATE would fail and
 		// retry_count would never advance, retrying forever over text nobody reads.
 		{name: "invalid_utf8_is_dropped", in: "err: " + string([]byte{0xff, 0xfe}) + " tail", wantExact: "err:  tail"},
+		// The pair that matters: invalid BYTES are dropped by ToValidUTF8 above,
+		// so by the time the mapping runs, a U+FFFD is a character the sender
+		// actually wrote. Substituting it would silently discard real content,
+		// and the two cases together pin the seam between the two behaviors.
+		{
+			name:      "a_genuine_replacement_character_survives",
+			in:        "broker said \ufffd here",
+			wantExact: "broker said \ufffd here",
+		},
 		{name: "at_the_cap_is_untouched", in: strings.Repeat("a", maxPersistedErrorBytes), wantExact: strings.Repeat("a", maxPersistedErrorBytes)},
 		{name: "one_over_the_cap_truncates", in: strings.Repeat("a", maxPersistedErrorBytes+1), truncated: true},
 		{name: "pathological_10kb_truncates", in: strings.Repeat("broker unreachable; ", 512), truncated: true},

--- a/outbox/test_helpers_test.go
+++ b/outbox/test_helpers_test.go
@@ -2,6 +2,7 @@ package outbox
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -228,3 +229,50 @@ func (f *fakeAMQP) DeclareExchange(_ context.Context, _ *messaging.ExchangeDecla
 }
 func (f *fakeAMQP) BindQueue(_ context.Context, _ *messaging.BindingDeclaration) error { return nil }
 func (f *fakeAMQP) Close() error                                                       { return nil }
+
+// recordingLogger captures the message text of emitted lines. The relay's
+// secondary-error paths — "could not write down why this record failed" — have
+// no return value and no store side effect, so the emitted line is the only
+// observable they have.
+type recordingLogger struct {
+	mu    *sync.Mutex
+	lines *[]string
+}
+
+func newRecordingLogger() *recordingLogger {
+	return &recordingLogger{mu: &sync.Mutex{}, lines: &[]string{}}
+}
+
+func (l *recordingLogger) messages() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), *l.lines...)
+}
+
+func (l *recordingLogger) event() logger.LogEvent                  { return &recordingEvent{owner: l} }
+func (l *recordingLogger) Info() logger.LogEvent                   { return l.event() }
+func (l *recordingLogger) Error() logger.LogEvent                  { return l.event() }
+func (l *recordingLogger) Debug() logger.LogEvent                  { return l.event() }
+func (l *recordingLogger) Warn() logger.LogEvent                   { return l.event() }
+func (l *recordingLogger) Fatal() logger.LogEvent                  { return l.event() }
+func (l *recordingLogger) WithContext(any) logger.Logger           { return l }
+func (l *recordingLogger) WithFields(map[string]any) logger.Logger { return l }
+
+type recordingEvent struct{ owner *recordingLogger }
+
+func (e *recordingEvent) Msg(msg string) {
+	e.owner.mu.Lock()
+	defer e.owner.mu.Unlock()
+	*e.owner.lines = append(*e.owner.lines, msg)
+}
+func (e *recordingEvent) Msgf(format string, args ...any)           { e.Msg(fmt.Sprintf(format, args...)) }
+func (e *recordingEvent) Err(error) logger.LogEvent                 { return e }
+func (e *recordingEvent) Str(_, _ string) logger.LogEvent           { return e }
+func (e *recordingEvent) Int(string, int) logger.LogEvent           { return e }
+func (e *recordingEvent) Int64(string, int64) logger.LogEvent       { return e }
+func (e *recordingEvent) Uint64(string, uint64) logger.LogEvent     { return e }
+func (e *recordingEvent) Dur(string, time.Duration) logger.LogEvent { return e }
+func (e *recordingEvent) Interface(string, any) logger.LogEvent     { return e }
+func (e *recordingEvent) Bytes(string, []byte) logger.LogEvent      { return e }
+func (e *recordingEvent) Bool(string, bool) logger.LogEvent         { return e }
+func (e *recordingEvent) Enabled() bool                             { return true }

--- a/wiki/outbox.md
+++ b/wiki/outbox.md
@@ -151,9 +151,10 @@ Consequences worth knowing:
   corruption (undecodable headers, which the framework essentially never produces).
 - **`maxretries` bounds poison only.** Connectivity failures (including a permanently-failing publish)
   retry indefinitely with a climbing `retry_count` — monitor that growth to catch a stuck event.
-- **The persisted error text is bounded to 1 KiB.** A failed attempt records why in the row's
-  `error` column (`error_msg` on Oracle), and that text comes from the broker or driver rather
-  than from the framework. Since a connectivity failure retries forever and rewrites the column
+- **The relay bounds the error text it persists to 1 KiB.** A failed attempt records why in the
+  row's `error` column (`error_msg` on Oracle), and that text comes from the broker or driver
+  rather than from the framework. The bound sits in the relay, not in `Store`, so a hand-rolled
+  relay writing that column directly is responsible for its own. Since a connectivity failure retries forever and rewrites the column
   every cycle, an unbounded message would be unbounded storage per retry on a table a service
   cannot drop. Longer text is **truncated**, not discarded — it is diagnostic and nothing keys
   on it, so a shortened error still says what went wrong — and a truncated value ends in

--- a/wiki/outbox.md
+++ b/wiki/outbox.md
@@ -151,6 +151,16 @@ Consequences worth knowing:
   corruption (undecodable headers, which the framework essentially never produces).
 - **`maxretries` bounds poison only.** Connectivity failures (including a permanently-failing publish)
   retry indefinitely with a climbing `retry_count` — monitor that growth to catch a stuck event.
+- **The persisted error text is bounded to 1 KiB.** A failed attempt records why in the row's
+  `error` column (`error_msg` on Oracle), and that text comes from the broker or driver rather
+  than from the framework. Since a connectivity failure retries forever and rewrites the column
+  every cycle, an unbounded message would be unbounded storage per retry on a table a service
+  cannot drop. Longer text is **truncated**, not discarded — it is diagnostic and nothing keys
+  on it, so a shortened error still says what went wrong — and a truncated value ends in
+  `...[truncated]` so a reader can tell it from a short one. Control bytes are replaced with
+  spaces (the column is read back into logs and dashboards, and a broker-supplied newline must
+  not be able to forge a line there) and invalid UTF-8 is dropped, which PostgreSQL would
+  otherwise reject outright — failing the UPDATE and leaving `retry_count` un-advanced.
 - **One stuck record cannot starve the batch:** each publish is bounded by `outbox.publishtimeout`
   (default 60s). It **must be ≥ `messaging.reconnect.connectiontimeout`** (default 30s) — the module
   **fails to start** otherwise, because a shorter value truncates every legitimate confirmation into a


### PR DESCRIPTION
## What

A failed publish records the driver's or broker's error text in the outbox row's
`error` column (`error_msg` on Oracle), and both ledgers declare that column
unbounded. Connectivity failures retry forever by design, rewriting the column
every cycle, so a server-supplied message of arbitrary length was unbounded
storage per retry on a table a service cannot drop. The relay now bounds what it
persists to 1 KiB, truncating rather than discarding — the text is diagnostic and
nothing keys on it, so a shortened error still says what went wrong — and marks a
shortened value `...[truncated]`. Invalid UTF-8 is dropped, which PostgreSQL would
otherwise reject outright, failing the UPDATE and leaving `retry_count`
un-advanced; control bytes become spaces so a broker-supplied newline cannot forge
a line in logs downstream.

## Impact

None. The classification logic that decides failed-vs-dead-lettered is untouched.

## Verification

Bound probed at the output with 10 KiB, CRLF/NUL/ANSI-escape, invalid-UTF-8, and
multibyte-straddling-the-boundary inputs rather than reasoned about. `make mutate`
clean: 8 mutants on changed lines, all killed. Two of those were pre-existing
untested branches that entered scope because the bound touched their lines; they
are covered rather than formatted out of scope.

Closes #1071


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Relay failure and dead-letter records now store sanitized, valid UTF-8 error messages.
  - Invalid UTF-8 bytes are removed, while genuine replacement characters are preserved.
  - Control characters are replaced with spaces.
  - Persisted errors are limited to 1 KiB, with longer messages marked as truncated.
  - Dead-letter outcomes and ledger-write failures are recorded more accurately.

- **Documentation**
  - Updated retry and dead-lettering guidance with error-storage limits and sanitization details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->