### PR TITLE
fix(scheduler): record job metrics under the traced context

### DIFF
--- a/scheduler/module.go
+++ b/scheduler/module.go
@@ -667,8 +667,8 @@ func (m *Module) executeJob(entry *jobEntry, ctx *jobContextImpl) {
 			executionStatus = "panic"
 			panicErr := fmt.Errorf("panic: %v", r)
 
-			// Log panic with stack trace
-			m.logger.Error().
+			// Log panic with stack trace, correlated like the summary line below.
+			m.logger.WithContext(ctx).Error().
 				Str("jobID", entry.metadata.JobID).
 				Interface("panic", r).
 				Str("stackTrace", string(debug.Stack())).
@@ -683,7 +683,7 @@ func (m *Module) executeJob(entry *jobEntry, ctx *jobContextImpl) {
 
 			entry.metadata.incrementFailed()
 
-			m.recordMetrics(entry.metadata.JobID, executionStatus, entry.metadata.ScheduleType, duration)
+			m.recordMetrics(ctx, entry.metadata.JobID, executionStatus, entry.metadata.ScheduleType, duration)
 
 			// Emit the structured action log so the panic path also gets the
 			// advertised 100% job-execution sampling (the normal-return call
@@ -712,7 +712,7 @@ func (m *Module) executeJob(entry *jobEntry, ctx *jobContextImpl) {
 		}
 
 		entry.metadata.incrementFailed()
-		m.recordMetrics(entry.metadata.JobID, executionStatus, entry.metadata.ScheduleType, duration)
+		m.recordMetrics(ctx, entry.metadata.JobID, executionStatus, entry.metadata.ScheduleType, duration)
 	} else {
 		executionStatus = "success"
 
@@ -723,7 +723,7 @@ func (m *Module) executeJob(entry *jobEntry, ctx *jobContextImpl) {
 		}
 
 		entry.metadata.incrementSuccess()
-		m.recordMetrics(entry.metadata.JobID, executionStatus, entry.metadata.ScheduleType, duration)
+		m.recordMetrics(ctx, entry.metadata.JobID, executionStatus, entry.metadata.ScheduleType, duration)
 	}
 }
 
