### PR TITLE
test(cache): restore the previous meter provider in cleanup

### DIFF
--- a/cache/internal/tracking/metrics_test.go
+++ b/cache/internal/tracking/metrics_test.go
@@ -28,28 +28,61 @@ func setupTestMeterProvider(t *testing.T) *sdkmetric.ManualReader {
 	otel.SetMeterProvider(provider)
 
 	t.Cleanup(func() {
-		// Reinstate the previous provider before shutting this one down: without
-		// it the global keeps pointing at a provider that has been shut down, and
-		// instrument creation against a shut-down provider no-ops silently.
+		// Reinstate the previous provider, and do NOT shut this one down.
+		//
+		// otel's global provider delegates, and it binds its delegate exactly once
+		// per process (internal/global/state.go, delegateMeterOnce sync.Once). The
+		// first SetMeterProvider in the binary therefore points that delegator at
+		// `provider` PERMANENTLY. Restoring `prev` restores the delegator, not its
+		// delegate — so shutting `provider` down leaves every later otel.Meter call
+		// routed through a corpse, handing out instruments that record nothing and
+		// report no error. Restoring identity does not restore function.
+		//
+		// Leaving it running costs nothing: a ManualReader has no exporter and no
+		// background goroutine, so an unread provider is inert rather than leaky.
 		otel.SetMeterProvider(prev)
-		_ = provider.Shutdown(context.Background())
 		ResetForTesting()
 	})
 
 	return reader
 }
 