@@ -737,9 +737,12 @@ func (m *Module) executeJob(entry *jobEntry, ctx *jobContextImpl) {
 // - job.panic.total (Counter) - Singular "panic" for consistency
 //
 // Attributes: job.id, job.status (success/failure/panic), job.schedule_type (fixed_rate/daily/weekly/hourly/monthly)
-func (m *Module) recordMetrics(jobID, status, scheduleType string, duration time.Duration) {
+//
+// ctx must be the traced job context: the SDK's default exemplar filter attaches
+// an exemplar only when the recording context carries a sampled span.
+func (m *Module) recordMetrics(ctx context.Context, jobID, status, scheduleType string, duration time.Duration) {
 	if m.executionCounter != nil {
-		m.executionCounter.Add(context.Background(), 1,
+		m.executionCounter.Add(ctx, 1,
 			metric.WithAttributes(
 				attribute.String(jobIDAttr, jobID),
 				attribute.String(jobStatusAttr, status),
@@ -749,7 +752,7 @@ func (m *Module) recordMetrics(jobID, status, scheduleType string, duration time
 	}
 
 	if m.durationHistogram != nil {
-		m.durationHistogram.Record(context.Background(), duration.Seconds(),
+		m.durationHistogram.Record(ctx, duration.Seconds(),
 			metric.WithAttributes(
 				attribute.String(jobIDAttr, jobID),
 				attribute.String(jobStatusAttr, status),
@@ -759,7 +762,7 @@ func (m *Module) recordMetrics(jobID, status, scheduleType string, duration time
 	}
 
 	if status == "panic" && m.panicCounter != nil {
-		m.panicCounter.Add(context.Background(), 1,
+		m.panicCounter.Add(ctx, 1,
 			metric.WithAttributes(
 				attribute.String(jobIDAttr, jobID),
 				attribute.String(jobScheduleTypeAttr, scheduleType),

--- a/scheduler/module_test.go
+++ b/scheduler/module_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/gaborage/go-bricks/config"
@@ -112,6 +113,102 @@ func TestJobExecutionPanicMetrics(t *testing.T) {
 
 	execMetric := obtest.FindMetric(rm, "job.execution.total")
 	require.NotNil(t, execMetric, "Execution counter metric should be recorded")
+}
+
+// jobExecuteSpan returns the single "job.execute" span recorded so far.
+// AssertCount(1) is load-bearing: "the exemplar names THE job's trace" is only
+// provable while exactly one job span exists.
+func jobExecuteSpan(t *testing.T, tp *obtest.TestTraceProvider) tracetest.SpanStub {
+	t.Helper()
+	spans := obtest.NewSpanCollector(t, tp.Exporter).WithName("job.execute")
+	spans.AssertCount(1)
+	return spans.First()
+}
+
+// runJobOnce runs one job body synchronously, the way the manual trigger does.
+// Driving the body directly pins the span count at one: an interval short enough
+// to observe can fire a second tick before the assertions read.
+func runJobOnce(module *Module, jobID string, job Executor) {
+	module.runJobBody(&jobEntry{
+		job:      job,
+		metadata: &JobMetadata{JobID: jobID, ScheduleType: "fixed-rate"},
+	}, "manual")
+}
+
+// logLineWith returns the single output line carrying message. Asserting on the
+// whole capture cannot tell "this line carries the trace id" from "some other
+// line does".
+func logLineWith(t *testing.T, out, message string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, message) {
+			return line
+		}
+	}
+	t.Fatalf("no log line with message %q in:\n%s", message, out)
+	return ""
+}
+
+// TestJobMetricsCarryExemplarsNamingTheJobSpan verifies the success-path
+// instruments record under the traced job context: the SDK's default
+// TraceBasedFilter attaches an exemplar only when the recording context carries
+// a sampled span, so recording against context.Background() silently drops the
+// metric-to-trace link.
+func TestJobMetricsCarryExemplarsNamingTheJobSpan(t *testing.T) {
+	module, tp, mp := newTracedMeteredScheduler(t)
+
+	runJobOnce(module, "exemplar-job", &slowJob{})
+
+	recorded := jobExecuteSpan(t, tp).SpanContext.TraceID()
+
+	rm := mp.Collect(t)
+
+	durationExemplars := obtest.HistogramExemplars[float64](t, rm, "job.execution.duration")
+	require.NotEmpty(t, durationExemplars, "duration histogram point carries no exemplar")
+	assert.Equal(t, recorded[:], durationExemplars[0].TraceID,
+		"the exemplar names the job.execute trace, not merely some trace")
+
+	execExemplars := obtest.SumExemplars[int64](t, rm, "job.execution.total")
+	require.NotEmpty(t, execExemplars, "execution counter point carries no exemplar")
+	assert.Equal(t, recorded[:], execExemplars[0].TraceID,
+		"the exemplar names the job.execute trace, not merely some trace")
+}
+
+// TestJobPanicMetricCarriesExemplarNamingTheJobSpan covers the deferred recovery
+// path, which reaches the traced context through the rebound ctx variable rather
+// than a parameter.
+func TestJobPanicMetricCarriesExemplarNamingTheJobSpan(t *testing.T) {
+	module, tp, mp := newTracedMeteredScheduler(t)
+
+	runJobOnce(module, "panic-exemplar-job", &panicJob{})
+
+	recorded := jobExecuteSpan(t, tp).SpanContext.TraceID()
+
+	rm := mp.Collect(t)
+
+	panicExemplars := obtest.SumExemplars[int64](t, rm, "job.panic.total")
+	require.NotEmpty(t, panicExemplars, "panic counter point carries no exemplar")
+	assert.Equal(t, recorded[:], panicExemplars[0].TraceID,
+		"the exemplar names the job.execute trace, not merely some trace")
+}
+
+// TestJobPanicLogCarriesTraceCorrelation pins the stack-trace line to the job
+// trace. It is the artifact an operator pivots to from the exemplar, and it used
+// to be the one line in the traced region logged without correlation.
+func TestJobPanicLogCarriesTraceCorrelation(t *testing.T) {
+	var recorded trace.TraceID
+
+	out := captureStdout(t, func() {
+		module, tp, _ := newTracedMeteredScheduler(t)
+
+		runJobOnce(module, "panic-correlation-job", &panicJob{})
+
+		recorded = jobExecuteSpan(t, tp).SpanContext.TraceID()
+	})
+
+	panicLine := logLineWith(t, out, "Job panicked - recovered and marked as failed")
+	assert.Contains(t, panicLine, `"trace_id":"`+recorded.String()+`"`,
+		"the stack-trace line must carry the job's trace, like the summary line does")
 }
 
 // TestJobExecutionPanicEmitsActionLogSummary verifies that a panicking job still emits
@@ -323,13 +420,8 @@ func TestJobExecutionWithTracer(t *testing.T) {
 
 	require.NoError(t, module.Shutdown())
 
-	// Verify span was created
-	collector := obtest.NewSpanCollector(t, tp.Exporter)
-	spans := collector.WithName("job.execute")
-	spans.AssertCount(1)
-
 	// Verify span attributes
-	span := spans.First()
+	span := jobExecuteSpan(t, tp)
 	obtest.AssertSpanAttribute(t, &span, "job.id", "traced-job")
 	obtest.AssertSpanAttribute(t, &span, "job.trigger", "scheduled")
 }
@@ -356,15 +448,11 @@ func TestJobExecutionWithTracerPropagatesContext(t *testing.T) {
 	require.NoError(t, module.Shutdown())
 
 	// Verify both parent and child spans exist
-	collector := obtest.NewSpanCollector(t, tp.Exporter)
-	parentSpans := collector.WithName("job.execute")
-	parentSpans.AssertCount(1)
+	parentSpan := jobExecuteSpan(t, tp)
 
-	childSpans := collector.WithName("child.operation")
+	childSpans := obtest.NewSpanCollector(t, tp.Exporter).WithName("child.operation")
 	childSpans.AssertCount(1)
 
-	// Verify the child span's parent is the "job.execute" span
-	parentSpan := parentSpans.First()
 	childSpan := childSpans.First()
 	assert.Equal(t, parentSpan.SpanContext.TraceID(), childSpan.SpanContext.TraceID(),
 		"Child span should share the same trace ID as the parent")

--- a/scheduler/test_helpers_test.go
+++ b/scheduler/test_helpers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gaborage/go-bricks/database/types"
 	"github.com/gaborage/go-bricks/logger"
 	"github.com/gaborage/go-bricks/messaging"
+	obtest "github.com/gaborage/go-bricks/observability/testing"
 )
 
 // assertWaitGroupDrains fails if module m's in-flight WaitGroup does not reach
@@ -55,6 +56,25 @@ func withSlowJobThreshold(threshold time.Duration) testSchedulerOption {
 
 func withTimezone(tz string) testSchedulerOption {
 	return func(d *app.ModuleDeps) { d.Config.Scheduler.Timezone = tz }
+}
+
+// newTracedMeteredScheduler wires a scheduler with both providers, so a recorded
+// metric point can be matched against the span it was recorded under.
+func newTracedMeteredScheduler(t *testing.T) (*Module, *obtest.TestTraceProvider, *obtest.TestMeterProvider) {
+	t.Helper()
+
+	tp := obtest.NewTestTraceProvider()
+	mp := obtest.NewTestMeterProvider()
+	t.Cleanup(func() {
+		require.NoError(t, tp.Shutdown(context.Background()))
+		require.NoError(t, mp.Shutdown(context.Background()))
+	})
+
+	module, _ := newTestScheduler(t, 5*time.Second,
+		withTracer(tp.Tracer("test-scheduler")),
+		withMeterProvider(mp.MeterProvider))
+
+	return module, tp, mp
 }
 
 // newTestScheduler creates and initializes a scheduler module for testing.

--- a/wiki/observability.md
+++ b/wiki/observability.md
@@ -181,7 +181,11 @@ consume metrics record inside the delivery span, so their data points carry an
 exemplar naming that span. Note the consume span is a **root** on both lanes:
 re-parenting a consume trace onto its producer is deliberately out of scope, so
 an exemplar resolves to a per-message trace containing that one delivery. That is
-expected, not a gap.
+expected, not a gap. Scheduler job metrics behave the same way: `job.execution.total`,
+`job.execution.duration`, and `job.panic.total` record inside the `job.execute`
+span, which is a root on both the scheduled and the manually-triggered path —
+an exemplar on a hand-triggered job resolves to that job's own trace, not to the
+`POST /_sys/job/:jobId` request's.
 
 **One configuration is worth naming**, because it fails quietly:
 `observability.enabled: true` with `observability.trace.enabled: false` leaves


### PR DESCRIPTION
## What

`recordMetrics` recorded all three scheduler job instruments against `context.Background()` while a live sampled `job.execute` span sat in the job context, and the SDK's default `TraceBasedFilter` attaches an exemplar only when the recording context carries a sampled span — so `job.execution.total`, `job.execution.duration` and `job.panic.total` could never link back to their trace. They now record under the job context, and the panic stack-trace log (the one line in the traced region emitted without correlation) goes through `logger.WithContext`.

## Impact

None. Metric names, attributes and values are unchanged; job metric points gain exemplars and the panic log line gains `trace_id`/`span_id` whenever tracing is enabled.

## Verification

`make mutate` reports no mutants on the changed lines — argument substitution is outside gremlins' mutator set — so each recording site was instead reverted individually to confirm a distinct assertion fails.

Closes #1065


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Observability**
  - Scheduler execution, duration, and panic metrics now include trace correlations for easier troubleshooting.
  - Panic logs are linked to the corresponding job trace.
  - Scheduled and manually triggered jobs now resolve metric exemplars to the job’s execution trace.

- **Documentation**
  - Updated observability guidance to explain scheduler metric exemplars and trace correlation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->