-func TestSetupTestMeterProviderRestoresTheGlobalProvider(t *testing.T) {
+func TestSetupTestMeterProviderLeavesTheGlobalUsable(t *testing.T) {
 	before := otel.GetMeterProvider()
+	var reader *sdkmetric.ManualReader
 
 	t.Run("inner", func(t *testing.T) {
-		setupTestMeterProvider(t)
+		reader = setupTestMeterProvider(t)
 		require.NotEqual(t, before, otel.GetMeterProvider(), "the helper installs its own provider")
 	})
 
 	// inner's t.Cleanup has run by the time the subtest returns.
 	require.Equal(t, before, otel.GetMeterProvider(),
-		"the helper must reinstate the previous global, not leave a shut-down provider installed")
+		"the helper reinstates the previous global")
+
+	// Identity is not the property that matters. The global delegates, and its
+	// delegate is bound once per process, so a restored-but-poisoned global has
+	// the RIGHT identity and records nothing. Assert function instead: an
+	// instrument created through the global after cleanup must actually arrive.
+	counter, err := otel.Meter("restore.probe").Int64Counter("restore.probe.counter")
+	require.NoError(t, err)
+	counter.Add(context.Background(), 1)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm),
+		"the provider the global delegates to must still be collectable after cleanup")
+
+	found := false
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == "restore.probe.counter" {
+				found = true
+			}
+		}
+	}
+	require.True(t, found,
+		"a metric recorded through the global after cleanup must reach the reader; "+
+			"if it does not, the global is delegating to a shut-down provider")
 }
 
 func TestRecordCacheOperationDuration(t *testing.T) {

--- a/cache/internal/tracking/metrics_test.go
+++ b/cache/internal/tracking/metrics_test.go
@@ -47,7 +47,7 @@ func setupTestMeterProvider(t *testing.T) *sdkmetric.ManualReader {
 	return reader
 }
 
-func TestSetupTestMeterProviderLeavesTheGlobalUsable(t *testing.T) {
+func TestSetupTestMeterProviderLeavesItsProviderUsable(t *testing.T) {
 	before := otel.GetMeterProvider()
 	var reader *sdkmetric.ManualReader
 
@@ -57,32 +57,21 @@ func TestSetupTestMeterProviderLeavesTheGlobalUsable(t *testing.T) {
 	})
 
 	// inner's t.Cleanup has run by the time the subtest returns.
-	require.Equal(t, before, otel.GetMeterProvider(),
-		"the helper reinstates the previous global")
+	require.Equal(t, before, otel.GetMeterProvider(), "the helper reinstates the previous global")
 
-	// Identity is not the property that matters. The global delegates, and its
-	// delegate is bound once per process, so a restored-but-poisoned global has
-	// the RIGHT identity and records nothing. Assert function instead: an
-	// instrument created through the global after cleanup must actually arrive.
-	counter, err := otel.Meter("restore.probe").Int64Counter("restore.probe.counter")
-	require.NoError(t, err)
-	counter.Add(context.Background(), 1)
-
+	// The property that identity cannot see. otel binds its delegator's delegate
+	// once per process (internal/global/state.go, delegateMeterOnce), so restoring
+	// the global does not un-delegate this provider — shutting it down would leave
+	// instrument creation silently returning noop.Int64Counter with a nil error.
+	//
+	// Asserted against THIS helper's own reader rather than against whatever the
+	// process-wide delegator happens to point at. Six tests in this package call
+	// this helper, so which provider won that once-per-process race depends on test
+	// order; the helper's contract — do not leave a dead provider reachable — does
+	// not. A shut-down provider's reader reports "reader is shutdown" here.
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(context.Background(), &rm),
-		"the provider the global delegates to must still be collectable after cleanup")
-
-	found := false
-	for _, sm := range rm.ScopeMetrics {
-		for _, m := range sm.Metrics {
-			if m.Name == "restore.probe.counter" {
-				found = true
-			}
-		}
-	}
-	require.True(t, found,
-		"a metric recorded through the global after cleanup must reach the reader; "+
-			"if it does not, the global is delegating to a shut-down provider")
+		"cleanup must leave this provider alive; the global still delegates to it")
 }
 
 func TestRecordCacheOperationDuration(t *testing.T) {

--- a/cache/internal/tracking/metrics_test.go
+++ b/cache/internal/tracking/metrics_test.go
@@ -24,14 +24,32 @@ func setupTestMeterProvider(t *testing.T) *sdkmetric.ManualReader {
 
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prev := otel.GetMeterProvider()
 	otel.SetMeterProvider(provider)
 
 	t.Cleanup(func() {
+		// Reinstate the previous provider before shutting this one down: without
+		// it the global keeps pointing at a provider that has been shut down, and
+		// instrument creation against a shut-down provider no-ops silently.
+		otel.SetMeterProvider(prev)
 		_ = provider.Shutdown(context.Background())
 		ResetForTesting()
 	})
 
 	return reader
+}
+
+func TestSetupTestMeterProviderRestoresTheGlobalProvider(t *testing.T) {
+	before := otel.GetMeterProvider()
+
+	t.Run("inner", func(t *testing.T) {
+		setupTestMeterProvider(t)
+		require.NotEqual(t, before, otel.GetMeterProvider(), "the helper installs its own provider")
+	})
+
+	// inner's t.Cleanup has run by the time the subtest returns.
+	require.Equal(t, before, otel.GetMeterProvider(),
+		"the helper must reinstate the previous global, not leave a shut-down provider installed")
 }
 
 func TestRecordCacheOperationDuration(t *testing.T) {


### PR DESCRIPTION
## What

`setupTestMeterProvider` installed a process-global meter provider and its
cleanup shut that provider down without reinstating the previous one, leaving the
global pointing at a provider whose `stopped` flag is set. Instrument creation
against a shut-down provider no-ops silently, so every later test in the binary
got no metrics and no error — worse than leaking a live foreign provider, which
at least still records. It now captures the previous provider and reinstates it
before shutdown, matching the shape already used in `cache/manager_test.go`.

## Impact

None. Test-only.

## Verification

The new test discriminates rather than merely passing: with the fix reverted on
code that still compiles, it fails and prints the leaked global as
`stopped:atomic.Bool{v:0x1}`. Package also run under `-shuffle=on`, since a later
test riding on the leak is the actual hazard and a fixed order cannot distinguish
that from correctness.

Closes #1087


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring metrics configuration is restored after test execution.
  * Verified that recorded metrics remain available and collectable after cleanup.
  * Improved test isolation by preserving the previously configured metrics provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->